### PR TITLE
Mobile terminal parity: scrollback + cursor style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local working notes — never committed
+*.local.md
+
 # Gradle
 .gradle/
 build/

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -45,9 +45,12 @@ import app.skerry.ui.known.KnownHostsController
 import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
+import app.skerry.ui.terminal.DEFAULT_TERMINAL_SCROLLBACK
 import app.skerry.ui.i18n.AppLocaleProvider
 import app.skerry.ui.i18n.UiLanguage
 import app.skerry.ui.terminal.TERMINAL_FONT_SIZE_RANGE
+import app.skerry.ui.terminal.TERMINAL_SCROLLBACK_OPTIONS
+import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.tunnel.TunnelManager
 import app.skerry.ui.tunnel.resolveTunnel
@@ -153,6 +156,10 @@ class MainActivity : FragmentActivity() {
                     onUiLanguageChange = { currentUiLanguage.value = it; writeUiLanguage(dir, it) },
                     initialAutoLock = readAutoLock(dir),
                     onAutoLockChange = { writeAutoLock(dir, it) },
+                    initialTerminalScrollback = readTerminalScrollback(dir),
+                    onTerminalScrollbackChange = { writeTerminalScrollback(dir, it) },
+                    initialTerminalCursorStyle = readTerminalCursorStyle(dir),
+                    onTerminalCursorStyleChange = { writeTerminalCursorStyle(dir, it) },
                 )
             }
             AppLocaleProvider(currentUiLanguage.value) {
@@ -242,6 +249,39 @@ class MainActivity : FragmentActivity() {
     private fun writeTerminalFontSize(dir: File, px: Int) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_font_size").writeText(px.toString()) }
+        }
+    }
+
+    /**
+     * Scrollback depth for new sessions (More → Appearance → Terminal): a number in
+     * `terminal_scrollback`. Missing/unreadable/outside [TERMINAL_SCROLLBACK_OPTIONS] →
+     * [DEFAULT_TERMINAL_SCROLLBACK]. Write is best-effort, off the UI thread.
+     */
+    private fun readTerminalScrollback(dir: File): Int {
+        val lines = runCatching { File(dir, "terminal_scrollback").readText().trim().toInt() }
+            .getOrDefault(DEFAULT_TERMINAL_SCROLLBACK)
+        return if (lines in TERMINAL_SCROLLBACK_OPTIONS) lines else DEFAULT_TERMINAL_SCROLLBACK
+    }
+
+    private fun writeTerminalScrollback(dir: File, lines: Int) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_scrollback").writeText(lines.toString()) }
+        }
+    }
+
+    /**
+     * Default cursor style for new sessions (More → Appearance → Terminal): stable
+     * [TerminalCursorStyle.id] in `terminal_cursor_style`. Missing/unreadable/unknown →
+     * [TerminalCursorStyle.DEFAULT]. Write is best-effort, off the UI thread.
+     */
+    private fun readTerminalCursorStyle(dir: File): TerminalCursorStyle = runCatching {
+        TerminalCursorStyle.fromId(File(dir, "terminal_cursor_style").readText().trim())
+    }.getOrDefault(TerminalCursorStyle.DEFAULT)
+
+    private fun writeTerminalCursorStyle(dir: File, style: TerminalCursorStyle) {
+        val id = style.id
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_cursor_style").writeText(id) }
         }
     }
 
