### PR TITLE
Fix connection-test feedback, jump-host label, and mobile team dialog

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -15,7 +15,7 @@
     <string name="conn_field_authentication">Аутентификация</string>
     <string name="conn_field_group">Группа</string>
     <string name="conn_field_tags">Теги</string>
-    <string name="conn_field_jump_host">Прыжковый хост (необязательно)</string>
+    <string name="conn_field_jump_host">Прыжковый хост</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
     <string name="conn_field_ai_policy">Политика AI для этого подключения</string>
     <string name="conn_field_ai_policy_short">Политика AI</string>
@@ -81,4 +81,5 @@
     <string name="conn_test_checking">Проверка подключения…</string>
     <string name="conn_test_connected">Подключено</string>
     <string name="conn_test_rtt_ms">%1$d мс</string>
+    <string name="conn_test_incomplete">Введите хост, логин и данные для входа</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -15,7 +15,7 @@
     <string name="conn_field_authentication">Authentication</string>
     <string name="conn_field_group">Group</string>
     <string name="conn_field_tags">Tags</string>
-    <string name="conn_field_jump_host">Jump host (optional)</string>
+    <string name="conn_field_jump_host">Jump host</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
     <string name="conn_field_ai_policy">AI policy for this connection</string>
     <string name="conn_field_ai_policy_short">AI policy</string>
@@ -81,4 +81,5 @@
     <string name="conn_test_checking">Testing connection…</string>
     <string name="conn_test_connected">Connected</string>
     <string name="conn_test_rtt_ms">%1$d ms</string>
+    <string name="conn_test_incomplete">Enter host, username and credentials to test</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -109,6 +109,7 @@ import app.skerry.ui.generated.resources.conn_subtitle_new
 import app.skerry.ui.generated.resources.conn_tag_add_placeholder
 import app.skerry.ui.generated.resources.conn_test
 import app.skerry.ui.generated.resources.conn_test_checking
+import app.skerry.ui.generated.resources.conn_test_incomplete
 import app.skerry.ui.generated.resources.conn_test_connected
 import app.skerry.ui.generated.resources.conn_test_rtt_ms
 import app.skerry.ui.generated.resources.conn_title_edit
@@ -190,6 +191,9 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
         findCredential = { id -> credentials?.find(id) },
     )
     val jumpErrorText = (testJump as? JumpChainResolution.Unavailable)?.let { jumpProblemText(it.problem) }
+    // Shown as the test result when "Test" is clicked with an incomplete form (no username/host/secret):
+    // the button stays tappable, so give feedback instead of silently doing nothing.
+    val incompleteTestMessage = stringResource(Res.string.conn_test_incomplete)
     ModalScrim(onDismiss = state::closeModal) {
         Column(
             Modifier
@@ -346,6 +350,10 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                                 is JumpChainResolution.Resolved ->
                                     tester.test(SshTarget(form.address.trim(), form.portOrNull ?: 22, form.username.trim(), jump = testJump.jump), auth)
                             }
+                        } else {
+                            // Form isn't ready to dial (missing host/username/credentials): report it as a
+                            // failure so the click isn't a silent no-op.
+                            tester?.fail(incompleteTestMessage)
                         }
                     },
                     fg = if (canTest) D.text else D.faint,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
@@ -63,6 +65,9 @@ import app.skerry.ui.session.sessionDotColor
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_accept
 import app.skerry.ui.generated.resources.lib_teams_create
+import app.skerry.ui.generated.resources.lib_teams_create_subtitle
+import app.skerry.ui.generated.resources.lib_teams_create_title
+import app.skerry.ui.generated.resources.lib_teams_name_placeholder
 import app.skerry.ui.generated.resources.lib_teams_decline
 import app.skerry.ui.generated.resources.lib_teams_delete
 import app.skerry.ui.generated.resources.lib_teams_delete_message
@@ -89,9 +94,10 @@ import app.skerry.ui.generated.resources.lib_teams_shared_hosts
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.generated.resources.lib_teams_sync_now
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.generated.resources.shell_create
 import app.skerry.ui.generated.resources.shell_route_team
 import app.skerry.ui.teams.AuditLogDialog
