### PR TITLE
Pin Compose toolchain to the last stable material3 pair

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
     groups:
       gradle-dependencies:
         patterns: ["*"]
+    # CMP + material3 are a hand-managed matched pair, frozen at the last CMP with a stable material3.
+    # Newer stable CMP only pairs with -alpha material3. Revisit by hand if a stable material3 > 1.9.0 ships.
+    ignore:
+      - dependency-name: "org.jetbrains.compose*"

--- a/composeApp/flatpak/flatpak-sources.json
+++ b/composeApp/flatpak/flatpak-sources.json
@@ -113,290 +113,185 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.11.2/runtime-annotation-jvm-1.11.2.jar",
-    "sha512": "8e669556eba6ed47fadd9ff631b0f0dc530615e2b926d3073afdbd05ab4a7195936f07bca7357ec1de7ca3244537a9c052ebcaf3d0dcb106cc4c84978e14d846",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.11.2",
-    "dest-filename": "runtime-annotation-jvm-1.11.2.jar"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.9.4/runtime-annotation-jvm-1.9.4.jar",
+    "sha512": "d7584a09724a239e1df22dd3b7fe9d2ce9ef8924bc7281952312e4d3b63a63dd8b132e77a5683dae346af25e8006e8ce462b29929707584080ff537688717252",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.9.4",
+    "dest-filename": "runtime-annotation-jvm-1.9.4.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.11.2/runtime-annotation-jvm-1.11.2.module",
-    "sha512": "a4db592276bebfc2543928ade4e2be6ed393f6ec39eb33bc0fe69ff106e50e1ffad3f58454a63f34534cbc6b51457280cb14f697a830ecf7858a2cde0d285555",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.11.2",
-    "dest-filename": "runtime-annotation-jvm-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.9.4/runtime-annotation-jvm-1.9.4.module",
+    "sha512": "b10ff1c2c0694c7fdac8342fcfc60d089ca3b501a1b41c02a586d6ddbbad8fad72fb738435cc3d061526f2b5b359734c12fa9e8189cbb0fcdb8b5ee0837f24a7",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.9.4",
+    "dest-filename": "runtime-annotation-jvm-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.11.2/runtime-annotation-jvm-1.11.2.pom",
-    "sha512": "bbd0264c4490ff2ca729f59f93467f52a778c9822b2eae85769653cccf15c9696e9655e483c654faa6dc1c9ca5fcb4ab44710c445274e9ceef0fefa0a3beb3c3",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.11.2",
-    "dest-filename": "runtime-annotation-jvm-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation-jvm/1.9.4/runtime-annotation-jvm-1.9.4.pom",
+    "sha512": "1a8b1709cfab06865570a42c27fe7a48e1826e4ff2d5e2a159932df9a4680ed3255dcff4cd986f4aa60c0142eb8f3f131c6c14cd8ab78ddc1ec13326476d3df4",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation-jvm/1.9.4",
+    "dest-filename": "runtime-annotation-jvm-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation/1.11.2/runtime-annotation-1.11.2.module",
-    "sha512": "fd771e563760d608e121a8f4ac1d2784e1e7fdf469034823d88198727d3b27c29fcfab7f4c2e2fd05f2678cf62f330f569a2c99a93356600aceddae18df5e37d",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation/1.11.2",
-    "dest-filename": "runtime-annotation-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation/1.9.4/runtime-annotation-1.9.4.module",
+    "sha512": "f9d801220ac661faa9eb126faf9d428ca2dd78a47fb578ba593b92d992a596eca4143b01abd8ba902e22235bff607850bc63e57ed09ff879ca09b00129241df0",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation/1.9.4",
+    "dest-filename": "runtime-annotation-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation/1.11.2/runtime-annotation-1.11.2.pom",
-    "sha512": "b2b545b956356d719c540c372c9c95dc2c5e87d2dc6135cfcdc786c87384e571d0a24f0dc1ce93355da06bee0eced99c27221c5869d4f479a3b7129214634ce4",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation/1.11.2",
-    "dest-filename": "runtime-annotation-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation/1.9.4/../../runtime-annotation-jvm/1.9.4/runtime-annotation-jvm-1.9.4.module",
+    "sha512": "b10ff1c2c0694c7fdac8342fcfc60d089ca3b501a1b41c02a586d6ddbbad8fad72fb738435cc3d061526f2b5b359734c12fa9e8189cbb0fcdb8b5ee0837f24a7",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation/1.9.4/../../runtime-annotation-jvm/1.9.4",
+    "dest-filename": "runtime-annotation-jvm-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-annotation/1.11.2/../../runtime-annotation-jvm/1.11.2/runtime-annotation-jvm-1.11.2.module",
-    "sha512": "a4db592276bebfc2543928ade4e2be6ed393f6ec39eb33bc0fe69ff106e50e1ffad3f58454a63f34534cbc6b51457280cb14f697a830ecf7858a2cde0d285555",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-annotation/1.11.2/../../runtime-annotation-jvm/1.11.2",
-    "dest-filename": "runtime-annotation-jvm-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.9.4/runtime-desktop-1.9.4.jar",
+    "sha512": "fd3504f8966eeba5e52c32df6e64412356af07acee627d369dca0823f2eced2ec7b37d53e8a8f44d229b0ff8ef081708ba5e3a59a7ada34d685b6b90d543bd40",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.9.4",
+    "dest-filename": "runtime-desktop-1.9.4.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.11.2/runtime-desktop-1.11.2.jar",
-    "sha512": "4cd17d7aa0ab764f0ec5d57bbad68e7d7f3fbb6980d3e70852bd84458dc7eae49a46a6c40b3f5e68b8ed704f0ef319b5299764ccabc0faa0f7abb7c41287f04e",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.11.2",
-    "dest-filename": "runtime-desktop-1.11.2.jar"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.9.4/runtime-desktop-1.9.4.module",
+    "sha512": "97fd663657c9fd8e71abe69d5856b29a7d9ba8a6ce7f9f34872681f185e87b899ef16211123c467f2b9998909fbdead2d04cf4c779c19b3be8f0bd9ec860c7b5",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.9.4",
+    "dest-filename": "runtime-desktop-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.11.2/runtime-desktop-1.11.2.module",
-    "sha512": "dd8ad3c3b229d2640a8d46120cd23ef3689f43b957c03d23ac363430fb39f0ed5f344b5c1b401a225cc1d47f89eeeb3213024f50bcb7d62188e2c1a3069caf3d",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.11.2",
-    "dest-filename": "runtime-desktop-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.9.4/runtime-desktop-1.9.4.pom",
+    "sha512": "c40817d1e9bb5d3309bfeda62126df92faa61c8e2482d786757aa2ab41b5aabb272c9738b16ef1adbc22a3ac689079fb8c1eaf19914b466fe48559d1620c39e3",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.9.4",
+    "dest-filename": "runtime-desktop-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-desktop/1.11.2/runtime-desktop-1.11.2.pom",
-    "sha512": "6e5d1a66444fa240ae3d7b2ddab6ccdf8fbfd57b69c86e33c5aa4d005f9cb7e3fce38059a9927e4f1fd3df80c79eb62c7bb56dc0d011b93a2e3c7742dbb2cd1b",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-desktop/1.11.2",
-    "dest-filename": "runtime-desktop-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-lint/1.9.4/runtime-lint-1.9.4.pom",
+    "sha512": "95fe9ee1a8f19435df0de9a7c214494d9de582e1fce505f589eb325a3a36073f434bf1ea7b2f7e900986d02a2fe237ca3c89bf31055966ad30a2d80ca31cf7ad",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-lint/1.9.4",
+    "dest-filename": "runtime-lint-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-lint/1.11.2/runtime-lint-1.11.2.pom",
-    "sha512": "8e2ef1a6a6e946fdaebe7e0448f39b201a12678b0d3e2e936fe9574ce06f72653305c752d26fb6a5d08ccb5551aadb96e74a8fc1c18b3b4a9dd0f5737fb44d78",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-lint/1.11.2",
-    "dest-filename": "runtime-lint-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-livedata/1.9.4/runtime-livedata-1.9.4.pom",
+    "sha512": "dcfba23e32f8f1470db9a89cd50c1a623aab7de4f7cde7d7785f25b9d9a1f4558d65f2a94c21ed98e6700821bb177a554bdc8a1a11b60a003c727d2ae1e16b43",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-livedata/1.9.4",
+    "dest-filename": "runtime-livedata-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-livedata/1.11.2/runtime-livedata-1.11.2.pom",
-    "sha512": "def8516baac901b83d2670d118529e25f7681b34bb150cb6b71130be7e3c63b75341d1be0dd465f194344eec10983a95b716436a1236afd7c9ed7e49e9d7a23d",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-livedata/1.11.2",
-    "dest-filename": "runtime-livedata-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-rxjava3/1.9.4/runtime-rxjava3-1.9.4.pom",
+    "sha512": "c2326e625d9ac90fb7420c3e37846113af390c0e5d901e9a58d78af1b1f3e4ac0afcd9bdcdf5d444c95d7fdb95c56a3e73db45f226c7d76745a16bdda4f4028d",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-rxjava3/1.9.4",
+    "dest-filename": "runtime-rxjava3-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain-desktop/1.11.2/runtime-retain-desktop-1.11.2.jar",
-    "sha512": "4e2b54075a3ebbafd68642df798fc5542d571c405b971094e96e03376551e3a1c9466157a68476da738d81d8fdf242d08f2cf595f16bcb5a3e3c56448dfb4fb2",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain-desktop/1.11.2",
-    "dest-filename": "runtime-retain-desktop-1.11.2.jar"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.9.4/runtime-saveable-desktop-1.9.4.jar",
+    "sha512": "9814214310df60273ac4594a69364a029ff169694c7c39718546e3a1413cc2518cb0c552d552da43cc7b0cc836012bcb313680a5f9202aea83b65db116d1cb54",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.9.4",
+    "dest-filename": "runtime-saveable-desktop-1.9.4.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain-desktop/1.11.2/runtime-retain-desktop-1.11.2.module",
-    "sha512": "c45d19125ac6d8b5d6c135d2419f44a9912f281e36f9a5271ca4da7ca12ef125f63b3ea14b716ea25648aabbef9a237bd8c4a5b67beff5ae3377caa4ba357694",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain-desktop/1.11.2",
-    "dest-filename": "runtime-retain-desktop-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.9.4/runtime-saveable-desktop-1.9.4.module",
+    "sha512": "b3ff6b95d78986b868d03557ee9ad22797ae0a8b0211cfedb811d12864f5e990f11db4f75499adc505fc46572320683acab207956042f7e095ca5be12fdd548c",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.9.4",
+    "dest-filename": "runtime-saveable-desktop-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain-desktop/1.11.2/runtime-retain-desktop-1.11.2.pom",
-    "sha512": "33aa2f7d32ee6cf6fa92720f1d9593c056356e787dde1240949b49af9695a8bd7f9a8231bed3e48b12551a59f8bbaecdd0d146c9a0915ae6f05e14985a5cc9fa",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain-desktop/1.11.2",
-    "dest-filename": "runtime-retain-desktop-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.9.4/runtime-saveable-desktop-1.9.4.pom",
+    "sha512": "3936f8410a8383563d7f1c5632829afa62abce7bfca1b658d3dd6986dfd29d3a821d45245c308e2189ba5a98d0a410e50015e5ce049397141e451764cdc38b4e",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.9.4",
+    "dest-filename": "runtime-saveable-desktop-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain-lint/1.11.2/runtime-retain-lint-1.11.2.pom",
-    "sha512": "4d728d2b81fea7ab304c35de17f6236d567f47128bc0fa9f17dca323cfa0444fd18c3585e6bfd4bb4d061acd8a78fcff0a983acb19d6f564ceb8fc29ed3c1161",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain-lint/1.11.2",
-    "dest-filename": "runtime-retain-lint-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-lint/1.9.4/runtime-saveable-lint-1.9.4.pom",
+    "sha512": "f3fad2edefcd3609aa1b8b10281957125a6b98aaa1ba18336c172bebc3dc07afee073c70b12b36c3df9b97b0e5670d620be5e57ab60008a1adb7107c493bdc35",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-lint/1.9.4",
+    "dest-filename": "runtime-saveable-lint-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain/1.11.2/runtime-retain-1.11.2.module",
-    "sha512": "c1aec03c902625d33d642c02f26183487cf2ed0126375ec94227cfc93d28dc02697f59b7f38081085c950f2590f3059661508385f59e71c5846c6b38075bf20e",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain/1.11.2",
-    "dest-filename": "runtime-retain-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.9.4/runtime-saveable-1.9.4.module",
+    "sha512": "364778b4731492e960183d7334e520f38f3d2c66feaf109a97826a0c80f91ac1f74578e88d15b44b81d5ba97336c73f1c7961fd5e7dce0ff727e21c81c1aadb9",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.9.4",
+    "dest-filename": "runtime-saveable-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain/1.11.2/runtime-retain-1.11.2.pom",
-    "sha512": "ae8d40957731e0d21b179222dbbf4e14a5a700186ea7a07289efcd6c80f640b66de7ec2efd209c665c28797ba48cbba24810ebed889ac7373e93a9971ab634c6",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain/1.11.2",
-    "dest-filename": "runtime-retain-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.9.4/runtime-saveable-1.9.4.pom",
+    "sha512": "f4f78b02b3936bfb0d640913d29dc57e525155c354f933b5cad1d437739d15b7c24030b0b390a8a6569d56861782030f054b0774f895f110df9cf5fdc6739b78",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.9.4",
+    "dest-filename": "runtime-saveable-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-retain/1.11.2/../../runtime-retain-desktop/1.11.2/runtime-retain-desktop-1.11.2.module",
-    "sha512": "c45d19125ac6d8b5d6c135d2419f44a9912f281e36f9a5271ca4da7ca12ef125f63b3ea14b716ea25648aabbef9a237bd8c4a5b67beff5ae3377caa4ba357694",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-retain/1.11.2/../../runtime-retain-desktop/1.11.2",
-    "dest-filename": "runtime-retain-desktop-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.9.4/../../runtime-saveable-desktop/1.9.4/runtime-saveable-desktop-1.9.4.module",
+    "sha512": "b3ff6b95d78986b868d03557ee9ad22797ae0a8b0211cfedb811d12864f5e990f11db4f75499adc505fc46572320683acab207956042f7e095ca5be12fdd548c",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.9.4/../../runtime-saveable-desktop/1.9.4",
+    "dest-filename": "runtime-saveable-desktop-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-rxjava2/1.11.2/runtime-rxjava2-1.11.2.pom",
-    "sha512": "ed0209bba5480a53548fe65cb2cacc55ccb84b933d527eef6825418f190428cbc272efc99ab293d409357d092e53e36cf43997de45b538a8c2a4063e90accd92",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-rxjava2/1.11.2",
-    "dest-filename": "runtime-rxjava2-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-tracing/1.9.4/runtime-tracing-1.9.4.pom",
+    "sha512": "70c2fe10c74115f0a8e21525b63678138399d592197be385ca7835ee477f91deaa48477055d83305031edf3d33cce36caacc6b9e1220b90f01ace8d9868bffdf",
+    "dest": "offline-repository/androidx/compose/runtime/runtime-tracing/1.9.4",
+    "dest-filename": "runtime-tracing-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-rxjava3/1.11.2/runtime-rxjava3-1.11.2.pom",
-    "sha512": "9fe9940085db342836e6b2377fe0b5c3d7222f91203d4c6ddbb69baade27d26270f3d0ec1221efd5199fec5f968a6fdd2fbb2c2608c5fb9b6b4fad67b18136e3",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-rxjava3/1.11.2",
-    "dest-filename": "runtime-rxjava3-1.11.2.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.9.4/runtime-1.9.4.module",
+    "sha512": "d66b3694232416e75a8cf203e3f088da72e9400f3f2c9a4c458ce51247f658d7a94dd2e88a4de20c495a8735bfff87673ee3bc4cc83de8b4b1f71fd4ea11dd3c",
+    "dest": "offline-repository/androidx/compose/runtime/runtime/1.9.4",
+    "dest-filename": "runtime-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.11.2/runtime-saveable-desktop-1.11.2.jar",
-    "sha512": "a5e651c0395c1254854361d3623f70dafa75bbf66fccd71645cb65ea17ef161f730861172551e674fdcba172bc2e5e3cb62408d36825461793fa1193923f4732",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.11.2",
-    "dest-filename": "runtime-saveable-desktop-1.11.2.jar"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.9.4/runtime-1.9.4.pom",
+    "sha512": "50973d821af51e2f7a6ffd023fa7f079876ce5aede86d978b7b57dae4749be85418ffe4d394217447688a834c76175729f86ee2c5c3905f4a0c8f4bc5cc4cdca",
+    "dest": "offline-repository/androidx/compose/runtime/runtime/1.9.4",
+    "dest-filename": "runtime-1.9.4.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.11.2/runtime-saveable-desktop-1.11.2.module",
-    "sha512": "7e155d121341211d7498f7392777684290dcfdcdccb385d20c49e9ea68779bbe64c67be7676e647677f9bd0de7acbba384540dafebfcc4d97688bd7c271236b9",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.11.2",
-    "dest-filename": "runtime-saveable-desktop-1.11.2.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.9.4/../../runtime-desktop/1.9.4/runtime-desktop-1.9.4.module",
+    "sha512": "97fd663657c9fd8e71abe69d5856b29a7d9ba8a6ce7f9f34872681f185e87b899ef16211123c467f2b9998909fbdead2d04cf4c779c19b3be8f0bd9ec860c7b5",
+    "dest": "offline-repository/androidx/compose/runtime/runtime/1.9.4/../../runtime-desktop/1.9.4",
+    "dest-filename": "runtime-desktop-1.9.4.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-desktop/1.11.2/runtime-saveable-desktop-1.11.2.pom",
-    "sha512": "8e5cab6392a0d59727b3b9f6f8dda3037b2effa0449b798242d32d0ca8d5e69e31518baa82dd0b393d77223a7080fedcadcdcd18ad1fe5caccece8eba4427664",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-desktop/1.11.2",
-    "dest-filename": "runtime-saveable-desktop-1.11.2.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable-lint/1.11.2/runtime-saveable-lint-1.11.2.pom",
-    "sha512": "1ef8c9ef2bff8ed9d26fd56a9e0e3daa619f6910f3ed59a1bff04b31b8c69234309acb45e2e4a712b39b1fd87b2f88f5d62abbd0b89596d134924ed40425b5eb",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable-lint/1.11.2",
-    "dest-filename": "runtime-saveable-lint-1.11.2.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.11.2/runtime-saveable-1.11.2.module",
-    "sha512": "ae39de7c613e841a02a87f631c5c4dd9afdcf62014683373918d174a8dcffc6bf7c01c7961c9fb4444e8d8e7be2044c6b657659abb4a34c5ff410505bc544daa",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.11.2",
-    "dest-filename": "runtime-saveable-1.11.2.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.11.2/runtime-saveable-1.11.2.pom",
-    "sha512": "ceb9bf73ca33adeed6a696319158f21ce8f6404ef2963501ef591da99f586637a6a6b4d4d5a548c02e6e904cf1821d0fd580a34586115911950e56c9fc857f02",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.11.2",
-    "dest-filename": "runtime-saveable-1.11.2.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-saveable/1.11.2/../../runtime-saveable-desktop/1.11.2/runtime-saveable-desktop-1.11.2.module",
-    "sha512": "7e155d121341211d7498f7392777684290dcfdcdccb385d20c49e9ea68779bbe64c67be7676e647677f9bd0de7acbba384540dafebfcc4d97688bd7c271236b9",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-saveable/1.11.2/../../runtime-saveable-desktop/1.11.2",
-    "dest-filename": "runtime-saveable-desktop-1.11.2.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime-tracing/1.11.2/runtime-tracing-1.11.2.pom",
-    "sha512": "2ff0767980f07c98e3d348b508470abd4701e00e8aa6c0736febd68a7f4a5258784700c0abf6f995de96e4d1c371e0a939e1b5499a489881065d024a3df3376c",
-    "dest": "offline-repository/androidx/compose/runtime/runtime-tracing/1.11.2",
-    "dest-filename": "runtime-tracing-1.11.2.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.11.2/runtime-1.11.2.module",
-    "sha512": "b170f677e45cd5a9b5e2783c693507c27e46f2c791e9ace06d9f16295a2d26a8e6b35be42e67ccc1e4cae70545fb6191b14bb5c770af451e5c7fa50b5d1d2abc",
-    "dest": "offline-repository/androidx/compose/runtime/runtime/1.11.2",
-    "dest-filename": "runtime-1.11.2.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.11.2/runtime-1.11.2.pom",
-    "sha512": "69260ae2468f5ce349176c8e9535a065671c1098d19d901b9c0c840669050bf84d56c47b674c6b9f5a441191d605492b2d4b603aec89779cb519112094f35169",
-    "dest": "offline-repository/androidx/compose/runtime/runtime/1.11.2",
-    "dest-filename": "runtime-1.11.2.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/compose/runtime/runtime/1.11.2/../../runtime-desktop/1.11.2/runtime-desktop-1.11.2.module",
-    "sha512": "dd8ad3c3b229d2640a8d46120cd23ef3689f43b957c03d23ac363430fb39f0ed5f344b5c1b401a225cc1d47f89eeeb3213024f50bcb7d62188e2c1a3069caf3d",
-    "dest": "offline-repository/androidx/compose/runtime/runtime/1.11.2/../../runtime-desktop/1.11.2",
-    "dest-filename": "runtime-desktop-1.11.2.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/9.0.1/databinding-common-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/9.1.1/databinding-common-9.1.1.jar",
     "sha512": "5d7539ba242138ae5ed2f0ddc9da6b0c3700bdf67c763196dc26e3557172f1a97284a3bb9592d3049bf96cab89602d0e65df95c7e3cb73f7c4632b166bae6ebd",
-    "dest": "offline-repository/androidx/databinding/databinding-common/9.0.1",
-    "dest-filename": "databinding-common-9.0.1.jar"
+    "dest": "offline-repository/androidx/databinding/databinding-common/9.1.1",
+    "dest-filename": "databinding-common-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/9.0.1/databinding-common-9.0.1.pom",
-    "sha512": "361f1bf9bf8920f40628adeb41429b5fad8f4f31e4334fb8fb0afbdb937e10fa3aa2840d60c476f95f3d70eef08062dbfad3db6d36ff61991d2dfe346a6840e6",
-    "dest": "offline-repository/androidx/databinding/databinding-common/9.0.1",
-    "dest-filename": "databinding-common-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-common/9.1.1/databinding-common-9.1.1.pom",
+    "sha512": "3527b992c3e2f49ac07bdfd122a70895efd5d03fa9691b0d166d51c69e66b9df75f4cf3d49e3eb522e391ae0022f34b062be736f1f872a95a7ea6a5e7e6690cd",
+    "dest": "offline-repository/androidx/databinding/databinding-common/9.1.1",
+    "dest-filename": "databinding-common-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/9.0.1/databinding-compiler-common-9.0.1.jar",
-    "sha512": "0c0bdccf346c34795d85eab6dc938b747df603d9ac090f2322d56dd46087fa63752bb021cd2470dd39b2ade4b288a6f8a2bce0608ec2d2238ad980e37afd6e25",
-    "dest": "offline-repository/androidx/databinding/databinding-compiler-common/9.0.1",
-    "dest-filename": "databinding-compiler-common-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/9.1.1/databinding-compiler-common-9.1.1.jar",
+    "sha512": "158f08481c2cbe0e536745c5fbb684f6e1e6ce098dcd3b17dbb3aaf0e2dd18ff368231d73e72bf67c82ed6c5ed4fac098b2c5980e38a6bbb24694a2d122baf48",
+    "dest": "offline-repository/androidx/databinding/databinding-compiler-common/9.1.1",
+    "dest-filename": "databinding-compiler-common-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/9.0.1/databinding-compiler-common-9.0.1.pom",
-    "sha512": "a88972f49f3c637eb84daf04a726e1fb10dc04a78b6254b4699542a6a62baedb2e70f6dd1b51be17e8b23d565918ea8e366206822d7538246d5eba9063fc9b90",
-    "dest": "offline-repository/androidx/databinding/databinding-compiler-common/9.0.1",
-    "dest-filename": "databinding-compiler-common-9.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes-desktop/1.1.0/graphics-shapes-desktop-1.1.0.jar",
-    "sha512": "7608c41cb100113ca0f95388ef538ef67d60a51390294c33964c2a71fcb7d2de042b76f0c31310cad8ddcac7be4fd0fff650b89c02cebaf35e83ce9284cca2aa",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes-desktop/1.1.0",
-    "dest-filename": "graphics-shapes-desktop-1.1.0.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes-desktop/1.1.0/graphics-shapes-desktop-1.1.0.module",
-    "sha512": "f6baf8e884b52fd6f2082e5575d31649cb5e572c0863aba6d8080d4e5e1bcf91ce3d5b4bfbaa0c51c253ffd43bd80bf3a5ccbe083176a6892b188a56a559edd9",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes-desktop/1.1.0",
-    "dest-filename": "graphics-shapes-desktop-1.1.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes-desktop/1.1.0/graphics-shapes-desktop-1.1.0.pom",
-    "sha512": "acf7e502ff804c15933d5dc7dbc47b275f4f0e56af06daf5b8c85b16664c5a9d7df6d4001d852d334063d1596373821ec4547cf1ff1b2f7b62c8365dad32d2c5",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes-desktop/1.1.0",
-    "dest-filename": "graphics-shapes-desktop-1.1.0.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes/1.1.0/graphics-shapes-1.1.0.module",
-    "sha512": "6e700d4a00608afaf01e81cf37b511cfae24f5eaecca27bd2e8fe1583f2f7e9a26b56c59863d530c00145f66a705109a8e39087d67acbfeedb8132eec8caefdb",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes/1.1.0",
-    "dest-filename": "graphics-shapes-1.1.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes/1.1.0/graphics-shapes-1.1.0.pom",
-    "sha512": "4108194f352833ff3b7039cf0cda42463b081667088846e7bbbaf34eb5b6d9eef0225a36677f3597d9f178d906b94230917947ead024e2b4f59178112dd10c21",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes/1.1.0",
-    "dest-filename": "graphics-shapes-1.1.0.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/graphics/graphics-shapes/1.1.0/../../graphics-shapes-desktop/1.1.0/graphics-shapes-desktop-1.1.0.module",
-    "sha512": "f6baf8e884b52fd6f2082e5575d31649cb5e572c0863aba6d8080d4e5e1bcf91ce3d5b4bfbaa0c51c253ffd43bd80bf3a5ccbe083176a6892b188a56a559edd9",
-    "dest": "offline-repository/androidx/graphics/graphics-shapes/1.1.0/../../graphics-shapes-desktop/1.1.0",
-    "dest-filename": "graphics-shapes-desktop-1.1.0.module"
+    "url": "https://dl.google.com/dl/android/maven2/androidx/databinding/databinding-compiler-common/9.1.1/databinding-compiler-common-9.1.1.pom",
+    "sha512": "91530dc2f6d68cec7744d84f737868c9b8efe1ea6af2b3149ebfa1bda64bd3b57e884ecb4834bc87cfaf1125e4dc5d4db82c57fc7a6b469ddb9184bf854776b3",
+    "dest": "offline-repository/androidx/databinding/databinding-compiler-common/9.1.1",
+    "dest-filename": "databinding-compiler-common-9.1.1.pom"
   },
   {
     "type": "file",
@@ -418,13 +313,6 @@
     "sha512": "bb12f462dab0bd24daed5edb7a73e9786482803779b76f83fbedec7c2e176d0f1ee9a3866a339e5e3f31ccb37f6a9624523227647968d1451fd5ec45ad0f139f",
     "dest": "offline-repository/androidx/lifecycle/lifecycle-common-jvm/2.10.0",
     "dest-filename": "lifecycle-common-jvm-2.10.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-common-jvm/2.10.0/lifecycle-common-jvm-2.10.0.pom",
-    "sha512": "7e728b188dcc9f3421da3bd97bc09b0b702935e7e0836d74294a57c876d78e5335ab6ed09eb155c4d3af3abe82c90ee2ffb238ff1744bd1f5650bba5899987d7",
-    "dest": "offline-repository/androidx/lifecycle/lifecycle-common-jvm/2.10.0",
-    "dest-filename": "lifecycle-common-jvm-2.10.0.pom"
   },
   {
     "type": "file",
@@ -477,13 +365,6 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-livedata/2.10.0/lifecycle-livedata-2.10.0.pom",
-    "sha512": "7f46f7c563097b63ff6e4824366ed0d9d615f6c134b7a578c389ae370581fbad46440fd0aaa5331476a611c0f17962013d989275d42944a736eb6bfcc8ee7866",
-    "dest": "offline-repository/androidx/lifecycle/lifecycle-livedata/2.10.0",
-    "dest-filename": "lifecycle-livedata-2.10.0.pom"
-  },
-  {
-    "type": "file",
     "url": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-process/2.10.0/lifecycle-process-2.10.0.pom",
     "sha512": "14e86dc8a9d141c98af0bcdff866d0f01b6b1afd852adf2d19c0c093208591ce868eea1bb1eaeb8adba42dc2f5ea16428e7ba3b70f45ea2e6d635b7cfcb9433f",
     "dest": "offline-repository/androidx/lifecycle/lifecycle-process/2.10.0",
@@ -502,13 +383,6 @@
     "sha512": "556e17b5d09c4d4d8c74ff94b0e6d7905c18d3db3229e09a381f107f98f51234bddf2fa3f791d14074729f7dafcdcf31cad281bbed54172c1eaa518a02a533f6",
     "dest": "offline-repository/androidx/lifecycle/lifecycle-reactivestreams/2.10.0",
     "dest-filename": "lifecycle-reactivestreams-2.10.0.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-runtime-compose-desktop/2.10.0/lifecycle-runtime-compose-desktop-2.10.0.jar",
-    "sha512": "953bed967097b6d77d971810e980b12188817c10cc84f1e9337555803ee64d700fb57330a0d1a71381b5cb982b71a876ae49e7875a0ea7548e23b8606242c5fa",
-    "dest": "offline-repository/androidx/lifecycle/lifecycle-runtime-compose-desktop/2.10.0",
-    "dest-filename": "lifecycle-runtime-compose-desktop-2.10.0.jar"
   },
   {
     "type": "file",
@@ -558,13 +432,6 @@
     "sha512": "8234672f1c88fadf13aa5cb20e7e6a1de7db610b3b2970f47c24d243ed3ef0e011c549d6ee6e9a086e11492198585b303ccaee003e699e6b521ecd6e4c95b4ac",
     "dest": "offline-repository/androidx/lifecycle/lifecycle-runtime-desktop/2.10.0",
     "dest-filename": "lifecycle-runtime-desktop-2.10.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-runtime-desktop/2.10.0/lifecycle-runtime-desktop-2.10.0.pom",
-    "sha512": "33e133a3632335ad4bb50271f06a99a58c0997ed30cbce16887c603f5fe8471faf85ed6e2d78cdbbe0d9d4d3f1e1307c99cf09eaaae9de631208aacb91379d6d",
-    "dest": "offline-repository/androidx/lifecycle/lifecycle-runtime-desktop/2.10.0",
-    "dest-filename": "lifecycle-runtime-desktop-2.10.0.pom"
   },
   {
     "type": "file",
@@ -722,62 +589,6 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent-compose/1.0.1/navigationevent-compose-1.0.1.pom",
-    "sha512": "08db50d553651c3e04308731c049ec91c7270da7e4bd3496bf51e8fbd05e58d499c9491ae345715249e32f0ef595e39b0f07a745ecddf7d47fb9262163710739",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent-compose/1.0.1",
-    "dest-filename": "navigationevent-compose-1.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent-desktop/1.0.1/navigationevent-desktop-1.0.1.jar",
-    "sha512": "1747d03e468e083547aa45cb1d5ef0a8685ad651a005fd169d63ab919d403525bc7eb737bf426e6c4c6d464ce95ce925016b29e1677b30dace6bc030dad3971a",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent-desktop/1.0.1",
-    "dest-filename": "navigationevent-desktop-1.0.1.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent-desktop/1.0.1/navigationevent-desktop-1.0.1.module",
-    "sha512": "b2c0735a6b6993697426ebd793045096b92443a5626be4a419d03fc78e896b093dd94ff6cd709815d50a89d2ea0da8e2c88bfc6def709e3a6509a30d14d9d2f3",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent-desktop/1.0.1",
-    "dest-filename": "navigationevent-desktop-1.0.1.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent-desktop/1.0.1/navigationevent-desktop-1.0.1.pom",
-    "sha512": "a791cf95bb410bd45e136ddb3381258140f887d7bc4a3bb640ac90823d22da51ce2f1f456865f76e3d85ed65d405950c2258d06bab8bb3938f80590571c01167",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent-desktop/1.0.1",
-    "dest-filename": "navigationevent-desktop-1.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent-testing/1.0.1/navigationevent-testing-1.0.1.pom",
-    "sha512": "b0faaa1ad6389c53730072c3a7aa82982f4297d729c13b2eff5d4bae94e2650245f35a905cfd4fe53cfe2b4aa3472aa8c07ec7745e87bea2dcda60869621c61b",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent-testing/1.0.1",
-    "dest-filename": "navigationevent-testing-1.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent/1.0.1/navigationevent-1.0.1.module",
-    "sha512": "03ac3e6f3029d70c2508461aef6506475f691a30a206293d63c5ea995311b51dcecfe7b12d459b6bfe0d385cc912c75f35558441d9e0f545676720e2a2627bad",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent/1.0.1",
-    "dest-filename": "navigationevent-1.0.1.module"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent/1.0.1/navigationevent-1.0.1.pom",
-    "sha512": "6f941436c962259eb7122fece475df3fafbf62b75571b0da3b676f9cadbff980ac54750f8ae0843dad757a59336ea42fc78bed2792cc7670552932d7c245d124",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent/1.0.1",
-    "dest-filename": "navigationevent-1.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/androidx/navigationevent/navigationevent/1.0.1/../../navigationevent-desktop/1.0.1/navigationevent-desktop-1.0.1.module",
-    "sha512": "b2c0735a6b6993697426ebd793045096b92443a5626be4a419d03fc78e896b093dd94ff6cd709815d50a89d2ea0da8e2c88bfc6def709e3a6509a30d14d9d2f3",
-    "dest": "offline-repository/androidx/navigationevent/navigationevent/1.0.1/../../navigationevent-desktop/1.0.1",
-    "dest-filename": "navigationevent-desktop-1.0.1.module"
-  },
-  {
-    "type": "file",
     "url": "https://dl.google.com/dl/android/maven2/androidx/savedstate/savedstate-compose-desktop/1.4.0/savedstate-compose-desktop-1.4.0.jar",
     "sha512": "4251e8be5a4de897531ed20fa50d255a2a51b02c314e9f4fdba5b4477335d2bb6cea2e52ccf6d91b0ea37f0a55d6accb29b4835d9fd2f52194b83ccee0517c59",
     "dest": "offline-repository/androidx/savedstate/savedstate-compose-desktop/1.4.0",
@@ -876,248 +687,241 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/application/com.android.application.gradle.plugin/9.0.1/com.android.application.gradle.plugin-9.0.1.pom",
-    "sha512": "d7d712e7519042374a7db1d629cc0a30a0b4bb2b52c037d1a43535dcba716c13f3e2329abd34f1202a1045a8edd9ac43c31b38413840dd51966b09e8698427c0",
-    "dest": "offline-repository/com/android/application/com.android.application.gradle.plugin/9.0.1",
-    "dest-filename": "com.android.application.gradle.plugin-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/application/com.android.application.gradle.plugin/9.1.1/com.android.application.gradle.plugin-9.1.1.pom",
+    "sha512": "687953bee518f8f08eea5f7d06c419df89bbd45356f03861a312c1678034f10cc84ca22bc9146a6399a25f3a4be088b217d174397ab9cdbdbb3aa1ef007ace88",
+    "dest": "offline-repository/com/android/application/com.android.application.gradle.plugin/9.1.1",
+    "dest-filename": "com.android.application.gradle.plugin-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/9.0.1/baseLibrary-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/9.1.1/baseLibrary-9.1.1.jar",
     "sha512": "c1f350e35e37c065c887b52a4720186f96dfe87436791a61ea6424c094edd0d41435925f26b8433388608e197fe1c82a9596be0d366f28f3d3373f2c8bd2693a",
-    "dest": "offline-repository/com/android/databinding/baseLibrary/9.0.1",
-    "dest-filename": "baseLibrary-9.0.1.jar"
+    "dest": "offline-repository/com/android/databinding/baseLibrary/9.1.1",
+    "dest-filename": "baseLibrary-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/9.0.1/baseLibrary-9.0.1.pom",
-    "sha512": "f7f4a0fb51a8f110909741b6a882ffda6e655b4a50f28d3d54b3f6c995da571cce69c5cba39f6089e74c51d06be17dfd7a10617001e636f2cfccabd081ee4f8c",
-    "dest": "offline-repository/com/android/databinding/baseLibrary/9.0.1",
-    "dest-filename": "baseLibrary-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/databinding/baseLibrary/9.1.1/baseLibrary-9.1.1.pom",
+    "sha512": "6aa0f8b7429124916e73e75d197f637ce342aad381e5a265b4d5b5d24822a28a468c2ca9b5651954afaac9b7ba463f3ce87692d50b16544b5cb6220813741ce1",
+    "dest": "offline-repository/com/android/databinding/baseLibrary/9.1.1",
+    "dest-filename": "baseLibrary-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/kotlin/multiplatform/library/com.android.kotlin.multiplatform.library.gradle.plugin/9.0.1/com.android.kotlin.multiplatform.library.gradle.plugin-9.0.1.pom",
-    "sha512": "a8b65d0dc213ec191d0edda8a2e2d5325cdcb907469dc742af5e5be18ce13b21ede4f5954019c41cfee819d8b9336d6e437c6de757c6f482fe6248d03966a432",
-    "dest": "offline-repository/com/android/kotlin/multiplatform/library/com.android.kotlin.multiplatform.library.gradle.plugin/9.0.1",
-    "dest-filename": "com.android.kotlin.multiplatform.library.gradle.plugin-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/kotlin/multiplatform/library/com.android.kotlin.multiplatform.library.gradle.plugin/9.1.1/com.android.kotlin.multiplatform.library.gradle.plugin-9.1.1.pom",
+    "sha512": "b938791b2adf555e30e20882aae3afaff587854572563d7cff4a548011a582c54f5ff1dee2adf110a47d71b832915dceb44f506fddc697154d1481aa62e80603",
+    "dest": "offline-repository/com/android/kotlin/multiplatform/library/com.android.kotlin.multiplatform.library.gradle.plugin/9.1.1",
+    "dest-filename": "com.android.kotlin.multiplatform.library.gradle.plugin-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/signflinger/9.0.1/signflinger-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/signflinger/9.1.1/signflinger-9.1.1.jar",
     "sha512": "a301b05e1d86ed1c26a3faf798f3f768bbf63917cc092c3bb090a13bca6c349f4f74ab57ea8c8a33edc946a62305e263569ea891352b8d945a81323f6b9eb01f",
-    "dest": "offline-repository/com/android/signflinger/9.0.1",
-    "dest-filename": "signflinger-9.0.1.jar"
+    "dest": "offline-repository/com/android/signflinger/9.1.1",
+    "dest-filename": "signflinger-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/signflinger/9.0.1/signflinger-9.0.1.pom",
-    "sha512": "4726f2dfa8bdfdd0bfd918b422aed5feea899ad5698bb12e874afcfce6d02f205a17314e1195628d0c0e76bd18f7192a35168a96ee382a2478b6304db0531a8c",
-    "dest": "offline-repository/com/android/signflinger/9.0.1",
-    "dest-filename": "signflinger-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/signflinger/9.1.1/signflinger-9.1.1.pom",
+    "sha512": "4638380dbbab4156fdc2af0531dbc8b6d48dbce23cdc8aabf9d4cebaef8173a4cb0689c870822e238b773e3874fe16163fcdf1ac1c130c8ed37fcdb3052698bb",
+    "dest": "offline-repository/com/android/signflinger/9.1.1",
+    "dest-filename": "signflinger-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/32.0.1/crash-32.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/32.1.1/crash-32.1.1.jar",
     "sha512": "88ede5999ec069d8181714bc2d38866bdd2a94c5897f655f6d8996596d9f281453d278eb9b59adb35122f950949a47040def24ae902099674687a02024e2c458",
-    "dest": "offline-repository/com/android/tools/analytics-library/crash/32.0.1",
-    "dest-filename": "crash-32.0.1.jar"
+    "dest": "offline-repository/com/android/tools/analytics-library/crash/32.1.1",
+    "dest-filename": "crash-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/32.0.1/crash-32.0.1.pom",
-    "sha512": "988bfaf56e888a9ce09fe6d7730cac791ae70b8da02ecbd9f070423f668ddd2cce71ec5c47b376f600ec99868e7d54604ec0689224513521b57c3a681e7850e9",
-    "dest": "offline-repository/com/android/tools/analytics-library/crash/32.0.1",
-    "dest-filename": "crash-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/crash/32.1.1/crash-32.1.1.pom",
+    "sha512": "4653a9fe1919b95a1196ccc309d8bd0575e09500a9bf32be5daa57dd706098c8df3646f1b6c545da86ff7ae33e0ca544dbc77e5ce07d772d5f51af2bbd51d4a0",
+    "dest": "offline-repository/com/android/tools/analytics-library/crash/32.1.1",
+    "dest-filename": "crash-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/32.0.1/protos-32.0.1.jar",
-    "sha512": "8ad917ec04a3c8660258447c0379f2e679d74f70e24f3031dcb068bfe7d6e214407ceac1e82e7d6b53a20ad391910b90bccc74ba50dc8af770163f7d194e04e8",
-    "dest": "offline-repository/com/android/tools/analytics-library/protos/32.0.1",
-    "dest-filename": "protos-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/32.1.1/protos-32.1.1.jar",
+    "sha512": "d904d2b7ac80c0897117e4b9c24b8764a9d4aa7c87029bf377af4119070b29061539a0b1c12418b291f3072f14d4b24c0a6db2734ba66162d6915076cea4a0be",
+    "dest": "offline-repository/com/android/tools/analytics-library/protos/32.1.1",
+    "dest-filename": "protos-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/32.0.1/protos-32.0.1.pom",
-    "sha512": "f5bd52112416dcbd7b37a126a682371e8fc14339369ff7d864108e223df11211d1cba8792a27b38b0bd5dde31e00b7448a33f665dff730667faf6127c72a3903",
-    "dest": "offline-repository/com/android/tools/analytics-library/protos/32.0.1",
-    "dest-filename": "protos-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/protos/32.1.1/protos-32.1.1.pom",
+    "sha512": "1c75de7388e18c700214654bad181075d2dd0cd9ee90fb4e78525f9867453f8db9b406b32d2684125c12d16140b65d65b1ee2fecc90e87ba276266fe2a875ba5",
+    "dest": "offline-repository/com/android/tools/analytics-library/protos/32.1.1",
+    "dest-filename": "protos-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/32.0.1/shared-32.0.1.jar",
-    "sha512": "a65cd3df41b8ff7689ea0a4a8fe46d39fa71dcbde91e27143e1aeec10a60613d2c5532c2ed6ad7b0a83be6e28a6ca8ce5ed167a7b4a66beba5ad8e42a47cd27b",
-    "dest": "offline-repository/com/android/tools/analytics-library/shared/32.0.1",
-    "dest-filename": "shared-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/32.1.1/shared-32.1.1.jar",
+    "sha512": "4364c3298450a612be8b5d33140c0a3054a2f7b3208e53a20a1a976f9166cf025f71413178fefb5767d5281e56e0337afd674b49abda89128a03a8eacf688761",
+    "dest": "offline-repository/com/android/tools/analytics-library/shared/32.1.1",
+    "dest-filename": "shared-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/32.0.1/shared-32.0.1.pom",
-    "sha512": "465b3de34f2a4fc6d2981d5dda0868ce1439de574f7334238d046b26b01a6c7f3213dc78a034ad594d30b9614a2cf63899388e0f741695ee05db078e594de8fb",
-    "dest": "offline-repository/com/android/tools/analytics-library/shared/32.0.1",
-    "dest-filename": "shared-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/shared/32.1.1/shared-32.1.1.pom",
+    "sha512": "3b33f3a57714a8074efecd8fe3fa0bd82e48530cf82b2bdc1d21f6510c260be33c9569a6369ae26de2bd6f3e71175458e2126e3789063c8f6c8d84aedd47503c",
+    "dest": "offline-repository/com/android/tools/analytics-library/shared/32.1.1",
+    "dest-filename": "shared-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/32.0.1/tracker-32.0.1.jar",
-    "sha512": "79577344179b7c2c21484be00c652e38d1bf2608fb67e354d7b5c4ac554108e30294496de6d2a9c4c8bcac0cd914d71968cace12cc28d973b492fe6942dc02b5",
-    "dest": "offline-repository/com/android/tools/analytics-library/tracker/32.0.1",
-    "dest-filename": "tracker-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/32.1.1/tracker-32.1.1.jar",
+    "sha512": "dfc3b71864244de00cf0bba4e0836ae5fa44298ad01b164b8e78f7237daec3676290da090dc0bee52ea504b7dce1de94bc3a068086439f207ed12f348b912095",
+    "dest": "offline-repository/com/android/tools/analytics-library/tracker/32.1.1",
+    "dest-filename": "tracker-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/32.0.1/tracker-32.0.1.pom",
-    "sha512": "da6853bda479ad65b5b714d256f0311c6c29cbbe9cc8c3164d5d06af222fc2ceae05f506980ea96830c29f66f014191207a20c1de332f288644b0190d78c9950",
-    "dest": "offline-repository/com/android/tools/analytics-library/tracker/32.0.1",
-    "dest-filename": "tracker-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/analytics-library/tracker/32.1.1/tracker-32.1.1.pom",
+    "sha512": "1710b69de79e9644a344ebe69491e7cc4302bd68f531ed3eb7b165f061636779247e533e3bd6e37327a9ffb547d4a30f5bb457bcefa8abe2c256eb2f124751b3",
+    "dest": "offline-repository/com/android/tools/analytics-library/tracker/32.1.1",
+    "dest-filename": "tracker-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/annotations/32.0.1/annotations-32.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/annotations/32.1.1/annotations-32.1.1.jar",
     "sha512": "a6ea020912ec68b3bfc20c3ca5df0627d5a3cf6cae544e7d8a25a7b71e7fbd6af722883ef3085a25d9669de47373a27fb281a4e677725ced788dabbfea6c8c77",
-    "dest": "offline-repository/com/android/tools/annotations/32.0.1",
-    "dest-filename": "annotations-32.0.1.jar"
+    "dest": "offline-repository/com/android/tools/annotations/32.1.1",
+    "dest-filename": "annotations-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/annotations/32.0.1/annotations-32.0.1.pom",
-    "sha512": "e589f32a9af2d68637951cba2d0894aeaf15abf751c100c87f1238c963e66307e616ca5dbf447448584dfd6964b50e7a686ba26d63d43ff9406a419b5959477d",
-    "dest": "offline-repository/com/android/tools/annotations/32.0.1",
-    "dest-filename": "annotations-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/annotations/32.1.1/annotations-32.1.1.pom",
+    "sha512": "06858cf759498e0ae8a7683da9c04e2bb6701ce9728ade08a83575f30c2f8b15724e53896d87c03ab52818b6cdf99f47c269a482cf39df721a0288ae43132b45",
+    "dest": "offline-repository/com/android/tools/annotations/32.1.1",
+    "dest-filename": "annotations-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.0.1-14304508/aapt2-proto-9.0.1-14304508.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.1.1-14792394/aapt2-proto-9.1.1-14792394.jar",
     "sha512": "8287f9436f93b37cdbadb0f4ccb6ec0b89ff62b9d20411c36ebf30de7f9675ee17f9b9e0345efe67135bd159d13f8f538095d3c16d1003df050bc8edb490f7ac",
-    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.0.1-14304508",
-    "dest-filename": "aapt2-proto-9.0.1-14304508.jar"
+    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.1.1-14792394",
+    "dest-filename": "aapt2-proto-9.1.1-14792394.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.0.1-14304508/aapt2-proto-9.0.1-14304508.module",
-    "sha512": "5449fbfc18a1144c59e882e6537f6778dac79b62263de1586e3353fa5f6e8c55bf552ddf0536e69a87bfdbf65f5157cca5b92ecb707851dd8089aafefa6aa67f",
-    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.0.1-14304508",
-    "dest-filename": "aapt2-proto-9.0.1-14304508.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.1.1-14792394/aapt2-proto-9.1.1-14792394.module",
+    "sha512": "1678213c3659abc59f609d1a7c0e383d51306ffd56467314c41c14784355ccc69c72592a3fcfe2807c6ad30d856c55b5f800a78ac9960e7bfa69c786011b792c",
+    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.1.1-14792394",
+    "dest-filename": "aapt2-proto-9.1.1-14792394.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.0.1-14304508/aapt2-proto-9.0.1-14304508.pom",
-    "sha512": "d37024f15e209956a3789083770d873cb6cbe6115df54c577c14dbb618e315651425f6ca2efd286dbe1c88a69dd0a5ac7ef425eb7150dc31e4e6a6c3562096e7",
-    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.0.1-14304508",
-    "dest-filename": "aapt2-proto-9.0.1-14304508.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aapt2-proto/9.1.1-14792394/aapt2-proto-9.1.1-14792394.pom",
+    "sha512": "ca93a5e42dcb6fdc7d7f6a4334428caa7b0c0d5819a30c5b9c49e17a42fd881c3931397057d67c456b2122f9139562e3ff0604e20c215b3a5b395073bca4312a",
+    "dest": "offline-repository/com/android/tools/build/aapt2-proto/9.1.1-14792394",
+    "dest-filename": "aapt2-proto-9.1.1-14792394.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/9.0.1/aaptcompiler-9.0.1.jar",
-    "sha512": "63c9783199c561ab736af3a84c7f1042eda2aa7a0e387a2f379fa1f888f3d31fe5b309e0c7d98a9d475002cf5280dfa06e2c9aa49374f284c6762e2e067fab3e",
-    "dest": "offline-repository/com/android/tools/build/aaptcompiler/9.0.1",
-    "dest-filename": "aaptcompiler-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/9.1.1/aaptcompiler-9.1.1.jar",
+    "sha512": "d328654d7caf59e8a0e2c25311064921a9930037cf7b489da94cf58445986d25fc2fb4b6788152faa401d777c7b9341389753ba58371f00ebce8acd49a85cf50",
+    "dest": "offline-repository/com/android/tools/build/aaptcompiler/9.1.1",
+    "dest-filename": "aaptcompiler-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/9.0.1/aaptcompiler-9.0.1.module",
-    "sha512": "02261866c6ccb2070fd700218e3e3a45ffe59c0033366f1ba1178e7d7128a10368bfa568a96e8a082d84e68973796cf06ab0bc62654b6ad0dd69432129539587",
-    "dest": "offline-repository/com/android/tools/build/aaptcompiler/9.0.1",
-    "dest-filename": "aaptcompiler-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/9.1.1/aaptcompiler-9.1.1.pom",
+    "sha512": "b100eb3c47f72dfd33b1e75a417d6318513b5eb52c35c22390edb7f833327987a1a1f1b393b8aceb3539158e56dcc6baf0e867f7bd875e1d43586b17b0971ce4",
+    "dest": "offline-repository/com/android/tools/build/aaptcompiler/9.1.1",
+    "dest-filename": "aaptcompiler-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/aaptcompiler/9.0.1/aaptcompiler-9.0.1.pom",
-    "sha512": "3da02100a6d7ae62dccee564e12d31412647ae790024de43854bbcd4c1a4b7c7f3cecb3d1d86548f5dd0aa42b91fa63f3fd6596f334fa3898ecc24d4cfc11aa6",
-    "dest": "offline-repository/com/android/tools/build/aaptcompiler/9.0.1",
-    "dest-filename": "aaptcompiler-9.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/9.0.1/apksig-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/9.1.1/apksig-9.1.1.jar",
     "sha512": "75f4613b20ed254f1cbc34f5a3f54cf87dc6deb101bbcd12b256394a6878cffb9b3a91c29989709673e27f54a70d2c80db63f572f1f0ffb3254f102d89edae91",
-    "dest": "offline-repository/com/android/tools/build/apksig/9.0.1",
-    "dest-filename": "apksig-9.0.1.jar"
+    "dest": "offline-repository/com/android/tools/build/apksig/9.1.1",
+    "dest-filename": "apksig-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/9.0.1/apksig-9.0.1.pom",
-    "sha512": "3c1a60236c2915b597e345be49c17ba385ceac93056bf10ed108250d03d5167e4e16c9f39533428257d4eb47371b433d4f14a213b3f38d34c4b8972191410ce9",
-    "dest": "offline-repository/com/android/tools/build/apksig/9.0.1",
-    "dest-filename": "apksig-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apksig/9.1.1/apksig-9.1.1.pom",
+    "sha512": "baa62501bd8a6df084f7285a6f54df32bc97743ff712285656b8eab633d2ecfc21df16abc098ef64fc81e347c2b3589f37cde4c3d6c549e81ee9f2fd200de222",
+    "dest": "offline-repository/com/android/tools/build/apksig/9.1.1",
+    "dest-filename": "apksig-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/9.0.1/apkzlib-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/9.1.1/apkzlib-9.1.1.jar",
     "sha512": "1308bd00fa4c9847f9d841acf430f2df6c48faf9ce4ba6b3277103e6725b81ab1af521a0e4e22be832bebd784b670123a753d36b6a0b5ada88f8a5812c0940ca",
-    "dest": "offline-repository/com/android/tools/build/apkzlib/9.0.1",
-    "dest-filename": "apkzlib-9.0.1.jar"
+    "dest": "offline-repository/com/android/tools/build/apkzlib/9.1.1",
+    "dest-filename": "apkzlib-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/9.0.1/apkzlib-9.0.1.pom",
-    "sha512": "768c57c2a9cb0b27770028890fa8a8c09d3fcf9627d956547adf3eb04068504a15c3f24e27b3e0e18af178d1d92d8eb6af6244556f411a60ffdbdf0441a9f8fe",
-    "dest": "offline-repository/com/android/tools/build/apkzlib/9.0.1",
-    "dest-filename": "apkzlib-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/apkzlib/9.1.1/apkzlib-9.1.1.pom",
+    "sha512": "2f67c619af6c20ddd41bbd874f17c073859196b0aac1bc725a2b59d4a31562cc13f812bb1d06dd011022a4f2fd588078d1feffeefef0a5ef2c015dac99f09b39",
+    "dest": "offline-repository/com/android/tools/build/apkzlib/9.1.1",
+    "dest-filename": "apkzlib-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.0.1/builder-model-9.0.1.jar",
-    "sha512": "0439d498b6a6695ae67c22897b9974bfadcacb233e8736efa7a82e9aa38585eaf85309c27f24962478c5be08b3a687aa22819467dd1c336195a30de8eec7f156",
-    "dest": "offline-repository/com/android/tools/build/builder-model/9.0.1",
-    "dest-filename": "builder-model-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.1.1/builder-model-9.1.1.jar",
+    "sha512": "8c8e91d7455ca9e4912e4a2c43d4ad7a6d70033ce29da8a7b153dc84aba1c37b434525b72c754d6772d08091fe019eb528ebaa822addf612e9bab44ff2486242",
+    "dest": "offline-repository/com/android/tools/build/builder-model/9.1.1",
+    "dest-filename": "builder-model-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.0.1/builder-model-9.0.1.module",
-    "sha512": "df0543f0616df69c30a7937fdccbb146448e559eeed070590339a8899cd187e75c10f7b082f8fda470a0bc9ae82cdf8b4b022e056ab58d0299828ca2d4756a40",
-    "dest": "offline-repository/com/android/tools/build/builder-model/9.0.1",
-    "dest-filename": "builder-model-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.1.1/builder-model-9.1.1.module",
+    "sha512": "6dfa2243fba0849a4669e02d026b234a3cb3ca71e800d5663f3995b32c427a7cbe88bafd1b464c1b12a96ce5f9a1d62bb614e52d10917dae4a8d4d9927fa55ea",
+    "dest": "offline-repository/com/android/tools/build/builder-model/9.1.1",
+    "dest-filename": "builder-model-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.0.1/builder-model-9.0.1.pom",
-    "sha512": "41ad33cfcffd4f3fe6aa3e69d64a807c494c25f8ec1df4fd80674f9725759e518fecdaae6464c7955c3af227b0aee6d8959d9bddb60b8620d90d3b1fb34180b7",
-    "dest": "offline-repository/com/android/tools/build/builder-model/9.0.1",
-    "dest-filename": "builder-model-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-model/9.1.1/builder-model-9.1.1.pom",
+    "sha512": "284e53d988143461d03a1c9a7c286b8ae1b60ac14674d6cf140b282f816eb023b2263fab2b798266ad512bf02024f0141bd76a8e2d751417acddbd18302455f0",
+    "dest": "offline-repository/com/android/tools/build/builder-model/9.1.1",
+    "dest-filename": "builder-model-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.0.1/builder-test-api-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.1.1/builder-test-api-9.1.1.jar",
     "sha512": "d71493b3e77176faa4de22c733ec48fe996a1fffaddc7a6f4ede98c4ba0d76bcb28198f2f39f3ca6d2b1956900079665c6916a42619a610481d3105fee6bb43e",
-    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.0.1",
-    "dest-filename": "builder-test-api-9.0.1.jar"
+    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.1.1",
+    "dest-filename": "builder-test-api-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.0.1/builder-test-api-9.0.1.module",
-    "sha512": "5fdb514951e7d4cea40182dd4b4fc946a53ebfb533f82a99c37f5d1e4a3ecf500e2985694c82fe428d204cabebad471419f399cd6ffbbfc1e9079b44d3c478ec",
-    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.0.1",
-    "dest-filename": "builder-test-api-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.1.1/builder-test-api-9.1.1.module",
+    "sha512": "74ed5fd71eea3874dfae48b7d4ca82910b91bc8e1657e9cdbc9b46d15eab93b99347ace45bf13f03c600be060160af13e8f0019ad422bf7b5e46ca7418d13a0f",
+    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.1.1",
+    "dest-filename": "builder-test-api-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.0.1/builder-test-api-9.0.1.pom",
-    "sha512": "3f6a52aea30b2719450eba0cef955f7081542d75136a80f3c7ae273cac042fe8e51b303be4f8a9728fbe030bcfc221eb8776813083f5f0ab0b47b977c7262629",
-    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.0.1",
-    "dest-filename": "builder-test-api-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder-test-api/9.1.1/builder-test-api-9.1.1.pom",
+    "sha512": "147ff08b298a4f552cc0937c60c7e60228f4036ef460fe60d36d505a5c8664cf742269f513cc6636375249869485e769710cc15cee915c284cd84eb4b6b964c9",
+    "dest": "offline-repository/com/android/tools/build/builder-test-api/9.1.1",
+    "dest-filename": "builder-test-api-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.0.1/builder-9.0.1.jar",
-    "sha512": "b44732a94a93b8468a4b874dee2784e81e9f6c02305d08f63aaa76bacbfa8afc5c57b8690874735772b84afa435170cd761dd61fb01241862e36f12d4004cad9",
-    "dest": "offline-repository/com/android/tools/build/builder/9.0.1",
-    "dest-filename": "builder-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.1.1/builder-9.1.1.jar",
+    "sha512": "55dd635e9723f3b288ab6bf94033d5bcde625c5b0c9d7967939f8da7c4d4dcafcc01e91acf43a33ee8a9b33df7d647132ecf6d5be9e9114702428feac4c073a7",
+    "dest": "offline-repository/com/android/tools/build/builder/9.1.1",
+    "dest-filename": "builder-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.0.1/builder-9.0.1.module",
-    "sha512": "a964edb78d8127228c0d34aaad1469b449a56fd806cb343260301e4a367b6910cb6fad7c49663184912d81d078360516fd1aad09b57a80f42864024b4b280c79",
-    "dest": "offline-repository/com/android/tools/build/builder/9.0.1",
-    "dest-filename": "builder-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.1.1/builder-9.1.1.module",
+    "sha512": "8612aa6ca658fd7cf8beeadc217d653cb1cac26b6435329737386d5160d115680fd3e1bb82e2e094dcf84b624285a70b7c8f50919d5e793c4f23d86ae09541ce",
+    "dest": "offline-repository/com/android/tools/build/builder/9.1.1",
+    "dest-filename": "builder-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.0.1/builder-9.0.1.pom",
-    "sha512": "597326d43fe17d77f8bfbd5387f1c3601ffe982f93ccf8dde09245dde946e587656c582eb9966852b204cf3a89b746d1cd609e28a84ad843dcc94a076fa69075",
-    "dest": "offline-repository/com/android/tools/build/builder/9.0.1",
-    "dest-filename": "builder-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/builder/9.1.1/builder-9.1.1.pom",
+    "sha512": "ff6fa26e6cf7556495e344a8c82c4973815cf0238f04abb140681b0889e0be3decde02424f4488703d2a5372bf50988150ae95bf8180aa55622150d26c70c14f",
+    "dest": "offline-repository/com/android/tools/build/builder/9.1.1",
+    "dest-filename": "builder-9.1.1.pom"
   },
   {
     "type": "file",
@@ -1135,87 +939,73 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.0.1/gradle-api-9.0.1.jar",
-    "sha512": "fab266495c1c2133fcfb1cc643a6a865cf0fa0653b0c64de8f4e308ed7725b55f0c6b7ac23d69b609f9572358504be299a3f76be6fcce9b578b0b9c992db2df1",
-    "dest": "offline-repository/com/android/tools/build/gradle-api/9.0.1",
-    "dest-filename": "gradle-api-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.1.1/gradle-api-9.1.1.jar",
+    "sha512": "76f13c4d46798dc7155ffae28d7d08ee0cced258c90e232f5e71886c2f0920e2c6da1b80a80656458a49360b790b249f6e35fb1e0c4e99b86bd7019b25fc5bbc",
+    "dest": "offline-repository/com/android/tools/build/gradle-api/9.1.1",
+    "dest-filename": "gradle-api-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.0.1/gradle-api-9.0.1.module",
-    "sha512": "d8b8eb94f82593e38560aefc23c88b00a73d85f44237c0c3ea74848f53727ea74834716d9a1e2bb9ac8c86585f94257b1dd97fc807f19a5c7a586918b36535fc",
-    "dest": "offline-repository/com/android/tools/build/gradle-api/9.0.1",
-    "dest-filename": "gradle-api-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.1.1/gradle-api-9.1.1.pom",
+    "sha512": "b05fc5ac274f8cbac461d234e6509129dcb790e826ea5bd9619ac3c2510ff5cd87a96952c87bd3be394e7a4ded1b0475ed0d36c68d7ff94df2ccd7cc919ecbf8",
+    "dest": "offline-repository/com/android/tools/build/gradle-api/9.1.1",
+    "dest-filename": "gradle-api-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-api/9.0.1/gradle-api-9.0.1.pom",
-    "sha512": "4eb653004c97c9436f78f5b20bf308c782ea6542da19bc4b2e9cbe5f78b3ed5c49c4fc6c3a9e530b4e0c9d7af4570ded5022b94a0e3c3cbb02de12f6c42c7ae7",
-    "dest": "offline-repository/com/android/tools/build/gradle-api/9.0.1",
-    "dest-filename": "gradle-api-9.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-common-api/9.0.1/gradle-common-api-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-common-api/9.1.1/gradle-common-api-9.1.1.jar",
     "sha512": "0bc21cbd88003ab83085fbf5cc8090ce8e3d74d7a18cca99d36e2f26c6f0deff2cf28580ff4fbaa109f5a1d9282b57798ec8b5a8977009fdf7b5492075611fbe",
-    "dest": "offline-repository/com/android/tools/build/gradle-common-api/9.0.1",
-    "dest-filename": "gradle-common-api-9.0.1.jar"
+    "dest": "offline-repository/com/android/tools/build/gradle-common-api/9.1.1",
+    "dest-filename": "gradle-common-api-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-common-api/9.0.1/gradle-common-api-9.0.1.module",
-    "sha512": "9217faf5393102c8181087012f7e3d334fa39c7db864736c2eee54eb31acdbe199817fb970c0a95552d8d9bb10a09af3190c1c38ff4b996b488e45831b4222de",
-    "dest": "offline-repository/com/android/tools/build/gradle-common-api/9.0.1",
-    "dest-filename": "gradle-common-api-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-common-api/9.1.1/gradle-common-api-9.1.1.module",
+    "sha512": "1c5da35174535f494604bff455f7e0d1c9a5444960a9a32ba00f2f62142f265cbfd02e847c538992f87ab57391d614dc31d90ad08f3f3b112df508828d01bb22",
+    "dest": "offline-repository/com/android/tools/build/gradle-common-api/9.1.1",
+    "dest-filename": "gradle-common-api-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-common-api/9.0.1/gradle-common-api-9.0.1.pom",
-    "sha512": "600e83ffa7421926dfb8731c5ee8c74669ca36f17d87addcf050c05ab40095b70870012ca41d605aeccdefbcba260e432784fae16a21415d434f81eb2c282415",
-    "dest": "offline-repository/com/android/tools/build/gradle-common-api/9.0.1",
-    "dest-filename": "gradle-common-api-9.0.1.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.0.1/gradle-settings-api-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.1.1/gradle-settings-api-9.1.1.jar",
     "sha512": "2c1cd27560b7c6980d0fb952c5a49b00b4a157c6cb7805fb493786cdd31cdc98fae5db6d5a9b799e9167517a418b40c443e0bbe10d0684becf6b0f5473023207",
-    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.0.1",
-    "dest-filename": "gradle-settings-api-9.0.1.jar"
+    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.1.1",
+    "dest-filename": "gradle-settings-api-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.0.1/gradle-settings-api-9.0.1.module",
-    "sha512": "54c4592927dce1177a10cb008b04f288587f08edd9b931780d1d6b07339b5427269dda02b0a3bdf7a9928780722782b18ba56109a5a2b429ba7baebf9dc84e19",
-    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.0.1",
-    "dest-filename": "gradle-settings-api-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.1.1/gradle-settings-api-9.1.1.module",
+    "sha512": "360c26f265cf8d46394b57c974d5980c2bca82e8857d09b5c4e2c1891bda5e1dab00af5c8146e0a3a89851463e2b47a3db9ddcdae3a5d5400b7cc084373963a7",
+    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.1.1",
+    "dest-filename": "gradle-settings-api-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.0.1/gradle-settings-api-9.0.1.pom",
-    "sha512": "871f3484487ad808ad2945dbab1686280b5eaf220fe80e21c01ff7460fb68d2982492db7cb70bfdb4e7f846bb151ecb9df646cdfe9d9441dfd0c9ee2243d2333",
-    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.0.1",
-    "dest-filename": "gradle-settings-api-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle-settings-api/9.1.1/gradle-settings-api-9.1.1.pom",
+    "sha512": "e019f494e1c0c46bacf0de9034790e64efd243b8b2872653dc0e3900c3620856746e27600a7530ff908fbfacb347e99593c9db5b93f768a575383d0764d68b6a",
+    "dest": "offline-repository/com/android/tools/build/gradle-settings-api/9.1.1",
+    "dest-filename": "gradle-settings-api-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.0.1/gradle-9.0.1.jar",
-    "sha512": "7aa63b1315594d78c26f7ca5255fdea4959700d58a6faa35c4e6bc4622b47a4a3c56e6b0ca775ddf62444693f7a223bd4903eecd452a77ee02094f1303978fad",
-    "dest": "offline-repository/com/android/tools/build/gradle/9.0.1",
-    "dest-filename": "gradle-9.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.1.1/gradle-9.1.1.jar",
+    "sha512": "80961a3f684f2abf313240684297c8fc20509076b77b63d746cb87f11edea56b91f33430f5c12aee8c133a1cdc52440e31a11dfff889b01423dd88ffd18ac3f9",
+    "dest": "offline-repository/com/android/tools/build/gradle/9.1.1",
+    "dest-filename": "gradle-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.0.1/gradle-9.0.1.module",
-    "sha512": "6786a305d977d8e027bd0cc93598e7e0c94da09a4ab76a12a2dbbf7742ed31c55f4013e180a2fa9bca4557e39ab6bb5d19ff8343d03792ba06e867de031be853",
-    "dest": "offline-repository/com/android/tools/build/gradle/9.0.1",
-    "dest-filename": "gradle-9.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.1.1/gradle-9.1.1.module",
+    "sha512": "9a33234bcf893fd99c114632d1052fd33776feb4be37e6e4bc61647ef72466f6d8ad13a3406427a04f68ae8277cbbc1b4f418767ae029a141811296ebaa53fb7",
+    "dest": "offline-repository/com/android/tools/build/gradle/9.1.1",
+    "dest-filename": "gradle-9.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.0.1/gradle-9.0.1.pom",
-    "sha512": "7da2ea1f81571e5946480c634ddb7ebe6f7202a4161efc26c31e0a12084fdee70a6f5d7230a21217388750a1d4427114c04cacc769bad90d63bda58b4c62f3c6",
-    "dest": "offline-repository/com/android/tools/build/gradle/9.0.1",
-    "dest-filename": "gradle-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/9.1.1/gradle-9.1.1.pom",
+    "sha512": "b076978ef8a10fe6e3a2f947acb91fcdc9d14ecc92a32eb3e7e1f7626235204eef4ee2d0cd4379479c6f93559384d1bd75bb9a94d369fe120d04faa0d2bd5e47",
+    "dest": "offline-repository/com/android/tools/build/gradle/9.1.1",
+    "dest-filename": "gradle-9.1.1.pom"
   },
   {
     "type": "file",
@@ -1261,206 +1051,199 @@
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.0.1/manifest-merger-32.0.1.jar",
-    "sha512": "924f0fbef8c43433e56dc261cdbb960fd2e609d8fb62299205fd9d752ae2b4f35062f860049643934012827382e8dd9c9b96fe8a3eecaa7db9f0f593576143a5",
-    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.0.1",
-    "dest-filename": "manifest-merger-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.1.1/manifest-merger-32.1.1.jar",
+    "sha512": "d0ad5802942912b1e837497dab87f2e0c7d235a111cabdc6634b5308505a0ffea18dc68ce2b4e7a129e6fa5e347108cc7e1303d84b3b38945c46385c096a50bd",
+    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.1.1",
+    "dest-filename": "manifest-merger-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.0.1/manifest-merger-32.0.1.module",
-    "sha512": "5571c65dd3c00a81dbba754607f148af404d8440930015418b4b4f219d48608af9d0bd8499923ca82d7d55b3dfb4ff4851a1ae40e98acc284741489bdc1e6b4c",
-    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.0.1",
-    "dest-filename": "manifest-merger-32.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.1.1/manifest-merger-32.1.1.module",
+    "sha512": "d593022b4aa27458b3b473178df200a6bb007f1f293f8db233d47a124f86479986e4bfd8873846cf4788de6ab0bbf170dc6928c625f0106c0dadac5589274a97",
+    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.1.1",
+    "dest-filename": "manifest-merger-32.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.0.1/manifest-merger-32.0.1.pom",
-    "sha512": "48371a5a19a6e06b6a83512478149ad9d9418737d77beb5bb8bded2fd693ae6245b70c1748d275bbf1a1ca956a95fbc9d9607b00bb87538b77039e9043908dea",
-    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.0.1",
-    "dest-filename": "manifest-merger-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/build/manifest-merger/32.1.1/manifest-merger-32.1.1.pom",
+    "sha512": "9f88e36339ef7d042f6bb590bc147e39d7f3292dfbd7d00d5b025c7e605ef424530747b20f1de8ae0fd1155af20c6582cce353fd70ff255946840305c14c07bc",
+    "dest": "offline-repository/com/android/tools/build/manifest-merger/32.1.1",
+    "dest-filename": "manifest-merger-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/common/32.0.1/common-32.0.1.jar",
-    "sha512": "250ab1efd2c3f848f61088edefee5b97371ca0333ca1b888336b8916527d4df7fe57f8f36bbf52831c3c5c39c58d868a2c6edd42dd45c5ac9b3b2f70f9c26e1c",
-    "dest": "offline-repository/com/android/tools/common/32.0.1",
-    "dest-filename": "common-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/common/32.1.1/common-32.1.1.jar",
+    "sha512": "f6735c3dde39141de5b6a49711e775196f0e4376ca47176d2c97e0fd02f9327d7d40820b4c22071862ea31f1f908310db498a1b58fa2248bb5c3566d9fb4509b",
+    "dest": "offline-repository/com/android/tools/common/32.1.1",
+    "dest-filename": "common-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/common/32.0.1/common-32.0.1.pom",
-    "sha512": "c4c5da0c518a9cca81141eddfb86ff3eff3bf45e45f4c9c7f9205370875af29d97a2f396c1a170b59d57996c89b5f1e887ee166220e80941b5a0d8bda9a2a03f",
-    "dest": "offline-repository/com/android/tools/common/32.0.1",
-    "dest-filename": "common-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/common/32.1.1/common-32.1.1.pom",
+    "sha512": "18f8dbf1faccdd86bd1ef2a686d168f10401f63bcca3e20beed4f86f8e5eedd81be2a20b0a0941f466dc96222e908d16ebfb0d8600ac436f1f2f4a39cf5fb8e7",
+    "dest": "offline-repository/com/android/tools/common/32.1.1",
+    "dest-filename": "common-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/32.0.1/ddmlib-32.0.1.jar",
-    "sha512": "586233372f439723db73486a5f740b158b07958f9636203cb390502304d7807bea139c05bdf715853e93bb5dc9b9c0de10f8d38b96517dfb256ae5b95df51685",
-    "dest": "offline-repository/com/android/tools/ddms/ddmlib/32.0.1",
-    "dest-filename": "ddmlib-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/32.1.1/ddmlib-32.1.1.jar",
+    "sha512": "103032bd7f534d144650ce3c1d6b45ede801866628f1aba69e2cb8e6785f64fdfb093643de9ae1a883e83c010ddab629ca41e664a1580a0c59d6a78e1cb2e898",
+    "dest": "offline-repository/com/android/tools/ddms/ddmlib/32.1.1",
+    "dest-filename": "ddmlib-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/32.0.1/ddmlib-32.0.1.pom",
-    "sha512": "cb046bbb291c7911ad5247a423959ce59093719c5cb0d0e75660042ed1c2ab500b540f6ccf099fa041ca92d99aac84917639c0c8ff97a9b76875eb4717e210d3",
-    "dest": "offline-repository/com/android/tools/ddms/ddmlib/32.0.1",
-    "dest-filename": "ddmlib-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/ddms/ddmlib/32.1.1/ddmlib-32.1.1.pom",
+    "sha512": "8d234329ace27e8ce1bf2aaffb77f922da166d918e387aecd6eed8821061b75575f4d54f90f7a885ac1a8a2763a529333eb4f1f0774af8518114d6d87b2a2df9",
+    "dest": "offline-repository/com/android/tools/ddms/ddmlib/32.1.1",
+    "dest-filename": "ddmlib-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/32.0.1/dvlib-32.0.1.jar",
-    "sha512": "f196fa7ae6c12ab831b5b92fe43e4a544bf00c9c9a8133b999d0cefd5c5439f75c782100d6f19285ebbdbf1482cd32c523eb6a07f011c1487043f58d9cd306f5",
-    "dest": "offline-repository/com/android/tools/dvlib/32.0.1",
-    "dest-filename": "dvlib-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/32.1.1/dvlib-32.1.1.jar",
+    "sha512": "9088967cd5c077f482968d620c4645e309c499bebd7d4324365cab04134ffda2badcc23e61533164ced42f96c3706be5a40b6a0f13eb85060468146261593931",
+    "dest": "offline-repository/com/android/tools/dvlib/32.1.1",
+    "dest-filename": "dvlib-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/32.0.1/dvlib-32.0.1.pom",
-    "sha512": "860a5debfbefefa77e7744a956de9c1928dbaf84eaa7e34d6458d0f1217577e4ad85e89ab3d8f41fabd3183a9c14f66191f54ebd9b422990488f20cef6e42887",
-    "dest": "offline-repository/com/android/tools/dvlib/32.0.1",
-    "dest-filename": "dvlib-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/dvlib/32.1.1/dvlib-32.1.1.pom",
+    "sha512": "349bf9ed65f2aa6ba2bf1de3b6fdaf76cec4d8ed9121e419a7e6c6a228ee0e94731f174373c0258de9017c80d797ff4b8805974d598ca528cfae6d496d80d88e",
+    "dest": "offline-repository/com/android/tools/dvlib/32.1.1",
+    "dest-filename": "dvlib-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/32.0.1/layoutlib-api-32.0.1.jar",
-    "sha512": "945b3cca6f2d113387b97103717a58243b593247bc5dc581841bcfac4034f402bb547d8a61ee18707b978b75f336d2205ecbb2dd65e06ceafd549e6bab808eca",
-    "dest": "offline-repository/com/android/tools/layoutlib/layoutlib-api/32.0.1",
-    "dest-filename": "layoutlib-api-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/32.1.1/layoutlib-api-32.1.1.jar",
+    "sha512": "bb468d67522f6d10f1077729e060d6c20daa60ba35af392916639df8e582ac4b0149eff120cfd12d15d0601a3fcb8b37dcfe4e146ee11eb357673662af3fb8a8",
+    "dest": "offline-repository/com/android/tools/layoutlib/layoutlib-api/32.1.1",
+    "dest-filename": "layoutlib-api-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/32.0.1/layoutlib-api-32.0.1.pom",
-    "sha512": "302d51283a54aabd1febd3cb97ece664d1c72870d02d959abda099c6dae68d63c161795be8530574196e6eba6f0f0b0e4e3ddf37728dd5a7fa64a3dfda9e3080",
-    "dest": "offline-repository/com/android/tools/layoutlib/layoutlib-api/32.0.1",
-    "dest-filename": "layoutlib-api-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/layoutlib/layoutlib-api/32.1.1/layoutlib-api-32.1.1.pom",
+    "sha512": "9460ae30a648daacd7abcb5d45364a2385745e2f662bbf8edcc00acbae49fc6d18eb4b90c2292229948eb97c9d20e85c8b2e438a3478755607b43a960bcf2b3e",
+    "dest": "offline-repository/com/android/tools/layoutlib/layoutlib-api/32.1.1",
+    "dest-filename": "layoutlib-api-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-model/32.0.1/lint-model-32.0.1.jar",
-    "sha512": "037fd7ef8a52774f1cc544b53a1ab23b0081f28a121139238816440a59fb1b3aa375627f814adc04572126ac9d7a92768f85a3b6a30a588926fb7a13189841e0",
-    "dest": "offline-repository/com/android/tools/lint/lint-model/32.0.1",
-    "dest-filename": "lint-model-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-model/32.1.1/lint-model-32.1.1.jar",
+    "sha512": "653fecc3ff8a3660e887d2e4b1fb5062d7b0f1830a3d84fd353248c022d8bbe08e6f61a3fdb12a46fb9e974baf0b9f089e46ce576193cf6d13f8d920b3f5ac4b",
+    "dest": "offline-repository/com/android/tools/lint/lint-model/32.1.1",
+    "dest-filename": "lint-model-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-model/32.0.1/lint-model-32.0.1.pom",
-    "sha512": "02e53cd8e05e51c6cfbedd90dad20603e931568877e952060734145ec3684f7b6a12a62e17c52ed1310a8020dd9b1754dc344f5c16e9597aef1be538a45e2d5b",
-    "dest": "offline-repository/com/android/tools/lint/lint-model/32.0.1",
-    "dest-filename": "lint-model-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-model/32.1.1/lint-model-32.1.1.pom",
+    "sha512": "5ca09134c75ca8108a84fc8b0e57b704ade2f82f623e9a449daebcd2d0ea0fd584c84c8e810d33dfa297f79c05fcdddbcd286e61fc6862ce4813c87680dae8af",
+    "dest": "offline-repository/com/android/tools/lint/lint-model/32.1.1",
+    "dest-filename": "lint-model-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-typedef-remover/32.0.1/lint-typedef-remover-32.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-typedef-remover/32.1.1/lint-typedef-remover-32.1.1.jar",
     "sha512": "48529436c42269656e44240577b0b9e09ec8d4608f1ca7dad8f6fd8fc9e5fe41080a8447e8e8d81ee1a1edc7da9c0726e57edef79841a9785d9b729310fbb9be",
-    "dest": "offline-repository/com/android/tools/lint/lint-typedef-remover/32.0.1",
-    "dest-filename": "lint-typedef-remover-32.0.1.jar"
+    "dest": "offline-repository/com/android/tools/lint/lint-typedef-remover/32.1.1",
+    "dest-filename": "lint-typedef-remover-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-typedef-remover/32.0.1/lint-typedef-remover-32.0.1.pom",
-    "sha512": "0d24cc87f627174ca7ac54744be8ffc314fcefa628dac39a8af84801b2ef4a03fe25df043034b46533e6e39b9894f35279c179aac5a6f36bd5a6bb2517f71904",
-    "dest": "offline-repository/com/android/tools/lint/lint-typedef-remover/32.0.1",
-    "dest-filename": "lint-typedef-remover-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/lint/lint-typedef-remover/32.1.1/lint-typedef-remover-32.1.1.pom",
+    "sha512": "487e875d058223bda65ac1c281148e18d144da6ce90d0b65d0e76d3709d783ea73025174b9e93ae9478c2cbad755d17c750e99f0b2b86717e2096bf72d374e2c",
+    "dest": "offline-repository/com/android/tools/lint/lint-typedef-remover/32.1.1",
+    "dest-filename": "lint-typedef-remover-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/repository/32.0.1/repository-32.0.1.jar",
-    "sha512": "bcba5bc028d8b649bb33693f486b37fa7661ba21147bc12aed5270d95a1f9661fbee3b6f9d915c43e69dd4366fac51a177f814f23a7861ec4464b3f5ace7c14b",
-    "dest": "offline-repository/com/android/tools/repository/32.0.1",
-    "dest-filename": "repository-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/repository/32.1.1/repository-32.1.1.jar",
+    "sha512": "9cc8416efb605bda71f41224e08c8afc35cc81b8b628c0aa22ef18781e81d041b32346662c72f358f9110e22104576027723f53827eae478a2dd537d0471bbf8",
+    "dest": "offline-repository/com/android/tools/repository/32.1.1",
+    "dest-filename": "repository-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/repository/32.0.1/repository-32.0.1.pom",
-    "sha512": "0d3a9aa2dc1be04aae80489e4c83e3abac18470519ade7cf2b95c02d1114ad80166a1fcb54203024bc08e6e41a526cd909f87d4dc1c58cc11c20ba136d519687",
-    "dest": "offline-repository/com/android/tools/repository/32.0.1",
-    "dest-filename": "repository-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/repository/32.1.1/repository-32.1.1.pom",
+    "sha512": "7735b060a8d0d0f21b5f651c742fba382e7d2b7abcae64fb3ecc69419eb0169815b2f9177d9df61eeba22f346e3a1211a1c6de5ec195807259f89fc99863434f",
+    "dest": "offline-repository/com/android/tools/repository/32.1.1",
+    "dest-filename": "repository-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/32.0.1/sdk-common-32.0.1.jar",
-    "sha512": "28e69902b28947700a045ed0ba2445afdfdde500344471b789b0721f683787f705f68594909325d25a8eacd055a0637fb553ed4463c2d16624cc74ee558be4dc",
-    "dest": "offline-repository/com/android/tools/sdk-common/32.0.1",
-    "dest-filename": "sdk-common-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/32.1.1/sdk-common-32.1.1.jar",
+    "sha512": "28b00c994ba17ae01b467c2ce0767fc0916a51c1b310565ae5d2f3f2d9e1de4bb09e8827e7c5a49444d18de123e62d72bd9381513e63b9093d6844abc3b3ef60",
+    "dest": "offline-repository/com/android/tools/sdk-common/32.1.1",
+    "dest-filename": "sdk-common-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/32.0.1/sdk-common-32.0.1.pom",
-    "sha512": "ee027fc833147f35a6672993b9c06ff4ef8a16c187d5d1c7d583972326e15b54b7e51f3e7a05c36c338c1d05717c5a64865e29859b6c7fc37cc900e1ef422d13",
-    "dest": "offline-repository/com/android/tools/sdk-common/32.0.1",
-    "dest-filename": "sdk-common-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdk-common/32.1.1/sdk-common-32.1.1.pom",
+    "sha512": "f47518b275e12b363d6280abef31b809f52f3ef2c7749034d976607dbd68de6bd0e7aef70d6f0f86f6d5ab281962f94da0354ea0c2c3e106fadf9b0b7e114cf2",
+    "dest": "offline-repository/com/android/tools/sdk-common/32.1.1",
+    "dest-filename": "sdk-common-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/32.0.1/sdklib-32.0.1.jar",
-    "sha512": "d615b6c58ffe16298ba7266026f2e3b1ff104fc0b06debaca2bac3254098ad8904a9a68ad9308f87f718caa95881df547363cd8a2c2d3ece6c4243d90f104cdc",
-    "dest": "offline-repository/com/android/tools/sdklib/32.0.1",
-    "dest-filename": "sdklib-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/32.1.1/sdklib-32.1.1.jar",
+    "sha512": "f490ed2702dddefa84297d438a5752dd3639be248130ffde842af2eea89d1d3709aa8623e2e1e4ef790293eb829ea157ef5aedbbc7039fea7e14ce982dca5a18",
+    "dest": "offline-repository/com/android/tools/sdklib/32.1.1",
+    "dest-filename": "sdklib-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/32.0.1/sdklib-32.0.1.pom",
-    "sha512": "1dbef998a9363260a8987cc53e68ea79649c7dc516ea26933fec8ba4f28c4a8288beec45a13ad3c44680c176d95cd8d3a5893b1385552223600b0a49514e10fe",
-    "dest": "offline-repository/com/android/tools/sdklib/32.0.1",
-    "dest-filename": "sdklib-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/sdklib/32.1.1/sdklib-32.1.1.pom",
+    "sha512": "0216ca90d917be0c87c10abb558f7af9afa224d8e19e03a8a94af6f4ef8bc65fe22967586a85116f6ebad1973229ef355604cb3bd0fe7d4a267d475305a8cf85",
+    "dest": "offline-repository/com/android/tools/sdklib/32.1.1",
+    "dest-filename": "sdklib-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.0.1/gradle-work-action-api-32.0.1.jar",
-    "sha512": "a5a0cf16fbc291499dbc81210aab819ee7107ab12a9bfaa4e407c9bc1b4ff73f5e01bf446a39411474da18b0536fdb1a27a3fd3baaeac6be95d1520fc45fbe8c",
-    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.0.1",
-    "dest-filename": "gradle-work-action-api-32.0.1.jar"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.1.1/gradle-work-action-api-32.1.1.jar",
+    "sha512": "49a108f75248cb052f512b53cf64d1df6d007019896dde544d73c50e4df9e8a0d97c07bde76ecd41f15b058172f9fb0886bb3f1566715896368219a6f2dd1eac",
+    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.1.1",
+    "dest-filename": "gradle-work-action-api-32.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.0.1/gradle-work-action-api-32.0.1.module",
-    "sha512": "22bfcd8e9243822da6eb582400f12f169f59f0533e887b6c13eb3c38be3cf5ce596c7f93d04dc59b6b6cdf2718bf14f0c08ca7e6269843a801dcbe097525daa4",
-    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.0.1",
-    "dest-filename": "gradle-work-action-api-32.0.1.module"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.1.1/gradle-work-action-api-32.1.1.module",
+    "sha512": "f33b8e295f5d2f5df21405c94307789e936781d647e01d8248b7f51e1af5822e457b19ed4d2c90b397e5523ed62321c10a6fa7e9ec0b54a3eec7fa2d3a0fd285",
+    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.1.1",
+    "dest-filename": "gradle-work-action-api-32.1.1.module"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.0.1/gradle-work-action-api-32.0.1.pom",
-    "sha512": "314ab61162092d15756ea54c137960f0c7ed2bd0a7a325684bafadfacce11290f19fdea293c2faaf8598abff885cefc213c211a76bfe9c7b80c3842f23fbe00f",
-    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.0.1",
-    "dest-filename": "gradle-work-action-api-32.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/tools/utp/gradle-work-action-api/32.1.1/gradle-work-action-api-32.1.1.pom",
+    "sha512": "664b350afe9c5ce91781093796126e5c084254fefd8bb85d9b1e9327a5a687fafe1b54dc5afe4e9472a9776b33702dd283faaabe5a0939cc8388fac412aa6700",
+    "dest": "offline-repository/com/android/tools/utp/gradle-work-action-api/32.1.1",
+    "dest-filename": "gradle-work-action-api-32.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/zipflinger/9.0.1/zipflinger-9.0.1.jar",
+    "url": "https://dl.google.com/dl/android/maven2/com/android/zipflinger/9.1.1/zipflinger-9.1.1.jar",
     "sha512": "809b16d45f317403acc3ba5c6d575b7d68e7c37a644b1e8afca94590e29b87a0d8078f2f72312fe3358ec969582769df553711b1bc1c18a0cf468102291d4ca0",
-    "dest": "offline-repository/com/android/zipflinger/9.0.1",
-    "dest-filename": "zipflinger-9.0.1.jar"
+    "dest": "offline-repository/com/android/zipflinger/9.1.1",
+    "dest-filename": "zipflinger-9.1.1.jar"
   },
   {
     "type": "file",
-    "url": "https://dl.google.com/dl/android/maven2/com/android/zipflinger/9.0.1/zipflinger-9.0.1.pom",
-    "sha512": "ecf10015fb58734cd25012b21ce9a86e8ca940c2771722eff2767d86c7648b0fef17e6ba9ec166a661ed3f76a804cc6206428a3c56e8e653dc0012960e3f2dcf",
-    "dest": "offline-repository/com/android/zipflinger/9.0.1",
-    "dest-filename": "zipflinger-9.0.1.pom"
+    "url": "https://dl.google.com/dl/android/maven2/com/android/zipflinger/9.1.1/zipflinger-9.1.1.pom",
+    "sha512": "0e2f24fc54ce5fb299b106094157def3c35ba489500b914543871e266dc26fa051abba037b38d3ed820ef3ee19501fe1ed7f5a902a838d7b52da1e347ad0c1a6",
+    "dest": "offline-repository/com/android/zipflinger/9.1.1",
+    "dest-filename": "zipflinger-9.1.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/fazecast/jSerialComm/2.11.0/jSerialComm-2.11.0.jar",
-    "sha512": "2d0dce58ea07d7785348fcf51e48870d7cbcf6b7ddde23fa91e54a73385b6bee90f236e4025547fb7401ca4838dcc7f5d8307fd3bc2ab7a44c4e04bf3814b1ec",
-    "dest": "offline-repository/com/fazecast/jSerialComm/2.11.0",
-    "dest-filename": "jSerialComm-2.11.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/com/fazecast/jSerialComm/2.11.4/jSerialComm-2.11.4.jar",
+    "sha512": "7d42abc5a2e6cb1226eaec172df3c0923b10e62ae2fc82612ea98cd5c4f85d1c4058d800f0fcf3c33ecd6ffa987baf326dc334930b724dd6d3c8cdc864a2d89a",
+    "dest": "offline-repository/com/fazecast/jSerialComm/2.11.4",
+    "dest-filename": "jSerialComm-2.11.4.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/fazecast/jSerialComm/2.11.0/jSerialComm-2.11.0.module",
-    "sha512": "d5868c6371455cb5eb912de60709a60d45dc3925d29bc4ba78ab148f00265f98eae6024b76862295f59888b33e6c8b7a9365683fe535dd584551879d4c8da796",
-    "dest": "offline-repository/com/fazecast/jSerialComm/2.11.0",
-    "dest-filename": "jSerialComm-2.11.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/fazecast/jSerialComm/2.11.0/jSerialComm-2.11.0.pom",
-    "sha512": "902b5918eaa2930a5dd9efb2ba1e38a3d1697d1237fd2e06d8baca5a6a572d34531d5e41c0e6f760b6903f5667e76c59f0a292c690dfe4ce63f73a1fc5d8532e",
-    "dest": "offline-repository/com/fazecast/jSerialComm/2.11.0",
-    "dest-filename": "jSerialComm-2.11.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/fazecast/jSerialComm/2.11.4/jSerialComm-2.11.4.pom",
+    "sha512": "2b5c7046bb6efce9cc1db9c6c4fb3ef31e1335be54875be7590d0e93facb4dd6e62e911fb0183d462a9e55aa4a397d43b2d2775ee74aec55f925926c61f9122d",
+    "dest": "offline-repository/com/fazecast/jSerialComm/2.11.4",
+    "dest-filename": "jSerialComm-2.11.4.pom"
   },
   {
     "type": "file",
@@ -1730,24 +1513,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/core/3.5.3/core-3.5.3.jar",
-    "sha512": "0b5f04f1c17c2686a709bfbd217a3bcd8c9e143139305986b062a6cfc4050d0de43debbc8a0cea15dfc0f8c009b62b0c99207228c17530ef05a465cf9d68b959",
-    "dest": "offline-repository/com/google/zxing/core/3.5.3",
-    "dest-filename": "core-3.5.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/core/3.5.4/core-3.5.4.jar",
+    "sha512": "967023e2aa3268cfde113b658c6dae70188d5e24e43fc8bcd414592225d66d5c2203045a32f7b185bab884990ec66dcb1ce93b7f61906f666c7ccd0646c8a764",
+    "dest": "offline-repository/com/google/zxing/core/3.5.4",
+    "dest-filename": "core-3.5.4.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/core/3.5.3/core-3.5.3.pom",
-    "sha512": "d7cf0b34848ee87693976cc1751f44438bd57b7255e0dc58c517ed6ff320649bc8110c9661a707b2ac264ce0626e60a3e0aa87e797704f9bb0342ffe808df884",
-    "dest": "offline-repository/com/google/zxing/core/3.5.3",
-    "dest-filename": "core-3.5.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/core/3.5.4/core-3.5.4.pom",
+    "sha512": "d8cfad82a0b2431f8b3e63d21f10c4b2edc02bafd247341be5e8911bc9e33b00c43a90ff4c4849bc567a575d5f04000ecb7f64b6acf6cf0d538be5c1703d68ea",
+    "dest": "offline-repository/com/google/zxing/core/3.5.4",
+    "dest-filename": "core-3.5.4.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/zxing-parent/3.5.3/zxing-parent-3.5.3.pom",
-    "sha512": "f508de41cf1549d2e2d729d434f22f79f9828967c39859e831fefb4e80e921d5ab21e0d84c6ef586c175b7700ac6ec319a75871ea20d314587911f430c86ed32",
-    "dest": "offline-repository/com/google/zxing/zxing-parent/3.5.3",
-    "dest-filename": "zxing-parent-3.5.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/google/zxing/zxing-parent/3.5.4/zxing-parent-3.5.4.pom",
+    "sha512": "a0da56f83ce6b52d0fc5405215d75947a5c70ecf274f4a17b0fefd24c4bdd9488ca8e8cc2a182197efe751c0eb22fb221c8663f9cc3aec3076463f733778dad6",
+    "dest": "offline-repository/com/google/zxing/zxing-parent/3.5.4",
+    "dest-filename": "zxing-parent-3.5.4.pom"
   },
   {
     "type": "file",
@@ -1870,45 +1653,45 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.8.1/library-jvm-1.8.1.jar",
-    "sha512": "806de4bbe639415f9d1388fe5a8eedd8e8b225b5893ce98609cccfa2cd61e7a5980a58783794002605554897ddc803bdbbfdbbf39b34d5c6883a27be4bcc356d",
-    "dest": "offline-repository/com/llamatik/library-jvm/1.8.1",
-    "dest-filename": "library-jvm-1.8.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.9.0/library-jvm-1.9.0.jar",
+    "sha512": "a5709759028e7913930b6587b4991a26ae6b4ee12c4c773649162f9a2997b6ff8a315ba011834ff542cba0de904efeaa0195e6743b4c56ae46288988ca126a24",
+    "dest": "offline-repository/com/llamatik/library-jvm/1.9.0",
+    "dest-filename": "library-jvm-1.9.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.8.1/library-jvm-1.8.1.module",
-    "sha512": "1ebc8eb1f1a8b0dc8d00bcf06f8180640a742264d3ea2f7316a2836db1223027958b2b02d8d97d8cf9fa602a67566762efe23815bae6075e7da16ed7cda248ae",
-    "dest": "offline-repository/com/llamatik/library-jvm/1.8.1",
-    "dest-filename": "library-jvm-1.8.1.module"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.9.0/library-jvm-1.9.0.module",
+    "sha512": "042b7f8ec7775834111d6dfbc1d944d7e1b635e259d7f1562d9851ff61bfc2d88f697f8f9a09cd0cb38780b70be451e08bd2240efd8a1e7e5f575a9d49c95ea5",
+    "dest": "offline-repository/com/llamatik/library-jvm/1.9.0",
+    "dest-filename": "library-jvm-1.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.8.1/library-jvm-1.8.1.pom",
-    "sha512": "4c081f41c85ccfda388ae4a993cfe93e575fa500638b6686a3df413380b97984f32d3b934f4e7005f4703564bddeb0a1a236dacd23fbf347db55c085f871af02",
-    "dest": "offline-repository/com/llamatik/library-jvm/1.8.1",
-    "dest-filename": "library-jvm-1.8.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library-jvm/1.9.0/library-jvm-1.9.0.pom",
+    "sha512": "2e55e4d910f97c40c593d6abc3220918f1b50b2db16dcdaefbfcfcbb51ee22e7c517b2e25116b513438e7c4e93f501998e86ae1932ec87e240110804def3ad0b",
+    "dest": "offline-repository/com/llamatik/library-jvm/1.9.0",
+    "dest-filename": "library-jvm-1.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.8.1/library-1.8.1.module",
-    "sha512": "9909b6bf34e694e48bf67beb0ee004838b8a2e80fed361081655d557d243e55177c1884d6d326495b1292bf8f63b5e1929e7514903b5aac9e971228fa4bc4c04",
-    "dest": "offline-repository/com/llamatik/library/1.8.1",
-    "dest-filename": "library-1.8.1.module"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.9.0/library-1.9.0.module",
+    "sha512": "9d0dbbe0222747884bc48e107d83a95e6c484963b84db91ed0752eb5a986d53f8f0dfa110d6d1bc338c2b23789dfe20071abb40a379c3363e9479163abe311f5",
+    "dest": "offline-repository/com/llamatik/library/1.9.0",
+    "dest-filename": "library-1.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.8.1/library-1.8.1.pom",
-    "sha512": "6695db247b9d8692d692eb264f0e04b6358276c3ab5561803ac01129a8912fea9b052ddf67f0e62dabe6fd1cc55b25393d3ba20dbf1652677088a5c0c76dfe5a",
-    "dest": "offline-repository/com/llamatik/library/1.8.1",
-    "dest-filename": "library-1.8.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.9.0/library-1.9.0.pom",
+    "sha512": "dd228fda7c1a0fc62c7935456cfb1900fb86bb939c328d8d4fa1b7a18fa7bd30dad47e2cd5ec61ad07764f1807bb136a441d44f4b473880bc5185658e6839965",
+    "dest": "offline-repository/com/llamatik/library/1.9.0",
+    "dest-filename": "library-1.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.8.1/../../library-jvm/1.8.1/library-jvm-1.8.1.module",
-    "sha512": "1ebc8eb1f1a8b0dc8d00bcf06f8180640a742264d3ea2f7316a2836db1223027958b2b02d8d97d8cf9fa602a67566762efe23815bae6075e7da16ed7cda248ae",
-    "dest": "offline-repository/com/llamatik/library/1.8.1/../../library-jvm/1.8.1",
-    "dest-filename": "library-jvm-1.8.1.module"
+    "url": "https://repo.maven.apache.org/maven2/com/llamatik/library/1.9.0/../../library-jvm/1.9.0/library-jvm-1.9.0.module",
+    "sha512": "042b7f8ec7775834111d6dfbc1d944d7e1b635e259d7f1562d9851ff61bfc2d88f697f8f9a09cd0cb38780b70be451e08bd2240efd8a1e7e5f575a9d49c95ea5",
+    "dest": "offline-repository/com/llamatik/library/1.9.0/../../library-jvm/1.9.0",
+    "dest-filename": "library-jvm-1.9.0.module"
   },
   {
     "type": "file",
@@ -2115,717 +1898,717 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.4.3/ktor-client-cio-jvm-3.4.3.jar",
-    "sha512": "400d4c8d3e820625a93cb8bb948e55d6b7920d325150c5117e73dfe8e6265404ac040f087ad0d9481b5cbd427c34254b095248752a7169bd465b5a6f17dfe4df",
-    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.4.3",
-    "dest-filename": "ktor-client-cio-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.5.1/ktor-client-cio-jvm-3.5.1.jar",
+    "sha512": "73e304f34e395391ce1e11c9fb9fd879c0043cd75364cb3f49c9df18c94b3f020e902137468e7ec935b66d64528da0454e623365607675fa32a0eca23e2204d9",
+    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.5.1",
+    "dest-filename": "ktor-client-cio-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.4.3/ktor-client-cio-jvm-3.4.3.module",
-    "sha512": "e100dce8a477be6d50c8181413ee831af3fdf28f0fa218c52cbfb5cb5fbecaa452b6b1b223cefb152a7d40f4fd6cf11a13c49dff45d33d111f810a3ab2b1187c",
-    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.4.3",
-    "dest-filename": "ktor-client-cio-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.5.1/ktor-client-cio-jvm-3.5.1.module",
+    "sha512": "8b2cc5df65a8ad79370801d77f4896fa83029ca077f28ef1c0d8301b03ac6b0f5e0d107a48d33af4e5be7d4e0e2fe5eb92b8643a1b88deea10c63504a9be5686",
+    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.5.1",
+    "dest-filename": "ktor-client-cio-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.4.3/ktor-client-cio-jvm-3.4.3.pom",
-    "sha512": "4d2cfb730a65f02625eaa5dd2e7daa3a54402050d1cc7c65614738a99382f9c831d2ae143586ceae05fa1f0fa992ceed18a5d6c7bac29ad244e7b54c8167a893",
-    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.4.3",
-    "dest-filename": "ktor-client-cio-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio-jvm/3.5.1/ktor-client-cio-jvm-3.5.1.pom",
+    "sha512": "d166dfbd793b68c5c2219bc3f3aeb24cb5716f859d4f1a0c6477ce694edb895a73c0822996b67876802940b41d32e802df234cef60b312ab2321846696de16f2",
+    "dest": "offline-repository/io/ktor/ktor-client-cio-jvm/3.5.1",
+    "dest-filename": "ktor-client-cio-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.4.3/ktor-client-cio-3.4.3.module",
-    "sha512": "eb649b9d6ed89a728a2db5d5c3c8e8c5a38993e8025cccdb5975f0441449196d0d0091ea3f9681ecfe75e2b7605c4ecefb67c6a7f700e7bb4b2979b8ef0cf6ad",
-    "dest": "offline-repository/io/ktor/ktor-client-cio/3.4.3",
-    "dest-filename": "ktor-client-cio-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.5.1/ktor-client-cio-3.5.1.module",
+    "sha512": "94f59afaca014e5a0c286a01fd4ca192836fcfc1d29e20a11fa2fef461233441d85a817768ffc8b518be355d59163150afd6d77125df7a536be3d54c6734bbc7",
+    "dest": "offline-repository/io/ktor/ktor-client-cio/3.5.1",
+    "dest-filename": "ktor-client-cio-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.4.3/ktor-client-cio-3.4.3.pom",
-    "sha512": "43fe566d2c5cb969148ab7cc2e68df14e0d90c50a4ded7e4ee182d6ca7fec98fe3c8ed35c8460c88cc423fc5b68dc8eb57e6414fea9e088149c2a52bca5c5ae3",
-    "dest": "offline-repository/io/ktor/ktor-client-cio/3.4.3",
-    "dest-filename": "ktor-client-cio-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.5.1/ktor-client-cio-3.5.1.pom",
+    "sha512": "636ec95d052ccb1e8fbc04907367e71e9142454f37670fb097ffed00d8bd69d39b9d32c87b79de602ae6cfba84feea8a75c955e672d10910193799333bd18f4f",
+    "dest": "offline-repository/io/ktor/ktor-client-cio/3.5.1",
+    "dest-filename": "ktor-client-cio-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.4.3/../../ktor-client-cio-jvm/3.4.3/ktor-client-cio-jvm-3.4.3.module",
-    "sha512": "e100dce8a477be6d50c8181413ee831af3fdf28f0fa218c52cbfb5cb5fbecaa452b6b1b223cefb152a7d40f4fd6cf11a13c49dff45d33d111f810a3ab2b1187c",
-    "dest": "offline-repository/io/ktor/ktor-client-cio/3.4.3/../../ktor-client-cio-jvm/3.4.3",
-    "dest-filename": "ktor-client-cio-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-cio/3.5.1/../../ktor-client-cio-jvm/3.5.1/ktor-client-cio-jvm-3.5.1.module",
+    "sha512": "8b2cc5df65a8ad79370801d77f4896fa83029ca077f28ef1c0d8301b03ac6b0f5e0d107a48d33af4e5be7d4e0e2fe5eb92b8643a1b88deea10c63504a9be5686",
+    "dest": "offline-repository/io/ktor/ktor-client-cio/3.5.1/../../ktor-client-cio-jvm/3.5.1",
+    "dest-filename": "ktor-client-cio-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.4.3/ktor-client-content-negotiation-jvm-3.4.3.jar",
-    "sha512": "01359b57c11721c46209c46374c9342898d09b4683f05f3e4ca86104982ccd1b5dffceeb6cb11121d8b65e769bf473a24ce14487b31649cfcc53ec0c6e28b59f",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.5.1/ktor-client-content-negotiation-jvm-3.5.1.jar",
+    "sha512": "a2a190cd6d48b80e9796d9b1f8a7df33846f86ef989a04255a483e1537a52054c87b55cc5ec34effff041a2b1b279c1986aac1b7e1db0aaf7ba78309f01547db",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.4.3/ktor-client-content-negotiation-jvm-3.4.3.module",
-    "sha512": "b080c883ebae0126cfdc8b7f4adc7b4f22ea453ae001dde0f0636ec4762612d0d287893de76684de4b097a9ed76458c9fc9d1fc30fc29f897e754cdf1a8ef1ea",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.5.1/ktor-client-content-negotiation-jvm-3.5.1.module",
+    "sha512": "0c065ab9898d2ecd02ca78d2e0bc15a2791cd3ae3a6482857ddb6fceae0ec19ebb47830a36eedea4acda6302148b5f2b5565e81473cb17847dfa3bbda8cfb99f",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.4.3/ktor-client-content-negotiation-jvm-3.4.3.pom",
-    "sha512": "3286eda9cf1a73fbecaaaf67ec0ac238b6af7885fb5660cce826224e984e2980639375654cb96c5ba58304309b3265ca5f851026320ea62cdc9bba771650eafe",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation-jvm/3.5.1/ktor-client-content-negotiation-jvm-3.5.1.pom",
+    "sha512": "1716ba620b642ead4b13a619880e788ca59602c5fefdb41d6972909be5adbef34302417f7ec4b68ee3a0e18a65b878d5348fc46a8db4d144059656c00d2662bf",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation-jvm/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.4.3/ktor-client-content-negotiation-3.4.3.module",
-    "sha512": "564dd9b57f21c50b88db7977c440f4632365132441c128207c7da6fc0b71356613582957f97b5df4c9f409ac7342adc4fe31a74c2d41d21332fd0feafefc8d3f",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.5.1/ktor-client-content-negotiation-3.5.1.module",
+    "sha512": "15777ed4c050f06f40851518e920f85dab7f1ac6037d51a402845d3a1471f63b499357d391cc9c85cad644dd973f0d68367a19baac30487dd101992e3d1e56c2",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.4.3/ktor-client-content-negotiation-3.4.3.pom",
-    "sha512": "fc35b331741acc89bd92f8119aa0bb36f3f3e9142c2cc21389abff173c5238c06b22d72194adcb36aa0ca717a534042f7bcbd036451fd3949f3faece9fb95a23",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.5.1/ktor-client-content-negotiation-3.5.1.pom",
+    "sha512": "4afeb2577600546641d573f4b7d61d59fbf3e5ff384b80b78f0ccda48b1c67105b4430d864e07b6a12eae551b653ae7edff2bee9f2b718fdcafe187f9e6b3400",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.4.3/../../ktor-client-content-negotiation-jvm/3.4.3/ktor-client-content-negotiation-jvm-3.4.3.module",
-    "sha512": "b080c883ebae0126cfdc8b7f4adc7b4f22ea453ae001dde0f0636ec4762612d0d287893de76684de4b097a9ed76458c9fc9d1fc30fc29f897e754cdf1a8ef1ea",
-    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.4.3/../../ktor-client-content-negotiation-jvm/3.4.3",
-    "dest-filename": "ktor-client-content-negotiation-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-content-negotiation/3.5.1/../../ktor-client-content-negotiation-jvm/3.5.1/ktor-client-content-negotiation-jvm-3.5.1.module",
+    "sha512": "0c065ab9898d2ecd02ca78d2e0bc15a2791cd3ae3a6482857ddb6fceae0ec19ebb47830a36eedea4acda6302148b5f2b5565e81473cb17847dfa3bbda8cfb99f",
+    "dest": "offline-repository/io/ktor/ktor-client-content-negotiation/3.5.1/../../ktor-client-content-negotiation-jvm/3.5.1",
+    "dest-filename": "ktor-client-content-negotiation-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.4.3/ktor-client-core-jvm-3.4.3.jar",
-    "sha512": "eeb254dcf4f2792c769be6207cacef0412921640e5f5916d23e9339b069bb7e34b468cfdfc659093813dfb5690d164c7ab8c1c34d0eadc32c9becd0728d5b734",
-    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.4.3",
-    "dest-filename": "ktor-client-core-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.5.1/ktor-client-core-jvm-3.5.1.jar",
+    "sha512": "73c9672f8a95290d629bbaf94d6504b5e6300851e4828e8c93a60b29c71ac090710435b215e5e5734a54214cc1d42385cf4b9576d0eccaafeb00d341c4adda17",
+    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.5.1",
+    "dest-filename": "ktor-client-core-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.4.3/ktor-client-core-jvm-3.4.3.module",
-    "sha512": "e4aa4014db283c0bc799a88426acb516de61491f59b2f89c962e2c50ada2254fdb9d62fbc3cb622f7b50e347d5cc7d428b6a90d191b0df2ba3e196120b16fb07",
-    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.4.3",
-    "dest-filename": "ktor-client-core-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.5.1/ktor-client-core-jvm-3.5.1.module",
+    "sha512": "e9b6cfc46f676e2ecb41e5bedbeaf73248787551e6a4afa54e1b5f2129b4552196417867323929e68ea4e8e85c960249c0bd568b03e91024a83837c6845fec6a",
+    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.5.1",
+    "dest-filename": "ktor-client-core-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.4.3/ktor-client-core-jvm-3.4.3.pom",
-    "sha512": "a7907e1fe74c343e1c6ed1df6b751eaed30c55a7282e23925ff1973c9008a96e0363a061778e9c633cdc291b4de0ce4865bb7c444501c6f8b579e187962720f9",
-    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.4.3",
-    "dest-filename": "ktor-client-core-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core-jvm/3.5.1/ktor-client-core-jvm-3.5.1.pom",
+    "sha512": "3c53dde5353747c55488493aeaad0591884a5e0087873237e5d55f60b5e333e51766d31d7a72e6b57556ab17662be2c99d755212d87ff518c4c22a5a4d47322d",
+    "dest": "offline-repository/io/ktor/ktor-client-core-jvm/3.5.1",
+    "dest-filename": "ktor-client-core-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.4.3/ktor-client-core-3.4.3.module",
-    "sha512": "27b377b871b31bab536f49800a6dcb8037b1987de29dcb8d78b6c94b9bf434614b32aa27f1c6bf41b0912147613acf98e9423b26c8843848b4e3f63b392deddf",
-    "dest": "offline-repository/io/ktor/ktor-client-core/3.4.3",
-    "dest-filename": "ktor-client-core-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.5.1/ktor-client-core-3.5.1.module",
+    "sha512": "a711850df9153035566cd652e1060bfc3548d9754330bbbde899f3831e851165ac1c36ba5175a13d9da66838893ed931fe009b916b90ba5e7cc135038f62c6f6",
+    "dest": "offline-repository/io/ktor/ktor-client-core/3.5.1",
+    "dest-filename": "ktor-client-core-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.4.3/ktor-client-core-3.4.3.pom",
-    "sha512": "20b216074f7abceb9da86b856ae0a526e31208e0be1106eaa2a04671c04969c8255d7655f9f937b3d2befdcc4f2917fdd88b53779738ad9afef811b01db60a7c",
-    "dest": "offline-repository/io/ktor/ktor-client-core/3.4.3",
-    "dest-filename": "ktor-client-core-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.5.1/ktor-client-core-3.5.1.pom",
+    "sha512": "f8b225bb7a245853dab04972aa6cbbe02c89b307f22d5fb62a83cf48567fcc86f7e36ac8bbcf15a9b5bded81119769016766c4d289377f34bde5075f3f5315e4",
+    "dest": "offline-repository/io/ktor/ktor-client-core/3.5.1",
+    "dest-filename": "ktor-client-core-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.4.3/../../ktor-client-core-jvm/3.4.3/ktor-client-core-jvm-3.4.3.module",
-    "sha512": "e4aa4014db283c0bc799a88426acb516de61491f59b2f89c962e2c50ada2254fdb9d62fbc3cb622f7b50e347d5cc7d428b6a90d191b0df2ba3e196120b16fb07",
-    "dest": "offline-repository/io/ktor/ktor-client-core/3.4.3/../../ktor-client-core-jvm/3.4.3",
-    "dest-filename": "ktor-client-core-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-core/3.5.1/../../ktor-client-core-jvm/3.5.1/ktor-client-core-jvm-3.5.1.module",
+    "sha512": "e9b6cfc46f676e2ecb41e5bedbeaf73248787551e6a4afa54e1b5f2129b4552196417867323929e68ea4e8e85c960249c0bd568b03e91024a83837c6845fec6a",
+    "dest": "offline-repository/io/ktor/ktor-client-core/3.5.1/../../ktor-client-core-jvm/3.5.1",
+    "dest-filename": "ktor-client-core-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.4.3/ktor-client-websockets-jvm-3.4.3.jar",
-    "sha512": "e2e7bffd81132f2a6b16ba9b2a2d8c336febfdc8638aac4af3b06b0d79cff861a2cb20891d22689d3d8318a3c4bced21833f51d2efc383f59ac090c1dea8bd6b",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-client-websockets-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.5.1/ktor-client-websockets-jvm-3.5.1.jar",
+    "sha512": "4f29ab3a10a802be39b891f7503a01da6db2dfa6c7a41881512188b0b116aa25f2af3d73e64767079c099e913dd06e4a8d1050d937826846c94caea3caa4590d",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-client-websockets-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.4.3/ktor-client-websockets-jvm-3.4.3.module",
-    "sha512": "69e74df6386263f78cfc7ae64244977961fc3773c9b2aa5f3ed252586832b0fd5326324717ebd1a6b28369b1ad4b9cc4c2663eec53bd4eedb6e31a7f92f6c8ed",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-client-websockets-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.5.1/ktor-client-websockets-jvm-3.5.1.module",
+    "sha512": "c2f0c77f3e696fc457ee89fa0e1817ac85646e2dacd8d35740e215b98bb306e0aab64aeabc4f86fee1f338cc178690862b0c0ec80546a5b1ceb23c4b7e655329",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-client-websockets-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.4.3/ktor-client-websockets-jvm-3.4.3.pom",
-    "sha512": "6810ea6ae8c2cac7e7357392b067b7c414c0270a4fe0b5d0df4861ee25ba916ccf82df6a869d3b0f828c20e9143ccca68cf742b4a09559b36f63196ee399bdf1",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-client-websockets-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets-jvm/3.5.1/ktor-client-websockets-jvm-3.5.1.pom",
+    "sha512": "dbd7d81f583ac15ae5dc242a7c40161dc3ea4d7bc5ec7a0954a42176ab913343509aa24cc16f0659a57a36505246ecb370e5c0174b293fd19a923d737fb1e3e5",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-client-websockets-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.4.3/ktor-client-websockets-3.4.3.module",
-    "sha512": "8c807df8977e7b9da4bcc1a2ab569bb2f2207452331ddd98d01c6bc54cdb5b414539bdc7df3c9cc3f176b5680a6db2d490f91e9a250b905af978e6c19cea5a3f",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.4.3",
-    "dest-filename": "ktor-client-websockets-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.5.1/ktor-client-websockets-3.5.1.module",
+    "sha512": "072149e8482239500c0fc57a2b7cf7e1bdbbc452696338c07882030106a680979dbe8e0b5d0edab6dddc856df8db441011560764a762a53b2e990653e87246d7",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.5.1",
+    "dest-filename": "ktor-client-websockets-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.4.3/ktor-client-websockets-3.4.3.pom",
-    "sha512": "df1fa3d4cfec47dd348ec97c64068df6fb2565363f33b1e14b6816850aabbace3cb6a79ab277009b42bda16e50999e5b71400f88e66940519b44d0793b35bfe1",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.4.3",
-    "dest-filename": "ktor-client-websockets-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.5.1/ktor-client-websockets-3.5.1.pom",
+    "sha512": "b94caf928cdc41d8405d3279569f52284596f2d804ed2fa76dc74a52a62f6fad7afb3a9ffaca13dc6c968fd474ce84b9a2230751a530101664309507f39431f5",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.5.1",
+    "dest-filename": "ktor-client-websockets-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.4.3/../../ktor-client-websockets-jvm/3.4.3/ktor-client-websockets-jvm-3.4.3.module",
-    "sha512": "69e74df6386263f78cfc7ae64244977961fc3773c9b2aa5f3ed252586832b0fd5326324717ebd1a6b28369b1ad4b9cc4c2663eec53bd4eedb6e31a7f92f6c8ed",
-    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.4.3/../../ktor-client-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-client-websockets-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-client-websockets/3.5.1/../../ktor-client-websockets-jvm/3.5.1/ktor-client-websockets-jvm-3.5.1.module",
+    "sha512": "c2f0c77f3e696fc457ee89fa0e1817ac85646e2dacd8d35740e215b98bb306e0aab64aeabc4f86fee1f338cc178690862b0c0ec80546a5b1ceb23c4b7e655329",
+    "dest": "offline-repository/io/ktor/ktor-client-websockets/3.5.1/../../ktor-client-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-client-websockets-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.4.3/ktor-events-jvm-3.4.3.jar",
-    "sha512": "66ab81c528553b0d648951be011f470be8a73ba67dc8064f7e49438cf52c8d1a356148ac8a85929ae7cda8873c51a2b32e74b09268939ab544f6158e11dcac26",
-    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.4.3",
-    "dest-filename": "ktor-events-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.5.1/ktor-events-jvm-3.5.1.jar",
+    "sha512": "142a8ed22ab04b707b392f29435dd24a8f8d9ad2c5af07242367ac1db538ca767da5a67ebd4c678a1483ec0113b0c3821320334b1b26d4b0eac43aff2072ba27",
+    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.5.1",
+    "dest-filename": "ktor-events-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.4.3/ktor-events-jvm-3.4.3.module",
-    "sha512": "5f977f8547e5cd74cf25914096d9fe8795934bd1d2611c876c685c6a47befc4320987df45ceb858f3f6c8e2fe2adce522ea80ceda96a394503b682f844433280",
-    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.4.3",
-    "dest-filename": "ktor-events-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.5.1/ktor-events-jvm-3.5.1.module",
+    "sha512": "67fc8d9bc767a985978441a8c614879b9f7849ac62f7fa21ec2a10d5d5dc6f1eb5df1159bfa1d04cf7399b127d21016db09a0ad3fc311f490a690eee35883ab0",
+    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.5.1",
+    "dest-filename": "ktor-events-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.4.3/ktor-events-jvm-3.4.3.pom",
-    "sha512": "c4ce66c0657a46a66126298e607d15edeb172dcce8d52945d59fd3b67ff941c7c922d267b0ded3ac6b0a38bf8c566102f0f288d20c15acf4991cfa1ed0d3c8b9",
-    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.4.3",
-    "dest-filename": "ktor-events-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events-jvm/3.5.1/ktor-events-jvm-3.5.1.pom",
+    "sha512": "34d2fb8ff9e04d98faaeefdb66b8e6bef986a452963248bac68c982fd3fe9e914945e134a747f794e24af5fcb6f50264b8c1d5578626b0b1e0112627a8e2170e",
+    "dest": "offline-repository/io/ktor/ktor-events-jvm/3.5.1",
+    "dest-filename": "ktor-events-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.4.3/ktor-events-3.4.3.module",
-    "sha512": "6b4bd9494fc763890f59fddd47191c8254bc690cfbabf684c301eab4150d0e8bdc04fd4726846cda8fcc06ce660b7fd560b956b924e28d6293cce3741ac934e6",
-    "dest": "offline-repository/io/ktor/ktor-events/3.4.3",
-    "dest-filename": "ktor-events-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.5.1/ktor-events-3.5.1.module",
+    "sha512": "0211fa6b927990f48bb893263db3e89329bca2139566322a1de1f31551c3b954ae1da8a182ce2c072f081dcdc802f70c638985fbcd1718540c4f892243846775",
+    "dest": "offline-repository/io/ktor/ktor-events/3.5.1",
+    "dest-filename": "ktor-events-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.4.3/ktor-events-3.4.3.pom",
-    "sha512": "438e102693e26b6276966cc5b0ba963c345911cd30eb24b99cc1f14c55afda0267dd24b4cb9a2cafec927772b7e9330b5c3bbc5b1b20ac702dbe592d23d42a61",
-    "dest": "offline-repository/io/ktor/ktor-events/3.4.3",
-    "dest-filename": "ktor-events-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.5.1/ktor-events-3.5.1.pom",
+    "sha512": "cf61a0a5809cf93d6f8aca973d2b0e9c6b25530d9c458d8dce567e4e3754d736a271c703230844a675fd8bae751c04c2864e0f353bc8de81b2fb896c50318562",
+    "dest": "offline-repository/io/ktor/ktor-events/3.5.1",
+    "dest-filename": "ktor-events-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.4.3/../../ktor-events-jvm/3.4.3/ktor-events-jvm-3.4.3.module",
-    "sha512": "5f977f8547e5cd74cf25914096d9fe8795934bd1d2611c876c685c6a47befc4320987df45ceb858f3f6c8e2fe2adce522ea80ceda96a394503b682f844433280",
-    "dest": "offline-repository/io/ktor/ktor-events/3.4.3/../../ktor-events-jvm/3.4.3",
-    "dest-filename": "ktor-events-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-events/3.5.1/../../ktor-events-jvm/3.5.1/ktor-events-jvm-3.5.1.module",
+    "sha512": "67fc8d9bc767a985978441a8c614879b9f7849ac62f7fa21ec2a10d5d5dc6f1eb5df1159bfa1d04cf7399b127d21016db09a0ad3fc311f490a690eee35883ab0",
+    "dest": "offline-repository/io/ktor/ktor-events/3.5.1/../../ktor-events-jvm/3.5.1",
+    "dest-filename": "ktor-events-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.4.3/ktor-http-cio-jvm-3.4.3.jar",
-    "sha512": "c220b0535821872792efc3ebfadaa5ef45ec56629799d20d449f978eea19ba9aea3228dd1c64f58f2837a38e2873161efdc9d29b88f266edcef9816f090309d8",
-    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.4.3",
-    "dest-filename": "ktor-http-cio-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.5.1/ktor-http-cio-jvm-3.5.1.jar",
+    "sha512": "a45011ad7b01646c2f06ec694b70b7670e2e7d3652a2d5de7e718ff2001e2c5ececc04d13ae785ec45b96ec5cd9849095e3248e86ca3d026b00a7d897fed263c",
+    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.5.1",
+    "dest-filename": "ktor-http-cio-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.4.3/ktor-http-cio-jvm-3.4.3.module",
-    "sha512": "8785b6c10ac8ee455b01673bd18c67fdd21ef3be4d1ff7c4564024c712beed706398c715c663adf4b5151261c7cb089b919e67d90f54b01e0d232792f741ecfb",
-    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.4.3",
-    "dest-filename": "ktor-http-cio-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.5.1/ktor-http-cio-jvm-3.5.1.module",
+    "sha512": "5fd9fb2fb33d04f88c72c94c605e80b6c63fff58948d7366d4cb89b9f8506bb6d9fd98f6105af70dfb77c72382fa1867cd1e2d5a5f70bf91a71b4e0fb058900e",
+    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.5.1",
+    "dest-filename": "ktor-http-cio-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.4.3/ktor-http-cio-jvm-3.4.3.pom",
-    "sha512": "6527559ce25854808d09540f056567d4e870a19584a70ccfbefe1640c16c69bb5e32df8cbfbbc7e84fa09d3203ceaa6a91ceb48d09d35ac65e8f538cbd17f50c",
-    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.4.3",
-    "dest-filename": "ktor-http-cio-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio-jvm/3.5.1/ktor-http-cio-jvm-3.5.1.pom",
+    "sha512": "5378881780955281d1220ab3afc4913c46191a9e93eea4e971aed6f75ade292ef569eeb330c79de718dae6597a0bdce3f65df4496bc2c95e1857bb6148036316",
+    "dest": "offline-repository/io/ktor/ktor-http-cio-jvm/3.5.1",
+    "dest-filename": "ktor-http-cio-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.4.3/ktor-http-cio-3.4.3.module",
-    "sha512": "7f1aeebab944c3ffdb472bafb9f7f4e292093cc39c2d9745e2cdb0edb472fe6bbb489d5891ba4c9ecd2168ba0cf9850b51a3106ff2849a86121fdd06b69ec9cd",
-    "dest": "offline-repository/io/ktor/ktor-http-cio/3.4.3",
-    "dest-filename": "ktor-http-cio-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.5.1/ktor-http-cio-3.5.1.module",
+    "sha512": "eb9da1781db8667835167762af7938b185e67e4fd506046d9e0e4d4fd466f33866aeef4d666fdf84a1981ecf7eac5bf32735be04fc652d74c05f24544fb385da",
+    "dest": "offline-repository/io/ktor/ktor-http-cio/3.5.1",
+    "dest-filename": "ktor-http-cio-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.4.3/ktor-http-cio-3.4.3.pom",
-    "sha512": "02866f4564f9586696f9fff3240e602c0da328e5514199ec39e16214047674d67e2a4ee1ab3e1a9806f857170f8de8392f05e2c33e8ea7d6d965af9e724f4a4c",
-    "dest": "offline-repository/io/ktor/ktor-http-cio/3.4.3",
-    "dest-filename": "ktor-http-cio-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.5.1/ktor-http-cio-3.5.1.pom",
+    "sha512": "597c7c705e5c9e3e4527ed99cf55b65a50837b9802b03da7d1815da9b3936cde0df61ca7dd84bec8a782185b5f41e854a3eb5802185fe6e452a1020b453a1f95",
+    "dest": "offline-repository/io/ktor/ktor-http-cio/3.5.1",
+    "dest-filename": "ktor-http-cio-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.4.3/../../ktor-http-cio-jvm/3.4.3/ktor-http-cio-jvm-3.4.3.module",
-    "sha512": "8785b6c10ac8ee455b01673bd18c67fdd21ef3be4d1ff7c4564024c712beed706398c715c663adf4b5151261c7cb089b919e67d90f54b01e0d232792f741ecfb",
-    "dest": "offline-repository/io/ktor/ktor-http-cio/3.4.3/../../ktor-http-cio-jvm/3.4.3",
-    "dest-filename": "ktor-http-cio-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-cio/3.5.1/../../ktor-http-cio-jvm/3.5.1/ktor-http-cio-jvm-3.5.1.module",
+    "sha512": "5fd9fb2fb33d04f88c72c94c605e80b6c63fff58948d7366d4cb89b9f8506bb6d9fd98f6105af70dfb77c72382fa1867cd1e2d5a5f70bf91a71b4e0fb058900e",
+    "dest": "offline-repository/io/ktor/ktor-http-cio/3.5.1/../../ktor-http-cio-jvm/3.5.1",
+    "dest-filename": "ktor-http-cio-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.4.3/ktor-http-jvm-3.4.3.jar",
-    "sha512": "31f7269b139bc9552f8e8c5be351db2a6ad9920e43ec91f6512839f7c62b4ce3f92cc15721649ec77b693e3fa3cfcda27dcb216f36ce3c174f4c404073ff1095",
-    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.4.3",
-    "dest-filename": "ktor-http-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.5.1/ktor-http-jvm-3.5.1.jar",
+    "sha512": "09c45b6ab294c1afdf441efaa249a87f26404673b0a30b19b2d065d388a2ca84602f1b09aac185f6abe226a08428785c82993d3564739104507d1b4df459e8c9",
+    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.5.1",
+    "dest-filename": "ktor-http-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.4.3/ktor-http-jvm-3.4.3.module",
-    "sha512": "c56a59699b6fa145a03ab0bfdbb68649cd377211dc54546e07eb21ee89f7911a255f8473cd6592d448764653e0c9a79a84c0f2f1a8496a7c3e14f643d0bb81e5",
-    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.4.3",
-    "dest-filename": "ktor-http-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.5.1/ktor-http-jvm-3.5.1.module",
+    "sha512": "4e26bbb233fd61fca1168c8bb75da6050e8188fbf6435b6aa9b2d48ea9fe9f177591c43f7ee6e854b47cf7b4c1698a8ad42f1e6a63f4f8c9807f7e476df081dd",
+    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.5.1",
+    "dest-filename": "ktor-http-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.4.3/ktor-http-jvm-3.4.3.pom",
-    "sha512": "da1233355331dc96b21bcb2489e193c882a14f74187e95ecf30984637f282d49190f925707120ff8e962b1c9a7ad2f3627bfe5105e61c520da4ba75b0d46f50c",
-    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.4.3",
-    "dest-filename": "ktor-http-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http-jvm/3.5.1/ktor-http-jvm-3.5.1.pom",
+    "sha512": "5539c48377bf577c8fa53d8b18cb4ed38aa498adb988d53e45cccb3482843fba323d0fb3262ce404c462027828638e6799de0221a02b17cb97ad24a67ca8ee01",
+    "dest": "offline-repository/io/ktor/ktor-http-jvm/3.5.1",
+    "dest-filename": "ktor-http-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.4.3/ktor-http-3.4.3.module",
-    "sha512": "731b4d1bfe5a9ea047abc67dc0abbe38f18429f8b11a61d65a1abb87a772a9aee788b7313aa16a5a39adb8e295ac4050b91245a228c936086b90d51eb4321099",
-    "dest": "offline-repository/io/ktor/ktor-http/3.4.3",
-    "dest-filename": "ktor-http-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.5.1/ktor-http-3.5.1.module",
+    "sha512": "065a90b2c2317c8a2068b454c7ea28166915f241d9fe1184e94db7160c95162a3aae631e2c16417f84c6dbccc04658b6ed5f46a919f0f5adbbf4a908fd5880fe",
+    "dest": "offline-repository/io/ktor/ktor-http/3.5.1",
+    "dest-filename": "ktor-http-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.4.3/ktor-http-3.4.3.pom",
-    "sha512": "749e3c0d1e979cba78e4a7a5d208ace426fc2f50ee55522c288dc3201bd7859a919adbac95e8cd6ce6a00059871549a794c3c9f2eb146665704ad693f69d4f50",
-    "dest": "offline-repository/io/ktor/ktor-http/3.4.3",
-    "dest-filename": "ktor-http-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.5.1/ktor-http-3.5.1.pom",
+    "sha512": "328d42f6e149ff38b467939ee1234abccd3b9794cfcbf3eea9ecc93c9a2d0075c872518440a899dbf26af4c1e35872f664ace162776127610aa5d6f7de7b5500",
+    "dest": "offline-repository/io/ktor/ktor-http/3.5.1",
+    "dest-filename": "ktor-http-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.4.3/../../ktor-http-jvm/3.4.3/ktor-http-jvm-3.4.3.module",
-    "sha512": "c56a59699b6fa145a03ab0bfdbb68649cd377211dc54546e07eb21ee89f7911a255f8473cd6592d448764653e0c9a79a84c0f2f1a8496a7c3e14f643d0bb81e5",
-    "dest": "offline-repository/io/ktor/ktor-http/3.4.3/../../ktor-http-jvm/3.4.3",
-    "dest-filename": "ktor-http-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-http/3.5.1/../../ktor-http-jvm/3.5.1/ktor-http-jvm-3.5.1.module",
+    "sha512": "4e26bbb233fd61fca1168c8bb75da6050e8188fbf6435b6aa9b2d48ea9fe9f177591c43f7ee6e854b47cf7b4c1698a8ad42f1e6a63f4f8c9807f7e476df081dd",
+    "dest": "offline-repository/io/ktor/ktor-http/3.5.1/../../ktor-http-jvm/3.5.1",
+    "dest-filename": "ktor-http-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.4.3/ktor-io-jvm-3.4.3.jar",
-    "sha512": "04774eb7b227b3cbf5e48945a87a8014d68704941c6ec091ffcd0e79f993ea0a8ad84085005fed8f05204e94abaf9977edfddd34de1bf23cb02ff208ab987946",
-    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.4.3",
-    "dest-filename": "ktor-io-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.5.1/ktor-io-jvm-3.5.1.jar",
+    "sha512": "3a8c4fc510abc6d125e2a522c8b89bd8ef7b48e5ae6e48da3c14f82f289bd8f5614dd9832e961d32c1e005719fb77cd3fd705fc07cb1a8be45cc95f4770be8ca",
+    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.5.1",
+    "dest-filename": "ktor-io-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.4.3/ktor-io-jvm-3.4.3.module",
-    "sha512": "2c9d40cea6aa57bfe336d477cf6045bc1f379919eeb8946925aa92d01f263e940b0fe56db99cfd658443395f55956ba97eafcb4ae97766ca55048d3cd35aa5f8",
-    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.4.3",
-    "dest-filename": "ktor-io-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.5.1/ktor-io-jvm-3.5.1.module",
+    "sha512": "9110d7ab56a80e7b28583f743553be4903a02c30d1340e14bee274f82e698be8ae9823ef85423c5637f8e5885ac20b5882edfdf0747e311f3427bfdcddd1d530",
+    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.5.1",
+    "dest-filename": "ktor-io-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.4.3/ktor-io-jvm-3.4.3.pom",
-    "sha512": "e397e422885fcbc57f17684d794c20b8e9191c194bb3be826a443b4982e0c2456353580abbd38a8867b6c0cef5c82fde63f32f9a3c60a4b9a47dc55e1488743b",
-    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.4.3",
-    "dest-filename": "ktor-io-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io-jvm/3.5.1/ktor-io-jvm-3.5.1.pom",
+    "sha512": "5959f2a50e779380d03b20f79b21b1e29c838e530c6012e5be30dbd7c9735b6caa4f6974a9bbb5a69b332a39a1cfb22d941d8aa992042769d856a6e6cec3c391",
+    "dest": "offline-repository/io/ktor/ktor-io-jvm/3.5.1",
+    "dest-filename": "ktor-io-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.4.3/ktor-io-3.4.3.module",
-    "sha512": "93c0c31c9f7e76b16f8dd6d856490e47bad196a942a997177ea814aa21bcf2a8adab32329f8ff796cbe6f038ea21bef925f1942aca6506d94b0dd32a234f617c",
-    "dest": "offline-repository/io/ktor/ktor-io/3.4.3",
-    "dest-filename": "ktor-io-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.5.1/ktor-io-3.5.1.module",
+    "sha512": "3f882fd630ba1912d566d6f4db45bf72af0228d2e13df02f749f34a2089633a8be1b185bddb9d851926579d7f07664a1b3dc16e2b35ed0558680be09115c3db0",
+    "dest": "offline-repository/io/ktor/ktor-io/3.5.1",
+    "dest-filename": "ktor-io-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.4.3/ktor-io-3.4.3.pom",
-    "sha512": "654e2c97ac7906c5788c5ffe73952869cfc7d4d30602a72c314fbf498479f543429e2184c868b083c9e87558c882b613a0cfbe65b208d86659ebc2e3f7addb6b",
-    "dest": "offline-repository/io/ktor/ktor-io/3.4.3",
-    "dest-filename": "ktor-io-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.5.1/ktor-io-3.5.1.pom",
+    "sha512": "37a05a29ca7df472c64cee19f53afb19c14e9f2058c8a31104c7a1875b2467e43114f1fc4f090fd3fa27acd58d57b256f65089dab981bd93be985d16c5f95ee2",
+    "dest": "offline-repository/io/ktor/ktor-io/3.5.1",
+    "dest-filename": "ktor-io-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.4.3/../../ktor-io-jvm/3.4.3/ktor-io-jvm-3.4.3.module",
-    "sha512": "2c9d40cea6aa57bfe336d477cf6045bc1f379919eeb8946925aa92d01f263e940b0fe56db99cfd658443395f55956ba97eafcb4ae97766ca55048d3cd35aa5f8",
-    "dest": "offline-repository/io/ktor/ktor-io/3.4.3/../../ktor-io-jvm/3.4.3",
-    "dest-filename": "ktor-io-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-io/3.5.1/../../ktor-io-jvm/3.5.1/ktor-io-jvm-3.5.1.module",
+    "sha512": "9110d7ab56a80e7b28583f743553be4903a02c30d1340e14bee274f82e698be8ae9823ef85423c5637f8e5885ac20b5882edfdf0747e311f3427bfdcddd1d530",
+    "dest": "offline-repository/io/ktor/ktor-io/3.5.1/../../ktor-io-jvm/3.5.1",
+    "dest-filename": "ktor-io-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.4.3/ktor-network-jvm-3.4.3.jar",
-    "sha512": "11800c1a399af6e0aff597e85673ccc13aab8a38e42809947400a002b2db8daa6b02d51e2511ecc0f807130468bf55537852bffc9eb109fa2d6b992902dd5c6e",
-    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.4.3",
-    "dest-filename": "ktor-network-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.5.1/ktor-network-jvm-3.5.1.jar",
+    "sha512": "c757d3321ac91351ee98cc8421a87535924a96de6cdecb58405a4397a6790b8a372c0dc906b713831ba6b6f088317570109f48aa30ff430b51f73d07b9b666d5",
+    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.5.1",
+    "dest-filename": "ktor-network-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.4.3/ktor-network-jvm-3.4.3.module",
-    "sha512": "57aa7a4f496291e241980a75e09b8e33338dc128b5845ac1fbb5a2a448d1268940d7886fd3917b2fee4642818dff92954dcbb1e1839c5eb0b45eb1204ef47894",
-    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.4.3",
-    "dest-filename": "ktor-network-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.5.1/ktor-network-jvm-3.5.1.module",
+    "sha512": "d50b3bea2b4e90ec9b796be8a5752140da25376f49f01c8588c683a2a4157e68d8bd44496ca1316e24abd8d3d23cb0b1687523c81c13a735adc2535bd686484d",
+    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.5.1",
+    "dest-filename": "ktor-network-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.4.3/ktor-network-jvm-3.4.3.pom",
-    "sha512": "5813104acad918a5d25abec524abbed961de0cd41b7df891346ba8420e61419492516ae6d54d95d8d5a27db99908575ad1bf9d8026200090fc5445543bfd45f4",
-    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.4.3",
-    "dest-filename": "ktor-network-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-jvm/3.5.1/ktor-network-jvm-3.5.1.pom",
+    "sha512": "fd85a6f4c611b6ffe6c7620e7762838277199de89d9634e68e6d152df23ad01d95f3d79d229fa296da0c88d3ba987de3cf280e15e0ed1ab47c9988a4c7be6428",
+    "dest": "offline-repository/io/ktor/ktor-network-jvm/3.5.1",
+    "dest-filename": "ktor-network-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.4.3/ktor-network-tls-jvm-3.4.3.jar",
-    "sha512": "8f22d8885cfb23c76c15e56aedf671a434355f3eb20b81ae5aa8238b9b208c9e0932b3b3be3005d884538ac4aea52a4bdbc81481bd208230d2b998c31e623791",
-    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.4.3",
-    "dest-filename": "ktor-network-tls-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.5.1/ktor-network-tls-jvm-3.5.1.jar",
+    "sha512": "67eb4cc6a6247078ce4b382e833f2060b11080ff166d83a065c258438ccde6b414adda5dc11e23c3d449bb7a7ac698b22c70efb4c4664a30ce2e893a7a11f6b7",
+    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.5.1",
+    "dest-filename": "ktor-network-tls-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.4.3/ktor-network-tls-jvm-3.4.3.module",
-    "sha512": "c033a0297c01e56b224f844099421ee8fe7252e320a49178849afac26355aabf46d4ea957c7f46c428f2a531617b3b149d381d4d5dbe9f4dad3487fa0d4ae347",
-    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.4.3",
-    "dest-filename": "ktor-network-tls-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.5.1/ktor-network-tls-jvm-3.5.1.module",
+    "sha512": "2898b51b7dd4c613666002b213d513ef31dfdff86ad37150ccdd7f8dd85a1f1a33a8efeb3b100f71769e5d1bc875647497ae4a25f8bb37e157024fd0c0fa78e9",
+    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.5.1",
+    "dest-filename": "ktor-network-tls-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.4.3/ktor-network-tls-jvm-3.4.3.pom",
-    "sha512": "3f7957083bf2ab78850dddd0b2c704d0f7aa9046bafee5ea7736b91287af2917f3a99f72cd439afce2f44802ed5746dadc5e828f30e1d8020ec9cab3bce6495c",
-    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.4.3",
-    "dest-filename": "ktor-network-tls-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls-jvm/3.5.1/ktor-network-tls-jvm-3.5.1.pom",
+    "sha512": "ff381e51c91119178ceda084afb07c339db7fbe674f5d0aa369285b0fc9155eb336a8ea4e843f62dce998d7ea7dd7862b8b53e852ffc558aa3b500575291a831",
+    "dest": "offline-repository/io/ktor/ktor-network-tls-jvm/3.5.1",
+    "dest-filename": "ktor-network-tls-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.4.3/ktor-network-tls-3.4.3.module",
-    "sha512": "d44d9c29199fc92b91714798d4133746c5fddc7add7fc32f42b9e63e7f839f2813e9c970b56ea6adca1ffd3cb1c16819f6f27b1742ade8584556f08943ef225a",
-    "dest": "offline-repository/io/ktor/ktor-network-tls/3.4.3",
-    "dest-filename": "ktor-network-tls-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.5.1/ktor-network-tls-3.5.1.module",
+    "sha512": "904a7c53bbb467262be4600b0c3bcdc0213cc94fbe7fe4ffe5088e7af8725cb2e9ab6936a47f2d3721d3ea447d9db812ca2fc5f59d7b81a09dd9a18ba27a7506",
+    "dest": "offline-repository/io/ktor/ktor-network-tls/3.5.1",
+    "dest-filename": "ktor-network-tls-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.4.3/ktor-network-tls-3.4.3.pom",
-    "sha512": "ea568633daa45bc63b9785d043613d545cb89d43c9bdd8b59a91a3dda6fae3600a0d47f89a0ab5db708a34bbe4280a997ade1ad372f7a7e3f6b3c86f58ecd577",
-    "dest": "offline-repository/io/ktor/ktor-network-tls/3.4.3",
-    "dest-filename": "ktor-network-tls-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.5.1/ktor-network-tls-3.5.1.pom",
+    "sha512": "936ec00ca1a7d0bc6cac5e5f24a88a6e81dbe948864adeb748b827a7ab47fa5b98eec1ed6e4dcfda88aa5fac275d010a1dbc3f23897ee4917a94a03bb6595e77",
+    "dest": "offline-repository/io/ktor/ktor-network-tls/3.5.1",
+    "dest-filename": "ktor-network-tls-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.4.3/../../ktor-network-tls-jvm/3.4.3/ktor-network-tls-jvm-3.4.3.module",
-    "sha512": "c033a0297c01e56b224f844099421ee8fe7252e320a49178849afac26355aabf46d4ea957c7f46c428f2a531617b3b149d381d4d5dbe9f4dad3487fa0d4ae347",
-    "dest": "offline-repository/io/ktor/ktor-network-tls/3.4.3/../../ktor-network-tls-jvm/3.4.3",
-    "dest-filename": "ktor-network-tls-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network-tls/3.5.1/../../ktor-network-tls-jvm/3.5.1/ktor-network-tls-jvm-3.5.1.module",
+    "sha512": "2898b51b7dd4c613666002b213d513ef31dfdff86ad37150ccdd7f8dd85a1f1a33a8efeb3b100f71769e5d1bc875647497ae4a25f8bb37e157024fd0c0fa78e9",
+    "dest": "offline-repository/io/ktor/ktor-network-tls/3.5.1/../../ktor-network-tls-jvm/3.5.1",
+    "dest-filename": "ktor-network-tls-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.4.3/ktor-network-3.4.3.module",
-    "sha512": "959e17772952a4e826abc4c73e6cecd24acd53be2e57c857f9aceb275276fb6497a521176223b45b25bb103ae269eb8569f454c6014243a20eedce565a7cec96",
-    "dest": "offline-repository/io/ktor/ktor-network/3.4.3",
-    "dest-filename": "ktor-network-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.5.1/ktor-network-3.5.1.module",
+    "sha512": "35393d7448ff8fa0c1284e5f5383f4172bbc069b74690513c5adfb9373c8723dcb39f6a92c8720fb602d16310c518064179c9170e9686ad0c1fd3a0aec1497eb",
+    "dest": "offline-repository/io/ktor/ktor-network/3.5.1",
+    "dest-filename": "ktor-network-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.4.3/ktor-network-3.4.3.pom",
-    "sha512": "1e80df1e808ec24c66a4fd1aa03740538872694c1af5c6d2ac05a4e83905da10c769e48277c83d51a4cf796a68ae12024852c6ef279ba9d29d4dd8243f1dd78e",
-    "dest": "offline-repository/io/ktor/ktor-network/3.4.3",
-    "dest-filename": "ktor-network-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.5.1/ktor-network-3.5.1.pom",
+    "sha512": "ec89b1b19e8ecb28d833bd884b497a8ff9e00770d6d80757d110aa6887b9411ddd976c9d5b7b54bdc790e2d6607ccd26b661a01eb95af0a330e281f62ff636c2",
+    "dest": "offline-repository/io/ktor/ktor-network/3.5.1",
+    "dest-filename": "ktor-network-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.4.3/../../ktor-network-jvm/3.4.3/ktor-network-jvm-3.4.3.module",
-    "sha512": "57aa7a4f496291e241980a75e09b8e33338dc128b5845ac1fbb5a2a448d1268940d7886fd3917b2fee4642818dff92954dcbb1e1839c5eb0b45eb1204ef47894",
-    "dest": "offline-repository/io/ktor/ktor-network/3.4.3/../../ktor-network-jvm/3.4.3",
-    "dest-filename": "ktor-network-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-network/3.5.1/../../ktor-network-jvm/3.5.1/ktor-network-jvm-3.5.1.module",
+    "sha512": "d50b3bea2b4e90ec9b796be8a5752140da25376f49f01c8588c683a2a4157e68d8bd44496ca1316e24abd8d3d23cb0b1687523c81c13a735adc2535bd686484d",
+    "dest": "offline-repository/io/ktor/ktor-network/3.5.1/../../ktor-network-jvm/3.5.1",
+    "dest-filename": "ktor-network-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.4.3/ktor-serialization-jvm-3.4.3.jar",
-    "sha512": "b387b57f5786c642532c8ee1187bdb1cfff26f869244729d29c12b37bb12ad3fb9af9706d87576bfda03892ba4751aacbc4f6b028d215b9b8ee1155994191e5b",
-    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.5.1/ktor-serialization-jvm-3.5.1.jar",
+    "sha512": "89ad540874a89b4fc55b4aa90aeb9267047044b9e02631e1f7e5fbb7bb45d1995d935c9e9c6dd26ad89f5d38a2627cfe81bf85d2cccda238d6bad1fcc2be1533",
+    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.4.3/ktor-serialization-jvm-3.4.3.module",
-    "sha512": "bbff27530abc297cafcf9526405ac66490fb61bbce92048ed76377e5d632d92a001e8ad7ecca0283c7ee97a4cf4533367f64e674f2f645da4fbfa4518f2cf156",
-    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.5.1/ktor-serialization-jvm-3.5.1.module",
+    "sha512": "a48b58eedc9a2f29c6d4e465ae3eca1618c5f86f553e7d5541c0a82d544836f45a8d6b7840449c8ea574d00e40a578da5512b2e0a1f0309aa9a8c97d3b7a267b",
+    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.4.3/ktor-serialization-jvm-3.4.3.pom",
-    "sha512": "07f2634d2a1af2ea85d3a11019bef52af3ab908c1423941300da424f7afa0d21fe0390cdc284730a52c9cd1ada1702530639600e94b06fea204b96e877762a92",
-    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-jvm/3.5.1/ktor-serialization-jvm-3.5.1.pom",
+    "sha512": "cd112f222a36dce2d0c444e6c59cb61ce184dbbe90b2b971d25ff074394704c4682e403b3ea5c7a5b3a20d3ad21502c3d608bf793c4232f4d652a119567b00d5",
+    "dest": "offline-repository/io/ktor/ktor-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3/ktor-serialization-kotlinx-json-jvm-3.4.3.jar",
-    "sha512": "2b5307c1b86b4fd0e24586201511b5cc7f8fd8d27b51c6e90dbd9aa699a04032320362ae98f083f1c93a1461073111bcf1e6cb8ee4986c5f8770b864573fb793",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1/ktor-serialization-kotlinx-json-jvm-3.5.1.jar",
+    "sha512": "bb103a972b596039cc1cd808fd3aa02005dc29f7e490306588760d94ee67f8ff36b6901560ed18a2d3a1f17279d3d64659d6305b41154a6cded983cacd549a2f",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3/ktor-serialization-kotlinx-json-jvm-3.4.3.module",
-    "sha512": "c6d516f3b71fc882bb92e3e06f6d81e5a5bdd13335c32a91ebfbf1374fbf6f5fd0b7c4d3587326b2e19419dde88e3508e26203fdebdd0a328e639a3b2e07bd6c",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1/ktor-serialization-kotlinx-json-jvm-3.5.1.module",
+    "sha512": "a03312a09f6c65093e16bb61e6dcf86827699fab130ad63768486e1f49557e43182c7c80cd746dde720f1419ab978e81208d18c547e7f82c96e46d2cd1078641",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3/ktor-serialization-kotlinx-json-jvm-3.4.3.pom",
-    "sha512": "e996493afb847b7bba218e36e9013ab9de87561537d162e5e924d5dbb92821ac858b27a55d94424ff48cdceab3aeb6055a790657d10b9f2affa917d259360dad",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1/ktor-serialization-kotlinx-json-jvm-3.5.1.pom",
+    "sha512": "110b69a7daf6d5d920d6b47de88d625ca0260e3f85fc36c346621934d9aefcd3e638d90d4a7d122741f8753bbd37172c16fb204bc84028554226f34dfd536715",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.4.3/ktor-serialization-kotlinx-json-3.4.3.module",
-    "sha512": "89ed17a4b95005041a35c1e9eca48702e4087899207fcc22ee70c2884ef5d7a3c0103b9a3333a030f0a5adfde6658a07b02546786d40b5d41e665ac9f593a242",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.5.1/ktor-serialization-kotlinx-json-3.5.1.module",
+    "sha512": "c834072bb911061dd71969ca08032198788439fc9816c428ac3d444b71265168c722af33afc441e2a37932db5a6d9ea977ca0575a404b6319e5ebf4f9faa23b8",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.4.3/ktor-serialization-kotlinx-json-3.4.3.pom",
-    "sha512": "3c46b38423be6e5d4ff3c6cd889e0e4bb27fab96a4ec08d8e49ff1e201216a258edb73717f51db219a1c04a09dff8a6a644baff74f2e6d82f46354d1081e9a1e",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.5.1/ktor-serialization-kotlinx-json-3.5.1.pom",
+    "sha512": "93f5206b8e1c48994eab50d985c55997bee22ba9af002886eeca6e1f82f043521ff90898f2b32ffdbef39efde7d629a0f69960464f838af3d42fbecb203beaad",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.4.3/../../ktor-serialization-kotlinx-json-jvm/3.4.3/ktor-serialization-kotlinx-json-jvm-3.4.3.module",
-    "sha512": "c6d516f3b71fc882bb92e3e06f6d81e5a5bdd13335c32a91ebfbf1374fbf6f5fd0b7c4d3587326b2e19419dde88e3508e26203fdebdd0a328e639a3b2e07bd6c",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.4.3/../../ktor-serialization-kotlinx-json-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-json/3.5.1/../../ktor-serialization-kotlinx-json-jvm/3.5.1/ktor-serialization-kotlinx-json-jvm-3.5.1.module",
+    "sha512": "a03312a09f6c65093e16bb61e6dcf86827699fab130ad63768486e1f49557e43182c7c80cd746dde720f1419ab978e81208d18c547e7f82c96e46d2cd1078641",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-json/3.5.1/../../ktor-serialization-kotlinx-json-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-json-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3/ktor-serialization-kotlinx-jvm-3.4.3.jar",
-    "sha512": "60fe7dcd14a92a8402e0e6fd027face4379d9cd22751efcfdb8d7098d38e189ea0536f57c1aaa50c36817fc111486053080760897dcf47f8447740c1a815d6e6",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1/ktor-serialization-kotlinx-jvm-3.5.1.jar",
+    "sha512": "6bcc8269c3b9eb47b7f068687a21840afe78fd3fd49c6bd59e3f96900f9bd952e2ae620582413b6d454cf09346a4ef15dcd20613dd33a94c33c7080070762d1d",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3/ktor-serialization-kotlinx-jvm-3.4.3.module",
-    "sha512": "53b2e4e77177d5af25c9a3b6319770d99bfd89bc305270c934f5ccd21b46a610446a850ee0846bb2e8352f3c7865f37010248bc1627c119dc62c25722eaf8878",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1/ktor-serialization-kotlinx-jvm-3.5.1.module",
+    "sha512": "93dcdfc5ef2cdf8a9c74723de32a108246124077e2ece96a9d54cf908928258f4b65b2905e63f20f26730e8a9807d3b6cc3a5bbc188e232a2bada9abdb9ab8c8",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3/ktor-serialization-kotlinx-jvm-3.4.3.pom",
-    "sha512": "87332e9b3a08a81d9c85a2b7c342b3f9780577d4f13ad1e0b1ae945727e881308c332240eed57edaccf4f1281fac9bb65603d580105d571b898949a89e8f8c0d",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1/ktor-serialization-kotlinx-jvm-3.5.1.pom",
+    "sha512": "a2cdc7d86653c6e5065860993e778213c14d25a71702493829e5b123de1620f8abd25eb99408b6024583a3bb7f7464622e7a4661c73694caa3e2808d92c10ed5",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.4.3/ktor-serialization-kotlinx-3.4.3.module",
-    "sha512": "62efc453b7b0db0a2791e0128d6a007dceed509c115a9b55f3437ff651e2e80db016a0d9faa04baa562b972475ccd4d2d29998df4a854f935ed91d4f1ed13871",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.5.1/ktor-serialization-kotlinx-3.5.1.module",
+    "sha512": "9fb70b4712179a760c506cf2f058039151a036dbd79cffdaac9f9af85d221e05f83f9c30cd697cd0b7330b8563ddf6f222d1bee56707042726f5b1a57b24df51",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.4.3/ktor-serialization-kotlinx-3.4.3.pom",
-    "sha512": "ca99cbf4e0eed0656721e72be259ebc765a0eaeb5496d3d5acde81096cbee8b91059c12f83db7521ce315737f73c6a0139ec076894625cb4d65958f026662b69",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.5.1/ktor-serialization-kotlinx-3.5.1.pom",
+    "sha512": "e36bafdec714d831b980bb68fb654774c614cc045627b4dc527e560a637f90372423db850a6b5a2cd00a6fea47572c8ef348931c6600427c3c7da76a151adf67",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.4.3/../../ktor-serialization-kotlinx-jvm/3.4.3/ktor-serialization-kotlinx-jvm-3.4.3.module",
-    "sha512": "53b2e4e77177d5af25c9a3b6319770d99bfd89bc305270c934f5ccd21b46a610446a850ee0846bb2e8352f3c7865f37010248bc1627c119dc62c25722eaf8878",
-    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.4.3/../../ktor-serialization-kotlinx-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-kotlinx-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization-kotlinx/3.5.1/../../ktor-serialization-kotlinx-jvm/3.5.1/ktor-serialization-kotlinx-jvm-3.5.1.module",
+    "sha512": "93dcdfc5ef2cdf8a9c74723de32a108246124077e2ece96a9d54cf908928258f4b65b2905e63f20f26730e8a9807d3b6cc3a5bbc188e232a2bada9abdb9ab8c8",
+    "dest": "offline-repository/io/ktor/ktor-serialization-kotlinx/3.5.1/../../ktor-serialization-kotlinx-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-kotlinx-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.4.3/ktor-serialization-3.4.3.module",
-    "sha512": "b3b8f359c28714a5f7add81053dcf2fb5dca1081ecbba0d88247fd6c46fbd76bb062beab481bcb95356972bd9d1560261190468e9c15b443567e2f258be3cdfe",
-    "dest": "offline-repository/io/ktor/ktor-serialization/3.4.3",
-    "dest-filename": "ktor-serialization-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.5.1/ktor-serialization-3.5.1.module",
+    "sha512": "9fa2f0d63e6f201082710a40e97e065d5b13b90944a6283bbad6b9acaebe07d97b43af0a35a1b59da16557470456e0c10a91010a134e7bb04ba0fdf4e1d54625",
+    "dest": "offline-repository/io/ktor/ktor-serialization/3.5.1",
+    "dest-filename": "ktor-serialization-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.4.3/ktor-serialization-3.4.3.pom",
-    "sha512": "da33e4e600d805936041e2ea200499fb4e1ed7d10a71aa9e514f7e95ba1400f88a4b5984cb32ebb89520c4e7bba450157d0e1fb84c2e7e7c29c389b7e4a9c872",
-    "dest": "offline-repository/io/ktor/ktor-serialization/3.4.3",
-    "dest-filename": "ktor-serialization-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.5.1/ktor-serialization-3.5.1.pom",
+    "sha512": "e19471936cf007ad60913f3543676cf6b4a0f0f1231763276c622ee0e512b19421d59568b2c1df0d175f15b3ea7ab005f32d4f77bb894d97eed5ac2238e00259",
+    "dest": "offline-repository/io/ktor/ktor-serialization/3.5.1",
+    "dest-filename": "ktor-serialization-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.4.3/../../ktor-serialization-jvm/3.4.3/ktor-serialization-jvm-3.4.3.module",
-    "sha512": "bbff27530abc297cafcf9526405ac66490fb61bbce92048ed76377e5d632d92a001e8ad7ecca0283c7ee97a4cf4533367f64e674f2f645da4fbfa4518f2cf156",
-    "dest": "offline-repository/io/ktor/ktor-serialization/3.4.3/../../ktor-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-serialization-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-serialization/3.5.1/../../ktor-serialization-jvm/3.5.1/ktor-serialization-jvm-3.5.1.module",
+    "sha512": "a48b58eedc9a2f29c6d4e465ae3eca1618c5f86f553e7d5541c0a82d544836f45a8d6b7840449c8ea574d00e40a578da5512b2e0a1f0309aa9a8c97d3b7a267b",
+    "dest": "offline-repository/io/ktor/ktor-serialization/3.5.1/../../ktor-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-serialization-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.4.3/ktor-sse-jvm-3.4.3.jar",
-    "sha512": "a6f7e938472da6c53b34414636fc587a3bed6390e58fdf0005bbf39512887d5a23a758f82bf74a16a9a9244e4c028062a9f1021b7dc9a138b83f70b481fb439d",
-    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.4.3",
-    "dest-filename": "ktor-sse-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.5.1/ktor-sse-jvm-3.5.1.jar",
+    "sha512": "ea3558905e7d111b1a3241b25d1a2d7f8f967a3828adcfb939174c8f7d6883d50910d876813ba65aeaf3ebcc41add263bbc970780fc54ab0f03cf4410847c582",
+    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.5.1",
+    "dest-filename": "ktor-sse-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.4.3/ktor-sse-jvm-3.4.3.module",
-    "sha512": "0268962c22cc49320464babf9b3ee1e137d96b47df708177646e5836ae631f33a274c010211903df047c5c310298e97311cf386ac0ea96d05d8babf7e3795f4a",
-    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.4.3",
-    "dest-filename": "ktor-sse-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.5.1/ktor-sse-jvm-3.5.1.module",
+    "sha512": "79a5a3e047440abbf21bbfd16f42d77c6a1ac166b3fbca46d3cc5328e2a3e6d0e1663b5f86678945af1986116e9d88598e387f6627621fd6ba25059e35581167",
+    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.5.1",
+    "dest-filename": "ktor-sse-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.4.3/ktor-sse-jvm-3.4.3.pom",
-    "sha512": "b6470e22830fd041f3a8d99a590e31cce18a3d01d675b045fd8513162d4db04c7decca4ede8faa69db5f6f23ed0c27846e17f7fbad6f106502c41f118a39cf2d",
-    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.4.3",
-    "dest-filename": "ktor-sse-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse-jvm/3.5.1/ktor-sse-jvm-3.5.1.pom",
+    "sha512": "a96a4a13bee080cdefadf17704fb9ea87443d684e86f3100bfa53f18ef24898a26f1ef3c605014f8bc81c716f3122f2fc24c7ce2c193efc26a275d3f45a6d070",
+    "dest": "offline-repository/io/ktor/ktor-sse-jvm/3.5.1",
+    "dest-filename": "ktor-sse-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.4.3/ktor-sse-3.4.3.module",
-    "sha512": "7c7c42077cf2fa0085a88e113b666e5dd64431247c941cb29b27b969535307a74f15241b3b765daa1308e75eb85254116f8e87a202ecbed7418229eb9034ca49",
-    "dest": "offline-repository/io/ktor/ktor-sse/3.4.3",
-    "dest-filename": "ktor-sse-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.5.1/ktor-sse-3.5.1.module",
+    "sha512": "40bba5d1bbb5f66cb74f7fc256b612f373e16c1d501f556a08e8a5a059f0acee52a3cd4256bfd7578de63ddfe5fda626d752c5a21dbf3e3f3c3243035c4e24f8",
+    "dest": "offline-repository/io/ktor/ktor-sse/3.5.1",
+    "dest-filename": "ktor-sse-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.4.3/ktor-sse-3.4.3.pom",
-    "sha512": "3e014824a4b8f5d4f461e31b464cbbe9ebecdee7c89b65249f732e89de0ccd2facadf5bc28395d895eaf0c2383401ec338bba0868920bca8cca68ccfb5fc90bb",
-    "dest": "offline-repository/io/ktor/ktor-sse/3.4.3",
-    "dest-filename": "ktor-sse-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.5.1/ktor-sse-3.5.1.pom",
+    "sha512": "724670a9dfed5e1250edb33d19a94ed2fe7e57a6079daa758d9015338d484c7de7994910ae6043eaee79ec70de4b396f016857b68cc25824f09ee7dfec2e5d27",
+    "dest": "offline-repository/io/ktor/ktor-sse/3.5.1",
+    "dest-filename": "ktor-sse-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.4.3/../../ktor-sse-jvm/3.4.3/ktor-sse-jvm-3.4.3.module",
-    "sha512": "0268962c22cc49320464babf9b3ee1e137d96b47df708177646e5836ae631f33a274c010211903df047c5c310298e97311cf386ac0ea96d05d8babf7e3795f4a",
-    "dest": "offline-repository/io/ktor/ktor-sse/3.4.3/../../ktor-sse-jvm/3.4.3",
-    "dest-filename": "ktor-sse-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-sse/3.5.1/../../ktor-sse-jvm/3.5.1/ktor-sse-jvm-3.5.1.module",
+    "sha512": "79a5a3e047440abbf21bbfd16f42d77c6a1ac166b3fbca46d3cc5328e2a3e6d0e1663b5f86678945af1986116e9d88598e387f6627621fd6ba25059e35581167",
+    "dest": "offline-repository/io/ktor/ktor-sse/3.5.1/../../ktor-sse-jvm/3.5.1",
+    "dest-filename": "ktor-sse-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.4.3/ktor-utils-jvm-3.4.3.jar",
-    "sha512": "18a6bd6a16b32d45c694b08f1c2793aa91411841e9711ebb8fded7ec81901859bdfeed2a20e90fd6a166014b3673fd44a7eb643fcd137245451a8b94dc8770a9",
-    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.4.3",
-    "dest-filename": "ktor-utils-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.5.1/ktor-utils-jvm-3.5.1.jar",
+    "sha512": "f3fa55a696804912f1f961c8e56cffaf0e069a79219944a7a8590a6ea128793e6a8d820283bf63b3296454cb475043e9d91205b1c08ef901910d4230314b7470",
+    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.5.1",
+    "dest-filename": "ktor-utils-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.4.3/ktor-utils-jvm-3.4.3.module",
-    "sha512": "97f166804c56ec25cdb8c8a0846c5fdddb8a2e0c60639d4c670aef3e6b28dd188ce474751f3d7af6231aeb0cf1b5967ebe32cf3c2b1118a48010669c831470c1",
-    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.4.3",
-    "dest-filename": "ktor-utils-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.5.1/ktor-utils-jvm-3.5.1.module",
+    "sha512": "174e4863240cfc0535d94585d444d9f84c15246c2da522c81446b33318e83788bc6a17d0ca6c8e91f9a6e49a6e4cd6e7c887c235af4bdc5c64d644d973dd98f8",
+    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.5.1",
+    "dest-filename": "ktor-utils-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.4.3/ktor-utils-jvm-3.4.3.pom",
-    "sha512": "a9a9f03021fc719654d41861c5c8d91da07cd3aaec032ec3c16355b7d17067adec310387fba8021093d2e82e61d879c0960206345c869c16dec87e5c0b4d6f93",
-    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.4.3",
-    "dest-filename": "ktor-utils-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils-jvm/3.5.1/ktor-utils-jvm-3.5.1.pom",
+    "sha512": "4fa7f227d91cca207f69fddc40d0e9ed57ecd5c88d8c2ad18bcc9c95abe49351b8f658e258c3274e768f167bd2a1ce463e55363fc52e559adb2e145246f8dc10",
+    "dest": "offline-repository/io/ktor/ktor-utils-jvm/3.5.1",
+    "dest-filename": "ktor-utils-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.4.3/ktor-utils-3.4.3.module",
-    "sha512": "097c165dbafa31165bb52bf4e631a1087b2b58ae69a72c85b8c49b1e36f7c317bd31925eadcdcb51e1501fddfbba79119a913c1822ebbfb4a6938444e8b5f575",
-    "dest": "offline-repository/io/ktor/ktor-utils/3.4.3",
-    "dest-filename": "ktor-utils-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.5.1/ktor-utils-3.5.1.module",
+    "sha512": "69964760cb48820fc6f661e78b8d544569c5652a60986a0e3568e5acc386147b52496e3684e3017c01d0a8933dad52d7dc8e7b07c618ece7c8d44142da342892",
+    "dest": "offline-repository/io/ktor/ktor-utils/3.5.1",
+    "dest-filename": "ktor-utils-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.4.3/ktor-utils-3.4.3.pom",
-    "sha512": "6c30597031921944ef92630e869d5bac8a420568dc93cd5b0c1a8859fe6b590c9d63ecdfa0514b5a94625edde909c6290f986d75689e53fdacb0a4cc3ca49a40",
-    "dest": "offline-repository/io/ktor/ktor-utils/3.4.3",
-    "dest-filename": "ktor-utils-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.5.1/ktor-utils-3.5.1.pom",
+    "sha512": "e55b3bca1bb3e4f4408d308b0a30a01013b47d784f5ff04ad5308a5bad60c1ffe659b91c90b6f280ef1c28ee11c75db6082c8d8532a72b4e81bfb8b40abb684b",
+    "dest": "offline-repository/io/ktor/ktor-utils/3.5.1",
+    "dest-filename": "ktor-utils-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.4.3/../../ktor-utils-jvm/3.4.3/ktor-utils-jvm-3.4.3.module",
-    "sha512": "97f166804c56ec25cdb8c8a0846c5fdddb8a2e0c60639d4c670aef3e6b28dd188ce474751f3d7af6231aeb0cf1b5967ebe32cf3c2b1118a48010669c831470c1",
-    "dest": "offline-repository/io/ktor/ktor-utils/3.4.3/../../ktor-utils-jvm/3.4.3",
-    "dest-filename": "ktor-utils-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-utils/3.5.1/../../ktor-utils-jvm/3.5.1/ktor-utils-jvm-3.5.1.module",
+    "sha512": "174e4863240cfc0535d94585d444d9f84c15246c2da522c81446b33318e83788bc6a17d0ca6c8e91f9a6e49a6e4cd6e7c887c235af4bdc5c64d644d973dd98f8",
+    "dest": "offline-repository/io/ktor/ktor-utils/3.5.1/../../ktor-utils-jvm/3.5.1",
+    "dest-filename": "ktor-utils-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.4.3/ktor-websocket-serialization-jvm-3.4.3.jar",
-    "sha512": "7c9867ce64420aa0b045df57e9fe718850c65ef2cea484ac1591d9cfbf1f4d69b29ef1478d11257be4667402aceb4a9de4306208ffef471064970223a5dfee68",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.5.1/ktor-websocket-serialization-jvm-3.5.1.jar",
+    "sha512": "77348dae8866eeb7c61aa745084208d82e387764262297fa47f11083f7399571a93c35abe255d5d7b9338bc633f2a09e36c5942e9890d18803d5ad4e267ceffe",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.4.3/ktor-websocket-serialization-jvm-3.4.3.module",
-    "sha512": "e8875262fe36e77df87ee969e460f08f406f7bc73863d42a4ddc348e9ba23687d60608b10845efa42f90e20cf25f2937c0ecb7254419ecae218daec39db36802",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.5.1/ktor-websocket-serialization-jvm-3.5.1.module",
+    "sha512": "e196c6d7e6fcdfdce2f429c74365ebe33a4de093fae0957a3f21f3aeebfd02f3f0d69738bd27baa514da45727e4dbe70885f7412970c3412a4485419080539af",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.4.3/ktor-websocket-serialization-jvm-3.4.3.pom",
-    "sha512": "22ddfc590c7bdfa1351de235111b59ae657c3061830c400c78e73347e26080618ad5dbafde75921545d508906e1fdce13e18f1da4acbd6609b0caf2b0f15c6fe",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization-jvm/3.5.1/ktor-websocket-serialization-jvm-3.5.1.pom",
+    "sha512": "2924479eb3e68d4899703f1fba6d12c1dc6c4b35599fced8f716ddb74d666eb4b1e345835d1c2971ce9e5b891008eca463b807ac5323fce43b129fdd05315005",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.4.3/ktor-websocket-serialization-3.4.3.module",
-    "sha512": "943ccbf3b79f2d8c1517a600a65a6a90e11afbe5723dc349819da874f60b531f6f7fe2bcf0833301aa0615736d2b48a49a027bf59840579eec52eb84839a3c89",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.5.1/ktor-websocket-serialization-3.5.1.module",
+    "sha512": "cf7d65f045655c6a0cc71852abbd5403639dfa9feba30837b6ceb0d2605bafa988f147ddd8ab6ecb796706341b2891e02a9cc0f7fb0ac1a3fcab649c658a75ad",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.4.3/ktor-websocket-serialization-3.4.3.pom",
-    "sha512": "e62048f9003f9850610d6fffa83a65a8c0db1b0441eccfbaf6fcec8c2da248cddcf63f6f833dffd93dfd4155c53b0a04988267fe37f216e4657898e92afed361",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.5.1/ktor-websocket-serialization-3.5.1.pom",
+    "sha512": "5f613a9ba03c7715f986094dc61057ce3408169388d95543cc4fe74ceb373d1bd7dea93644cc573b3a310ce58bae3f3933cc83f8a8d5a7c58a1b340ded4e3b59",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.4.3/../../ktor-websocket-serialization-jvm/3.4.3/ktor-websocket-serialization-jvm-3.4.3.module",
-    "sha512": "e8875262fe36e77df87ee969e460f08f406f7bc73863d42a4ddc348e9ba23687d60608b10845efa42f90e20cf25f2937c0ecb7254419ecae218daec39db36802",
-    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.4.3/../../ktor-websocket-serialization-jvm/3.4.3",
-    "dest-filename": "ktor-websocket-serialization-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websocket-serialization/3.5.1/../../ktor-websocket-serialization-jvm/3.5.1/ktor-websocket-serialization-jvm-3.5.1.module",
+    "sha512": "e196c6d7e6fcdfdce2f429c74365ebe33a4de093fae0957a3f21f3aeebfd02f3f0d69738bd27baa514da45727e4dbe70885f7412970c3412a4485419080539af",
+    "dest": "offline-repository/io/ktor/ktor-websocket-serialization/3.5.1/../../ktor-websocket-serialization-jvm/3.5.1",
+    "dest-filename": "ktor-websocket-serialization-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.4.3/ktor-websockets-jvm-3.4.3.jar",
-    "sha512": "93f7d25634228e4f89d5dfa4861f573fc619ba1a3e2bf3622481ed999bc1ec8ea1c3c97bffc6dd8c0d3d95a1fb10aa25e283151ba3d2d851f2fbe8869dd31e64",
-    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-websockets-jvm-3.4.3.jar"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.5.1/ktor-websockets-jvm-3.5.1.jar",
+    "sha512": "edb356fabb76dc6dbed72b195716331369ec613f424fe285c6fe6ddccc469980d0f52f6f09b2713d1cfbd87bcccd4e054c70d5e99091020d31ca0a2d6c282c66",
+    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-websockets-jvm-3.5.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.4.3/ktor-websockets-jvm-3.4.3.module",
-    "sha512": "6cd2ddb28cb1b1c9ae0c79956d2c64def76788bcd7faf3ef6bc9aae0eaa4dceb3c8184c5de820801c145c523883254eefc32c88ddcfa4b08bf76fbeb2c2f0f44",
-    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-websockets-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.5.1/ktor-websockets-jvm-3.5.1.module",
+    "sha512": "78476465f68e751dab4063cf5159eb867c7a410699bd88ac1883c692bcc4c651ee8bac97e240da6b7cea70ff5475a898eda98793b5d98b2def623221675373b0",
+    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-websockets-jvm-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.4.3/ktor-websockets-jvm-3.4.3.pom",
-    "sha512": "b2b5617bd5f5a7fae0d65006a964c3baafc363cfdff438e693bceefc228d72df0e1595d3e4d7b75a677af6185ac4b80f575adeccbb0e9f77f335bb88e204a4cb",
-    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-websockets-jvm-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets-jvm/3.5.1/ktor-websockets-jvm-3.5.1.pom",
+    "sha512": "8da56152eeb79b83b8a7a8dc4b08e1c1a339ec4e0a10c84953e6a567cbac7e7b7cb3735e04d795722043d0a2cf83e00efdb4bce53693f3732c2416569187b6f8",
+    "dest": "offline-repository/io/ktor/ktor-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-websockets-jvm-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.4.3/ktor-websockets-3.4.3.module",
-    "sha512": "fc397d9ef869f40952a4693635284e355227912c5806a5383e1259f577e68cc00c8decef42b61873735257e8d318ee544dba359ef330ce4f797f3cacd6e3a448",
-    "dest": "offline-repository/io/ktor/ktor-websockets/3.4.3",
-    "dest-filename": "ktor-websockets-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.5.1/ktor-websockets-3.5.1.module",
+    "sha512": "3881bf44afe6aef1edfc6d72b852a3e130db0e07f69efdf6a4cae4e231ddf830fe0e359926014b0422443b7e5d71071b31143fad210494702da7e7b1561ceec7",
+    "dest": "offline-repository/io/ktor/ktor-websockets/3.5.1",
+    "dest-filename": "ktor-websockets-3.5.1.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.4.3/ktor-websockets-3.4.3.pom",
-    "sha512": "03642a3a879031cf154a9d26e334e46342700a92630c5f69716a0317ca98f4982e2f4d05810628cbeb7d56ff8935c6954148a796454d403d4d90a128f3bedd87",
-    "dest": "offline-repository/io/ktor/ktor-websockets/3.4.3",
-    "dest-filename": "ktor-websockets-3.4.3.pom"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.5.1/ktor-websockets-3.5.1.pom",
+    "sha512": "b53f5f3c4b6828dc486fc180c790e8a998f09b577a246de096befdee6ba305a62c1ce46c34f465daf24285670620a2cf846ff05faf621c925144e713b9ae7ba8",
+    "dest": "offline-repository/io/ktor/ktor-websockets/3.5.1",
+    "dest-filename": "ktor-websockets-3.5.1.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.4.3/../../ktor-websockets-jvm/3.4.3/ktor-websockets-jvm-3.4.3.module",
-    "sha512": "6cd2ddb28cb1b1c9ae0c79956d2c64def76788bcd7faf3ef6bc9aae0eaa4dceb3c8184c5de820801c145c523883254eefc32c88ddcfa4b08bf76fbeb2c2f0f44",
-    "dest": "offline-repository/io/ktor/ktor-websockets/3.4.3/../../ktor-websockets-jvm/3.4.3",
-    "dest-filename": "ktor-websockets-jvm-3.4.3.module"
+    "url": "https://repo.maven.apache.org/maven2/io/ktor/ktor-websockets/3.5.1/../../ktor-websockets-jvm/3.5.1/ktor-websockets-jvm-3.5.1.module",
+    "sha512": "78476465f68e751dab4063cf5159eb867c7a410699bd88ac1883c692bcc4c651ee8bac97e240da6b7cea70ff5475a898eda98793b5d98b2def623221675373b0",
+    "dest": "offline-repository/io/ktor/ktor-websockets/3.5.1/../../ktor-websockets-jvm/3.5.1",
+    "dest-filename": "ktor-websockets-jvm-3.5.1.module"
   },
   {
     "type": "file",
@@ -2878,17 +2661,17 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.18.1/jna-platform-5.18.1.jar",
-    "sha512": "77ca3355c637707840125529f6f4720434f1a115d0b27b51b6d04e10210acd2af70ebb1e58ce2f5103423a060f9e9c64e1788a0f2457be1abdc406027bc91478",
-    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.18.1",
-    "dest-filename": "jna-platform-5.18.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1.jar",
+    "sha512": "a8cdc1a080f0a11905014c125697d54815d5102f50a42380bc6b1230f229d84e44d1a0a501f12b49da90e191437259b4fa7b7e2a43bfc3b5485e8cb253c0c490",
+    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.19.1",
+    "dest-filename": "jna-platform-5.19.1.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.18.1/jna-platform-5.18.1.pom",
-    "sha512": "4e54efc80064a5b9df328e6bd47d1ba5aefd676a57f6b64fd18cc110004d429d0fba923e9e9bfe99812a6597501021f077cba2d813f9cc81cc9577afa6d41ee9",
-    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.18.1",
-    "dest-filename": "jna-platform-5.18.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1.pom",
+    "sha512": "b97196b4b7b07a22840f8e6ab6fc6696d719a6f913fc6c12633fc581e3c97bc81877c883eceb2a147f85cc7c67de9c7625be30a8a632bbb5e392401256fe546b",
+    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.19.1",
+    "dest-filename": "jna-platform-5.19.1.pom"
   },
   {
     "type": "file",
@@ -2917,6 +2700,20 @@
     "sha512": "f8d33a926703c383c3d22654080aaf074a2fa807b7432780887012d03eb4be080462bab89b79c3bbbb07ac6a7ed7f8b98ca723605f7d7413975b01418d29b9bd",
     "dest": "offline-repository/net/java/dev/jna/jna/5.18.1",
     "dest-filename": "jna-5.18.1.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.19.1/jna-5.19.1.jar",
+    "sha512": "0e6a960acfd6fac77486da7b6d18eb9d98e0a205bdf78189548997fb6f6093e713e570e9829ecc6d7dec813276eaf5d3af56d30c627febb3a0b324fa9035e88f",
+    "dest": "offline-repository/net/java/dev/jna/jna/5.19.1",
+    "dest-filename": "jna-5.19.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna/5.19.1/jna-5.19.1.pom",
+    "sha512": "8dab160079fbaae745753fcfc0da3f9b26f24f8ac02b3413427befc88bc3409b9c99cb4bbc2e0739b6c03f6400cc908b4724cabe66ad7127e86fe8a6ea746ffe",
+    "dest": "offline-repository/net/java/dev/jna/jna/5.19.1",
+    "dest-filename": "jna-5.19.1.pom"
   },
   {
     "type": "file",
@@ -3165,17 +2962,17 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.80/bcpkix-jdk18on-1.80.jar",
-    "sha512": "a7bcd25a8c93e163fd6c5f43d8b9d102c77c94edd78614e5a98b90412ea3519a7752cd9efd035eb0647b5fc6c261cfec56080ec067dc84df2fc22c5ebb317d3f",
-    "dest": "offline-repository/org/bouncycastle/bcpkix-jdk18on/1.80",
-    "dest-filename": "bcpkix-jdk18on-1.80.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.85/bcpkix-jdk18on-1.85.jar",
+    "sha512": "142ce817145f7348dc97f62872eac931280c578bc61ff4cfcff927d4247ab2bf15e858edf74f2549074c4685ebe8de1d815c42637eacdb65b344b741c2bf1415",
+    "dest": "offline-repository/org/bouncycastle/bcpkix-jdk18on/1.85",
+    "dest-filename": "bcpkix-jdk18on-1.85.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.80/bcpkix-jdk18on-1.80.pom",
-    "sha512": "7300d345d1b78953dd918d17aaf79daa7d7fdf793e78e0af9075204ffa38accb015351aa18de5dce8fe34f6a3e0ddf5ca8659256dbae39c8bd18a44b8bb7263f",
-    "dest": "offline-repository/org/bouncycastle/bcpkix-jdk18on/1.80",
-    "dest-filename": "bcpkix-jdk18on-1.80.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.85/bcpkix-jdk18on-1.85.pom",
+    "sha512": "9f44c6bdebd36f47e9d6de4e759225de56af58b9a84dc4006640af4a93bbca6ef620ee62bf347874f0def2d687760a2998862bc0680a1fef18643caaeb432c43",
+    "dest": "offline-repository/org/bouncycastle/bcpkix-jdk18on/1.85",
+    "dest-filename": "bcpkix-jdk18on-1.85.pom"
   },
   {
     "type": "file",
@@ -3193,17 +2990,17 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk18on/1.80.2/bcprov-jdk18on-1.80.2.jar",
-    "sha512": "e10408106bfb52e67ec56fd28185bf835ca47c56ed020167dffdaafaf1cfcf78d7d8e52feb0c8b9b98106df23399ca874d044c29fe2e751fd2c73d91436ba476",
-    "dest": "offline-repository/org/bouncycastle/bcprov-jdk18on/1.80.2",
-    "dest-filename": "bcprov-jdk18on-1.80.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.jar",
+    "sha512": "33bbcbc3ad823898bda1fec8cea270fffa4688886b1c351afd93e713f41d29afd71aae9982cbe896d510aa98fece8b9a66c132536625801fe2c1af283a76e2b5",
+    "dest": "offline-repository/org/bouncycastle/bcprov-jdk18on/1.85",
+    "dest-filename": "bcprov-jdk18on-1.85.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk18on/1.80.2/bcprov-jdk18on-1.80.2.pom",
-    "sha512": "db8f6e8266b6306dbde27871cc49c1733e09be5e695fdbffa7e3cc0df772a0f2fd98afce0705d6882926a381c3aaeaf5ed28c9827aab8b1cd764cc90c0937079",
-    "dest": "offline-repository/org/bouncycastle/bcprov-jdk18on/1.80.2",
-    "dest-filename": "bcprov-jdk18on-1.80.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcprov-jdk18on/1.85/bcprov-jdk18on-1.85.pom",
+    "sha512": "9e935704aaba4f604a11eb67f243f72777d6efe5b16c3c0972c04b6a6dc84b1beb9e76eb1a3ecc4423552f26106e2e7f36a5b5a3f92233aba00b7569f666c3b1",
+    "dest": "offline-repository/org/bouncycastle/bcprov-jdk18on/1.85",
+    "dest-filename": "bcprov-jdk18on-1.85.pom"
   },
   {
     "type": "file",
@@ -3221,17 +3018,17 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcutil-jdk18on/1.80.2/bcutil-jdk18on-1.80.2.jar",
-    "sha512": "b66828b52dcf223fb8d73eb2f052e9503a264769db56489bb9a283231380921db9612225676ba93f6d9bb5207ac5e6b1527fb3f0c4831e36ff68f3c824fe5cc6",
-    "dest": "offline-repository/org/bouncycastle/bcutil-jdk18on/1.80.2",
-    "dest-filename": "bcutil-jdk18on-1.80.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcutil-jdk18on/1.85/bcutil-jdk18on-1.85.jar",
+    "sha512": "1cf5011448dfaed7daea587807b9513961bdfd7b41ee5ce42444254dfa3677fdba78fe5191bca4ecf2a51eb3883be59f0374affc1efae3fd1728a64fa094027d",
+    "dest": "offline-repository/org/bouncycastle/bcutil-jdk18on/1.85",
+    "dest-filename": "bcutil-jdk18on-1.85.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcutil-jdk18on/1.80.2/bcutil-jdk18on-1.80.2.pom",
-    "sha512": "24fd85870e6bcba8a4ee4c37277c63de217f9511957dfe067bc80e2eaf62eb670a9870254d8fa82f6860ec6070305e2198e0d10c836f97f198bbc790010efa8e",
-    "dest": "offline-repository/org/bouncycastle/bcutil-jdk18on/1.80.2",
-    "dest-filename": "bcutil-jdk18on-1.80.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/bouncycastle/bcutil-jdk18on/1.85/bcutil-jdk18on-1.85.pom",
+    "sha512": "5b5e9d908abca64c308a23d2621259cc10832d7f0b69f1e4d2717d311d17b9db2ec6de7bd46647fe77dac5c24afbd4c898bd347b4e53a1a89a83e8c01bd4ef55",
+    "dest": "offline-repository/org/bouncycastle/bcutil-jdk18on/1.85",
+    "dest-filename": "bcutil-jdk18on-1.85.pom"
   },
   {
     "type": "file",
@@ -3316,13 +3113,6 @@
     "sha512": "b88512eaf3aeda8862ba52b7b1a7cc5d3b232eb09f02bb288521910f018c8ede7acfe56fbceb167ad01a3a4f0092c07f675b5ae7d7906284e04f14414fb643f9",
     "dest": "offline-repository/org/gradle/toolchains/foojay-resolver/1.0.0",
     "dest-filename": "foojay-resolver-1.0.0.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://plugins.gradle.org/m2/org/gradle/toolchains/foojay-resolver/1.0.0/foojay-resolver-1.0.0.module",
-    "sha512": "1e40f52c1d48034b6a76cb72065b7c4c033bf04e45c2bed3f81d759a2b207ae7ebc1b4b33688285e91b5a9b5d486da3509ad753227415ea0ea0969bac3260186",
-    "dest": "offline-repository/org/gradle/toolchains/foojay-resolver/1.0.0",
-    "dest-filename": "foojay-resolver-1.0.0.module"
   },
   {
     "type": "file",
@@ -3571,1319 +3361,1214 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.11.1/animation-core-desktop-1.11.1.jar",
-    "sha512": "2b3e5b13c763a3b44c2f56ea7901c149119f0698fa248fc2c07a6015824a26ca78df368b639a21f9f2cf641ca233c657c0ed8897bbf7dde7eddfc796a1bacb20",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.11.1",
-    "dest-filename": "animation-core-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.9.3/animation-core-desktop-1.9.3.jar",
+    "sha512": "b618551cce4991b563478540b32fb7f0359373b20c95022926959d6b83c35f7abda42c330ce95095c0a1916fe31a79feaea891c4f0cea08bf9684d2373b9aec8",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.9.3",
+    "dest-filename": "animation-core-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.11.1/animation-core-desktop-1.11.1.module",
-    "sha512": "082505e59db2799b5460a15b2a5e0229ad4fb960a25dd497e24b838877aea8bb4010931f7a22d8a95105c16cd883290a2596108997bc454934e73215d26d22a6",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.11.1",
-    "dest-filename": "animation-core-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.9.3/animation-core-desktop-1.9.3.module",
+    "sha512": "da6c60e7ac7fe264afd8e8820104bf0710b2fbbb31331e7f179bf5142146fae2df008df58682e4c7c8f1c6b0631c7eb3b49b955bc8c4cc3d8f4e1434abd5f58c",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.9.3",
+    "dest-filename": "animation-core-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.11.1/animation-core-desktop-1.11.1.pom",
-    "sha512": "61788e48496815de397d0230a420e1974b4bbc9b801a41eeae6795c84d16be3e5618d02555c36c359cb6af2072ba8535f8bb0c4bc8f769678c0dac81c444f083",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.11.1",
-    "dest-filename": "animation-core-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core-desktop/1.9.3/animation-core-desktop-1.9.3.pom",
+    "sha512": "70b81734bc02570b9e54bde4fe5d25a0e7fa688c20398112a06652699627fefe1eb830fed22c0212c6e1d8c5dffe60a837f2dfa82f5e830bc6956de15362cb1f",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core-desktop/1.9.3",
+    "dest-filename": "animation-core-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.11.1/animation-core-1.11.1.module",
-    "sha512": "02f126e7d15d86acd501b559e3f3a05f0e180aa8e8075674729a688f7aff00910bf6a2e86a74357193076ce4097e9700f7a8843b8c33129ed19099467fbd0e28",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.11.1",
-    "dest-filename": "animation-core-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.9.3/animation-core-1.9.3.module",
+    "sha512": "2f0133f9d011067750b5b5cee10f21232cd3109721fb230c95ac80bff19ecdcf120db197ad0691390dc049cac8daa80964e799eab778570212d674ee365cedfe",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.9.3",
+    "dest-filename": "animation-core-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.11.1/animation-core-1.11.1.pom",
-    "sha512": "1eb8bca339898cf79518bf80abb95b59426df4b89fd55827e6bd714e11facc360eb0ceee374f0b1b7bb70a40cef0e74b362a44ae581d1f5e6c3af6b6eb1e7617",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.11.1",
-    "dest-filename": "animation-core-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.9.3/animation-core-1.9.3.pom",
+    "sha512": "e047b69f64f8042683c9dedb4d9d46591764563256de78e4c44f471866403b97c858e67f87d9b5635cdc17466a5093445ea69d350e943381415a7d67f51ef31a",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.9.3",
+    "dest-filename": "animation-core-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.11.1/../../animation-core-desktop/1.11.1/animation-core-desktop-1.11.1.module",
-    "sha512": "082505e59db2799b5460a15b2a5e0229ad4fb960a25dd497e24b838877aea8bb4010931f7a22d8a95105c16cd883290a2596108997bc454934e73215d26d22a6",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.11.1/../../animation-core-desktop/1.11.1",
-    "dest-filename": "animation-core-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-core/1.9.3/../../animation-core-desktop/1.9.3/animation-core-desktop-1.9.3.module",
+    "sha512": "da6c60e7ac7fe264afd8e8820104bf0710b2fbbb31331e7f179bf5142146fae2df008df58682e4c7c8f1c6b0631c7eb3b49b955bc8c4cc3d8f4e1434abd5f58c",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-core/1.9.3/../../animation-core-desktop/1.9.3",
+    "dest-filename": "animation-core-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-desktop/1.11.1/animation-desktop-1.11.1.jar",
-    "sha512": "7da6126cdf28e7319aaf99891cece708662422d0927211edba38ca2e250566100c5343e61d2ec7b5348fff523b23507d2e1708d2b222605009621ead9341b845",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-desktop/1.11.1",
-    "dest-filename": "animation-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-desktop/1.9.3/animation-desktop-1.9.3.jar",
+    "sha512": "8d1d32dbd3c45d1c3d2cb2857fd6190524ff611f8e3ad0c952104bf7a068ed32019bfae759cf35e2d512e45beb0ea7ea6bddc9730c0e8420c7e6ce57591e575a",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-desktop/1.9.3",
+    "dest-filename": "animation-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-desktop/1.11.1/animation-desktop-1.11.1.module",
-    "sha512": "af0611f86504b9971c55956237c889a9c63135a7809f03fef2ff300732ba811a860d34ed9f5f8dc0ab0ea904a88c043e354be18ad615b4ee50d5f8d7738c30b9",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-desktop/1.11.1",
-    "dest-filename": "animation-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-desktop/1.9.3/animation-desktop-1.9.3.pom",
+    "sha512": "e2f9c2d55e3988d828648f67fae8ace275b08ff1b52c924c3850a184a4a5d1f25c578670805b4e3db62408d15f63197feaf63ce9705f38e7cf06a6c23d1f5c14",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation-desktop/1.9.3",
+    "dest-filename": "animation-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-desktop/1.11.1/animation-desktop-1.11.1.pom",
-    "sha512": "07767418348a0c274a6c1da7692945d4050c620f8b61abdcd723f9ec3e734cbab32b3713d06fdcb7e345ae8cded06fd5c66eb902b143eb0b3816d7182979d325",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-desktop/1.11.1",
-    "dest-filename": "animation-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.9.3/animation-1.9.3.module",
+    "sha512": "c4133d79388b890e556578cb793f15022d4575c1d6d03c1102d5b301f5347ef04d53abb9080a24fe7c21b03808f14ceabb35d2bdd74fd290396ee861abbdc355",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.9.3",
+    "dest-filename": "animation-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation-graphics/1.11.1/animation-graphics-1.11.1.pom",
-    "sha512": "65eb39206fa84290a03d0029350146e62059afa9a41ee6e9f6e1bc23eabbd29a0c959ff22c2e1748e2ffdd7977861d2f18db62542a731aec3c5d46e71ca0e1ae",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation-graphics/1.11.1",
-    "dest-filename": "animation-graphics-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.9.3/animation-1.9.3.pom",
+    "sha512": "1b74b98018dccd3dd4f6c62fbca855129491c97070b024154d1fa916c7aa5e41f1c008e158d94720daf263d44c14aabc8ccd9aecf19204d987a5a626f926ed86",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.9.3",
+    "dest-filename": "animation-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.11.1/animation-1.11.1.module",
-    "sha512": "1f98a73ed4b0fc8f515441bd6ec1faa863eaff00e28d8df6267e2dab78dc6ff5435a87d4022085887c439444977c16368975dcdde79e48457078aedd656e456b",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.11.1",
-    "dest-filename": "animation-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.9.3/../../animation-desktop/1.9.3/animation-desktop-1.9.3.module",
+    "sha512": "a5872ab5211c0ecfcf50d2c70529587620c4e06519b9170c56d3116cadf56057ff64e4112d2e97dc597c9aaf81b83224fb0fbbfa9f037e641d073cc70797ba5f",
+    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.9.3/../../animation-desktop/1.9.3",
+    "dest-filename": "animation-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.11.1/animation-1.11.1.pom",
-    "sha512": "423fb2ea6aed81596dc000e9630ae59623f7a61ba6a948e5cf48152cea29f2322af6bcb10db737d0b99ad8a395f3a6997583ef2423a1b885a460bcf42a940ec5",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.11.1",
-    "dest-filename": "animation-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/annotation-internal/annotation/1.9.3/annotation-1.9.3.module",
+    "sha512": "08a96a797f0034cdafdc78117759a6faf39912d06d923e020a6c50df031825c44cf93b078c9de7fbf26f0b26d93d9342ebe1159ab227d8f5a87d6635d3f723f3",
+    "dest": "offline-repository/org/jetbrains/compose/annotation-internal/annotation/1.9.3",
+    "dest-filename": "annotation-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/animation/animation/1.11.1/../../animation-desktop/1.11.1/animation-desktop-1.11.1.module",
-    "sha512": "af0611f86504b9971c55956237c889a9c63135a7809f03fef2ff300732ba811a860d34ed9f5f8dc0ab0ea904a88c043e354be18ad615b4ee50d5f8d7738c30b9",
-    "dest": "offline-repository/org/jetbrains/compose/animation/animation/1.11.1/../../animation-desktop/1.11.1",
-    "dest-filename": "animation-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/annotation-internal/annotation/1.9.3/annotation-1.9.3.pom",
+    "sha512": "0c2eb257341c69587331cbfd161c26661d5bbba3628282489f1bce828146ae020f24625fd719bd20dc8b6ca2d1d8d4703b7c89d6d92576399b94be821a10c40e",
+    "dest": "offline-repository/org/jetbrains/compose/annotation-internal/annotation/1.9.3",
+    "dest-filename": "annotation-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.11.1/components-resources-desktop-1.11.1.jar",
-    "sha512": "fcc166b1b50968b027a26263a49fa874fd42813c80db183df7d25164dfc22b98499917a0dab1cd413f02ab9d139a40d313d245df2931ad38030fd5155a9ab9f2",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.11.1",
-    "dest-filename": "components-resources-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/collection-internal/collection/1.9.3/collection-1.9.3.module",
+    "sha512": "0ba2366147928951f92288d47fcdbd9886fb496758ffcbae239ed542860cbe6779f3074ed7d087f9ec731f0c42b4e6352f68610ba167a25be9a1b224babdfa90",
+    "dest": "offline-repository/org/jetbrains/compose/collection-internal/collection/1.9.3",
+    "dest-filename": "collection-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.11.1/components-resources-desktop-1.11.1.module",
-    "sha512": "e064e28991066d7f764276fe71ecb8216326416c16a85d0fbe3faee1641625cebae8e5ef2739f26f7e521da6f6cf4dd88b8c158559f5440736efe44c32f7a37a",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.11.1",
-    "dest-filename": "components-resources-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/collection-internal/collection/1.9.3/collection-1.9.3.pom",
+    "sha512": "6a7e6f4953471249b3683a450c07366c708fa4cb67035bccbae116f76a32ca6781c331c42037b30b13146d272463a22ac8a1e062ce9ad7b7ad93916092e230e3",
+    "dest": "offline-repository/org/jetbrains/compose/collection-internal/collection/1.9.3",
+    "dest-filename": "collection-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.11.1/components-resources-desktop-1.11.1.pom",
-    "sha512": "448a576b90b5fe5340625682f5f77209e994522b2c59e79b3d14e3066f05f708d7acb365bc67a55e8fdde89464a121dfec45f4929405182bd9484490ba372a00",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.11.1",
-    "dest-filename": "components-resources-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.9.3/components-resources-desktop-1.9.3.jar",
+    "sha512": "59f293d06311c6c5035f296e510dccadc175fa088f892efe977d1424f06ea860cb41a944f9e8c75c89290c103c99befd20d1e2a19602b51aff68a34e57bb3931",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.9.3",
+    "dest-filename": "components-resources-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.11.1/components-resources-1.11.1.module",
-    "sha512": "6a4b53c86a99ac55b4fbe101bf5f9b0c394737762dfa7510ef0458ef0efdc33b0a1b47ae4f2a21e1b890560cf4f8d135bd14c29783d41cbdf40ce8c90d1c545b",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.11.1",
-    "dest-filename": "components-resources-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.9.3/components-resources-desktop-1.9.3.module",
+    "sha512": "1228cd2380879a4c144bf500e13fdd44c6d58e7523c898264ace5171bebb7b90885b876fe85ce7ece18b7215f5172fee232360f6ed04b3c372f6b4102efabc21",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.9.3",
+    "dest-filename": "components-resources-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.11.1/components-resources-1.11.1.pom",
-    "sha512": "d1492461a971d5a57ddd45eed235d8b12a697b1bba6c063a83c5ddcbbc0fcd2363c88410003c409c04980f14e8275063c4b052d8b2a609c565352ad6e866f19f",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.11.1",
-    "dest-filename": "components-resources-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources-desktop/1.9.3/components-resources-desktop-1.9.3.pom",
+    "sha512": "6db0ec5f97f4e534f9d14a2bae043a02111240fa00e74e30846cdfec22143a5b300390cb7cc4bac7c322f0a49343713eb13767b8f5f75d1b19d4ed8268317550",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources-desktop/1.9.3",
+    "dest-filename": "components-resources-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.11.1/../../components-resources-desktop/1.11.1/components-resources-desktop-1.11.1.module",
-    "sha512": "e064e28991066d7f764276fe71ecb8216326416c16a85d0fbe3faee1641625cebae8e5ef2739f26f7e521da6f6cf4dd88b8c158559f5440736efe44c32f7a37a",
-    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.11.1/../../components-resources-desktop/1.11.1",
-    "dest-filename": "components-resources-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.9.3/components-resources-1.9.3.module",
+    "sha512": "ddebfcec9097ba1151ab126fba4cb5d482f387b33801e3d647286a668fd9c442ecefb169dc67d6f9332f8c5e4cd5637dee9d4a9b896497505be7f617ca983996",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.9.3",
+    "dest-filename": "components-resources-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.11.1/compose-gradle-plugin-1.11.1.jar",
-    "sha512": "781058ebcac56cf090075c76a116adb1f8121a212d8626ecc17262a985c9ed0955a764c3f9292e5be06982a65d62c399409e462828af9683ea2d9806d1eab877",
-    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.11.1",
-    "dest-filename": "compose-gradle-plugin-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.9.3/components-resources-1.9.3.pom",
+    "sha512": "56722fa4793db0705a08d40673e8af5f87c2346fdbf243789ca7cc37811de3653fac8dddae92f361d412e62c2bf06879f63d1d044ca4daf746ffdf9ea4b963bd",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.9.3",
+    "dest-filename": "components-resources-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.11.1/compose-gradle-plugin-1.11.1.module",
-    "sha512": "1ca92b2382e5a75747c8acdfe87f49eba320b31ff8d5833426dff10bd8126a2c09a44868dc7492e995f2e33793d46af3cc70dfd0a4e9445d762b30d5d5690e17",
-    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.11.1",
-    "dest-filename": "compose-gradle-plugin-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/components/components-resources/1.9.3/../../components-resources-desktop/1.9.3/components-resources-desktop-1.9.3.module",
+    "sha512": "1228cd2380879a4c144bf500e13fdd44c6d58e7523c898264ace5171bebb7b90885b876fe85ce7ece18b7215f5172fee232360f6ed04b3c372f6b4102efabc21",
+    "dest": "offline-repository/org/jetbrains/compose/components/components-resources/1.9.3/../../components-resources-desktop/1.9.3",
+    "dest-filename": "components-resources-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.11.1/compose-gradle-plugin-1.11.1.pom",
-    "sha512": "8a21e33501ba6f0940849c3c8a1d7f34da1c781468cfa009cfbc3e3ab8994073b283ce504984b33fd339caa43e5763fd987e08b453266345913c3455b84433d3",
-    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.11.1",
-    "dest-filename": "compose-gradle-plugin-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.9.3/compose-gradle-plugin-1.9.3.jar",
+    "sha512": "d3399bc68edf86211fd8a234f9a4ef137ebbca26faeb3d6e458ddb744dfea2c5e0add8dc442c681b332774d296dc58f41db7144c6fc2217ddaed4c6cd3afbb76",
+    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.9.3",
+    "dest-filename": "compose-gradle-plugin-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm-linux-x64/1.11.1/desktop-jvm-linux-x64-1.11.1.pom",
-    "sha512": "76bbff77e1c549ea14701d787141169f819e013b24e6f9c0e3406da52f71a81e08fda5b3b92df66292e474fac94fc462ade40dae2b96358dd051547a0986b8ac",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm-linux-x64/1.11.1",
-    "dest-filename": "desktop-jvm-linux-x64-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.9.3/compose-gradle-plugin-1.9.3.module",
+    "sha512": "93a618cbec996871a5c8da0b727c1158d3b79e35139bcd7bb8411b3bc595cb3af1fe64b56e72bb7d75ded89942707c22c89e42e5ae481877b4de3b7dfa44a480",
+    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.9.3",
+    "dest-filename": "compose-gradle-plugin-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.11.1/desktop-jvm-1.11.1.jar",
-    "sha512": "1a5a41683073353e8983f17f011cd582a79096453249ed9f131cc3b5595f6eb7a7323b7fe7b7c210abbd3f64b397bb7550262b71d91e2520ceefe53ce04f34cf",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.11.1",
-    "dest-filename": "desktop-jvm-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/compose-gradle-plugin/1.9.3/compose-gradle-plugin-1.9.3.pom",
+    "sha512": "467893fee9574a4f911d18e2ec80f535fdd4d11cc36cdd7f844c090086b42a0184063124ca1c0a09f37ebffdae1a8f364308bfe53586bdde402ad121a2215770",
+    "dest": "offline-repository/org/jetbrains/compose/compose-gradle-plugin/1.9.3",
+    "dest-filename": "compose-gradle-plugin-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.11.1/desktop-jvm-1.11.1.module",
-    "sha512": "e1eb905d5a7aac8ea16541dd018dd97339fa05f69b9bbf3676d92915835ec81dbbfaf2eb6625299c3f3239d0c911c367edc1a4d70b75a400655ad09da1ab6934",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.11.1",
-    "dest-filename": "desktop-jvm-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm-linux-x64/1.9.3/desktop-jvm-linux-x64-1.9.3.pom",
+    "sha512": "b8519ba4328a802cb42b7d312456df93d149ef9710da9f9abab000ace674a1b46c4fd3b14bb281105052a0e600065b0ce2ed2723ef3564fe463e7acc43bb956f",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm-linux-x64/1.9.3",
+    "dest-filename": "desktop-jvm-linux-x64-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.11.1/desktop-jvm-1.11.1.pom",
-    "sha512": "d1cae56b76c78ab9769a0a9751fb7f747632661237ccac095ef43a921aa6abb035baf9e7988f6c24b2c17da0d52c1483dcc3cfe577b135efd0a2cfbeab034d39",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.11.1",
-    "dest-filename": "desktop-jvm-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.9.3/desktop-jvm-1.9.3.jar",
+    "sha512": "ccf5e6aca8d03074c5924891e7b4714bf280fc583cb43936a20a7a7b4bcef6e457952657300a904a36d62de862695dc27bb02c42ca4842ee63e665c30f901b3b",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.9.3",
+    "dest-filename": "desktop-jvm-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.11.1/desktop-1.11.1.module",
-    "sha512": "45ae7141d70d0cd86fed6755e7e680ad448d0133e9ec63828a760824167776323932ae93f015d2169f771cda965147cc473819108d8b9cd14cc542da8a5374f8",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.11.1",
-    "dest-filename": "desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.9.3/desktop-jvm-1.9.3.module",
+    "sha512": "172811c213ea91faf4eddf9390841bb62b9efc84733d6ffcc10bd89387c87410997689ab242cc776eb6cbed2cccdc7bff40c99001a569a3dd41d67595ea5ae1a",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.9.3",
+    "dest-filename": "desktop-jvm-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.11.1/desktop-1.11.1.pom",
-    "sha512": "d373ebc2d9c27ab4f475f457bad3b915da457d6ef7bbe99e94de572f1417b2de8625609932b21ec0000e727e29ec9b6e6a956399a93fd6fe8cbbc2576a57e23c",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.11.1",
-    "dest-filename": "desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop-jvm/1.9.3/desktop-jvm-1.9.3.pom",
+    "sha512": "51a8c2a9611ff289071bbc2b3427187b44bf28f4fcb0c0537a8d363520a57ea6597e0a6e6253aa9cd9ee096f80743be4a1780aede1322f8cfd62f9a9ad3e1068",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop-jvm/1.9.3",
+    "dest-filename": "desktop-jvm-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.11.1/../../desktop-jvm/1.11.1/desktop-jvm-1.11.1.module",
-    "sha512": "e1eb905d5a7aac8ea16541dd018dd97339fa05f69b9bbf3676d92915835ec81dbbfaf2eb6625299c3f3239d0c911c367edc1a4d70b75a400655ad09da1ab6934",
-    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.11.1/../../desktop-jvm/1.11.1",
-    "dest-filename": "desktop-jvm-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.9.3/desktop-1.9.3.module",
+    "sha512": "ad32c9ebf9dfd42f66af9376dd5edabe429170069fc031fea978e0ffa1a20ba3b166b94d2349024b0e00a4936c3759a823d7d012262b8140f715f67ddb94a99f",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.9.3",
+    "dest-filename": "desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.11.1/foundation-desktop-1.11.1.jar",
-    "sha512": "7ed68d35bd1badfcc584649dcbfe8940f4b9afef7ead12fa548da9259612e6a15c199237e8b87d6dd98119424876d0308637338315bcd6085feec54645d12dee",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.11.1",
-    "dest-filename": "foundation-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.9.3/desktop-1.9.3.pom",
+    "sha512": "91de3e0ff933c6f0e219a2776dedcea3e3784e1958034feeeae0c5bca8af042b0290dd363ad1319a68d48a1696a66440073d42b951ea687b78a7cb4dee831814",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.9.3",
+    "dest-filename": "desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.11.1/foundation-desktop-1.11.1.module",
-    "sha512": "f2533f89a07500ebf104140c9ab024be43ed4038f8fe829d0538b243609a066cf1941822dc002fc422b3ce906fcc0fe8ace81961fdf2a324b9f9495dc1fb33fc",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.11.1",
-    "dest-filename": "foundation-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/desktop/desktop/1.9.3/../../desktop-jvm/1.9.3/desktop-jvm-1.9.3.module",
+    "sha512": "172811c213ea91faf4eddf9390841bb62b9efc84733d6ffcc10bd89387c87410997689ab242cc776eb6cbed2cccdc7bff40c99001a569a3dd41d67595ea5ae1a",
+    "dest": "offline-repository/org/jetbrains/compose/desktop/desktop/1.9.3/../../desktop-jvm/1.9.3",
+    "dest-filename": "desktop-jvm-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.11.1/foundation-desktop-1.11.1.pom",
-    "sha512": "0418fa884cc387a1a4f35687f8a494edb3d5b013dce971d705d3d7f0052b7b05c0d585ef3005cb519131716a31f4c053a7edbe31d56423856cc89f9d6edd9ce4",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.11.1",
-    "dest-filename": "foundation-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.9.3/foundation-desktop-1.9.3.jar",
+    "sha512": "411d8a9b25fbf67be4201f24ac86f913046cca22ac193896211f5b097e532ffb61dab00f1d3655e88c0691b9a8db1cc5810c9b0652425094de56e2bc24848b9d",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.9.3",
+    "dest-filename": "foundation-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1/foundation-layout-desktop-1.11.1.jar",
-    "sha512": "78c1070c0ebbe9a6c58db51c3eb6a07b68e5101b86c277ee36a609016493a746aa62536ea0b587bd3aff252d36833dfc1aacc70a5413c79f25be9693347ab325",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1",
-    "dest-filename": "foundation-layout-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.9.3/foundation-desktop-1.9.3.module",
+    "sha512": "e13ea536a6b29848a74c036ddbd1fd5cafd12a7ccbf0f6cbeaa9b02a22130d8762e2d44a6d4c6ad5d2917a8927f61e9799546f939b2ed3c39257ae1c03011b9a",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.9.3",
+    "dest-filename": "foundation-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1/foundation-layout-desktop-1.11.1.module",
-    "sha512": "5e780c9140e49d3a7de4971fc43007a6ae605e2ffb1c71724c683e49678372837a6941d99d11fa99d65dbee0df03f95b5f7c0c6623265d9ec65c68771d9bc61e",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1",
-    "dest-filename": "foundation-layout-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-desktop/1.9.3/foundation-desktop-1.9.3.pom",
+    "sha512": "518313373bc82c98e0cc17d6996a1be87db5973293b1ab32f92e4d74c27bd09ce9add002d74d63e871fbe6a7abb51557826c13c8f474eb882631be968d358ed2",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-desktop/1.9.3",
+    "dest-filename": "foundation-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1/foundation-layout-desktop-1.11.1.pom",
-    "sha512": "3a476b703d793efc9af68ae37764f9f7cc41c40cb21176a2d0f949b8df2a96283fbfacea956ef3228bbc4b9baef52880742bfa5d207c1be2329c235c15cc4abd",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.11.1",
-    "dest-filename": "foundation-layout-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3/foundation-layout-desktop-1.9.3.jar",
+    "sha512": "daaee666c60a2692e9992a2011e5e5f2534461c7676efeed31c96de239bc58c0ee9fc38349140c239335fae4d916351b5cf2e4293f0bb138a8122d4c684b0d97",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3",
+    "dest-filename": "foundation-layout-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.11.1/foundation-layout-1.11.1.module",
-    "sha512": "cae7ea145a17222ec009d10dfaa57d3a0b17afbc19b729b59a3ca58dd6f840ee42970141de03aae3e0605b2b18f55e5e939609e4e088baa2f39f963923325080",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.11.1",
-    "dest-filename": "foundation-layout-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3/foundation-layout-desktop-1.9.3.module",
+    "sha512": "3839e8e262b9b129858a2ae3289b5fe303f991d9774181633789497176c582670bbceb6c8f37456397309c205057f68e5fad64bb84e62fec41af1f148606ab85",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3",
+    "dest-filename": "foundation-layout-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.11.1/foundation-layout-1.11.1.pom",
-    "sha512": "2b12fca489215421aff9dbdf4a7b675516ef3a08a84a7c747f8fc35080e7df1e7c63cee863c117cffbee86df22e01d4513e39a9f6cdc0182b0de0a287ad9a810",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.11.1",
-    "dest-filename": "foundation-layout-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3/foundation-layout-desktop-1.9.3.pom",
+    "sha512": "365b7cf4fd76433f957e7a45c8daf5d5c1ce9f7c743ebf8416d51e6df2ec19b40975a145ccf06ad89d159ff3ed8fb52cc9932cb17212c81492f0aa53bd0d80a4",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout-desktop/1.9.3",
+    "dest-filename": "foundation-layout-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.11.1/../../foundation-layout-desktop/1.11.1/foundation-layout-desktop-1.11.1.module",
-    "sha512": "5e780c9140e49d3a7de4971fc43007a6ae605e2ffb1c71724c683e49678372837a6941d99d11fa99d65dbee0df03f95b5f7c0c6623265d9ec65c68771d9bc61e",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.11.1/../../foundation-layout-desktop/1.11.1",
-    "dest-filename": "foundation-layout-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.9.3/foundation-layout-1.9.3.module",
+    "sha512": "8d972865edff6b655f06b48091139563ab2a7d2b662b0ff6eaa04575a834d892570e9ea42c60543468aac575394438afb53ae2a786e12451d65578a2b3c5d756",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.9.3",
+    "dest-filename": "foundation-layout-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.11.1/foundation-1.11.1.module",
-    "sha512": "31a6f1382084433638e8600d553feb9aa5272e88c894ee322253890e8056ce1045aaad7b309034bb2624d56260f08bb5eb6af97d81c6692c25ba6dbe7881732a",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.11.1",
-    "dest-filename": "foundation-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.9.3/foundation-layout-1.9.3.pom",
+    "sha512": "ebef54e98996c7f239a5e6ac64d39863c449fcfd435ff52e151d69b0c1176efc0dfab746fd1cd2952a50731d12d96a6d0f9a532975482bee8056002b22e6cb19",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.9.3",
+    "dest-filename": "foundation-layout-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.11.1/foundation-1.11.1.pom",
-    "sha512": "128326fe802324c6ac7e5169178de1776adf5f5fdb2756b7e2a48725991980829b8d5527f9865b0dcb1e04db5cea9729dddc82057ab86cfa2070773f7df661a5",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.11.1",
-    "dest-filename": "foundation-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation-layout/1.9.3/../../foundation-layout-desktop/1.9.3/foundation-layout-desktop-1.9.3.module",
+    "sha512": "3839e8e262b9b129858a2ae3289b5fe303f991d9774181633789497176c582670bbceb6c8f37456397309c205057f68e5fad64bb84e62fec41af1f148606ab85",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation-layout/1.9.3/../../foundation-layout-desktop/1.9.3",
+    "dest-filename": "foundation-layout-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.11.1/../../foundation-desktop/1.11.1/foundation-desktop-1.11.1.module",
-    "sha512": "f2533f89a07500ebf104140c9ab024be43ed4038f8fe829d0538b243609a066cf1941822dc002fc422b3ce906fcc0fe8ace81961fdf2a324b9f9495dc1fb33fc",
-    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.11.1/../../foundation-desktop/1.11.1",
-    "dest-filename": "foundation-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.9.3/foundation-1.9.3.module",
+    "sha512": "f67ba52babc067a13b748217c818973057cc057cf30947bc99e31d7fe12106747d4ef39c8d1b703ee2de632b0d0d677db808fc8470b4d712c1b66521bac78421",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.9.3",
+    "dest-filename": "foundation-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1/gradle-plugin-internal-jdk-version-probe-1.11.1.jar",
-    "sha512": "9ab66f7ce3cd61dd3aee07ded89c85a7773de88b260f875d243091cd9e02f976d24371a714c51fcbbf39fbab8f43064811350f3f5f3a87670421b307c3f6657d",
-    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1",
-    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.9.3/foundation-1.9.3.pom",
+    "sha512": "16b9c362a407836a969453e0d3f818e8018dacf840173d8911a1f2a0475fd31e400830d849505ee0d0023c4e56fa83148b0a08b2638b5d0fd849cae9774de642",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.9.3",
+    "dest-filename": "foundation-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1/gradle-plugin-internal-jdk-version-probe-1.11.1.module",
-    "sha512": "256f42b162a32a312fd761763e642d9224a35b6477b9f906d0d611ca9913e0b47b01efad859189dc5c97cbb8d6fc6bc6e79cbb19aea75ec2feed6e3d6a2602e7",
-    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1",
-    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/foundation/foundation/1.9.3/../../foundation-desktop/1.9.3/foundation-desktop-1.9.3.module",
+    "sha512": "e13ea536a6b29848a74c036ddbd1fd5cafd12a7ccbf0f6cbeaa9b02a22130d8762e2d44a6d4c6ad5d2917a8927f61e9799546f939b2ed3c39257ae1c03011b9a",
+    "dest": "offline-repository/org/jetbrains/compose/foundation/foundation/1.9.3/../../foundation-desktop/1.9.3",
+    "dest-filename": "foundation-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1/gradle-plugin-internal-jdk-version-probe-1.11.1.pom",
-    "sha512": "45ce037e302ab879673b89b074068c3d5bf5eeee16fc1d5a6edb5e3cddd2cd85cfc4d0d6f839fc485731ad1d49d4596c565249537f86fb04fbd17174898b2456",
-    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.11.1",
-    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3/gradle-plugin-internal-jdk-version-probe-1.9.3.jar",
+    "sha512": "ef69f2fa597b5af78df8aa8178f1fabf9f8a7ade04354d75643fa097384410a9d0db075c84a60655f98f96bab4a1826418a795bf68a61b8143dba40822c4449d",
+    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3",
+    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1/hot-reload-gradle-plugin-1.1.1.jar",
-    "sha512": "06d0fe16105a8217831054b49219e4be09f0f82bfbc08cc29a8091310506e73c7ee9225a79cd6f0bcd203a3f5ee1fd89e5d01b901a8762f92b7c13ad71920497",
-    "dest": "offline-repository/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1",
-    "dest-filename": "hot-reload-gradle-plugin-1.1.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3/gradle-plugin-internal-jdk-version-probe-1.9.3.module",
+    "sha512": "18fe95e8bb15a3fc459b4fc34de4debb0bd9013a60cebb3a87112dcddbfda3bd9ce741570cf86b7c8da966554d9ffefb85f695c8a7ed1bbd85ea66bc87ca12a2",
+    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3",
+    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1/hot-reload-gradle-plugin-1.1.1.module",
-    "sha512": "aee5b98df565167c9336d1167214c7bc10eed0dc91955fc2bc8a9dd1a2225b067e7e81de5b2611fdad7d45cfb9f85ed3a040fef9523b485bfcca8c4085a026e5",
-    "dest": "offline-repository/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1",
-    "dest-filename": "hot-reload-gradle-plugin-1.1.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3/gradle-plugin-internal-jdk-version-probe-1.9.3.pom",
+    "sha512": "c69c5c213a2e5cb37bf321389c41d5fec4d49950dbce4949c4a244e65b5d8d4b17de1f1d03e3fe21a632685df7c95a5bdbcd5b1fd16eb560c90e67d24e3a5ca7",
+    "dest": "offline-repository/org/jetbrains/compose/gradle-plugin-internal-jdk-version-probe/1.9.3",
+    "dest-filename": "gradle-plugin-internal-jdk-version-probe-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1/hot-reload-gradle-plugin-1.1.1.pom",
-    "sha512": "e1acbad2ebd9ca8b56c319c0cebbf230d4ddc84bb00fbad595207e68bbe18d561ecc4f9a9d6224cc7dcfeaa384349e43f8ecbca92bd61ba639c7e45c1d641c1e",
-    "dest": "offline-repository/org/jetbrains/compose/hot-reload/hot-reload-gradle-plugin/1.1.1",
-    "dest-filename": "hot-reload-gradle-plugin-1.1.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.9.3/material-desktop-1.9.3.jar",
+    "sha512": "eae5e7de5ea7ffda134d2320be29f19588e198345256a0d8ffa0c95c9e137b998b544a776de7c3c68f1c9547dcf328356779deedee4203ce66ddc603c02ea138",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.9.3",
+    "dest-filename": "material-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.11.1/material-desktop-1.11.1.jar",
-    "sha512": "6d5d9567e06fdef7873ab4cc83d0cd56645a93bcf0801dd8c92a17f92e886098f7ad9c9426d519aca93cdc7a9a4f8c163cdf94d44ce08df749def170c1d26f53",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.11.1",
-    "dest-filename": "material-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.9.3/material-desktop-1.9.3.module",
+    "sha512": "0435dbdbeeacadf482ba0cf7eebf1533ca6235353f060c48da9b1f6072e0b4b217d2a3e808b8c69ea00ffa74f202bcb88d9ec57ffebc81bd4823565447f1c415",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.9.3",
+    "dest-filename": "material-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.11.1/material-desktop-1.11.1.module",
-    "sha512": "68c661b8c688014466bfa9c9c515f42ac54678205d5aa29ce361713662545f78bf7d415d5f02b777a0aabf2183582856c9ce171443c24a95cfcf04e22b21b39f",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.11.1",
-    "dest-filename": "material-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.9.3/material-desktop-1.9.3.pom",
+    "sha512": "fa9b8c5889faae62916a7c2b5d6caec4c534069d549de63ff8282c903b05b5985eb1236c9cc940b96a6d1af1583bd95f1e1afbf36b83fc9cac763bb41fb9bad2",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.9.3",
+    "dest-filename": "material-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-desktop/1.11.1/material-desktop-1.11.1.pom",
-    "sha512": "230083dfd58f4385bd3544f79475d30aa4e13c9b1aaa066e65cff5f963dd7df9630a23eefd707845d2dda883b6a0c46008ae5f76370997e1872b4fc089acd388",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-desktop/1.11.1",
-    "dest-filename": "material-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.9.3/material-ripple-desktop-1.9.3.jar",
+    "sha512": "d9553279f7fdb9f3fe3f2217b9b7576f2d9d13ce4dcf532dfe8e2ecf553327f230dfac1781675f991d5f6aabdee3ecfcf0af1b58ffdaecec7c5343fb28b0505d",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.9.3",
+    "dest-filename": "material-ripple-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.11.1/material-ripple-desktop-1.11.1.jar",
-    "sha512": "bfa8754c4161ff52b1afe1a9a497bc98c9c01b52dd92d97dee029d3219ef56614771ab84e26a18c98a1729c78364dbcec976bc0b6e3a7244a40f7c59bf5c0b7b",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.11.1",
-    "dest-filename": "material-ripple-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.9.3/material-ripple-desktop-1.9.3.module",
+    "sha512": "acba1bf96326c9cd2e87f4238da6f33aa5e0ef65f92e033e332c1c69f3c9ed4834dbe5b967571f73da54105257a985633e5f1ec3279f2ee219d35e0e17e710b7",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.9.3",
+    "dest-filename": "material-ripple-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.11.1/material-ripple-desktop-1.11.1.module",
-    "sha512": "cd6f74d788146a8c476b5dbce8de51dc1e54558f9c2ed60da7494c2089c3862efbff4806383c06b9dc1d18c03afd397a8a22e9dae418669da172e65930c3c010",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.11.1",
-    "dest-filename": "material-ripple-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.9.3/material-ripple-desktop-1.9.3.pom",
+    "sha512": "9f3fc86310625dda4e4e70b2e643907c898311ff294f6ee09cf9676347b6b1a7906140f0f2e650e4470f66d8c2c21f11f4fafd961a73be4bb0d92c25f122021e",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.9.3",
+    "dest-filename": "material-ripple-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple-desktop/1.11.1/material-ripple-desktop-1.11.1.pom",
-    "sha512": "ef36bb1ab9bb7b6bb371a0df28edec11333ec8772c30b9407fb48ddf5213a5d647b7b35ca78e2dae60c3eedf48518a715f1df7e2807ba806ca2782c831cae9c9",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple-desktop/1.11.1",
-    "dest-filename": "material-ripple-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.9.3/material-ripple-1.9.3.module",
+    "sha512": "3361ab3d44d670d575fc8ad6a1639b4803815bd69681b55f4dfec1cd64736f624fa643ffb102efe8443fb8aeb52938a3c479193fd759c17fe2ca7421f1683062",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.9.3",
+    "dest-filename": "material-ripple-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.11.1/material-ripple-1.11.1.module",
-    "sha512": "97364f422290da1c88ab2bb5af3926c419c5263ebaf37dc90e9d5880bf2846b67dd0916ecc8cf7713103642767c3bae4d28f152f93e6f56820c494e5b57d7a1b",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.11.1",
-    "dest-filename": "material-ripple-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.9.3/material-ripple-1.9.3.pom",
+    "sha512": "eb2d36916202ff18f389bc642619eeead5abe1e04a888300c613d71612b083348ee15cc2dbd171906445ccbf35f05e655788e6b47f1c1be0694832ab65a6c6ec",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.9.3",
+    "dest-filename": "material-ripple-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.11.1/material-ripple-1.11.1.pom",
-    "sha512": "bd686d6317038998d4d68c110031a06be7732615196f4640d6d866f4baae72a1555117a0695c364cdcb0f8a8bcb06c323ccd09dda5fe08ff233749b65d960102",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.11.1",
-    "dest-filename": "material-ripple-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.9.3/../../material-ripple-desktop/1.9.3/material-ripple-desktop-1.9.3.module",
+    "sha512": "acba1bf96326c9cd2e87f4238da6f33aa5e0ef65f92e033e332c1c69f3c9ed4834dbe5b967571f73da54105257a985633e5f1ec3279f2ee219d35e0e17e710b7",
+    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.9.3/../../material-ripple-desktop/1.9.3",
+    "dest-filename": "material-ripple-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material-ripple/1.11.1/../../material-ripple-desktop/1.11.1/material-ripple-desktop-1.11.1.module",
-    "sha512": "cd6f74d788146a8c476b5dbce8de51dc1e54558f9c2ed60da7494c2089c3862efbff4806383c06b9dc1d18c03afd397a8a22e9dae418669da172e65930c3c010",
-    "dest": "offline-repository/org/jetbrains/compose/material/material-ripple/1.11.1/../../material-ripple-desktop/1.11.1",
-    "dest-filename": "material-ripple-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.9.3/material-1.9.3.module",
+    "sha512": "ed14119a3ed533e28502d66804d94ef4014de25cff14b7a53861ec7f188237cdfcc91286cb6b8f188d8c96ae560725060a786ff16ad0cd96a1e2e334a80c4151",
+    "dest": "offline-repository/org/jetbrains/compose/material/material/1.9.3",
+    "dest-filename": "material-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.11.1/material-1.11.1.module",
-    "sha512": "629fdffd5d0e1f808719a7da843f9898057a19c98ac7e288cebd3c44e220ce70541714986f35f2a0bb364d29d51cbeeca0eac15ffd3bbba4d5bd11d82c412290",
-    "dest": "offline-repository/org/jetbrains/compose/material/material/1.11.1",
-    "dest-filename": "material-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.9.3/material-1.9.3.pom",
+    "sha512": "3107ce8f22d1ac7ceca58397ff8413af20d1c42d1fc397d0a75f6e820ff30789324808303d477370f1f995e68c87cd7ee6e379b2b398f828ce70e1e6b04e2991",
+    "dest": "offline-repository/org/jetbrains/compose/material/material/1.9.3",
+    "dest-filename": "material-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.11.1/material-1.11.1.pom",
-    "sha512": "bb264bf8c621a05cde7c00b1d260b893b87ef5b4487c87b3d1ce59c3d647e885d89facbf87160da7744d6947aa51eeddb4e2492dc5463e1440a2eac0307fe362",
-    "dest": "offline-repository/org/jetbrains/compose/material/material/1.11.1",
-    "dest-filename": "material-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.9.3/../../material-desktop/1.9.3/material-desktop-1.9.3.module",
+    "sha512": "0435dbdbeeacadf482ba0cf7eebf1533ca6235353f060c48da9b1f6072e0b4b217d2a3e808b8c69ea00ffa74f202bcb88d9ec57ffebc81bd4823565447f1c415",
+    "dest": "offline-repository/org/jetbrains/compose/material/material/1.9.3/../../material-desktop/1.9.3",
+    "dest-filename": "material-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material/material/1.11.1/../../material-desktop/1.11.1/material-desktop-1.11.1.module",
-    "sha512": "68c661b8c688014466bfa9c9c515f42ac54678205d5aa29ce361713662545f78bf7d415d5f02b777a0aabf2183582856c9ce171443c24a95cfcf04e22b21b39f",
-    "dest": "offline-repository/org/jetbrains/compose/material/material/1.11.1/../../material-desktop/1.11.1",
-    "dest-filename": "material-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.9.0/material3-desktop-1.9.0.jar",
+    "sha512": "e4ceb5bb991b131ebda6792c162625771709d8c65fd371a0e618c6c6eacbf6b3c82ba22dd4d9d1fc422d88ab5d753f9d1cc64ae736b43ee41a667aace422c608",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.9.0",
+    "dest-filename": "material3-desktop-1.9.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-adaptive-navigation-suite/1.11.0-alpha07/material3-adaptive-navigation-suite-1.11.0-alpha07.pom",
-    "sha512": "58b404a30be7d3f8bd23679ae05622c7fd3b44373077ccf628c1a3328d763a88f2017af4edbcbd942dc006a7c259056e53736585b1b99cdd5f5d8115af2359b8",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3-adaptive-navigation-suite/1.11.0-alpha07",
-    "dest-filename": "material3-adaptive-navigation-suite-1.11.0-alpha07.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.9.0/material3-desktop-1.9.0.module",
+    "sha512": "af53f9d0c6b777b6f5c8e27d8fae486ea115cb32ce4a227c9240b656ddc152fbc81988fda69c6e3751d103b1336e8dcd78ca9d9392fbf5d7dec9dd9484e64790",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.9.0",
+    "dest-filename": "material3-desktop-1.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07/material3-desktop-1.11.0-alpha07.jar",
-    "sha512": "b7aa65ef56280d1c4bf79d638228aa3e6ff6432cb4c8ac924d71f211d2340e36e83d1faf67613a934fd551ba9a7597fd924ee18e87758d988b37847ed8830dbd",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07",
-    "dest-filename": "material3-desktop-1.11.0-alpha07.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.9.0/material3-desktop-1.9.0.pom",
+    "sha512": "5b4770783acc6fcfa45c104f4a0b38096bd09f71d173eb171ed573f7dd015027b30e045dccf33b0f85db7673f88bcbc9fc2bce67c29165162455f305a3bf7d12",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.9.0",
+    "dest-filename": "material3-desktop-1.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07/material3-desktop-1.11.0-alpha07.module",
-    "sha512": "a6d1d1f5d84aa06da140d3136a4bf5cd050a5577b158a217faec9146f395b8a2cdf8800dd5636424c02d26131b94c8852ebb4f085615c42c1ae720b4210e7ea4",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07",
-    "dest-filename": "material3-desktop-1.11.0-alpha07.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.9.0/material3-1.9.0.module",
+    "sha512": "6a6358ce46c003eaa83f633d64c67230c1c5e79cd2e3f7a0e64f965475e5d87a5ee6849dbf7628ce18c27864d5fbf30744bb41fc5219936f53ff27f189156058",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.9.0",
+    "dest-filename": "material3-1.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07/material3-desktop-1.11.0-alpha07.pom",
-    "sha512": "256863500a7877986ce0505be898063b30d006ac9624f7f4303cf1753905daae43de66dd3e53b22ba0a833b2e1bd8690f06c1ead52bf22e482f7c1b7caa71f16",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3-desktop/1.11.0-alpha07",
-    "dest-filename": "material3-desktop-1.11.0-alpha07.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.9.0/material3-1.9.0.pom",
+    "sha512": "0aa373a0d575b98d185056cd57df188ed7a4b25d25915bf7652eec322ef987f7d2cc5033db72a4d93b89f2f0d7fb608533795442f3490dd4f69be9bffa55d191",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.9.0",
+    "dest-filename": "material3-1.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3-window-size-class/1.11.0-alpha07/material3-window-size-class-1.11.0-alpha07.pom",
-    "sha512": "42a63b3285b5bd89ff38b29f0808e327931f24d12c85e2064b3ab011b542ef24a3c4c1f58e4ceebeec3851799304ee14152515942520d7f062b4ea506b5e0912",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3-window-size-class/1.11.0-alpha07",
-    "dest-filename": "material3-window-size-class-1.11.0-alpha07.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.9.0/../../material3-desktop/1.9.0/material3-desktop-1.9.0.module",
+    "sha512": "af53f9d0c6b777b6f5c8e27d8fae486ea115cb32ce4a227c9240b656ddc152fbc81988fda69c6e3751d103b1336e8dcd78ca9d9392fbf5d7dec9dd9484e64790",
+    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.9.0/../../material3-desktop/1.9.0",
+    "dest-filename": "material3-desktop-1.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.11.0-alpha07/material3-1.11.0-alpha07.module",
-    "sha512": "ae6a014247597d1561630e38b8984ae4fb7f882c6bc7b9a2e213dcf8bd3dc39e1ce80d8acce449257bb066a7e326835b3ffd16cfc01cd442c6d14b1e4b674bca",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.11.0-alpha07",
-    "dest-filename": "material3-1.11.0-alpha07.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/org.jetbrains.compose.gradle.plugin/1.9.3/org.jetbrains.compose.gradle.plugin-1.9.3.pom",
+    "sha512": "c688763727c8f9dd5839d21cd18c59f25ac0e23c5dffb311e71e803ac5b08a10a5d33799456bde251ec1795c086644b6e306a4c7a8a3453e1e24bcafe5ddd91e",
+    "dest": "offline-repository/org/jetbrains/compose/org.jetbrains.compose.gradle.plugin/1.9.3",
+    "dest-filename": "org.jetbrains.compose.gradle.plugin-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.11.0-alpha07/material3-1.11.0-alpha07.pom",
-    "sha512": "9b9a7062bc1a43d0406064dc3ac78d307e3e70ce0b8147b7465cdbdb4dab9261612c22472f61d1b68403451ab094cb16fbe9a03b99346c19ff6e6748ef5a1919",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.11.0-alpha07",
-    "dest-filename": "material3-1.11.0-alpha07.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.9.3/runtime-desktop-1.9.3.jar",
+    "sha512": "cec8fcf3ef05065a8ebc31311d6fc3b2029717d8942560ba2aeabe66e5bb08da4d440bc4ec72479d078a555cfc19eef3848cb730b344a46e3b29a9a1e4011a30",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.9.3",
+    "dest-filename": "runtime-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/material3/material3/1.11.0-alpha07/../../material3-desktop/1.11.0-alpha07/material3-desktop-1.11.0-alpha07.module",
-    "sha512": "a6d1d1f5d84aa06da140d3136a4bf5cd050a5577b158a217faec9146f395b8a2cdf8800dd5636424c02d26131b94c8852ebb4f085615c42c1ae720b4210e7ea4",
-    "dest": "offline-repository/org/jetbrains/compose/material3/material3/1.11.0-alpha07/../../material3-desktop/1.11.0-alpha07",
-    "dest-filename": "material3-desktop-1.11.0-alpha07.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.9.3/runtime-desktop-1.9.3.module",
+    "sha512": "74970e27c56c6b09296887f1af1b4f1ea5d71e5ec5ec8e823dbefd50c63ca32d4fea4e816a3d9eb4f9155e0c930c99342428aba3a84d304d539c3d58025b3b0d",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.9.3",
+    "dest-filename": "runtime-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/org.jetbrains.compose.gradle.plugin/1.11.1/org.jetbrains.compose.gradle.plugin-1.11.1.pom",
-    "sha512": "f83fa6266e2e41db9ab3b42a0e4a54db5b088fb43d47020ac4256b7b584fec245443fed04f7eb754e353c177417bc137dd122fde56e1faa7dd37300e43ff6a07",
-    "dest": "offline-repository/org/jetbrains/compose/org.jetbrains.compose.gradle.plugin/1.11.1",
-    "dest-filename": "org.jetbrains.compose.gradle.plugin-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.9.3/runtime-desktop-1.9.3.pom",
+    "sha512": "45954a61c0703d011f3527a8c8b820ea0b2b6eb980e1705373d8b0d8a49c5b70b86c81c4573eabeadd29881023823cee1d34afc283c8b8692cfea4402565d088",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.9.3",
+    "dest-filename": "runtime-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.11.1/runtime-desktop-1.11.1.jar",
-    "sha512": "82deab772f419edd20321f802d0397ef2e21b97444ad173edc2867aa75dd3cebb751111dd0e67f944a3f2bd19783aac3ccbdfca636c27721570682fe5a364896",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.11.1",
-    "dest-filename": "runtime-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3/runtime-saveable-desktop-1.9.3.jar",
+    "sha512": "9bfa029d2cff9a1d5c0cf01a74ba6ae50da585be27af2f1a63c3b059f7b37ef85bd8dfa21775e87bb4e6dd8654ffd90c8077f826ada81489dd7e3af0ad8519fb",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3",
+    "dest-filename": "runtime-saveable-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.11.1/runtime-desktop-1.11.1.module",
-    "sha512": "69a6422a8c4ada07ddc4667b29a1deac7aa8f0429df81c2e387857e1c79aa5dfccf4bb4d1571bc3798786fd5cd5c8fb71db5f5bd7fe3adbeb865fb0dab859c47",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.11.1",
-    "dest-filename": "runtime-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3/runtime-saveable-desktop-1.9.3.module",
+    "sha512": "3f828b5d45da085feb5bde1e0e4319849ef3f2e63b7bae564407598bea6db8f8868f5a31d6ec51f6d67f7dd097d18aa3efe5458bf6cf8afe687799d8b31681f9",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3",
+    "dest-filename": "runtime-saveable-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-desktop/1.11.1/runtime-desktop-1.11.1.pom",
-    "sha512": "6826ac1dd1848b1b2570737ef4d9e2addf274bc2a2b3fd35520b2b5d1a5844c9ad5b3052f1fc318e5aa712666bb18f3bdf5c2b87df3b493238dcaa1985acd869",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-desktop/1.11.1",
-    "dest-filename": "runtime-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3/runtime-saveable-desktop-1.9.3.pom",
+    "sha512": "c2ddee1f5062b7f4f716fa749a6b3acc8058e0f9728f2f4782c967a62e59dc4f7d730d19d1a16040d3f1d3d6c32adb22b588aad6da2bed17c090c39ed0dea547",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.9.3",
+    "dest-filename": "runtime-saveable-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1/runtime-saveable-desktop-1.11.1.jar",
-    "sha512": "db8a7dbbf90ff5db7160fb6805dc874fcafa70ab7b99ad646bc15174577f7d0ddbaeabd1b8b94fc1d1b154592dbb4ed9392341cef17c7f2ab63d25d8c85c82fc",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1",
-    "dest-filename": "runtime-saveable-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.9.3/runtime-saveable-1.9.3.module",
+    "sha512": "5589bbcab0d5d6f1aad2705bbcf046225ffcc6971a2afdbe6b1680e5f84a4a2774b63e3c5629fb838eb1b132b1524f584ba0ccd83d963ee6ee964e49717fdd8d",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.9.3",
+    "dest-filename": "runtime-saveable-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1/runtime-saveable-desktop-1.11.1.module",
-    "sha512": "bb41124a3e79a44f9647187a92810e38ed0e5165244a9e1f4408cdbe72ccd6df70091818ed69070632262d774b222ec5a6a031aafa20ac051ec426948925d83c",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1",
-    "dest-filename": "runtime-saveable-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.9.3/runtime-saveable-1.9.3.pom",
+    "sha512": "fcdd0fcaff7f3038c75ba3c3921952e48bc74c94cec923cdc5ad291c38ef4de4ab7e0d44ed58950f0873f833992b0986e7c08d2910f5ab40b693330a989c941f",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.9.3",
+    "dest-filename": "runtime-saveable-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1/runtime-saveable-desktop-1.11.1.pom",
-    "sha512": "1d209d3dca94dcac34740e5d355f5ff1452150320b2cdec11c8ce496d7c63d22fde38c30df822bf3caa22a757a7973c4028faf1d59f00c8e9a3e3aa6fc54efb4",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable-desktop/1.11.1",
-    "dest-filename": "runtime-saveable-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.9.3/../../runtime-saveable-desktop/1.9.3/runtime-saveable-desktop-1.9.3.module",
+    "sha512": "3f828b5d45da085feb5bde1e0e4319849ef3f2e63b7bae564407598bea6db8f8868f5a31d6ec51f6d67f7dd097d18aa3efe5458bf6cf8afe687799d8b31681f9",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.9.3/../../runtime-saveable-desktop/1.9.3",
+    "dest-filename": "runtime-saveable-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.11.1/runtime-saveable-1.11.1.module",
-    "sha512": "b603c0b564c2bf55e515f83b7ab741fd85bfb6665fc217e34c1dc4babbd26c99bed5abf5ed0f46c3abe07dadd3477a20a255fdd9ce3e4f9bab1f23f8ebf62c6e",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.11.1",
-    "dest-filename": "runtime-saveable-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime/1.9.3/runtime-1.9.3.pom",
+    "sha512": "5eea444e20f41f03a25ad168a87e5057c2c0a77225bf381802694b4372257c40eaa3bdcdb826ecaffe68826228f13d81b37b388d92a2bedeecb1af317bcea5bb",
+    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime/1.9.3",
+    "dest-filename": "runtime-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.11.1/runtime-saveable-1.11.1.pom",
-    "sha512": "17651e3a859b4a1d3c2722e11a9e32d20c8e03dfa599ff96e05d3423217ec9904ae2a093d0af9817b16806979068c88501d9da3573d7be8888655ef4ba3cc07a",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.11.1",
-    "dest-filename": "runtime-saveable-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3/ui-backhandler-desktop-1.9.3.jar",
+    "sha512": "cd6b875b670c2f256f7aacca0911d6147df1e9a2921f375a2544f8e0d93de0c33dd1655219a75300b19616d9d6443c4f7f8add93deb667ed7c70e4406ae5d436",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3",
+    "dest-filename": "ui-backhandler-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime-saveable/1.11.1/../../runtime-saveable-desktop/1.11.1/runtime-saveable-desktop-1.11.1.module",
-    "sha512": "bb41124a3e79a44f9647187a92810e38ed0e5165244a9e1f4408cdbe72ccd6df70091818ed69070632262d774b222ec5a6a031aafa20ac051ec426948925d83c",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime-saveable/1.11.1/../../runtime-saveable-desktop/1.11.1",
-    "dest-filename": "runtime-saveable-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3/ui-backhandler-desktop-1.9.3.module",
+    "sha512": "df877b3cfa19865986b48f54950c0530e8aff2bb6488fc2e9da7bcb8e93e61ed7d3b3d1fee13cce4f7043ca76bd4b78bdc84c792a968a18da3cbd541c5517965",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3",
+    "dest-filename": "ui-backhandler-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime/1.11.1/runtime-1.11.1.module",
-    "sha512": "00af4761879226e4795f180a699c8880a454ca4ffa9feb1965826c62e4498f174ea42980836f7f3fd0505637e568390b6456712ce75d92b905108e1d8852fea9",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime/1.11.1",
-    "dest-filename": "runtime-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3/ui-backhandler-desktop-1.9.3.pom",
+    "sha512": "4d7f9b45255d96e7816c7ece6232f4a704784781cb2916c4f92109cd6d8c2a5141d8b67be1778aa1d055279ad19f750015590569393d0a1002380c79da461e41",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.9.3",
+    "dest-filename": "ui-backhandler-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime/1.11.1/runtime-1.11.1.pom",
-    "sha512": "6d63e25f83b187330785e19d0f52e2afd2543aff5080703948f0afdd165e3b1fca6bd8a22818309aa3b08cc620c4fb30541896eb3ea05e8268524a37759f5fa4",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime/1.11.1",
-    "dest-filename": "runtime-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.9.3/ui-backhandler-1.9.3.module",
+    "sha512": "7081671068fffcac4fd21c27ae720f97913e53f58fbae98d2415fcc0b7b385febca60853e4e8215b0267b48f71390222ed25364b5cb24fbf381582a2ed57656d",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.9.3",
+    "dest-filename": "ui-backhandler-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/runtime/runtime/1.11.1/../../runtime-desktop/1.11.1/runtime-desktop-1.11.1.module",
-    "sha512": "69a6422a8c4ada07ddc4667b29a1deac7aa8f0429df81c2e387857e1c79aa5dfccf4bb4d1571bc3798786fd5cd5c8fb71db5f5bd7fe3adbeb865fb0dab859c47",
-    "dest": "offline-repository/org/jetbrains/compose/runtime/runtime/1.11.1/../../runtime-desktop/1.11.1",
-    "dest-filename": "runtime-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.9.3/ui-backhandler-1.9.3.pom",
+    "sha512": "0e3d6a11562fc19ee366c92bde03e956f39f705c42f33d0e1bce99cdcd5bc22211367ea567fd68b64ce0778328a1f4087f52e191281ce71f9356a466c4e33c88",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.9.3",
+    "dest-filename": "ui-backhandler-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1/ui-backhandler-desktop-1.11.1.jar",
-    "sha512": "09e1b694683a237a10e55c61babfcfac704edd9e243d3b42b42263a23915245100a9adfc034b4fc0704e218e4149a21ccaa1a717e5975caa0d15e0f6a883e105",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1",
-    "dest-filename": "ui-backhandler-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.9.3/../../ui-backhandler-desktop/1.9.3/ui-backhandler-desktop-1.9.3.module",
+    "sha512": "df877b3cfa19865986b48f54950c0530e8aff2bb6488fc2e9da7bcb8e93e61ed7d3b3d1fee13cce4f7043ca76bd4b78bdc84c792a968a18da3cbd541c5517965",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.9.3/../../ui-backhandler-desktop/1.9.3",
+    "dest-filename": "ui-backhandler-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1/ui-backhandler-desktop-1.11.1.module",
-    "sha512": "de2a03df6329c490a4cba0eb320434d7f5d2901836c07d349ec329e1bf763c3a6b581c8b79635c86f2936beaecec168d1a41dcedea265677df7901bc6e1df82b",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1",
-    "dest-filename": "ui-backhandler-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.9.3/ui-desktop-1.9.3.jar",
+    "sha512": "09dd7bdb50b47919df7215eb2e1cdea4ffcb2f123b106c8932d5e329837977f40a63ac03becfc2e72ed51d4d418ca93e0acfc2aa0a1703dbfa914e3f0e7d1911",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.9.3",
+    "dest-filename": "ui-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1/ui-backhandler-desktop-1.11.1.pom",
-    "sha512": "8e102e91fb7807d08dd99d6d2788b4f962c088d0efa974fb512a0697040fd07e66952db5968f52d1d57f79881b6e0d546deb763becd4cab5e74acea003fc1589",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler-desktop/1.11.1",
-    "dest-filename": "ui-backhandler-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.9.3/ui-desktop-1.9.3.module",
+    "sha512": "6ed87ac4b0c23727b825af9de9d734ad3f221b3e8b28e9da5acf56f35e3d66b7ca33084cd4577ec97f73d5b85af3b67dc1c3a2417f60aedcb2ded50bc4cc2872",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.9.3",
+    "dest-filename": "ui-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.11.1/ui-backhandler-1.11.1.module",
-    "sha512": "291d9236f0ea3c93c0b36cf8eb78131a9915bbc3e4838d20db282a05d096e1db59bb00a109d3cfee7ee04a4c364500b6ea778a51d00ce2f1ae2d5b8c832f9164",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.11.1",
-    "dest-filename": "ui-backhandler-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.9.3/ui-desktop-1.9.3.pom",
+    "sha512": "a27ccd7b935e1ab39735d740e3e05b64b47540e0c7c297042e3ba0b5763d09f3fac7c7175740a639b47c9f546d45b42113431b1826832f050842f74e50685299",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.9.3",
+    "dest-filename": "ui-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.11.1/ui-backhandler-1.11.1.pom",
-    "sha512": "f25cfaa47bed34e64b39c36644aac5c3a6ef8883b47e72e558bc5f0ee01a18e89752eaa7a729da10d2a6deb69c152d6e30cb810363b3c421218e424cafdb5d61",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.11.1",
-    "dest-filename": "ui-backhandler-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3/ui-geometry-desktop-1.9.3.jar",
+    "sha512": "663c2a97b4fbcc90220b78ac688c88e3a22d65043497fde5e12441fb39ea03564da996b981104b2d4c643a8d7b13603914053641b8562e08186db4a13a4f6f8b",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3",
+    "dest-filename": "ui-geometry-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-backhandler/1.11.1/../../ui-backhandler-desktop/1.11.1/ui-backhandler-desktop-1.11.1.module",
-    "sha512": "de2a03df6329c490a4cba0eb320434d7f5d2901836c07d349ec329e1bf763c3a6b581c8b79635c86f2936beaecec168d1a41dcedea265677df7901bc6e1df82b",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-backhandler/1.11.1/../../ui-backhandler-desktop/1.11.1",
-    "dest-filename": "ui-backhandler-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3/ui-geometry-desktop-1.9.3.module",
+    "sha512": "3d7a9e247e3e1e8b936219c806c87eec62edb0e94901f27e589c296cf2acbc560950b59e43a249d39fc686ced3040fb0869d557034f6d716a83008b680ca2818",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3",
+    "dest-filename": "ui-geometry-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.jar",
-    "sha512": "94602f9a82302061113f08992a3886b47e26e011ba03260b098366930797a0d46ef3222a5462dca10f2d8a67c8c2e1451fc1f814e7a1389c0761e514989475e1",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.11.1",
-    "dest-filename": "ui-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3/ui-geometry-desktop-1.9.3.pom",
+    "sha512": "816bebcd3263a6cba8ecb88217c9de8f5c8b491a4e6c2e774d920941db30d64d9bc4b949e13aabb23d6518b36613350bac6522970a5df6304c8500f64c867acd",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.9.3",
+    "dest-filename": "ui-geometry-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.module",
-    "sha512": "75e9426532f976e9f550f8ba14867968da46ae4152d343d9963305ca2e30e1e49b035600b81e25bf70de966e036ba62e2883e1abdf92fe0806ad9f9106943ef6",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.11.1",
-    "dest-filename": "ui-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.9.3/ui-geometry-1.9.3.module",
+    "sha512": "9018afcc34f426258c8154e7c4b5dfa6d770ff05a72a849fa49d5dc4aae556988df56bdd943e22a8738f7bc41726fbd770892fb5b77f7d158a2745501c5c147f",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.9.3",
+    "dest-filename": "ui-geometry-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-desktop/1.11.1/ui-desktop-1.11.1.pom",
-    "sha512": "e6850c6e0d4babf7a17b1fbbb20931904e6aa8f3e079ff61de4a08b2b67e20eaedf743b2db190862d593ad4bec7ee08c53ef34e0ec3f2e5c0bea5086a9219255",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-desktop/1.11.1",
-    "dest-filename": "ui-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.9.3/ui-geometry-1.9.3.pom",
+    "sha512": "d3d88282c37aaca6c8a03446044dc7c71c9569e66593cfa87f163639591ba93aa45b4851d5b0c342088f0542b344a5422a536a06c4063883c8ab753681f2a3ea",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.9.3",
+    "dest-filename": "ui-geometry-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1/ui-geometry-desktop-1.11.1.jar",
-    "sha512": "c80c503787b8bd70cce388095813b3700edd47400856c5ce0a744b44d9e4346cacc98ab1fa532bf1d9c27253d769e2f98328592cbff684b2ef859999f2342dcd",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1",
-    "dest-filename": "ui-geometry-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.9.3/../../ui-geometry-desktop/1.9.3/ui-geometry-desktop-1.9.3.module",
+    "sha512": "3d7a9e247e3e1e8b936219c806c87eec62edb0e94901f27e589c296cf2acbc560950b59e43a249d39fc686ced3040fb0869d557034f6d716a83008b680ca2818",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.9.3/../../ui-geometry-desktop/1.9.3",
+    "dest-filename": "ui-geometry-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1/ui-geometry-desktop-1.11.1.module",
-    "sha512": "e7fab0160b0b788a64f03dd77d8f9f674e5f5f9f99b973ae2e3c319b009652f5a065a483f32085f84c036b2728f50d3aeee4022fbd9741f4ac3c4c31035ebed0",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1",
-    "dest-filename": "ui-geometry-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3/ui-graphics-desktop-1.9.3.jar",
+    "sha512": "7bb47535ee9b00f44c28353defcae56d147b77cc6af48c40a2c5359175fdb9a960f508d1427861d5a961a34425bfd2de62d51dc4b4c6c3546ad236999bb3c7a2",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3",
+    "dest-filename": "ui-graphics-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1/ui-geometry-desktop-1.11.1.pom",
-    "sha512": "2aa3a0354bf66823e452e1f07e7ed751dceae81971941f7daac1dc9d80fc131fe01a8e2309f6acbe293b3503a75c85fc68bcc397b720e0a6617faec8dd079aec",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry-desktop/1.11.1",
-    "dest-filename": "ui-geometry-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3/ui-graphics-desktop-1.9.3.module",
+    "sha512": "8ab7228618c1a0409ecdd4370b8515bd6ec6d8e2bb7e89ddf12575894e14d0a11a6abcefd32dd742c5a9ae58ccb4cfbbda381d4b065f68a46364b92bffe40f87",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3",
+    "dest-filename": "ui-graphics-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.11.1/ui-geometry-1.11.1.module",
-    "sha512": "c7fcf230de0665ee1544d2bb7e8202aebd7c33adacbd5b88ed92972b6fc30ca724c25d345ce15f27030b2c3b5c7a1140d01ec57461501ce50f4f4181a43f6ec0",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.11.1",
-    "dest-filename": "ui-geometry-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3/ui-graphics-desktop-1.9.3.pom",
+    "sha512": "f75ecd1d88f9f4b8f669973e36984941a8ab3938aa2eb44c08f61edd5f2e4ce15b0578a6adc87927a7e23059c50326cf3ae48489e84b8d439d1591b256a6a097",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.9.3",
+    "dest-filename": "ui-graphics-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.11.1/ui-geometry-1.11.1.pom",
-    "sha512": "619d364286b5c22e220e85918f9d3396a30cf0b7277c279d347166bb4eced403f7c08cb41c44264cfe394dbb8420183c8a80a2cfd8f19ea09ee949a139e59fb1",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.11.1",
-    "dest-filename": "ui-geometry-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.9.3/ui-graphics-1.9.3.module",
+    "sha512": "2973294f4c5cfb7bd9996368c5dcdf76bd47a98612ea2d77497f983940bae895d54974f88666b960a49687c6ed1130c8e4ac0e926c21ba27f65db500f624e950",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.9.3",
+    "dest-filename": "ui-graphics-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-geometry/1.11.1/../../ui-geometry-desktop/1.11.1/ui-geometry-desktop-1.11.1.module",
-    "sha512": "e7fab0160b0b788a64f03dd77d8f9f674e5f5f9f99b973ae2e3c319b009652f5a065a483f32085f84c036b2728f50d3aeee4022fbd9741f4ac3c4c31035ebed0",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-geometry/1.11.1/../../ui-geometry-desktop/1.11.1",
-    "dest-filename": "ui-geometry-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.9.3/ui-graphics-1.9.3.pom",
+    "sha512": "7e9beac13bda1cc6b7ca880a69c9642ca9248476acb569ef4da0187df25a385af7cddcf7d7b2fc8ad8c3370e92bba7baec849c838981be42311ddb0cd41130d8",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.9.3",
+    "dest-filename": "ui-graphics-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1/ui-graphics-desktop-1.11.1.jar",
-    "sha512": "1edfd38a40cfd8005c34267f145dd15956b459060ccccb3e157ecc50c753939606ea9f21131e50ac1c2b9c9537a8daaa22f060e9577d5e1548087ea00809d7c5",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1",
-    "dest-filename": "ui-graphics-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.9.3/../../ui-graphics-desktop/1.9.3/ui-graphics-desktop-1.9.3.module",
+    "sha512": "8ab7228618c1a0409ecdd4370b8515bd6ec6d8e2bb7e89ddf12575894e14d0a11a6abcefd32dd742c5a9ae58ccb4cfbbda381d4b065f68a46364b92bffe40f87",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.9.3/../../ui-graphics-desktop/1.9.3",
+    "dest-filename": "ui-graphics-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1/ui-graphics-desktop-1.11.1.module",
-    "sha512": "3c9a726583d3906231184ca6afa6df4764c804292c9748392f33e1e45e4d57922593cd2602a6ed7491388726a2c87730a5ba5b7fa15f6eeecb3176128b757b12",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1",
-    "dest-filename": "ui-graphics-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.9.3/ui-text-desktop-1.9.3.jar",
+    "sha512": "cadd5621be8539cf2e4e3fc609625cbe26f351ed07ac96a64ed2c3f647ce27b45af9de0a6788595b04854ec7911280a4983adb373f61d1a924d53ece9a279a03",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.9.3",
+    "dest-filename": "ui-text-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1/ui-graphics-desktop-1.11.1.pom",
-    "sha512": "29d0d4817735bcbe2ca5a3332d0f40b22240846244a50b5731dcd39a097dbc20cc5819f945c064009e0709e32f4567d9f532d4a2873fc7c0ee920f0f292aee48",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics-desktop/1.11.1",
-    "dest-filename": "ui-graphics-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.9.3/ui-text-desktop-1.9.3.module",
+    "sha512": "d225952902d429c88d9c3bd582899fe87ce713129e2c961de533d8163af74e63afb99e2e333b76acd0b947fe8e87d9748d4ea263cd34a47f4548dda752f3cd80",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.9.3",
+    "dest-filename": "ui-text-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.11.1/ui-graphics-1.11.1.module",
-    "sha512": "5d3481be5f4fba285fac0efce24400e0b026fefa06d4507437a065c44ed82b6a16feed5078ddb4d806d4bd6cd27e8def83243f3291353d633999af37ebca2940",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.11.1",
-    "dest-filename": "ui-graphics-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.9.3/ui-text-desktop-1.9.3.pom",
+    "sha512": "fc973cbeb703a5ec2afc62efa653e47c063b6825885c0aab460df2f6d64a99d3b51911a99a0ae32e94cfc587cb5f9d23b9b5e22be963656d6cb34a401a9e899b",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.9.3",
+    "dest-filename": "ui-text-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.11.1/ui-graphics-1.11.1.pom",
-    "sha512": "db19934a9bf2c754899b8518453085d9112ec9834dba00cc8c9d16a28314f4e69238126df72e1d96895c0a526ed36f227338a415c36ffd84c96947e1e235405b",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.11.1",
-    "dest-filename": "ui-graphics-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text/1.9.3/ui-text-1.9.3.module",
+    "sha512": "cc28b9c4cf22be2920d8f28bd78be73b4d972df85795eb71a2d7c45623f4e4166a0ce0c2cdce1774f5b941150160cfbd6fab093562eb954cd67b3b089f642fb0",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text/1.9.3",
+    "dest-filename": "ui-text-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-graphics/1.11.1/../../ui-graphics-desktop/1.11.1/ui-graphics-desktop-1.11.1.module",
-    "sha512": "3c9a726583d3906231184ca6afa6df4764c804292c9748392f33e1e45e4d57922593cd2602a6ed7491388726a2c87730a5ba5b7fa15f6eeecb3176128b757b12",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-graphics/1.11.1/../../ui-graphics-desktop/1.11.1",
-    "dest-filename": "ui-graphics-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text/1.9.3/ui-text-1.9.3.pom",
+    "sha512": "e4e59d5477720f48b45b6948a4a0cfa2e017d8a4fa46f3061c8480391fccecfb227a51ca844645d86c67693287d9cbcffe994d3d30c6f2f4278d1b029ffefaad",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text/1.9.3",
+    "dest-filename": "ui-text-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-test-junit4/1.11.1/ui-test-junit4-1.11.1.pom",
-    "sha512": "c5a73a184ec3c1d9798e70657fa6762b764c6e7f753f7a681ad257c3f34d66afa0effe61a72de4b08d5f9b69ef89b9c7b38402e8f5ad61a0fd51aaeff80b9eb1",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-test-junit4/1.11.1",
-    "dest-filename": "ui-test-junit4-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3/ui-tooling-preview-desktop-1.9.3.jar",
+    "sha512": "146443afb99e2d8f27994d2c15c51b740ddbe69641e130c5921cedcb275919a2d1d7adbb935a2272334a5411d1c94e68ecd9de834b83df4bd039002b25bf1e9b",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3",
+    "dest-filename": "ui-tooling-preview-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-test/1.11.1/ui-test-1.11.1.pom",
-    "sha512": "ab75f97f58c7c4edf4ba2f6dcd6663bf0f78537cad3861c48368ab462b1c589fc8027132ab750fe71fe4ed6c31fbe1cdd8bdc6a282286b5edc2f2a8657d5a73a",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-test/1.11.1",
-    "dest-filename": "ui-test-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3/ui-tooling-preview-desktop-1.9.3.module",
+    "sha512": "81f9060641dca5dfc6113eab7794ca81239196a88dbe7a036fa13891fcfb5544828547500af8166dc78426e22e2fce7bc9bfde60047b0696d42ee169a6881e0b",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3",
+    "dest-filename": "ui-tooling-preview-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.11.1/ui-text-desktop-1.11.1.jar",
-    "sha512": "cf38786562f187f262a655d8832e5fa9701e74bc77316b59133e0202df78f6a4b54fad35402c349e2de43cb1cdca6601f69024b70a2570896e3ad39c17238bc4",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.11.1",
-    "dest-filename": "ui-text-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3/ui-tooling-preview-desktop-1.9.3.pom",
+    "sha512": "fcd6253c831bf273f960ae382c0ad50100e107fd2618ceecb3dc64186da533d78bb4f3e53e132387b209c90d6883797a42f423436896437c1a83d246995cc887",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.9.3",
+    "dest-filename": "ui-tooling-preview-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.11.1/ui-text-desktop-1.11.1.module",
-    "sha512": "4d3db6f88c1c0c056ad61bea7c6a2ae0f22647d9e853b676a473000cdb4e8b92e604c8cf8200187138e7a5e5ff22ebf4ea896c02a831e2268c17eeb20960a325",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.11.1",
-    "dest-filename": "ui-text-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3/ui-tooling-preview-1.9.3.module",
+    "sha512": "fe48daf641e128f3b7059eae25c06e327dc515243f28d5c37455cf197e0516b8724926d058cf2865833cc0d279daeb6203eb77621237128d969f3df0c46a1a2e",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3",
+    "dest-filename": "ui-tooling-preview-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text-desktop/1.11.1/ui-text-desktop-1.11.1.pom",
-    "sha512": "5e935327fefc29b5c2c24967599d2f41babec8640763e6d105a4399d51c10474cd974a93fa6155bcbd78d66b8440c7e2ee229af9e0769f5ebdbf812add704f94",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text-desktop/1.11.1",
-    "dest-filename": "ui-text-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3/ui-tooling-preview-1.9.3.pom",
+    "sha512": "bcf4ece1a28b05798b0d942b0043cda71bc155bd76617b59a9108dc315eccaf6e860fc9a10e49be7fb07fc6b4c74bbd515cba58774270af5720c91c284ddf7d8",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3",
+    "dest-filename": "ui-tooling-preview-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text/1.11.1/ui-text-1.11.1.module",
-    "sha512": "ff292bbf6674a3c338bad94c49a885080840fb91c4f1e83a4b570d1b06a0bd13ad8aa31e884f48e22e25408f2a173e40db127dec01273207efbd036716338c14",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text/1.11.1",
-    "dest-filename": "ui-text-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3/../../ui-tooling-preview-desktop/1.9.3/ui-tooling-preview-desktop-1.9.3.module",
+    "sha512": "81f9060641dca5dfc6113eab7794ca81239196a88dbe7a036fa13891fcfb5544828547500af8166dc78426e22e2fce7bc9bfde60047b0696d42ee169a6881e0b",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.9.3/../../ui-tooling-preview-desktop/1.9.3",
+    "dest-filename": "ui-tooling-preview-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text/1.11.1/ui-text-1.11.1.pom",
-    "sha512": "d27a7541cc47d227c15e709dc775994fdb7b9e02b6884c0c926905cb6987d880f6cf8274701ee7fdba5bbe1fbe7407834eb621f16d17fc53f75726554272b2b7",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text/1.11.1",
-    "dest-filename": "ui-text-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3/ui-unit-desktop-1.9.3.jar",
+    "sha512": "6a00b042eb629fff864e9628e325f8359c7fa1f659ebff7613d975376425afa8e9d9f02750f65f85eef1da387fa1bb7e0e094ab5533ac598b28194ae9bbf2645",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3",
+    "dest-filename": "ui-unit-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-text/1.11.1/../../ui-text-desktop/1.11.1/ui-text-desktop-1.11.1.module",
-    "sha512": "4d3db6f88c1c0c056ad61bea7c6a2ae0f22647d9e853b676a473000cdb4e8b92e604c8cf8200187138e7a5e5ff22ebf4ea896c02a831e2268c17eeb20960a325",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-text/1.11.1/../../ui-text-desktop/1.11.1",
-    "dest-filename": "ui-text-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3/ui-unit-desktop-1.9.3.module",
+    "sha512": "cc9ce7d674e54a60322449cac54fe4a919ca34cabf20c4610868ad951215bd4322727d25434da9191479c0830665c78c93d7d6795eb6ff2a28d8a3a8360a8b31",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3",
+    "dest-filename": "ui-unit-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-data/1.11.1/ui-tooling-data-1.11.1.pom",
-    "sha512": "2e57574c65d617ae1090ce52ea0e638994891e51b5aace84a4235f644bed98869bcfb2d0957f0dbb3c36985d8459f65beb1b034bbfdc6afb478e87a32f5ebb67",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-data/1.11.1",
-    "dest-filename": "ui-tooling-data-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3/ui-unit-desktop-1.9.3.pom",
+    "sha512": "525caeb5655e483bc1bcb8a007bc4bd3ba713a93ce9a933861fa0f463832a88eeff8496e70e1cabad46139b46d7b880db875b027117423515001a94fa84892fa",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.9.3",
+    "dest-filename": "ui-unit-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1/ui-tooling-preview-desktop-1.11.1.jar",
-    "sha512": "7f8a165ff980224b26dd1c55d8f552670349e12b681a3ab7fb01c93441ee799245abc1ea2f84e5fbf33dc36d5866888455f747d4b6a8772ad33bbe6f2a7cd0a2",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1",
-    "dest-filename": "ui-tooling-preview-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.9.3/ui-unit-1.9.3.module",
+    "sha512": "59ef0b3ff80d8b663e0856d89d580f9e80bd3d25b2771a99c8a59bc1983f48010d2f630cdf725f4b8e2cfadb2cb22f5cf27c78cbe426ada546dd0cb02844a8ec",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.9.3",
+    "dest-filename": "ui-unit-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1/ui-tooling-preview-desktop-1.11.1.module",
-    "sha512": "4d38b9a8403a4221a751d174b6a45aef1b051b598f679f3360894c64c5ee8cd3f7a2c3a19ef5569fe50788ef13e2e05ca60b3869eb1ea1f8ddb88cd8edd20797",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1",
-    "dest-filename": "ui-tooling-preview-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.9.3/ui-unit-1.9.3.pom",
+    "sha512": "e89996f60b04ca5ba2988ce59f649c98edf9f4712cbac1675d87c5ce1b37ddbbd685b294f26d31ffb2791c36ba65b892ea4b15fe29ef17d3398be0e44d3a9766",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.9.3",
+    "dest-filename": "ui-unit-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1/ui-tooling-preview-desktop-1.11.1.pom",
-    "sha512": "fb3e5d15e6c6235f971708862618e4af178f724ef78e9e1b17466cd26e465b975c6d49ec8fec7a97dcdd751eb34ddd02d72f44eb4f567390c8baf1c9b4d99e0f",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview-desktop/1.11.1",
-    "dest-filename": "ui-tooling-preview-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.9.3/../../ui-unit-desktop/1.9.3/ui-unit-desktop-1.9.3.module",
+    "sha512": "cc9ce7d674e54a60322449cac54fe4a919ca34cabf20c4610868ad951215bd4322727d25434da9191479c0830665c78c93d7d6795eb6ff2a28d8a3a8360a8b31",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.9.3/../../ui-unit-desktop/1.9.3",
+    "dest-filename": "ui-unit-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1/ui-tooling-preview-1.11.1.module",
-    "sha512": "ae375862a26e856b78f31940d0b781a7dee2fc232a1bff8b09a52292fc3a9ac2827105b00ae6add5013331042c19ae7f76feafb3bae07a0087b3e3b41953a724",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1",
-    "dest-filename": "ui-tooling-preview-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.9.3/ui-util-desktop-1.9.3.jar",
+    "sha512": "c942bbc9dde42cb69eef783d7dedfa9b90b58eb7c559bc76705a6363b62013da566892c5915d4b5e5a3f3aa322fef2d62ef4eff75f8fd5d4019b73b9e2d12729",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.9.3",
+    "dest-filename": "ui-util-desktop-1.9.3.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1/ui-tooling-preview-1.11.1.pom",
-    "sha512": "31830452c4986750e7d439896dfc0cedef7b43dc3235ece48f09c6420345227b6aeb842c3c9f25297476dd59580f1464e63ff0f375e934c3b40a37867a1978d9",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1",
-    "dest-filename": "ui-tooling-preview-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.9.3/ui-util-desktop-1.9.3.module",
+    "sha512": "5baee9cd519263a6018019d5277162697300cb41903883e97490cd7e18b477e3719707ff78209d4820bc886578a816afa3834b70399af94aa4158841b5ab67e5",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.9.3",
+    "dest-filename": "ui-util-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1/../../ui-tooling-preview-desktop/1.11.1/ui-tooling-preview-desktop-1.11.1.module",
-    "sha512": "4d38b9a8403a4221a751d174b6a45aef1b051b598f679f3360894c64c5ee8cd3f7a2c3a19ef5569fe50788ef13e2e05ca60b3869eb1ea1f8ddb88cd8edd20797",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling-preview/1.11.1/../../ui-tooling-preview-desktop/1.11.1",
-    "dest-filename": "ui-tooling-preview-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.9.3/ui-util-desktop-1.9.3.pom",
+    "sha512": "5e4a7949e0143a81f06926fbbcfa10d96c1657ab25883f5bc775939bf0fab00e133be4aabd690453da37c837d81b7681fe63605efe496d42a0dc6253f4c32875",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.9.3",
+    "dest-filename": "ui-util-desktop-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-tooling/1.11.1/ui-tooling-1.11.1.pom",
-    "sha512": "159c818d3aefe02a2e2012461efe97adc62a5ba0c3d53042a4280b937aae874c8f499ae8afe4569a28d0fa5b1f9a4eafd61c5d2c0f211d3cc621c031056893c5",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-tooling/1.11.1",
-    "dest-filename": "ui-tooling-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.9.3/ui-util-1.9.3.module",
+    "sha512": "a9aeb7ee8cac5ac32c1ae2b60fb942fdd033707e89b5f4a5017546992465eacd456e8cd6b45b04accad25ae76683a743c1f68dff0630f8ac48ee2cd2b398f513",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.9.3",
+    "dest-filename": "ui-util-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1/ui-unit-desktop-1.11.1.jar",
-    "sha512": "59c54f15c5f43dd5128bfe3f5de4b112ea026657bda7fad2afc1340bd71b1a07ed0421e67d376f1aedd29fd5d288185683fa1e032be3e368b74e7b5033c6cfa0",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1",
-    "dest-filename": "ui-unit-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.9.3/ui-util-1.9.3.pom",
+    "sha512": "d9376e49d60a7eba156d10bc1dfd25c4beaa8ac5183aab2b8224def69a62fbbecc4f0c62040741601ec9b1257b23f2440d81a9eefca0702d042423fb35881d04",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.9.3",
+    "dest-filename": "ui-util-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1/ui-unit-desktop-1.11.1.module",
-    "sha512": "f818b43f34c4abae22353b7b750de114707b292830c2baf9b0816ed55a7e098e03230f17edb6d7eb34c7e086f48b9bb35ad0f03a9cdcca254a34dc0bad399407",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1",
-    "dest-filename": "ui-unit-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.9.3/../../ui-util-desktop/1.9.3/ui-util-desktop-1.9.3.module",
+    "sha512": "5baee9cd519263a6018019d5277162697300cb41903883e97490cd7e18b477e3719707ff78209d4820bc886578a816afa3834b70399af94aa4158841b5ab67e5",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.9.3/../../ui-util-desktop/1.9.3",
+    "dest-filename": "ui-util-desktop-1.9.3.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1/ui-unit-desktop-1.11.1.pom",
-    "sha512": "0b539a050f1468159afedb1dcdeb798b89d94c0d52a02a4b07182a71c41c651673b0e3dd7469f7ba394ea09bd237cff7d603da341a49084567bf05eb7c72d362",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit-desktop/1.11.1",
-    "dest-filename": "ui-unit-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui/1.9.3/ui-1.9.3.pom",
+    "sha512": "432e05879697afb4f4b5b24733737959da339cc8aa8c73c85a4e013a26ddc362a0865897e1ba4e745517f99c924cdb3f717344bd1498d7033dc2f021447ecb93",
+    "dest": "offline-repository/org/jetbrains/compose/ui/ui/1.9.3",
+    "dest-filename": "ui-1.9.3.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.11.1/ui-unit-1.11.1.module",
-    "sha512": "c2e5170f23624019e0bc0756163accf1e833347cceb5ffb49ba5fc2b1476d324f4dbc0aa14b2da3a6308bab8d183217598eab944f6c741d98004445a759a7e89",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.11.1",
-    "dest-filename": "ui-unit-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/atomicfu/2.4.0/atomicfu-2.4.0.pom",
+    "sha512": "530b394ab82bf1b6f8312d11d559ab6fface1e571155686ccb0efbda840513d59df6434a217a01834408a1a90c53fd11326c44a7ad036283df93e2eeaa035415",
+    "dest": "offline-repository/org/jetbrains/kotlin/atomicfu/2.4.0",
+    "dest-filename": "atomicfu-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.11.1/ui-unit-1.11.1.pom",
-    "sha512": "d95371d5d6ef7412dfdff2da86d7d55fd0cf1514af61bb8140cc2ba7c13d18154e5cf9da2855a111df1c7425832f07e9d7f6892f3cb27057a03130c834f6251f",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.11.1",
-    "dest-filename": "ui-unit-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.4.0/compose-compiler-gradle-plugin-2.4.0-gradle813.jar",
+    "sha512": "b6637a18f1566f3f4def7f8a0fa81548d79d1773b6e1821501a4ec426fbb6de1f329d4cb8652ba4222816d10c6a162ade196ac5b1b73bacbb37d6a69c10b9073",
+    "dest": "offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.4.0",
+    "dest-filename": "compose-compiler-gradle-plugin-2.4.0-gradle813.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-unit/1.11.1/../../ui-unit-desktop/1.11.1/ui-unit-desktop-1.11.1.module",
-    "sha512": "f818b43f34c4abae22353b7b750de114707b292830c2baf9b0816ed55a7e098e03230f17edb6d7eb34c7e086f48b9bb35ad0f03a9cdcca254a34dc0bad399407",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-unit/1.11.1/../../ui-unit-desktop/1.11.1",
-    "dest-filename": "ui-unit-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.4.0/compose-compiler-gradle-plugin-2.4.0.pom",
+    "sha512": "d50d59cf0417531fa23b1d03307abb05c8da3af12f484ac5bd73442804f3ef5a57c7817a18bae61e4681d6f918833863bffda272079f1daae5e1ab2dfb9a3156",
+    "dest": "offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.4.0",
+    "dest-filename": "compose-compiler-gradle-plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.11.1/ui-util-desktop-1.11.1.jar",
-    "sha512": "15fced135c1de09d4f054ca0904b5373e0c573c76222a531a9b27ff1e8735f12cb7ad10ca741c4aa9bfacf120afbb72e2404d14ccb1ef5b7c73d73aec97191fa",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.11.1",
-    "dest-filename": "ui-util-desktop-1.11.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0/fus-statistics-gradle-plugin-2.4.0-gradle813.jar",
+    "sha512": "ac6a05cb49bf94ec6b9582711d9e5629637bd7390dc7f3e568a16e19c203efeb148acc3e860ca2e80936ec6162dcde9c2a2bf781cb0e3d3a1ffbcaafbdec52b3",
+    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0",
+    "dest-filename": "fus-statistics-gradle-plugin-2.4.0-gradle813.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.11.1/ui-util-desktop-1.11.1.module",
-    "sha512": "e476aba38f2c5875a6b8911486feab4d4ac07159661f716f7c4ba326815ebfa8c0d3bdb79778415fe312cd0fb02fd5c64d1723e1ef6645146adec4e9d796374a",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.11.1",
-    "dest-filename": "ui-util-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0/fus-statistics-gradle-plugin-2.4.0.module",
+    "sha512": "a1ee6d927c6dd83621db245a4f6754749b95c798385ce9ef902d406555666f0960b6c5a17141e0092537fe7e29d9da3e465a6a9c9da120cf843631b7b37d47d0",
+    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0",
+    "dest-filename": "fus-statistics-gradle-plugin-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util-desktop/1.11.1/ui-util-desktop-1.11.1.pom",
-    "sha512": "4f9d603b68655a30b4abe0541f2d04bbbe4161e1a521e23543abe9fe012e2d16a393dc8e7b065ec76145a04321b2a5c376581c284bf12dd22a5832d8678dde2b",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util-desktop/1.11.1",
-    "dest-filename": "ui-util-desktop-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0/fus-statistics-gradle-plugin-2.4.0.pom",
+    "sha512": "097b25a315b87b53c8c54cefb45f2b2a9a1941181e468a522af3ebe3c4ab2d781df1afa90528fa947c45405ad7ce264b5f9a7435791dfa863b6e51b3f0bb390f",
+    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.4.0",
+    "dest-filename": "fus-statistics-gradle-plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.11.1/ui-util-1.11.1.module",
-    "sha512": "7ec30b1a2e3da8261ce0eefa35731ad6887c97bf01e3af78896b2861680fc1f326d9af4cbf68afb4061938e5b605770c3dbe9c69b8dcea709a8926cccaf82ab8",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.11.1",
-    "dest-filename": "ui-util-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/2.4.0/org.jetbrains.kotlin.jvm.gradle.plugin-2.4.0.pom",
+    "sha512": "95bbcec643e5e628bedbf35cc4b0229c4e7facc369f4fbc180f4151a7e4e9df686a79de230e733534c38aa4a32ac0de2af69798dbb7987419db0c6939a5c7e92",
+    "dest": "offline-repository/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/2.4.0",
+    "dest-filename": "org.jetbrains.kotlin.jvm.gradle.plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.11.1/ui-util-1.11.1.pom",
-    "sha512": "e8ed04b72ae053a7f72cd8c273b58fc8672ee905fe05e884496571bfc070c2248bd73fa262bd262f092a98f2c5a5d9c882ea62968e3470fda9d3a42813012fa5",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.11.1",
-    "dest-filename": "ui-util-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-allopen/2.4.0/kotlin-allopen-2.4.0.pom",
+    "sha512": "1d7f294c4f7715113be56678d12ff1c311acff5e758f3d910c980aa065adc9078751096160ae855d43823849bf85148191e097bcaa77b80bec45d709bb680a09",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-allopen/2.4.0",
+    "dest-filename": "kotlin-allopen-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui-util/1.11.1/../../ui-util-desktop/1.11.1/ui-util-desktop-1.11.1.module",
-    "sha512": "e476aba38f2c5875a6b8911486feab4d4ac07159661f716f7c4ba326815ebfa8c0d3bdb79778415fe312cd0fb02fd5c64d1723e1ef6645146adec4e9d796374a",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui-util/1.11.1/../../ui-util-desktop/1.11.1",
-    "dest-filename": "ui-util-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-assignment/2.4.0/kotlin-assignment-2.4.0.pom",
+    "sha512": "9d94bd07d95d0bcc2f9697dc6ae2f6feb53664116cd70a60d49342585ca92471d395336dc415299627de5f81c4b119dbde53aea0dc9b0ebbae1905c220484c00",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-assignment/2.4.0",
+    "dest-filename": "kotlin-assignment-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui/1.11.1/ui-1.11.1.module",
-    "sha512": "bccfdc7eff64da50485250b009d10eee0c32352a5e2a0370543e3e4fb518d692609bcb71ec914f127a8e6806d207b721fe55d34b9b5bcdeb93b2eb2efddaa4c9",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui/1.11.1",
-    "dest-filename": "ui-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-statistics/2.4.0/kotlin-build-statistics-2.4.0.jar",
+    "sha512": "2f9dbc827b70ad469873f6b3b1a20d2db018e47927bc43f7810bd7fb096c4109c840409221c942b5da99f0999493b1fa544a5d0e7ab0525fe666889f6861bbc1",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-statistics/2.4.0",
+    "dest-filename": "kotlin-build-statistics-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui/1.11.1/ui-1.11.1.pom",
-    "sha512": "c8ad39a391d4d096501170646bcff8520221ebcaeca0e761fa78da36321c0c65357fe13bc86db541df32d079d1295555d61f5b8045d5e5c532324257dce1ba94",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui/1.11.1",
-    "dest-filename": "ui-1.11.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-statistics/2.4.0/kotlin-build-statistics-2.4.0.pom",
+    "sha512": "e5a61d1a5c60601c05cff6c4b20f617ad754ba677fcaf31f9dbbd5bddd31a5568442caa339ec6371fcee9e4a17ade5c3030f66664de0abe85addd17d8a7bacb4",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-statistics/2.4.0",
+    "dest-filename": "kotlin-build-statistics-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/compose/ui/ui/1.11.1/../../ui-desktop/1.11.1/ui-desktop-1.11.1.module",
-    "sha512": "75e9426532f976e9f550f8ba14867968da46ae4152d343d9963305ca2e30e1e49b035600b81e25bf70de966e036ba62e2883e1abdf92fe0806ad9f9106943ef6",
-    "dest": "offline-repository/org/jetbrains/compose/ui/ui/1.11.1/../../ui-desktop/1.11.1",
-    "dest-filename": "ui-desktop-1.11.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/2.4.0/kotlin-build-tools-api-2.4.0.jar",
+    "sha512": "e78eed46c18fce4a193aecb91930d08ddfb0e0f7c09ee89f4cea95ca3717555e6e2ce027ee6a8cc17ddc00e147bf890e21b5cdecc91e4a814e829753c5ddc440",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.4.0",
+    "dest-filename": "kotlin-build-tools-api-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/abi-tools-api/2.3.21/abi-tools-api-2.3.21.jar",
-    "sha512": "deee0ca2c74e998bc8525b6a4514ba3b643c91263e656c67a7ec040238f18b654ce1862506b9a8eb1e1961a1758d215f040bf456d547c7d183d02fb3f08e43ff",
-    "dest": "offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.21",
-    "dest-filename": "abi-tools-api-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/2.4.0/kotlin-build-tools-api-2.4.0.pom",
+    "sha512": "7f7f82143e51c30ca822cfa058195174c9e908f1390492461f6fa18442632f572059271ed441e22af914efd86c05700b21faacc0a5823959623b869a027273b1",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.4.0",
+    "dest-filename": "kotlin-build-tools-api-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/abi-tools-api/2.3.21/abi-tools-api-2.3.21.pom",
-    "sha512": "0e87d1d46bbdaee5b6736091789f3a351f4f2cb597b7188ee44729b5ba5a78d9653c94ba36eb99e337376a8c5ea547dd2ff16afe97c4470ea7b79c96c33763db",
-    "dest": "offline-repository/org/jetbrains/kotlin/abi-tools-api/2.3.21",
-    "dest-filename": "abi-tools-api-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.4.0/kotlin-build-tools-compat-2.4.0.jar",
+    "sha512": "bb6eea9e4abb165e30170c2c274afafefcdb841f78c2d4d5c2a19d6226b61fe8d20aee95996148bfaedcc55be5aa612cb2849041cf67e4f9b83fb2659f0cda11",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.4.0",
+    "dest-filename": "kotlin-build-tools-compat-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/atomicfu/2.3.21/atomicfu-2.3.21.pom",
-    "sha512": "603e6235b6b0cd6add5cbc764656d5a66e73059a7be76b921f8bc5f5da40fb1efa44d49a4712bfb2baaf1290521cff37216dc843d793ddf418e5209f736fd89f",
-    "dest": "offline-repository/org/jetbrains/kotlin/atomicfu/2.3.21",
-    "dest-filename": "atomicfu-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.4.0/kotlin-build-tools-compat-2.4.0.pom",
+    "sha512": "6118425c0b7f15b559bf2ae832789ccf4b83700a3c7ab73bae841eb16d288e239058203303716f9e2997659f57a9431237733d5c994b96c5d673122b4a4ddc68",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.4.0",
+    "dest-filename": "kotlin-build-tools-compat-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21/compose-compiler-gradle-plugin-2.3.21-gradle813.jar",
-    "sha512": "6092d19d6b2bce2c940146df813eec6a157331d95c7f52102a1251148c1b3872fb3a624fb14558dbe4bb331b7f9a5e6ed7d63cdb7ad97cbe0f5e5191945bed79",
-    "dest": "offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21",
-    "dest-filename": "compose-compiler-gradle-plugin-2.3.21-gradle813.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.4.0/kotlin-build-tools-cri-impl-2.4.0.jar",
+    "sha512": "40846dc3a50e03dfe114b5732f75aae16c8be6646dab98347ab3cb2d7da9b2e5426c49e11f036e5530d5bc9778e31d4bd60ccb95060e390d45932ee958afc435",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.4.0",
+    "dest-filename": "kotlin-build-tools-cri-impl-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21/compose-compiler-gradle-plugin-2.3.21.module",
-    "sha512": "15d9078feecd18e0e0fea8d18431ca39cf3344296c9073499481417807c9f5e204d6fbbe841b6ce60ef43239ffbccc3c04197a18f88ffd16c3a27e13d5db16d4",
-    "dest": "offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21",
-    "dest-filename": "compose-compiler-gradle-plugin-2.3.21.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.4.0/kotlin-build-tools-cri-impl-2.4.0.pom",
+    "sha512": "cf0ebfefd6f113db34b714eff40aac00e0e2046d8f423e18e787db2afd7c77f1d23d31be7185aa88fb86a48811663ae224f95225b2a93266e0fc42d00fb7b0c2",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.4.0",
+    "dest-filename": "kotlin-build-tools-cri-impl-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21/compose-compiler-gradle-plugin-2.3.21.pom",
-    "sha512": "29728b9494fbdea66043d183546cf65ce6573108e0a6713ac2b28481a77ac967129d16062f4709311be09a4ed067aa3073a895de3762f5b7035ec9f52457da38",
-    "dest": "offline-repository/org/jetbrains/kotlin/compose-compiler-gradle-plugin/2.3.21",
-    "dest-filename": "compose-compiler-gradle-plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.4.0/kotlin-build-tools-impl-2.4.0.jar",
+    "sha512": "6604d3b797056bf8ef3717de35ed6ab8c37682309516ecef6088a38ed3554df28a925ead642e9b699d07ed5efad60f7040900e434fc1db8e7bfaa5c32b9373e5",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.4.0",
+    "dest-filename": "kotlin-build-tools-impl-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21/fus-statistics-gradle-plugin-2.3.21-gradle813.jar",
-    "sha512": "fe29c0d391a2c8dfed9668f4ddc4c81e649619c42c8d8810efbd8386bd9ea00e68e64f484462e3aaab15b2118f66c662146183123f23ec99cea75356d23aa580",
-    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21",
-    "dest-filename": "fus-statistics-gradle-plugin-2.3.21-gradle813.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.4.0/kotlin-build-tools-impl-2.4.0.pom",
+    "sha512": "2fd3f6b9aad327f7adc4203972171b4dd80b5ef0af1ced7a9dba787f59edc10ea41734260a307cb063f58d19a2638306b96863504003d2cd176b450102b8678e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.4.0",
+    "dest-filename": "kotlin-build-tools-impl-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21/fus-statistics-gradle-plugin-2.3.21.module",
-    "sha512": "11e12b9eec56ce384d1f31b6414276fc5392246f2aa0e32b11af95036f08ac8f8ad72f61f274cd29cdba24cebef62b56b4a7cc189bf9d13b0d86dfb18016bb64",
-    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21",
-    "dest-filename": "fus-statistics-gradle-plugin-2.3.21.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.4.0/kotlin-compiler-embeddable-2.4.0.jar",
+    "sha512": "28cd52ea0df2fe34bc30516106d522a331c13dfab05458954e49f4a4430cb6292586282fbd0d278b17ec0ce97dc866691c10359506b6ebc9a53f0db8247c3d87",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.4.0",
+    "dest-filename": "kotlin-compiler-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21/fus-statistics-gradle-plugin-2.3.21.pom",
-    "sha512": "95aa3afc0a0102b61cb269eb7c589d3587f4ed7321cc9bdbcae2acc865462f9ce83c88e5ef31d6d5c86ce2537d3e2bbaa44af4913f3d749b40901c92da8a2697",
-    "dest": "offline-repository/org/jetbrains/kotlin/fus-statistics-gradle-plugin/2.3.21",
-    "dest-filename": "fus-statistics-gradle-plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.4.0/kotlin-compiler-embeddable-2.4.0.pom",
+    "sha512": "6d35085a15b81fca006037aeab0c03cd54b421f02bcf5ba10fb5b2df2cd2915a590b3fa09668100446f8c7662e2fd01cf19c8c9a4534d3db35def2e9f799361a",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.4.0",
+    "dest-filename": "kotlin-compiler-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/2.3.21/org.jetbrains.kotlin.jvm.gradle.plugin-2.3.21.pom",
-    "sha512": "548cee8aaca55fe3688296e62189e1986628fc9d71e2d89cd6a29280549c973ee02fdd3399d66837e000991debd7d2577303bb9c55898cb74cf27e7eb63a55b8",
-    "dest": "offline-repository/org/jetbrains/kotlin/jvm/org.jetbrains.kotlin.jvm.gradle.plugin/2.3.21",
-    "dest-filename": "org.jetbrains.kotlin.jvm.gradle.plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-runner/2.4.0/kotlin-compiler-runner-2.4.0.jar",
+    "sha512": "3edc036410548e3b1a564ae73e615376c275338a2a3355c4827a9d9d60855ad8fdab01bd0a7bcb85fcc51e961f0a1d0599f575e96b20aab9c40a36b0a5e7bc35",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.4.0",
+    "dest-filename": "kotlin-compiler-runner-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-allopen/2.3.21/kotlin-allopen-2.3.21.pom",
-    "sha512": "83405d9c488a1adec5d8d7d25782d39cec7660b675ee733878e62d6f0222382771f3e393797f50b72a812fe2edf5695984eada73509a479b5b075254c07a7d4d",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-allopen/2.3.21",
-    "dest-filename": "kotlin-allopen-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-runner/2.4.0/kotlin-compiler-runner-2.4.0.pom",
+    "sha512": "31317e97d25a621b562e72819179a80853a62c528d7a01f79bda898a57524370dd725a5a6f0b770e5116f9a3d26593807382e5d7700fb931c0747a438503d1b6",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.4.0",
+    "dest-filename": "kotlin-compiler-runner-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-assignment/2.3.21/kotlin-assignment-2.3.21.pom",
-    "sha512": "0ce2c1265177968bf4d320f367cae89681d604b2afa0a240bcbdef9bbac49240ec43d3a1e7adee9756584f07bfed427970e61cef028f2e5c68afac913eeb6551",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-assignment/2.3.21",
-    "dest-filename": "kotlin-assignment-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.4.0/kotlin-compose-compiler-plugin-embeddable-2.4.0.jar",
+    "sha512": "9571bf64e412017f873e84e12b8760fc10727da56af43463c85b8979a2a0badb960be58414e471f02e00ff3da640d7fde50d890df390770801031d736f178a46",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.4.0",
+    "dest-filename": "kotlin-compose-compiler-plugin-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-statistics/2.3.21/kotlin-build-statistics-2.3.21.jar",
-    "sha512": "0d9954fcce4ebcd18958cbef1576c4ffbbec2d00f62d9c4b46801ca4ba7d40a18532cdcaafc1b5914e51883edbfd860206fc40b00755b17bed6986ae8840dffc",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-statistics/2.3.21",
-    "dest-filename": "kotlin-build-statistics-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.4.0/kotlin-compose-compiler-plugin-embeddable-2.4.0.pom",
+    "sha512": "bfadbe99b399f98c58d2340eaa1c9cddcf40e4ad3d2fa40e96539c7372ad973d76546fd72c3af3542551dbb6fcd5f0bcd2fca3b8049a4f904a62be19ca13cd6c",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.4.0",
+    "dest-filename": "kotlin-compose-compiler-plugin-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-statistics/2.3.21/kotlin-build-statistics-2.3.21.pom",
-    "sha512": "f66a6414c41d62654055d666cb22cb074184762d0eb1c3292bf4b48299caf63ad1f3a28dcd0af2421ac53a6915b0551e1df5947456dad8f1d96f2ca225d53027",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-statistics/2.3.21",
-    "dest-filename": "kotlin-build-statistics-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-client/2.4.0/kotlin-daemon-client-2.4.0.jar",
+    "sha512": "46aaba5a5e260031cb88615e627e487f103595b62d0dbce0990e38abc3830318006ca35a18fb052c6cfad0c1971c0c4b68c001d4e651982d1d740e4eac53d349",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.4.0",
+    "dest-filename": "kotlin-daemon-client-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.21/kotlin-build-tools-api-2.3.21.jar",
-    "sha512": "cffca37e461e51792ff62356931f384e22c44192fcd8ec7d6ccebfa76c59717a1539093b9174ba3082ae63ddff71bf8fa9f60ec1ac5f9e126e73642e8c509ba6",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.21",
-    "dest-filename": "kotlin-build-tools-api-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-client/2.4.0/kotlin-daemon-client-2.4.0.pom",
+    "sha512": "e732183118c1ede809fe642466e84d4e5d171b209d25a0b50ec8ef85f144e160bb4b83da94f6faeada6d1a8de380174350ac8202ca143ae630890a4bd3123f08",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.4.0",
+    "dest-filename": "kotlin-daemon-client-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.21/kotlin-build-tools-api-2.3.21.pom",
-    "sha512": "43cf6b02af42e322ec92a2013ef9c56b65acb85a5271a6f28dc2e4ad7d887110f9cc3db4bdd47ecd3bdb1d93cbc13a44c8530a81f8a8c52b2ebff586edcf31ba",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-api/2.3.21",
-    "dest-filename": "kotlin-build-tools-api-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.4.0/kotlin-daemon-embeddable-2.4.0.jar",
+    "sha512": "f3f3c7a3256d19928b7edf41061c34a0d0242c664b5ca9547ba45f7940ff15a7d146c065aa436ee302e7a9e0cc3376cd88575ec9bf343b45b100cfded8cd4753",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.4.0",
+    "dest-filename": "kotlin-daemon-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.21/kotlin-build-tools-compat-2.3.21.jar",
-    "sha512": "add16f6efc93e3fe2305eaf741e311d62af226b11b2c5da685e7ef70a6f622cea3904aac9a4e86e87a61f18ed097127a05c49f3fb71468893723bd99783be888",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.21",
-    "dest-filename": "kotlin-build-tools-compat-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.4.0/kotlin-daemon-embeddable-2.4.0.pom",
+    "sha512": "6846846d6eabb0ba30944477c900f668dab4c302f11d4d4b06619b5dd517a94c185d27b3e77424ced6a309fd08c94eacd8eff505e4044340b8ade3891b5985bb",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.4.0",
+    "dest-filename": "kotlin-daemon-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.21/kotlin-build-tools-compat-2.3.21.pom",
-    "sha512": "48926987bf9e6956e0467a4242c48e58d41755334df8348abaca141bbe1b66c638e25b5248f70c1542d6e4909c3ecd9a98966fd2688d4a19d94b391f68139874",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-compat/2.3.21",
-    "dest-filename": "kotlin-build-tools-compat-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-dataframe/2.4.0/kotlin-dataframe-2.4.0.pom",
+    "sha512": "f9c74ca9ffd516e5634199c0f2f82207159f1b2718e7ebebb9dabdd7e3c69055bd91590a1dd8fd946ba0b7af487192e14bd3ba53d2a10fd8bef5a7b450f38875",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-dataframe/2.4.0",
+    "dest-filename": "kotlin-dataframe-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.3.21/kotlin-build-tools-cri-impl-2.3.21.jar",
-    "sha512": "95e4adc97c362f149b945c4e22260dd3b9e4bc22dfb389e70f2b4ec25b6262b4b644e5c240bfe2701267735d3646a1b4c0f9646bfe54ab41c370b6b1955a64a5",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.3.21",
-    "dest-filename": "kotlin-build-tools-cri-impl-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.4.0/kotlin-gradle-ecosystem-plugin-2.4.0.pom",
+    "sha512": "a445521865b6a6b7f6972ea158e40de27ad7e7023b877df3cbc41482c8aca0be1a79176d9d78e290a539574de21ee8d29874707cc26d04ff0f8134b3f2b8c64b",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.4.0",
+    "dest-filename": "kotlin-gradle-ecosystem-plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.3.21/kotlin-build-tools-cri-impl-2.3.21.pom",
-    "sha512": "75d8e6eb50078b22f3489414df5db7283c93747807541dde9139e44f9446a9d8887c4cf854ab318a1258e60ce46151376cf2f8f6375c359c125520347089c839",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-cri-impl/2.3.21",
-    "dest-filename": "kotlin-build-tools-cri-impl-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.4.0/kotlin-gradle-plugin-annotations-2.4.0.jar",
+    "sha512": "76993305089d933214221c63557d1a380f434faf6131ad0521f2c7c883ab54040e4682447fecafbddfd5100b823a203f05ddd28ba68fda3196efc9ad019a332e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-annotations-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.21/kotlin-build-tools-impl-2.3.21.jar",
-    "sha512": "69fd74b11a412857b121d6398e36faa54cc1c0c60920637e33c7bf71f48f593d57adfc4c9de74f04b7a2fc3a37f08240a8dae8448a3fe516e2246411a4d6f205",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.21",
-    "dest-filename": "kotlin-build-tools-impl-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.4.0/kotlin-gradle-plugin-annotations-2.4.0.pom",
+    "sha512": "78b183ddf23ac0490d6fb4eea51040d10325639854a4373f70320fa798683fc928faf63a56033891c6da6ce418a717565b70105b8f407a437b2f1f346577b02a",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-annotations-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.21/kotlin-build-tools-impl-2.3.21.pom",
-    "sha512": "9e7bd0df8165040eed562c7ee6ed47b98709f3fd3dbec8d05294f18297b03226bd95bf0fdb0eaaf668b0c15d152fb2bcfea4ddecd90ca92892e054b1dfb7edcd",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-build-tools-impl/2.3.21",
-    "dest-filename": "kotlin-build-tools-impl-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0/kotlin-gradle-plugin-api-2.4.0-gradle813.jar",
+    "sha512": "f60b41aed58d4d085553603d63602556ec9bd42456f1f12a17daac8d9e3041d06bc21cd214d5dd442f690e376b97fd581ea7728bf14437714eff082ce242670e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-api-2.4.0-gradle813.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.21/kotlin-compiler-embeddable-2.3.21.jar",
-    "sha512": "e4a413a4169ad277895cab73566a766cdfe6df70928395aa7cec4d766c73f30953bf04fc488e452c6886cf86a2f9dcc0e188a16ec6456ee65eee2775f639f8a8",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.21",
-    "dest-filename": "kotlin-compiler-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0/kotlin-gradle-plugin-api-2.4.0.module",
+    "sha512": "bde2adc80632616c829c2937e1a2194086b90d424b077f0c42b0714e1146baa56556ce8f03c5c6558428090bfc73e1c2c85978b7c0372a03c3e4363ac9324c1a",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-api-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.21/kotlin-compiler-embeddable-2.3.21.pom",
-    "sha512": "d6f330ca2eb69debfeb3f717c3be74aa3aaa8df6b242ca9e4a12a5ca999337512a659f1043f2d6d33f619723a6816984be902f5c55d8accc5a5b092791e020c7",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-embeddable/2.3.21",
-    "dest-filename": "kotlin-compiler-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0/kotlin-gradle-plugin-api-2.4.0.pom",
+    "sha512": "0435c98765913fc1666337e5837bbe368bbe492844bae57f3baf36f0136929054c6d63a035fdf12f1c014c8e069c72ec61e7988f760b6043dc9347f9c00cb603",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-api-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.21/kotlin-compiler-runner-2.3.21.jar",
-    "sha512": "0cb9fae3d6a825736ef7663ffba4bcc88299e0fc5762693adfe40f6daee372408d1263d67e70a2f700c14f610ab8ac2b9d7092ce49d7c51e3d01fb6502f0b439",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.21",
-    "dest-filename": "kotlin-compiler-runner-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.4.0/kotlin-gradle-plugin-idea-proto-2.4.0.jar",
+    "sha512": "7a37a29730b7768a1e7af8c734b2cdacce287538cefe6aefce741cc5803d86ac28c3296cf8f134aa2104b92d4a6c09e0a3b4b6d5b972d030409fa38a2e8e553c",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-idea-proto-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.21/kotlin-compiler-runner-2.3.21.pom",
-    "sha512": "3a33e4009310713dae4597bd637aba6af4a1ff9229e580c54635f672d0afde83a53686bcb9cff9e7183f2dad2e74462c34b252e8da7646a9b8493b8c07728ccb",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compiler-runner/2.3.21",
-    "dest-filename": "kotlin-compiler-runner-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.4.0/kotlin-gradle-plugin-idea-proto-2.4.0.pom",
+    "sha512": "3a1f43ecaa2267700b74e08bf8fa00affb67328319589c0070621af5c5876c925fc222e45d6fdec1d7fb6ef39222e11dd77d231626eda069223286021ca350fb",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-idea-proto-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.3.21/kotlin-compose-compiler-plugin-embeddable-2.3.21.jar",
-    "sha512": "0f8a63c826ca120fdd73521c07d03bb0cddf9eba75597efe0d7c12531d032e2374dfc71c67147dbd5eed67c35dd77fb2276827cb9b8064999c25209b6f828656",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.3.21",
-    "dest-filename": "kotlin-compose-compiler-plugin-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0/kotlin-gradle-plugin-idea-2.4.0.jar",
+    "sha512": "faa395f08613f5bcbcc4f17faeedbb2ba10967d5aa47377631f0d497533d5db9a2ea631d43e89ad237b8e84b13bdae44dadd7ed43765f4e7d376e5b8a475db8e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-idea-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.3.21/kotlin-compose-compiler-plugin-embeddable-2.3.21.pom",
-    "sha512": "b56cc343d1e9e9f72a7669438c8d75980169c16d2a2a8752fc8b2ca1cdacd7479dcfae797b02b761019e73bd63c7de904f7fcb82e15bf5402f6305700db71d5a",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-compose-compiler-plugin-embeddable/2.3.21",
-    "dest-filename": "kotlin-compose-compiler-plugin-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0/kotlin-gradle-plugin-idea-2.4.0.module",
+    "sha512": "071c683dc03ad8d473fc3b67da3da36385f9cc5445898dafac58f4f75cac73ebb505a9b437b04a0c268353daed3665a44b21674fe774481bdf02ec40af4f3f89",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-idea-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.21/kotlin-daemon-client-2.3.21.jar",
-    "sha512": "7d0916da8eb8a427aaa6face27b363e05a1001c94023089a3c03eb7c564baa255370475d8e21bf7b9fdb6198e21e209f8a4a51d742b5c6b64b3f32cf8acf77ac",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.21",
-    "dest-filename": "kotlin-daemon-client-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0/kotlin-gradle-plugin-idea-2.4.0.pom",
+    "sha512": "a85fcb562428d17fa09615a28ce330b0ece2e1edbbb3efcb1f3fad6594b45c4985d65c4a9ae48568eb58b2f6c5d43283fdd346d36f9f4bddf0e6e65c42d0ff87",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-idea-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-client/2.3.21/kotlin-daemon-client-2.3.21.pom",
-    "sha512": "f28de530edd0962f01b173a13351823025989eabdfbab18c6440ea029e9f7b3e6cb99441442b789c0beeb5e9f530dbf19830b184814dbceba1dd4ad6f8c13480",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-client/2.3.21",
-    "dest-filename": "kotlin-daemon-client-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0/kotlin-gradle-plugin-2.4.0-gradle813.jar",
+    "sha512": "a749054cf99e60caa3da740cf17a12b948cf24d1f9d6c9a7679be98339a374ed66a0a0540538236151723017125df17b0c1fb449f4dcfa090481af5c5991cd7c",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-2.4.0-gradle813.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.21/kotlin-daemon-embeddable-2.3.21.jar",
-    "sha512": "283e08886b09fcd181119afeca1004c1fcab9606104ebccf67cf51faf81654b92d7642515e573374df97f7ad629c2cebcd5dee206473488e6881edee15fb4843",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.21",
-    "dest-filename": "kotlin-daemon-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0/kotlin-gradle-plugin-2.4.0.module",
+    "sha512": "167c06522e3379deaf32bb79e121a45892b1ab5b362cbd75f2a29f5fd5922ec71f4d79908195f3216c2f665fb1d2260b4465e20f5acb2e620264d8bc2fadf7db",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.21/kotlin-daemon-embeddable-2.3.21.pom",
-    "sha512": "9d78305e2141bad1efdfc1daf68feeabe9bfa1cc261e6fd86d0ca52a8ef75de9f3106b07d7339f9429d6d74c108471023002c2b87b4e6e1b2aab0a482c695b17",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-daemon-embeddable/2.3.21",
-    "dest-filename": "kotlin-daemon-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0/kotlin-gradle-plugin-2.4.0.pom",
+    "sha512": "bdab7d4a4c2675a74524168a971bc615c66c5768a9dfe6a8fd9e166fc6c3674b6d4b606e6fa78e19595783708c7bbf34a2e3a033d3ec995d95d2136641e99379",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.4.0",
+    "dest-filename": "kotlin-gradle-plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-dataframe/2.3.21/kotlin-dataframe-2.3.21.pom",
-    "sha512": "2ca6ecd3c0ac070eba9b069ab22d88890fd4b2fb1d4c6b498b33747d5068e21ab91fba3a6fd03b8c897c884a3b6a3bd79cc8958988324552cbee3d8d654e267e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-dataframe/2.3.21",
-    "dest-filename": "kotlin-dataframe-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.4.0/kotlin-gradle-plugins-bom-2.4.0.module",
+    "sha512": "07b40ab9cc152509bc82090898d9f37ff7570e7b05fb92660538c35153f5e36ca0807eba1c74cca45092c9e382f4a34ce14938a541235058b1e836adea8e436b",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.4.0",
+    "dest-filename": "kotlin-gradle-plugins-bom-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.3.21/kotlin-gradle-ecosystem-plugin-2.3.21.pom",
-    "sha512": "fc1a1feb493a1674cee1ab6807459bf06638de480afd6c2146e5f53189e53b951a3c2331725c2732aae83c7d5a27444fcf6ea7ce8932aa15646d9fed5e21c04f",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-ecosystem-plugin/2.3.21",
-    "dest-filename": "kotlin-gradle-ecosystem-plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.4.0/kotlin-gradle-plugins-bom-2.4.0.pom",
+    "sha512": "7b977ce65dab3bef7d5ea3ae83c11ff65d3b1dedffb6f36f759f255eaf850fcdc01aa345861745797c8fbc74eaf01cc8d9dc4225e2e94f86d40ec22cc6326e84",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.4.0",
+    "dest-filename": "kotlin-gradle-plugins-bom-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.21/kotlin-gradle-plugin-annotations-2.3.21.jar",
-    "sha512": "bd793f4894c4fa6269b30b97b57c79b2c80d28a7b4cef6a2d5bcd3bb71988a263cf055f1413157d6eae7d03a483c80e8856f45b33f6c6efae549d19be54cc54a",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-annotations-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.4.0/kotlin-klib-commonizer-api-2.4.0.jar",
+    "sha512": "a36a0c392d059e2b24e710e609b58f5ab90b4de6fedcc5da21194f211e62a409d76c0ef23aa3751ba036f46ca3992a2408bd0f7a5ce61fbdcbca9f611e76566a",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.4.0",
+    "dest-filename": "kotlin-klib-commonizer-api-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.21/kotlin-gradle-plugin-annotations-2.3.21.pom",
-    "sha512": "689860b328bf6867f759e183dd2c1afe4ae06c99dd2e4121c9d1075010c5fe36e1d5fe8d4cbb214212eb887650427c3a603d33286949452cf941e293e1983a9d",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-annotations/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-annotations-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.4.0/kotlin-klib-commonizer-api-2.4.0.pom",
+    "sha512": "ce6c39d189c6bd15d3b885c75f4487107dc23750a3ca9d0f169f082e1896df50379705622623e040bf39c03c90e5a8d24e0c756e44ff66e4035971252f15c1cf",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.4.0",
+    "dest-filename": "kotlin-klib-commonizer-api-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21/kotlin-gradle-plugin-api-2.3.21-gradle813.jar",
-    "sha512": "2d44a6bcb414cb00ad1d9e231ed46288d6557228954ac2653a531d59b6ad26682364965a59c03f8b79e569c3c673c024879e1efc520cae2412f5061cdd03bec7",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-api-2.3.21-gradle813.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-lombok/2.4.0/kotlin-lombok-2.4.0.pom",
+    "sha512": "6efc586e14074ddb40eded6821ce6b04bb0f1504b4a3bd09b22f6e9dcecae380c4865f75ce1ace7f4275aa00bf9ecdb0546bfbbdef9846443b31f1d8478806de",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-lombok/2.4.0",
+    "dest-filename": "kotlin-lombok-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21/kotlin-gradle-plugin-api-2.3.21.module",
-    "sha512": "385d8898fb4057d3c57e3d8098b8cf6b557ff505c65a217705fe2ab6a831f4064327f97a1515dc49a6d1f4244e30cbf51980e2ebe6c048d0b74f29f0c15e30b6",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-api-2.3.21.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-native-utils/2.4.0/kotlin-native-utils-2.4.0.jar",
+    "sha512": "35101beb6ddd2f6fba2cd1fd11885fbc72caa4be7ff8974e806e00f9816430cf81f27012116d9a34de70cb4486665b31817ae1d332634d57570e5b38ccec3394",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.4.0",
+    "dest-filename": "kotlin-native-utils-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21/kotlin-gradle-plugin-api-2.3.21.pom",
-    "sha512": "ad49b18f9e07fa154c38ce1d0614975ffa5c0242364b0ccd7857eb098cdcdaacbddf6b1e1918b8a29a8bb191a699d807cdcc4b36ce80cdc757261ad59b6409b5",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-api/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-api-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-native-utils/2.4.0/kotlin-native-utils-2.4.0.pom",
+    "sha512": "93fb9569b137670cf0bf92688238762995a4b8e9e32a6742b77873b9516828387954b7b27f80a2b2086b6e4ef06759f6054fad1477001ff5ac5525bcc442750b",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.4.0",
+    "dest-filename": "kotlin-native-utils-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.3.21/kotlin-gradle-plugin-idea-proto-2.3.21.jar",
-    "sha512": "994cab2cfcf87fc6fc5bed03d8077f53e247b6c937ef6103ee8f48a69e49335118231d3c5122fa8ecd21b14f74b8fde26bb167a9f1929618f517e3b217d236e5",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-idea-proto-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-noarg/2.4.0/kotlin-noarg-2.4.0.pom",
+    "sha512": "b0ea38a35b61f9261a227cf1a5518d7b11c16bcf0517ab578b86d6b532d3e808ccf570e371d621218a4b68f92e0d47bb8440c5e42b04e2b5552706513be6a107",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-noarg/2.4.0",
+    "dest-filename": "kotlin-noarg-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.3.21/kotlin-gradle-plugin-idea-proto-2.3.21.pom",
-    "sha512": "a33b5652853e607ffc7639edd03554a98fb254a6aca4477a2335ddc9e7eaa76330f6d66d238192d4b6d96e207a2af9b40345147f4d3629a9f05f2a784d880a9e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea-proto/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-idea-proto-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21/kotlin-gradle-plugin-idea-2.3.21.jar",
-    "sha512": "82a20b477b6105fa99e83cfeee8ba7a5ca41c34e78ccdffc18405c21a405c865e8c0bd4af246d1604e5c62ac4ff6be16fad8bc2f7f48bc41996203c96fd95ece",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-idea-2.3.21.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21/kotlin-gradle-plugin-idea-2.3.21.module",
-    "sha512": "7c67953dac0aba624f7b9d64cc4eb47cf5936d95ad232b29b0c7bb18355c957f785e9675268b12325507cfaaf51025e80ae7b4a2519b583d107cf8299f6808d2",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-idea-2.3.21.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21/kotlin-gradle-plugin-idea-2.3.21.pom",
-    "sha512": "c8992a3db382993457c2e88c440ea4b2654d56ae758d35857de2e435db69d510f556b28b0df7ec3f45c42037782f9a4800a347922418cde69b94a73237933e5e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin-idea/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-idea-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21/kotlin-gradle-plugin-2.3.21-gradle813.jar",
-    "sha512": "3c908c20e4fa3ec27b0e7316f4f003afb67bfc6c5e3cd78de0a27f14820cf4e58158e2b8044507816ffcb9ad4c152a28b26e457e8dabb1c6762348e6ff6d63c0",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-2.3.21-gradle813.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21/kotlin-gradle-plugin-2.3.21.module",
-    "sha512": "6c2c7ac059fb0d83337fd7873ba78ce00bc92a246d0e2ba46a35ac8e6caaa1c076f2dd04a1a8e5e3d58d4f6754e5b05f8048c4ca9a22705427e006e656017dd0",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-2.3.21.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21/kotlin-gradle-plugin-2.3.21.pom",
-    "sha512": "899c8bb4b7d15bb110cbbefa12da12768c8e0843f38cfb0b1f3f645dc25d7b4ecd6509139b0f64970630daafbb3b3ddf5bc583e98d7edded49728edeae7ecbd1",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugin/2.3.21",
-    "dest-filename": "kotlin-gradle-plugin-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.21/kotlin-gradle-plugins-bom-2.3.21.module",
-    "sha512": "b39bfd0981548b133c828d0f84462c0aa60a87c0dde9b5a18f266b8c8c275125b26b60586d86fe2c2ae00aaec335b3a5a63ee8cdb47745f3370e12b51fdc6f2b",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.21",
-    "dest-filename": "kotlin-gradle-plugins-bom-2.3.21.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.21/kotlin-gradle-plugins-bom-2.3.21.pom",
-    "sha512": "b637b80534891de2cda220ee3677b14cf12f05b14a32028612441c109d2329140e43187ae46211faa24b504d6ce264dd89f3ac88f6993cef25d5d860024a8c23",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-gradle-plugins-bom/2.3.21",
-    "dest-filename": "kotlin-gradle-plugins-bom-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.3.21/kotlin-klib-commonizer-api-2.3.21.jar",
-    "sha512": "bd6bdc7b42c3add9839cc8e07e3ce39137f18e2cf31328eb8210b58381c76ae47309ac4413e6b85098f9d4ff5245cc2567571efeb44c16f36b9619e1b1787a8c",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.3.21",
-    "dest-filename": "kotlin-klib-commonizer-api-2.3.21.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.3.21/kotlin-klib-commonizer-api-2.3.21.pom",
-    "sha512": "8cd4876de81ba8c3eb303ee76ccf26e97161b44253e8c1a6241f5dedc3cca8baba34e4a9f28e8bcdd3f06bb47bf53bc0ed2166ed0426dc3b1c3dd40dd2cc9a16",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-klib-commonizer-api/2.3.21",
-    "dest-filename": "kotlin-klib-commonizer-api-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-lombok/2.3.21/kotlin-lombok-2.3.21.pom",
-    "sha512": "bb476fab1d740438831120d3bb763117072361b97570932a6155ff915c1c48210592cfe75f7ffe57a3a2e450614558c1d7ef64ea24c9c2f2a3f887c7538fbefe",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-lombok/2.3.21",
-    "dest-filename": "kotlin-lombok-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-native-utils/2.3.21/kotlin-native-utils-2.3.21.jar",
-    "sha512": "52c9ea9d5c65cd7f8efbba3cf00702be330e4b56d00eb28ae3e915d7d3bb2ee10c1fb128416eeb2eac1ae9aaf9c453bcfcd8a524c0b746827e211a9871cf33de",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.3.21",
-    "dest-filename": "kotlin-native-utils-2.3.21.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-native-utils/2.3.21/kotlin-native-utils-2.3.21.pom",
-    "sha512": "aaffe0bcae55d31751ab726b8a4f60139da29312c48004847ebf257178ff8673d4375a2f8478470b9386e59f8aa04079e323def13c64da7313843662bfade9d1",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-native-utils/2.3.21",
-    "dest-filename": "kotlin-native-utils-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-noarg/2.3.21/kotlin-noarg-2.3.21.pom",
-    "sha512": "ec6bba9a8cc357af9c283afc215dbe328b15d791489edec2ff78a4c7ba6f85ec9e9fe229361b84252bdfc3d414720b3f2ab59301fd5a15cd0f9866ac1158a33f",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-noarg/2.3.21",
-    "dest-filename": "kotlin-noarg-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-power-assert/2.3.21/kotlin-power-assert-2.3.21.pom",
-    "sha512": "b596086a6013e4e8190a0fdd6a5112470c4cbf9365b510f547a209b66402e1ebd8ca0e1e8a41a5b9f04ee74284f3f89c4f8d8005e0f2c76ab07744676b4d6324",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-power-assert/2.3.21",
-    "dest-filename": "kotlin-power-assert-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-power-assert/2.4.0/kotlin-power-assert-2.4.0.pom",
+    "sha512": "b3a41242e40fb7786bca53b2c0d01c341e719c037ef413527d68d808b87e5ce9fbaba6f384789f7087e08516ec42275906e1a8eb75596443c0cd87f1298aaa25",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-power-assert/2.4.0",
+    "dest-filename": "kotlin-power-assert-2.4.0.pom"
   },
   {
     "type": "file",
@@ -4901,143 +4586,129 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.2.21/kotlin-reflect-2.2.21.jar",
-    "sha512": "168b2f8bd3c0c395a78d9bc237dde726eea63090407c448c3deef2916661c19e1c7013f5a13f5a16578694a2a0842a985f1f6c7c519a48858b35a1a602ad9406",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.2.21",
-    "dest-filename": "kotlin-reflect-2.2.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.3.21/kotlin-reflect-2.3.21.jar",
+    "sha512": "8251a4c44d9deec972a70bca2a9037401f0d1357c48507894f5ae834b61707237fa8ee75e8fd05be83404dc9796daa58ff2a8bc2ad3e4f51603f353ce75b56ec",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.21",
+    "dest-filename": "kotlin-reflect-2.3.21.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.2.21/kotlin-reflect-2.2.21.pom",
-    "sha512": "5dc41f2190d67113f960c615afe5bee951d1384ef8886f8b68a699f8ff3ca7e816e2f67528fc9c9b8809cc4a559666fe01438f85ee95d82cc876abca4db31603",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.2.21",
-    "dest-filename": "kotlin-reflect-2.2.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-reflect/2.3.21/kotlin-reflect-2.3.21.pom",
+    "sha512": "73c58bce8ca98d5a84665ca18e3aecf25f76fe2857023b4964b8bee0127763bfc10fa8618ebc147d94b7e0b14c396d4e207c09c9b9ce9b3335a2a9c16a3fcbe8",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-reflect/2.3.21",
+    "dest-filename": "kotlin-reflect-2.3.21.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.3.21/kotlin-sam-with-receiver-2.3.21.pom",
-    "sha512": "48bef24bc2793a10c44eeeb27909db5df360707be0fc1bd41ceb35053ff9f275564a671c5c5392067f1f620e1665e1a99f9c41e5f982e14bf2e98a26d798afed",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.3.21",
-    "dest-filename": "kotlin-sam-with-receiver-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.4.0/kotlin-sam-with-receiver-2.4.0.pom",
+    "sha512": "21ec2605ecdba2bf8aa7063c574ab6bd7490c35d8f501b953539710a5023c098d54e852054db90a83333b232ea33156ee498de2ba33ac15dbb92de740091ecc9",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-sam-with-receiver/2.4.0",
+    "dest-filename": "kotlin-sam-with-receiver-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.21/kotlin-script-runtime-2.3.21.jar",
-    "sha512": "3befabdbfa68e5b8666b15095c8f7908d54282025ec2e41e508f48727bb9ddb3f8bcc005f0127ff4cb87d4e4e27376997034e734ccbbea6193f9fbeeb0e5e322",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.21",
-    "dest-filename": "kotlin-script-runtime-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/2.4.0/kotlin-script-runtime-2.4.0.jar",
+    "sha512": "8e94e25c455ca0f9b02c0217dfbfb43ceac3d9bc5a199263396cb044b5072d8cc382f7666b16027476067401b42644786ee5bb6c758c6b755d7c02c11c32d492",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.4.0",
+    "dest-filename": "kotlin-script-runtime-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/2.3.21/kotlin-script-runtime-2.3.21.pom",
-    "sha512": "5a36f87fa9edfb64957ab608b9f8b665b99b2a0f08e3b6c967284d8000b5f8957d59bea3be7e579a7e3b4acc6a818f26f28a32b53117ca6e99597697a8e9991d",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.3.21",
-    "dest-filename": "kotlin-script-runtime-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-script-runtime/2.4.0/kotlin-script-runtime-2.4.0.pom",
+    "sha512": "f848d1dbb617fb297abe5831c12b22c2debb61e674c352672b44cf454f5a24e7ea0f8d285d1a20a84df59f7f628befcb54350cf9304a492ef42bd7d4cb599516",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-script-runtime/2.4.0",
+    "dest-filename": "kotlin-script-runtime-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.21/kotlin-scripting-common-2.3.21.jar",
-    "sha512": "4756d34adab6ef43aa98fcf4983f2f5da49dbd52b24a9243e1d381efff861b193530d0b742fcd5edf735da59a04dcb03934631c8f899c595a68fe3fbbf4105b1",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.21",
-    "dest-filename": "kotlin-scripting-common-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/2.4.0/kotlin-scripting-common-2.4.0.jar",
+    "sha512": "065a3635e6b38772258596bbc0dcb4863a52a9afd8db0dc79d22338d61487a3ff42d8023fb986e5be22854d18404a3d2b07eafe27311d466051ad6bc2180e0a1",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.4.0",
+    "dest-filename": "kotlin-scripting-common-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/2.3.21/kotlin-scripting-common-2.3.21.pom",
-    "sha512": "9fccc6303b6f2ce128283156dd7d4e9b2de58a1b565196c86aaed36fcaefe8ffe8860c42a2373c61df504d0ace2d9102f4aabdd5cab399afcedff602582a0320",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.3.21",
-    "dest-filename": "kotlin-scripting-common-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-common/2.4.0/kotlin-scripting-common-2.4.0.pom",
+    "sha512": "bf5b83b350b1e209738c8e6bdfe825776c9918a41430bb5c75bdd19a9f18a2f6d07ced817921466a81fccb12bf4466f0de5b1a19a20cbb5c4a77abc22496f3a9",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-common/2.4.0",
+    "dest-filename": "kotlin-scripting-common-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.21/kotlin-scripting-compiler-embeddable-2.3.21.jar",
-    "sha512": "38f302093e11602f36f0351f42d30d3cf03822238906188ac038894d430057916a3a3f04490d94aa8bf10656bf62f2a9ad0048c0ba196fa36c6795656cc512a1",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.21",
-    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.4.0/kotlin-scripting-compiler-embeddable-2.4.0.jar",
+    "sha512": "12954132d1a713cc73da76deb93623a7882898dc290f1e6a0d334576be7a3a7e9e2de1dd0d7c0467f2c93bccf904443968a2446bdd1ca8bc7869f60a8343a3a5",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.4.0",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.21/kotlin-scripting-compiler-embeddable-2.3.21.pom",
-    "sha512": "54ef090c152668e71d500e2ced0a36e53ea1666653ce30b598464bdaa26e2f22c55fb7608eb13d48441426920a367a6d7483a993e80fcaa227fa172608a86533",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.3.21",
-    "dest-filename": "kotlin-scripting-compiler-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.4.0/kotlin-scripting-compiler-embeddable-2.4.0.pom",
+    "sha512": "0baace8ce3b3eb7a2c3420afb67656987fea4a3885d9265cee1b3aaea7f2649c4a469eaae2a893e4949fa89a423e672d5611e7949b639b96f1815dfb230f0f07",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-embeddable/2.4.0",
+    "dest-filename": "kotlin-scripting-compiler-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.21/kotlin-scripting-compiler-impl-embeddable-2.3.21.jar",
-    "sha512": "e95d7d295a4f9af03536665b939c4f8c074641f405f1d85a4c99d476552850f872360f3cd7db6216427e35d2887a7b52eb48b49ea54ac2b6b6fe37c299f40f7b",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.21",
-    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.4.0/kotlin-scripting-compiler-impl-embeddable-2.4.0.jar",
+    "sha512": "4d6e5f66ced2218313a71c1ccb81791795f818d78c40ef5038c9f00e91bebf9d69344170d69cb339802d1ab8d053b26f9499ca382b0a5fa5241e4b453b169440",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.4.0",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.21/kotlin-scripting-compiler-impl-embeddable-2.3.21.pom",
-    "sha512": "6b040fd6e9eccc7ee31d3da9ec710af1642f1ba0d0d51bcb59f9e5416d84a339abed60a7556b593acfc619a672fc740e2da0cef59fbdc15f82e1db459d0af65e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.3.21",
-    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.4.0/kotlin-scripting-compiler-impl-embeddable-2.4.0.pom",
+    "sha512": "53dc957a3bd02ddcb8589e55f744b9e5163c94f231345ef9ca92d5272e5397bb578707d50f1102102a966d8e7fd758312ab226b475fc223af594c596c99225c6",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-compiler-impl-embeddable/2.4.0",
+    "dest-filename": "kotlin-scripting-compiler-impl-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.21/kotlin-scripting-jvm-2.3.21.jar",
-    "sha512": "19a3b5cc1df1fca142aa3beffed00bf5407a35aaae406c211ea909899060cdf64fee687246f77059bb72e8a59c44468d0bbe3f48370430ea97ad22c132279f75",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.21",
-    "dest-filename": "kotlin-scripting-jvm-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.4.0/kotlin-scripting-jvm-2.4.0.jar",
+    "sha512": "32b21c607c3e6181e5169cecf670182fd429ac329a70736f1745658e643ac4a957067be25c8978b0ee205bc3421d26b867af67f909d952ba43560874ebb0ea4b",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.4.0",
+    "dest-filename": "kotlin-scripting-jvm-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.21/kotlin-scripting-jvm-2.3.21.pom",
-    "sha512": "e6103432c032645ac6d514b92e9ba98d8d2eb890a435adac3d5c8e63504eab5b7a45eb9ec649035c5bec1841fcd307e3f46aff40bc142e37109d8b5ee8ac4759",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.3.21",
-    "dest-filename": "kotlin-scripting-jvm-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-scripting-jvm/2.4.0/kotlin-scripting-jvm-2.4.0.pom",
+    "sha512": "01841e19c57c1a21b97b6e3b20234bf989da7baef503c5ab65043a6292d3bc1e719a2a41937e0901aa611b79142e2e3a3ed7cc09731742e03e48fb1133183799",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-scripting-jvm/2.4.0",
+    "dest-filename": "kotlin-scripting-jvm-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.21/kotlin-serialization-compiler-plugin-embeddable-2.3.21.jar",
-    "sha512": "ee9751db616ce69bfa49838a2caad938a04610d1ffb01bd1b23d99319d550462720125e318367987a129907868397a912a1583d8b618c43f4321f4b34e389ece",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.21",
-    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.4.0/kotlin-serialization-compiler-plugin-embeddable-2.4.0.jar",
+    "sha512": "5d25c7924d80cdc5e8ff8fbbe7be08b2e9b9d882618a14f54cf50cc2b98747554455293c2464fd408feda9fe51dea0f5c3717f862f323d920c13743c7bb48845",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.4.0",
+    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.21/kotlin-serialization-compiler-plugin-embeddable-2.3.21.pom",
-    "sha512": "7f35a04905170d3b826b892f0dd73878c4680bda5dc339e0fc2cc3d7d81b006b48b34fc1b6ff2d2c7a3d296c3a9ac050c038cee913cdd6b21fba90290ec799ea",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.3.21",
-    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.4.0/kotlin-serialization-compiler-plugin-embeddable-2.4.0.pom",
+    "sha512": "8857eed32a4dbb4bb118061e51a30ae7fca3ee31fe2ae651e59a1f8b3805e84e9571b02e333e764aa2ee1db77f5807c90cc61f5ce5fe6a70d724f51e1c1dd9d7",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization-compiler-plugin-embeddable/2.4.0",
+    "dest-filename": "kotlin-serialization-compiler-plugin-embeddable-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.3.21/kotlin-serialization-2.3.21-gradle813.jar",
-    "sha512": "8a06ef65f9554a24109bf59c8a89aecdb885480b9b983e292f2e68da5332d0ed6bafa18201481c807f2d48f1a29186cb204189a78ecd6876e2bfb2043858f339",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.21",
-    "dest-filename": "kotlin-serialization-2.3.21-gradle813.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.4.0/kotlin-serialization-2.4.0-gradle813.jar",
+    "sha512": "7f4112cfa493fcda96a1bce192bf71bb90809e4b832d7e19b707c4dfbd605ef4aacc64b38b19ae1ecdbfb8d16935b964d462e8b0944b4535bc102aa91bba7789",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.4.0",
+    "dest-filename": "kotlin-serialization-2.4.0-gradle813.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.3.21/kotlin-serialization-2.3.21.module",
-    "sha512": "82bfa6e9c147828a32716bf75990e6bd3726394a2269c5889e646f1a230df7151b14b0e42b8c0d4ed17a396c51ff2d428249057124d0ed56c18a9caf643ec994",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.21",
-    "dest-filename": "kotlin-serialization-2.3.21.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.4.0/kotlin-serialization-2.4.0.module",
+    "sha512": "8c2b54f8f4f2450ac9dce77d3978c946938b1a72636cc7a5147a01b25c03ea8709b84c749b50c0032a736e104a7079c6a058a0ffdb463d79262d8ef84d56230e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.4.0",
+    "dest-filename": "kotlin-serialization-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.3.21/kotlin-serialization-2.3.21.pom",
-    "sha512": "a4403078c4da514e64ec33acf2d0b35dd5c8c001131ee2bfa10ffd5cb2a011ae859a98d6f0eddc5e37ed427cadab7c8a368b28212473232edb5a9095f92558a9",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.3.21",
-    "dest-filename": "kotlin-serialization-2.3.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.21/kotlin-stdlib-common-2.2.21.pom",
-    "sha512": "5f7c50736d5f73554941d3b66861fd903b9acf82e4519cafc3148b59626141d6d04834fa3fb1b3804efe69fc8e4429b2172fba123fa906b6a071cbb9a881511e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.2.21",
-    "dest-filename": "kotlin-stdlib-common-2.2.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.21/kotlin-stdlib-common-2.3.21.module",
-    "sha512": "00b8f9c6355ef6ce2b73dc581ba72071f9c9a76aa2b8492eabdc453cb5c5d4223c3539cbd56acb0021cf3d3d90cbe9a9a2bf40e87e384f8b2103870f3a5cf44a",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.21",
-    "dest-filename": "kotlin-stdlib-common-2.3.21.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-serialization/2.4.0/kotlin-serialization-2.4.0.pom",
+    "sha512": "6c3ce3e82cbf36317524f451864fbb0ae08d7a2aece87fadcb3396d9d8061b85b4c18eb007c0848178efa714710d80fb6eef802b7d17e3ead4b0f48b23ceea4f",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-serialization/2.4.0",
+    "dest-filename": "kotlin-serialization-2.4.0.pom"
   },
   {
     "type": "file",
@@ -5045,6 +4716,20 @@
     "sha512": "e9f45435cf2fc7d03d9bbddcc8bdb581f89ba22d6b8f362c4bd31d0c03c96193f0d0fe60712a6b712e042b275eabaab379251340192a702eae46160ac102b892",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.3.21",
     "dest-filename": "kotlin-stdlib-common-2.3.21.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/2.4.0/kotlin-stdlib-common-2.4.0.module",
+    "sha512": "ee8a2e5a4eeebcecdcda73bf631611a6509a9632b6559d82cdd66f6e4d560271507753f5eb5cd2081042e52d2d95286f93812b5cd2d15e8110ff485843274762",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.4.0",
+    "dest-filename": "kotlin-stdlib-common-2.4.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/2.4.0/kotlin-stdlib-common-2.4.0.pom",
+    "sha512": "72a1e21205b7466cd9f77d622039aeeb6edafa36eb676c625f6a27c9af2fcf3fbf49564e054758f365804c57188ff1540e50e5caac3fcc87e0838a98c881b193",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-common/2.4.0",
+    "dest-filename": "kotlin-stdlib-common-2.4.0.pom"
   },
   {
     "type": "file",
@@ -5069,6 +4754,20 @@
   },
   {
     "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.1.21/kotlin-stdlib-jdk7-2.1.21.jar",
+    "sha512": "26b8a2316e115bae3061b65f6a1996eeda570df8e1f138d9e99e39d8a649a514803382b9231258d48f1ee36b816b6b9d0b2954e8e57d0ceb45322aa2feb8b18e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.1.21",
+    "dest-filename": "kotlin-stdlib-jdk7-2.1.21.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.1.21/kotlin-stdlib-jdk7-2.1.21.pom",
+    "sha512": "d05ac493cd6e3c8178243269949d2c9122487f1f9b1fbc901d1a64a665293ee9cd1b58916013dc80206e21288d19138b68be054a55ca56f03da3de9267849923",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.1.21",
+    "dest-filename": "kotlin-stdlib-jdk7-2.1.21.pom"
+  },
+  {
+    "type": "file",
     "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.2.10/kotlin-stdlib-jdk7-2.2.10.jar",
     "sha512": "2ad67dea67107f4c30ef37300ba77e26de26ce1d2b90cbd13341c0c63d5cc3d1c27609e87c05a04bedf29bc5835e577a5b4521036049c01d58a5af1b2965603a",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.2.10",
@@ -5076,7 +4775,7 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.2.10/kotlin-stdlib-jdk7-2.2.10.pom",
+    "url": "https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.2.10/kotlin-stdlib-jdk7-2.2.10.pom",
     "sha512": "32fc9844c5e0a129b7610487792c8773bcccdea773aecd8048091eb59d4c597b3e573c231df786d190ef3de99db7027b52b892b3d2a432b3487167fc204f32f9",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk7/2.2.10",
     "dest-filename": "kotlin-stdlib-jdk7-2.2.10.pom"
@@ -5104,6 +4803,20 @@
   },
   {
     "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.1.21/kotlin-stdlib-jdk8-2.1.21.jar",
+    "sha512": "90839cce2cc5c2c2a03efe352dbd0fabd7bf2fd827fe4c107f715c7f12afec6a22eec05847a2b50dc7c829498856b79c791eebeac4a57ba25f620e500e252e42",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.1.21",
+    "dest-filename": "kotlin-stdlib-jdk8-2.1.21.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.1.21/kotlin-stdlib-jdk8-2.1.21.pom",
+    "sha512": "9f1be34a54622f38a3d98c45722eb016435c7e5a017f43b31bfe531fe3980696a59b2ff7247719a937c65763a2692a6e8839a7773170dce605f3f10a12a68621",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.1.21",
+    "dest-filename": "kotlin-stdlib-jdk8-2.1.21.pom"
+  },
+  {
+    "type": "file",
     "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.2.10/kotlin-stdlib-jdk8-2.2.10.jar",
     "sha512": "357c39ade01e3d6790df2c31445aaada4a7435e6f39de7bdcba84f85e9a45a7a9c0baa8cb09137cb275b5071e9a08ef7babdf6216e3fe3f12044297d01d8dd49",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib-jdk8/2.2.10",
@@ -5118,38 +4831,17 @@
   },
   {
     "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.1.21/kotlin-stdlib-2.1.21.pom",
+    "sha512": "2f821f6abdaa894bd2d62b4e33dc4e54c8ed80fbc69a1be639bdb11a86254aceac88dd66e9802bf9767fe9bdec33854437248185d2cc1c8fc6b26e91f99bc3fd",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.1.21",
+    "dest-filename": "kotlin-stdlib-2.1.21.pom"
+  },
+  {
+    "type": "file",
     "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.2.20/kotlin-stdlib-2.2.20.pom",
     "sha512": "24e048e39ba8ac1fd249c8276a7024e4ec03fabc10b95c5cc5f8c996ea6e7a29e48457091cae0c1e59985d1f439878b7f12fe77314de14b02824dd986dbdb8ca",
     "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.20",
     "dest-filename": "kotlin-stdlib-2.2.20.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.2.21/kotlin-stdlib-2.2.21.jar",
-    "sha512": "cb7f62e2eb4c13f7a9873876f19d9dcb69c33d5e963c7cd87178f3789d65f29d2b6cf697573c04758428d2da6e26f2fdd3f0af46dedd8d04ad81d331e95859d7",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.21",
-    "dest-filename": "kotlin-stdlib-2.2.21.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.2.21/kotlin-stdlib-2.2.21.module",
-    "sha512": "4c44e2226dc8baf91685545d49db558de088241c87ac54d0f4a83af9b641d7d8c1f3ece654e41f3953690b81274e75fd57baffc51f74cd6da4787219ecfeaa99",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.21",
-    "dest-filename": "kotlin-stdlib-2.2.21.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.2.21/kotlin-stdlib-2.2.21.pom",
-    "sha512": "713bba2f5a0e0c320ae5e8446ede182212151f283f66355333c5f427829a655a22d8f3139b86094aed23f1cf5aecfab36a02da780785ad42a31236eef191fae0",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.2.21",
-    "dest-filename": "kotlin-stdlib-2.2.21.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.3.21/kotlin-stdlib-2.3.21.jar",
-    "sha512": "5564b17f006a9fdf93c93439b357e1fb82742c72d23b7aaa2e50d6db730d0b40426257e4e40eca7c70f9d514367b0057e51b84e1d0e49817002bc463939fee59",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.3.21",
-    "dest-filename": "kotlin-stdlib-2.3.21.jar"
   },
   {
     "type": "file",
@@ -5167,129 +4859,150 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.21/kotlin-tooling-core-2.3.21.jar",
-    "sha512": "831ec9092a896fefa8c4b2bd0c2304307dfe812ad83738e83870ae4de75d3d829cd89c576e9daadcda5c8d54777371bb5611482cfd9d6bab5fe1645dda7132a3",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.21",
-    "dest-filename": "kotlin-tooling-core-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.4.0/kotlin-stdlib-2.4.0.jar",
+    "sha512": "2bac8b87409ae19aa9d91f8e3faabe9090549d05811249d30dd1811112e37f8650ace8cdcb1f21c96552edecd7d700c448b3ddf80cd4db9f61a3bc7ee3435627",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.4.0",
+    "dest-filename": "kotlin-stdlib-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/2.3.21/kotlin-tooling-core-2.3.21.pom",
-    "sha512": "9efe1421cb67443d14b68f6dbf5b87dba8c1ffafd66181515f90e0e676e574e91cd6ef4c80cf6ccd1bba9ec0e414961d01ccb1c4ded4706fc1fc708a0f27c1c4",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.3.21",
-    "dest-filename": "kotlin-tooling-core-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.4.0/kotlin-stdlib-2.4.0.module",
+    "sha512": "c8b8970e1ccf8000b962e1d7aa68d49b50ae2a7d3fb324c532ea798c43d6be65e2f04820778f0edbf00660afcda43d7b660bd6c1d3d620bb3f92284b04fb378c",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.4.0",
+    "dest-filename": "kotlin-stdlib-2.4.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-io/2.3.21/kotlin-util-io-2.3.21.jar",
-    "sha512": "417a4e5a8768e146504e44455266eb4b337966ee5feca3ad1e8f632fc2602cb36bf3a65cc4ec51ce3ee3252b26e2085c9ca85b596004fe2e10d35fe5beaa748b",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.3.21",
-    "dest-filename": "kotlin-util-io-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/2.4.0/kotlin-stdlib-2.4.0.pom",
+    "sha512": "ce37bd679da72a793e1e2c717a1ad792ddf59832e02120c9d358db543916de2991ec2d3a574c05bd08e06afba0b082e5637bb2c2b8f8b3a043d2104e508fc9e1",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-stdlib/2.4.0",
+    "dest-filename": "kotlin-stdlib-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-io/2.3.21/kotlin-util-io-2.3.21.pom",
-    "sha512": "47b4b7669578b8e1a2a93d00ee6fc7dab0cd3b200153e1c3acaef2b3f9dd95361265591587201454bd7a99a59f9332f018d94efa4445dc38eb7644104e93b754",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.3.21",
-    "dest-filename": "kotlin-util-io-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/2.4.0/kotlin-tooling-core-2.4.0.jar",
+    "sha512": "f86d6c87577bafc1b1d39772bb0377898ee9ba30f974931b5e31b59504946376cf48920101007e5168f0a5fc13c2836ccbad9512a88aeb72bab515e0419081a2",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.4.0",
+    "dest-filename": "kotlin-tooling-core-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.3.21/kotlin-util-klib-metadata-2.3.21.jar",
-    "sha512": "ed8014ba910b26e9de9c124c839dff1b89775ff4639098dfb80079c24eb59632c705c981a7253eacb9f0592b3dcded9e0dc6a3d2c4145d05f97e067b68a18161",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.3.21",
-    "dest-filename": "kotlin-util-klib-metadata-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-tooling-core/2.4.0/kotlin-tooling-core-2.4.0.pom",
+    "sha512": "4bfd5bc47a5ac556128fdf0f2c6d2c1bf2287f1c2ce6da39e9d4486db8d73b9511bfcede5409e070f6cdc1412cfdeaf7d35c124edaa911fa808fedeeded72f0e",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-tooling-core/2.4.0",
+    "dest-filename": "kotlin-tooling-core-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.3.21/kotlin-util-klib-metadata-2.3.21.pom",
-    "sha512": "5b56a8cbbf367e0d6eb8a04d99a472130474d2bdfe58ed8b6e09e01695ba64e5fdc6185107730c45a18d648d97c1ef5549a2fdcf8a3616a58ca6bf6283e0524e",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.3.21",
-    "dest-filename": "kotlin-util-klib-metadata-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-io/2.4.0/kotlin-util-io-2.4.0.jar",
+    "sha512": "c612d1d70c546922ba45ca0d2f31b8da774c31e92290ab0c939ea9f40205457721fb200be6d3cf20bd23d05852d3b8b13d6ecb293485aa900bd2dffc553b2526",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.4.0",
+    "dest-filename": "kotlin-util-io-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib/2.3.21/kotlin-util-klib-2.3.21.jar",
-    "sha512": "073d3739e8df6b22c1e9bb474b56f007336d0cdb6ca8f7a27f61d6be4a42e3cf48072e4f9f1e972425d2b42fc90a022b95c2c48da458990738cc5902f5666e12",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib/2.3.21",
-    "dest-filename": "kotlin-util-klib-2.3.21.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-io/2.4.0/kotlin-util-io-2.4.0.pom",
+    "sha512": "59132ab88986ca2f71e642bc5de48e140fc4f17435be1f60a8b07729cb8b1db5cbb01fe80be64461e3d6d535d6b17d6193ae248b2deaff37f45e61a0a65d4e08",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-io/2.4.0",
+    "dest-filename": "kotlin-util-io-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib/2.3.21/kotlin-util-klib-2.3.21.pom",
-    "sha512": "42321ec6623cb3b1be5ef635ff23aa745dd82c34c22d82eb3b6532eb223a2f51b456e10902572f50d02c0617a4e5d4f1f534433611fa7e334a719ad58af33094",
-    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib/2.3.21",
-    "dest-filename": "kotlin-util-klib-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.4.0/kotlin-util-klib-metadata-2.4.0.jar",
+    "sha512": "73026751bdf26d104df255fd8e5edce1171374059419a7dec9bbfa7d7a363ea2dbf2cbf17f7702396ff85330774a02114d3dcd35e5989512aadd4b278b03cd16",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.4.0",
+    "dest-filename": "kotlin-util-klib-metadata-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/2.3.21/org.jetbrains.kotlin.multiplatform.gradle.plugin-2.3.21.pom",
-    "sha512": "af9471f06702cb9c0039d3ddc96691293f9e7c180856329102285ccc53ffcedd835876ccc8e1ec02860d1ceb40f17603c65a2833dbdb9724d8714217d62cfcc0",
-    "dest": "offline-repository/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/2.3.21",
-    "dest-filename": "org.jetbrains.kotlin.multiplatform.gradle.plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.4.0/kotlin-util-klib-metadata-2.4.0.pom",
+    "sha512": "bf8d27353d16c464d92ad6d575678468e2944d6101f3c7f61d62f86644c1bb1070480c4052c21d8ef28193da35a314c9de18c6c97251f454b04af35fbd85af1c",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib-metadata/2.4.0",
+    "dest-filename": "kotlin-util-klib-metadata-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.3.21/org.jetbrains.kotlin.plugin.compose.gradle.plugin-2.3.21.pom",
-    "sha512": "f455e38506c0b7e99ec96288d9bbd8c9263c37d3a4a1077d3ea03adfd774214a26ac905e0dd30c7463850ca46946606d7732228a5db3e69e7856305d64b04608",
-    "dest": "offline-repository/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.3.21",
-    "dest-filename": "org.jetbrains.kotlin.plugin.compose.gradle.plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib/2.4.0/kotlin-util-klib-2.4.0.jar",
+    "sha512": "5323b0d33f2a7a067ce5d46a061b219bc4215c1a807099edd0df97da8f4bf0c8e660fe619fb5dc3abaa0d0a2996904683f80191da16c59806f9b1cc75f409ee0",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib/2.4.0",
+    "dest-filename": "kotlin-util-klib-2.4.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.21/org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.3.21.pom",
-    "sha512": "e48d54022922bcd298e64f6b1835b1f52d3100e68db89a1fa290d5ffe7a25e8b10bb458d7ad9c2493c0bb6895d8426ce937016af9aaaa6b2f281e35f15bc9017",
-    "dest": "offline-repository/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.3.21",
-    "dest-filename": "org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.3.21.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/kotlin-util-klib/2.4.0/kotlin-util-klib-2.4.0.pom",
+    "sha512": "bfc0fb97b8585caa7b7810d7a6fb7d2acbc5c5d9485369c5be6f2e23bd38d74e64c6a02fb49d2ac80c7eb9c32c99616c7ca96dc153b068dcc4d2549936f0572d",
+    "dest": "offline-repository/org/jetbrains/kotlin/kotlin-util-klib/2.4.0",
+    "dest-filename": "kotlin-util-klib-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1/atomicfu-jvm-0.32.1.jar",
-    "sha512": "183668d1a97a2ef0390f0710718e3c8069f5b30ef7f6f9eab75c872cd2b99ca579719f2f3dca7eea985fe37f83ec0a432dd00dde3cc4d7b21c1c05619152e65b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1",
-    "dest-filename": "atomicfu-jvm-0.32.1.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/2.4.0/org.jetbrains.kotlin.multiplatform.gradle.plugin-2.4.0.pom",
+    "sha512": "bbcf844757c2b886bcfcc2682ead72c0ca76f2fa3306c81edaf5a2cdaaf6780759d3dacd0f34ea9a10cafe19049645f072bef7eae709f4eda51599f66c2552f0",
+    "dest": "offline-repository/org/jetbrains/kotlin/multiplatform/org.jetbrains.kotlin.multiplatform.gradle.plugin/2.4.0",
+    "dest-filename": "org.jetbrains.kotlin.multiplatform.gradle.plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1/atomicfu-jvm-0.32.1.module",
-    "sha512": "e23c0b50cf9cc6b4ac90f3464a8bf5e8aeaed0eed9d83f4155feaa09dbdea139a164bae22a56abaf6c2feb957c3eee0769b6e8a38f9d41502896e7da50b480a7",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1",
-    "dest-filename": "atomicfu-jvm-0.32.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.4.0/org.jetbrains.kotlin.plugin.compose.gradle.plugin-2.4.0.pom",
+    "sha512": "c25926303c42a8c55c6fa5db48ec557d9f9d3d3658d479328f75076d21eeb73804562e64371526f5a753e3921883800f99afd42dc458a400f16075ee3022b024",
+    "dest": "offline-repository/org/jetbrains/kotlin/plugin/compose/org.jetbrains.kotlin.plugin.compose.gradle.plugin/2.4.0",
+    "dest-filename": "org.jetbrains.kotlin.plugin.compose.gradle.plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1/atomicfu-jvm-0.32.1.pom",
-    "sha512": "20b44a492d802d9bb80817637610ffdf5abf64373df1a5677d1111e25a99fb44760a37314aecfdba13073609a7e9ad7a67cf838f64a62a124486b61285aecb77",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.32.1",
-    "dest-filename": "atomicfu-jvm-0.32.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.4.0/org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.4.0.pom",
+    "sha512": "ad49f5563b9d9b49ed5380693068da3d8ecb38c8250c378c148a1a719f41c04d2a2e532602d0a37702656f296e4b26582176d17d8369af3afc48aad0f055a88b",
+    "dest": "offline-repository/org/jetbrains/kotlin/plugin/serialization/org.jetbrains.kotlin.plugin.serialization.gradle.plugin/2.4.0",
+    "dest-filename": "org.jetbrains.kotlin.plugin.serialization.gradle.plugin-2.4.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.32.1/atomicfu-0.32.1.module",
-    "sha512": "b08f9fe9e015494e38f786bb95d9849a257c096b1216c46aa101f7b6fbcec5afc2ba43ca34390d1be25cddc062d015656e482c4446f5c6ff8f7a12413b4faaa7",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.32.1",
-    "dest-filename": "atomicfu-0.32.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0/atomicfu-jvm-0.33.0.jar",
+    "sha512": "7a41603bcb0eaf6d8e4fc7531f70860f1d0cc719a0abb34b65d8bfd1bc2e14cf7ed810c11a1f1709407520121972769744a108aab64ea9995e03f9cb544b8f2f",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0",
+    "dest-filename": "atomicfu-jvm-0.33.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.32.1/atomicfu-0.32.1.pom",
-    "sha512": "cf17b893c37e1fb6abe6f3ec01fdc42095c1074a39f75b7fbfe780d7c0712780b57c4f3db0d603a16db86552d7ab11d2c8ca59583f03b8f675d26d05e45eff03",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.32.1",
-    "dest-filename": "atomicfu-0.32.1.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0/atomicfu-jvm-0.33.0.module",
+    "sha512": "3ffe292b153c98f92d22503c9d1b3d195828b9a80eee69d97e487568433372e2873577e077758735ce6d8e940ee237c6cd4d6451094babfc38a8c9d9f7cbe09a",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0",
+    "dest-filename": "atomicfu-jvm-0.33.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.32.1/../../atomicfu-jvm/0.32.1/atomicfu-jvm-0.32.1.module",
-    "sha512": "e23c0b50cf9cc6b4ac90f3464a8bf5e8aeaed0eed9d83f4155feaa09dbdea139a164bae22a56abaf6c2feb957c3eee0769b6e8a38f9d41502896e7da50b480a7",
-    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.32.1/../../atomicfu-jvm/0.32.1",
-    "dest-filename": "atomicfu-jvm-0.32.1.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0/atomicfu-jvm-0.33.0.pom",
+    "sha512": "c401acf82b054dcfec3ca426cfd202794cbeb4aaaceee66514c3a9fd2a2386a4eeb7187d3a33cd7d6c282862a3b930e2f6895851e4eec357a5a45982b337a6de",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu-jvm/0.33.0",
+    "dest-filename": "atomicfu-jvm-0.33.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2/kotlinx-coroutines-android-1.10.2.pom",
-    "sha512": "5c607bf7f1f5da9c7991cb9b8075b0acb8f24065c89b1336f1a433361eb56044b9f2100b707d8e8a1dccdd0b0f0c741728a246d6ecf5b14d2f16916e9360725a",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.10.2",
-    "dest-filename": "kotlinx-coroutines-android-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.33.0/atomicfu-0.33.0.module",
+    "sha512": "48c8f844f2a5733dbd93d177a00e870ca279a55277555a31d79506cb76686a4ec43f7452eac2f65a563ff60dca7f6d941611bad1ada8ca1b3f210fde8becb65e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.33.0",
+    "dest-filename": "atomicfu-0.33.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.33.0/atomicfu-0.33.0.pom",
+    "sha512": "d0cdb54bc063739183ac881182347b7fcd363a13ba613d2087a0d6b4d8d003297e9b95b697b7c4e678aeba56b5ca6df62e203dd91a0e037876c88f29444283ba",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.33.0",
+    "dest-filename": "atomicfu-0.33.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/atomicfu/0.33.0/../../atomicfu-jvm/0.33.0/atomicfu-jvm-0.33.0.module",
+    "sha512": "3ffe292b153c98f92d22503c9d1b3d195828b9a80eee69d97e487568433372e2873577e077758735ce6d8e940ee237c6cd4d6451094babfc38a8c9d9f7cbe09a",
+    "dest": "offline-repository/org/jetbrains/kotlinx/atomicfu/0.33.0/../../atomicfu-jvm/0.33.0",
+    "dest-filename": "atomicfu-jvm-0.33.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.11.0/kotlinx-coroutines-android-1.11.0.pom",
+    "sha512": "992f21dd11eed735d4bd1c4d864c55ee9a697b7a01bb4d6a39358c4f4da4430cf3ff18f626b60b8e82893531889782f0a007db112852b9e612d50da22fbed3a8",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-android/1.11.0",
+    "dest-filename": "kotlinx-coroutines-android-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5300,10 +5013,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2/kotlinx-coroutines-bom-1.10.2.pom",
-    "sha512": "019fd13ac4ed6829a32489afe003762936937d6894f16ac36f611beb2ef7e9fbb282e56479863da8daa156aa77f834c30420604e431b6e2e56311e3e0240b606",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.10.2",
-    "dest-filename": "kotlinx-coroutines-bom-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.11.0/kotlinx-coroutines-bom-1.11.0.pom",
+    "sha512": "2bdb68d3407ce1c99f30845bf239da7130a2eb523572dfc88e5d097ce9f1018d2fa46579cb42ef5d12916ea9c75beab47603fb3617ad6f1671f2d2503673fc3b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-bom/1.11.0",
+    "dest-filename": "kotlinx-coroutines-bom-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5321,24 +5034,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.jar",
-    "sha512": "238fd451f80e222480c880dd8bcfd76e9203b6833a0306a55483b3f9eb0b25651242a3e7beaf7510d5e39922f1d3d987fca79468d945eb35b0f07156a7887ba0",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0/kotlinx-coroutines-core-jvm-1.11.0.jar",
+    "sha512": "6d7daee4c8d796dbf20f31225cd0a5d01c45d6f57fecd4e3b91c0e47fa59ac095f9605edad0fdd21954fb06eeab4a7b3a9c52cbe01f7033b058273642ec85e78",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.11.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
-    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0/kotlinx-coroutines-core-jvm-1.11.0.module",
+    "sha512": "d6e34c42956e5b15abc950af2bec1b1712d6f5ad8fde77402c94df2c2e90e7fd3e81fa0b37064e1d040bd6ea5c0cf4380394f7c81fff8d7813eeef00cfe80c44",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.pom",
-    "sha512": "e146303a289ff4ca6e6b93470d37036816a4a77c6d72f7fe8200befe3ba9317dad18e6aa6ee216403a163146b3cc3f55e9a53beec582029fb734d363255f1522",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0/kotlinx-coroutines-core-jvm-1.11.0.pom",
+    "sha512": "6d1e3d260b534761b7d0bf7c1bf94683ef2d43999555374cbf9629ef6d2b07b10ca469a6118e13da4d6a43c665b1361f3c6a4ca7300e1c3bbcb3bebb7d9a53e9",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5384,24 +5097,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.module",
-    "sha512": "a88eb8e578850c3ca9e12f9067d761287a3e70c99657f41df959085bd47a9fe7982f835ab37880ca55fe5ebf62e02dbc947794194aee9b03330bc1fb24ed9404",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-1.10.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0/kotlinx-coroutines-core-1.11.0.module",
+    "sha512": "a4acbf13165eb34e8dbbefe25f5f29b7d19b88c5dc24bb01ec78f61a801509013fa102cd0a227187b6cd43b1c783724c7a6c3885ce9be21737c26b2e96af5ed2",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/kotlinx-coroutines-core-1.10.2.pom",
-    "sha512": "63ec46c4f2af79f6c88184a39cd78f3ddd26cf25a89c01a9a2068c7a7d4cf44670def8462703e72505e8a1b0a6530e6b65426486b6d8098ad5a547086025f7ff",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0/kotlinx-coroutines-core-1.11.0.pom",
+    "sha512": "092bfa60b92880fed35220152ee254421822c6261c26c7396ccb617e49e601e7c3ad8f6b94dd46cef3fcc301fc8be390e85e192fba0e80f7e57c6b424841c72a",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-1.11.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2/kotlinx-coroutines-core-jvm-1.10.2.module",
-    "sha512": "d105252b959981bf5a1accd86ff176d032eeed22d0e5647eb2d5c811e43019408743ba91a59a21250bcc2bdb0b135c545b57eeba345679ae749d241bec16df7b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.10.2/../../kotlinx-coroutines-core-jvm/1.10.2",
-    "dest-filename": "kotlinx-coroutines-core-jvm-1.10.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0/../../kotlinx-coroutines-core-jvm/1.11.0/kotlinx-coroutines-core-jvm-1.11.0.module",
+    "sha512": "d6e34c42956e5b15abc950af2bec1b1712d6f5ad8fde77402c94df2c2e90e7fd3e81fa0b37064e1d040bd6ea5c0cf4380394f7c81fff8d7813eeef00cfe80c44",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-core/1.11.0/../../kotlinx-coroutines-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-coroutines-core-jvm-1.11.0.module"
   },
   {
     "type": "file",
@@ -5426,10 +5139,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2/kotlinx-coroutines-debug-1.10.2.pom",
-    "sha512": "62e88aa9c8399cb1550d8ffe6830768f00562383b0d8074c733945acd89ea1aed8664186a49a872ea521623a94183da217a2d0aa9a34d322f1cabf2464c20c13",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.10.2",
-    "dest-filename": "kotlinx-coroutines-debug-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.11.0/kotlinx-coroutines-debug-1.11.0.pom",
+    "sha512": "cf5390b40eb0d25bcf816531c2963cf63413032c37176607bd2895b13a240ad83375d53af6c172052f860a0fbd25ca087d56ae270c1e9cbacc33f770c896d6e1",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-debug/1.11.0",
+    "dest-filename": "kotlinx-coroutines-debug-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5440,10 +5153,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2/kotlinx-coroutines-guava-1.10.2.pom",
-    "sha512": "2f5744e09018bf1fe6358e79d4e72ac0e0c040141e093490e3046402e4bacf8d5e228ab7576270e625753899c2f8e7c0732bd05d95b92c20e30724a67835023b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.10.2",
-    "dest-filename": "kotlinx-coroutines-guava-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.11.0/kotlinx-coroutines-guava-1.11.0.pom",
+    "sha512": "72a18b47b1dc03538e4567aed7d5bb51209106a87a29f87508354eb3d64eb9f304488ed79513dafad4ef5e1961389c839ecc15fe0d967274acea598aac0a84a0",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-guava/1.11.0",
+    "dest-filename": "kotlinx-coroutines-guava-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5454,10 +5167,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2/kotlinx-coroutines-javafx-1.10.2.pom",
-    "sha512": "38dc16d847a1579c67781b50be82395eccec98ea02eb25b434457819259a3fd98d7a10cf29a40f4b2a49e77f10dea49acccf888c9950ce9dc8ee9dbfb0ce8620",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.10.2",
-    "dest-filename": "kotlinx-coroutines-javafx-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.11.0/kotlinx-coroutines-javafx-1.11.0.pom",
+    "sha512": "028885d4968797a717f0d4b154e929a59e6bad1796465b3940c07bb352360d582f19b7c4b5648bba2cdee08ca9f90c2ab028a4add90601f90054ab90f3489711",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-javafx/1.11.0",
+    "dest-filename": "kotlinx-coroutines-javafx-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5468,10 +5181,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2/kotlinx-coroutines-jdk8-1.10.2.pom",
-    "sha512": "ae0c0e8e79a390d815e5f50787cbc17ee5dffa1dfc99fd3c586b459748e97866176401c408d9d65db2ff0fcd064ed19b31316c03404e29846ced2798247b965a",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.10.2",
-    "dest-filename": "kotlinx-coroutines-jdk8-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.11.0/kotlinx-coroutines-jdk8-1.11.0.pom",
+    "sha512": "d74c0fca56490b2f34719f9bc4846e215a2b9ba59ca14da4a60e3d58921deaca7962375ee425907b5a15e3e5803848c89ee8a05bd6ded57ce530ad9155be2f44",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk8/1.11.0",
+    "dest-filename": "kotlinx-coroutines-jdk8-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5482,10 +5195,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2/kotlinx-coroutines-jdk9-1.10.2.pom",
-    "sha512": "1d6dd9c33bd42d8170bc2196346ef84445f74ce11b47730b6194a1c5ec1e066fcfcf2ff11c071f24cc53476d917ab04773c7e478c054d26fac159ca4c3ce7230",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.10.2",
-    "dest-filename": "kotlinx-coroutines-jdk9-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.11.0/kotlinx-coroutines-jdk9-1.11.0.pom",
+    "sha512": "215a8c3c0aafc81d77f09dedd8ab1220b6d1309e11ddc1829a707f81b6a42fa3dcbb201c04f56a847e4fdbfc56c461f342278d9aac541eb01d52e8ad409d224e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-jdk9/1.11.0",
+    "dest-filename": "kotlinx-coroutines-jdk9-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5496,10 +5209,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2/kotlinx-coroutines-play-services-1.10.2.pom",
-    "sha512": "1d86a2fb6e27ad9c8f5f2650178151216097628491fdb2d1beaa1c4a8cfaf29ed0f54039ed005aa8923b57db807627cefc5c95f6476139b5d72a0d33184dbfad",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.10.2",
-    "dest-filename": "kotlinx-coroutines-play-services-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.11.0/kotlinx-coroutines-play-services-1.11.0.pom",
+    "sha512": "7a33dd1e44288203c0b6f6e867775d48327dd305ea6a62b61c658afd7605a39fc42fa6e0f04bb8fcba669829726cc5cda5db600a8085abfaf2627b28d04a6867",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-play-services/1.11.0",
+    "dest-filename": "kotlinx-coroutines-play-services-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5510,10 +5223,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2/kotlinx-coroutines-reactive-1.10.2.pom",
-    "sha512": "9ba65dfa502929f8916f57894b8ea6205bb52a44eb8aaa5cea0c5630837ce476747e4af8d72ac9df6cabbab8f34398106f825be985600c37fb77e79a9552d17a",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.10.2",
-    "dest-filename": "kotlinx-coroutines-reactive-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.11.0/kotlinx-coroutines-reactive-1.11.0.pom",
+    "sha512": "4a2fd4fb2f6bd90adb202b1664d15ecab4060000500d7594aa4e9436546ab9dd8b557920315ca495f16f404660570f9a6c20bb0382cc608511a501a87ca06f7e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactive/1.11.0",
+    "dest-filename": "kotlinx-coroutines-reactive-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5524,10 +5237,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2/kotlinx-coroutines-reactor-1.10.2.pom",
-    "sha512": "f4d42f9d92dd3cf83b720df9032e417e661eaa9d52c6e6666f83f5560124675d7a3c82ff56cdaba00b5da64e30fe3fb61960c9de5faf1046bbb4e953fcd4a49c",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.10.2",
-    "dest-filename": "kotlinx-coroutines-reactor-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.11.0/kotlinx-coroutines-reactor-1.11.0.pom",
+    "sha512": "ba3171d61148aea6817dfba3dfaf5cf8cee44959ff5051afd5b66cc23aed69e1eb69de45801cbce38891f02802f864f9c34f58f66572ac3201dbc88547a5394b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-reactor/1.11.0",
+    "dest-filename": "kotlinx-coroutines-reactor-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5538,10 +5251,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2/kotlinx-coroutines-rx2-1.10.2.pom",
-    "sha512": "19966b5d3355093806434a106588b8d988a23688e602ae9200a0dda5f159e04856049815509f5b7ab9bfeeb1929c700f0a9bc9b8f0848a27fdc19211e5dee711",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.10.2",
-    "dest-filename": "kotlinx-coroutines-rx2-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.11.0/kotlinx-coroutines-rx2-1.11.0.pom",
+    "sha512": "67d5c99e53c3e2124e73f3440cc1c2700a12cd2c6d9c52ca8e1a29ef09156f1f9e1bba781820cbcc8bd1f9bb25bcf3f729e1e959ec24ac54d3dad6b4222aa1d0",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx2/1.11.0",
+    "dest-filename": "kotlinx-coroutines-rx2-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5552,10 +5265,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2/kotlinx-coroutines-rx3-1.10.2.pom",
-    "sha512": "713797767bb99ea92ea9f1bd643a6abbfa957e4f54abaaeff8e2ef851ccece0e582204157b9d3f51887c92fa26190ecc9c2ceab0aa8c2413b954e5e24c182db4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.10.2",
-    "dest-filename": "kotlinx-coroutines-rx3-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.11.0/kotlinx-coroutines-rx3-1.11.0.pom",
+    "sha512": "6684643348c5167a78969fdbb3846c735a0d1703de65bee28ba7602c31967195ef9c6888a698fd03b23f46fe003e93f5eb5a2f1176f6f383c1d668c9d6f9e61d",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-rx3/1.11.0",
+    "dest-filename": "kotlinx-coroutines-rx3-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5566,24 +5279,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.jar",
-    "sha512": "e0688d8b0d58774656d147c90438ca3bece9f2052c5ca8c6965817fc29c790e229751f81874a3d06b2291feacea004a7c1b8d7769d2cdd03cd3dc9ddaf5fa183",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
-    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0/kotlinx-coroutines-slf4j-1.11.0.jar",
+    "sha512": "08ab4f6624f1b35d3d32413b236b37eb88931d697834a856da74b70cb58c6ca2162d5d2b718c0c96f128d68fe55446071b9861baf39e828dfecac1e8bec0b021",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.11.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.module",
-    "sha512": "956e8b4b2a38dfca46012e1c6f1484d958f860ee57cb8d16767dc2c8c24ec4847c7271b911c30dd4b7e93470bcc3941a9c0d384dd53e41d0dc846394a9e097f4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
-    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0/kotlinx-coroutines-slf4j-1.11.0.module",
+    "sha512": "06057aed719a2ff12734c88f7c7f3ad9ab7d1bc46b96f3bd9f836b9e27a329d84050bd50b3a16d38165b909f9a328b5ba977a0ed2fdb1bc99a8c8d39a5f23d34",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2/kotlinx-coroutines-slf4j-1.10.2.pom",
-    "sha512": "e3aeda087f93866da540b152573520706daa7bd3f0cc46a18249f27cf35c17fa74f22203716e1f2ff91c7722fc9617bf7c8a1ce8a72992855ad52940be61bf30",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.10.2",
-    "dest-filename": "kotlinx-coroutines-slf4j-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0/kotlinx-coroutines-slf4j-1.11.0.pom",
+    "sha512": "5a6dc36b9ac3bd8de8099f03d5bc95b5ff9a4a795516a4bf62aa5e75570fcbdfc19fb8988052f861283e7f740890fc973d280e4b5dbfd611ca7d99825a3e4bb8",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-slf4j/1.11.0",
+    "dest-filename": "kotlinx-coroutines-slf4j-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5594,24 +5307,17 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2/kotlinx-coroutines-swing-1.10.2.jar",
-    "sha512": "7bc199dfc87184d652773203c75837b00def9c542ca378bd5d384d5a396eb0cca67d079d2ac4c6de0f7d3c7c69b28032a9b302c1bf05e4d7955e4dfd4fcdc702",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2",
-    "dest-filename": "kotlinx-coroutines-swing-1.10.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.11.0/kotlinx-coroutines-swing-1.11.0.jar",
+    "sha512": "ef883725c7d3bdc0fabd70381a36abb3b6ec1018e10efab184919f2a5610235ceb9c18400e8570fd6b17a4fa22006798071d6b956ab4c05449e4d157f01ad952",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.11.0",
+    "dest-filename": "kotlinx-coroutines-swing-1.11.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2/kotlinx-coroutines-swing-1.10.2.module",
-    "sha512": "1430640a57bf13f99ae44b2aa2f076c73a54c9d774c21631d0d5c2c9f83b87c8f9d2eaa7382c4889fe9b6a683f1e0a686f34a3f7b83f274809a9f627aedd1325",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2",
-    "dest-filename": "kotlinx-coroutines-swing-1.10.2.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2/kotlinx-coroutines-swing-1.10.2.pom",
-    "sha512": "b88bb52e56146233d4703c7a9695049605a9a21d85e3f075f278ededeac80f76e9cf2110f4336cbafb46ee475558da664d8f068f6d2e524b0b18f20483478977",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.10.2",
-    "dest-filename": "kotlinx-coroutines-swing-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.11.0/kotlinx-coroutines-swing-1.11.0.pom",
+    "sha512": "6b46a7341532ebcde3c819de5edf226f58ad5899cb58dadb26e4cee3e2eddcce0d4532ea2c0a6e4b981689910d983b716b9923b97b373070fc96a52308f8b781",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-swing/1.11.0",
+    "dest-filename": "kotlinx-coroutines-swing-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5622,10 +5328,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2/kotlinx-coroutines-test-jvm-1.10.2.pom",
-    "sha512": "646a554dc77ea050467c5cc43518459ce33e7c1b9103673c13a9f0288f5c1cbdbb43913bcf7e0fb1c02f2323b92a0feab17ddc223a1a919b8392431be65fca6d",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.10.2",
-    "dest-filename": "kotlinx-coroutines-test-jvm-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.11.0/kotlinx-coroutines-test-jvm-1.11.0.pom",
+    "sha512": "bc641916de36f54cd628230346e9be7cb125d82caea803ba5d4ad5d4ef9bcc5cca1828c427d8e34a4aa4787fddb0fe8d02bdbf6ec2fb399151a67c3b42283369",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test-jvm/1.11.0",
+    "dest-filename": "kotlinx-coroutines-test-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5636,10 +5342,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2/kotlinx-coroutines-test-1.10.2.pom",
-    "sha512": "4d49f5a32e32558d490f6159be5740a361b2ed615f762a63623b430feca757d499934157e16c52669b07a14cbe5ffe42e192db26b81190b06e3b84963ddaaeed",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.10.2",
-    "dest-filename": "kotlinx-coroutines-test-1.10.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.11.0/kotlinx-coroutines-test-1.11.0.pom",
+    "sha512": "98947c36fea0db3496a3a49fc6e2f66c99c2b3f6c9d494b11a23fb4be96d9d4cbcb845448499d093aba29c098ea99f1e03094dd6e7cf2c4f2ca88359a183ac4f",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-coroutines-test/1.11.0",
+    "dest-filename": "kotlinx-coroutines-test-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5692,87 +5398,94 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.jar",
-    "sha512": "400f5deae09a285bea68bb00fcc247b9be4c76746584516b6aa5e612719783b6ee79979b497053f28d8878dd7d7514e91aa3611aaa1ce7ce369862f53f3a9c4b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0/kotlinx-io-bytestring-jvm-0.9.0.jar",
+    "sha512": "c7ea5967fb8f5ebba547a4d15f923f6a550f6f7cc9047c69f09b905e2a0ffd3319b5f336473ae93ca29068a466d97d83f38f80075f4a556787954de6849138ec",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.9.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
-    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0/kotlinx-io-bytestring-jvm-0.9.0.module",
+    "sha512": "d2bdbaf46fa31d3d811618cf1b76efee64ad5ee3a618093b01b6362965c1d9316fbb7acd68c881f8f330c401267e3fb6deb87b59e0885623a53e8e6c9aa6d14e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.pom",
-    "sha512": "7fd502441d8a7211df8a6732e321bc6aa5218c2f99ee3c155cf268837fdd70f7b34127c347326e405f9ceaf50959b74677ed704a6991ae5d9157286d7121b7cb",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0/kotlinx-io-bytestring-jvm-0.9.0.pom",
+    "sha512": "6f701f289d8a4185976529daf3f893bbb35cd5c08be746b58000224c6d7b66b789ae6b0850e99f8b9bc252d1d6aefc7dc9b4d410c67afc7b1c782162813d9ae8",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.module",
-    "sha512": "1245511dea7361b90b71211c16af13ba06f3c240abc7d60be367808680b9e291ad3f23bfa21f5421a05b8bae7e7e2db0779d97a7e80d013731013651ad0687f0",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0/kotlinx-io-bytestring-0.9.0.module",
+    "sha512": "77715eec3a090b24945dabb066be53591b423cd462cc92ec566c625df5b6f39fa5d96528f94e3e5dcb6912c66b4a1a45ec5f16d5f6b5e6ac0593b1fd28516892",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-0.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/kotlinx-io-bytestring-0.8.2.pom",
-    "sha512": "8d8734e25410a5a4926b0a1aee099c817076ad0a222db54cb4d5e150f7fc7b09a32d02aea05e9a029e9921849ac7899a8c7b777fff7c34f8252a477e481f8378",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-0.8.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0/kotlinx-io-bytestring-0.9.0.pom",
+    "sha512": "38509a4319075f443be3f971074e3859f3c7195ab8373fc5d1f8732fe56eead0ae278d340d246014ad93224908fbd501f253549d043c54758260c51962c269e7",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-0.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2/kotlinx-io-bytestring-jvm-0.8.2.module",
-    "sha512": "2d1ae5ce7a49681f9f48011301b4fea0bb11639ee4764cb698697576198a28f4e5d0dc446001d785ad882755dc020f1649231a0eb82679fb0610d75a0c133965",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.8.2/../../kotlinx-io-bytestring-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-bytestring-jvm-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0/../../kotlinx-io-bytestring-jvm/0.9.0/kotlinx-io-bytestring-jvm-0.9.0.module",
+    "sha512": "d2bdbaf46fa31d3d811618cf1b76efee64ad5ee3a618093b01b6362965c1d9316fbb7acd68c881f8f330c401267e3fb6deb87b59e0885623a53e8e6c9aa6d14e",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-bytestring/0.9.0/../../kotlinx-io-bytestring-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-bytestring-jvm-0.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.jar",
-    "sha512": "ccdc618cdead73b4702e1bffcdf503bda7c3e0eae3d4db65430442eff1c7b2fdaeb5838781994fc82e46310de81a806707b9c3c2e72e36bacc154da8a82214bd",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-core-jvm-0.8.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0/kotlinx-io-core-jvm-0.9.0.jar",
+    "sha512": "7642b13d8b65998d52a8b1190abcd26278c4eec7286583a35a7c76723d3a70ea387cb4e31c6dcf0bcc8b04866d8d907a0191ee99b970bc2de83ec18d2189348b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-core-jvm-0.9.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
-    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0/kotlinx-io-core-jvm-0.9.0.module",
+    "sha512": "9230496a117a18eb173b7806b88b6b172327a93bf93bb14bafdcd5db2823cd3f17473fe7304663f4ec1325d5bc021e881749475b49114ab099ecb7cdad7e9f8b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-core-jvm-0.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.pom",
-    "sha512": "12f0726310dccc60bb703fc13634e8719d01c80189a512faa7abe9107a51aefabebc04a47116d727473e84db2626c527b1338eead8f66becdb8793b95ea90687",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-core-jvm-0.8.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0/kotlinx-io-core-jvm-0.9.0.pom",
+    "sha512": "c61b335af7b6411f19d38fea6d5ce40d7405b42dfb9c11528394c7993481d0dbc3baf755b40be970877c363fad1a53bbba529137f46cf4c896907b7042798925",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-core-jvm-0.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.module",
-    "sha512": "d1c88ea8b8aa77bbd213fb63c72b22108223cdddc0109ec6495a63c9305dbb5d5cc4f33140b7c49b8b7ab7b554a0b42f4b4d75e997751d2854f8c5fcd176fac2",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
-    "dest-filename": "kotlinx-io-core-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0/kotlinx-io-core-0.9.0.module",
+    "sha512": "b818d19883e56b0e18a29720bd761bb900a442df3ad48b0c4ef01ce15ba52a343a93bb2112a545e3c898b0f67d45b7ee86a709be1a7604bb01e2a5f08249d979",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0",
+    "dest-filename": "kotlinx-io-core-0.9.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/kotlinx-io-core-0.8.2.pom",
-    "sha512": "f2c5a6d523358da2a0c994f1318c365285c710779f38a794a6cdea76c4a441271be4b5f0a61d0fdd72a0e6e7f2b7a158ddb4a115af5b39858d721e28f5082f1b",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2",
-    "dest-filename": "kotlinx-io-core-0.8.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0/kotlinx-io-core-0.9.0.pom",
+    "sha512": "996db60df33e191b9af0431dc0fb50cf492ab623f58b57aa41b593eb7e9c7fdcab3ce382acc770c7b458a90838d241e4e706e4b5fca22265a7d0aeaf4e094a08",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0",
+    "dest-filename": "kotlinx-io-core-0.9.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2/kotlinx-io-core-jvm-0.8.2.module",
-    "sha512": "481d06019b6fd1c2135fc20ddf30d9fd00a421297af7b12eb783c2afcd0c1c58def59b2d8db61700ccfcc717e2eaabc9070e25eba0779858d996ab3d42841789",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.8.2/../../kotlinx-io-core-jvm/0.8.2",
-    "dest-filename": "kotlinx-io-core-jvm-0.8.2.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0/../../kotlinx-io-core-jvm/0.9.0/kotlinx-io-core-jvm-0.9.0.module",
+    "sha512": "9230496a117a18eb173b7806b88b6b172327a93bf93bb14bafdcd5db2823cd3f17473fe7304663f4ec1325d5bc021e881749475b49114ab099ecb7cdad7e9f8b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-io-core/0.9.0/../../kotlinx-io-core-jvm/0.9.0",
+    "dest-filename": "kotlinx-io-core-jvm-0.9.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.11.0/kotlinx-serialization-bom-1.11.0.pom",
+    "sha512": "72f97c1a420ec95c3b067ca28c933c5b78668334602c0b52772b40297c8fc4edcc33ef268a70b6e5c979cf08252458571d8996f90526266eac88c67ed7b5a43d",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.11.0",
+    "dest-filename": "kotlinx-serialization-bom-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5783,10 +5496,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.9.0/kotlinx-serialization-bom-1.9.0.pom",
-    "sha512": "e2546ebfc39847d2567b72b152d7dea2c3a9ea6931cd826aeaac600bb60d615ae0dcb4a756fe6141a6c4ebb29b98639222e5404d565b94f3d09114f2674ac8c9",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-bom/1.9.0",
-    "dest-filename": "kotlinx-serialization-bom-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.11.0/kotlinx-serialization-cbor-jvm-1.11.0.pom",
+    "sha512": "0a6b153087162871fc8a88eeecafc4dc41e3ef88ade859d3e0a3fc66687947e57ede4c94ec78dceeebcfe1ffc109862a006144f8ab521c4035c21607a746c829",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-cbor-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5797,10 +5510,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.9.0/kotlinx-serialization-cbor-jvm-1.9.0.pom",
-    "sha512": "2ffee035430d1049f509ca6d98e940493ca534b3a34f61c73aa29a7508eb2dd10932fe7a01489e06cad7278fdfeeb21bbdf37f476a4feceb3031649ca85e4264",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-cbor-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.11.0/kotlinx-serialization-cbor-1.11.0.pom",
+    "sha512": "d6d3d61ea5cf9253cdac636665b3ba6a4da08b7c383e6562aa3a287c6eacea964ac6baea4c9cfedf9f30b1cfffad174d2b979954a537c400424b533f3b9f4bcb",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.11.0",
+    "dest-filename": "kotlinx-serialization-cbor-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5811,10 +5524,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.9.0/kotlinx-serialization-cbor-1.9.0.pom",
-    "sha512": "72ab8905b4865218eb0905bce2966009f90d7dbb53eaa63393b2b5fe38e8c4ba419a8bfe626ec73fcb952c04507a726ee7f0818ecbeea48a20ae868674a563e9",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-cbor/1.9.0",
-    "dest-filename": "kotlinx-serialization-cbor-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0/kotlinx-serialization-core-jvm-1.11.0.jar",
+    "sha512": "098993238d26951acc7172117685861d8728fba697bfa20bd6b246fc74b6bcb0b73cc36cdf9bfc14e8b40845259c78f59a4698f6e8dfff2ae6c673113ecfc135",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.11.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0/kotlinx-serialization-core-jvm-1.11.0.module",
+    "sha512": "9b008525c2651bf460547593746823a5659a357aa5c57fc89426230222b89ab6dd95cffcb351eae92c96d4d22ac4587324842088967eae0b32399664df385ff5",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.11.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0/kotlinx-serialization-core-jvm-1.11.0.pom",
+    "sha512": "521fd3499e64d0c3ca199b062b5a1ba983c2a62f215380b7c7ff6fb27308f54c6061169ddb0d61d3177cae9d850cef1f9d1b7a020f34375d45d33f749afbf925",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5839,24 +5566,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0/kotlinx-serialization-core-jvm-1.9.0.jar",
-    "sha512": "39d4fe619ab52edb20b12ea6aea6c046a14f88713c9e367318d5020c86f712bbe17a0a4fa552563693eca21ab478cebe4f394cd8d9cadbc1d9d77885c84ff29f",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-jvm-1.9.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0/kotlinx-serialization-core-1.11.0.module",
+    "sha512": "8f8dc277fc82f1a21e22b98deb742b0228e33a1bb11529f7cbceb156c1fcfafac84e126ccb1577014ab8a167db40ed46c5ae2562bad61a3780d558211b2a32ad",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0/kotlinx-serialization-core-jvm-1.9.0.module",
-    "sha512": "7b8ca98f9c0d7f38e1e82cdf0e0d8796441bdee2701469220c25c4921e6785856bdef1c5ffc8d8d6b11a3dc14ceb9df35653bae5a35785dace7444d6f968caad",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-jvm-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0/kotlinx-serialization-core-1.11.0.pom",
+    "sha512": "e5a14ef517fdebc1faf51417300e9b7c42feb3d4c35738c89be6865eb4e4f8baa965400ce453e9d68119504084c79206941082ac84ce6fb563a8c7f788b51ce7",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-1.11.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0/kotlinx-serialization-core-jvm-1.9.0.pom",
-    "sha512": "227bc8cdd89656eead46e16737dc47fea6a5370db9530bfb5dc7f94d008e7e5ebf481c086a7919bde82b02bb5269e8dbef8b590333d4099f5e8257c2c9b2e0af",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0/../../kotlinx-serialization-core-jvm/1.11.0/kotlinx-serialization-core-jvm-1.11.0.module",
+    "sha512": "9b008525c2651bf460547593746823a5659a357aa5c57fc89426230222b89ab6dd95cffcb351eae92c96d4d22ac4587324842088967eae0b32399664df385ff5",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.11.0/../../kotlinx-serialization-core-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-core-jvm-1.11.0.module"
   },
   {
     "type": "file",
@@ -5881,24 +5608,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0/kotlinx-serialization-core-1.9.0.module",
-    "sha512": "b363db2d7a795b7404100e4b38fa530a12f5fbc81c8f32b8284606d62226704b17cc75a18b14bd5191699b4b83336d1eefd97dd3523955a7c85c9bf16579c4ba",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-1.9.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0/kotlinx-serialization-core-1.9.0.pom",
-    "sha512": "44d0860121fc35b62e781e925d0185847673b76a5997f5f34f65349f9685040dcdc6cd400b6c16782c5511fafed37520797bd8aaa008cfcdd594b625f878da9e",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-1.9.0.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0/../../kotlinx-serialization-core-jvm/1.9.0/kotlinx-serialization-core-jvm-1.9.0.module",
-    "sha512": "7b8ca98f9c0d7f38e1e82cdf0e0d8796441bdee2701469220c25c4921e6785856bdef1c5ffc8d8d6b11a3dc14ceb9df35653bae5a35785dace7444d6f968caad",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-core/1.9.0/../../kotlinx-serialization-core-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-core-jvm-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.11.0/kotlinx-serialization-hocon-1.11.0.pom",
+    "sha512": "99aa819a25eb8edcba313255f490a3d35d31d25da7e89d322b0d0d523e9c93c5504192e72aa1a9573361fd81a93b895389c5e2653a6813eec08c16453d9297ff",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.11.0",
+    "dest-filename": "kotlinx-serialization-hocon-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5909,10 +5622,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.9.0/kotlinx-serialization-hocon-1.9.0.pom",
-    "sha512": "b25f032c6ecf47a30c782f53feb563141f54570aa4e333c46cc73daaf023541d5c1f1fec25979ab60faf685c81c82ed3007d2a6a4d1ad54413b3d514ff6809e4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-hocon/1.9.0",
-    "dest-filename": "kotlinx-serialization-hocon-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0/kotlinx-serialization-json-io-jvm-1.11.0.jar",
+    "sha512": "4a7354a5ff432d90a48c912af119aa1eca0c14a9152b130badae52e9205b039e3d4b0d161062eb4e82c171e9e99c6c42576a3b5272f86aa51c7a2ffd3c2bdfe0",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.11.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0/kotlinx-serialization-json-io-jvm-1.11.0.module",
+    "sha512": "16a61cf4c502422ecb1bd230d5479430178909790339729190811057cb4b8cc58f1227a34f94cd207bdb65e5d3700ed7401220db9eedefb469577a9a4340449b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.11.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0/kotlinx-serialization-json-io-jvm-1.11.0.pom",
+    "sha512": "fd53b7e4087879c5b3ebe993612232e9fb08c6825b319332427871cfd0ba95e5f2bf808173d1b14394b879bf97a8634b1a6ccc20022a3f2094cd0adb27dfaac8",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5923,24 +5650,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0/kotlinx-serialization-json-io-jvm-1.9.0.jar",
-    "sha512": "e516a8f7418c2ab78b46f42294dad599704cf20e64184d8d3ba34373d27dc9ed48feb8f22f74f64cf69d3ef55f59056de9cedf4e8cf96979a2beb1ad23b96abf",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-jvm-1.9.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0/kotlinx-serialization-json-io-1.11.0.module",
+    "sha512": "baa5543119ebdc190084f9d3640771333246d7f0eb20c67e6739a97e35b636be6c7dd807ee5d5962375e9db784627dec38bd2dd6115026007318f83cb49d54a5",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0/kotlinx-serialization-json-io-jvm-1.9.0.module",
-    "sha512": "6bc6e6828a4c9e34b747f64869ae3cf9e03377a1c4fdf39fcea8200aac72b7a0cc94f488c7e91f38d6c7b32b1113b00922edc0471467f613dd885eded62a72f4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-jvm-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0/kotlinx-serialization-json-io-1.11.0.pom",
+    "sha512": "af7e3eabbf82bdf35f4b36dda0789eca6ac0853fa6e0f01149660f7fcd954785d0537254b600e6e85693afdc3e337a96a785c9f79374580d83e59bf4b6694d66",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-1.11.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0/kotlinx-serialization-json-io-jvm-1.9.0.pom",
-    "sha512": "848505a5ce077b791e6002d15cc9f45411866bd8de23ba13614ec4c37c393007028d5c439306b19c06a9c4bc5f82e6981fbfa57351bdbe0a18ae40db941558db",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0/../../kotlinx-serialization-json-io-jvm/1.11.0/kotlinx-serialization-json-io-jvm-1.11.0.module",
+    "sha512": "16a61cf4c502422ecb1bd230d5479430178909790339729190811057cb4b8cc58f1227a34f94cd207bdb65e5d3700ed7401220db9eedefb469577a9a4340449b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.11.0/../../kotlinx-serialization-json-io-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-io-jvm-1.11.0.module"
   },
   {
     "type": "file",
@@ -5951,24 +5678,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0/kotlinx-serialization-json-io-1.9.0.module",
-    "sha512": "001680a981fd33d2892ada21a0f6338b1126591c7a53b01c96bd286c8eb569b69ff9334245378756c8cb44bcb3e665ea223a0625e30e712f29cac9551b10745d",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0/kotlinx-serialization-json-jvm-1.11.0.jar",
+    "sha512": "4cf6dc06159bda70017887719eaf529ad28d30f714c007d4895f80ffce6d5c849c98d5fb6ba7de142749c424be94e5935f367053a92c2ca4118cecd653af87cc",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.11.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0/kotlinx-serialization-json-io-1.9.0.pom",
-    "sha512": "168d5ccbdbfb03f7b146c6a8f8ab496d087fd752a46948eeeaf3505bd3f7dec77c806fb35cc66dce4d4b123dc61d9cd949b5d61a4147e8395432d2f6d47f421e",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0/kotlinx-serialization-json-jvm-1.11.0.module",
+    "sha512": "5a9025c119479028f8582b885a85ea0ef1eaf7ee39a4087677d14a18b5eb2beefc29d2b8034f524ae9987beb317bffa03e99fc708d0e83ca6504b6fffdf7d5ee",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.11.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0/../../kotlinx-serialization-json-io-jvm/1.9.0/kotlinx-serialization-json-io-jvm-1.9.0.module",
-    "sha512": "6bc6e6828a4c9e34b747f64869ae3cf9e03377a1c4fdf39fcea8200aac72b7a0cc94f488c7e91f38d6c7b32b1113b00922edc0471467f613dd885eded62a72f4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-io/1.9.0/../../kotlinx-serialization-json-io-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-io-jvm-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0/kotlinx-serialization-json-jvm-1.11.0.pom",
+    "sha512": "3c860a26bf4e34a5a573ade29df5dbc525801620fa339c5b476867b4a865dd5b0fc8e98e5e6b6c5c543997cf61461c50b76b86887845fbe124bb2486c7c4ea0a",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -5979,24 +5706,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0/kotlinx-serialization-json-jvm-1.9.0.jar",
-    "sha512": "a2abfcf5751c4c5c5cc0f37e9200794f22d0c28daa76a6a8edfed4bebd8375e2e49b263671ef86b4ec2925079970b8424cf3971f47eae03914f5b3cee48459fa",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-jvm-1.9.0.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0/kotlinx-serialization-json-jvm-1.9.0.module",
-    "sha512": "c2b78a12054fc0dd974e8ba4b62f33c909b7033cf1ec5b408deb5a96e4d919ca6dbb6e726614e16f20e9126fc7201bc67c1235f7840da79ae8a417002dbcbee4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-jvm-1.9.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0/kotlinx-serialization-json-jvm-1.9.0.pom",
-    "sha512": "87399da85b2ce8f0229f038955adf4a60fb83b27cb33f5dd572426ccae07ba6b4703735827f2d2359b32115dd8ce1ff9434427244bd1f346bb2f23c84a05ac29",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0/kotlinx-serialization-json-okio-jvm-1.11.0.pom",
+    "sha512": "779b19db51aaffdedb7d6821c00cc25fef05ef2b5842bf1c78471bb2444206249960616e4e39f300879c91ea3bf8226ed531ead0a51cddcbf6331b08554d739f",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-okio-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6007,10 +5720,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.9.0/kotlinx-serialization-json-okio-jvm-1.9.0.pom",
-    "sha512": "bc8dc1c7bcf69f5b6a814970c0f0704cdea9b548d78e8533398295f8dbd38176773149cf65a0d14735cd99e67b72b5c72f4946ca5fc0f73ab677bf6d2d6907ef",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-okio-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.11.0/kotlinx-serialization-json-okio-1.11.0.pom",
+    "sha512": "caf14f8310a1037acd1f47d300dea8681d40feb57f704fdbb43ccf5f378183f3de7866d1d74b4715977d8999fa13ddc3dedcc28b2e7b645318dd1fcb54717555",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-okio-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6021,10 +5734,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.9.0/kotlinx-serialization-json-okio-1.9.0.pom",
-    "sha512": "9b01e0a71b988e77bcd35ea515b114a305106418c2c43127a351be27aaee3e4b3a9bc295c94d2a54a336569f51fa8f4eecb938ba63964d68391411d828f2d45e",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json-okio/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-okio-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0/kotlinx-serialization-json-1.11.0.module",
+    "sha512": "5be4dc0111d6719e5dcd5804e1ecc2d17b16eca8db22e7e3c61eb61eaea9c2070d0ec74aeac7a81c7ad6e316fd9703a01a9ece603c1dc4726136111e64e9de1b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-1.11.0.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0/kotlinx-serialization-json-1.11.0.pom",
+    "sha512": "3119c3a907bf58cde4e4782e3b578c3fb0a222d943fd54012f458ea87efb15cb8b0ed7d32e447bc3aa5a49090873ecc8f7f02d0c3dbfe5f8d2f1560211a675ce",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-1.11.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0/../../kotlinx-serialization-json-jvm/1.11.0/kotlinx-serialization-json-jvm-1.11.0.module",
+    "sha512": "5a9025c119479028f8582b885a85ea0ef1eaf7ee39a4087677d14a18b5eb2beefc29d2b8034f524ae9987beb317bffa03e99fc708d0e83ca6504b6fffdf7d5ee",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.11.0/../../kotlinx-serialization-json-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-json-jvm-1.11.0.module"
   },
   {
     "type": "file",
@@ -6035,24 +5762,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0/kotlinx-serialization-json-1.9.0.module",
-    "sha512": "c52da640763cb754a4d393fc1e0a5b9828815719b0e6f60b1f9e2ffc5724cd0dc00121e2e8a3d5a195bf17453f7906c884cbfed4e294c3753f886b1cdb192d76",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-1.9.0.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0/kotlinx-serialization-json-1.9.0.pom",
-    "sha512": "fee046e7aab665b9024548ef73db4fc876cd0eb640f50fd6dd80edad72b7173c84b5af6ebe1fbd97570aa21face8081260a770950a926fdef5f6c353f20309ef",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-1.9.0.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0/../../kotlinx-serialization-json-jvm/1.9.0/kotlinx-serialization-json-jvm-1.9.0.module",
-    "sha512": "c2b78a12054fc0dd974e8ba4b62f33c909b7033cf1ec5b408deb5a96e4d919ca6dbb6e726614e16f20e9126fc7201bc67c1235f7840da79ae8a417002dbcbee4",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-json/1.9.0/../../kotlinx-serialization-json-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-json-jvm-1.9.0.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.11.0/kotlinx-serialization-properties-jvm-1.11.0.pom",
+    "sha512": "0496cab0fa875ea1c9cb1cd58c1e73ab21481232a6f0be1b9f0981afa20ec25edf650ae1e4e298848778d7d967bcbc3f20abf03f7e9d9a59bfa9f0a3a7f64b8a",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-properties-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6063,10 +5776,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.9.0/kotlinx-serialization-properties-jvm-1.9.0.pom",
-    "sha512": "c60c9a6eda280c2c00a64b18bf500f02e81b23ad8a4a192f079696cadb2a909305208ec6bdba74ba0a9dca1b8cf7982f72aa078d1970e1d6d96259e6e5706bf0",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-properties-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.11.0/kotlinx-serialization-properties-1.11.0.pom",
+    "sha512": "d5b404cb7b0129fec5087946de4c53d2a47d4efc1e388eb6b37d4877a50ee511cddaa49f436bba121176bf8c34b03dd1c26b169bfc5092ad7224515c371fb015",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.11.0",
+    "dest-filename": "kotlinx-serialization-properties-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6077,10 +5790,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.9.0/kotlinx-serialization-properties-1.9.0.pom",
-    "sha512": "21704d1edafb582e33a83dd4ace679fc6bae9ccff290829c0129553a45a98b3ae290e7b42f199377930d47d0a3023da5bc2bf04d92e8010dfc2de0b56c8fc153",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-properties/1.9.0",
-    "dest-filename": "kotlinx-serialization-properties-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.11.0/kotlinx-serialization-protobuf-jvm-1.11.0.pom",
+    "sha512": "4716cba5ce8dc7b519d266a880eddfb620d265abffa6c98cc6b4c3533baf3b7154ad1bf4d4cdd1047a40062dc9ff37c6f3069f18e3c2448c11584a877ec86e7b",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.11.0",
+    "dest-filename": "kotlinx-serialization-protobuf-jvm-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6091,10 +5804,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0/kotlinx-serialization-protobuf-jvm-1.9.0.pom",
-    "sha512": "e63c235778cde2e1ee675ad836e91c9c62cd7e9e3c3da16c363a62fe23f3133d8090bb45f7aa8377c98e209654c79445923150297fb3cc158f4597f0d914420c",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf-jvm/1.9.0",
-    "dest-filename": "kotlinx-serialization-protobuf-jvm-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.11.0/kotlinx-serialization-protobuf-1.11.0.pom",
+    "sha512": "49b2d882abf3ea09dc0a2fa7c04bd4c106e0350a18a64e7e2d9b16a62c9d066eca7e5e8e45e0fe11c726caeb4b70a327a1ede3625adc513f39ea31096f89c650",
+    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.11.0",
+    "dest-filename": "kotlinx-serialization-protobuf-1.11.0.pom"
   },
   {
     "type": "file",
@@ -6105,115 +5818,73 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.9.0/kotlinx-serialization-protobuf-1.9.0.pom",
-    "sha512": "4dfea789bfc56233416867012cc05c623b3f0abddfdc9a3c1be98fdda7f9c2e4f88b4605533eb543d9e0c3984ff673ca2b032edad6989aecf5b683ef7cc88472",
-    "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.9.0",
-    "dest-filename": "kotlinx-serialization-protobuf-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/runtime/jbr-api/1.5.0/jbr-api-1.5.0.jar",
+    "sha512": "66429587d347a766d49506391e0c1e390f5b9927fa9dedb5ff37f59539fd5a2a523d9f15df4898229b6de395b44749395af6f87ab7d693a175f85fa750120f62",
+    "dest": "offline-repository/org/jetbrains/runtime/jbr-api/1.5.0",
+    "dest-filename": "jbr-api-1.5.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.jar",
-    "sha512": "fa9465c1947166ccf027a16a325fc3b2ecdafc16daf43925eaecd86e9601a7d80ca8204474e55f17f75077a4bc9c6311540dd931656cfffcefc1dc69db5fb306",
-    "dest": "offline-repository/org/jetbrains/runtime/jbr-api/1.9.0",
-    "dest-filename": "jbr-api-1.9.0.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/runtime/jbr-api/1.5.0/jbr-api-1.5.0.pom",
+    "sha512": "ffb70fc51ab65cfcff540503b3217c020fe3b86608012379ddd7cdd9c552b61aa42f7e07743a2276d62d2072772e667e60771c58f6da52383a3da28007848417",
+    "dest": "offline-repository/org/jetbrains/runtime/jbr-api/1.5.0",
+    "dest-filename": "jbr-api-1.5.0.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/runtime/jbr-api/1.9.0/jbr-api-1.9.0.pom",
-    "sha512": "2f3245c918a1343a147c2c1e4b469367b30178b7c4c77567a551e5c605b8ce0d75db88953db8d24f5c462756e761154c8f41a67ece8232e204aa26f221fac77d",
-    "dest": "offline-repository/org/jetbrains/runtime/jbr-api/1.9.0",
-    "dest-filename": "jbr-api-1.9.0.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.22.2/skiko-awt-runtime-linux-x64-0.9.22.2.jar",
+    "sha512": "b817f2b933938b3b77792ab63bf8f8f1b40f9be01937cea630aeeab6790eb4dbf98f75e83edf5d9ecf0f887de156d612652fb2330d15cb58c99243516edb4317",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.22.2",
+    "dest-filename": "skiko-awt-runtime-linux-x64-0.9.22.2.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-linux-arm64/0.144.6/skiko-awt-runtime-linux-arm64-0.144.6.pom",
-    "sha512": "488c12bac4c74ba301952d789851b64a2c25db200a4cfaa6d8f5fd9f93aaf3832d9b5039e8094b63bafa41e88cd6ecceb6c4fb8aa6a848710d9ce18580f2797f",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-linux-arm64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-linux-arm64-0.144.6.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.22.2/skiko-awt-runtime-linux-x64-0.9.22.2.pom",
+    "sha512": "dab1ea58b4a27e49726d64d375e98b40d8416b3988f5349107fb8f70a9f5a81d818a437b6d63b87afa69da12f722f79c20e5f16d86c8110d426e80c8fd78d953",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.9.22.2",
+    "dest-filename": "skiko-awt-runtime-linux-x64-0.9.22.2.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.144.6/skiko-awt-runtime-linux-x64-0.144.6.jar",
-    "sha512": "37e1716996f1862c6a4c5f502afc134d060f3ef48c8d5db7fa97260a278d02d8f52c045a3cf24d7df8adb5983aa90fd65e0d1863aa1eebc852a9ee4368596e1c",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-linux-x64-0.144.6.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.9.22.2/skiko-awt-0.9.22.2.jar",
+    "sha512": "6796c3fdc9a4aec09c2db48800478fd5937eed1f0293d5e8088976bc5f0fa7d8e730996025165d655c3010f74415387720c3cb66304b602611963de58f04c702",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.9.22.2",
+    "dest-filename": "skiko-awt-0.9.22.2.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.144.6/skiko-awt-runtime-linux-x64-0.144.6.pom",
-    "sha512": "a3e36f026bc0078d60db8264b9fe87383ee8c03890edf0622f706b3e146326665d4f4691e30f2e8ad0ffd15f0e012379b610317d378026572b921e45d1349a88",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-linux-x64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-linux-x64-0.144.6.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.9.22.2/skiko-awt-0.9.22.2.module",
+    "sha512": "1f081f959593dc8fa5296f7017f29c14214e96d8cf82ca71dbfa58aa503ccc6b33c547cfaaf141e75d219496df1a1774b0d88eef53dc6ec54f6a90d1bc70b167",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.9.22.2",
+    "dest-filename": "skiko-awt-0.9.22.2.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-macos-arm64/0.144.6/skiko-awt-runtime-macos-arm64-0.144.6.pom",
-    "sha512": "53f516f307de4c297dc8df3a6a0452f6ca8260ec6ab4b4e5d2185aad0c8443ff374c129710ab3afb7ce72d6922def0d41a713356870dda491010e44678d44379",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-macos-arm64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-macos-arm64-0.144.6.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.9.22.2/skiko-awt-0.9.22.2.pom",
+    "sha512": "552fddd78a296adfddfa64c59662c7ef9c2c78ab708acf7466bbb51500e9347a6c2da8630c3a5c0a9a7daf1edff4415705a56e350d25ad4ca611586d72e8e90f",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.9.22.2",
+    "dest-filename": "skiko-awt-0.9.22.2.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-macos-x64/0.144.6/skiko-awt-runtime-macos-x64-0.144.6.pom",
-    "sha512": "ae1b38e273bc22769f81e4eb2672f70c8ab768d5c6c251ebdbba9bc317abfe014461dc78168cad039bd8779bede047155045071da1e97e26f3eb3dc4b2b18d37",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-macos-x64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-macos-x64-0.144.6.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.9.22.2/skiko-0.9.22.2.module",
+    "sha512": "cfc2d4e139633411a96b4e90b81dccb042cb24fa7fc20cb5666c2016573e8dcdee5d2f06b78cc7e528f91e9b4e3669b275cfd0f5171e7196b2f5bb908f458c6c",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.9.22.2",
+    "dest-filename": "skiko-0.9.22.2.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-windows-arm64/0.144.6/skiko-awt-runtime-windows-arm64-0.144.6.pom",
-    "sha512": "e2fbe1cd2844d6993b8aa94251ae69a07221d6df2e42f7d48e376688d9c8e9b1dcc73f4ad9b2b49af577c35d25b5042825181e417d6f4019a6559c69cf1cd13f",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-windows-arm64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-windows-arm64-0.144.6.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.9.22.2/skiko-0.9.22.2.pom",
+    "sha512": "72a93ab38ef8c003e7e9783e06c49f2f41e98ef9b507e4cf622be83b328084528921f27f05cdb5207f8abcd3c78010942bd6b8917a694f0f7a7276fae268a02a",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.9.22.2",
+    "dest-filename": "skiko-0.9.22.2.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt-runtime-windows-x64/0.144.6/skiko-awt-runtime-windows-x64-0.144.6.pom",
-    "sha512": "a1163caae20652adbc8f8b2812e795c43dac0620671e3112e8a8a93dcab4b59fbab8ca01d3cd1b3587a796fcbe2147bf6de3b5eaa7206405d1151fe48463be7e",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt-runtime-windows-x64/0.144.6",
-    "dest-filename": "skiko-awt-runtime-windows-x64-0.144.6.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.144.6/skiko-awt-0.144.6.jar",
-    "sha512": "b1b613fe4ba49d7b148ff80a3e3f9177a4a1f0b553d0ad80eeee8aa1cd7dc19cbae2f1db67ea83bd3e259f66b584d8c1feec6bc0b370e55573524b426662f9d4",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.144.6",
-    "dest-filename": "skiko-awt-0.144.6.jar"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.144.6/skiko-awt-0.144.6.module",
-    "sha512": "cc148469a40c359e0e7ea3a4547961b10afe313d1b5c7e5a6ecd5a0cb9114d31a0b9388acbfbafd342072a60519adf81d4857ab96363ede8a2bdcea7ffd78055",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.144.6",
-    "dest-filename": "skiko-awt-0.144.6.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko-awt/0.144.6/skiko-awt-0.144.6.pom",
-    "sha512": "bd2bd7ac59ee10c27130386e2e97621eb6ece6d385f3e8469ffd78ca9a332ca15f4521262961199b3bbb93b4851c73b8695e1b590ea1fcc7ac094fd354e78f59",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko-awt/0.144.6",
-    "dest-filename": "skiko-awt-0.144.6.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.144.6/skiko-0.144.6.module",
-    "sha512": "0e1b8b637f1a66b19427b3ef983d792a8efbd45420343c52745ea32855ccb7cae40ea1143dba6fa46a9f6c5d5a578219046426e3e2f300d4118439056134bde8",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.144.6",
-    "dest-filename": "skiko-0.144.6.module"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.144.6/skiko-0.144.6.pom",
-    "sha512": "d157ef009e9ef863815813078cc01dc61e1b92efd8f0cb1feb94c7b11ba4980d6c792a49804bb8af9c5f5bfd37213d05b9bc041163b0f6eae1fc133e8512f945",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.144.6",
-    "dest-filename": "skiko-0.144.6.pom"
-  },
-  {
-    "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.144.6/../../skiko-awt/0.144.6/skiko-awt-0.144.6.module",
-    "sha512": "cc148469a40c359e0e7ea3a4547961b10afe313d1b5c7e5a6ecd5a0cb9114d31a0b9388acbfbafd342072a60519adf81d4857ab96363ede8a2bdcea7ffd78055",
-    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.144.6/../../skiko-awt/0.144.6",
-    "dest-filename": "skiko-awt-0.144.6.module"
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/skiko/skiko/0.9.22.2/../../skiko-awt/0.9.22.2/skiko-awt-0.9.22.2.module",
+    "sha512": "1f081f959593dc8fa5296f7017f29c14214e96d8cf82ca71dbfa58aa503ccc6b33c547cfaaf141e75d219496df1a1774b0d88eef53dc6ec54f6a90d1bc70b167",
+    "dest": "offline-repository/org/jetbrains/skiko/skiko/0.9.22.2/../../skiko-awt/0.9.22.2",
+    "dest-filename": "skiko-awt-0.9.22.2.module"
   },
   {
     "type": "file",
@@ -6266,73 +5937,73 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.jar",
-    "sha512": "0268e6dc2cc4965180ca1b62372e3c5fc280d6dc09cfeace2ac4e43468025e8a78813e4e93beafc0352e67498c70616cb4368313aaab532025fa98146c736117",
-    "dest": "offline-repository/org/ow2/asm/asm-analysis/9.8",
-    "dest-filename": "asm-analysis-9.8.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/9.9/asm-analysis-9.9.jar",
+    "sha512": "293fdf9ffd6858559d9bf4a2b68dfcfc58cb581d27e0fbcd2c2d0c540520498e9d587094534dd58d782ff5051b90f160971cfc388ea132e06eafa089bcc0bed7",
+    "dest": "offline-repository/org/ow2/asm/asm-analysis/9.9",
+    "dest-filename": "asm-analysis-9.9.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/9.8/asm-analysis-9.8.pom",
-    "sha512": "7b65663a02d30ac3c499cd63d8b057091a394a73f5187c33f325c4f6dfdf103940ba29e1d02c3f59e0cb262b3015daf5dcb058ff87e0a08762071e47a1f0ffec",
-    "dest": "offline-repository/org/ow2/asm/asm-analysis/9.8",
-    "dest-filename": "asm-analysis-9.8.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-analysis/9.9/asm-analysis-9.9.pom",
+    "sha512": "bdfc8936b1784610997ecae933d077fe218082b0d8f76d8e0cd48469d0206b77ba442b83750ae5037af7e3c498a9b977e4e7c7e088b5d73df327ebe3a79abd0f",
+    "dest": "offline-repository/org/ow2/asm/asm-analysis/9.9",
+    "dest-filename": "asm-analysis-9.9.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/9.8/asm-commons-9.8.jar",
-    "sha512": "d2add10e25416b701bd84651b42161e090df2f32940de5e06e0e2a41c6106734db2fe5136f661d8a8af55e80dc958bc7b385a1004f0ebe550828dfa1e9d70d41",
-    "dest": "offline-repository/org/ow2/asm/asm-commons/9.8",
-    "dest-filename": "asm-commons-9.8.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/9.9/asm-commons-9.9.jar",
+    "sha512": "4949cde2b51e5d171d0ff02ebd1f9f7f111bf538c8bfd62f139364181ee4bebd6598949d895f1c78daaba6dd1da4e564fab10e602cfe297915cd0287f8c2f1d5",
+    "dest": "offline-repository/org/ow2/asm/asm-commons/9.9",
+    "dest-filename": "asm-commons-9.9.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/9.8/asm-commons-9.8.pom",
-    "sha512": "a5137b1ead49660b104f0e8d54b9df646d0f87645905c38e7df0b6d10d7f8e0aabe43db227dc005fd63765eded2554c23fd0495cc25cdf4112447bd3300d9bae",
-    "dest": "offline-repository/org/ow2/asm/asm-commons/9.8",
-    "dest-filename": "asm-commons-9.8.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-commons/9.9/asm-commons-9.9.pom",
+    "sha512": "0b141c1bf673023cb2da95d5b030995051b5d284d7c00d23ff5f4aa8853d343f835392c732c832a71648ea04a70090ee0b4ca53242f324401164e9f533ab2e0e",
+    "dest": "offline-repository/org/ow2/asm/asm-commons/9.9",
+    "dest-filename": "asm-commons-9.9.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/9.8/asm-tree-9.8.jar",
-    "sha512": "4493f573d9f0cfc8837db9be25a8b61a825a06aafc0e02f0363875584ff184a5a14600e53793c09866300859e44f153faffd0e050de4a7fba1a63b5fb010a9a7",
-    "dest": "offline-repository/org/ow2/asm/asm-tree/9.8",
-    "dest-filename": "asm-tree-9.8.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/9.9/asm-tree-9.9.jar",
+    "sha512": "8b555d9166a17dcd0d1b297bd61fb3da59279b00a97fd7d0a3b139cb68ca8012ac14fb9bab0a6fa7ebe5612337f8e39b240d97b05a2c25ebc9ece15b7a1bc131",
+    "dest": "offline-repository/org/ow2/asm/asm-tree/9.9",
+    "dest-filename": "asm-tree-9.9.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/9.8/asm-tree-9.8.pom",
-    "sha512": "db2073ff628d0a146bf4c132fc900d9a646476fdeda35cee7f1f0d2a486848d4cbc77fd28bf2a28bd9855e54ec3b8114d2961cee580dd27ce7d48f4ebf2821be",
-    "dest": "offline-repository/org/ow2/asm/asm-tree/9.8",
-    "dest-filename": "asm-tree-9.8.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-tree/9.9/asm-tree-9.9.pom",
+    "sha512": "7770a74d27cd6259778a564267f17f49fc8e992f5bc7b5e3b261b0e7793d5f76954195964b82a76d0eb48a0d662301be23e40efbcc7a4221ff6e928384abc18c",
+    "dest": "offline-repository/org/ow2/asm/asm-tree/9.9",
+    "dest-filename": "asm-tree-9.9.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/9.8/asm-util-9.8.jar",
-    "sha512": "b68048e199c49d2f90b2990c6993f1fcddccd34fb9d91154ef327d874aa5ff8609db5fbd63e23141020cdeda8fb753e97a61c2152e1b4e8f20003a5390e7e1d9",
-    "dest": "offline-repository/org/ow2/asm/asm-util/9.8",
-    "dest-filename": "asm-util-9.8.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/9.9/asm-util-9.9.jar",
+    "sha512": "cd4f82589e0acc801618e4f55de2e7b85718d30cf5a7d2e5ead383dcdc2689a934abea37b81f5a7c508d9f7fc9ceb2e8ae5c8e4e958537ebb80b621814b099fb",
+    "dest": "offline-repository/org/ow2/asm/asm-util/9.9",
+    "dest-filename": "asm-util-9.9.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/9.8/asm-util-9.8.pom",
-    "sha512": "281e96ee5a2bffc3cd4af80bab993a57ad2833769cd4c3941fa8709a9d552ab36c4336e85dfebd5e98aa7eaceb647211f8d5938f11fdd54edd846a2e8013523c",
-    "dest": "offline-repository/org/ow2/asm/asm-util/9.8",
-    "dest-filename": "asm-util-9.8.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm-util/9.9/asm-util-9.9.pom",
+    "sha512": "539f23586675667c04c4b102418ae4c0b258db2045976b887ac41fec7c7efd5b72d0d4794397f0528ecf45e9e56c1f832e41554d52eb9d6c7ec89f04ab0eab61",
+    "dest": "offline-repository/org/ow2/asm/asm-util/9.9",
+    "dest-filename": "asm-util-9.9.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.8/asm-9.8.jar",
-    "sha512": "cbd250b9c698a48a835e655f5f5262952cc6dd1a434ec0bc3429a9de41f2ce08fcd3c4f569daa7d50321ca6ad1d32e131e4199aa4fe54bce9e9691b37e45060e",
-    "dest": "offline-repository/org/ow2/asm/asm/9.8",
-    "dest-filename": "asm-9.8.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9/asm-9.9.jar",
+    "sha512": "197a4fb3ecb34d05ac555c6a510e69affcb1e476f24c5e935ad513ecdabf74b45aa1b0e0b25dbe91224fc6db7959b2677ea5876ee49e7487265e2a29c560c21c",
+    "dest": "offline-repository/org/ow2/asm/asm/9.9",
+    "dest-filename": "asm-9.9.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.8/asm-9.8.pom",
-    "sha512": "a34a1cc4ac50724e0798f4d8ee677207ba68e4f311d9d5cc200dd9351ea63f556589aa42c7a0df90b53634ae41bae3646d5115eb029aab11077a20f7b144bf3f",
-    "dest": "offline-repository/org/ow2/asm/asm/9.8",
-    "dest-filename": "asm-9.8.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/ow2/asm/asm/9.9/asm-9.9.pom",
+    "sha512": "201409cd84e380484657fbff4da7d1a0f24a6135010b307289947d9279dae399c7eb2516a822e0d6cd06371ae609806e1c5cfbd5401535da41294bf4fc811a40",
+    "dest": "offline-repository/org/ow2/asm/asm/9.9",
+    "dest-filename": "asm-9.9.pom"
   },
   {
     "type": "file",
@@ -6357,38 +6028,38 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.jar",
-    "sha512": "9a3e79db6666a6096a3021bb2e1d918f30f589d8de51d6b600f8ebd92515a510ae2d8f87919cc2dfa8365d64f10194cac8dfa0fb950160eef0e9da06f6caaeb9",
-    "dest": "offline-repository/org/slf4j/slf4j-api/2.0.17",
-    "dest-filename": "slf4j-api-2.0.17.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.jar",
+    "sha512": "539288fa0c96cea750d11293dbed4c562630587aa7cd88bbf76ad04390d1c40636506da48faa6453090c7e9baa6b690b9fbded55a7e2b4a91547eeea011f971a",
+    "dest": "offline-repository/org/slf4j/slf4j-api/2.0.18",
+    "dest-filename": "slf4j-api-2.0.18.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.17/slf4j-api-2.0.17.pom",
-    "sha512": "462872ccda241179a77ebc89c3f7be93870fffae344e09d3cccc33d6448336dc77affc9572f420d7da788b3f0eb072b7facc9b7e609b33742ed48f4bb467cb70",
-    "dest": "offline-repository/org/slf4j/slf4j-api/2.0.17",
-    "dest-filename": "slf4j-api-2.0.17.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/2.0.18/slf4j-api-2.0.18.pom",
+    "sha512": "885fe6fc408c657d9fc72b5e8d9263e74360597b30b9bac7bd9f34e9f79b4ed8d1ec79257ac1760cc4c452697e9fb912313f3370f6492470579921efea01fd0a",
+    "dest": "offline-repository/org/slf4j/slf4j-api/2.0.18",
+    "dest-filename": "slf4j-api-2.0.18.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.17/slf4j-bom-2.0.17.pom",
-    "sha512": "cb2db4597b98b9981959413e3ffcd5882f8e267d3d51f989c396807c36893296065cbe443a173029e8d3a0851eced25f5149dc2dafa0dd2c29fca737180a7029",
-    "dest": "offline-repository/org/slf4j/slf4j-bom/2.0.17",
-    "dest-filename": "slf4j-bom-2.0.17.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-bom/2.0.18/slf4j-bom-2.0.18.pom",
+    "sha512": "f93a6f3374bfe09a24f7ad19c1b75a3991ae58d758b6d521066a35b712b6f769847bef6693085494e55114e41bf1c4d1da6cba1b6e10144691094b977db3c94c",
+    "dest": "offline-repository/org/slf4j/slf4j-bom/2.0.18",
+    "dest-filename": "slf4j-bom-2.0.18.pom"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-nop/2.0.17/slf4j-nop-2.0.17.jar",
-    "sha512": "4c5992d3de8416bb44434fec90cd06776c0a891450378b97455e80d6acd7bff88ab517b989d30cad2da91d1bb7973a397fe081a3188ec8db998bc66b25f4a4e6",
-    "dest": "offline-repository/org/slf4j/slf4j-nop/2.0.17",
-    "dest-filename": "slf4j-nop-2.0.17.jar"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-nop/2.0.18/slf4j-nop-2.0.18.jar",
+    "sha512": "fd5b3456a5c4f10a5a129371024f74ed69d41eb531c6a040587e2d0fac4757c59ab4d70e70c1fbdcd9f7c3f20e5839c6b26598dc23fb2ee08077815459b7a4fe",
+    "dest": "offline-repository/org/slf4j/slf4j-nop/2.0.18",
+    "dest-filename": "slf4j-nop-2.0.18.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-nop/2.0.17/slf4j-nop-2.0.17.pom",
-    "sha512": "bf38a41e2540ea8b50b387b59e26d9040c45287887d4e9f43ab14ab8300e39939fe3b2e6fadfdf19589ad047f24c0535644f2c0349eb5ca6c2a11f1499773e3f",
-    "dest": "offline-repository/org/slf4j/slf4j-nop/2.0.17",
-    "dest-filename": "slf4j-nop-2.0.17.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-nop/2.0.18/slf4j-nop-2.0.18.pom",
+    "sha512": "6999dd8dc5ca65216a0f582268ebf736aecf258a23592ce3d3420dc3a5f8bf916040c24620082167f215e387c11786542f2c36247e185d7aefa3419dde386a04",
+    "dest": "offline-repository/org/slf4j/slf4j-nop/2.0.18",
+    "dest-filename": "slf4j-nop-2.0.18.pom"
   },
   {
     "type": "file",
@@ -6399,10 +6070,10 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.17/slf4j-parent-2.0.17.pom",
-    "sha512": "5b16a209843c18a478a0a16dff83ae1c75eedbdeadc15a958d536a36631d4d39a9998e085c165a79ced8ad187f021e2f3cd4068856ca174db35657ef5a473c5a",
-    "dest": "offline-repository/org/slf4j/slf4j-parent/2.0.17",
-    "dest-filename": "slf4j-parent-2.0.17.pom"
+    "url": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/2.0.18/slf4j-parent-2.0.18.pom",
+    "sha512": "d7c316e27a5e42876a72ebd61db5c428b1383efad84c957d3482c0d2c744ef6a85943cc37e5f292e7a49d61336229b5757e6ee01b0a41fc54f10ef7061017cd1",
+    "dest": "offline-repository/org/slf4j/slf4j-parent/2.0.18",
+    "dest-filename": "slf4j-parent-2.0.18.pom"
   },
   {
     "type": "file",

--- a/composeApp/flatpak/tools/flatpak-gen.init.gradle.kts
+++ b/composeApp/flatpak/tools/flatpak-gen.init.gradle.kts
@@ -41,16 +41,16 @@ gradle.allprojects {
             fun marker(id: String, version: String) =
                 dependencies.add("classpath", "$id:$id.gradle.plugin:$version")
             marker("org.gradle.toolchains.foojay-resolver-convention", "1.0.0")
-            marker("org.jetbrains.kotlin.multiplatform", "2.3.21")
-            marker("org.jetbrains.kotlin.jvm", "2.3.21")
-            marker("org.jetbrains.kotlin.plugin.compose", "2.3.21")
-            marker("org.jetbrains.kotlin.plugin.serialization", "2.3.21")
-            marker("org.jetbrains.compose", "1.11.1")
-            marker("com.android.application", "9.0.1")
-            marker("com.android.kotlin.multiplatform.library", "9.0.1")
+            marker("org.jetbrains.kotlin.multiplatform", "2.4.0")
+            marker("org.jetbrains.kotlin.jvm", "2.4.0")
+            marker("org.jetbrains.kotlin.plugin.compose", "2.4.0")
+            marker("org.jetbrains.kotlin.plugin.serialization", "2.4.0")
+            marker("org.jetbrains.compose", "1.9.3")
+            marker("com.android.application", "9.1.1")
+            marker("com.android.kotlin.multiplatform.library", "9.1.1")
             // Resolved by the Compose plugin at task-execution time via a detached configuration the
             // generator can't see — vendor it explicitly so createDistributable runs offline.
-            dependencies.add("classpath", "org.jetbrains.compose:gradle-plugin-internal-jdk-version-probe:1.11.1")
+            dependencies.add("classpath", "org.jetbrains.compose:gradle-plugin-internal-jdk-version-probe:1.9.3")
         }
     }
     if (name in desktopModules) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 agp = "9.1.1"
-# compileSdk 37 pairs with build-tools 37.0.0; AGP 9.1 is the minimum that supports compiling
-# against API 37, which Compose 1.12 (material3 1.12.0-alpha03 → androidx-compose 1.12.0-beta01) demands
+# compileSdk 37 pairs with build-tools 37.0.0; AGP 9.1 is the minimum that compiles against API 37.
 android-buildTools = "37.0.0"
 android-compileSdk = "37"
 # minSdk 26 (Android 8.0): java.nio.file is available since API 26 — the shared JVM source set
@@ -14,11 +13,10 @@ androidx-lifecycle = "2.10.0"
 androidx-biometric = "1.1.0"
 # FragmentActivity — an androidx.biometric requirement for the prompt host
 androidx-fragment = "1.8.5"
-composeMultiplatform = "1.12.0-beta01"
+# Last CMP line with a stable material3 (1.9.0). Newer CMP only pairs with -alpha material3.
+composeMultiplatform = "1.9.3"
 kotlin = "2.4.0"
-# material3 is versioned separately from CMP; 1.12.0-alpha03 tracks CMP 1.12.0-beta01
-# (it depends on org.jetbrains.compose.foundation:1.12.0-beta01)
-material3 = "1.12.0-alpha03"
+material3 = "1.9.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 ktor = "3.5.1"


### PR DESCRIPTION
## Why

Dependabot kept proposing pre-release Compose bumps because the catalog was pinned to a pre-release stack (CMP `1.12.0-beta01` / material3 `1.12.0-alpha03`) — Dependabot only offers pre-releases when the current pin is itself a pre-release. For the 1.0 base we want stable only.

## What

Move onto the newest **fully stable, matched** Compose pair:

| | before | after |
|---|---|---|
| Compose Multiplatform | `1.12.0-beta01` | `1.9.3` |
| material3 | `1.12.0-alpha03` | `1.9.0` |
| Kotlin / AGP / compileSdk | 2.4.0 / 9.1.1 / 37 | unchanged |

`org.jetbrains.compose.material3` has **no stable coordinate above 1.9.0** (the 1.10+ line is perpetually `-alpha`, tracking androidx material3 "expressive"), so CMP is deliberately held at 1.9.x. Kotlin 2.4.0 compiles cleanly against CMP 1.9.3 — no Kotlin rollback, **no source changes**.

Dependabot now ignores `org.jetbrains.compose*` so it cannot bump one half of the hand-managed pair. Revisit by hand if JetBrains ships a stable material3 > 1.9.0.

## Flatpak toolchain refresh (drift fix)

The Flatpak offline build had silently drifted — it was frozen at kotlin `2.3.21` / compose `1.11.1` / agp `9.0.1` and never updated when the catalog moved to the beta stack. Since Flatpak only builds on release tags, this was latent and **would have broken the next release**. Fixed here:

- `flatpak-gen.init.gradle.kts`: plugin marker versions now mirror the catalog (kotlin 2.4.0 / compose 1.9.3 / agp 9.1.1)
- `flatpak-sources.json`: regenerated for the new pair

## Verification

- `:composeApp:compileKotlinDesktop`, `:composeApp:compileAndroidMain`, `:androidApp:compileDebugKotlin` — clean
- `:shared:desktopTest :composeApp:desktopTest :server:test` — green
- Flatpak manifest regenerated with the canonical generator; version consistency checked. A full `flatpak-builder` run was not executed (runs on release tags only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)