### PR TITLE
Fix resource leaks on session teardown and failed channel setup

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -516,6 +516,7 @@ class ConnectionController(
      */
     private fun releaseSessionResources() {
         val conn = connection
+        portForwards?.stop()
         portForwards?.closeAll()
         portForwards = null
         val sftp = sftpClient

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/PortForwardController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/PortForwardController.kt
@@ -99,15 +99,19 @@ class PortForwardController(
 
     private var nextId = 0L
 
-    init {
-        // Telemetry polling runs on the session scope: for each active forward, samples byte
-        // counters and derives rate (bytes/s) from the delta. Exits via isActive on scope cancel.
-        scope.launch {
-            while (isActive) {
-                delay(pollIntervalMillis)
-                pollTelemetry()
-            }
+    // Telemetry polling: for each active forward, samples byte counters and derives rate (bytes/s)
+    // from the delta. [scope] is the shared controller scope that outlives the session, so session
+    // teardown must call [stop] — nothing cancels this job otherwise.
+    private val pollJob = scope.launch {
+        while (isActive) {
+            delay(pollIntervalMillis)
+            pollTelemetry()
         }
+    }
+
+    /** Stops the telemetry poller. Session teardown; the controller is not reusable afterwards. */
+    fun stop() {
+        pollJob.cancel()
     }
 
     internal fun pollTelemetry() {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -184,6 +184,8 @@ class TeamsCoordinator(
                 keyStore.remove(gone)
                 teamVaults.reset(gone)
             }
+            // A cached invite of a vanished team holds teamKey material — drop it with the team.
+            verifiedInvites.update { cached -> cached.filterKeys { it in liveIds } }
             onTeamsChanged()
             maybeRecoverKeys()
         }
@@ -565,7 +567,7 @@ class TeamsCoordinator(
         }
     }
 
-    private class VerifiedInvite(val payload: TeamInvitePayload)
+    internal class VerifiedInvite(val payload: TeamInvitePayload)
 
     /**
      * Open the invite envelope for [teamId] and verify the inviter's signature and binding. Returns
@@ -585,7 +587,7 @@ class TeamsCoordinator(
         }
     }
 
-    private fun cachedInvite(teamId: String): VerifiedInvite? = verifiedInvites.value[teamId]
+    internal fun cachedInvite(teamId: String): VerifiedInvite? = verifiedInvites.value[teamId]
 
     /** Open the team vault under [key] (no stale-file handling — used where the exact key is known). */
     private fun openTeamVault(teamId: String, key: DataKey): Vault? {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -22,6 +22,7 @@ import app.skerry.shared.ssh.SshTransport
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -545,6 +546,24 @@ class ConnectionControllerTest {
 
         assertEquals(2, conn.roundTrips)
         scope.cancel()
+    }
+
+    @Test
+    fun `disconnect stops the port-forward telemetry poller`() = runTest {
+        val conn = FakeSshConnection(FakeShellChannel())
+        val (controller, scope) = controllerWith(FakeSshTransport(conn))
+        controller.connect(target, SshAuth.Password("pw"))
+        controller.openPortForwards()
+
+        controller.disconnect()
+
+        // The forward controller polls on the shared controller scope (it outlives the session), so
+        // disconnect must cancel the poll job — otherwise every closed session leaks a live loop.
+        // Check before cancel, but cancel unconditionally: a leaked poller re-schedules forever and
+        // would hang runTest's idle-wait.
+        val leaked = scope.coroutineContext[Job]!!.children.any { it.isActive }
+        scope.cancel()
+        assertFalse(leaked)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/PortForwardControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/PortForwardControllerTest.kt
@@ -12,11 +12,13 @@ import app.skerry.shared.ssh.ShellChannel
 import app.skerry.shared.ssh.SshConnection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -157,6 +159,19 @@ class PortForwardControllerTest {
         assertEquals(5500, entry.bytesUp)
         assertEquals(500, entry.upRate)
         assertEquals(0, entry.downRate)
+    }
+
+    @Test
+    fun `stop cancels the telemetry poller`() {
+        val job = Job()
+        val scope = CoroutineScope(UnconfinedTestDispatcher() + job)
+        val controller = PortForwardController(FakeForwardConnection(localPort = 50004), scope)
+
+        controller.stop()
+
+        val leaked = job.children.any { it.isActive }
+        job.cancel()
+        assertFalse(leaked)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
@@ -1,0 +1,115 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamIdentityStore
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The verified-invite cache holds decrypted teamKey material, so it must not outlive the invite:
+ * a team that vanished from the server (revoked invite, deleted team) has to drop its cached entry
+ * on the next refresh, not linger until accept/leave/lock.
+ */
+class TeamsCoordinatorInviteCacheTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val teamId = "team-inv"
+    private val self = "alice@example.com"
+    private val bob = "bob@example.com"
+
+    /** Fake team network: a mutable team list and the inviter's published keys. */
+    private class FakeInviteClient(
+        private val inviterId: String,
+        private val inviterKeys: AccountKeys,
+    ) : TeamClient {
+        var teams: List<TeamSummary> = emptyList()
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = teams
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? =
+            if (accountId == inviterId) inviterKeys else null
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = emptyList()
+        override suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage =
+            RecordPage(emptyList(), since)
+        override suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage =
+            RecordPage(emptyList(), 0)
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) = error("unused")
+        override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+    }
+
+    @Test
+    fun `refresh drops the cached invite of a team gone from the server`() = runBlocking {
+        initializeVaultCrypto()
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile)
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        val identity = TeamIdentityStore(vault, crypto).ensure()
+
+        val bobSigning = crypto.newSigningKeyPair()
+        val envelope = TeamInviteCodec(crypto).seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = bobSigning,
+            inviterId = bob,
+            inviteeId = self,
+            teamId = teamId,
+            teamKey = crypto.newDataKey(),
+            teamName = "Ops",
+            epoch = 0,
+        )
+        val client = FakeInviteClient(bob, AccountKeys(crypto.newSharingKeyPair().publicKey, bobSigning.publicKey))
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
+                status = TeamMemberStatus.INVITED, createdAt = 0, memberCount = 2,
+                envelope = envelope, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+        val coord = TeamsCoordinator(
+            session = { SyncSession(self, "access", "refresh") },
+            client = { client },
+            vault = vault,
+            crypto = crypto,
+            teamVaults = TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }),
+            teamState = InMemorySyncStateStore(),
+            newTeamId = { "unused" },
+        )
+
+        assertNotNull(coord.acceptPreview(teamId)) // banner shown: the verified invite is now cached
+        client.teams = emptyList() // invite revoked / team deleted server-side
+        coord.refresh()
+
+        assertNull(coord.cachedInvite(teamId))
+    }
+
+    private companion object {
+        const val NOW = "2026-07-20T00:00:00Z"
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjConnectionCleanupTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjConnectionCleanupTest.kt
@@ -1,0 +1,92 @@
+package app.skerry.shared.ssh
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import net.schmizz.sshj.common.LoggerFactory
+import net.schmizz.sshj.common.Message
+import net.schmizz.sshj.common.SSHException
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.ConnectionException
+import net.schmizz.sshj.connection.channel.direct.PTYMode
+import net.schmizz.sshj.connection.channel.direct.Session
+
+/** Failure paths of channel/listener setup must not leak the half-open resource. */
+class SshjConnectionCleanupTest {
+
+    @Test
+    fun `a failed bind closes the socket it created`() {
+        ServerSocket().use { taken ->
+            taken.bind(InetSocketAddress("127.0.0.1", 0))
+            var created: ServerSocket? = null
+
+            assertFailsWith<PortForwardException> {
+                bindForwardListener("127.0.0.1", taken.localPort) { ServerSocket().also { created = it } }
+            }
+
+            assertTrue(created!!.isClosed)
+        }
+    }
+
+    @Test
+    fun `a rejected pty closes the session channel`() {
+        val session = PtyRejectingSession()
+
+        assertFailsWith<ConnectionException> {
+            openShellChannel(session, PtySize(cols = 80, rows = 24, widthPx = 640, heightPx = 480), "xterm")
+        }
+
+        assertTrue(session.closed)
+    }
+}
+
+/** Stub session whose PTY request fails, like a server rejecting pty-req would. */
+private class PtyRejectingSession : Session {
+    var closed = false
+
+    override fun allocatePTY(
+        term: String,
+        cols: Int,
+        rows: Int,
+        width: Int,
+        height: Int,
+        modes: MutableMap<PTYMode, Int>,
+    ): Unit = throw ConnectionException("pty rejected")
+
+    override fun close() {
+        closed = true
+    }
+
+    override fun allocateDefaultPTY(): Unit = throw UnsupportedOperationException()
+    override fun exec(command: String): Session.Command = throw UnsupportedOperationException()
+    override fun reqX11Forwarding(authProto: String, authCookie: String, screen: Int): Unit =
+        throw UnsupportedOperationException()
+    override fun setEnvVar(name: String, value: String): Unit = throw UnsupportedOperationException()
+    override fun startShell(): Session.Shell = throw UnsupportedOperationException()
+    override fun startSubsystem(name: String): Session.Subsystem = throw UnsupportedOperationException()
+    override fun getAutoExpand(): Boolean = throw UnsupportedOperationException()
+    override fun getID(): Int = throw UnsupportedOperationException()
+    override fun getInputStream(): InputStream = throw UnsupportedOperationException()
+    override fun getLocalMaxPacketSize(): Int = throw UnsupportedOperationException()
+    override fun getLocalWinSize(): Long = throw UnsupportedOperationException()
+    override fun getOutputStream(): OutputStream = throw UnsupportedOperationException()
+    override fun getRecipient(): Int = throw UnsupportedOperationException()
+    override fun getRemoteCharset(): Charset = throw UnsupportedOperationException()
+    override fun getRemoteMaxPacketSize(): Int = throw UnsupportedOperationException()
+    override fun getRemoteWinSize(): Long = throw UnsupportedOperationException()
+    override fun getType(): String = throw UnsupportedOperationException()
+    override fun isOpen(): Boolean = throw UnsupportedOperationException()
+    override fun setAutoExpand(autoExpand: Boolean): Unit = throw UnsupportedOperationException()
+    override fun join(): Unit = throw UnsupportedOperationException()
+    override fun join(timeout: Long, unit: TimeUnit): Unit = throw UnsupportedOperationException()
+    override fun isEOF(): Boolean = throw UnsupportedOperationException()
+    override fun getLoggerFactory(): LoggerFactory = throw UnsupportedOperationException()
+    override fun handle(msg: Message, buf: SSHPacket): Unit = throw UnsupportedOperationException()
+    override fun notifyError(error: SSHException): Unit = throw UnsupportedOperationException()
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.connection.ConnectionException
+import net.schmizz.sshj.connection.channel.direct.Session
 import net.schmizz.sshj.connection.channel.forwarded.RemotePortForwarder
 import net.schmizz.sshj.transport.TransportException
 
@@ -85,9 +86,7 @@ internal class SshjConnection(
     override suspend fun openShell(size: PtySize, term: String): ShellChannel =
         withContext(Dispatchers.IO) {
             try {
-                val session = client.startSession()
-                session.allocatePTY(term, size.cols, size.rows, size.widthPx, size.heightPx, emptyMap())
-                SshjShellChannel(session, session.startShell())
+                openShellChannel(client.startSession(), size, term)
             } catch (e: IOException) {
                 throw SshConnectionException("Failed to open shell channel", e)
             }
@@ -106,7 +105,7 @@ internal class SshjConnection(
             // Each accepted connection is tunneled ourselves through a direct-tcpip channel to
             // destHost:destPort — this gives traffic counters and pause (see [SshjLocalForward]);
             // sshj's stock LocalPortForwarder hides the pumping internally.
-            SshjLocalForward(client, bindListener(spec.bindHost, spec.bindPort), spec.destHost, spec.destPort)
+            SshjLocalForward(client, bindForwardListener(spec.bindHost, spec.bindPort), spec.destHost, spec.destPort)
         }
 
     override suspend fun forwardRemote(spec: RemoteForwardSpec): PortForward =
@@ -128,21 +127,7 @@ internal class SshjConnection(
     override suspend fun forwardDynamic(spec: DynamicForwardSpec): PortForward =
         withContext(Dispatchers.IO) {
             // Listener as for `-L`; each accepted connection then speaks the SOCKS5 protocol.
-            SshjDynamicForward(client, bindListener(spec.bindHost, spec.bindPort))
-        }
-
-    /**
-     * Bind a local listener for forwards (`-L`, `-D`): bound ourselves so the actual port can be read
-     * when bindPort=0, and "port in use" is caught as [PortForwardException] before the accept loop starts.
-     */
-    private fun bindListener(bindHost: String, bindPort: Int): ServerSocket =
-        try {
-            ServerSocket().apply {
-                reuseAddress = true
-                bind(InetSocketAddress(bindHost, bindPort))
-            }
-        } catch (e: IOException) {
-            throw PortForwardException("Failed to bind local port $bindHost:$bindPort", e)
+            SshjDynamicForward(client, bindForwardListener(spec.bindHost, spec.bindPort))
         }
 
     override suspend fun disconnect() {
@@ -185,3 +170,39 @@ internal class SshjConnection(
         const val MAX_EXEC_OUTPUT_BYTES = 1 * 1024 * 1024 // 1 MiB per stdout and per stderr
     }
 }
+
+/**
+ * Bind a local listener for forwards (`-L`, `-D`): bound ourselves so the actual port can be read
+ * when bindPort=0, and "port in use" is caught as [PortForwardException] before the accept loop
+ * starts. The socket is closed on a failed bind — its fd would otherwise linger until GC.
+ */
+internal fun bindForwardListener(
+    bindHost: String,
+    bindPort: Int,
+    newSocket: () -> ServerSocket = ::ServerSocket,
+): ServerSocket {
+    var socket: ServerSocket? = null
+    return try {
+        newSocket().apply {
+            socket = this
+            reuseAddress = true
+            bind(InetSocketAddress(bindHost, bindPort))
+        }
+    } catch (e: IOException) {
+        runCatching { socket?.close() }
+        throw PortForwardException("Failed to bind local port $bindHost:$bindPort", e)
+    }
+}
+
+/**
+ * Open the shell on an already-open [session] channel. On a failed PTY/shell request the channel is
+ * closed before rethrowing — abandoned open channels accumulate on the connection until disconnect.
+ */
+internal fun openShellChannel(session: Session, size: PtySize, term: String): SshjShellChannel =
+    try {
+        session.allocatePTY(term, size.cols, size.rows, size.widthPx, size.heightPx, emptyMap())
+        SshjShellChannel(session, session.startShell())
+    } catch (e: Exception) {
+        runCatching { session.close() }
+        throw e
+    }


### PR DESCRIPTION
## What

Fixes four resource leaks found by a leak-focused review of the codebase:

1. **Port-forward telemetry poller outlived the session** (the main one). `PortForwardController` starts an infinite 1s polling loop on the shared controller scope, which lives for the whole app process — and nothing ever cancelled it. Every session that opened the tunnels panel leaked a live coroutine (and the controller it captured) until app exit. The poll loop is now a `pollJob` with a `stop()`, called from `ConnectionController.releaseSessionResources()` alongside the existing `ping`/`metrics`/`throughput` stops.
2. **`SshjConnection.openShell`**: if `allocatePTY`/`startShell` threw, the already-open session channel was abandoned unclosed and accumulated on the connection until disconnect. Extracted `openShellChannel` closes it before rethrowing.
3. **`SshjConnection` forward bind**: a failed local bind (`-L`/`-D`, e.g. port already in use) leaked the `ServerSocket` fd until GC. Extracted `bindForwardListener` closes it on failure.
4. **`TeamsCoordinator`**: cached verified invites hold decrypted teamKey material and were only cleared on accept/leave/lock. `refresh()` now also drops entries for teams that vanished from the server (revoked invite, deleted team).

## Tests (TDD)

Each fix landed test-first:

- `ConnectionControllerTest`: `disconnect stops the port-forward telemetry poller` — before the fix this test hung the suite (the leaked poller re-scheduled forever on the test scheduler), which is the leak demonstrating itself; the committed form checks the leak flag before cancelling the scope so a regression fails fast instead of hanging.
- `PortForwardControllerTest`: `stop cancels the telemetry poller`.
- `SshjConnectionCleanupTest` (new): failed bind closes the socket (occupied port + injected socket factory); rejected PTY closes the channel (stub sshj `Session`).
- `TeamsCoordinatorInviteCacheTest` (new): real crypto, sealed invite envelope, server-side revocation → cache dropped on refresh.

`:shared:desktopTest` + `:composeApp:desktopTest` green, `:composeApp:compileAndroidMain` green. Kotlin review pass: no CRITICAL/HIGH findings; the two minor notes (exception wrapping edge in the bind helper, import order) are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)