### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.1.2
-skerry.versionCode=4
+skerry.versionName=0.1.3
+skerry.versionCode=5

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.2"
+version = "0.1.3"
 
 application {
     mainClass.set("app.skerry.server.ApplicationKt")

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.2"
+version = "0.1.3"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Version bump for the 0.1.3 release: `gradle.properties`, `server`, `sync-wire`.

Client changes since 0.1.2 (security hardening + mobile terminal parity) ship under tag \`v0.1.3\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)