### PR TITLE
Fix dead click zones in input fields

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/PasswordDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/PasswordDialog.kt
@@ -79,28 +79,33 @@ fun DesktopPasswordDialog(host: Host, onDismiss: () -> Unit, onConnect: (String)
             Txt(host.connectionSubtitle(), color = D.dim, size = 12.5.sp, font = LocalFonts.current.mono, modifier = Modifier.padding(top = 4.dp, bottom = 16.dp))
 
             Txt(stringResource(Res.string.shell_password_caps), color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 5.dp))
-            Row(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Sym("key", size = 16.sp, color = D.faint)
-                val ui = LocalFonts.current.ui
-                val style = remember(ui) { TextStyle(color = D.text, fontSize = 13.sp, fontFamily = ui) }
-                Box(Modifier.fillMaxWidth()) {
-                    if (password.isEmpty()) Txt(stringResource(Res.string.shell_password_host_placeholder), color = D.faint, size = 13.sp)
-                    BasicTextField(
-                        value = password,
-                        onValueChange = { password = it },
-                        singleLine = true,
-                        textStyle = style,
-                        cursorBrush = SolidColor(D.cyan),
-                        visualTransformation = PasswordVisualTransformation(),
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Password),
-                        keyboardActions = KeyboardActions(onDone = { submit() }),
-                    )
-                }
-            }
+            val ui = LocalFonts.current.ui
+            val style = remember(ui) { TextStyle(color = D.text, fontSize = 13.sp, fontFamily = ui) }
+            // Capsule/padding/icon live in decorationBox so a click anywhere in the field places the caret.
+            BasicTextField(
+                value = password,
+                onValueChange = { password = it },
+                singleLine = true,
+                textStyle = style,
+                cursorBrush = SolidColor(D.cyan),
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, keyboardType = KeyboardType.Password),
+                keyboardActions = KeyboardActions(onDone = { submit() }),
+                modifier = Modifier.fillMaxWidth(),
+                decorationBox = { inner ->
+                    Row(
+                        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Sym("key", size = 16.sp, color = D.faint)
+                        Box(Modifier.weight(1f)) {
+                            if (password.isEmpty()) Txt(stringResource(Res.string.shell_password_host_placeholder), color = D.faint, size = 13.sp)
+                            inner()
+                        }
+                    }
+                },
+            )
 
             Row(
                 Modifier.fillMaxWidth().padding(top = 18.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.host
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +36,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -272,6 +275,7 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                 Field(stringResource(Res.string.conn_field_tags)) {
                     // Suggestions = other hosts' tags not yet added here, narrowed by the typed draft.
                     var tagFocused by remember(editHost) { mutableStateOf(false) }
+                    val tagFocus = remember { FocusRequester() }
                     val tagSugs = remember(allHosts, form.tags, tagDraft) { tagSuggestions(allHosts, form.tags, tagDraft) }
                     AnchoredDropdown(
                         expanded = tagFocused && tagSugs.isNotEmpty(),
@@ -279,7 +283,10 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                         focusable = false, // don't steal focus from the tag input field
                         trigger = {
                             FlowRow(
-                                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 10.dp, vertical = 7.dp),
+                                // Tapping anywhere in the capsule (padding, gaps between pills) focuses the input.
+                                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp))
+                                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) { tagFocus.requestFocus() }
+                                    .padding(horizontal = 10.dp, vertical = 7.dp),
                                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                                 verticalArrangement = Arrangement.spacedBy(6.dp),
                             ) {
@@ -290,6 +297,7 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                                     onValueChange = { v -> if (v.contains(',')) { form.addTag(v); tagDraft = "" } else tagDraft = v },
                                     onCommit = { form.addTag(tagDraft); tagDraft = "" },
                                     onFocusChanged = { tagFocused = it },
+                                    modifier = Modifier.focusRequester(tagFocus),
                                 )
                             }
                         },
