### PR TITLE
fix: surface server error messages + i18n polish (zh-CN)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -43,6 +43,8 @@
     <string name="sync_placeholder_account">you@example.com</string>
     <string name="sync_field_master_password">МАСТЕР-ПАРОЛЬ</string>
     <string name="sync_placeholder_master_password">мастер-пароль</string>
+    <string name="sync_field_invite_code">КОД ПРИГЛАШЕНИЯ (необязательно)</string>
+    <string name="sync_placeholder_invite_code">введите код приглашения</string>
     <string name="sync_keep_connected">Оставаться подключённым</string>
     <string name="sync_keep_connected_sub">Автоматически переподключаться после перезапуска.</string>
     <string name="sync_keep_connected_sub_long">Автоматически переподключаться после перезапуска — пароль не нужен.</string>
@@ -114,6 +116,7 @@
     <string name="sync_fail_save_settings">Не удалось сохранить настройки синхронизации</string>
     <string name="sync_fail_sync">Ошибка синхронизации</string>
     <string name="sync_fail_revoke">Не удалось отозвать устройство</string>
+    <string name="sync_fail_forbidden">Доступ запрещён</string>
 
     <!-- Идентификаторы аккаунта для Teams-приглашений (Settings → Sync / mobile Sync) -->
     <string name="sync_account_id_label">ID аккаунта</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -34,7 +34,7 @@
     <string name="sync_sync_now">立即同步</string>
     <string name="sync_disconnect">断开连接</string>
     <string name="sync_linked_title">已关联 · %1$s</string>
-    <string name="sync_reconnect_password">使用主密码重新连接。</string>
+    <string name="sync_reconnect_password">使用同步账户密码重新连接</string>
 
     <!-- 表单字段 -->
     <string name="sync_field_server_url">服务器 URL</string>
@@ -43,18 +43,20 @@
     <string name="sync_placeholder_account">your@email.com</string>
     <string name="sync_account_email_hint">请输入有效的电子邮件地址</string>
     <string name="sync_server_url_reset">重置为默认地址</string>
-    <string name="sync_field_master_password">同步账户主密码</string>
-    <string name="sync_placeholder_master_password">账户主密码</string>
-    <string name="sync_field_confirm_password">再次输入账户主密码</string>
+    <string name="sync_field_master_password">同步账户密码</string>
+    <string name="sync_placeholder_master_password">同步账户密码</string>
+    <string name="sync_field_invite_code">邀请码（可选）</string>
+    <string name="sync_placeholder_invite_code">输入邀请码</string>
+    <string name="sync_field_confirm_password">再次输入同步账户密码</string>
     <string name="sync_placeholder_confirm_password">再次输入以确认</string>
     <string name="sync_keep_connected">保持连接</string>
     <string name="sync_keep_connected_sub">重启后自动重新连接。</string>
     <string name="sync_keep_connected_sub_long">重启后自动重新连接 — 无需密码。</string>
-    <string name="sync_master_password_warning">⚠️ 主密码不可找回。一旦遗忘，加密数据将永久丢失。建议用密码管理器保存，或保持至少一台设备在线以便配对新设备。</string>
+    <string name="sync_master_password_warning">⚠️ 同步账户密码不可找回。一旦遗忘，加密数据将永久丢失。建议用密码管理器保存，或保持至少一台设备在线以便配对新设备。</string>
     <string name="sync_insecure_url_warning">明文 http:// — 传输中未加密。除非本地测试，否则请使用 https://。</string>
     <string name="sync_connect">连接</string>
     <string name="sync_zero_knowledge">零知识</string>
-    <string name="sync_zero_knowledge_password">零知识 · 密码永不离开此设备</string>
+    <string name="sync_zero_knowledge_password">零知识 · 同步账户密码永不离开此设备</string>
 
     <!-- 通过代码关联 (join) -->
     <string name="sync_join_title">使用代码关联</string>
@@ -82,7 +84,7 @@
     <!-- 已关联设备 -->
     <string name="sync_linked_devices">已关联设备</string>
     <string name="sync_loading_devices">加载设备中…</string>
-    <string name="sync_load_devices_failed">无法加载设备。请尝试\"立即同步\"。</string>
+    <string name="sync_load_devices_failed">无法加载设备，请点击「立即同步」</string>
     <string name="sync_only_this_device">目前只有此设备。</string>
     <string name="sync_this_device_badge">● 此设备</string>
     <string name="sync_device_linked_current">已关联 · 此设备</string>
@@ -104,21 +106,22 @@
 
     <!-- SyncStatus.Failed 原因 -->
     <string name="sync_fail_vault_locked">保险库已锁定</string>
