### PR TITLE
Add Kover code coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,15 @@
+// Kover (code coverage) is loaded via the buildscript classpath instead of the plugins {} DSL, and
+// applied conditionally below. A versioned plugins {} entry is resolved even with `apply false` (the
+// same trap that keeps io.ktor.plugin out of this block — see the note there), which would make the
+// hermetic offline Flatpak build (-Dskerry.offlineRepo) fail: its offline repo doesn't carry Kover.
+// Coverage is a dev/CI concern, so it is simply absent from the offline packaging build.
+buildscript {
+    if (System.getProperty("skerry.offlineRepo") == null) {
+        repositories { gradlePluginPortal() }
+        dependencies { classpath("org.jetbrains.kotlinx:kover-gradle-plugin:" + libs.versions.kover.get()) }
+    }
+}
+
 plugins {
     // io.ktor.plugin is intentionally NOT declared here — it is applied directly (with its catalog
     // version) by its only consumer, :server. Declaring it at root made every build resolve its full
@@ -12,4 +24,24 @@ plugins {
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.kotlinxSerialization) apply false
+}
+
+// Aggregate coverage at the root over the modules that carry real logic and tests. Each measured
+// module applies Kover itself (see its build.gradle.kts). findProject keeps this correct under the
+// serverOnly / desktopOnly settings graphs, which drop some modules. Run: ./gradlew koverHtmlReport
+if (System.getProperty("skerry.offlineRepo") == null) {
+    apply(plugin = "org.jetbrains.kotlinx.kover")
+    dependencies {
+        listOf(":shared", ":composeApp", ":server", ":sync-wire").forEach { path ->
+            findProject(path)?.let { add("kover", it) }
+        }
+    }
+    extensions.configure<kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension> {
+        reports.filters.excludes {
+            // Generated code has no tests by design and swamps the denominator: the Compose
+            // resource accessors alone are ~43k lines of generated Kotlin (the i18n string table).
+            packages("app.skerry.ui.generated.resources")
+            classes("app.skerry.ui.app.AppVersion")
+        }
+    }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -212,3 +212,9 @@ tasks.register<JavaExec>("screenshotDesign") {
     // Stub window chrome: draws the custom window buttons of the undecorated window in the titlebar.
     systemProperty("skerry.screenshot.windowChrome", providers.systemProperty("skerry.screenshot.windowChrome").getOrElse("false"))
 }
+
+// Kover coverage — applied via pluginManager (classpath comes from the root buildscript) so the
+// offline Flatpak build, which sets -Dskerry.offlineRepo, never resolves it. See the root build.
+if (System.getProperty("skerry.offlineRepo") == null) {
+    pluginManager.apply("org.jetbrains.kotlinx.kover")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,11 @@ mlkit-barcode = "17.3.0"
 # JNA platform bindings — desktop-only; used for the Linux/X11 _NET_WM_MOVERESIZE native window drag
 # (the JNA core is already on the classpath transitively via the libsodium binding).
 jna = "5.18.1"
+# Kover — code-coverage for the JVM/KMP test suites. Loaded via the root buildscript classpath and
+# applied conditionally (see the root build.gradle.kts) so the offline Flatpak build never resolves it.
+# 0.9.8+ is required: earlier releases can't handle the com.android.kotlin.multiplatform.library
+# target used by :shared and :composeApp (they demand a legacy `android` extension). See kover #747/#772.
+kover = "0.9.8"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -56,3 +56,9 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+// Kover coverage — applied via pluginManager (classpath comes from the root buildscript) so the
+// offline Flatpak build, which sets -Dskerry.offlineRepo, never resolves it. See the root build.
+if (System.getProperty("skerry.offlineRepo") == null) {
+    pluginManager.apply("org.jetbrains.kotlinx.kover")
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -127,3 +127,9 @@ kotlin {
         }
     }
 }
+
+// Kover coverage — applied via pluginManager (classpath comes from the root buildscript) so the
+// offline Flatpak build, which sets -Dskerry.offlineRepo, never resolves it. See the root build.
+if (System.getProperty("skerry.offlineRepo") == null) {
+    pluginManager.apply("org.jetbrains.kotlinx.kover")
+}

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -14,3 +14,9 @@ dependencies {
     // api: the contract's @Serializable types are visible to consumers together with their serializers.
     api(libs.kotlinx.serialization.json)
 }
+
+// Kover coverage — applied via pluginManager (classpath comes from the root buildscript) so the
+// offline Flatpak build, which sets -Dskerry.offlineRepo, never resolves it. See the root build.
+if (System.getProperty("skerry.offlineRepo") == null) {
+    pluginManager.apply("org.jetbrains.kotlinx.kover")
+}


### PR DESCRIPTION
Adds [Kover](https://github.com/Kotlin/kotlinx-kover) so we can measure test coverage across the JVM/KMP suites. Aggregated at the root over `:shared`, `:composeApp`, `:server` and `:sync-wire`.

## Usage
- `./gradlew koverHtmlReport` → `build/reports/kover/html/index.html` (aggregate "all code")
- `./gradlew koverLog` → coverage % to console
- `:server:koverHtmlReport` etc. for a single module

## How it's wired (and why not the plugins {} DSL)
A versioned `plugins {}` entry resolves its plugin marker **even with `apply false`** (verified empirically) — the same trap that keeps `io.ktor.plugin` out of the root block. The hermetic offline Flatpak build (`-Dskerry.offlineRepo`) has no Kover in its offline repo, so any `plugins {}` reference would break it.

So Kover is loaded through the root `buildscript` classpath and applied via `pluginManager.apply`, every application guarded by `System.getProperty("skerry.offlineRepo") == null`. Offline packaging, `serverOnly` and `desktopOnly` builds never resolve or apply it; `findProject` keeps the root aggregation valid when those graphs drop modules.

## Notes
- Requires **Kover 0.9.8+** — earlier releases reject the `com.android.kotlin.multiplatform.library` target used by `:shared` / `:composeApp` (kover #747/#772).
- Generated Compose resource accessors and `AppVersion` are excluded so they don't swamp the denominator.

## Baseline (line coverage, generated excluded)
Aggregate ~41%. Core is well-covered — `sync-wire` 98%, `server` 89%, shared core 80–98% (terminal/mosh/ssh/ai 93–94%). The gap is the pure `@Composable` render layer (screens near 0%), which needs `compose.uiTest` / instrumented tests — a follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)