-import app.skerry.ui.teams.CreateTeamDialog
 import app.skerry.ui.teams.InviteMemberDialog
 import app.skerry.ui.teams.RoleBadge
 import app.skerry.ui.teams.RolePickerDialog
@@ -112,6 +118,55 @@ private sealed interface MobileTeamsConfirm {
     data class Leave(val teamId: String) : MobileTeamsConfirm
     data class Delete(val teamId: String) : MobileTeamsConfirm
     data class Remove(val teamId: String, val accountId: String) : MobileTeamsConfirm
+}
+
+/**
+ * Create team on the phone: the native centered dialog ([MobileCenteredDialog], parity with
+ * "New group") rather than the desktop [app.skerry.ui.teams.CreateTeamDialog] card — it rides above
+ * the keyboard (root safeDrawing) and lays out for a narrow screen. Single name field; the team key
+ * is generated locally (the caption notes it).
+ */
+@Composable
+private fun MobileCreateTeamDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
+    var name by remember { mutableStateOf("") }
+    val canCreate = name.isNotBlank()
+    val submit = { if (canCreate) onCreate(name.trim()) }
+    MobileCenteredDialog(onDismiss = onDismiss) {
+        Txt(stringResource(Res.string.lib_teams_create_title), color = D.text, size = 18.sp, weight = FontWeight.Bold)
+        Txt(
+            stringResource(Res.string.lib_teams_create_subtitle),
+            color = D.dim,
+            size = 12.5.sp,
+            lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 6.dp, bottom = 16.dp),
+        )
+        MobileFormInput(name, { name = it }, stringResource(Res.string.lib_teams_name_placeholder), imeAction = ImeAction.Done, onSubmit = submit)
+        Spacer(Modifier.height(18.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(
+                Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(12.dp))
+                    .border(1.dp, D.cyan14, RoundedCornerShape(12.dp))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onDismiss)
+                    .padding(vertical = 13.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Txt(stringResource(Res.string.shell_cancel), color = D.dim, size = 15.sp, weight = FontWeight.Medium)
+            }
+            Box(
+                Modifier
+                    .weight(1f)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (canCreate) D.cyan else D.cyan.copy(alpha = 0.4f))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = submit)
+                    .padding(vertical = 13.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Txt(stringResource(Res.string.shell_create), color = D.ink, size = 15.sp, weight = FontWeight.Bold)
+            }
+        }
+    }
 }
 
 /**
@@ -156,6 +211,10 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
 
     val selected = teams.firstOrNull { it.id == selectedId } ?: teams.firstOrNull()
 
+    // Box, not a bare Column: the dialogs below are plain in-composition overlays (ModalScrim /
+    // MobileCenteredDialog fill their parent), so they must be siblings in a full-size Box — as a
+    // Column's trailing children they'd get whatever height the scroll body left (≈0) and collapse.
+    Box(Modifier.fillMaxSize()) {
     Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp)) {
         error?.let { Txt(teamsFailureText(it), color = D.sunset, size = 11.5.sp, modifier = Modifier.padding(vertical = 6.dp)) }
         Row(
@@ -193,7 +252,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     }
 
     if (showCreate) {
-        CreateTeamDialog(
+        MobileCreateTeamDialog(
             onDismiss = { showCreate = false },
             onCreate = { name -> showCreate = false; scope.launch { tc.createTeam(name); tick++ } },
         )
@@ -257,6 +316,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
             },
             onDismiss = { confirm = null },
         )
+    }
     }
 }
 


### PR DESCRIPTION
Three client bug fixes for the (still-draft) 0.1.3 release:

- **Test connection** now reports a failure with a hint ("Enter host, username and credentials to test") instead of a silent no-op when the form isn't ready to dial. The button was always tappable but the click was gated on a complete form, so an empty/typo'd username made it appear dead.
- **Jump-host field label** shortened — dropped "(optional)" so it no longer wraps to two lines and misaligns with the keep-alive field next to it.
- **Create team on mobile** uses the native centered dialog (parity with "New group"), which rides above the keyboard, instead of the desktop card. The teams body is wrapped in a `Box` so the in-composition overlays fill the screen instead of collapsing to ~0 height as trailing `Column` children (that dropped the Cancel/Create buttons off-screen).

Verified: desktop compiles; installed on device (S24) and the create-team popup renders correctly above the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)