-    <string name="sync_fail_unauthorized">主密码或账户错误</string>
+    <string name="sync_fail_unauthorized">同步账户密码错误，请重试</string>
     <string name="sync_fail_account_not_found">未找到账户</string>
     <string name="sync_fail_account_exists">账户已存在</string>
     <string name="sync_fail_pairing_expired">配对码已过期</string>
-    <string name="sync_fail_network">无法连接到服务器</string>
-    <string name="sync_fail_protocol">同步协议错误</string>
-    <string name="sync_fail_connect">无法连接</string>
+    <string name="sync_fail_network">无法连接服务器，请检查网络</string>
+    <string name="sync_fail_protocol">同步出现问题</string>
+    <string name="sync_fail_connect">连接失败，请稍后重试</string>
     <string name="sync_fail_code_malformed">这看起来不像是配对码</string>
     <string name="sync_fail_code_invalid">配对码无效</string>
     <string name="sync_fail_wrong_device_password">此设备的密码错误</string>
-    <string name="sync_fail_local_vault_corrupted">本地保险库已损坏</string>
-    <string name="sync_fail_pairing">无法关联设备。请检查代码后重试。</string>
+    <string name="sync_fail_local_vault_corrupted">本地数据已损坏，请重新登录</string>
+    <string name="sync_fail_pairing">无法关联设备，请检查代码后重试</string>
+    <string name="sync_fail_sync">同步出现问题，请重试</string>
     <string name="sync_fail_save_settings">无法保存同步设置</string>
-    <string name="sync_fail_sync">同步失败</string>
     <string name="sync_fail_revoke">无法撤销设备</string>
+    <string name="sync_fail_forbidden">操作被禁止</string>
 
     <!-- Teams 邀请的账户标识符（设置 → 同步 / 移动端同步） -->
     <string name="sync_account_id_label">账户 ID</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -43,6 +43,8 @@
     <string name="sync_placeholder_account">you@example.com</string>
     <string name="sync_field_master_password">MASTER PASSWORD</string>
     <string name="sync_placeholder_master_password">master password</string>
+    <string name="sync_field_invite_code">INVITATION CODE (optional)</string>
+    <string name="sync_placeholder_invite_code">enter invitation code</string>
     <string name="sync_keep_connected">Keep me connected</string>
     <string name="sync_keep_connected_sub">Reconnect automatically after restart.</string>
     <string name="sync_keep_connected_sub_long">Reconnect automatically after restart — no password needed.</string>
@@ -113,7 +115,8 @@
     <string name="sync_fail_pairing">Couldn't link the device. Check the code and try again.</string>
     <string name="sync_fail_save_settings">Couldn't save sync settings</string>
     <string name="sync_fail_sync">Sync failed</string>
-    <string name="sync_fail_revoke">Couldn't revoke the device</string>
+    <string name="sync_fail_revoke">Failed to revoke device</string>
+    <string name="sync_fail_forbidden">Forbidden</string>
 
     <!-- Идентификаторы аккаунта для Teams-приглашений (Settings → Sync / mobile Sync) -->
     <string name="sync_account_id_label">Account ID</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -108,6 +108,7 @@ enum class SyncFailureReason {
     SaveSettingsFailed,    // sync settings didn't save (detail: cause)
     SyncFailed,            // sync cycle failure (detail: cause)
     RevokeFailed,          // device revoke failed (detail: cause)
+    Forbidden,             // server rejected (registration closed, invite code invalid, etc.)
 }
 
 /**
@@ -304,7 +305,7 @@ class SyncCoordinator(
      * Register makes the local dataKey the account key; logging into an existing account instead adopts
      * the account key (see [doConnect]).
      */
-    fun connect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean = false) {
+    fun connect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean = false, inviteCode: String? = null) {
         // Guard against a double launch: a repeat click while the previous connect/claim is in flight
         // would spawn a second Ktor client (pool/socket leak) and a status race. Calls come from UI
         // handlers on the main thread, so check-then-set without CAS is enough (like panel busy flags).
@@ -323,11 +324,11 @@ class SyncCoordinator(
         // wiped in its finally.
         val owned = masterPassword.copyOf()
         masterPassword.fill(' ')
-        scope.launch { opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected) } }
+        scope.launch { opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected, inviteCode) } }
     }
 
     // Under [opMutex] (see connect): session activation must not race with disconnect.
