### PR TITLE
fix: treat the vault password as the single account password (issue #28)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -115,6 +115,12 @@
     <string name="sync_fail_sync">Ошибка синхронизации</string>
     <string name="sync_fail_revoke">Не удалось отозвать устройство</string>
 
+    <!-- issue #28: подключение к существующему аккаунту с другим паролём меняет пароль этого устройства -->
+    <string name="sync_password_replace_title">Использовать пароль аккаунта?</string>
+    <string name="sync_password_replace_body">Аккаунт «%1$s» защищён другим паролём. Чтобы синхронизировать, это устройство будет разблокироваться паролём аккаунта.</string>
+    <string name="sync_password_replace_confirm">Использовать пароль аккаунта</string>
+    <string name="sync_password_replace_cancel">Отмена</string>
+
     <!-- Идентификаторы аккаунта для Teams-приглашений (Settings → Sync / mobile Sync) -->
     <string name="sync_account_id_label">ID аккаунта</string>
     <string name="sync_sharing_fingerprint_label">Отпечаток ключа шеринга</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -99,7 +99,7 @@
 
     <!-- Причины SyncStatus.Failed (typed reason → текст; техническая деталь добавляется после двоеточия) -->
     <string name="sync_fail_vault_locked">Хранилище заблокировано</string>
-    <string name="sync_fail_unauthorized">Неверный мастер-пароль или аккаунт</string>
+    <string name="sync_fail_unauthorized">Неверный пароль или аккаунт. Для нового аккаунта введите пароль этого хранилища.</string>
     <string name="sync_fail_account_not_found">Аккаунт не найден</string>
     <string name="sync_fail_account_exists">Аккаунт уже существует</string>
     <string name="sync_fail_pairing_expired">Код паринга истёк</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -104,7 +104,7 @@
 
     <!-- SyncStatus.Failed 原因 -->
     <string name="sync_fail_vault_locked">保险库已锁定</string>
-    <string name="sync_fail_unauthorized">主密码或账户错误</string>
+    <string name="sync_fail_unauthorized">密码或账户错误。若要新建账户，请使用此保险库的密码。</string>
     <string name="sync_fail_account_not_found">未找到账户</string>
     <string name="sync_fail_account_exists">账户已存在</string>
     <string name="sync_fail_pairing_expired">配对码已过期</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -120,6 +120,12 @@
     <string name="sync_fail_sync">同步失败</string>
     <string name="sync_fail_revoke">无法撤销设备</string>
 
+    <!-- issue #28: 连接到使用其他密码的现有账户会将本设备改用该密码 -->
+    <string name="sync_password_replace_title">使用账户密码？</string>
+    <string name="sync_password_replace_body">账户「%1$s」使用其他密码保护。若要同步，此设备将改用您的账户密码解锁。</string>
+    <string name="sync_password_replace_confirm">使用账户密码</string>
+    <string name="sync_password_replace_cancel">取消</string>
+
     <!-- Teams 邀请的账户标识符（设置 → 同步 / 移动端同步） -->
     <string name="sync_account_id_label">账户 ID</string>
     <string name="sync_sharing_fingerprint_label">共享密钥指纹</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -115,6 +115,12 @@
     <string name="sync_fail_sync">Sync failed</string>
     <string name="sync_fail_revoke">Couldn't revoke the device</string>
 
+    <!-- issue #28: joining an existing account whose password differs re-keys this device to it -->
+    <string name="sync_password_replace_title">Use your account password?</string>
+    <string name="sync_password_replace_body">The account “%1$s” is protected by a different password. To sync, this device will start unlocking with your account password.</string>
+    <string name="sync_password_replace_confirm">Use account password</string>
+    <string name="sync_password_replace_cancel">Cancel</string>
+
     <!-- Идентификаторы аккаунта для Teams-приглашений (Settings → Sync / mobile Sync) -->
     <string name="sync_account_id_label">Account ID</string>
     <string name="sync_sharing_fingerprint_label">Sharing key fingerprint</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -99,7 +99,7 @@
 
     <!-- Причины SyncStatus.Failed (typed reason → текст; техническая деталь добавляется после двоеточия) -->
     <string name="sync_fail_vault_locked">Vault is locked</string>
-    <string name="sync_fail_unauthorized">Wrong master password or account</string>
+    <string name="sync_fail_unauthorized">Wrong password or account. For a new account, use this vault's password.</string>
     <string name="sync_fail_account_not_found">Account not found</string>
     <string name="sync_fail_account_exists">Account already exists</string>
     <string name="sync_fail_pairing_expired">Pairing code expired</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -208,7 +208,7 @@ private fun syncSubtitle(): String {
     val sync = LocalSync.current ?: return stringResource(Res.string.more_sync_local_only)
     return when (sync.status.collectAsState().value) {
         is app.skerry.ui.sync.SyncStatus.Online -> stringResource(Res.string.more_sync_synced)
-        app.skerry.ui.sync.SyncStatus.Busy -> stringResource(Res.string.more_sync_syncing)
+        app.skerry.ui.sync.SyncStatus.Busy, is app.skerry.ui.sync.SyncStatus.NeedsPasswordReplaceConfirm -> stringResource(Res.string.more_sync_syncing)
         is app.skerry.ui.sync.SyncStatus.Configured -> stringResource(Res.string.more_sync_linked_locked)
         is app.skerry.ui.sync.SyncStatus.Failed -> stringResource(Res.string.more_sync_error)
         app.skerry.ui.sync.SyncStatus.Disabled -> stringResource(Res.string.more_sync_local_only)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.sync.RemoteDevice
 import app.skerry.ui.sync.AccountIdentityBlock
+import app.skerry.ui.sync.PasswordReplaceConfirm
 import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.sync.SyncSetupBody
 import app.skerry.ui.sync.SyncStatus
@@ -211,6 +212,9 @@ private fun SyncBody(sync: SyncCoordinator) {
             MobileWhatSyncs(sync)
             MobileLinkedDevices(sync)
         }
+        // Connecting hit an existing account under a different password → confirm re-keying this device
+        // to the account password before adopting it (issue #28).
+        is SyncStatus.NeedsPasswordReplaceConfirm -> PasswordReplaceConfirm(sync, s.accountId)
         // One shared SyncSetupBody call site for all form states: separate when-branches would be
         // separate composition slots, and a Disabled → Failed transition would still reset the
         // typed fields even though the form never visually left the screen.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -214,7 +215,14 @@ private fun SyncBody(sync: SyncCoordinator) {
         }
         // Connecting hit an existing account under a different password → confirm re-keying this device
         // to the account password before adopting it (issue #28).
-        is SyncStatus.NeedsPasswordReplaceConfirm -> PasswordReplaceConfirm(sync, s.accountId)
+        is SyncStatus.NeedsPasswordReplaceConfirm -> {
+            // Mobile shows the confirmation inline, so there's no dismiss callback to hang the decline on
+            // (desktop declines on Esc). Any exit — header back, system back/gesture, tab switch — must
+            // decline it: a pending replace left behind keeps the typed password in memory and strands the
+            // status on "Syncing…". Leaving on confirm/cancel is a no-op — both clear the pending first.
+            DisposableEffect(Unit) { onDispose { sync.cancelPasswordReplace() } }
+            PasswordReplaceConfirm(sync, s.accountId)
+        }
         // One shared SyncSetupBody call site for all form states: separate when-branches would be
         // separate composition slots, and a Disabled → Failed transition would still reset the
         // typed fields even though the form never visually left the screen.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/AccountCardModel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/AccountCardModel.kt
@@ -36,7 +36,7 @@ data class AccountCardModel(
  */
 fun accountCardModel(status: SyncStatus?, serverUrl: String? = null): AccountCardModel = when (status) {
     null, SyncStatus.Disabled -> localVaultCard("Encrypted on this device")
-    SyncStatus.Busy -> localVaultCard("Syncing…")
+    SyncStatus.Busy, is SyncStatus.NeedsPasswordReplaceConfirm -> localVaultCard("Syncing…")
     is SyncStatus.Online -> AccountCardModel(
         initials = accountInitials(status.accountId),
         title = status.accountId,
@@ -65,7 +65,7 @@ private fun localVaultCard(subtitle: String) =
 @Composable
 fun accountCardModelLocalized(status: SyncStatus?, serverUrl: String? = null): AccountCardModel = when (status) {
     null, SyncStatus.Disabled -> localizedLocalVaultCard(stringResource(Res.string.stail_encrypted_on_device))
-    SyncStatus.Busy -> localizedLocalVaultCard(stringResource(Res.string.stail_syncing))
+    SyncStatus.Busy, is SyncStatus.NeedsPasswordReplaceConfirm -> localizedLocalVaultCard(stringResource(Res.string.stail_syncing))
     is SyncStatus.Online -> AccountCardModel(
         initials = accountInitials(status.accountId),
         title = status.accountId,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PasswordReplaceConfirm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PasswordReplaceConfirm.kt
@@ -1,0 +1,94 @@
+package app.skerry.ui.sync
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.D
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.ModalScrim
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sync_password_replace_body
+import app.skerry.ui.generated.resources.sync_password_replace_cancel
+import app.skerry.ui.generated.resources.sync_password_replace_confirm
+import app.skerry.ui.generated.resources.sync_password_replace_title
+import app.skerry.ui.generated.resources.sync_setup_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Confirmation for [SyncStatus.NeedsPasswordReplaceConfirm] (issue #28): the typed password is a valid
+ * password for the existing account [accountId] but not this device's vault password, so joining re-keys
+ * the vault to the account password — this device will start unlocking with it. The user explicitly
+ * agrees ([SyncCoordinator.confirmPasswordReplace]) or backs out ([SyncCoordinator.cancelPasswordReplace]).
+ *
+ * Column content: the caller places it inside its own Column (mobile sync body / desktop dialog). For a
+ * standalone modal on desktop use [PasswordReplaceConfirmDialog].
+ */
+@Composable
+fun PasswordReplaceConfirm(sync: SyncCoordinator, accountId: String) {
+    SyncStatusNotice(
+        icon = "warning",
+        iconColor = D.amber,
+        title = stringResource(Res.string.sync_password_replace_title),
+        subtitle = stringResource(Res.string.sync_password_replace_body, accountId),
+    )
+    Row(
+        Modifier.fillMaxWidth().padding(top = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        GhostButton(
+            stringResource(Res.string.sync_password_replace_cancel),
+            onClick = { sync.cancelPasswordReplace() },
+            fg = D.dim,
+        )
+        GhostButton(
+            stringResource(Res.string.sync_password_replace_confirm),
+            onClick = { sync.confirmPasswordReplace() },
+            icon = "cloud_sync",
+            fg = D.amber,
+            border = D.amber.copy(alpha = 0.4f),
+        )
+    }
+}
+
+/** [PasswordReplaceConfirm] as a standalone desktop modal (same card chrome as [SyncSetupDialog]). */
+@Composable
+fun PasswordReplaceConfirmDialog(sync: SyncCoordinator, accountId: String, onDismiss: () -> Unit) {
+    val noop = remember { MutableInteractionSource() }
+    ModalScrim(onDismiss = onDismiss, scrimColor = Color(0xB3060E16)) {
+        Column(
+            Modifier
+                .widthIn(max = 440.dp)
+                .fillMaxWidth()
+                .padding(20.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(D.surfaceDeep)
+                .border(1.dp, D.cyan14, RoundedCornerShape(12.dp))
+                .clickable(interactionSource = noop, indication = null, onClick = {})
+                .padding(26.dp),
+        ) {
+            Txt(
+                stringResource(Res.string.sync_setup_title),
+                color = D.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+            PasswordReplaceConfirm(sync, accountId)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PasswordReplaceConfirm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PasswordReplaceConfirm.kt
@@ -67,11 +67,22 @@ fun PasswordReplaceConfirm(sync: SyncCoordinator, accountId: String) {
     }
 }
 
+/**
+ * Dismissing the confirmation (Esc — a scrim click is deliberately swallowed, see [ModalScrim]) declines the
+ * replace, it doesn't just hide the modal: the paused
+ * connect would otherwise keep holding the typed password and leave the status on
+ * [SyncStatus.NeedsPasswordReplaceConfirm] — a sync indicator stuck on "Syncing…" with no way back to it.
+ */
+fun dismissPasswordReplace(sync: SyncCoordinator, onDismiss: () -> Unit): () -> Unit = {
+    sync.cancelPasswordReplace()
+    onDismiss()
+}
+
 /** [PasswordReplaceConfirm] as a standalone desktop modal (same card chrome as [SyncSetupDialog]). */
 @Composable
 fun PasswordReplaceConfirmDialog(sync: SyncCoordinator, accountId: String, onDismiss: () -> Unit) {
     val noop = remember { MutableInteractionSource() }
-    ModalScrim(onDismiss = onDismiss, scrimColor = Color(0xB3060E16)) {
+    ModalScrim(onDismiss = dismissPasswordReplace(sync, onDismiss), scrimColor = Color(0xB3060E16)) {
         Column(
             Modifier
                 .widthIn(max = 440.dp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -83,6 +83,15 @@ sealed interface SyncStatus {
     data class Online(val accountId: String, val lastPushed: Int, val lastPulled: Int) : SyncStatus
 
     /**
+     * The typed password is a valid password for an EXISTING account, but not this device's vault
+     * password. Joining that account re-keys the local vault to the account password — i.e. this device
+     * will start unlocking with the account password (issue #28). We don't do it silently: the UI must
+     * confirm ([SyncCoordinator.confirmPasswordReplace]) or cancel ([SyncCoordinator.cancelPasswordReplace]).
+     * Server/account are echoed for the dialog copy.
+     */
+    data class NeedsPasswordReplaceConfirm(val serverUrl: String, val accountId: String) : SyncStatus
+
+    /**
      * Failure: [reason] is a typed cause (localized in the UI layer), [detail] an optional technical
      * detail (exception message) for cases where it aids diagnosis; the UI appends it after the
      * localized text.
@@ -182,6 +191,31 @@ class SyncCoordinator(
      */
     private val _biometricResetNeeded = MutableStateFlow(false)
     val biometricResetNeeded: StateFlow<Boolean> = _biometricResetNeeded.asStateFlow()
+
+    /**
+     * Connect paused on [SyncStatus.NeedsPasswordReplaceConfirm]: the params to re-run the connect once the
+     * user confirms replacing the vault unlock password. Holds an owned password copy — wiped on confirm
+     * (handed to the re-run, wiped in its finally), cancel, a superseding connect, and [close].
+     */
+    private class PendingReplace(
+        val serverUrl: String,
+        val accountId: String,
+        val password: CharArray,
+        val keepConnected: Boolean,
+    )
+
+    // Set under [opMutex] in doConnect; read/cleared from the UI thread (confirm/cancel/connect) and [close].
+    // @Volatile for cross-thread visibility (doConnect runs on [scope]); the status flips to
+    // NeedsPasswordReplaceConfirm only after the stash, and the UI acts on that status, so confirm/cancel
+    // always observe a set value.
+    @Volatile
+    private var pendingReplace: PendingReplace? = null
+
+    /** Stash the pending replace, wiping any superseded one's password first. */
+    private fun stashPendingReplace(next: PendingReplace) {
+        pendingReplace?.password?.fill(' ')
+        pendingReplace = next
+    }
 
     // "What to sync" (account level) — stored as a SETTINGS record in the vault, synced by the same
     // sync (see [SyncSettings]). Read lazily from the vault: on a locked vault the store returns default.
@@ -291,6 +325,8 @@ class SyncCoordinator(
      * process/test teardown. Does not touch the saved link (that's [disconnect]).
      */
     fun close() {
+        pendingReplace?.password?.fill(' ')
+        pendingReplace = null
         scope.cancel()
     }
 
@@ -317,6 +353,8 @@ class SyncCoordinator(
         // Disabled and Skip is active: proceeding to biometric enroll, the user would wrap it under a key
         // that connect then replaces (account-key adoption race).
         _status.value = SyncStatus.Busy
+        // A fresh connect supersedes any pending vault-password-replace confirmation: wipe its kept password.
+        pendingReplace?.let { it.password.fill(' '); pendingReplace = null }
         // Copy synchronously and wipe the original before launch: the coroutine starts on
         // Dispatchers.Default not immediately, and the caller may wipe the array first — otherwise
         // deriveMasterKey would get an empty password (TOCTOU). The copy is owned by [doConnect] and
@@ -327,7 +365,7 @@ class SyncCoordinator(
     }
 
     // Under [opMutex] (see connect): session activation must not race with disconnect.
-    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean) {
+    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false) {
         _status.value = SyncStatus.Busy
         val dataKey = vault.exportDataKey()
         if (dataKey == null) {
@@ -348,13 +386,52 @@ class SyncCoordinator(
             val device = DeviceInfo(deviceId, deviceName, platformName)
             val syncClient = clientFactory(serverUrl)
 
-            // Register-or-login: a new account publishes our dataKey; an existing one — log in and
-            // adopt its dataKey, else other records won't decrypt. CONFLICT = account already exists.
+            // The account (remote) password is the single source of truth: every device shares one
+            // account dataKey wrapped under it, so a synced device MUST unlock with the account password.
+            // [matchesVault] — is the typed password THIS vault's own unlock password? — decides the flow
+            // and whether the unlock password changes (issue #28). verifyPassword runs Argon2id over the
+            // vault salt; a rare user-initiated connect, so the extra derivation is acceptable.
+            val matchesVault = vault.verifyPassword(masterPassword.copyOf())
             var adoptedKey = false
-            val newSession = try {
-                syncClient.register(accountId, ak, crypto.wrapDataKey(mk, dataKey), device)
-            } catch (e: SyncException) {
-                if (e.kind != SyncException.Kind.CONFLICT) throw e
+            val newSession: SyncSession = if (matchesVault) {
+                // Establish the account under the vault's own password: register a new one (publishes our
+                // dataKey), or on CONFLICT log into our existing account and adopt its key. Adopting here
+                // never changes the unlock password (same password, at most a new dataKey → full re-pull).
+                try {
+                    syncClient.register(accountId, ak, crypto.wrapDataKey(mk, dataKey), device)
+                } catch (e: SyncException) {
+                    if (e.kind != SyncException.Kind.CONFLICT) throw e
+                    val s = syncClient.login(accountId, ak, device)
+                    adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())
+                    s
+                }
+            } else if (!allowPasswordReplace) {
+                // Typed password isn't this vault's. Never register — creating an account under a non-vault
+                // password permanently splits the local unlock password from the account password (issue
+                // #28's root cause). The only valid intent is joining an EXISTING account under its own
+                // password, which re-keys this vault to that password. Log in to verify it's a real account
+                // password (don't prompt on a wrong one), then pause for the user to confirm the change.
+                val s = try {
+                    syncClient.login(accountId, ak, device)
+                } catch (e: SyncException) {
+                    // The server hides "no such account" behind a wrong-password shape — both surface as
+                    // Unauthorized (the UI hint tells the user to use their vault password).
+                    if (e.kind == SyncException.Kind.UNAUTHORIZED || e.kind == SyncException.Kind.NOT_FOUND) {
+                        runCatching { syncClient.close() }
+                        _status.value = SyncStatus.Failed(SyncFailureReason.Unauthorized)
+                        return
+                    }
+                    throw e
+                }
+                // Verified only — close this client; the confirmed re-run opens its own. Stash the connect
+                // params + password and ask the UI to confirm (finally still wipes mk/authKey/dataKey/password).
+                runCatching { syncClient.close() }
+                stashPendingReplace(PendingReplace(serverUrl, accountId, masterPassword.copyOf(), keepConnected))
+                _status.value = SyncStatus.NeedsPasswordReplaceConfirm(serverUrl, accountId)
+                return
+            } else {
+                // Confirmed ([confirmPasswordReplace]): log into the existing account and adopt its key,
+                // re-keying this vault to the account password (the intended, consented password change).
                 val s = syncClient.login(accountId, ak, device)
                 adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())
                 s
@@ -432,6 +509,10 @@ class SyncCoordinator(
      * re-login. If the wrap doesn't unwrap (different password) — keep the local key. adoptDataKey
      * wipes [password] and consumes [accountDataKey]. Returns `true` if the key was adopted (changed) —
      * the caller forces a full re-pull on that.
+     *
+     * Whether this changes the vault UNLOCK password is decided by the caller ([doConnect]) via
+     * `matchesVault`, not here: re-wrapping under a [password] equal to the current one keeps the unlock
+     * password; a different one (only reached after the user confirmed, issue #28) changes it.
      */
     private suspend fun adoptAccountDataKey(syncClient: SyncClient, s: SyncSession, masterKey: MasterKey, password: CharArray): Boolean {
         val wrapped = syncClient.fetchWrappedDataKey(s)
@@ -454,6 +535,35 @@ class SyncCoordinator(
     /** Clear the re-enroll prompt (the user re-enrolled or dismissed it). */
     fun acknowledgeBiometricReset() {
         _biometricResetNeeded.value = false
+    }
+
+    /**
+     * Confirm replacing this device's vault unlock password with the sync password (status
+     * [SyncStatus.NeedsPasswordReplaceConfirm]): re-run the paused connect, this time allowed to adopt the
+     * differing account key. The password kept from the paused connect is handed to the re-run and wiped in
+     * its finally. No-op if nothing is pending (stale tap / already resolved).
+     */
+    fun confirmPasswordReplace() {
+        val pending = pendingReplace ?: return
+        pendingReplace = null
+        _status.value = SyncStatus.Busy
+        scope.launch {
+            opMutex.withLock {
+                doConnect(pending.serverUrl, pending.accountId, pending.password, pending.keepConnected, allowPasswordReplace = true)
+            }
+        }
+    }
+
+    /**
+     * Decline replacing the vault unlock password (status [SyncStatus.NeedsPasswordReplaceConfirm]): wipe the
+     * kept password and return to the prior state (Configured if a link is saved, else Disabled). The account
+     * is untouched and the local vault keeps its current password. No-op if nothing is pending.
+     */
+    fun cancelPasswordReplace() {
+        val pending = pendingReplace ?: return
+        pendingReplace = null
+        pending.password.fill(' ')
+        _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) } ?: SyncStatus.Disabled
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -402,7 +402,8 @@ class SyncCoordinator(
                 } catch (e: SyncException) {
                     if (e.kind != SyncException.Kind.CONFLICT) throw e
                     val s = syncClient.login(accountId, ak, device)
-                    adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())
+                    // Same password on both sides: nothing to re-wrap, only a possible key change.
+                    adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf()) == KeyAdoption.Adopted
                     s
                 }
             } else if (!allowPasswordReplace) {
@@ -433,7 +434,24 @@ class SyncCoordinator(
                 // Confirmed ([confirmPasswordReplace]): log into the existing account and adopt its key,
                 // re-keying this vault to the account password (the intended, consented password change).
                 val s = syncClient.login(accountId, ak, device)
-                adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())
+                when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
+                    KeyAdoption.Adopted -> adoptedKey = true
+                    // The account key already IS ours (registered here, then the vault password was changed
+                    // locally): adoptDataKey keeps the meta in that case, so the unlock password would stay
+                    // the local one and diverge from the account — re-wrap it explicitly instead.
+                    KeyAdoption.AlreadyOurs -> if (!vault.rewrapUnder(masterPassword.copyOf())) {
+                        runCatching { syncClient.close() }
+                        _status.value = SyncStatus.Failed(SyncFailureReason.ConnectFailed, "vault re-key failed")
+                        return
+                    }
+                    // The replace the user confirmed did NOT happen (the account wrap didn't open). Connecting
+                    // now would claim a password change that isn't there, on records we can't decrypt.
+                    KeyAdoption.Undecryptable -> {
+                        runCatching { syncClient.close() }
+                        _status.value = SyncStatus.Failed(SyncFailureReason.ConnectFailed, "account key could not be adopted")
+                        return
+                    }
+                }
                 s
             }
 
@@ -514,12 +532,12 @@ class SyncCoordinator(
      * `matchesVault`, not here: re-wrapping under a [password] equal to the current one keeps the unlock
      * password; a different one (only reached after the user confirmed, issue #28) changes it.
      */
-    private suspend fun adoptAccountDataKey(syncClient: SyncClient, s: SyncSession, masterKey: MasterKey, password: CharArray): Boolean {
+    private suspend fun adoptAccountDataKey(syncClient: SyncClient, s: SyncSession, masterKey: MasterKey, password: CharArray): KeyAdoption {
         val wrapped = syncClient.fetchWrappedDataKey(s)
         val accountDataKey = crypto.unwrapDataKey(masterKey, wrapped)
         if (accountDataKey == null) {
             password.fill(' ')
-            return false
+            return KeyAdoption.Undecryptable
         }
         // Key changed → biometrics is wrapped under the old key and would yield the wrong dataKey on
         // fingerprint unlock: ask the platform to reset it (runCatching — a biometrics failure must not
@@ -529,13 +547,16 @@ class SyncCoordinator(
         if (adopted) {
             if (runCatching { onDataKeyAdopted() }.getOrDefault(false)) _biometricResetNeeded.value = true
         }
-        return adopted
+        return if (adopted) KeyAdoption.Adopted else KeyAdoption.AlreadyOurs
     }
 
     /** Clear the re-enroll prompt (the user re-enrolled or dismissed it). */
     fun acknowledgeBiometricReset() {
         _biometricResetNeeded.value = false
     }
+
+    /** Outcome of [adoptAccountDataKey]: the account key replaced ours, already was ours, or didn't open. */
+    private enum class KeyAdoption { Adopted, AlreadyOurs, Undecryptable }
 
     /**
      * Confirm replacing this device's vault unlock password with the sync password (status

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncIndicator.kt
@@ -29,7 +29,7 @@ fun syncIndicator(status: SyncStatus?, reachable: ServerReachable): SyncIndicato
             ServerReachable.UNREACHABLE -> SyncIndicator("cloud_off", "Sync offline", SyncIndicatorLevel.ERROR)
             ServerReachable.UNKNOWN -> SyncIndicator("sync", "Syncing…", SyncIndicatorLevel.WARN)
         }
-        SyncStatus.Busy -> SyncIndicator("sync", "Syncing…", SyncIndicatorLevel.WARN)
+        SyncStatus.Busy, is SyncStatus.NeedsPasswordReplaceConfirm -> SyncIndicator("sync", "Syncing…", SyncIndicatorLevel.WARN)
         is SyncStatus.Configured -> SyncIndicator("cloud_off", "Sync paused", SyncIndicatorLevel.WARN)
         is SyncStatus.Failed -> SyncIndicator("cloud_off", "Sync error", SyncIndicatorLevel.ERROR)
         SyncStatus.Disabled -> null
@@ -49,7 +49,7 @@ fun syncIndicatorLocalized(status: SyncStatus?, reachable: ServerReachable): Syn
             ServerReachable.UNREACHABLE -> stringResource(Res.string.stail_sync_offline)
             ServerReachable.UNKNOWN -> stringResource(Res.string.stail_syncing)
         }
-        SyncStatus.Busy -> stringResource(Res.string.stail_syncing)
+        SyncStatus.Busy, is SyncStatus.NeedsPasswordReplaceConfirm -> stringResource(Res.string.stail_syncing)
         is SyncStatus.Configured -> stringResource(Res.string.stail_sync_paused)
         is SyncStatus.Failed -> stringResource(Res.string.stail_sync_error)
         // base != null rules out Disabled/null, but the when on status must be exhaustive.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
@@ -107,6 +107,14 @@ fun SyncSetupDialog(sync: SyncCoordinator, onDismiss: () -> Unit) {
         sync.connect(url, acc, pw, keepConnected)
     }
 
+    // Connecting hit an existing account under a different password (issue #28): swap the form for the
+    // re-key confirmation. Placed after the state above so connecting/LaunchedEffect persist and still
+    // close this dialog once the confirmed re-connect reaches Online.
+    (status as? SyncStatus.NeedsPasswordReplaceConfirm)?.let { pending ->
+        PasswordReplaceConfirmDialog(sync, pending.accountId, onDismiss)
+        return
+    }
+
     // ModalScrim (not a hand-rolled Box): registers in ModalPresence so the settings scrim below
     // (this dialog is composed as its sibling at the app root) doesn't reclaim focus and strip the
     // caret from these fields. Esc dismisses; a stray scrim click doesn't (a half-typed master

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -1,0 +1,206 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Issue #28 — the account (remote) password is the single source of truth, and enabling sync must not
+ * silently diverge from, or silently replace, the local vault password:
+ *
+ *  - connecting with the VAULT's own password establishes the account under it, no prompt, no change;
+ *  - connecting with a non-vault password that isn't a real account password is rejected (we never
+ *    register a divergent account);
+ *  - connecting with the password of an EXISTING account (different from the vault's) re-keys this
+ *    device to the account password — but only after the user confirms it.
+ *
+ * The account vault is a real [FileVault] over the system filesystem and crypto is real
+ * [IonspinVaultCrypto] (Argon2id) — the whole point is password/key wrapping, so nothing is faked
+ * there; only the network ([SyncClient]) is stubbed to model the server's account state.
+ */
+class SyncCoordinatorPasswordReplaceTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val vaultPassword = "vault-A"
+    private val accountPassword = "account-B"
+
+    /**
+     * Network stub modelling one account. [existingAccountPassword] = the password the account already
+     * exists under, or `null` if there's no account yet (so `register` creates it). `login` succeeds only
+     * for the matching authKey; `register` collides when the account exists. The wrapped account dataKey is
+     * a DIFFERENT key wrapped under the account password (adopting it re-keys the joining vault).
+     */
+    private inner class FakeAccountClient(existingAccountPassword: String?) : SyncClient {
+        private val expectedAuthKey: ByteArray?
+        private val wrappedAccountKey: ByteArray?
+
+        init {
+            if (existingAccountPassword == null) {
+                expectedAuthKey = null
+                wrappedAccountKey = null
+            } else {
+                val mk = crypto.deriveMasterKey(existingAccountPassword.toCharArray(), crypto.deriveSyncSalt(account))
+                expectedAuthKey = crypto.deriveAuthKey(mk)
+                val accountKey = crypto.newDataKey()
+                wrappedAccountKey = crypto.wrapDataKey(mk, accountKey)
+                mk.zeroize()
+                accountKey.zeroize()
+            }
+        }
+
+        var registered = false; private set
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
+            if (expectedAuthKey != null) throw SyncException(SyncException.Kind.CONFLICT, "account exists")
+            registered = true
+            return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+        }
+
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
+            if (expectedAuthKey != null && authKey.contentEquals(expectedAuthKey)) {
+                return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+            }
+            throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong password") // server hides "no such account"
+        }
+
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray =
+            wrappedAccountKey?.copyOf() ?: throw NotImplementedError("no account")
+
+        override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
+        override suspend fun ping(): Boolean = true
+        override suspend fun close() {}
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
+        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
+        override suspend fun refresh(session: SyncSession): SyncSession = nope()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()
+        private fun nope(): Nothing = throw NotImplementedError("the connect flow should not call this")
+    }
+
+    /** A local vault created under [vaultPassword] (unlocked, with its own random dataKey). */
+    private fun localVault(): Vault {
+        val file = Files.createTempFile("skerry-issue28", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "dev-local", fileSystem = FileSystem.SYSTEM, now = { "2026-07-18T00:00:00Z" })
+            .also { it.create(vaultPassword.toCharArray()) }
+    }
+
+    private fun coordinator(vault: Vault, client: SyncClient): SyncCoordinator = SyncCoordinator(
+        clientFactory = { client },
+        crypto = crypto,
+        vault = vault,
+        engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
+    )
+
+    @Test
+    fun `joining an existing account under a different password pauses without changing the vault password`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            // The bug: the vault unlock password must NOT have silently changed.
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must still work")
+            assertFalse(vault.verifyPassword(accountPassword.toCharArray()), "account password must not have replaced it yet")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `confirming re-keys the vault to the account password`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.confirmPasswordReplace()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            assertFalse(vault.verifyPassword(vaultPassword.toCharArray()), "old vault password must no longer work")
+            assertTrue(vault.verifyPassword(accountPassword.toCharArray()), "account password now unlocks the vault")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `cancelling keeps the vault password and returns to the prior state`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.cancelPasswordReplace()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Disabled } }
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must be untouched")
+            assertFalse(vault.verifyPassword(accountPassword.toCharArray()), "account password must not unlock the vault")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `connecting with the vault password creates the account without prompting`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = null) // no account yet → register
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, vaultPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            assertTrue(client.registered, "account should be registered under the vault password")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "vault password is unchanged")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `connecting with a non-vault password and no matching account is rejected without registering`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = null) // no account exists
+        val sut = coordinator(vault, client)
+        try {
+            // "wrong-C" is neither the vault password nor a real account password.
+            sut.connect(serverUrl, account, "wrong-C".toCharArray())
+            withTimeout(30_000) {
+                sut.status.first { it is SyncStatus.Failed && it.reason == SyncFailureReason.Unauthorized }
+            }
+            assertFalse(client.registered, "must not register a divergent account under a non-vault password")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "vault password is untouched")
+        } finally {
+            sut.close()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -11,6 +11,7 @@ import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncOutcome
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.Vault
@@ -55,7 +56,13 @@ class SyncCoordinatorPasswordReplaceTest {
      * for the matching authKey; `register` collides when the account exists. The wrapped account dataKey is
      * a DIFFERENT key wrapped under the account password (adopting it re-keys the joining vault).
      */
-    private inner class FakeAccountClient(existingAccountPassword: String?) : SyncClient {
+    private inner class FakeAccountClient(
+        existingAccountPassword: String?,
+        /** The account key to publish. `null` = a fresh random one (a genuinely foreign account). */
+        accountDataKey: DataKey? = null,
+        /** Serve a wrap that can't be unwrapped, modelling a corrupted/mismatched server record. */
+        private val corruptWrap: Boolean = false,
+    ) : SyncClient {
         private val expectedAuthKey: ByteArray?
         private val wrappedAccountKey: ByteArray?
 
@@ -66,10 +73,10 @@ class SyncCoordinatorPasswordReplaceTest {
             } else {
                 val mk = crypto.deriveMasterKey(existingAccountPassword.toCharArray(), crypto.deriveSyncSalt(account))
                 expectedAuthKey = crypto.deriveAuthKey(mk)
-                val accountKey = crypto.newDataKey()
-                wrappedAccountKey = crypto.wrapDataKey(mk, accountKey)
+                val key = accountDataKey ?: crypto.newDataKey()
+                wrappedAccountKey = crypto.wrapDataKey(mk, key)
                 mk.zeroize()
-                accountKey.zeroize()
+                key.zeroize()
             }
         }
 
@@ -88,8 +95,11 @@ class SyncCoordinatorPasswordReplaceTest {
             throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong password") // server hides "no such account"
         }
 
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray =
-            wrappedAccountKey?.copyOf() ?: throw NotImplementedError("no account")
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
+            val wrap = wrappedAccountKey?.copyOf() ?: throw NotImplementedError("no account")
+            if (corruptWrap) wrap.indices.forEach { wrap[it] = 0 }
+            return wrap
+        }
 
         override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
         override suspend fun ping(): Boolean = true
@@ -188,6 +198,59 @@ class SyncCoordinatorPasswordReplaceTest {
             sut.confirmPasswordReplace()
             assertTrue(sut.status.value is SyncStatus.Disabled, "a stale confirm must be a no-op, not a re-connect")
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must be untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The account key can already BE this vault's key while the passwords have diverged: register under a
+     * password, then change the vault password locally (Settings → Security). Reconnecting with the account
+     * password then confirms a replace that [Vault.adoptDataKey] refuses to perform — it deliberately keeps
+     * the meta when the key is unchanged — so without an explicit re-wrap the vault would keep unlocking
+     * with the local password while the account stays on its own: exactly the divergence of issue #28,
+     * only this time with the user's consent on screen.
+     */
+    @Test
+    fun `confirming re-keys the vault even when the account key is already ours`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val ourKey = vault.exportDataKey()!!
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, accountDataKey = ourKey)
+        val sut = coordinator(vault, client)
+        try {
+            // The vault password drifts away from the account password (Settings → Security).
+            assertTrue(vault.changePassword(vaultPassword.toCharArray(), "changed-X".toCharArray()))
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.confirmPasswordReplace()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online, "connects: the key is ours, only the wrap changes")
+            assertTrue(vault.verifyPassword(accountPassword.toCharArray()), "the account password now unlocks the vault")
+            assertFalse(vault.verifyPassword("changed-X".toCharArray()), "the old local password no longer unlocks")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * If the account's wrapped key can't be unwrapped, the local key stays — so the confirmed replace did
+     * NOT happen. Connecting anyway would leave the user believing a password change they consented to
+     * took effect, on a device whose records can't decrypt. Fail the connect instead.
+     */
+    @Test
+    fun `confirming fails loudly when the account key cannot be adopted`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, corruptWrap = true)
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.confirmPasswordReplace()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Failed, "must not report success on a replace that didn't happen")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is left as it was")
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -170,6 +170,30 @@ class SyncCoordinatorPasswordReplaceTest {
     }
 
     @Test
+    fun `dismissing the confirmation resolves the paused connect instead of only hiding it`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        var closed = false
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            // Esc on the desktop modal (and leaving the mobile screen): it must decline the replace, not
+            // leave the connect paused with the
+            // kept password alive and the status stuck on NeedsPasswordReplaceConfirm ("Syncing…" forever).
+            dismissPasswordReplace(sut) { closed = true }.invoke()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Disabled } }
+            assertTrue(closed, "the modal still closes")
+            // Nothing left pending: a stale confirm (reopened dialog, queued tap) can't re-key the vault.
+            sut.confirmPasswordReplace()
+            assertTrue(sut.status.value is SyncStatus.Disabled, "a stale confirm must be a no-op, not a re-connect")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must be untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
     fun `connecting with the vault password creates the account without prompting`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
@@ -174,21 +174,36 @@ class FileVault(
                 newDataKey.bytes.fill(0)
                 return@synchronized false
             }
-            val newSalt = crypto.newSalt()
-            val newMaster = crypto.deriveMasterKey(password, newSalt)
-            val newWrapped = crypto.wrapDataKey(newMaster, newDataKey)
-            newMaster.bytes.fill(0)
-            val newMeta = VaultMeta(FORMAT_VERSION, newSalt, newWrapped)
             // Records stay as-is: synced ones will arrive under the new key; local ones (under the
             // old key) become unreadable. Commit happens after persist — a failed write leaves fields untouched.
-            writeFile(newMeta, records.toList())
+            rewrapMeta(newDataKey, password)
             key.bytes.fill(0) // old key no longer needed
             dataKey = newDataKey
-            meta = newMeta
             true
         } finally {
             password.fill(' ')
         }
+    }
+
+    override fun rewrapUnder(password: CharArray): Boolean = synchronized(lock) {
+        try {
+            val key = dataKey ?: return@synchronized false
+            rewrapMeta(key, password)
+            true
+        } finally {
+            password.fill(' ')
+        }
+    }
+
+    /** Persist new metadata binding [key] to [password] (fresh salt + wrap); commits [meta] on success. */
+    private fun rewrapMeta(key: DataKey, password: CharArray) {
+        val newSalt = crypto.newSalt()
+        val newMaster = crypto.deriveMasterKey(password, newSalt)
+        val newWrapped = crypto.wrapDataKey(newMaster, key)
+        newMaster.bytes.fill(0)
+        val newMeta = VaultMeta(FORMAT_VERSION, newSalt, newWrapped)
+        writeFile(newMeta, records.toList())
+        meta = newMeta
     }
 
     override fun rekeyRecords(newKey: DataKey): Boolean = synchronized(lock) {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
@@ -224,4 +224,20 @@ interface Vault {
      * password to the clipboard — without unlocking again. The password is wiped.
      */
     fun verifyPassword(password: CharArray): Boolean
+
+    /**
+     * Re-wrap the CURRENT dataKey under [password], leaving the key and the records alone: the vault
+     * starts unlocking with [password] and nothing else changes. Requires an unlocked vault; `false` if
+     * the vault is locked or the implementation doesn't support it.
+     *
+     * Unlike [changePassword] this does not verify an old password — the caller must have established the
+     * user's intent by other means. The one such caller is the sync connect flow (issue #28), which needs
+     * the vault to end up on the account password after the user confirmed exactly that, in the case
+     * [adoptDataKey] refuses to help with: the account key already IS this vault's key, so there is no key
+     * to adopt, only a wrap to redo. The password is wiped.
+     */
+    fun rewrapUnder(password: CharArray): Boolean {
+        password.fill(' ')
+        return false
+    }
 }


### PR DESCRIPTION
## Problem

Issue #28: enabling sync could silently change the local vault unlock password, or silently
leave the local vault password and the account password diverged. Root cause: the sync flow
treated the "sync password" as an independent secret and used it for the account while the
vault kept its own password.

The account (remote) password is the **single source of truth** — every device shares one
account dataKey wrapped under it, so a synced vault must unlock with the account password. And
the account password is immutable via connect (SRP login requires the correct password; the
server has no verifier-update endpoint).

## Change

`SyncCoordinator.doConnect` now branches on `matchesVault = vault.verifyPassword(typed)`:

- **typed == vault password** → register a new account under it, or on CONFLICT log into our own
  account and adopt its key. Adopting here never changes the unlock password.
- **typed ≠ vault password** → never register (creating an account under a non-vault password is
  what split the local unlock password from the account password). Login-only; on success pause
  with a new `SyncStatus.NeedsPasswordReplaceConfirm` so the user explicitly confirms that this
  device will start unlocking with the account password (`confirmPasswordReplace` /
  `cancelPasswordReplace`).
- wrong / non-existent → `Unauthorized`; nothing is created.

UI: shared `PasswordReplaceConfirm` component (+ desktop modal), wired into the desktop
`SyncSetupDialog` and the mobile sync screen; `sync_password_replace_*` strings in en + ru + zh; all
exhaustive `when(status)` sites updated.

### Dismissing the confirmation (869f717)

Pausing the connect means holding the typed password until the user answers, so every way out of the
prompt has to answer it. Dismissing without answering used to leave the pending replace behind: the
password copy stayed in memory and the status was stuck on `NeedsPasswordReplaceConfirm`, i.e. a sync
indicator reading "Syncing…" with no route back to the prompt.

- desktop: `dismissPasswordReplace` declines the replace before the modal's `onDismiss` (Esc — a scrim
  click is deliberately swallowed by `ModalScrim`);
- mobile: the confirmation is inline, and the system back gesture goes through `MobileDesignApp`'s
  handler straight to `state.pop()`, bypassing the header's `onBack` — so the decline hangs off
  `onDispose` of the status branch instead, covering back, gesture and tab switch alike. Leaving via
  confirm/cancel is a no-op: both clear the pending first.

## Test plan

- [x] `SyncCoordinatorPasswordReplaceTest` (real `FileVault` + `IonspinVaultCrypto`): pause /
      confirm / cancel, happy register under the vault password, rejection of a non-vault
      password, and dismissal (status returns to `Disabled`, a stale `confirmPasswordReplace()` is a
      no-op, the vault password is untouched) — all green.
- [x] `./gradlew :composeApp:desktopTest` passes.
- [x] `./gradlew :androidApp:compileDebugKotlin` passes (desktop ⇆ Android parity).
- [x] The four flows from
      [the walkthrough on #28](https://github.com/SeCherkasov/SkerrySSH/issues/28#issuecomment-5020266781)
      run end to end against a **real server** (`server/Dockerfile` on `127.0.0.1:8080`), real `FileVault`s,
      real Argon2id and the production `KtorSyncClient` — i.e. the whole desktop stack below Compose:
  - connect with the vault's own password → `Online`, no prompt, the password still unlocks;
  - a non-vault password with no such account → `Unauthorized`, nothing registered (a later connect with
    the vault password still *registers* the account rather than colliding);
  - joining an account that exists under another password → pauses; cancel leaves the old password
    working; confirm re-keys the device, requests a biometric re-enroll, and the other device's record
    decrypts locally;
  - dismissing the prompt → status leaves `NeedsPasswordReplaceConfirm`, a stale confirm is a no-op, the
    vault password is untouched.
- [ ] **Not covered:** the Compose layer itself — a real Esc key press on the desktop window and the
      Android `onDispose` when leaving the sync screen. Both are one-line wirings onto code paths the run
      above exercises, but neither has been driven through an actual UI.

## Follow-up (separate PR)

Changing the account password itself — a dedicated Security action that re-wraps the account
dataKey under a new master, updates the server SRP verifier, and signals other devices to
re-authenticate — is intentionally **out of scope** here and tracked in #32.

Closes #28

