### PR TITLE
Show a "Copied" banner when copying a terminal selection

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -40,6 +40,9 @@
     <string name="terminal_reverse_search_prompt">(reverse-i-search)`%1$s`:  ↑↓ выбрать · Enter вставить · Del убрать · Esc</string>
     <string name="terminal_reverse_search_no_matches">— нет совпадений —</string>
 
+    <!-- Transient "copied to clipboard" banner shown after copying a terminal selection. -->
+    <string name="terminal_copied">Скопировано</string>
+
     <!-- Экран сканирования QR (mobile, связывание устройств). -->
     <string name="qr_scan_hint">Наведите камеру на QR-код, показанный на другом устройстве.</string>
     <string name="qr_permission_needed">Для сканирования кода связывания нужен доступ к камере.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,6 +41,9 @@
     <string name="terminal_reverse_search_prompt">(reverse-i-search)`%1$s`:  ↑↓ select · Enter insert · Del remove · Esc</string>
     <string name="terminal_reverse_search_no_matches">— no matches —</string>
 
+    <!-- Transient "copied to clipboard" banner shown after copying a terminal selection. -->
+    <string name="terminal_copied">Copied</string>
+
     <!-- Экран сканирования QR (mobile, связывание устройств). -->
     <string name="qr_scan_hint">Point the camera at the QR code shown on your other device.</string>
     <string name="qr_permission_needed">Camera permission is needed to scan the pairing code.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalOverlayBanner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalOverlayBanner.kt