@@ -799,7 +807,7 @@ private fun TestStatusLabel(status: ConnectionTestStatus) {
 
 /** Inline input for a new tag inside the Tags block: Enter ([onCommit]) or a comma commits the pill. */
 @Composable
-private fun TagInput(value: String, onValueChange: (String) -> Unit, onCommit: () -> Unit, onFocusChanged: ((Boolean) -> Unit)? = null) {
+private fun TagInput(value: String, onValueChange: (String) -> Unit, onCommit: () -> Unit, onFocusChanged: ((Boolean) -> Unit)? = null, modifier: Modifier = Modifier) {
     val fonts = LocalFonts.current
     val textStyle = remember(fonts.ui) { TextStyle(color = D.text, fontSize = 12.5.sp, fontFamily = fonts.ui) }
     BasicTextField(
@@ -810,7 +818,7 @@ private fun TagInput(value: String, onValueChange: (String) -> Unit, onCommit: (
         cursorBrush = SolidColor(D.cyan),
         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = { onCommit() }),
-        modifier = Modifier.widthIn(min = 72.dp).onFocusChanged { onFocusChanged?.invoke(it.isFocused) },
+        modifier = modifier.widthIn(min = 72.dp).onFocusChanged { onFocusChanged?.invoke(it.isFocused) },
         decorationBox = { inner ->
             Box(contentAlignment = Alignment.CenterStart) {
                 if (value.isEmpty()) Txt(stringResource(Res.string.conn_tag_add_placeholder), color = D.faint, size = 12.5.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTagsEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTagsEditor.kt
@@ -31,6 +31,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
@@ -69,13 +71,17 @@ internal fun MobileTagsEditor(
     val fonts = LocalFonts.current
     val textStyle = remember(fonts.ui) { TextStyle(color = D.text, fontSize = 14.sp, fontFamily = fonts.ui) }
     var focused by remember { mutableStateOf(false) }
+    val focus = remember { FocusRequester() }
     AnchoredDropdown(
         expanded = focused && suggestions.isNotEmpty(),
         onDismiss = { focused = false },
         focusable = false, // don't steal focus from the tag input field
         trigger = {
             FlowRow(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(11.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(11.dp)).padding(horizontal = 12.dp, vertical = 10.dp),
+                // Tapping anywhere in the capsule (padding, gaps between pills) focuses the input.
+                Modifier.fillMaxWidth().clip(RoundedCornerShape(11.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(11.dp))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) { focus.requestFocus() }
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
                 horizontalArrangement = Arrangement.spacedBy(7.dp),
                 verticalArrangement = Arrangement.spacedBy(7.dp),
             ) {
@@ -104,7 +110,7 @@ internal fun MobileTagsEditor(
                     cursorBrush = SolidColor(D.cyan),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { onCommit() }),
-                    modifier = Modifier.widthIn(min = 90.dp).onFocusChanged { focused = it.isFocused },
+                    modifier = Modifier.widthIn(min = 90.dp).focusRequester(focus).onFocusChanged { focused = it.isFocused },
                     decorationBox = { inner ->
                         Box(contentAlignment = Alignment.CenterStart) {
                             if (draft.isEmpty()) Txt(placeholder, color = D.faint, size = 14.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -587,27 +586,14 @@ fun MobilePasswordSheet(host: Host, onDismiss: () -> Unit, onConnect: (String) -
             Spacer(Modifier.height(18.dp))
             Txt(stringResource(Res.string.term_password_label), color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp)
             Spacer(Modifier.height(6.dp))
-            Box(
-                Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(11.dp))
-                    .background(D.bg)
-                    .border(1.dp, D.cyan14, RoundedCornerShape(11.dp))
-                    .padding(horizontal = 14.dp, vertical = 13.dp),
-            ) {
-                if (password.isEmpty()) Txt("••••••••", color = D.faint, size = 15.sp)
-                BasicTextField(
-                    value = password,
-                    onValueChange = { password = it },
-                    singleLine = true,
-                    visualTransformation = PasswordVisualTransformation(),
-                    textStyle = TextStyle(color = D.text, fontSize = 15.sp, fontFamily = LocalFonts.current.ui),
-                    cursorBrush = SolidColor(D.cyan),
-                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Go),
-                    keyboardActions = KeyboardActions(onGo = { submit() }, onDone = { submit() }),
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
+            MobileFormInput(
+                value = password,
+                onValueChange = { password = it },
+                placeholder = "••••••••",
+                masked = true,
+                imeAction = ImeAction.Go,
+                onSubmit = { submit() },
+            )
             Spacer(Modifier.height(20.dp))
             Box(
                 Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.snippet
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -312,13 +313,17 @@ private fun SnipTagsField(
 ) {
     val mono = LocalFonts.current.mono
     var focused by remember { mutableStateOf(false) }
+    val focus = remember { FocusRequester() }
     AnchoredDropdown(
         expanded = focused && suggestions.isNotEmpty(),
         onDismiss = { focused = false },
         focusable = false, // don't steal focus from the tag input field
         trigger = {
             FlowRow(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 10.dp, vertical = 7.dp),
+                // Tapping anywhere in the capsule (padding, gaps between pills) focuses the input.
+                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) { focus.requestFocus() }
+                    .padding(horizontal = 10.dp, vertical = 7.dp),
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
             ) {
@@ -332,7 +337,7 @@ private fun SnipTagsField(
                     cursorBrush = SolidColor(D.cyan),
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = { onCommit() }),
-                    modifier = Modifier.widthIn(min = 72.dp).onFocusChanged { focused = it.isFocused },
+                    modifier = Modifier.widthIn(min = 72.dp).focusRequester(focus).onFocusChanged { focused = it.isFocused },
                     decorationBox = { inner ->
                         Box(contentAlignment = Alignment.CenterStart) {
                             if (draft.isEmpty()) Txt(stringResource(Res.string.lib_snippets_add_tag), color = D.faint, size = 12.5.sp, font = mono)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
@@ -216,27 +216,31 @@ internal fun SyncField(
     onSubmit: () -> Unit = {},
     onChange: (String) -> Unit,
 ) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Sym(icon, size = 16.sp, color = D.faint)
-        val ui = LocalFonts.current.ui
-        val style = remember(ui) { TextStyle(color = D.text, fontSize = 13.sp, fontFamily = ui) }
-        Box(Modifier.fillMaxWidth()) {
-            if (value.isEmpty()) Txt(placeholder, color = D.faint, size = 13.sp)
-            BasicTextField(
-                value = value,
-                onValueChange = onChange,
-                singleLine = true,
-                textStyle = style,
-                cursorBrush = SolidColor(D.cyan),
-                visualTransformation = if (secret) PasswordVisualTransformation() else VisualTransformation.None,
-                keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = keyboardType),
-                keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }, onSend = { onSubmit() }),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
+    val ui = LocalFonts.current.ui
+    val style = remember(ui) { TextStyle(color = D.text, fontSize = 13.sp, fontFamily = ui) }
+    // Capsule/padding/icon live in decorationBox so a click anywhere in the field places the caret.
+    BasicTextField(
+        value = value,
+        onValueChange = onChange,
+        singleLine = true,
+        textStyle = style,
+        cursorBrush = SolidColor(D.cyan),
+        visualTransformation = if (secret) PasswordVisualTransformation() else VisualTransformation.None,
+        keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = keyboardType),
+        keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }, onSend = { onSubmit() }),
+        modifier = Modifier.fillMaxWidth(),
+        decorationBox = { inner ->
+            Row(
+                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Sym(icon, size = 16.sp, color = D.faint)
+                Box(Modifier.weight(1f)) {
+                    if (value.isEmpty()) Txt(placeholder, color = D.faint, size = 13.sp)
+                    inner()
+                }
+            }
+        },
+    )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -840,26 +840,30 @@ private fun DialogField(
     }
     Column {
         Txt(label, color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 5.dp))
-        Box(
-            Modifier.fillMaxWidth().bringIntoViewRequester(requester).onSizeChanged { fieldSize = it }.clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp))
-                .then(if (singleLine) Modifier else Modifier.heightIn(min = 72.dp, max = 132.dp))
-                .padding(horizontal = 11.dp, vertical = 10.dp),
-        ) {
-            if (value.isEmpty()) Txt(placeholder, color = D.faint, size = if (singleLine) 13.sp else 11.sp, font = if (singleLine) ui else mono)
-            BasicTextField(
-                value = value,
-                onValueChange = onValueChange,
-                modifier = Modifier.fillMaxWidth()
-                    .onFocusChanged { focused = it.isFocused }
-                    .then(if (singleLine) Modifier else Modifier.verticalScroll(rememberScrollState())),
-                singleLine = singleLine,
-                textStyle = style,
-                cursorBrush = SolidColor(D.cyan),
-                visualTransformation = if (password) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None,
-                keyboardOptions = KeyboardOptions(imeAction = if (singleLine) ImeAction.Done else ImeAction.Default, keyboardType = keyboardType ?: if (password) KeyboardType.Password else KeyboardType.Text),
-                keyboardActions = KeyboardActions(),
-            )
-        }
+        // Capsule/padding live in decorationBox so a click anywhere in the field (incl. the empty area
+        // below the caret in multi-line PEM/certificate fields) places the caret.
+        BasicTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth().onFocusChanged { focused = it.isFocused },
+            singleLine = singleLine,
+            textStyle = style,
+            cursorBrush = SolidColor(D.cyan),
+            visualTransformation = if (password) PasswordVisualTransformation() else androidx.compose.ui.text.input.VisualTransformation.None,
+            keyboardOptions = KeyboardOptions(imeAction = if (singleLine) ImeAction.Done else ImeAction.Default, keyboardType = keyboardType ?: if (password) KeyboardType.Password else KeyboardType.Text),
+            keyboardActions = KeyboardActions(),
+            decorationBox = { inner ->
+                Box(
+                    Modifier.fillMaxWidth().bringIntoViewRequester(requester).onSizeChanged { fieldSize = it }.clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan14, RoundedCornerShape(7.dp))
+                        .then(if (singleLine) Modifier else Modifier.heightIn(min = 72.dp, max = 132.dp))
+                        .padding(horizontal = 11.dp, vertical = 10.dp)
+                        .then(if (singleLine) Modifier else Modifier.verticalScroll(rememberScrollState())),
+                ) {
+                    if (value.isEmpty()) Txt(placeholder, color = D.faint, size = if (singleLine) 13.sp else 11.sp, font = if (singleLine) ui else mono)
+                    inner()
+                }
+            },
+        )
     }
 }
 


### PR DESCRIPTION
## Problem

An old bug: on some forms the input area ignored taps in part of the field. Several forms placed the visual capsule (`clip/background/border/padding`) on an outer `Row`/`Box` with the `BasicTextField` nested as a sibling. In Compose only the text node's own area accepts the caret-placing tap, so the padding ring — and, where the field lacked `fillMaxWidth`, the whole right side — was a dead zone that never focused the field.

I audited **all 25 files** with a `TextField` in `composeApp/` against the correct in-repo pattern (`MobileForm.MobileFormInput`: capsule inside `decorationBox`, field `fillMaxWidth()`).

## Fix

**Classic fields** — moved the capsule into the field's `decorationBox`:
- `PasswordDialog` — SSH connect-password (desktop). Worst case: field had no `fillMaxWidth`, so the whole right half was dead too.
- `SyncSetupDialog.SyncField` — server / account / master-password.
- `VaultView.DialogField` — vault key/password fields. Notably fixes the large dead area **below the caret** in multi-line PEM/certificate fields (`min 72dp`); long-key scroll preserved.
- `MobileTerminalView.MobilePasswordSheet` — SSH password (mobile); folded onto the shared `MobileFormInput` (also removes duplication).

**Tag inputs** — the field is a `FlowRow` sibling of the chip pills, so `decorationBox` can't wrap the capsule. Instead focus the field on a capsule tap via `FocusRequester` + a click handler:
- `NewConnectionModal.TagInput`
- `SnippetsView.SnipTagsField`
- `MobileTagsEditor`

## Verified as already correct
`MobileFormInput`, `GroupDialog`, `ModalTextField`, `SyncTextField`, `TeamsTextField`, `TunnelsView.EditField`, `SftpView.NameDialog`, `LockScreen`/`MobileLockField`, `AiBar`, `SnippetPalette`, Material `OutlinedTextField` (vault gate/reset), and the hidden terminal IME proxies. `PathJumpField` is autofocus + blur-cancel (always focused while open); `MockTerminalPane` is an offscreen preview.

## Notes
- Change is purely modifier composition, bringing the fields onto the already-working `MobileFormInput` pattern; verified via `:composeApp:compileKotlinDesktop` (green). A hit-area unit test would be a brittle coordinate-based Compose UI test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)