@@ -417,6 +457,8 @@ class MainActivity : FragmentActivity() {
                 knownHosts.entries.toList().forEach { knownHosts.forget(it) }
                 writeTerminalFont(dir, TerminalFont.DEFAULT)
                 writeTerminalFontSize(dir, DEFAULT_TERMINAL_FONT_SIZE)
+                writeTerminalScrollback(dir, DEFAULT_TERMINAL_SCROLLBACK)
+                writeTerminalCursorStyle(dir, TerminalCursorStyle.DEFAULT)
                 writeClipboardWrite(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -8,11 +8,14 @@ import app.skerry.shared.host.Host
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
+import app.skerry.ui.terminal.DEFAULT_TERMINAL_SCROLLBACK
 import app.skerry.ui.terminal.TERMINAL_FONT_SIZE_RANGE
+import app.skerry.ui.terminal.TERMINAL_SCROLLBACK_OPTIONS
 import app.skerry.ui.terminal.clampTerminalLetterSpacing
 import app.skerry.ui.terminal.clampTerminalLineHeight
 import app.skerry.ui.i18n.UiLanguage
 import app.skerry.ui.vault.AutoLockDuration
+import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.terminal.TerminalTheme
 import app.skerry.ui.terminal.TerminalThemes
@@ -102,6 +105,14 @@ class MobileDesignState(
     // back; threaded into [app.skerry.ui.vault.VaultGate] as the timer's idleMs.
     initialAutoLock: AutoLockDuration = AutoLockDuration.DEFAULT,
     private val onAutoLockChange: (AutoLockDuration) -> Unit = {},
+    // Terminal behaviour (More -> Appearance -> Terminal): scrollback depth and default cursor style.
+    // Read from persistence at startup, written back via the callbacks. Defaults (10,000 lines,
+    // blinking block, no-op) are for previews/tests. Both apply to NEW sessions on connect (see
+    // [app.skerry.ui.terminal.TerminalSessionPrefs]) and are also pushed live into already-open sessions.
+    initialTerminalScrollback: Int = DEFAULT_TERMINAL_SCROLLBACK,
+    private val onTerminalScrollbackChange: (Int) -> Unit = {},
+    initialTerminalCursorStyle: TerminalCursorStyle = TerminalCursorStyle.DEFAULT,
+    private val onTerminalCursorStyleChange: (TerminalCursorStyle) -> Unit = {},
 ) {
     var tab: MobileTab by mutableStateOf(MobileTab.Hosts); private set
     var route: MobileRoute? by mutableStateOf(null); private set
@@ -234,6 +245,12 @@ class MobileDesignState(
     /** Idle auto-lock threshold (More -> Security). Threaded into [app.skerry.ui.vault.VaultGate]. */
     var autoLock: AutoLockDuration by mutableStateOf(initialAutoLock); private set
 
+    /** Scrollback depth for new sessions, lines (More -> Appearance -> Terminal). Applies to new sessions. */
+    var terminalScrollback: Int by mutableStateOf(initialTerminalScrollback); private set
+
+    /** Default cursor style (More -> Appearance -> Terminal). Applies to new sessions. */
+    var terminalCursorStyle: TerminalCursorStyle by mutableStateOf(initialTerminalCursorStyle); private set
+
     /** Choose the auto-lock threshold and report outward (for persistence). Repeating the same value is a no-op. */
     fun chooseAutoLock(duration: AutoLockDuration) {
         if (duration == autoLock) return
@@ -292,5 +309,23 @@ class MobileDesignState(
         if (language == uiLanguage) return
         uiLanguage = language
         onUiLanguageChange(language)
+    }
+
+    /**
+     * Set the scrollback depth and report outward (for persistence). A value outside
+     * [TERMINAL_SCROLLBACK_OPTIONS] or equal to the current one is a no-op (no write, no callback).
+     * Applies to subsequent sessions.
+     */
+    fun chooseTerminalScrollback(lines: Int) {
+        if (lines == terminalScrollback || lines !in TERMINAL_SCROLLBACK_OPTIONS) return
+        terminalScrollback = lines
+        onTerminalScrollbackChange(lines)
+    }
+
+    /** Choose the cursor style and report outward (for persistence). Repeating the same value is a no-op. */
+    fun chooseTerminalCursorStyle(style: TerminalCursorStyle) {
+        if (style == terminalCursorStyle) return
+        terminalCursorStyle = style
+        onTerminalCursorStyleChange(style)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -132,9 +132,15 @@ fun MobileDesignApp(
                 controllerFactory = {
                     ConnectionController(
                         t, scope, history = termHistory,
-                        // OSC 52 clipboard-write gate is read at connect time — new sessions pick up
-                        // the current choice, already-open ones are updated live below.
-                        terminalPrefs = { TerminalSessionPrefs(clipboardWriteEnabled = state.allowServerClipboardWrite) },
+                        // Terminal settings are read at connect time — new sessions pick up the current
+                        // scrollback/cursor/clipboard choice, already-open ones are updated live below.
+                        terminalPrefs = {
+                            TerminalSessionPrefs(
+                                state.terminalScrollback,
+                                state.terminalCursorStyle,
+                                clipboardWriteEnabled = state.allowServerClipboardWrite,
+                            )
+                        },
                     )
                 },
             )
@@ -142,6 +148,27 @@ fun MobileDesignApp(
     }
     val ownsSessions = sessions == null
     DisposableEffect(liveSessions) { onDispose { if (ownsSessions) liveSessions?.disconnectAll() } }
+    // A cursor-style change applies to ALREADY open sessions live (new ones pick it up at connect via
+    // terminalPrefs). Pushed into each session's terminal; the command goes through the emulator's
+    // queue, so no race. Mobile has no split pane, but push into it too for parity/safety.
+    val cursorStyle = state.terminalCursorStyle
+    LaunchedEffect(cursorStyle, liveSessions) {
+        val manager = liveSessions ?: return@LaunchedEffect
+        manager.sessions.forEach { s ->
+            s.liveTerminal?.applyCursorStyle(cursorStyle.shape, cursorStyle.blink)
+            s.splitSession?.liveTerminal?.applyCursorStyle(cursorStyle.shape, cursorStyle.blink)
+        }
+    }
+    // A scrollback change likewise applies to ALREADY open sessions live: shrinking trims old history,
+    // growing keeps new lines around longer. New sessions pick up the value at connect via terminalPrefs.
+    val scrollbackLines = TerminalSessionPrefs(scrollback = state.terminalScrollback).effectiveScrollback
+    LaunchedEffect(scrollbackLines, liveSessions) {
+        val manager = liveSessions ?: return@LaunchedEffect
+        manager.sessions.forEach { s ->
+            s.liveTerminal?.applyScrollback(scrollbackLines)
+            s.splitSession?.liveTerminal?.applyScrollback(scrollbackLines)
+        }
+    }
     // Toggling the OSC 52 clipboard-write gate applies to ALREADY open sessions live; new sessions
     // pick the value up at connect via terminalPrefs above.
     val allowClipboardWrite = state.allowServerClipboardWrite

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -50,6 +50,8 @@ import app.skerry.ui.generated.resources.appearance_section_interface
 import app.skerry.ui.generated.resources.appearance_section_terminal
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
+import app.skerry.ui.generated.resources.settings_terminal_cursor_style
+import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.appearance_title
 import app.skerry.ui.generated.resources.more_about
 import app.skerry.ui.generated.resources.more_ai_privacy
@@ -79,6 +81,8 @@ import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
 import app.skerry.ui.terminal.TERMINAL_FONT_SIZE_MAX
 import app.skerry.ui.terminal.TERMINAL_FONT_SIZE_MIN
+import app.skerry.ui.terminal.TERMINAL_SCROLLBACK_OPTIONS
+import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.terminal.TerminalTheme
 import app.skerry.ui.terminal.TerminalThemes
@@ -126,7 +130,9 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.settings.autoLockLabel
+import app.skerry.ui.settings.cursorStyleLabel
 import app.skerry.ui.settings.formatDecimal
+import app.skerry.ui.settings.formatScrollback
 import app.skerry.ui.settings.masterPasswordSubtitle
 import app.skerry.ui.settings.securityEventLine
 
@@ -480,6 +486,16 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
                     fieldWidth = 52.dp,
                 )
             }
+            // Scrollback depth and default cursor style for new sessions (behaviour, desktop parity).
+            // Both apply to new sessions at connect and are pushed live into already-open ones.
+            Box(Modifier.fillMaxWidth().height(1.dp).background(D.cyan.copy(alpha = 0.05f)))
+            FontSettingRow(stringResource(Res.string.settings_terminal_scrollback)) {
+                MobileScrollbackPicker(state.terminalScrollback, onPick = state::chooseTerminalScrollback)
+            }
+            Box(Modifier.fillMaxWidth().height(1.dp).background(D.cyan.copy(alpha = 0.05f)))
+            FontSettingRow(stringResource(Res.string.settings_terminal_cursor_style)) {
+                MobileCursorStylePicker(state.terminalCursorStyle, onPick = state::chooseTerminalCursorStyle)
+            }
             // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host
             // from silently overwriting the system clipboard. Applies to new and already-open sessions.
             Box(Modifier.fillMaxWidth().height(1.dp).background(D.cyan.copy(alpha = 0.05f)))
@@ -579,6 +595,42 @@ private fun MobileFontPicker(current: TerminalFont, onPick: (TerminalFont) -> Un
             MobileDropdownMenu(width) {
                 TerminalFont.entries.forEach { option ->
                     MobileDropdownOption(option.displayName, selected = option == current) { onPick(option); open = false }
+                }
+            }
+        },
+    )
+}
+
+/** Scrollback-depth dropdown ([TERMINAL_SCROLLBACK_OPTIONS], lines; formatted as "10 000"). */
+@Composable
+private fun MobileScrollbackPicker(current: Int, onPick: (Int) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { MobileSelectTrigger(formatScrollback(current), onClick = { open = !open }) },
+        menu = { width ->
+            MobileDropdownMenu(width) {
+                TERMINAL_SCROLLBACK_OPTIONS.forEach { option ->
+                    MobileDropdownOption(formatScrollback(option), selected = option == current) { onPick(option); open = false }
+                }
+            }
+        },
+    )
+}
+
+/** Cursor-style dropdown (shape × blink, [TerminalCursorStyle.entries]). */
+@Composable
+private fun MobileCursorStylePicker(current: TerminalCursorStyle, onPick: (TerminalCursorStyle) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { MobileSelectTrigger(current.cursorStyleLabel(), onClick = { open = !open }) },
+        menu = { width ->
+            MobileDropdownMenu(width) {
+                TerminalCursorStyle.entries.forEach { option ->
+                    MobileDropdownOption(option.cursorStyleLabel(), selected = option == current) { onPick(option); open = false }
                 }
             }
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -237,7 +237,7 @@ private fun ThemeCard(
 
 /** Localized cursor style label (shape + blink) for the dropdown and its trigger. */
 @Composable
-private fun TerminalCursorStyle.label(): String = stringResource(
+internal fun TerminalCursorStyle.cursorStyleLabel(): String = stringResource(
     when (this) {
         TerminalCursorStyle.BlockBlink -> Res.string.settings_terminal_cursor_block_blink
         TerminalCursorStyle.BlockSteady -> Res.string.settings_terminal_cursor_block_steady
@@ -257,9 +257,9 @@ private fun ScrollbackPicker(current: Int, onPick: (Int) -> Unit) {
 /** Dropdown for cursor style ([TerminalCursorStyle.entries]). */
 @Composable
 private fun CursorStylePicker(current: TerminalCursorStyle, onPick: (TerminalCursorStyle) -> Unit) {
-    DropdownField(current, TerminalCursorStyle.entries, label = { it.label() }, onPick = onPick)
+    DropdownField(current, TerminalCursorStyle.entries, label = { it.cursorStyleLabel() }, onPick = onPick)
 }
 
 /** "10000" -> "10 000" (space between thousands) for readable line counts. */
-private fun formatScrollback(lines: Int): String =
+internal fun formatScrollback(lines: Int): String =
     lines.toString().reversed().chunked(3).joinToString(" ").reversed()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -4,8 +4,10 @@ import app.skerry.shared.host.Host
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
+import app.skerry.ui.terminal.DEFAULT_TERMINAL_SCROLLBACK
 import app.skerry.ui.terminal.TERMINAL_LETTER_SPACING_MIN
 import app.skerry.ui.terminal.TERMINAL_LINE_HEIGHT_MAX
+import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -99,6 +101,47 @@ class MobileDesignStateTest {
         s.chooseTerminalLetterSpacing(-9f) // out of range → clamp to MIN
         assertEquals(TERMINAL_LETTER_SPACING_MIN, s.terminalLetterSpacing)
         assertEquals(listOf(1f, TERMINAL_LETTER_SPACING_MIN), seen)
+    }
+
+    // Terminal behaviour: scrollback depth + cursor style (More → Appearance → Terminal; desktop parity)
+
+    @Test
+    fun terminal_behaviour_defaults_to_10k_and_block_blink() {
+        val s = MobileDesignState()
+        assertEquals(DEFAULT_TERMINAL_SCROLLBACK, s.terminalScrollback)
+        assertEquals(TerminalCursorStyle.BlockBlink, s.terminalCursorStyle)
+    }
+
+    @Test
+    fun terminal_behaviour_honours_initial_values() {
+        val s = MobileDesignState(
+            initialTerminalScrollback = 50_000,
+            initialTerminalCursorStyle = TerminalCursorStyle.BarSteady,
+        )
+        assertEquals(50_000, s.terminalScrollback)
+        assertEquals(TerminalCursorStyle.BarSteady, s.terminalCursorStyle)
+    }
+
+    @Test
+    fun chooseTerminalScrollback_updates_and_reports_skipping_repeat_and_out_of_range() {
+        val seen = mutableListOf<Int>()
+        val s = MobileDesignState(onTerminalScrollbackChange = { seen += it })
+        s.chooseTerminalScrollback(5_000)
+        s.chooseTerminalScrollback(5_000)   // repeat — no-op
+        s.chooseTerminalScrollback(1_234)   // outside TERMINAL_SCROLLBACK_OPTIONS — no-op
+        s.chooseTerminalScrollback(1_000)
+        assertEquals(1_000, s.terminalScrollback)
+        assertEquals(listOf(5_000, 1_000), seen)
+    }
+
+    @Test
+    fun chooseTerminalCursorStyle_updates_and_reports_once_skipping_repeat() {
+        val seen = mutableListOf<TerminalCursorStyle>()
+        val s = MobileDesignState(onTerminalCursorStyleChange = { seen += it })
+        s.chooseTerminalCursorStyle(TerminalCursorStyle.UnderlineBlink)
+        s.chooseTerminalCursorStyle(TerminalCursorStyle.UnderlineBlink) // repeat — no-op
+        assertEquals(TerminalCursorStyle.UnderlineBlink, s.terminalCursorStyle)
+        assertEquals(listOf(TerminalCursorStyle.UnderlineBlink), seen)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes the last real code-parity gap before 1.0: the terminal **scrollback depth** and **default cursor style** settings existed on desktop but were entirely absent on Android (no state, no UI, no persistence). This brings mobile to feature parity with desktop, mirroring the existing desktop implementation.

## What changed

- **`MobileDesignState`** — `terminalScrollback` / `terminalCursorStyle` state + `chooseTerminalScrollback` / `chooseTerminalCursorStyle` mutators, with the same no-op guards as desktop (repeat value, out-of-range scrollback).
- **`MobileAppearanceScreen`** (`MobileMoreView`) — dropdown pickers for scrollback (1000/5000/10000/50000) and cursor style (block/underline/bar × steady/blink) in the Terminal section.
- **`MobileDesignApp`** — both settings threaded into `TerminalSessionPrefs` (applied to new sessions on connect) plus `LaunchedEffect` live-push into already-open sessions, mirroring desktop.
- **`MainActivity`** — file-backed persistence (`terminal_scrollback`, `terminal_cursor_style`) with validation on read and factory-reset coverage (`ResetScope.Everything`).
- **`TerminalSection`** — `formatScrollback` and the cursor-style label extension widened to `internal` (renamed `label()` → `cursorStyleLabel()`) so the mobile screen reuses them instead of duplicating.
- Ignore `*.local.md` so local working notes never get committed.

## Testing

- New `MobileDesignStateTest` cases (TDD): defaults, initial-value injection, no-op-on-repeat, no-op-on-out-of-range.
- `:composeApp:desktopTest` green; `:androidApp:compileDebugKotlin` clean.
- kotlin-reviewer pass: APPROVE, 0 findings — desktop⇆Android parity verified against the reference implementation.

Remaining manual step: live verification on a physical device (S24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)