### PR TITLE
Add CI and release build pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null || true
+          sdkmanager "platforms;android-36" "build-tools;36.1.0"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test
+        run: ./gradlew test --stacktrace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,136 @@
+name: Release build
+
+# Builds distributables but publishes NOTHING: artifacts stay on the run
+# (Actions → run → Artifacts). Triggered manually only. A GitHub Release will be
+# added later, as a separate decision, once we actually start shipping builds.
+on:
+  workflow_dispatch:
+    inputs:
+      versionName:
+        description: "Override versionName (e.g. 0.2.0). Empty — taken from gradle.properties."
+        required: false
+        type: string
+      versionCode:
+        description: "Override Android versionCode (integer). Empty — from gradle.properties."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux-desktop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install jpackage tooling (deb/rpm)
+        # jpackage needs the rpm package for .rpm; fakeroot is needed for .deb.
+        run: sudo apt-get update && sudo apt-get install -y rpm fakeroot
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Package deb + rpm
+        run: >
+          ./gradlew :composeApp:packageDeb :composeApp:packageRpm --stacktrace
+          ${{ inputs.versionName && format('-Pskerry.versionName={0}', inputs.versionName) || '' }}
+
+      - name: Upload Linux distributables
+        uses: actions/upload-artifact@v4
+        with:
+          name: skerry-linux
+          path: |
+            composeApp/build/compose/binaries/main/deb/*.deb
+            composeApp/build/compose/binaries/main/rpm/*.rpm
+          if-no-files-found: error
+
+  windows-desktop:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install WiX Toolset (jpackage MSI)
+        # jpackage needs WiX 3.x (candle.exe/light.exe) for .msi; recent
+        # windows runners may not ship it.
+        run: choco install wixtoolset -y --no-progress
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Package msi
+        shell: bash
+        run: >
+          ./gradlew :composeApp:packageMsi --stacktrace
+          ${{ inputs.versionName && format('-Pskerry.versionName={0}', inputs.versionName) || '' }}
+
+      - name: Upload Windows distributable
+        uses: actions/upload-artifact@v4
+        with:
+          name: skerry-windows
+          path: composeApp/build/compose/binaries/main/msi/*.msi
+          if-no-files-found: error
+
+  android:
+    runs-on: ubuntu-latest
+    env:
+      # Secrets via job env so the decode step can be gated on env (secrets aren't available in if).
+      ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+      SKERRY_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      SKERRY_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+      SKERRY_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK packages
+        run: |
+          yes | sdkmanager --licenses >/dev/null || true
+          sdkmanager "platforms;android-36" "build-tools;36.1.0"
+
+      - name: Decode release keystore
+        # Without the secret this step is skipped → release is built unsigned (fallback in build.gradle.kts).
+        if: ${{ env.ANDROID_KEYSTORE_BASE64 != '' }}
+        run: |
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/skerry-release.jks"
+          echo "SKERRY_KEYSTORE_FILE=$RUNNER_TEMP/skerry-release.jks" >> "$GITHUB_ENV"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assemble release APK
+        run: >
+          ./gradlew :androidApp:assembleRelease --stacktrace
+          ${{ inputs.versionName && format('-Pskerry.versionName={0}', inputs.versionName) || '' }}
+          ${{ inputs.versionCode && format('-Pskerry.versionCode={0}', inputs.versionCode) || '' }}
+
+      - name: Upload Android APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: skerry-android
+          path: androidApp/build/outputs/apk/release/*.apk
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,11 @@ DerivedData/
 .DS_Store
 Thumbs.db
 
+# Signing secrets — never commit (the release keystore comes from GH Secrets)
+*.jks
+*.keystore
+keystore.properties
+
 # Логи и временные файлы
 *.log
 *.hprof

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -21,8 +21,9 @@ android {
         applicationId = "app.skerry"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
+        // Version from the single source (gradle.properties); the release workflow overrides it.
+        versionCode = (providers.gradleProperty("skerry.versionCode").orNull ?: "1").toInt()
+        versionName = providers.gradleProperty("skerry.versionName").orNull ?: "0.1.0"
         // Локальный AI (Llamatik/llama.cpp): AAR несёт нативы четырёх ABI (~52 МБ распакованных).
         // Реальные Android-устройства проекта — arm64; остальные ABI — мёртвый вес в APK.
         ndk { abiFilters += "arm64-v8a" }
@@ -35,9 +36,28 @@ android {
         // extractNativeLibs не нужен.
         jniLibs { useLegacyPackaging = false }
     }
+    // Release signing from properties/environment (GH Secrets → -Pskerry.* or SKERRY_* env).
+    // The keystore is never stored in the repo (.gitignore); if it is absent the release is built
+    // unsigned, so local builds and forks without secrets don't fail.
+    fun signingValue(prop: String, env: String): String? =
+        providers.gradleProperty(prop).orNull ?: providers.environmentVariable(env).orNull
+    val keystorePath = signingValue("skerry.keystoreFile", "SKERRY_KEYSTORE_FILE")
+    val keystoreFile = keystorePath?.let { rootProject.file(it) }
+    val hasKeystore = keystoreFile?.exists() == true
+    if (hasKeystore) {
+        signingConfigs {
+            create("release") {
+                storeFile = keystoreFile
+                storePassword = signingValue("skerry.keystorePassword", "SKERRY_KEYSTORE_PASSWORD")
+                keyAlias = signingValue("skerry.keyAlias", "SKERRY_KEY_ALIAS")
+                keyPassword = signingValue("skerry.keyPassword", "SKERRY_KEY_PASSWORD")
+            }
+        }
+    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
+            if (hasKeystore) signingConfig = signingConfigs.getByName("release")
         }
     }
     compileOptions {

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -79,7 +79,8 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.Msi, TargetFormat.Dmg)
             packageName = "Skerry"
-            packageVersion = "0.1.0"
+            // Version from the single source (gradle.properties); the release workflow overrides it.
+            packageVersion = providers.gradleProperty("skerry.versionName").orNull ?: "0.1.0"
             // App icons per platform, rasterized from icons/skerry.svg (canonical mark, docs/design/Skerry Logo.html).
             linux { iconFile.set(project.file("icons/skerry.png")) }
             windows { iconFile.set(project.file("icons/skerry.ico")) }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,3 +10,8 @@ org.gradle.parallel=true
 # Android
 android.nonTransitiveRClass=true
 android.useAndroidX=true
+
+# Skerry release version — single source of truth for desktop packaging and Android.
+# The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
+skerry.versionName=0.1.0
+skerry.versionCode=1


### PR DESCRIPTION
## Summary
Lays the release infrastructure now that the repo is public. Nothing is published yet — this only wires up the pipeline.

- **CI** (`ci.yml`): build + test on push to `main` and PRs (JDK 21, Android SDK 36 / build-tools 36.1.0).
- **Release** (`release.yml`): manual `workflow_dispatch` only. Builds `.deb`/`.rpm` (Linux), `.msi` (Windows), signed `.apk` (Android) and uploads them as **run artifacts** — no GitHub Release is created.
- **Single-source version**: `skerry.versionName`/`skerry.versionCode` in `gradle.properties`, consumed by desktop packaging and Android; release workflow can override via `-P`.
- **Android signing**: reads keystore/passwords from GH Secrets (`ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`); falls back to an unsigned release when absent, so forks/local builds don't fail.

## Verified locally
- `./gradlew test` green.
- `assembleRelease` with/without keystore → signed / unsigned APK, no failure.
- Version override lands in both Android metadata and the desktop `.rpm` filename.

macOS `.dmg`, Flatpak, and tag-triggered GitHub Releases are intentionally out of scope for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)