### PR TITLE
Fix NoSuchFieldError: align BouncyCastle bcpkix/bcutil with bumped bcprov

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -120,6 +120,7 @@ sshj = { module = "com.hierynomus:sshj", version.ref = "sshj" }
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
 usbserial = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usbSerial" }
 bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 sshd-core = { module = "org.apache.sshd:sshd-core", version.ref = "sshd" }
 sshd-sftp = { module = "org.apache.sshd:sshd-sftp", version.ref = "sshd" }
 ionspin-libsodium = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "ionspin-libsodium" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -79,6 +79,10 @@ kotlin {
                 // Explicit: sshj's transitive bcprov is not visible on the compile classpath, while SshjTransport
                 // references BouncyCastleProvider to replace the stripped-down system "BC" on Android.
                 implementation(libs.bouncycastle.prov)
+                // sshj pins bcpkix/bcutil to 1.80; without this they stay behind the bumped bcprov (1.85),
+                // and 1.80's bcpkix references OIDs that moved in 1.85 -> NoSuchFieldError at runtime.
+                // Pinning bcpkix to the same version aligns bcutil transitively.
+                runtimeOnly(libs.bouncycastle.pkix)
                 // Sync client (Phase 2): HTTP+WS to the self-hosted server. iOS is deferred — the client
                 // lives in the shared JVM node (desktop + Android), same as the sshj transport.
                 implementation(libs.ktor.client.core)


### PR DESCRIPTION
## Problem

After the dependency bump, launching an SSH session crashed with:

> Class org.bouncycastle.asn1.iana.IANAObjectIdentifiers does not have member field 'org.bouncycastle.asn1.ASN1ObjectIdentifier id_MLDSA44_RSA2048_PSS_SHA256'

`bouncycastle` in the catalog was raised to **1.85** and only `bcprov-jdk18on` is declared explicitly. `bcpkix`/`bcutil` are pulled transitively by `sshj:0.40.0` and stayed at **1.80.x** (`bcutil` even range-pinned to `[1.80,1.81)`). `bcpkix:1.80` was compiled against `bcprov:1.80`, where the `id_MLDSA44_RSA2048_PSS_SHA256` OID lived in a different class; it moved in 1.85, so `BouncyCastleProvider` init threw `NoSuchFieldError` at runtime.

## Fix

- Add a `bouncycastle-pkix` catalog alias on the shared `bouncycastle` version ref.
- Declare `runtimeOnly(libs.bouncycastle.pkix)` in `shared` (`jvmSharedMain`). Only `bcprov` is referenced from code, so `bcpkix` is a pure runtime alignment; `bcutil` aligns transitively.

Verified via `dependencies` on both `desktopRuntimeClasspath` and Android `debugRuntimeClasspath`: all BC artifacts now resolve to **1.85**. Runtime crash confirmed gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)