### PR TITLE
Admin console: hide revoked devices, count only active

### DIFF
--- a/server/src/main/kotlin/app/skerry/server/db/DeviceRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/DeviceRepository.kt
@@ -67,19 +67,21 @@ class DeviceRepository(private val db: Database) {
 
     /**
      * Instance-wide devices for the admin console (zero-knowledge: metadata only). Most recently
-     * active first, capped at [limit] — devices are never deleted, only revoked, so an unbounded
-     * list would grow indefinitely.
+     * active first, capped at [limit]. Revoked devices are excluded: they're inert (no sync) and are
+     * never deleted, so including them would let the list grow without bound. A revoked device that
+     * re-authenticates clears its revocation and reappears here.
      */
     suspend fun listAll(limit: Int = 200): List<DeviceRow> = dbTransaction(db) {
         Devices.selectAll()
+            .where { Devices.revoked eq false }
             .orderBy(Devices.lastSeenAt to SortOrder.DESC)
             .limit(limit)
             .map { it.toDeviceRow() }
     }
 
-    /** Total devices on the instance, for an accurate "N of M" in the console. */
+    /** Active (non-revoked) devices on the instance, matching [listAll] for an accurate "N of M". */
     suspend fun count(): Long = dbTransaction(db) {
-        Devices.selectAll().count()
+        Devices.selectAll().where { Devices.revoked eq false }.count()
     }
 
     suspend fun find(accountId: String, deviceId: String): DeviceRow? = dbTransaction(db) {

--- a/server/src/main/kotlin/app/skerry/server/db/StatsRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/StatsRepository.kt
@@ -1,5 +1,6 @@
 package app.skerry.server.db
 
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.selectAll
 
@@ -16,7 +17,9 @@ class StatsRepository(private val db: Database) {
     suspend fun counts(): Counts = dbTransaction(db) {
         Counts(
             accounts = Accounts.selectAll().count(),
-            devices = Devices.selectAll().count(),
+            // Active devices only: a revoked device is inert (no sync) and devices are never
+            // deleted, so counting them would keep the tile climbing and never reflect a revoke.
+            devices = Devices.selectAll().where { Devices.revoked eq false }.count(),
             records = Records.selectAll().count(),
             pairingSessions = Pairing.selectAll().count(),
             // Total ciphertext size in bytes. `LENGTH(blob)` is computed DB-side (portable between

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
@@ -339,11 +339,13 @@ class RoutesTest {
             client.delete("/admin/devices/devA?accountId=$accountId") { header("X-Admin-Token", "s3cret") }.status,
         )
 
-        // after revoke the device shows as revoked and no longer authenticates
+        // after revoke the device is hidden from the admin list (revoked devices are inert, so the
+        // list — and the "N of M" total — count only active devices)
         val after: AdminDevicesResponse = client.get("/admin/devices") {
             header("X-Admin-Token", "s3cret")
         }.body()
-        assertTrue(after.devices.single().revoked)
+        assertTrue(after.devices.isEmpty())
+        assertEquals(0, after.total)
 
         // unknown device -> 404
         assertEquals(


### PR DESCRIPTION
Two admin-console fixes ahead of the server release:

- **Device list hides revoked devices.** `DeviceRepository.listAll` / `count` now filter out revoked devices — they're inert (no sync) and are never deleted, so including them let the list grow without bound. A revoked device that re-authenticates clears its revocation and reappears.
- **"Devices" stat tile counts active devices.** `StatsRepository` counts non-revoked devices, so the tile drops when a device is revoked instead of climbing forever.

`RoutesTest` updated: after a revoke the device disappears from the list and the total reflects active-only. All 76 server tests pass.

Deferred (separate design decision): deleting an account still lets a signed-in client re-register the same deterministic account id and re-upload its vault — needs an account blocklist to make deletion stick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)