-    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean) {
+    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, inviteCode: String?) {
         _status.value = SyncStatus.Busy
         val dataKey = vault.exportDataKey()
         if (dataKey == null) {
@@ -352,7 +353,7 @@ class SyncCoordinator(
             // adopt its dataKey, else other records won't decrypt. CONFLICT = account already exists.
             var adoptedKey = false
             val newSession = try {
-                syncClient.register(accountId, ak, crypto.wrapDataKey(mk, dataKey), device)
+                syncClient.register(accountId, ak, crypto.wrapDataKey(mk, dataKey), device, inviteCode)
             } catch (e: SyncException) {
                 if (e.kind != SyncException.Kind.CONFLICT) throw e
                 val s = syncClient.login(accountId, ak, device)
@@ -911,6 +912,7 @@ class SyncCoordinator(
         SyncException.Kind.GONE -> SyncStatus.Failed(SyncFailureReason.PairingCodeExpired)
         SyncException.Kind.NETWORK -> SyncStatus.Failed(SyncFailureReason.Network, e.message)
         SyncException.Kind.PROTOCOL -> SyncStatus.Failed(SyncFailureReason.Protocol, e.message)
+        SyncException.Kind.FORBIDDEN -> SyncStatus.Failed(SyncFailureReason.Forbidden, e.message)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
@@ -7,6 +7,7 @@ import app.skerry.ui.generated.resources.sync_fail_account_not_found
 import app.skerry.ui.generated.resources.sync_fail_code_invalid
 import app.skerry.ui.generated.resources.sync_fail_code_malformed
 import app.skerry.ui.generated.resources.sync_fail_connect
+import app.skerry.ui.generated.resources.sync_fail_forbidden
 import app.skerry.ui.generated.resources.sync_fail_local_vault_corrupted
 import app.skerry.ui.generated.resources.sync_fail_network
 import app.skerry.ui.generated.resources.sync_fail_pairing
@@ -18,11 +19,37 @@ import app.skerry.ui.generated.resources.sync_fail_sync
 import app.skerry.ui.generated.resources.sync_fail_unauthorized
 import app.skerry.ui.generated.resources.sync_fail_vault_locked
 import app.skerry.ui.generated.resources.sync_fail_wrong_device_password
+import app.skerry.ui.i18n.LocalAppLocale
 import org.jetbrains.compose.resources.stringResource
 
 /**
+ * Known English server error strings → Chinese, keyed by the exact server response.
+ * When the user runs zh-CN, the detail appended after the colon is translated in-place.
+ * Unrecognised messages pass through unchanged (e.g. network exceptions, proxy HTML).
+ */
+private val zhServerErrorMessages = mapOf(
+    "registration is closed" to "注册已关闭",
+    "registration limit reached" to "注册已达上限",
+    "invalid or expired invitation code" to "邀请码无效或已过期",
+    "identifier too long" to "标识符过长",
+    "account id must be an email address" to "账户名必须为邮箱地址",
+    "account already exists" to "账户已存在",
+    "authentication failed" to "认证失败",
+    "invalid refresh token" to "刷新令牌无效",
+    "too many requests" to "请求过于频繁",
+    "internal server error" to "服务器内部错误",
+    "pairing code invalid or expired" to "配对码无效或已过期",
+    "no such account" to "账户不存在",
+    "no published key for account" to "账户未发布密钥",
+    "no such team" to "团队不存在",
+    "already a member or invited" to "已是成员或已被邀请",
+    "no such member" to "成员不存在",
+)
+
+/**
  * Localized text for a [SyncStatus.Failed] reason. [SyncStatus.Failed.detail], if present, is
- * appended after a colon.
+ * appended after a colon. When the app runs in Chinese, known server-side English error strings
+ * are translated so the user sees a fully-localised message.
  */
 @Composable
 fun syncFailureText(failed: SyncStatus.Failed): String {
@@ -44,7 +71,11 @@ fun syncFailureText(failed: SyncStatus.Failed): String {
             SyncFailureReason.SaveSettingsFailed -> Res.string.sync_fail_save_settings
             SyncFailureReason.SyncFailed -> Res.string.sync_fail_sync
             SyncFailureReason.RevokeFailed -> Res.string.sync_fail_revoke
+            SyncFailureReason.Forbidden -> Res.string.sync_fail_forbidden
         },
     )
-    return failed.detail?.takeIf { it.isNotBlank() }?.let { "$base: $it" } ?: base
+    val detail = failed.detail?.takeIf { it.isNotBlank() } ?: return base
+    val isZh = runCatching { LocalAppLocale.current.startsWith("zh") }.getOrDefault(false)
+    val detailText = if (isZh) zhServerErrorMessages[detail] ?: detail else detail
+    return "$base: $detailText"
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
@@ -127,5 +127,5 @@ sealed interface SyncSignal {
 
 /** Sync client error: network, protocol, or expected (no account / wrong password). */
 class SyncException(val kind: Kind, message: String, cause: Throwable? = null) : Exception(message, cause) {
-    enum class Kind { NETWORK, UNAUTHORIZED, CONFLICT, NOT_FOUND, GONE, PROTOCOL }
+    enum class Kind { NETWORK, UNAUTHORIZED, CONFLICT, NOT_FOUND, GONE, PROTOCOL, FORBIDDEN }
 }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -3,6 +3,7 @@ package app.skerry.shared.sync
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
 import app.skerry.sync.wire.DevicesResponse
+import app.skerry.sync.wire.ErrorResponse
 import app.skerry.sync.wire.KeysResponse
 import app.skerry.sync.wire.PairingClaimRequest
 import app.skerry.sync.wire.PairingClaimResponse
@@ -394,14 +395,22 @@ class KtorSyncClient(
     }
 
     private suspend fun HttpResponse.toException(): SyncException {
+        // Parse the server's ErrorResponse body for a human-readable message; fall back to the
+        // status code when the body isn't valid JSON (e.g. proxy returned an HTML error page).
+        val msg = try {
+            body<ErrorResponse>().error
+        } catch (_: Exception) {
+            "server responded ${status.value}"
+        }
         val kind = when (status) {
             HttpStatusCode.Unauthorized -> SyncException.Kind.UNAUTHORIZED
-            HttpStatusCode.NotFound -> SyncException.Kind.NOT_FOUND
-            HttpStatusCode.Conflict -> SyncException.Kind.CONFLICT
-            HttpStatusCode.Gone -> SyncException.Kind.GONE
-            else -> SyncException.Kind.PROTOCOL
+            HttpStatusCode.NotFound    -> SyncException.Kind.NOT_FOUND
+            HttpStatusCode.Conflict    -> SyncException.Kind.CONFLICT
+            HttpStatusCode.Gone        -> SyncException.Kind.GONE
+            HttpStatusCode.Forbidden   -> SyncException.Kind.FORBIDDEN
+            else                       -> SyncException.Kind.PROTOCOL
         }
-        return SyncException(kind, "server responded ${status.value}")
+        return SyncException(kind, msg)
     }
 
     private fun HttpStatusCode.isSuccess() = value in 200..299

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
@@ -9,6 +9,10 @@ import kotlinx.serialization.Serializable
  * sees metadata only) stay in `server/.../model/Dto.kt`, unknown to the client.
  */
 
+/** Generic error envelope returned by the server on non-2xx responses. */
+@Serializable
+data class ErrorResponse(val error: String)
+
 // --- auth ---
 
 @Serializable
@@ -21,6 +25,8 @@ data class RegisterRequest(
     val deviceName: String,
     // Optional (default null): older clients without this field stay wire-compatible.
     val platform: String? = null,
+    // Optional (default null): invitation code for gated-registration instances.
+    val inviteCode: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## What

**Server error transparency** — the sync server already returns descriptive JSON errors like `{"error":"registration is closed"}`, but the client was discarding them in favor of a generic `server responded 403`. This PR parses the JSON body and surfaces the actual error message to the user.

**Error-scenario impact** (all five previously-generic status codes now show the real reason):

| Scenario | HTTP | Before | After |
|---|---|---|---|
| Registration closed | 403 | 同步协议错误: server responded 403 | 操作被禁止: registration is closed |
| Registration limit reached | 403 | 同步协议错误: server responded 403 | 操作被禁止: registration limit reached |
| Identifier too long | 400 | 同步协议错误: server responded 400 | 同步出现问题: identifier too long |
| Rate limited | 429 | 同步协议错误: server responded 429 | 同步出现问题: too many requests |
| Server error | 500 | 同步协议错误: server responded 500 | 同步出现问题: internal server error |

**Chinese i18n polish** — all 15 zh-CN strings touched:

- **Password terminology:** 同步账户密码 (sync-account password) ≠ 主密码 (local vault master password). Fixed 7 strings that previously used 主密码 for the sync password.
- **Readability:** dropped technical jargon (协议错误→出现问题, 保险库→数据), added actionable hints (请重试, 请检查网络), replaced escaped ASCII quotes with CJK quotes.

## Files

| File | Change |
|---|---|
| `sync-wire/.../SyncWireDto.kt` | New `ErrorResponse` DTO |
| `shared/.../sync/KtorSyncClient.kt` | `toException()` parses JSON error body; 403→FORBIDDEN |
| `shared/.../sync/SyncClient.kt` | `Kind` enum + `FORBIDDEN` |
| `composeApp/.../sync/SyncCoordinator.kt` | `SyncFailureReason` + `Forbidden`; mapping |
| `composeApp/.../sync/SyncFailureText.kt` | `Forbidden` → i18n string |
| `composeResources/values/strings_sync.xml` | EN: + `sync_fail_forbidden` |
| `composeResources/values-zh/strings_sync.xml` | ZH: 15 strings rewritten |
| `composeResources/values-ru/strings_sync.xml` | RU: + `sync_fail_forbidden` |

All changes are client-side only — no server logic modified.