@@ -1,0 +1,60 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+
+/** How long the transient "Copied" flash stays up before fading out. */
+internal const val COPIED_BANNER_MS = 1400L
+
+/**
+ * Whether the transient "Copied" flash should be visible for [nonce]. 0 is the initial / reset value
+ * (a tab switch re-keys the copy counter) and MUST hide the banner; any non-zero value — including a
+ * negative one after the counter wraps past Int.MAX_VALUE — is a real copy and shows it. Pulled out of
+ * the composable so the show/hide contract is unit-testable ([CopiedBannerTest]).
+ */
+internal fun shouldShowCopiedFlash(nonce: Int): Boolean = nonce != 0
+
+/**
+ * A small rounded pill floated over the terminal (disconnect status, copy confirmation, …): an icon +
+ * one line of mono text, a translucent [background] and a 40%-[accent] border. [contentColor] defaults
+ * to [accent] but can differ (e.g. a brighter foreground on a dark accent). [modifier] positions it
+ * (typically `Modifier.align(Alignment.TopCenter)`).
+ */
+@Composable
+internal fun TerminalOverlayBanner(
+    icon: String,
+    text: String,
+    accent: Color,
+    background: Color,
+    modifier: Modifier = Modifier,
+    contentColor: Color = accent,
+) {
+    val mono = LocalFonts.current.mono
+    Row(
+        modifier
+            .padding(top = 10.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(background)
+            .border(1.dp, accent.copy(alpha = 0.4f), RoundedCornerShape(6.dp))
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        Sym(icon, size = 14.sp, color = contentColor)
+        Txt(text, color = contentColor, size = 11.5.sp, font = mono)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -1,5 +1,8 @@
 package app.skerry.ui.terminal
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusable
@@ -102,6 +105,7 @@ import app.skerry.shared.terminal.UnderlineStyle
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.TerminalSelection
 import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.design.D
 import app.skerry.ui.design.ModalPresence
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
@@ -114,6 +118,7 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.terminal_copied
 import app.skerry.ui.generated.resources.terminal_reverse_search_no_matches
 import app.skerry.ui.generated.resources.terminal_reverse_search_prompt
 import app.skerry.ui.theme.SkerryColors
@@ -206,6 +211,11 @@ fun TerminalScreen(
     // hidden field is a no-op (focus remains after hiding, so the keyboard would not reappear).
     val keyboard = LocalSoftwareKeyboardController.current
     var layoutCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
+
+    // Bumped every time a selection is actually copied to the clipboard (right click / Ctrl+Shift+C /
+    // touch "Copy" menu) — drives the transient "Copied" banner overlay below. Starts at 0 (no banner
+    // on first composition); each increment re-triggers the banner's show-then-hide timer.
+    var copiedNonce by remember(state) { mutableStateOf(0) }
 
     // Ctrl+hover over a link shows the hand cursor (VS Code style). hoverPos is the last cell the
     // pointer was over (null when it left the terminal); linkHover drives the cursor icon and is
@@ -437,6 +447,7 @@ fun TerminalScreen(
     // copy/paste for the rest of the session. Rethrow cancellation, swallow the rest (clipboard unavailable).
     fun copySelection() {
         val text = state.selectedText() ?: return
+        copiedNonce++ // show the transient "Copied" banner (only when something was actually copied)
         clipboardScope.launch {
             try {
                 // Wayland: wl-copy (paired with paste via wl-paste); otherwise the standard Compose clipboard.
@@ -1094,6 +1105,38 @@ fun TerminalScreen(
               ),
           )
       }
+
+      // Transient "Copied" confirmation over the top of the terminal (right-click / Ctrl+Shift+C /
+      // touch "Copy"). Same overlay slot and visual language as the DisconnectedBanner in TerminalView.
+      CopiedBanner(copiedNonce, Modifier.align(Alignment.TopCenter))
+    }
+}
+
+/**
+ * Brief, self-dismissing "Copied" banner. [nonce] is bumped on each successful copy; 0 means "never
+ * copied yet / reset on tab switch" and hides it ([shouldShowCopiedFlash]). Each bump fades the banner
+ * in and hides it after [COPIED_BANNER_MS]; a re-key to 0 mid-show hides it immediately (no stuck pill).
+ */
+@Composable
+private fun CopiedBanner(nonce: Int, modifier: Modifier = Modifier) {
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(nonce) {
+        if (!shouldShowCopiedFlash(nonce)) {
+            visible = false
+            return@LaunchedEffect
+        }
+        visible = true
+        delay(COPIED_BANNER_MS)
+        visible = false
+    }
+    AnimatedVisibility(visible, modifier = modifier, enter = fadeIn(), exit = fadeOut()) {
+        TerminalOverlayBanner(
+            icon = "content_copy",
+            text = stringResource(Res.string.terminal_copied),
+            accent = D.cyan,
+            background = D.surfaceDeep.copy(alpha = 0.8f),
+            contentColor = D.cyanBright,
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -238,7 +238,6 @@ private fun LiveTerminalPane(sessions: SessionsController, modifier: Modifier = 
  */
 @Composable
 private fun DisconnectedBanner(state: ConnectionUiState.Disconnected, modifier: Modifier = Modifier) {
-    val mono = LocalFonts.current.mono
     val color = when {
         state.cleanExit -> D.dim
         state.reconnecting -> D.amber
@@ -254,19 +253,7 @@ private fun DisconnectedBanner(state: ConnectionUiState.Disconnected, modifier: 
         state.reconnecting -> stringResource(Res.string.term_reconnecting, state.attempt)
         else -> stringResource(Res.string.term_connection_lost)
     }
-    Row(
-        modifier
-            .padding(top = 10.dp)
-            .clip(RoundedCornerShape(6.dp))
-            .background(Color(0xCC1A0E0E))
-            .border(1.dp, color.copy(alpha = 0.4f), RoundedCornerShape(6.dp))
-            .padding(horizontal = 12.dp, vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(7.dp),
-    ) {
-        Sym(icon, size = 14.sp, color = color)
-        Txt(text, color = color, size = 11.5.sp, font = mono)
-    }
+    TerminalOverlayBanner(icon = icon, text = text, accent = color, background = Color(0xCC1A0E0E), modifier = modifier)
 }
 
 /** Centered message over the terminal background (no session / connecting / error). */

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/CopiedBannerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/CopiedBannerTest.kt
@@ -1,0 +1,28 @@
+package app.skerry.ui.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CopiedBannerTest {
+
+    // Regression for the stuck-banner bug: the copy counter is re-keyed to 0 on tab switch, and a 0
+    // must hide the flash rather than leaving whatever it was (else copying then switching tabs within
+    // the show window left "Copied" pinned on the other tab).
+    @Test
+    fun `nonce 0 hides the flash`() {
+        assertFalse(shouldShowCopiedFlash(0))
+    }
+
+    @Test
+    fun `a bumped nonce shows the flash`() {
+        assertTrue(shouldShowCopiedFlash(1))
+        assertTrue(shouldShowCopiedFlash(42))
+    }
+
+    // After ~2^31 copies the counter wraps to a negative value; still a real copy, still shown.
+    @Test
+    fun `a wrapped-around negative nonce still shows the flash`() {
+        assertTrue(shouldShowCopiedFlash(Int.MIN_VALUE))
+    }
+}


### PR DESCRIPTION
## What

Copying a terminal selection — right-click, `Ctrl+Shift+C`, or the touch **Copy** menu — now flashes a brief, self-dismissing **Copied** confirmation at the top of the terminal, so the copy is visibly acknowledged. Programmatic OSC 52 writes are unaffected (no banner).

## How

- Extract a shared `TerminalOverlayBanner` pill; the existing `DisconnectedBanner` now reuses it (no visual change — verified 1:1).
- `shouldShowCopiedFlash(nonce)` gates the flash and is unit-tested; a `0` (tab-switch re-key) hides the banner immediately instead of leaving it pinned.
- New string `terminal_copied` (EN/RU).

## Test

- `CopiedBannerTest` (3 cases, incl. the tab-switch regression) — green.
- Desktop compiles clean (no new warnings); reviewed at high + low effort, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)