### PR TITLE
Localize every user-facing string across the app

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
-        android:label="Skerry"
+        android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar">
         <activity

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Android platform resources only (launcher label). The app's UI strings live in
+  composeApp/src/commonMain/composeResources — this file exists so the manifest has no hardcoded
+  text and a locale-specific launcher label stays possible.
+-->
+<resources>
+    <string name="app_name">Skerry</string>
+</resources>

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.android.kt
@@ -24,7 +24,8 @@ actual fun platformLocalBrowser(): FileBrowser {
     return LocalFileBrowser(
         fileSystem = FileSystem.SYSTEM,
         home = home,
-        label = "On this device",
+        // Blank on purpose: the UI substitutes the localized `ftail_local_label` (parity with desktop).
+        label = "",
         ioDispatcher = Dispatchers.IO,
     )
 }

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/sftp/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/sftp/FilePicker.android.kt
@@ -4,13 +4,14 @@ import android.content.Context
 import android.net.Uri
 import android.provider.DocumentsContract
 import android.provider.OpenableColumns
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
-import java.io.IOException
 import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -45,7 +46,7 @@ actual suspend fun pickUploadSource(): UploadSource? {
         withContext(Dispatchers.IO) {
             ctx.contentResolver.openInputStream(uri)?.use { input ->
                 staging.outputStream().use { output -> input.copyTo(output) }
-            } ?: throw IOException("Failed to open the selected file")
+            } ?: throw FileBrowserException(FileBrowserFailure.OpenSource)
         }
         SafUploadSource(name, staging)
     } catch (e: CancellationException) {
@@ -72,7 +73,7 @@ private class SafDownloadTarget(
         try {
             ctx.contentResolver.openOutputStream(uri)?.use { output ->
                 staging.inputStream().use { input -> input.copyTo(output) }
-            } ?: throw IOException("Failed to open the write target")
+            } ?: throw FileBrowserException(FileBrowserFailure.OpenTarget)
         } finally {
             staging.delete()
         }

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -84,4 +84,19 @@
     <string name="conn_test_connected">Подключено</string>
     <string name="conn_test_rtt_ms">%1$d мс</string>
     <string name="conn_test_incomplete">Введите хост, логин и данные для входа</string>
+
+    <string name="conn_test_err_auth">Не удалось пройти аутентификацию</string>
+    <string name="conn_test_err_host_key">Ключ хоста отклонён</string>
+    <string name="conn_test_err_connection">Не удалось подключиться</string>
+    <string name="conn_error_failed">Не удалось подключиться</string>
+    <string name="conn_error_failed_detail">Не удалось подключиться (%1$s)</string>
+
+    <string name="conn_tunnel_error_host_missing">Хост не найден</string>
+    <string name="conn_tunnel_error_no_credential">Нет сохранённых учётных данных</string>
+
+    <string name="conn_serial_err_unsupported">На этом устройстве последовательные порты недоступны.</string>
+    <string name="conn_serial_err_not_found">Порт %1$s не найден. Переподключите устройство или выберите другой порт.</string>
+    <string name="conn_serial_err_permission">Доступ к порту %1$s запрещён.</string>
+    <string name="conn_serial_err_open">Не удалось открыть порт %1$s — возможно, он занят другой программой.</string>
+    <string name="conn_serial_err_configure">Порт %1$s не принял выбранную скорость или формат кадра.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
@@ -15,8 +15,28 @@
     <!-- Резервные сообщения об ошибках контроллеров/эффектов -->
     <string name="ftail_open_failed">Не удалось открыть SFTP</string>
     <string name="ftail_transfer_error">Ошибка передачи</string>
-    <string name="ftail_sftp_error">Ошибка SFTP</string>
-    <string name="ftail_file_pane_error">Ошибка файловой панели</string>
     <string name="ftail_delete_source_failed">Не удалось удалить источник после переноса</string>
     <string name="ftail_file_fallback">файл</string>
+
+    <!-- Типизированные ошибки файлового браузера/передачи (сырой текст платформы не показывается) -->
+    <string name="ftail_err_local_io">Ошибка локальной файловой системы</string>
+    <string name="ftail_err_sftp">Ошибка SFTP</string>
+    <string name="ftail_err_illegal_name">Недопустимое имя в списке файлов</string>
+    <string name="ftail_err_open_source">Не удалось открыть выбранный файл</string>
+    <string name="ftail_err_open_target">Не удалось открыть файл для записи</string>
+
+    <!-- Локальная файловая система: подпись панели и «хлебных крошек» -->
+    <string name="ftail_local_label">Это устройство</string>
+
+    <!-- Шаблоны размера: название единицы и десятичный разделитель переводятся -->
+    <string name="ftail_size_bytes">%1$d Б</string>
+    <string name="ftail_size_kb">%1$d,%2$d КБ</string>
+    <string name="ftail_size_mb">%1$d,%2$d МБ</string>
+    <string name="ftail_size_gb">%1$d,%2$d ГБ</string>
+    <string name="ftail_size_tb">%1$d,%2$d ТБ</string>
+    <string name="ftail_size_pb">%1$d,%2$d ПБ</string>
+
+    <!-- Строка передачи: имя файла со счётчиком пакета и «передано из общего» -->
+    <string name="ftail_transfer_counter">%1$s (%2$d/%3$d)</string>
+    <string name="ftail_transfer_progress">%1$s из %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -79,13 +79,11 @@
     <string name="lib_teams_accept">Принять</string>
     <string name="lib_teams_decline">Отклонить</string>
     <string name="lib_teams_role_owner">ВЛАДЕЛЕЦ</string>
-    <string name="lib_teams_role_member">УЧАСТНИК</string>
     <string name="lib_teams_role_admin">АДМИН</string>
     <string name="lib_teams_role_editor">РЕДАКТОР</string>
     <string name="lib_teams_role_viewer">НАБЛЮДАТЕЛЬ</string>
     <string name="lib_teams_status_invited">ПРИГЛАШЁН</string>
     <string name="lib_teams_invite_role">Роль</string>
-    <string name="lib_teams_change_role">Сменить роль</string>
     <string name="lib_teams_role_picker_title">Роль участника</string>
     <string name="lib_teams_history">Журнал</string>
     <string name="lib_teams_history_title">Журнал команды</string>
@@ -97,16 +95,17 @@
     <string name="lib_teams_event_role_change">Сменил роль</string>
     <string name="lib_teams_event_share">Поделился записями</string>
     <string name="lib_teams_event_delete">Удалил команду</string>
+    <!-- Фолбэк для неизвестного клиенту кода события аудита; %1$s — исходный код с сервера -->
+    <string name="lib_teams_event_unknown">Другое событие (%1$s)</string>
+    <string name="lib_teams_shared_hosts_count">Общие хосты · %1$d</string>
+    <string name="lib_teams_shared_snippets_count">Общие сниппеты · %1$d</string>
     <string name="lib_teams_members_count">Участников: %1$d</string>
-    <string name="lib_teams_shared_hosts">Общие хосты</string>
-    <string name="lib_teams_shared_snippets">Общие сниппеты</string>
     <string name="lib_teams_share_host">Поделиться хостом</string>
     <string name="lib_teams_share_snippet">Поделиться сниппетом</string>
     <string name="lib_teams_share_host_title">Поделиться хостом с командой</string>
     <string name="lib_teams_share_snippet_title">Поделиться сниппетом с командой</string>
     <string name="lib_teams_share_empty">Делиться больше нечем</string>
     <string name="lib_teams_nothing_shared">Пока ничем не поделились</string>
-    <string name="lib_teams_unshare">Убрать из команды</string>
     <string name="lib_teams_sync_now">Синхронизировать</string>
     <string name="lib_teams_no_key">Ключ команды ещё не доехал до этого устройства</string>
     <string name="lib_teams_remove_member_title">Удалить участника</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ptail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ptail.xml
@@ -11,4 +11,12 @@
     <string name="ptail_err_forward_failed">Не удалось пробросить порт</string>
     <string name="ptail_err_connection_failed">Ошибка подключения</string>
     <string name="ptail_forward_raise_failed">Не удалось поднять проброс</string>
+
+    <!-- Колонка SOURCE для удалённого (-R) проброса: слушатель на стороне сервера -->
+    <string name="ptail_source_server">сервер:%1$d</string>
+
+    <!-- Шаблоны скорости: название единицы и десятичный разделитель переводятся -->
+    <string name="ptail_rate_bytes">%1$d Б/с</string>
+    <string name="ptail_rate_kb">%1$d КБ/с</string>
+    <string name="ptail_rate_mb">%1$d,%2$d МБ/с</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -12,7 +12,6 @@
     <string name="settings_revoke">Отозвать</string>
     <string name="settings_change">Изменить</string>
     <string name="settings_manage">Управление</string>
-    <string name="settings_on">Вкл</string>
 
     <!-- Раздел AI -->
     <string name="settings_ai_title">AI</string>
@@ -50,7 +49,19 @@
     <string name="settings_ai_local_cancel">Отмена</string>
     <string name="settings_ai_local_delete">Удалить</string>
     <string name="settings_ai_local_retry">Повторить</string>
+    <string name="settings_ai_local_error_network">Ошибка сети — загрузка продолжится с места остановки.</string>
+    <string name="settings_ai_local_error_integrity">Скачанный файл не прошёл проверку. Попробуйте ещё раз.</string>
+    <string name="settings_ai_local_error_unknown">Не удалось скачать модель. Попробуйте ещё раз.</string>
     <string name="settings_ai_prompt_placeholder_needs_model">Сначала скачайте локальную модель</string>
+
+    <!-- Ошибки запроса к ИИ (быстрый чат и панель ИИ в терминале) -->
+    <string name="settings_ai_error_unauthorized">Неверный API-ключ — проверьте его в настройках ИИ.</string>
+    <string name="settings_ai_error_rate_limited">Провайдер ограничил частоту запросов. Повторите чуть позже.</string>
+    <string name="settings_ai_error_network">Ошибка сети при обращении к провайдеру ИИ.</string>
+    <string name="settings_ai_error_invalid_request">Провайдер отклонил запрос (проверьте модель и параметры).</string>
+    <string name="settings_ai_error_protocol">Неожиданный ответ от провайдера ИИ.</string>
+    <string name="settings_ai_error_unknown">Не удалось выполнить запрос к ИИ. Попробуйте ещё раз.</string>
+    <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">Очищать секреты перед отправкой</string>
     <string name="settings_ai_sanitize_desc">Вырезать очевидные пароли, токены и ключи из запросов до отправки внешним провайдерам.</string>
     <string name="settings_ai_preview">Показывать запрос перед отправкой</string>
@@ -119,7 +130,6 @@
     <string name="settings_autolock_30m">Через 30 минут</string>
     <string name="settings_autolock_never">Никогда</string>
     <string name="settings_security_2fa">Двухфакторная аутентификация</string>
-    <string name="settings_enabled">● включена</string>
     <string name="settings_security_2fa_desc">TOTP через приложение-аутентификатор.</string>
     <string name="settings_recent_security_events">НЕДАВНИЕ СОБЫТИЯ БЕЗОПАСНОСТИ</string>
     <string name="settings_security_no_events">Пока событий безопасности нет.</string>
@@ -129,6 +139,8 @@
     <string name="settings_event_biometric_disabled">Выключена разблокировка биометрией</string>
     <string name="settings_event_unlocked_biometric">Разблокировка биометрией</string>
     <string name="settings_event_device_paired">Привязано новое устройство</string>
+    <string name="settings_event_with_detail">%1$s: %2$s</string>
+    <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">сегодня %1$s</string>
     <string name="settings_time_yesterday">вчера %1$s</string>
     <string name="settings_time_days_ago">%1$d дн. назад</string>
@@ -140,7 +152,6 @@
     <string name="settings_change_pw_confirm">Повторите новый пароль</string>
     <string name="settings_change_pw_submit">Сменить пароль</string>
     <string name="settings_change_pw_err_wrong">Текущий пароль неверен.</string>
-    <string name="settings_change_pw_ok">Мастер-пароль изменён.</string>
 
     <!-- Раздел Keyboard -->
     <string name="settings_keyboard_title">Клавиатура</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -59,6 +59,6 @@
     <!-- Подтверждение перезаписи: в приёмнике уже есть объекты с такими именами -->
     <string name="sftp_overwrite_q">Перезаписать существующие?</string>
     <string name="sftp_overwrite_one">%1$s уже есть в каталоге-приёмнике.</string>
-    <string name="sftp_overwrite_many">%1$d объектов уже есть в каталоге-приёмнике — они будут перезаписаны.</string>
+    <string name="sftp_overwrite_many">В каталоге-приёмнике уже есть объектов: %1$d — они будут перезаписаны.</string>
     <string name="sftp_overwrite">Перезаписать</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
@@ -20,6 +20,9 @@
     <!-- Host grouping: synthetic bucket for hosts without a group (display only) -->
     <string name="shtail_ungrouped">Без группы</string>
 
+    <!-- Чипы фильтра хостов: чип «без фильтра по тегу» (только отображение, см. ALL_HOSTS_CHIP) -->
+    <string name="shtail_chip_all">Все</string>
+
     <!-- Mobile known hosts (MobileKnown.kt) -->
     <string name="shtail_known_changed">изменён</string>
     <string name="shtail_known_key_changed_title">Ключ изменён: %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_stail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_stail.xml
@@ -17,4 +17,10 @@
     <string name="stail_reenroll_prompt_title">Снова включить биометрическую разблокировку</string>
     <string name="stail_reenroll_prompt_cancel">Отмена</string>
     <string name="stail_reenroll_prompt_subtitle">Подтвердите биометрию, чтобы привязать быструю разблокировку к новому ключу аккаунта.</string>
+
+    <!-- Ошибки синхронизации (SyncFailureReason) — см. syncFailureText -->
+    <string name="stail_sync_fail_rekey">Не удалось перешифровать хранилище паролем аккаунта</string>
+    <string name="stail_sync_fail_key_adopt">Не удалось принять ключ аккаунта</string>
+    <!-- %1$s — локализованная причина, %2$s — техническая деталь (сообщение сервера/библиотеки) -->
+    <string name="stail_sync_fail_detail">%1$s (%2$s)</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -24,8 +24,6 @@
     <string name="term_no_host_selected">Хост не выбран</string>
     <string name="term_notice_pick_side_by_side">Выберите хост, чтобы открыть его рядом.</string>
     <string name="term_no_hosts_in_catalog">В каталоге нет хостов</string>
-    <string name="term_info_connection">ПОДКЛЮЧЕНИЕ</string>
-    <string name="term_info_live">АКТИВНО</string>
     <string name="term_info_host">Хост</string>
     <string name="term_info_address">Адрес</string>
     <string name="term_info_user">Пользователь</string>
@@ -50,6 +48,8 @@
     <string name="term_monitor_col_command">ПРОЦЕСС</string>
     <string name="term_monitor_unavailable">Метрики недоступны на этом хосте</string>
     <string name="term_monitor_title">Мониторинг хоста</string>
+    <string name="term_system_vcpu">%1$d vCPU</string>
+    <string name="term_system_load">загрузка %1$s</string>
     <string name="term_ai_thinking">Думаю…</string>
     <string name="term_ai_ask_placeholder">Спросите Skerry: «найди файлы больше 100 МБ»</string>
     <string name="term_ai_run">Выполнить</string>
@@ -63,6 +63,12 @@
     <string name="term_ai_blocked_disabled">AI выключен в настройках AI.</string>
     <string name="term_mobile_title_fallback">Терминал</string>
     <string name="term_mobile_open_host_connect">Откройте хост и нажмите «Подключиться».</string>
+    <!-- Строка состояния сессии под именем хоста (шапка мобильного терминала) — строчные буквы намеренно. -->
+    <string name="term_status_connected">подключено</string>
+    <string name="term_status_connecting">подключение…</string>
+    <string name="term_status_disconnected">отключено</string>
+    <string name="term_status_closed">закрыто</string>
+    <string name="term_status_no_session">нет сессии</string>
     <string name="term_ai_ask_short">Спросите Skerry…</string>
     <string name="term_ai_confirm">Подтвердить</string>
     <string name="term_password_label">ПАРОЛЬ</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -40,9 +40,9 @@
     <string name="vault_used_by_one">Используется · 1 хостом</string>
     <string name="vault_used_by">Используется · %1$d хостами</string>
     <string name="vault_not_attached">Пока не привязан ни к одному хосту.</string>
-    <string name="vault_cert_key_id">Key ID: %1$s</string>
+    <string name="vault_cert_key_id">Идентификатор ключа: %1$s</string>
     <string name="vault_cert_unreadable">Не удалось прочитать сертификат</string>
-    <string name="vault_label_principals">Principals</string>
+    <string name="vault_label_principals">Принципалы</string>
     <string name="vault_any_principal">любой principal</string>
     <string name="vault_label_valid">Срок действия</string>
     <string name="vault_badge_expired">ИСТЁК</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -3,6 +3,8 @@
     <string name="vnc_session_closed">Сессия завершена</string>
     <string name="vnc_connection_lost">Соединение потеряно</string>
     <string name="vnc_connect_failed">Не удалось подключиться</string>
+    <string name="vnc_error_auth">Сервер требует способ аутентификации, который Skerry не поддерживает.</string>
+    <string name="vnc_error_protocol">Сервер прислал неожиданный VNC-поток.</string>
     <string name="vnc_quality">Качество</string>
     <string name="vnc_quality_auto">Авто</string>
     <string name="vnc_quality_low">Низкое</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
@@ -32,4 +32,8 @@
     <string name="vtail_category_ssh_keys">SSH-ключи</string>
     <string name="vtail_category_passwords">Пароли</string>
     <string name="vtail_category_certificates">Сертификаты</string>
+
+    <!-- Строка метаданных карточки секрета: %1$s — принципалы сертификата / отпечаток ключа, %2$s — фрагмент «используется». -->
+    <string name="vtail_meta_principals">%1$s · %2$s</string>
+    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -84,4 +84,19 @@
     <string name="conn_test_connected">已连接</string>
     <string name="conn_test_rtt_ms">%1$d 毫秒</string>
     <string name="conn_test_incomplete">请输入主机、用户名和凭据以进行测试</string>
+
+    <string name="conn_test_err_auth">身份验证失败</string>
+    <string name="conn_test_err_host_key">主机密钥被拒绝</string>
+    <string name="conn_test_err_connection">连接失败</string>
+    <string name="conn_error_failed">连接失败</string>
+    <string name="conn_error_failed_detail">连接失败（%1$s）</string>
+
+    <string name="conn_tunnel_error_host_missing">未找到主机</string>
+    <string name="conn_tunnel_error_no_credential">没有已保存的凭据</string>
+
+    <string name="conn_serial_err_unsupported">此设备不支持串口。</string>
+    <string name="conn_serial_err_not_found">未找到端口 %1$s。请重新连接设备或选择其他端口。</string>
+    <string name="conn_serial_err_permission">访问端口 %1$s 被拒绝。</string>
+    <string name="conn_serial_err_open">无法打开端口 %1$s — 它可能正被其他程序占用。</string>
+    <string name="conn_serial_err_configure">端口 %1$s 拒绝了所选的速率或帧格式。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
@@ -15,8 +15,28 @@
     <!-- 控制器 / 副作用错误回退 -->
     <string name="ftail_open_failed">打开 SFTP 失败</string>
     <string name="ftail_transfer_error">传输错误</string>
-    <string name="ftail_sftp_error">SFTP 错误</string>
-    <string name="ftail_file_pane_error">文件面板错误</string>
     <string name="ftail_delete_source_failed">移动后删除源文件失败</string>
     <string name="ftail_file_fallback">文件</string>
+
+    <!-- 文件浏览器/传输的类型化失败原因（原始平台文本不会展示给用户） -->
+    <string name="ftail_err_local_io">本地文件系统错误</string>
+    <string name="ftail_err_sftp">SFTP 错误</string>
+    <string name="ftail_err_illegal_name">列表中的文件名不安全</string>
+    <string name="ftail_err_open_source">无法打开所选文件</string>
+    <string name="ftail_err_open_target">无法打开保存目标</string>
+
+    <!-- 本地文件系统：面板标题与路径导航中的名称 -->
+    <string name="ftail_local_label">本设备</string>
+
+    <!-- 大小模板：单位名称与小数点分隔符均可翻译 -->
+    <string name="ftail_size_bytes">%1$d B</string>
+    <string name="ftail_size_kb">%1$d.%2$d KB</string>
+    <string name="ftail_size_mb">%1$d.%2$d MB</string>
+    <string name="ftail_size_gb">%1$d.%2$d GB</string>
+    <string name="ftail_size_tb">%1$d.%2$d TB</string>
+    <string name="ftail_size_pb">%1$d.%2$d PB</string>
+
+    <!-- 传输栏：带批次计数的文件名，以及已传输/总量 -->
+    <string name="ftail_transfer_counter">%1$s (%2$d/%3$d)</string>
+    <string name="ftail_transfer_progress">%1$s / %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -79,13 +79,11 @@
     <string name="lib_teams_accept">接受</string>
     <string name="lib_teams_decline">拒绝</string>
     <string name="lib_teams_role_owner">拥有者</string>
-    <string name="lib_teams_role_member">成员</string>
     <string name="lib_teams_role_admin">管理员</string>
     <string name="lib_teams_role_editor">编辑者</string>
     <string name="lib_teams_role_viewer">查看者</string>
     <string name="lib_teams_status_invited">已邀请</string>
     <string name="lib_teams_invite_role">角色</string>
-    <string name="lib_teams_change_role">更改角色</string>
     <string name="lib_teams_role_picker_title">成员角色</string>
     <string name="lib_teams_history">历史</string>
     <string name="lib_teams_history_title">团队活动</string>
@@ -97,16 +95,17 @@
     <string name="lib_teams_event_role_change">更改了角色</string>
     <string name="lib_teams_event_share">共享了记录</string>
     <string name="lib_teams_event_delete">删除了团队</string>
+    <!-- 客户端未知的审计事件代码的回退文案；%1$s — 服务器返回的原始代码 -->
+    <string name="lib_teams_event_unknown">其他事件（%1$s）</string>
+    <string name="lib_teams_shared_hosts_count">共享的主机 · %1$d</string>
+    <string name="lib_teams_shared_snippets_count">共享的片段 · %1$d</string>
     <string name="lib_teams_members_count">%1$d 个成员</string>
-    <string name="lib_teams_shared_hosts">共享的主机</string>
-    <string name="lib_teams_shared_snippets">共享的片段</string>
     <string name="lib_teams_share_host">共享主机</string>
     <string name="lib_teams_share_snippet">共享片段</string>
     <string name="lib_teams_share_host_title">与团队共享主机</string>
     <string name="lib_teams_share_snippet_title">与团队共享片段</string>
     <string name="lib_teams_share_empty">没有可共享的内容</string>
     <string name="lib_teams_nothing_shared">暂无共享内容</string>
-    <string name="lib_teams_unshare">从团队中移除</string>
     <string name="lib_teams_sync_now">同步</string>
     <string name="lib_teams_no_key">团队密钥尚未到达此设备</string>
     <string name="lib_teams_remove_member_title">移除成员</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ptail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ptail.xml
@@ -11,4 +11,12 @@
     <string name="ptail_err_forward_failed">端口转发失败</string>
     <string name="ptail_err_connection_failed">连接失败</string>
     <string name="ptail_forward_raise_failed">无法启动端口转发</string>
+
+    <!-- 远程（-R）转发的 SOURCE 列：监听端在服务器一侧 -->
+    <string name="ptail_source_server">服务器:%1$d</string>
+
+    <!-- 速率模板：单位名称与小数点分隔符均可翻译 -->
+    <string name="ptail_rate_bytes">%1$d B/s</string>
+    <string name="ptail_rate_kb">%1$d KB/s</string>
+    <string name="ptail_rate_mb">%1$d.%2$d MB/s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -12,7 +12,6 @@
     <string name="settings_revoke">撤销</string>
     <string name="settings_change">更改</string>
     <string name="settings_manage">管理</string>
-    <string name="settings_on">开</string>
 
     <!-- AI 部分 -->
     <string name="settings_ai_title">AI</string>
@@ -50,7 +49,19 @@
     <string name="settings_ai_local_cancel">取消</string>
     <string name="settings_ai_local_delete">删除</string>
     <string name="settings_ai_local_retry">重试</string>
+    <string name="settings_ai_local_error_network">网络错误 — 下载将从中断处继续。</string>
+    <string name="settings_ai_local_error_integrity">下载的文件未通过校验。请重试。</string>
+    <string name="settings_ai_local_error_unknown">模型下载失败。请重试。</string>
     <string name="settings_ai_prompt_placeholder_needs_model">请先下载本地模型</string>
+
+    <!-- AI 请求错误（快速聊天和终端 AI 栏） -->
+    <string name="settings_ai_error_unauthorized">API 密钥无效 — 请在 AI 设置中检查。</string>
+    <string name="settings_ai_error_rate_limited">提供商已限流。请稍后重试。</string>
+    <string name="settings_ai_error_network">连接 AI 提供商时发生网络错误。</string>
+    <string name="settings_ai_error_invalid_request">提供商拒绝了该请求（请检查模型和参数）。</string>
+    <string name="settings_ai_error_protocol">AI 提供商返回了意外的响应。</string>
+    <string name="settings_ai_error_unknown">AI 请求失败。请重试。</string>
+    <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">发送前清除敏感信息</string>
     <string name="settings_ai_sanitize_desc">在发送到外部提供商前，从提示中移除明显的密码、令牌和密钥。</string>
     <string name="settings_ai_preview">发送前预览提示</string>
@@ -119,7 +130,6 @@
     <string name="settings_autolock_30m">30 分钟后</string>
     <string name="settings_autolock_never">从不</string>
     <string name="settings_security_2fa">双因素认证</string>
-    <string name="settings_enabled">● 已启用</string>
     <string name="settings_security_2fa_desc">通过身份验证器应用使用 TOTP。</string>
     <string name="settings_recent_security_events">最近安全事件</string>
     <string name="settings_security_no_events">暂无安全事件。</string>
@@ -129,6 +139,8 @@
     <string name="settings_event_biometric_disabled">生物识别解锁已禁用</string>
     <string name="settings_event_unlocked_biometric">通过生物识别解锁</string>
     <string name="settings_event_device_paired">新设备已配对</string>
+    <string name="settings_event_with_detail">%1$s：%2$s</string>
+    <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">今天 %1$s</string>
     <string name="settings_time_yesterday">昨天 %1$s</string>
     <string name="settings_time_days_ago">%1$d 天前</string>
@@ -140,7 +152,6 @@
     <string name="settings_change_pw_confirm">确认新密码</string>
     <string name="settings_change_pw_submit">更改密码</string>
     <string name="settings_change_pw_err_wrong">当前密码不正确。</string>
-    <string name="settings_change_pw_ok">主密码已更改。</string>
 
     <!-- 键盘部分 -->
     <string name="settings_keyboard_title">键盘</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -12,7 +12,6 @@
 
     <string name="shell_create_title">设置主密码</string>
     <string name="shell_create_subtitle">它加密此保险库且永远不会离开设备 — 无法恢复。</string>
-    <string name="shell_create_warning">此密码是你加密和解密数据保险库的唯一密钥，切勿丢失。即使使用云同步功能，也同样依赖这个密码。</string>
     <string name="shell_repeat_password">重复密码</string>
     <string name="shell_create_vault">创建保险库</string>
     <string name="shell_pairing_link">从其他设备关联？使用配对码</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
@@ -20,6 +20,9 @@
     <!-- 主机分组：无分组主机的合成桶（仅显示） -->
     <string name="shtail_ungrouped">未分组</string>
 
+    <!-- 主机筛选标签：无标签筛选的标签（仅用于显示，参见 ALL_HOSTS_CHIP） -->
+    <string name="shtail_chip_all">全部</string>
+
     <!-- 移动端已知主机 (MobileKnown.kt) -->
     <string name="shtail_known_changed">已变更</string>
     <string name="shtail_known_key_changed_title">密钥已变更：%1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_stail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_stail.xml
@@ -17,4 +17,10 @@
     <string name="stail_reenroll_prompt_title">重新启用生物识别解锁</string>
     <string name="stail_reenroll_prompt_cancel">取消</string>
     <string name="stail_reenroll_prompt_subtitle">确认你的生物识别以将快速解锁绑定到新的账户密钥。</string>
+
+    <!-- 同步失败原因（SyncFailureReason），参见 syncFailureText -->
+    <string name="stail_sync_fail_rekey">无法用账户密码重新加密保险库</string>
+    <string name="stail_sync_fail_key_adopt">无法采用账户密钥</string>
+    <!-- %1$s — 本地化原因，%2$s — 技术细节（服务器/库的原始消息） -->
+    <string name="stail_sync_fail_detail">%1$s（%2$s）</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -41,16 +41,11 @@
     <string name="sync_placeholder_server_url">https://sync.onepve.com</string>
     <string name="sync_field_account">账户邮箱</string>
     <string name="sync_placeholder_account">your@email.com</string>
-    <string name="sync_account_email_hint">请输入有效的电子邮件地址</string>
-    <string name="sync_server_url_reset">重置为默认地址</string>
     <string name="sync_field_master_password">同步账户主密码</string>
     <string name="sync_placeholder_master_password">账户主密码</string>
-    <string name="sync_field_confirm_password">再次输入账户主密码</string>
-    <string name="sync_placeholder_confirm_password">再次输入以确认</string>
     <string name="sync_keep_connected">保持连接</string>
     <string name="sync_keep_connected_sub">重启后自动重新连接。</string>
     <string name="sync_keep_connected_sub_long">重启后自动重新连接 — 无需密码。</string>
-    <string name="sync_master_password_warning">⚠️ 主密码不可找回。一旦遗忘，加密数据将永久丢失。建议用密码管理器保存，或保持至少一台设备在线以便配对新设备。</string>
     <string name="sync_insecure_url_warning">明文 http:// — 传输中未加密。除非本地测试，否则请使用 https://。</string>
     <string name="sync_connect">连接</string>
     <string name="sync_zero_knowledge">零知识</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -24,8 +24,6 @@
     <string name="term_no_host_selected">未选择主机</string>
     <string name="term_notice_pick_side_by_side">选择主机以分屏打开。</string>
     <string name="term_no_hosts_in_catalog">目录中无主机</string>
-    <string name="term_info_connection">连接</string>
-    <string name="term_info_live">实时</string>
     <string name="term_info_host">主机</string>
     <string name="term_info_address">地址</string>
     <string name="term_info_user">用户</string>
@@ -50,6 +48,8 @@
     <string name="term_monitor_col_command">进程</string>
     <string name="term_monitor_unavailable">此主机无法提供指标</string>
     <string name="term_monitor_title">主机监控</string>
+    <string name="term_system_vcpu">%1$d 个 vCPU</string>
+    <string name="term_system_load">负载 %1$s</string>
     <string name="term_ai_thinking">思考中…</string>
     <string name="term_ai_ask_placeholder">向 Skerry 提问：\"查找大于 100MB 的文件\"</string>
     <string name="term_ai_run">运行</string>
@@ -63,6 +63,12 @@
     <string name="term_ai_blocked_disabled">AI 已在 AI 设置中关闭。</string>
     <string name="term_mobile_title_fallback">终端</string>
     <string name="term_mobile_open_host_connect">打开一个主机并点击\"连接\"。</string>
+    <!-- 主机名下方的会话状态行（移动端终端标题栏）。 -->
+    <string name="term_status_connected">已连接</string>
+    <string name="term_status_connecting">连接中…</string>
+    <string name="term_status_disconnected">已断开</string>
+    <string name="term_status_closed">已关闭</string>
+    <string name="term_status_no_session">无会话</string>
     <string name="term_ai_ask_short">向 Skerry 提问…</string>
     <string name="term_ai_confirm">确认</string>
     <string name="term_password_label">密码</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -3,6 +3,8 @@
     <string name="vnc_session_closed">会话已结束</string>
     <string name="vnc_connection_lost">连接已断开</string>
     <string name="vnc_connect_failed">连接失败</string>
+    <string name="vnc_error_auth">服务器要求 Skerry 不支持的身份验证方式。</string>
+    <string name="vnc_error_protocol">服务器发送了意外的 VNC 数据流。</string>
     <string name="vnc_quality">画质</string>
     <string name="vnc_quality_auto">自动</string>
     <string name="vnc_quality_low">低</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -32,4 +32,8 @@
     <string name="vtail_category_ssh_keys">SSH 密钥</string>
     <string name="vtail_category_passwords">密码</string>
     <string name="vtail_category_certificates">证书</string>
+
+    <!-- 密钥卡片元信息行：%1$s — 证书主体 / 密钥指纹，%2$s — “使用者”片段。 -->
+    <string name="vtail_meta_principals">%1$s · %2$s</string>
+    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -84,4 +84,19 @@
     <string name="conn_test_connected">Connected</string>
     <string name="conn_test_rtt_ms">%1$d ms</string>
     <string name="conn_test_incomplete">Enter host, username and credentials to test</string>
+
+    <string name="conn_test_err_auth">Authentication failed</string>
+    <string name="conn_test_err_host_key">Host key rejected</string>
+    <string name="conn_test_err_connection">Connection failed</string>
+    <string name="conn_error_failed">Couldn't connect</string>
+    <string name="conn_error_failed_detail">Couldn't connect (%1$s)</string>
+
+    <string name="conn_tunnel_error_host_missing">Host not found</string>
+    <string name="conn_tunnel_error_no_credential">No saved credential</string>
+
+    <string name="conn_serial_err_unsupported">Serial ports are not available on this device.</string>
+    <string name="conn_serial_err_not_found">Port %1$s not found. Reconnect the device or pick another port.</string>
+    <string name="conn_serial_err_permission">Access to port %1$s was denied.</string>
+    <string name="conn_serial_err_open">Port %1$s could not be opened — it may be in use by another program.</string>
+    <string name="conn_serial_err_configure">Port %1$s rejected the selected speed or frame format.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
@@ -15,8 +15,28 @@
     <!-- Controller / effect error fallbacks -->
     <string name="ftail_open_failed">Failed to open SFTP</string>
     <string name="ftail_transfer_error">Transfer error</string>
-    <string name="ftail_sftp_error">SFTP error</string>
-    <string name="ftail_file_pane_error">File panel error</string>
     <string name="ftail_delete_source_failed">Failed to delete source after move</string>
     <string name="ftail_file_fallback">file</string>
+
+    <!-- Typed file browser / transfer failures (raw platform text never reaches the user) -->
+    <string name="ftail_err_local_io">Local filesystem error</string>
+    <string name="ftail_err_sftp">SFTP error</string>
+    <string name="ftail_err_illegal_name">Unsafe name in the listing</string>
+    <string name="ftail_err_open_source">Failed to open the selected file</string>
+    <string name="ftail_err_open_target">Failed to open the save target</string>
+
+    <!-- Local filesystem source, shown in the pane header and breadcrumbs -->
+    <string name="ftail_local_label">This device</string>
+
+    <!-- Size templates: unit name and decimal separator are part of the translation -->
+    <string name="ftail_size_bytes">%1$d B</string>
+    <string name="ftail_size_kb">%1$d.%2$d KB</string>
+    <string name="ftail_size_mb">%1$d.%2$d MB</string>
+    <string name="ftail_size_gb">%1$d.%2$d GB</string>
+    <string name="ftail_size_tb">%1$d.%2$d TB</string>
+    <string name="ftail_size_pb">%1$d.%2$d PB</string>
+
+    <!-- Transfer strip: file name with a batch counter, and transferred-of-total -->
+    <string name="ftail_transfer_counter">%1$s (%2$d/%3$d)</string>
+    <string name="ftail_transfer_progress">%1$s / %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -79,13 +79,11 @@
     <string name="lib_teams_accept">Accept</string>
     <string name="lib_teams_decline">Decline</string>
     <string name="lib_teams_role_owner">OWNER</string>
-    <string name="lib_teams_role_member">MEMBER</string>
     <string name="lib_teams_role_admin">ADMIN</string>
     <string name="lib_teams_role_editor">EDITOR</string>
     <string name="lib_teams_role_viewer">VIEWER</string>
     <string name="lib_teams_status_invited">INVITED</string>
     <string name="lib_teams_invite_role">Role</string>
-    <string name="lib_teams_change_role">Change role</string>
     <string name="lib_teams_role_picker_title">Member role</string>
     <string name="lib_teams_history">History</string>
     <string name="lib_teams_history_title">Team activity</string>
@@ -97,16 +95,17 @@
     <string name="lib_teams_event_role_change">Changed a role</string>
     <string name="lib_teams_event_share">Shared records</string>
     <string name="lib_teams_event_delete">Deleted team</string>
+    <!-- Fallback for an audit event code this client doesn't know; %1$s — the raw server code -->
+    <string name="lib_teams_event_unknown">Other event (%1$s)</string>
+    <string name="lib_teams_shared_hosts_count">Shared hosts · %1$d</string>
+    <string name="lib_teams_shared_snippets_count">Shared snippets · %1$d</string>
     <string name="lib_teams_members_count">%1$d members</string>
-    <string name="lib_teams_shared_hosts">Shared hosts</string>
-    <string name="lib_teams_shared_snippets">Shared snippets</string>
     <string name="lib_teams_share_host">Share host</string>
     <string name="lib_teams_share_snippet">Share snippet</string>
     <string name="lib_teams_share_host_title">Share host with team</string>
     <string name="lib_teams_share_snippet_title">Share snippet with team</string>
     <string name="lib_teams_share_empty">Nothing left to share</string>
     <string name="lib_teams_nothing_shared">Nothing shared yet</string>
-    <string name="lib_teams_unshare">Remove from team</string>
     <string name="lib_teams_sync_now">Sync</string>
     <string name="lib_teams_no_key">The team key has not arrived on this device yet</string>
     <string name="lib_teams_remove_member_title">Remove member</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_ptail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ptail.xml
@@ -11,4 +11,12 @@
     <string name="ptail_err_forward_failed">Port forwarding failed</string>
     <string name="ptail_err_connection_failed">Connection failed</string>
     <string name="ptail_forward_raise_failed">Couldn't start port forward</string>
+
+    <!-- SOURCE cell of a remote (-R) forward: the server owns the listener -->
+    <string name="ptail_source_server">server:%1$d</string>
+
+    <!-- Throughput templates: unit name and decimal separator are part of the translation -->
+    <string name="ptail_rate_bytes">%1$d B/s</string>
+    <string name="ptail_rate_kb">%1$d KB/s</string>
+    <string name="ptail_rate_mb">%1$d.%2$d MB/s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -12,7 +12,6 @@
     <string name="settings_revoke">Revoke</string>
     <string name="settings_change">Change</string>
     <string name="settings_manage">Manage</string>
-    <string name="settings_on">On</string>
 
     <!-- AI section -->
     <string name="settings_ai_title">AI</string>
@@ -50,7 +49,19 @@
     <string name="settings_ai_local_cancel">Cancel</string>
     <string name="settings_ai_local_delete">Delete</string>
     <string name="settings_ai_local_retry">Retry</string>
+    <string name="settings_ai_local_error_network">Network error — the download will resume from where it stopped.</string>
+    <string name="settings_ai_local_error_integrity">The downloaded file failed verification. Try again.</string>
+    <string name="settings_ai_local_error_unknown">Model download failed. Try again.</string>
     <string name="settings_ai_prompt_placeholder_needs_model">Download the on-device model first</string>
+
+    <!-- AI request failures (quick chat and the terminal AI bar) -->
+    <string name="settings_ai_error_unauthorized">Invalid API key — check it in AI settings.</string>
+    <string name="settings_ai_error_rate_limited">Rate limited by the provider. Try again shortly.</string>
+    <string name="settings_ai_error_network">Network error reaching the AI provider.</string>
+    <string name="settings_ai_error_invalid_request">The provider rejected the request (check model/params).</string>
+    <string name="settings_ai_error_protocol">Unexpected response from the AI provider.</string>
+    <string name="settings_ai_error_unknown">AI request failed. Try again.</string>
+    <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">Sanitize secrets before sending</string>
     <string name="settings_ai_sanitize_desc">Strip obvious passwords, tokens and keys from prompts before they reach external providers.</string>
     <string name="settings_ai_preview">Preview prompt before sending</string>
@@ -119,7 +130,6 @@
     <string name="settings_autolock_30m">After 30 minutes</string>
     <string name="settings_autolock_never">Never</string>
     <string name="settings_security_2fa">Two-factor authentication</string>
-    <string name="settings_enabled">● enabled</string>
     <string name="settings_security_2fa_desc">TOTP via an authenticator app.</string>
     <string name="settings_recent_security_events">RECENT SECURITY EVENTS</string>
     <string name="settings_security_no_events">No security events yet.</string>
@@ -129,6 +139,8 @@
     <string name="settings_event_biometric_disabled">Biometric unlock disabled</string>
     <string name="settings_event_unlocked_biometric">Unlocked with biometrics</string>
     <string name="settings_event_device_paired">New device paired</string>
+    <string name="settings_event_with_detail">%1$s: %2$s</string>
+    <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">today %1$s</string>
     <string name="settings_time_yesterday">yesterday %1$s</string>
     <string name="settings_time_days_ago">%1$d days ago</string>
@@ -140,7 +152,6 @@
     <string name="settings_change_pw_confirm">Confirm new password</string>
     <string name="settings_change_pw_submit">Change password</string>
     <string name="settings_change_pw_err_wrong">Current password is incorrect.</string>
-    <string name="settings_change_pw_ok">Master password changed.</string>
 
     <!-- Keyboard section -->
     <string name="settings_keyboard_title">Keyboard</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
@@ -20,6 +20,9 @@
     <!-- Host grouping: synthetic bucket for hosts without a group (display only) -->
     <string name="shtail_ungrouped">Ungrouped</string>
 
+    <!-- Host filter chips: "no tag filter" chip label (display only, see ALL_HOSTS_CHIP) -->
+    <string name="shtail_chip_all">All</string>
+
     <!-- Mobile known hosts (MobileKnown.kt) -->
     <string name="shtail_known_changed">changed</string>
     <string name="shtail_known_key_changed_title">Key changed: %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_stail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_stail.xml
@@ -17,4 +17,10 @@
     <string name="stail_reenroll_prompt_title">Re-enable biometric unlock</string>
     <string name="stail_reenroll_prompt_cancel">Cancel</string>
     <string name="stail_reenroll_prompt_subtitle">Confirm your biometrics to bind quick unlock to the new account key.</string>
+
+    <!-- Sync failures (SyncFailureReason) — see syncFailureText -->
+    <string name="stail_sync_fail_rekey">Couldn't re-key the vault to the account password</string>
+    <string name="stail_sync_fail_key_adopt">Couldn't adopt the account key</string>
+    <!-- %1$s — localized reason, %2$s — raw technical detail (server/library message) -->
+    <string name="stail_sync_fail_detail">%1$s (%2$s)</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -24,8 +24,6 @@
     <string name="term_no_host_selected">No host selected</string>
     <string name="term_notice_pick_side_by_side">Pick a host to open it side by side.</string>
     <string name="term_no_hosts_in_catalog">No hosts in catalog</string>
-    <string name="term_info_connection">CONNECTION</string>
-    <string name="term_info_live">LIVE</string>
     <string name="term_info_host">Host</string>
     <string name="term_info_address">Address</string>
     <string name="term_info_user">User</string>
@@ -50,6 +48,8 @@
     <string name="term_monitor_col_command">PROCESS</string>
     <string name="term_monitor_unavailable">Metrics are unavailable on this host</string>
     <string name="term_monitor_title">Host monitor</string>
+    <string name="term_system_vcpu">%1$d vCPU</string>
+    <string name="term_system_load">load %1$s</string>
     <string name="term_ai_thinking">Thinking…</string>
     <string name="term_ai_ask_placeholder">Ask Skerry: “find files larger than 100MB”</string>
     <string name="term_ai_run">Run</string>
@@ -63,6 +63,12 @@
     <string name="term_ai_blocked_disabled">AI is turned off in AI settings.</string>
     <string name="term_mobile_title_fallback">Terminal</string>
     <string name="term_mobile_open_host_connect">Open a host and tap Connect.</string>
+    <!-- Session status line under the host name (mobile terminal header) — lower case by design. -->
+    <string name="term_status_connected">connected</string>
+    <string name="term_status_connecting">connecting…</string>
+    <string name="term_status_disconnected">disconnected</string>
+    <string name="term_status_closed">closed</string>
+    <string name="term_status_no_session">no session</string>
     <string name="term_ai_ask_short">Ask Skerry…</string>
     <string name="term_ai_confirm">Confirm</string>
     <string name="term_password_label">PASSWORD</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -3,6 +3,8 @@
     <string name="vnc_session_closed">Session closed</string>
     <string name="vnc_connection_lost">Connection lost</string>
     <string name="vnc_connect_failed">Failed to connect</string>
+    <string name="vnc_error_auth">The server requires an authentication method Skerry doesn't support.</string>
+    <string name="vnc_error_protocol">The server sent an unexpected VNC stream.</string>
     <string name="vnc_quality">Quality</string>
     <string name="vnc_quality_auto">Auto</string>
     <string name="vnc_quality_low">Low</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
@@ -32,4 +32,8 @@
     <string name="vtail_category_ssh_keys">SSH keys</string>
     <string name="vtail_category_passwords">Passwords</string>
     <string name="vtail_category_certificates">Certificates</string>
+
+    <!-- Secret card meta line: %1$s — cert principals / key fingerprint, %2$s — "used by" fragment. -->
+    <string name="vtail_meta_principals">%1$s · %2$s</string>
+    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiAssistantController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiAssistantController.kt
@@ -52,7 +52,8 @@ class AiAssistantController(
 
     /** Partial reply while streaming; `null` when not generating. */
     var streaming by mutableStateOf<String?>(null); private set
-    var error by mutableStateOf<String?>(null); private set
+    /** Typed reason the last request failed; the UI resolves the text (see `aiFailureMessage`). */
+    var error by mutableStateOf<AiFailure?>(null); private set
     var busy by mutableStateOf(false); private set
 
     private var job: Job? = null

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiFailureMessage.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiFailureMessage.kt
@@ -1,0 +1,27 @@
+package app.skerry.ui.ai
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.settings_ai_error_invalid_request
+import app.skerry.ui.generated.resources.settings_ai_error_network
+import app.skerry.ui.generated.resources.settings_ai_error_protocol
+import app.skerry.ui.generated.resources.settings_ai_error_rate_limited
+import app.skerry.ui.generated.resources.settings_ai_error_unauthorized
+import app.skerry.ui.generated.resources.settings_ai_error_unknown
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Localized message for a failed AI request. Controllers store the typed [AiFailure]; the UI layer
+ * resolves it here so the text follows the interface language (see also `aiBlockedMessage`).
+ */
+@Composable
+fun aiFailureMessage(failure: AiFailure): String = stringResource(
+    when (failure) {
+        AiFailure.UNAUTHORIZED -> Res.string.settings_ai_error_unauthorized
+        AiFailure.RATE_LIMITED -> Res.string.settings_ai_error_rate_limited
+        AiFailure.NETWORK -> Res.string.settings_ai_error_network
+        AiFailure.INVALID_REQUEST -> Res.string.settings_ai_error_invalid_request
+        AiFailure.PROTOCOL -> Res.string.settings_ai_error_protocol
+        AiFailure.UNKNOWN -> Res.string.settings_ai_error_unknown
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiStreamRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiStreamRunner.kt
@@ -10,13 +10,27 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
-/** Human-readable error message for an AI provider exception (shared by chat and the terminal bar). */
-internal fun AiException.friendlyMessage(): String = when (kind) {
-    AiException.Kind.UNAUTHORIZED -> "Invalid API key — check it in AI settings."
-    AiException.Kind.RATE_LIMITED -> "Rate limited by the provider. Try again shortly."
-    AiException.Kind.NETWORK -> "Network error reaching the AI provider."
-    AiException.Kind.INVALID_REQUEST -> "The provider rejected the request (check model/params)."
-    AiException.Kind.PROTOCOL -> "Unexpected response from the AI provider."
+/**
+ * Why an AI request failed. Typed on purpose: controllers never build user-visible text, the UI
+ * resolves it via `aiFailureMessage`. [UNKNOWN] covers non-[AiException] failures — the raw library
+ * message is not shown to the user.
+ */
+enum class AiFailure {
+    UNAUTHORIZED,
+    RATE_LIMITED,
+    NETWORK,
+    INVALID_REQUEST,
+    PROTOCOL,
+    UNKNOWN,
+}
+
+/** Maps a provider exception to the typed UI failure. */
+internal fun AiException.toFailure(): AiFailure = when (kind) {
+    AiException.Kind.UNAUTHORIZED -> AiFailure.UNAUTHORIZED
+    AiException.Kind.RATE_LIMITED -> AiFailure.RATE_LIMITED
+    AiException.Kind.NETWORK -> AiFailure.NETWORK
+    AiException.Kind.INVALID_REQUEST -> AiFailure.INVALID_REQUEST
+    AiException.Kind.PROTOCOL -> AiFailure.PROTOCOL
 }
 
 /**
@@ -26,7 +40,7 @@ internal fun AiException.friendlyMessage(): String = when (kind) {
  *
  * - [onDelta] receives the accumulated text after each delta.
  * - [onComplete] fires with the full reply on successful stream completion.
- * - [onError] receives a ready-to-show message ([friendlyMessage] for [AiException]);
+ * - [onError] receives a typed [AiFailure] the UI turns into localized text;
  *   [CancellationException] is rethrown, not mapped to an error.
  * - [onFinally] always runs (success/error/cancel), after the provider is closed; generation
  *   guarding against job-reassignment races is the caller's responsibility.
@@ -40,7 +54,7 @@ internal class AiStreamRunner(
         messages: List<AiMessage>,
         onDelta: (String) -> Unit,
         onComplete: (String) -> Unit,
-        onError: (String) -> Unit,
+        onError: (AiFailure) -> Unit,
         onFinally: () -> Unit,
         // null uses the provider default; the terminal bar requests a low value (command, not creative).
         temperature: Double? = null,
@@ -57,9 +71,10 @@ internal class AiStreamRunner(
         } catch (e: CancellationException) {
             throw e
         } catch (e: AiException) {
-            onError(e.friendlyMessage())
-        } catch (e: Exception) {
-            onError("AI request failed: ${e.message}")
+            onError(e.toFailure())
+        } catch (_: Exception) {
+            // Library messages are not user-facing text: report a generic typed failure.
+            onError(AiFailure.UNKNOWN)
         } finally {
             provider?.let { runCatching { it.close() } }
             onFinally()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/LocalModelController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/LocalModelController.kt
@@ -17,8 +17,15 @@ sealed interface LocalModelStatus {
     data class Downloading(val downloadedBytes: Long, val totalBytes: Long) : LocalModelStatus
     data object Verifying : LocalModelStatus
     data object Installed : LocalModelStatus
-    data class Failed(val message: String) : LocalModelStatus
+    data class Failed(val failure: LocalModelFailure) : LocalModelStatus
 }
+
+/**
+ * Why a model download failed. Typed on purpose: the controller never builds user-visible text,
+ * the UI resolves it via `localModelFailureMessage`. [UNKNOWN] covers unexpected exceptions — the
+ * raw library message is not shown to the user.
+ */
+enum class LocalModelFailure { NETWORK, INTEGRITY, UNKNOWN }
 
 /**
  * UI controller for local model lifecycle: download with progress/cancel, delete, and current
@@ -69,9 +76,9 @@ class LocalModelController(
                 statuses[model.id] = if (installed(model)) LocalModelStatus.Installed else LocalModelStatus.NotInstalled
                 throw e
             } catch (e: ModelDownloadException) {
-                statuses[model.id] = LocalModelStatus.Failed(friendlyMessage(e))
-            } catch (e: Exception) {
-                statuses[model.id] = LocalModelStatus.Failed("Model download failed: ${e.message}")
+                statuses[model.id] = LocalModelStatus.Failed(e.toFailure())
+            } catch (_: Exception) {
+                statuses[model.id] = LocalModelStatus.Failed(LocalModelFailure.UNKNOWN)
             }
         }
     }
@@ -87,9 +94,10 @@ class LocalModelController(
         remove(model)
         statuses[model.id] = LocalModelStatus.NotInstalled
     }
+}
 
-    private fun friendlyMessage(e: ModelDownloadException): String = when (e.kind) {
-        ModelDownloadException.Kind.NETWORK -> "Network error — the download will resume from where it stopped."
-        ModelDownloadException.Kind.INTEGRITY -> "The downloaded file failed verification. Try again."
-    }
+/** Maps a downloader exception to the typed UI failure. */
+private fun ModelDownloadException.toFailure(): LocalModelFailure = when (kind) {
+    ModelDownloadException.Kind.NETWORK -> LocalModelFailure.NETWORK
+    ModelDownloadException.Kind.INTEGRITY -> LocalModelFailure.INTEGRITY
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/LocalModelFailureMessage.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/LocalModelFailureMessage.kt
@@ -1,0 +1,21 @@
+package app.skerry.ui.ai
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.settings_ai_local_error_integrity
+import app.skerry.ui.generated.resources.settings_ai_local_error_network
+import app.skerry.ui.generated.resources.settings_ai_local_error_unknown
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Localized message for a failed local model download. [LocalModelController] stores the typed
+ * [LocalModelFailure]; the UI layer resolves it here so the text follows the interface language.
+ */
+@Composable
+fun localModelFailureMessage(failure: LocalModelFailure): String = stringResource(
+    when (failure) {
+        LocalModelFailure.NETWORK -> Res.string.settings_ai_local_error_network
+        LocalModelFailure.INTEGRITY -> Res.string.settings_ai_local_error_integrity
+        LocalModelFailure.UNKNOWN -> Res.string.settings_ai_local_error_unknown
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
@@ -47,8 +47,8 @@ sealed interface AiNotice {
     /** The reply was prose or nothing usable; the UI shows a fixed localized "not a command" message. */
     data object Rejected : AiNotice
 
-    /** Provider/transport error text. */
-    data class Error(val message: String) : AiNotice
+    /** Provider/transport failure; the UI resolves the localized text (see `aiFailureMessage`). */
+    data class Error(val failure: AiFailure) : AiNotice
 }
 
 class TerminalAiController(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -26,11 +26,12 @@ import app.skerry.ui.terminal.TerminalThemes
  * No Files tab: SFTP opens as a push screen ([MobileRoute.Files]) from a host card's SFTP button —
  * a separate root tab would duplicate the terminal.
  */
-enum class MobileTab(val icon: String, val label: String) {
-    Hosts("dns", "Hosts"),
-    Snippets("code_blocks", "Snippets"),
-    Vault("vpn_key", "Vault"),
-    More("more_horiz", "More"),
+// Labels are not part of the enum: they are localized in the tab bar (nav_tab_* resources).
+enum class MobileTab(val icon: String) {
+    Hosts("dns"),
+    Snippets("code_blocks"),
+    Vault("vpn_key"),
+    More("more_horiz"),
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.shared.sftp.SftpClient
+import app.skerry.shared.serial.SerialProblem
+import app.skerry.shared.serial.SerialUnavailableException
 import app.skerry.shared.mosh.MoshSetupException
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
@@ -55,16 +57,19 @@ sealed interface ConnectionUiState {
     data class Connected(val terminal: TerminalScreenState) : ConnectionUiState
 
     /**
-     * Connect failed; [message] is shown to the user. [moshReason]/[moshDetail] are set when the
-     * failure is a typed Mosh setup problem — the view then renders a localized explanation
-     * (missing server package, locale, blocked UDP) instead of the raw English [message]
-     * (see `moshFailureText`); building the text here would bake in one language
+     * Connect failed; [message] is shown to the user. [moshReason]/[moshDetail] and
+     * [serialProblem]/[serialDetail] are set when the failure is a typed Mosh setup or serial port
+     * problem — the view then renders a localized explanation (missing server package, locale,
+     * blocked UDP; port missing, permission denied) instead of the raw English [message]
+     * (see `connectionErrorText`); building the text here would bake in one language
      * (same rule as [app.skerry.shared.sync.SyncFailureReason]).
      */
     data class Error(
         val message: String,
         val moshReason: MoshSetupException.Reason? = null,
         val moshDetail: String? = null,
+        val serialProblem: SerialProblem? = null,
+        val serialDetail: String? = null,
     ) : ConnectionUiState
 
     /**
@@ -191,10 +196,17 @@ class ConnectionController(
                 // establishSession; uiState was set to Form by disconnect() itself.
                 throw e
             } catch (e: Exception) {
+                // The serial transport wraps its typed failure into SshConnectionException, so the
+                // cause carries the reason the view localizes.
+                val serial = e as? SerialUnavailableException ?: e.cause as? SerialUnavailableException
                 uiState = ConnectionUiState.Error(
-                    message = e.message ?: "Failed to connect",
+                    // Transport text is diagnostics only: the view shows a localized base and keeps
+                    // this as a parenthetical detail (sshj/okio messages are always English).
+                    message = e.message.orEmpty(),
                     moshReason = (e as? MoshSetupException)?.reason,
                     moshDetail = (e as? MoshSetupException)?.detail,
+                    serialProblem = serial?.problem,
+                    serialDetail = serial?.detail,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTest.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTest.kt
@@ -18,23 +18,43 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
+ * Why a "Test connection" check failed. Typed, not a message string, so the view renders localized
+ * text (`connectionTestFailureText`) — same rule as [app.skerry.shared.sync.SyncFailureReason].
+ */
+sealed interface ConnectionTestProblem {
+    /** The server rejected the supplied credentials. */
+    data object AuthenticationFailed : ConnectionTestProblem
+
+    /** The host presented a key that doesn't match the pinned one. */
+    data object HostKeyRejected : ConnectionTestProblem
+
+    /** Anything else on the wire. Deliberately coarse: transport text would leak library/host detail. */
+    data object ConnectionFailed : ConnectionTestProblem
+
+    /** The form has no host/username/secret yet, so nothing was dialled. */
+    data object IncompleteForm : ConnectionTestProblem
+
+    /** The profile's ProxyJump chain didn't resolve, so the probe couldn't take the same route. */
+    data class Jump(val problem: JumpChainProblem) : ConnectionTestProblem
+}
+
+/**
  * Result of a "Test connection" check: a one-shot connect to the host without opening a session.
  * [Idle] — not run yet; [Checking] — connect in flight; [Success] — connection established (with
- * round-trip ms if the transport reported it, else `null`); [Failure] — with a human-readable
- * message describing the cause (auth/host key/network).
+ * round-trip ms if the transport reported it, else `null`); [Failure] — with a typed [problem].
  */
 sealed interface ConnectionTestStatus {
     data object Idle : ConnectionTestStatus
     data object Checking : ConnectionTestStatus
     data class Success(val roundTripMillis: Long?) : ConnectionTestStatus
-    data class Failure(val message: String) : ConnectionTestStatus
+    data class Failure(val problem: ConnectionTestProblem) : ConnectionTestStatus
 }
 
 /**
  * One-shot connectivity check: connect, measure round-trip (if available), then disconnect right
  * away — the connection is temporary, no session is opened. Transport exceptions are mapped to
- * [ConnectionTestStatus.Failure] with a friendly message by category (auth/host key/network); the
- * raw transport exception text is never surfaced in the UI (would leak library internals/host
+ * [ConnectionTestStatus.Failure] with a [ConnectionTestProblem] by category (auth/host key/network);
+ * the raw transport exception text is never surfaced in the UI (would leak library internals/host
  * address). A ping failure alone doesn't fail the test (the connection already succeeded).
  * [CancellationException] is rethrown (cooperative cancellation isn't masked); the temporary
  * connection is closed unconditionally ([NonCancellable]) so cancellation never leaves a socket
@@ -66,15 +86,15 @@ suspend fun runConnectionTest(
         }
     }
 } catch (e: SshAuthenticationException) {
-    ConnectionTestStatus.Failure("Authentication failed")
+    ConnectionTestStatus.Failure(ConnectionTestProblem.AuthenticationFailed)
 } catch (e: SshHostKeyRejectedException) {
-    ConnectionTestStatus.Failure("Host key rejected")
+    ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected)
 } catch (e: SshConnectionException) {
-    ConnectionTestStatus.Failure("Connection failed")
+    ConnectionTestStatus.Failure(ConnectionTestProblem.ConnectionFailed)
 } catch (e: CancellationException) {
     throw e
 } catch (e: Exception) {
-    ConnectionTestStatus.Failure("Connection failed")
+    ConnectionTestStatus.Failure(ConnectionTestProblem.ConnectionFailed)
 }
 
 /**
@@ -102,11 +122,11 @@ class ConnectionTestController(
 
     /**
      * Report a pre-connect failure (e.g. the profile's jump chain didn't resolve) as the test's
-     * result without dialing anything. [message] is already localized by the caller.
+     * result without dialing anything.
      */
-    fun fail(message: String) {
+    fun fail(problem: ConnectionTestProblem) {
         job?.cancel()
-        status = ConnectionTestStatus.Failure(message)
+        status = ConnectionTestStatus.Failure(problem)
     }
 
     fun reset() {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTestFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTestFailureText.kt
@@ -1,0 +1,19 @@
+package app.skerry.ui.connection
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_test_err_auth
+import app.skerry.ui.generated.resources.conn_test_err_connection
+import app.skerry.ui.generated.resources.conn_test_err_host_key
+import app.skerry.ui.generated.resources.conn_test_incomplete
+import org.jetbrains.compose.resources.stringResource
+
+/** Localized reason for a failed "Test connection" check (modal footer). */
+@Composable
+fun connectionTestFailureText(problem: ConnectionTestProblem): String = when (problem) {
+    ConnectionTestProblem.AuthenticationFailed -> stringResource(Res.string.conn_test_err_auth)
+    ConnectionTestProblem.HostKeyRejected -> stringResource(Res.string.conn_test_err_host_key)
+    ConnectionTestProblem.ConnectionFailed -> stringResource(Res.string.conn_test_err_connection)
+    ConnectionTestProblem.IncompleteForm -> stringResource(Res.string.conn_test_incomplete)
+    is ConnectionTestProblem.Jump -> jumpProblemText(problem.problem)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/JumpChain.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/JumpChain.kt
@@ -6,9 +6,8 @@ import app.skerry.shared.ssh.SshJump
 import app.skerry.shared.vault.Credential
 
 /**
- * Why a ProxyJump chain could not be assembled. Typed (not a message string) so each surface maps
- * it to its own localized text (`jumpProblemText` for the connect dialogs, English constants for
- * tunnels) — same pattern as `SyncFailureReason`.
+ * Why a ProxyJump chain could not be assembled. Typed (not a message string) so every surface
+ * resolves it through `jumpProblemText` — same pattern as `SyncFailureReason`.
  */
 enum class JumpChainProblem {
     /** [Host.jumpHostId] points to a deleted/unknown profile. */
@@ -104,18 +103,6 @@ fun jumpRouteLabel(host: Host, findHost: (String) -> Host?): String? {
         jumpId = hop?.jumpHostId ?: break
     }
     return labels.asReversed().joinToString(" → ")
-}
-
-/**
- * English status constant for a [JumpChainProblem] — the tunnels list shows plain-English reasons
- * ("Host not found", "No saved credential"), and these follow that convention. Localized surfaces
- * use `jumpProblemText` instead.
- */
-fun jumpProblemLabel(problem: JumpChainProblem): String = when (problem) {
-    JumpChainProblem.MISSING_HOST -> "Jump host not found"
-    JumpChainProblem.NOT_SSH -> "Jump host is not SSH"
-    JumpChainProblem.NO_CREDENTIAL -> "Jump host has no saved credential"
-    JumpChainProblem.CYCLE -> "Jump host chain forms a loop"
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/MoshFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/MoshFailureText.kt
@@ -3,6 +3,8 @@ package app.skerry.ui.connection
 import androidx.compose.runtime.Composable
 import app.skerry.shared.mosh.MoshSetupException
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_error_failed
+import app.skerry.ui.generated.resources.conn_error_failed_detail
 import app.skerry.ui.generated.resources.mosh_err_bootstrap
 import app.skerry.ui.generated.resources.mosh_err_bootstrap_no_output
 import app.skerry.ui.generated.resources.mosh_err_locale
@@ -11,14 +13,18 @@ import app.skerry.ui.generated.resources.mosh_err_udp
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * User-facing text for a connect error, localized for typed Mosh failures. Mosh problems are
- * almost always server-side and fixable — Skerry ships only the client, so the message must
+ * User-facing text for a connect error, localized for typed Mosh and serial failures. Mosh problems
+ * are almost always server-side and fixable — Skerry ships only the client, so the message must
  * say what to do on the server (install the package, generate a locale, open UDP) instead of
- * leaking a raw exception string. Non-Mosh errors keep the transport's message as before.
+ * leaking a raw exception string; serial problems say what to do with the device. Everything else
+ * keeps the transport's message as before.
  */
 @Composable
 fun connectionErrorText(error: ConnectionUiState.Error): String {
-    val reason = error.moshReason ?: return error.message
+    error.serialProblem?.let { return serialProblemText(it, error.serialDetail) }
+    val reason = error.moshReason ?: return error.message.takeIf { it.isNotBlank() }
+        ?.let { stringResource(Res.string.conn_error_failed_detail, it) }
+        ?: stringResource(Res.string.conn_error_failed)
     return when (reason) {
         MoshSetupException.Reason.SERVER_NOT_INSTALLED ->
             stringResource(Res.string.mosh_err_not_installed)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/SerialFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/SerialFailureText.kt
@@ -1,0 +1,27 @@
+package app.skerry.ui.connection
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.serial.SerialProblem
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_serial_err_configure
+import app.skerry.ui.generated.resources.conn_serial_err_not_found
+import app.skerry.ui.generated.resources.conn_serial_err_open
+import app.skerry.ui.generated.resources.conn_serial_err_permission
+import app.skerry.ui.generated.resources.conn_serial_err_unsupported
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Localized explanation of a [SerialProblem]; [port] is the device name the problem refers to.
+ * Same text on desktop and Android — the platforms report the same typed causes.
+ */
+@Composable
+fun serialProblemText(problem: SerialProblem, port: String?): String {
+    val name = port.orEmpty()
+    return when (problem) {
+        SerialProblem.UNSUPPORTED -> stringResource(Res.string.conn_serial_err_unsupported)
+        SerialProblem.PORT_NOT_FOUND -> stringResource(Res.string.conn_serial_err_not_found, name)
+        SerialProblem.PERMISSION_DENIED -> stringResource(Res.string.conn_serial_err_permission, name)
+        SerialProblem.OPEN_FAILED -> stringResource(Res.string.conn_serial_err_open, name)
+        SerialProblem.CONFIGURE_FAILED -> stringResource(Res.string.conn_serial_err_configure, name)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/LabelCase.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/LabelCase.kt
@@ -1,0 +1,27 @@
+package app.skerry.ui.design
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.i18n.LocalAppLocale
+
+/**
+ * Uppercase for the small-caps section/field labels of the design system.
+ *
+ * `String.uppercase()` is locale-invariant (Locale.ROOT), which is wrong for Turkish/Azerbaijani:
+ * dotted `i` must become `İ`, dotless `ı` must become `I`. Scripts without case (Chinese, …) are
+ * left alone by `uppercase()` itself, so only the dotted-i pair needs handling.
+ */
+@Composable
+fun labelUppercase(text: String): String = uppercaseForLocale(text, LocalAppLocale.current)
+
+/** Testable core of [labelUppercase]; [languageTag] is BCP-47 (e.g. `tr-TR`). */
+fun uppercaseForLocale(text: String, languageTag: String): String {
+    val language = languageTag.substringBefore('-').substringBefore('_').lowercase()
+    if (language != "tr" && language != "az") return text.uppercase()
+    return buildString(text.length) {
+        for (ch in text) when (ch) {
+            'i' -> append('İ')
+            'ı' -> append('I')
+            else -> append(ch.uppercase())
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
@@ -1,0 +1,37 @@
+package app.skerry.ui.files
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_delete_source_failed
+import app.skerry.ui.generated.resources.ftail_err_illegal_name
+import app.skerry.ui.generated.resources.ftail_err_local_io
+import app.skerry.ui.generated.resources.ftail_err_open_source
+import app.skerry.ui.generated.resources.ftail_err_open_target
+import app.skerry.ui.generated.resources.ftail_err_sftp
+import app.skerry.ui.generated.resources.ftail_transfer_error
+import org.jetbrains.compose.resources.stringResource
+
+/** Localized text for a file pane failure ([app.skerry.shared.files.FileBrowserException.failure]). */
+@Composable
+fun fileBrowserFailureText(failure: FileBrowserFailure): String = stringResource(
+    when (failure) {
+        FileBrowserFailure.LocalIo -> Res.string.ftail_err_local_io
+        FileBrowserFailure.Sftp -> Res.string.ftail_err_sftp
+        FileBrowserFailure.IllegalName -> Res.string.ftail_err_illegal_name
+        FileBrowserFailure.OpenSource -> Res.string.ftail_err_open_source
+        FileBrowserFailure.OpenTarget -> Res.string.ftail_err_open_target
+    },
+)
+
+/** Localized text for a [TransferState.Failed] reason. */
+@Composable
+fun transferFailureText(failure: FileTransferFailure): String = stringResource(
+    when (failure) {
+        FileTransferFailure.Transfer -> Res.string.ftail_transfer_error
+        FileTransferFailure.DeleteSource -> Res.string.ftail_delete_source_failed
+        FileTransferFailure.IllegalName -> Res.string.ftail_err_illegal_name
+        FileTransferFailure.OpenSource -> Res.string.ftail_err_open_source
+        FileTransferFailure.OpenTarget -> Res.string.ftail_err_open_target
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
@@ -6,13 +6,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ftail_file_pane_error
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.getString
 import kotlin.coroutines.cancellation.CancellationException
 
 /** Listing state of a single file pane (local or remote). */
@@ -23,8 +21,8 @@ sealed interface FilePaneState {
     /** Listing loaded; [entries] sorted directories-first, then by name. */
     data class Loaded(val entries: List<FileItem>) : FilePaneState
 
-    /** Last operation/load failed; [message] is user-facing. */
-    data class Error(val message: String) : FilePaneState
+    /** Last operation/load failed; [failure] is the typed reason, localized by the UI. */
+    data class Error(val failure: FileBrowserFailure) : FilePaneState
 }
 
 /**
@@ -41,6 +39,7 @@ class FilePaneController(
     private val browser: FileBrowser,
     private val scope: CoroutineScope,
 ) {
+    /** Source label for headers/breadcrumbs; blank for the local FS — the UI substitutes a localized name. */
     val label: String get() = browser.label
 
     var path: String by mutableStateOf("/")
@@ -157,7 +156,7 @@ class FilePaneController(
             // Deletes via a path rebuilt from [path] + a validated name, not server-controlled item.path.
             val name = item.name
             if (isUnsafeListingName(name)) {
-                throw FileBrowserException("Illegal name in listing: $name")
+                throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
             }
             browser.delete(item.copy(path = childPath(name)))
         }
@@ -396,7 +395,7 @@ class FilePaneController(
             rawEntries = raw
             FilePaneState.Loaded(visible(raw))
         } catch (e: FileBrowserException) {
-            FilePaneState.Error(e.message ?: getString(Res.string.ftail_file_pane_error))
+            FilePaneState.Error(e.failure)
         }
 
     /** Filters the listing by [showHidden]; hidden entries start with a dot. */
@@ -431,7 +430,7 @@ class FilePaneController(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: FileBrowserException) {
-                state = FilePaneState.Error(e.message ?: getString(Res.string.ftail_file_pane_error))
+                state = FilePaneState.Error(e.failure)
             } finally {
                 busy = false
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -6,22 +6,47 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntryType
-import app.skerry.shared.sftp.SftpException
 import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sftp.UploadSource
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ftail_delete_source_failed
-import app.skerry.ui.generated.resources.ftail_file_fallback
-import app.skerry.ui.generated.resources.ftail_transfer_error
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.getString
 import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Typed, user-facing reason for a failed transfer; the UI maps it to a localized string. Raw
+ * exception text is never shown — a [FileBrowserException] contributes only its
+ * [FileBrowserFailure], anything else lands on [Transfer].
+ */
+enum class FileTransferFailure {
+    /** The byte transfer itself failed (stream/SFTP/local I/O). */
+    Transfer,
+
+    /** Files reached the destination, but a source could not be removed after a move. */
+    DeleteSource,
+
+    /** A listing entry carried a name unsafe to use as a path component. */
+    IllegalName,
+
+    /** The picked upload source could not be opened. */
+    OpenSource,
+
+    /** The chosen download target could not be opened. */
+    OpenTarget,
+}
+
+/** Maps a browser failure onto the transfer bar's reason; I/O-level causes collapse to [FileTransferFailure.Transfer]. */
+private fun FileBrowserFailure.toTransferFailure(): FileTransferFailure = when (this) {
+    FileBrowserFailure.IllegalName -> FileTransferFailure.IllegalName
+    FileBrowserFailure.OpenSource -> FileTransferFailure.OpenSource
+    FileBrowserFailure.OpenTarget -> FileTransferFailure.OpenTarget
+    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp -> FileTransferFailure.Transfer
+}
 
 /** Cross-pane batch transfer state, for the bottom transfer bar. */
 sealed interface TransferState {
@@ -41,8 +66,12 @@ sealed interface TransferState {
         val total: Long,
     ) : TransferState
 
-    /** Transfer of [name] failed; [message] is user-facing. */
-    data class Failed(val name: String, val message: String) : TransferState
+    /**
+     * Transfer of [name] failed; [failure] is the typed reason, localized by the UI. [name] is
+     * blank when the failure happened before any file became active — the UI substitutes a
+     * localized placeholder.
+     */
+    data class Failed(val name: String, val failure: FileTransferFailure) : TransferState
 }
 
 /**
@@ -178,8 +207,8 @@ class TransferCoordinator(
         for (item in items) {
             try {
                 delete(item)
-            } catch (e: FileBrowserException) {
-                return TransferState.Failed(item.name, e.message ?: getString(Res.string.ftail_delete_source_failed))
+            } catch (_: FileBrowserException) {
+                return TransferState.Failed(item.name, FileTransferFailure.DeleteSource)
             }
         }
         return null
@@ -289,8 +318,10 @@ class TransferCoordinator(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                val name = (transfer as? TransferState.Active)?.name ?: getString(Res.string.ftail_file_fallback)
-                transfer = TransferState.Failed(name, e.message ?: getString(Res.string.ftail_transfer_error))
+                // Blank name = no file was active yet; the UI fills in a localized placeholder.
+                val name = (transfer as? TransferState.Active)?.name.orEmpty()
+                val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
+                transfer = TransferState.Failed(name, failure)
             } finally {
                 onFinally()
                 busy = false
@@ -374,7 +405,7 @@ class TransferCoordinator(
         plan: DownloadPlan,
     ) {
         if (isUnsafeListingName(name)) {
-            throw SftpException("Illegal name in listing: $name")
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
         }
         val localPath = childPath(localDir, name)
         when (type) {
@@ -438,7 +469,7 @@ class TransferCoordinator(
         plan: UploadPlan,
     ) {
         if (isUnsafeListingName(name)) {
-            throw SftpException("Illegal name in listing: $name")
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
         }
         val remotePath = childPath(remoteDir, name)
         when (type) {
@@ -460,7 +491,7 @@ class TransferCoordinator(
      */
     private fun safeRemoteChild(name: String, remoteDir: String): String {
         if (isUnsafeListingName(name)) {
-            throw SftpException("Illegal name in listing: $name")
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
         }
         return childPath(remoteDir, name)
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/ForwardDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/ForwardDisplay.kt
@@ -2,14 +2,21 @@ package app.skerry.ui.forward
 
 import androidx.compose.runtime.Composable
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ptail_forward_raise_failed
+import app.skerry.ui.generated.resources.ptail_rate_bytes
+import app.skerry.ui.generated.resources.ptail_rate_kb
+import app.skerry.ui.generated.resources.ptail_rate_mb
+import app.skerry.ui.generated.resources.ptail_source_server
 import app.skerry.ui.generated.resources.ptail_type_local
 import app.skerry.ui.generated.resources.ptail_type_remote
 import app.skerry.ui.generated.resources.ptail_type_socks
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Pure helpers rendering a single forward as table columns for `TunnelsView` (source/destination
- * as separate cells). Shared source of truth so the format stays consistent across views.
+ * Helpers rendering a single forward as table columns for `TunnelsView` (source/destination as
+ * separate cells). Shared source of truth so the format stays consistent across views. Anything
+ * with visible words or a decimal separator is `@Composable` and reads a localized template; the
+ * numeric decomposition behind it stays pure and unit-tested.
  */
 
 /** Forward type label for the table badge: `-L`->LOCAL, `-R`->REMOTE, `-D`->SOCKS. */
@@ -20,6 +27,14 @@ fun forwardTypeLabel(direction: ForwardDirection): String = when (direction) {
     ForwardDirection.Dynamic -> stringResource(Res.string.ptail_type_socks)
 }
 
+/** Localized text for a [ForwardStatus.Failed] reason. */
+@Composable
+fun forwardFailureText(failure: ForwardFailure): String = stringResource(
+    when (failure) {
+        ForwardFailure.RaiseFailed -> Res.string.ptail_forward_raise_failed
+    },
+)
+
 /**
  * Listener port: actual ([ForwardStatus.Active.boundPort]) once up, otherwise the requested port
  * ([ForwardEntry.requestedPort]) while Starting/Failed.
@@ -28,15 +43,21 @@ fun forwardListenPort(entry: ForwardEntry): Int =
     (entry.status as? ForwardStatus.Active)?.boundPort ?: entry.requestedPort
 
 /**
- * Source address (listener side). For `-L`/`-D` the listener is local ([ForwardEntry.bindHost]);
- * for `-R` the server owns the listener, so the host is shown as `server`.
+ * Host of the listener side, or `null` for `-R`, where the server owns the listener and the host is
+ * named by a localized word rather than an address. Pure counterpart of [forwardSourceText].
  */
+fun forwardSourceHost(entry: ForwardEntry): String? =
+    if (entry.direction == ForwardDirection.Remote) null else entry.bindHost
+
+/**
+ * Source address (listener side). For `-L`/`-D` the listener is local ([ForwardEntry.bindHost]);
+ * for `-R` the server owns the listener, so the host is a localized "server".
+ */
+@Composable
 fun forwardSourceText(entry: ForwardEntry): String {
     val port = forwardListenPort(entry)
-    return when (entry.direction) {
-        ForwardDirection.Remote -> "server:$port"
-        else -> "${entry.bindHost}:$port"
-    }
+    return forwardSourceHost(entry)?.let { "$it:$port" }
+        ?: stringResource(Res.string.ptail_source_server, port)
 }
 
 /**
@@ -48,17 +69,38 @@ fun forwardDestText(entry: ForwardEntry): String? = when (entry.direction) {
     else -> "${entry.destHost}:${entry.destPort}"
 }
 
+/** Throughput unit picked by [rateParts]; `B/s` and `KB/s` are whole, `MB/s` carries one decimal. */
+enum class RateUnit { Bytes, KB, MB }
+
 /**
- * Human-readable throughput label: `B/s` below 1 KiB, whole `KB/s` below 1 MiB, otherwise `MB/s`
- * with one decimal. Base 1024.
+ * Throughput split into unit and digits, so the visible string comes from a localized template
+ * (decimal separator included) rather than concatenation. [tenths] is used by [RateUnit.MB] only.
  */
-fun humanRate(bytesPerSec: Long): String {
-    if (bytesPerSec < 1024) return "$bytesPerSec B/s"
+data class RateParts(val unit: RateUnit, val whole: Long, val tenths: Long = 0)
+
+/**
+ * Human-readable throughput decomposition: `B/s` below 1 KiB, whole `KB/s` below 1 MiB, otherwise
+ * `MB/s` with one decimal. Base 1024. Pure (no resources), so it stays unit-testable.
+ */
+fun rateParts(bytesPerSec: Long): RateParts {
+    if (bytesPerSec < 1024) return RateParts(RateUnit.Bytes, bytesPerSec)
     val kb = bytesPerSec / 1024
-    if (kb < 1024) return "$kb KB/s"
+    if (kb < 1024) return RateParts(RateUnit.KB, kb)
     val mbTenths = bytesPerSec * 10 / (1024 * 1024)
-    return "${mbTenths / 10}.${mbTenths % 10} MB/s"
+    return RateParts(RateUnit.MB, mbTenths / 10, mbTenths % 10)
 }
+
+/** Renders [parts] through the localized throughput template. */
+@Composable
+fun rateText(parts: RateParts): String = when (parts.unit) {
+    RateUnit.Bytes -> stringResource(Res.string.ptail_rate_bytes, parts.whole)
+    RateUnit.KB -> stringResource(Res.string.ptail_rate_kb, parts.whole)
+    RateUnit.MB -> stringResource(Res.string.ptail_rate_mb, parts.whole, parts.tenths)
+}
+
+/** Human-readable throughput label ("512 B/s", "42 KB/s", "1.1 MB/s"). */
+@Composable
+fun humanRate(bytesPerSec: Long): String = rateText(rateParts(bytesPerSec))
 
 /** Fill fraction (0..1) of the throughput meter, linear and saturating at 1 MiB/s. */
 fun rateFraction(bytesPerSec: Long): Float =

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/PortForwardController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/forward/PortForwardController.kt
@@ -9,17 +9,20 @@ import app.skerry.shared.ssh.LocalForwardSpec
 import app.skerry.shared.ssh.PortForward
 import app.skerry.shared.ssh.RemoteForwardSpec
 import app.skerry.shared.ssh.SshConnection
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ptail_forward_raise_failed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.getString
 import kotlin.coroutines.cancellation.CancellationException
 
 /** Forward direction: local (`-L`), remote (`-R`), or dynamic SOCKS (`-D`). */
 enum class ForwardDirection { Local, Remote, Dynamic }
+
+/** Typed, user-facing reason a forward could not be raised; the UI maps it to localized text. */
+enum class ForwardFailure {
+    /** The listener never came up: port busy or denied, or the server refused the request. */
+    RaiseFailed,
+}
 
 /** State of a single forward in the list. */
 sealed interface ForwardStatus {
@@ -29,8 +32,8 @@ sealed interface ForwardStatus {
     /** Forward is active; [boundPort] is the actual listener port (assigned if requested as `0`). */
     data class Active(val boundPort: Int) : ForwardStatus
 
-    /** Failed to start; [message] is user-facing. */
-    data class Failed(val message: String) : ForwardStatus
+    /** Failed to start; [failure] is the typed reason, localized by the UI. */
+    data class Failed(val failure: ForwardFailure) : ForwardStatus
 }
 
 /**
@@ -166,10 +169,11 @@ class PortForwardController(
                 entry.status = ForwardStatus.Active(forward.boundPort)
             } catch (e: CancellationException) {
                 throw e
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 // Caught broadly (not just the expected PortForwardException) so an unexpected sshj
                 // exception doesn't crash the shared session scope; it lands on the row as Failed.
-                entry.status = ForwardStatus.Failed(e.message ?: getString(Res.string.ptail_forward_raise_failed))
+                // The library text carries addresses/internals, so it never reaches the UI.
+                entry.status = ForwardStatus.Failed(ForwardFailure.RaiseFailed)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
@@ -1,9 +1,21 @@
 package app.skerry.ui.host
 
+import androidx.compose.runtime.Composable
 import app.skerry.shared.host.Host
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shtail_chip_all
+import org.jetbrains.compose.resources.stringResource
 
-/** "All hosts" chip at the start of the Hosts list filter row (desktop sidebar and mobile). */
+/**
+ * Technical key of the "all hosts" chip at the start of the Hosts list filter row (desktop sidebar
+ * and mobile). Used as the filter value in [filterHosts] and as the chip identity; not localized,
+ * since that would break filtering on locale change. For display, use [allHostsChipLabel].
+ */
 const val ALL_HOSTS_CHIP = "All"
+
+/** Localized "all hosts" chip label for display (not for filtering, see [ALL_HOSTS_CHIP]). */
+@Composable
+fun allHostsChipLabel(): String = stringResource(Res.string.shtail_chip_all)
 
 /**
  * Filter chips: `All` plus unique host tags in order of first appearance (canonical form, no `#`).
@@ -17,8 +29,13 @@ fun hostTagChips(hosts: List<Host>): List<String> = buildList {
     for (host in hosts) for (tag in host.tags) if (seen.add(tag)) add(tag)
 }
 
-/** Chip label for display: `All` as-is, tags prefixed with `#` (model value has no `#`). */
-fun hostChipLabel(chip: String): String = if (chip == ALL_HOSTS_CHIP) chip else "#$chip"
+/** Chip label for display: localized for [ALL_HOSTS_CHIP], tags via [hostTagChipLabel]. */
+@Composable
+fun hostChipLabel(chip: String): String =
+    if (chip == ALL_HOSTS_CHIP) allHostsChipLabel() else hostTagChipLabel(chip)
+
+/** Tag chip label: `#` prefix (the model value has none). Pure, no localization involved. */
+fun hostTagChipLabel(tag: String): String = "#$tag"
 
 /**
  * Narrow [hosts] by the active chip ([activeChip] = tag, `All` = no filter) and [query] (AND).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -60,10 +60,11 @@ import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.connection.ConnectionTestController
+import app.skerry.ui.connection.ConnectionTestProblem
 import app.skerry.ui.connection.ConnectionTestStatus
 import app.skerry.ui.connection.JumpChainResolution
+import app.skerry.ui.connection.connectionTestFailureText
 import app.skerry.ui.connection.jumpHostCandidates
-import app.skerry.ui.connection.jumpProblemText
 import app.skerry.ui.connection.resolveJumpChain
 import app.skerry.ui.connection.toSshAuth
 import app.skerry.ui.design.DropdownField
@@ -116,7 +117,6 @@ import app.skerry.ui.generated.resources.conn_subtitle_new
 import app.skerry.ui.generated.resources.conn_tag_add_placeholder
 import app.skerry.ui.generated.resources.conn_test
 import app.skerry.ui.generated.resources.conn_test_checking
-import app.skerry.ui.generated.resources.conn_test_incomplete
 import app.skerry.ui.generated.resources.conn_test_connected
 import app.skerry.ui.generated.resources.conn_test_rtt_ms
 import app.skerry.ui.generated.resources.conn_title_edit
@@ -198,10 +198,6 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
         findHost = { id -> allHosts.firstOrNull { it.id == id } },
         findCredential = { id -> credentials?.find(id) },
     )
-    val jumpErrorText = (testJump as? JumpChainResolution.Unavailable)?.let { jumpProblemText(it.problem) }
-    // Shown as the test result when "Test" is clicked with an incomplete form (no username/host/secret):
-    // the button stays tappable, so give feedback instead of silently doing nothing.
-    val incompleteTestMessage = stringResource(Res.string.conn_test_incomplete)
     ModalScrim(onDismiss = state::closeModal) {
         Column(
             Modifier
@@ -372,14 +368,14 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                         }
                         if (canTest && auth != null) {
                             when (testJump) {
-                                is JumpChainResolution.Unavailable -> tester.fail(jumpErrorText.orEmpty())
+                                is JumpChainResolution.Unavailable -> tester.fail(ConnectionTestProblem.Jump(testJump.problem))
                                 is JumpChainResolution.Resolved ->
                                     tester.test(SshTarget(form.address.trim(), form.portOrNull ?: 22, form.username.trim(), jump = testJump.jump), auth)
                             }
                         } else {
                             // Form isn't ready to dial (missing host/username/credentials): report it as a
                             // failure so the click isn't a silent no-op.
-                            tester?.fail(incompleteTestMessage)
+                            tester?.fail(ConnectionTestProblem.IncompleteForm)
                         }
                     },
                     fg = if (canTest) D.text else D.faint,
@@ -837,7 +833,7 @@ private fun TestStatusLabel(status: ConnectionTestStatus) {
         }
         is ConnectionTestStatus.Failure -> Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
             Sym("error", size = 14.sp, color = D.storm)
-            Txt(status.message, color = D.storm, size = 11.5.sp)
+            Txt(connectionTestFailureText(status.problem), color = D.storm, size = 11.5.sp)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiScreen.kt
@@ -26,6 +26,7 @@ import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.ai.AiRole
 import app.skerry.ui.ai.AiChatBubble
 import app.skerry.ui.ai.AiQuickChatHeader
+import app.skerry.ui.ai.aiFailureMessage
 import app.skerry.ui.ai.isInsecureAiEndpoint
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.MobileDesignState
@@ -104,7 +105,7 @@ fun MobileAiScreen(state: MobileDesignState) {
                 ai.turns.forEach { turn -> AiChatBubble(turn.role, turn.text) }
                 ai.streaming?.let { AiChatBubble(AiRole.ASSISTANT, if (it.isEmpty()) "…" else it) }
                 // Request error uses the error token (D.storm), as on desktop; D.sunset is reserved for warnings.
-                ai.error?.let { Txt(it, color = D.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
+                ai.error?.let { Txt(aiFailureMessage(it), color = D.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
 
                 var prompt by remember { mutableStateOf("") }
                 val send = { if (prompt.isNotBlank() && !ai.busy) { ai.ask(prompt); prompt = "" } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFiles.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFiles.kt
@@ -2,7 +2,8 @@ package app.skerry.ui.mobile
 
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
-import app.skerry.ui.sftp.humanSize
+import app.skerry.ui.sftp.SizeParts
+import app.skerry.ui.sftp.sizeParts
 
 /**
  * Mode of the mobile Files screen (single-pane):
@@ -26,12 +27,12 @@ fun mobileFilesMode(hasSessions: Boolean, connected: Boolean, connecting: Boolea
 }
 
 /**
- * Row subtitle, a direct projection of [FileItem]: human-readable size for a file, empty for a
- * directory (the model doesn't carry permissions/item count, unlike the empty directory subtitle
- * in desktop `SftpView`).
+ * Row subtitle, a direct projection of [FileItem]: size parts for a file, `null` for a directory
+ * (the model doesn't carry permissions/item count, unlike the empty directory subtitle in desktop
+ * `SftpView`). The view renders it through the localized template ([app.skerry.ui.sftp.sizeText]).
  */
-fun mobileFileRowMeta(item: FileItem): String =
-    if (item.type == FileItemType.File) humanSize(item.size) else ""
+fun mobileFileRowMeta(item: FileItem): SizeParts? =
+    if (item.type == FileItemType.File) sizeParts(item.size) else null
 
 /**
  * Leading row icon ([Sym] ligature): directory → `folder`, symlink → `link`, shell script →

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -45,8 +45,12 @@ import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.PathJumpField
 import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.files.TransferState
+import app.skerry.ui.files.fileBrowserFailureText
 import app.skerry.ui.files.platformLocalBrowser
+import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_file_fallback
+import app.skerry.ui.generated.resources.ftail_local_label
 import app.skerry.ui.generated.resources.ftail_open_failed
 import app.skerry.ui.generated.resources.sftp_connecting
 import app.skerry.ui.generated.resources.sftp_create
@@ -68,6 +72,7 @@ import app.skerry.ui.generated.resources.sftp_transfer_error
 import app.skerry.ui.generated.resources.sftp_unavailable
 import app.skerry.ui.generated.resources.sftp_upload_file
 import app.skerry.ui.sftp.TransferDirection
+import app.skerry.ui.sftp.sizeText
 import app.skerry.ui.sftp.pickDownloadTarget
 import app.skerry.ui.sftp.pickUploadSource
 import org.jetbrains.compose.resources.stringResource
@@ -142,8 +147,9 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
             coord = controller.openTransferCoordinator(platformLocalBrowser(), subtitle)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
-            openError = e.message ?: openFailedMsg
+        } catch (_: Exception) {
+            // sshj/transport text carries addresses and internals — only the localized reason is shown.
+            openError = openFailedMsg
         }
     }
 
@@ -177,7 +183,10 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                     val downloadHere = remember(c) {
                         { item: FileItem -> c.remote.selectOnly(item); c.downloadSelection() }
                     }
-                    MobileFilesBreadcrumbRow(pane.label, pane.path, mono, onGoToPath = pane::goToPath)
+                    MobileFilesBreadcrumbRow(
+                        pane.label.ifBlank { stringResource(Res.string.ftail_local_label) },
+                        pane.path,
+                        mono, onGoToPath = pane::goToPath)
                     MobileLivePane(
                         pane = pane,
                         mono = mono,
@@ -276,7 +285,8 @@ private fun MobileLivePane(
     Box(modifier.fillMaxWidth()) {
         when (val st = pane.state) {
             FilePaneState.Loading -> MobileFilesNoticeBox("sync", stringResource(Res.string.sftp_loading), null, D.faint)
-            is FilePaneState.Error -> MobileFilesNoticeBox("error", stringResource(Res.string.sftp_error), st.message, D.sunset)
+            is FilePaneState.Error ->
+                MobileFilesNoticeBox("error", stringResource(Res.string.sftp_error), fileBrowserFailureText(st.failure), D.sunset)
             is FilePaneState.Loaded -> Column(
                 Modifier.fillMaxSize().verticalScroll(scroll).padding(top = 12.dp, start = 12.dp, end = 12.dp),
             ) {
@@ -352,8 +362,7 @@ private fun MobileFileRow(
         Sym(mobileFileIcon(entry), size = 23.sp, color = if (isDir) D.cyanBright else D.dim)
         Column(Modifier.weight(1f)) {
             Txt(entry.name, color = D.text, size = 14.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            val meta = mobileFileRowMeta(entry)
-            if (meta.isNotEmpty()) Txt(meta, color = D.faint, size = 11.sp)
+            mobileFileRowMeta(entry)?.let { Txt(sizeText(it), color = D.faint, size = 11.sp) }
         }
         Sym(mobileFileTrailingIcon(entry.type), size = 20.sp, color = D.faint)
     }
@@ -439,7 +448,13 @@ private fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDism
                 horizontalArrangement = Arrangement.spacedBy(9.dp),
             ) {
                 Sym("error", size = 17.sp, color = D.sunset)
-                Txt(stringResource(Res.string.sftp_transfer_error, transfer.name, transfer.message), color = D.sunset, size = 11.5.sp, maxLines = 6, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                Txt(
+                    stringResource(
+                        Res.string.sftp_transfer_error,
+                        transfer.name.ifBlank { stringResource(Res.string.ftail_file_fallback) },
+                        transferFailureText(transfer.failure),
+                    ),
+                    color = D.sunset, size = 11.5.sp, maxLines = 6, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
                 IconBtn("close", onClick = onDismiss, box = 26, icon = 16.sp)
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -48,6 +48,7 @@ import app.skerry.ui.tunnel.TunnelEntry
 import app.skerry.ui.tunnel.TunnelFormState
 import app.skerry.ui.tunnel.TunnelManager
 import app.skerry.ui.tunnel.TunnelStatus
+import app.skerry.ui.tunnel.tunnelFailureText
 import app.skerry.ui.tunnel.badgeColors
 import app.skerry.ui.tunnel.badgeLabel
 import app.skerry.ui.tunnel.displayLabel
@@ -221,7 +222,7 @@ private fun LiveTunnelCard(
         }
         (entry.status as? TunnelStatus.Failed)?.let {
             Spacer(Modifier.height(6.dp))
-            Txt(it.message, color = D.sunset, size = 11.sp, font = mono)
+            Txt(tunnelFailureText(it), color = D.sunset, size = 11.sp, font = mono)
         }
     }
     if (menuOpen) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -90,8 +90,8 @@ import app.skerry.ui.generated.resources.lib_teams_share_host
 import app.skerry.ui.generated.resources.lib_teams_share_host_title
 import app.skerry.ui.generated.resources.lib_teams_share_snippet
 import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
-import app.skerry.ui.generated.resources.lib_teams_shared_hosts
-import app.skerry.ui.generated.resources.lib_teams_shared_snippets
+import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
+import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.generated.resources.lib_teams_sync_now
 import app.skerry.ui.generated.resources.shell_cancel
@@ -436,7 +436,7 @@ private fun MobileTeamDetail(
         }
     }
 
-    MobileTeamsSectionLabel("${stringResource(Res.string.lib_teams_shared_hosts)} · ${sharedHosts.size}")
+    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
     sharedHosts.forEach { host ->
         MobileSharedRow(host.label, "${host.username}@${host.address}", canUnshare = canWrite) { onUnshare(host.id) }
@@ -445,7 +445,7 @@ private fun MobileTeamDetail(
         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
     }
 
-    MobileTeamsSectionLabel("${stringResource(Res.string.lib_teams_shared_snippets)} · ${sharedSnippets.size}")
+    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
     if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
     sharedSnippets.forEach { snippet ->
         MobileSharedRow(snippet.label, snippet.command, canUnshare = canWrite) { onUnshare(snippet.id) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.mobile
 
+import androidx.compose.runtime.Composable
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.app.MobileDesignState
@@ -10,18 +11,22 @@ import app.skerry.ui.app.MobileRoute
  * ([MobileTerminalScreen]) so it can be unit-tested without Compose.
  */
 
+/** Session state shown in the terminal header status line. The UI localizes it. */
+enum class MobileTerminalStatus { Connected, Connecting, Disconnected, Closed, NoSession }
+
 /**
- * Status-line text under the host name in the terminal header, from the active session's connection
+ * Status shown under the host name in the terminal header, from the active session's connection
  * state. Color comes separately via [sessionDotColor]. Live metrics (RTT/throughput) render alongside
  * as separate elements ([mobileRttLabel]/[mobileRateLabel]), not in this line.
  */
-fun mobileTerminalStatusText(state: ConnectionUiState?): String = when (state) {
-    is ConnectionUiState.Connected -> "connected"
-    ConnectionUiState.Connecting -> "connecting…"
-    is ConnectionUiState.Error -> "disconnected"
+fun mobileTerminalStatus(state: ConnectionUiState?): MobileTerminalStatus = when (state) {
+    is ConnectionUiState.Connected -> MobileTerminalStatus.Connected
+    ConnectionUiState.Connecting -> MobileTerminalStatus.Connecting
+    is ConnectionUiState.Error -> MobileTerminalStatus.Disconnected
     // Clean shell exit (`exit`) → neutral "closed"; transport drop → "disconnected".
-    is ConnectionUiState.Disconnected -> if (state.cleanExit) "closed" else "disconnected"
-    else -> "no session"
+    is ConnectionUiState.Disconnected ->
+        if (state.cleanExit) MobileTerminalStatus.Closed else MobileTerminalStatus.Disconnected
+    else -> MobileTerminalStatus.NoSession
 }
 
 /**
@@ -34,6 +39,7 @@ fun mobileRttLabel(rttMs: Long?): String = rttMs?.let { "$it ms" } ?: "—"
  * Throughput label (↑/↓) for terminal header metrics: human-readable rate ([humanRate]), or "—"
  * until the first sample. Parity with the desktop status bar.
  */
+@Composable
 fun mobileRateLabel(bytesPerSec: Long?): String = bytesPerSec?.let { humanRate(it) } ?: "—"
 
 /** What to do on Connect when the host already has an open session. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalStatusText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalStatusText.kt
@@ -1,0 +1,22 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_status_closed
+import app.skerry.ui.generated.resources.term_status_connected
+import app.skerry.ui.generated.resources.term_status_connecting
+import app.skerry.ui.generated.resources.term_status_disconnected
+import app.skerry.ui.generated.resources.term_status_no_session
+import org.jetbrains.compose.resources.stringResource
+
+/** Localized status-line text for [MobileTerminalStatus] (mobile terminal header). */
+@Composable
+fun mobileTerminalStatusText(status: MobileTerminalStatus): String = stringResource(
+    when (status) {
+        MobileTerminalStatus.Connected -> Res.string.term_status_connected
+        MobileTerminalStatus.Connecting -> Res.string.term_status_connecting
+        MobileTerminalStatus.Disconnected -> Res.string.term_status_disconnected
+        MobileTerminalStatus.Closed -> Res.string.term_status_closed
+        MobileTerminalStatus.NoSession -> Res.string.term_status_no_session
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -54,9 +54,12 @@ import app.skerry.shared.host.Host
 import app.skerry.ui.ai.AiNotice
 import app.skerry.ui.ai.TerminalAiController
 import app.skerry.ui.ai.aiBlockedMessage
+import app.skerry.ui.ai.aiFailureMessage
+import app.skerry.ui.ai.shortLabel
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.connectionErrorText
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.immersive.ImmersiveScreen
 import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.secure.SecureScreen
@@ -356,7 +359,7 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                         is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = D.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         is AiNotice.Ask -> Txt(notice.question, color = D.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         AiNotice.Rejected -> Txt(stringResource(Res.string.term_ai_not_a_command), color = D.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        is AiNotice.Error -> Txt(notice.message, color = D.sunset, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        is AiNotice.Error -> Txt(aiFailureMessage(notice.failure), color = D.sunset, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                     else -> {
                         if (prompt.isEmpty()) Txt(stringResource(Res.string.term_ai_ask_short), color = D.dim, size = 13.sp)
@@ -384,7 +387,7 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                 controller.notice != null ->
                     MobileAiChip(stringResource(Res.string.term_ai_dismiss), D.faint) { controller.dismiss() }
                 else -> {
-                    Txt(controller.policy.name.uppercase(), color = D.faint, size = 10.sp, font = mono)
+                    Txt(labelUppercase(controller.policy.shortLabel()), color = D.faint, size = 10.sp, font = mono)
                     Box(
                         Modifier.size(30.dp).clip(RoundedCornerShape(7.dp)).background(D.cyan)
                             .clickable(enabled = !controller.busy) { submit() },
@@ -465,7 +468,7 @@ private fun MobileTerminalHeader(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                     ) {
                         Dot(sessionDotColor(status))
-                        Txt(mobileTerminalStatusText(status), color = sessionDotColor(status), size = 10.5.sp)
+                        Txt(mobileTerminalStatusText(mobileTerminalStatus(status)), color = sessionDotColor(status), size = 10.5.sp)
                     }
                     // Live metrics of the active session (desktop status-bar parity) — only when connected.
                     if (connected) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -65,6 +65,8 @@ import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
 import app.skerry.ui.generated.resources.vault_subtitle_password
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_title
+import app.skerry.ui.generated.resources.vtail_meta_fingerprint
+import app.skerry.ui.generated.resources.vtail_meta_principals
 import app.skerry.ui.secure.SecureScreen
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -392,11 +394,15 @@ private fun MobileSecretCard(credential: Credential, usedByCount: Int, mono: Fon
             }
             val meta = when (credential.secret) {
                 is CredentialSecret.PrivateKey ->
-                    if (keyInfo != null) "${shortFingerprint(keyInfo.fingerprintSha256)} · $usedBy" else usedBy
+                    if (keyInfo != null) {
+                        stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(keyInfo.fingerprintSha256), usedBy)
+                    } else {
+                        usedBy
+                    }
                 is CredentialSecret.Certificate -> when {
                     certInfo == null -> stringResource(Res.string.vault_meta_certificate, usedBy)
                     certInfo.principals.isEmpty() -> stringResource(Res.string.vault_meta_any_principal, usedBy)
-                    else -> "${certInfo.principals.joinToString(", ")} · $usedBy"
+                    else -> stringResource(Res.string.vtail_meta_principals, certInfo.principals.joinToString(", "), usedBy)
                 }
                 is CredentialSecret.Password -> stringResource(Res.string.vault_meta_password, usedBy)
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -50,7 +50,6 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.vnc_connect_failed
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
 import app.skerry.ui.generated.resources.vnc_quality
@@ -66,6 +65,7 @@ import app.skerry.ui.vnc.VncUiState
 import app.skerry.ui.vnc.keySymFor
 import app.skerry.ui.vnc.label
 import androidx.compose.ui.input.key.Key
+import app.skerry.ui.vnc.vncFailureText
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 
@@ -105,7 +105,7 @@ fun MobileVncScreen(state: MobileDesignState) {
     Box(Modifier.fillMaxSize().background(Color.Black)) {
         when (val ui = vnc?.uiState) {
             is VncUiState.Connected -> VncTouchSurface(ui.screen)
-            is VncUiState.Error -> CenterText(ui.message.ifBlank { stringResource(Res.string.vnc_connect_failed) }, D.sunset)
+            is VncUiState.Error -> CenterText(vncFailureText(ui.failure), D.sunset)
             is VncUiState.Disconnected -> Box(Modifier.fillMaxSize()) {
                 VncTouchSurface(ui.screen, interactive = false)
                 CenterText(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiProviderCards.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiProviderCards.kt
@@ -28,12 +28,14 @@ import app.skerry.shared.ai.local.LocalModelCatalog
 import app.skerry.ui.ai.AiAssistantController
 import app.skerry.ui.ai.LocalModelController
 import app.skerry.ui.ai.LocalModelStatus
+import app.skerry.ui.ai.localModelFailureMessage
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.ChipButton
 import app.skerry.ui.design.D
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_transfer_progress
 import app.skerry.ui.generated.resources.settings_ai_badge_private
 import app.skerry.ui.generated.resources.settings_ai_default_provider
 import app.skerry.ui.generated.resources.settings_ai_default_provider_desc
@@ -44,6 +46,7 @@ import app.skerry.ui.generated.resources.settings_ai_local_download
 import app.skerry.ui.generated.resources.settings_ai_local_ready
 import app.skerry.ui.generated.resources.settings_ai_local_retry
 import app.skerry.ui.generated.resources.settings_ai_local_verifying
+import app.skerry.ui.generated.resources.settings_ai_model_meta
 import app.skerry.ui.generated.resources.settings_ai_provider_byok
 import app.skerry.ui.generated.resources.settings_ai_provider_byok_desc
 import app.skerry.ui.generated.resources.settings_ai_provider_device
@@ -127,7 +130,7 @@ private fun LocalModelRow(ai: AiAssistantController, models: LocalModelControlle
             }
             Column(Modifier.weight(1f)) {
                 Txt(model.displayName, color = D.text, size = 12.5.sp, weight = FontWeight.Medium)
-                Txt("${humanSize(model.sizeBytes)} · ${model.license}", color = D.dim, size = 10.5.sp, modifier = Modifier.padding(top = 1.dp))
+                Txt(stringResource(Res.string.settings_ai_model_meta, humanSize(model.sizeBytes), model.license), color = D.dim, size = 10.5.sp, modifier = Modifier.padding(top = 1.dp))
             }
             ModelActions(models, model, status)
         }
@@ -139,13 +142,13 @@ private fun LocalModelRow(ai: AiAssistantController, models: LocalModelControlle
                 Box(Modifier.fillMaxWidth(fraction).fillMaxHeight().background(D.cyan))
             }
             Txt(
-                "${humanSize(status.downloadedBytes)} / ${humanSize(status.totalBytes)}",
+                stringResource(Res.string.ftail_transfer_progress, humanSize(status.downloadedBytes), humanSize(status.totalBytes)),
                 color = D.dim, size = 10.sp,
                 modifier = Modifier.align(Alignment.End).padding(top = 4.dp),
             )
         }
         if (status is LocalModelStatus.Failed) {
-            Txt(status.message, color = D.storm, size = 10.5.sp, lineHeight = 14.sp, modifier = Modifier.padding(top = 6.dp))
+            Txt(localModelFailureMessage(status.failure), color = D.storm, size = 10.5.sp, lineHeight = 14.sp, modifier = Modifier.padding(top = 6.dp))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiSection.kt
@@ -21,6 +21,7 @@ import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.ai.AiRole
 import app.skerry.ui.ai.AiChatBubble
 import app.skerry.ui.ai.AiQuickChatHeader
+import app.skerry.ui.ai.aiFailureMessage
 import app.skerry.ui.ai.isInsecureAiEndpoint
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalAi
@@ -120,7 +121,7 @@ private fun LiveAiSection(ai: app.skerry.ui.ai.AiAssistantController) {
 
     ai.turns.forEach { turn -> AiChatBubble(turn.role, turn.text) }
     ai.streaming?.let { AiChatBubble(AiRole.ASSISTANT, if (it.isEmpty()) "…" else it) }
-    ai.error?.let { Txt(it, color = D.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
+    ai.error?.let { Txt(aiFailureMessage(it), color = D.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
 
     var prompt by remember { mutableStateOf("") }
     val send = { if (prompt.isNotBlank() && !ai.busy) { ai.ask(prompt); prompt = "" } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
@@ -44,6 +44,9 @@ import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.more_biometric_prompt_cancel
+import app.skerry.ui.generated.resources.more_biometric_prompt_subtitle
+import app.skerry.ui.generated.resources.more_biometric_prompt_title
 import app.skerry.ui.generated.resources.settings_autolock_15m
 import app.skerry.ui.generated.resources.settings_autolock_1m
 import app.skerry.ui.generated.resources.settings_autolock_30m
@@ -61,9 +64,11 @@ import app.skerry.ui.generated.resources.settings_change_pw_title
 import app.skerry.ui.generated.resources.settings_event_biometric_disabled
 import app.skerry.ui.generated.resources.settings_event_biometric_enabled
 import app.skerry.ui.generated.resources.settings_event_device_paired
+import app.skerry.ui.generated.resources.settings_event_line
 import app.skerry.ui.generated.resources.settings_event_password_changed
 import app.skerry.ui.generated.resources.settings_event_unlocked_biometric
 import app.skerry.ui.generated.resources.settings_event_vault_created
+import app.skerry.ui.generated.resources.settings_event_with_detail
 import app.skerry.ui.generated.resources.settings_manage
 import app.skerry.ui.generated.resources.settings_recent_security_events
 import app.skerry.ui.generated.resources.settings_security_2fa
@@ -95,13 +100,6 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 
 // Security section: master password, biometrics, auto-lock, event log.
-
-/** Prompt for enabling biometrics from the Security section (English, matching the rest of the UI). */
-private val SECURITY_ENABLE_BIOMETRIC_PROMPT = BiometricPrompt(
-    title = "Enable biometric unlock",
-    cancelLabel = "Cancel",
-    subtitle = "Confirm your biometrics to unlock Skerry without typing the master password.",
-)
 
 /**
  * Live Security section: master password change ([VaultGateController.changePassword] via a
@@ -140,6 +138,13 @@ internal fun SecuritySection(
     // headless desktop Linux — nothing to configure).
     val scope = rememberCoroutineScope()
     if (controller != null && controller.canEnableBiometric()) {
+        // Prompt strings resolved in composable scope (stringResource can't be called in onToggle);
+        // shares the mobile prompt wording (MobileMoreView) — the same system dialog.
+        val enablePrompt = BiometricPrompt(
+            title = stringResource(Res.string.more_biometric_prompt_title),
+            cancelLabel = stringResource(Res.string.more_biometric_prompt_cancel),
+            subtitle = stringResource(Res.string.more_biometric_prompt_subtitle),
+        )
         SettingToggleRow(
             stringResource(Res.string.settings_security_touch_id),
             stringResource(Res.string.settings_security_touch_id_desc),
@@ -148,7 +153,7 @@ internal fun SecuritySection(
                 if (controller.biometricInFlight) return@SettingToggleRow
                 scope.launch {
                     if (controller.biometricEnabled) controller.disableBiometric()
-                    else controller.enableBiometric(SECURITY_ENABLE_BIOMETRIC_PROMPT)
+                    else controller.enableBiometric(enablePrompt)
                     onBiometricToggled()
                 }
             },
@@ -212,8 +217,8 @@ internal fun masterPasswordSubtitle(lastChangeAt: String?): String {
 @Composable
 internal fun securityEventLine(event: SecurityEvent): String {
     val label = event.type.eventLabel()
-    val head = event.detail?.let { "$label: $it" } ?: label
-    return "$head · ${securityEventTime(event.at)}"
+    val head = event.detail?.let { stringResource(Res.string.settings_event_with_detail, label, it) } ?: label
+    return stringResource(Res.string.settings_event_line, head, securityEventTime(event.at))
 }
 
 /** Localized event type label. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpFormat.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpFormat.kt
@@ -1,28 +1,68 @@
 package app.skerry.ui.sftp
 
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_size_bytes
+import app.skerry.ui.generated.resources.ftail_size_gb
+import app.skerry.ui.generated.resources.ftail_size_kb
+import app.skerry.ui.generated.resources.ftail_size_mb
+import app.skerry.ui.generated.resources.ftail_size_pb
+import app.skerry.ui.generated.resources.ftail_size_tb
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToLong
 
-/** Binary size units (1 KB = 1024 B), as file managers conventionally use. */
-private val SIZE_UNITS = listOf("KB", "MB", "GB", "TB", "PB")
+/** Binary size unit (1 KB = 1024 B), as file managers conventionally use. */
+enum class SizeUnit { Bytes, KB, MB, GB, TB, PB }
 
 /**
- * Human-readable size: below 1 KiB, raw bytes ("96 B"); above, one decimal digit with a binary
- * unit ("1.5 KB", "418.0 MB"). No `String.format` (unavailable in commonMain); tenths computed by hand.
+ * A size split into unit and digits, so the visible string comes from a localized template
+ * (decimal separator included) rather than concatenation. [Bytes] uses [whole] alone; the scaled
+ * units render as `whole`+separator+`tenths`. Both digits are always below 1024, hence [Int].
  */
-fun humanSize(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
+data class SizeParts(val unit: SizeUnit, val whole: Int, val tenths: Int = 0)
+
+private val SCALED_UNITS = listOf(SizeUnit.KB, SizeUnit.MB, SizeUnit.GB, SizeUnit.TB, SizeUnit.PB)
+
+/**
+ * Human-readable size decomposition: below 1 KiB, raw bytes; above, one decimal digit with a
+ * binary unit. Pure (no resources), so it stays unit-testable; [sizeText] renders it.
+ */
+fun sizeParts(bytes: Long): SizeParts {
+    if (bytes < 1024) return SizeParts(SizeUnit.Bytes, bytes.toInt())
     var value = bytes.toDouble() / 1024
     var unit = 0
-    while (value >= 1024 && unit < SIZE_UNITS.lastIndex) {
+    while (value >= 1024 && unit < SCALED_UNITS.lastIndex) {
         value /= 1024
         unit++
     }
     var tenths = (value * 10).roundToLong()
     // Rounding can push the value to 1024.0 of the current unit (e.g. 1048575 B -> 1024.0 KB);
     // bump to the next unit so it shows "1.0 MB" instead of "1024.0 KB".
-    if (tenths >= 10_240 && unit < SIZE_UNITS.lastIndex) {
+    if (tenths >= 10_240 && unit < SCALED_UNITS.lastIndex) {
         unit++
         tenths = 10
     }
-    return "${tenths / 10}.${tenths % 10} ${SIZE_UNITS[unit]}"
+    return SizeParts(SCALED_UNITS[unit], (tenths / 10).toInt(), (tenths % 10).toInt())
 }
+
+/** Localized template for a scaled unit; [SizeUnit.Bytes] has its own single-argument template. */
+private fun scaledTemplate(unit: SizeUnit): StringResource = when (unit) {
+    SizeUnit.KB -> Res.string.ftail_size_kb
+    SizeUnit.MB -> Res.string.ftail_size_mb
+    SizeUnit.GB -> Res.string.ftail_size_gb
+    SizeUnit.TB -> Res.string.ftail_size_tb
+    SizeUnit.PB -> Res.string.ftail_size_pb
+    SizeUnit.Bytes -> Res.string.ftail_size_bytes
+}
+
+/** Renders [parts] through the localized size template. */
+@Composable
+fun sizeText(parts: SizeParts): String = when (parts.unit) {
+    SizeUnit.Bytes -> stringResource(Res.string.ftail_size_bytes, parts.whole)
+    else -> stringResource(scaledTemplate(parts.unit), parts.whole, parts.tenths)
+}
+
+/** Human-readable size of [bytes] ("96 B", "1.5 KB", "418.0 MB"). */
+@Composable
+fun humanSize(bytes: Long): String = sizeText(sizeParts(bytes))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -67,8 +67,11 @@ import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.PathJumpField
 import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.files.TransferState
+import app.skerry.ui.files.fileBrowserFailureText
 import app.skerry.ui.files.platformLocalBrowser
+import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_fkey_copy
 import app.skerry.ui.generated.resources.ftail_fkey_delete
 import app.skerry.ui.generated.resources.ftail_fkey_edit
@@ -79,6 +82,8 @@ import app.skerry.ui.generated.resources.ftail_fkey_refresh
 import app.skerry.ui.generated.resources.ftail_fkey_rename
 import app.skerry.ui.generated.resources.ftail_fkey_view
 import app.skerry.ui.generated.resources.ftail_open_failed
+import app.skerry.ui.generated.resources.ftail_transfer_counter
+import app.skerry.ui.generated.resources.ftail_transfer_progress
 import app.skerry.ui.generated.resources.sftp_already_exists
 import app.skerry.ui.generated.resources.sftp_cancel
 import app.skerry.ui.generated.resources.sftp_copy
@@ -128,6 +133,7 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSftpPrefs
 import app.skerry.ui.design.MeterBar
@@ -241,8 +247,9 @@ private fun LiveSftpView(
             coord = controller.openTransferCoordinator(platformLocalBrowser(), subtitle)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
-            openError = e.message ?: openFailedMsg
+        } catch (_: Exception) {
+            // sshj/transport text carries addresses and internals — only the localized reason is shown.
+            openError = openFailedMsg
         }
     }
 
@@ -623,7 +630,7 @@ private fun LivePane(
         ) {
             Sym(icon, size = 16.sp, color = if (active) iconColor else D.faint)
             Txt(
-                label.uppercase(),
+                labelUppercase(label),
                 color = if (active) D.cyanBright else D.faint,
                 size = 11.sp,
                 weight = FontWeight.SemiBold,
@@ -642,7 +649,8 @@ private fun LivePane(
         Box(Modifier.weight(1f).fillMaxWidth()) {
             when (val st = pane.state) {
                 FilePaneState.Loading -> PaneNotice("sync", stringResource(Res.string.sftp_loading), null, D.faint)
-                is FilePaneState.Error -> PaneNotice("error", stringResource(Res.string.sftp_error), st.message, D.sunset)
+                is FilePaneState.Error ->
+                    PaneNotice("error", stringResource(Res.string.sftp_error), fileBrowserFailureText(st.failure), D.sunset)
                 is FilePaneState.Loaded -> LivePaneList(
                     pane = pane,
                     entries = st.entries,
@@ -926,12 +934,16 @@ private fun LiveTransferStrip(transfer: TransferState, mono: FontFamily, onDismi
             ) {
                 val up = transfer.direction == TransferDirection.Upload
                 Sym(if (up) "upload" else "download", size = 16.sp, color = D.cyan)
-                val counter = if (transfer.fileCount > 1) " (${transfer.fileIndex}/${transfer.fileCount})" else ""
-                Txt(transfer.name + counter, color = D.textBright, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                val title = if (transfer.fileCount > 1) {
+                    stringResource(Res.string.ftail_transfer_counter, transfer.name, transfer.fileIndex, transfer.fileCount)
+                } else {
+                    transfer.name
+                }
+                Txt(title, color = D.textBright, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
                 val fraction = if (transfer.total > 0) transfer.transferred.toFloat() / transfer.total else 0f
                 MeterBar(fraction, D.cyan, Modifier.weight(1f))
                 val tail = if (transfer.total > 0) {
-                    "${humanSize(transfer.transferred)} / ${humanSize(transfer.total)}"
+                    stringResource(Res.string.ftail_transfer_progress, humanSize(transfer.transferred), humanSize(transfer.total))
                 } else {
                     humanSize(transfer.transferred)
                 }
@@ -948,7 +960,11 @@ private fun LiveTransferStrip(transfer: TransferState, mono: FontFamily, onDismi
             ) {
                 Sym("error", size = 16.sp, color = D.sunset)
                 Txt(
-                    stringResource(Res.string.sftp_transfer_error, transfer.name, transfer.message),
+                    stringResource(
+                        Res.string.sftp_transfer_error,
+                        transfer.name.ifBlank { stringResource(Res.string.ftail_file_fallback) },
+                        transferFailureText(transfer.failure),
+                    ),
                     color = D.sunset,
                     size = 11.5.sp,
                     maxLines = 2,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
@@ -84,6 +84,7 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
@@ -523,7 +524,7 @@ private fun MockSnippetRow(snippet: MockSnippet, mono: FontFamily) {
 
 @Composable
 private fun FieldLabelSnip(text: String) {
-    Txt(text.uppercase(), color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 8.dp))
+    Txt(labelUppercase(text), color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 8.dp))
 }
 
 /** Single-line editable field ([SnipInput] style plus placeholder and input). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -114,6 +114,8 @@ enum class SyncFailureReason {
     WrongDevicePassword,
     LocalVaultCorrupted,
     PairingFailed,         // other pairing failures (no detail: don't expose crypto/Ktor internals)
+    VaultRekeyFailed,      // vault couldn't be re-wrapped under the account password
+    AccountKeyNotAdopted,  // the account key didn't open, so the confirmed replace didn't happen
     SaveSettingsFailed,    // sync settings didn't save (detail: cause)
     SyncFailed,            // sync cycle failure (detail: cause)
     RevokeFailed,          // device revoke failed (detail: cause)
@@ -441,14 +443,14 @@ class SyncCoordinator(
                     // the local one and diverge from the account — re-wrap it explicitly instead.
                     KeyAdoption.AlreadyOurs -> if (!vault.rewrapUnder(masterPassword.copyOf())) {
                         runCatching { syncClient.close() }
-                        _status.value = SyncStatus.Failed(SyncFailureReason.ConnectFailed, "vault re-key failed")
+                        _status.value = SyncStatus.Failed(SyncFailureReason.VaultRekeyFailed)
                         return
                     }
                     // The replace the user confirmed did NOT happen (the account wrap didn't open). Connecting
                     // now would claim a password change that isn't there, on records we can't decrypt.
                     KeyAdoption.Undecryptable -> {
                         runCatching { syncClient.close() }
-                        _status.value = SyncStatus.Failed(SyncFailureReason.ConnectFailed, "account key could not be adopted")
+                        _status.value = SyncStatus.Failed(SyncFailureReason.AccountKeyNotAdopted)
                         return
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
@@ -12,6 +12,9 @@ import app.skerry.ui.generated.resources.sync_fail_network
 import app.skerry.ui.generated.resources.sync_fail_pairing
 import app.skerry.ui.generated.resources.sync_fail_pairing_expired
 import app.skerry.ui.generated.resources.sync_fail_protocol
+import app.skerry.ui.generated.resources.stail_sync_fail_detail
+import app.skerry.ui.generated.resources.stail_sync_fail_key_adopt
+import app.skerry.ui.generated.resources.stail_sync_fail_rekey
 import app.skerry.ui.generated.resources.sync_fail_revoke
 import app.skerry.ui.generated.resources.sync_fail_save_settings
 import app.skerry.ui.generated.resources.sync_fail_sync
@@ -21,8 +24,9 @@ import app.skerry.ui.generated.resources.sync_fail_wrong_device_password
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Localized text for a [SyncStatus.Failed] reason. [SyncStatus.Failed.detail], if present, is
- * appended after a colon.
+ * Localized text for a [SyncStatus.Failed] reason. [SyncStatus.Failed.detail] is a raw technical
+ * message (server/library): it never stands alone, only as a parenthetical after the localized
+ * reason, so the sentence stays translatable.
  */
 @Composable
 fun syncFailureText(failed: SyncStatus.Failed): String {
@@ -41,10 +45,13 @@ fun syncFailureText(failed: SyncStatus.Failed): String {
             SyncFailureReason.WrongDevicePassword -> Res.string.sync_fail_wrong_device_password
             SyncFailureReason.LocalVaultCorrupted -> Res.string.sync_fail_local_vault_corrupted
             SyncFailureReason.PairingFailed -> Res.string.sync_fail_pairing
+            SyncFailureReason.VaultRekeyFailed -> Res.string.stail_sync_fail_rekey
+            SyncFailureReason.AccountKeyNotAdopted -> Res.string.stail_sync_fail_key_adopt
             SyncFailureReason.SaveSettingsFailed -> Res.string.sync_fail_save_settings
             SyncFailureReason.SyncFailed -> Res.string.sync_fail_sync
             SyncFailureReason.RevokeFailed -> Res.string.sync_fail_revoke
         },
     )
-    return failed.detail?.takeIf { it.isNotBlank() }?.let { "$base: $it" } ?: base
+    val detail = failed.detail?.takeIf { it.isNotBlank() } ?: return base
+    return stringResource(Res.string.stail_sync_fail_detail, base, detail)
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
@@ -34,6 +34,7 @@ import app.skerry.ui.generated.resources.lib_teams_event_invite
 import app.skerry.ui.generated.resources.lib_teams_event_remove
 import app.skerry.ui.generated.resources.lib_teams_event_role_change
 import app.skerry.ui.generated.resources.lib_teams_event_share
+import app.skerry.ui.generated.resources.lib_teams_event_unknown
 import app.skerry.ui.generated.resources.lib_teams_history_empty
 import app.skerry.ui.generated.resources.lib_teams_history_title
 import app.skerry.ui.generated.resources.lib_teams_role_admin
@@ -70,7 +71,7 @@ internal fun roleBadgeColors(role: TeamRole): Pair<Color, Color> = when (role) {
     TeamRole.VIEWER -> D.dim to Color(0x0DFFFFFF)
 }
 
-/** Localized audit event summary; unknown events shown verbatim. */
+/** Localized audit event summary; an unknown code goes into a localized fallback as a detail. */
 @Composable
 internal fun teamEventLabel(event: String): String = when (event) {
     "team.create" -> stringResource(Res.string.lib_teams_event_create)
@@ -80,7 +81,7 @@ internal fun teamEventLabel(event: String): String = when (event) {
     "team.role_change" -> stringResource(Res.string.lib_teams_event_role_change)
     "team.push" -> stringResource(Res.string.lib_teams_event_share)
     "team.delete" -> stringResource(Res.string.lib_teams_event_delete)
-    else -> event
+    else -> stringResource(Res.string.lib_teams_event_unknown, event)
 }
 
 /** Member role/status badge (shared visual language for desktop and mobile). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -92,8 +92,8 @@ import app.skerry.ui.generated.resources.lib_teams_share_host
 import app.skerry.ui.generated.resources.lib_teams_share_host_title
 import app.skerry.ui.generated.resources.lib_teams_share_snippet
 import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
-import app.skerry.ui.generated.resources.lib_teams_shared_hosts
-import app.skerry.ui.generated.resources.lib_teams_shared_snippets
+import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
+import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
 import app.skerry.ui.generated.resources.lib_teams_sidebar
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.generated.resources.lib_teams_sync_now
@@ -383,7 +383,7 @@ private fun TeamDetail(
         if (!invited) {
             Row(Modifier.padding(top = 24.dp), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
                 Column(Modifier.weight(1f)) {
-                    LiveSectionLabel("${stringResource(Res.string.lib_teams_shared_hosts)} · ${sharedHosts.size}")
+                    LiveSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
                     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
                     sharedHosts.forEach { host ->
                         SharedRecordRow(host.label, "${host.username}@${host.address}", mono, canUnshare = canWrite) { onUnshare(host.id) }
@@ -393,7 +393,7 @@ private fun TeamDetail(
                     }
                 }
                 Column(Modifier.weight(1f)) {
-                    LiveSectionLabel("${stringResource(Res.string.lib_teams_shared_snippets)} · ${sharedSnippets.size}")
+                    LiveSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
                     if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
                     sharedSnippets.forEach { snippet ->
                         SharedRecordRow(snippet.label, snippet.command, mono, canUnshare = canWrite) { onUnshare(snippet.id) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
@@ -39,6 +39,8 @@ import app.skerry.shared.ai.CommandRisk
 import app.skerry.ui.ai.AiNotice
 import app.skerry.ui.ai.TerminalAiController
 import app.skerry.ui.ai.aiBlockedMessage
+import app.skerry.ui.ai.aiFailureMessage
+import app.skerry.ui.ai.shortLabel
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalFeatures
 import app.skerry.ui.design.ChipButton
@@ -47,6 +49,7 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_ai_ask_placeholder
 import app.skerry.ui.generated.resources.term_ai_confirm_run
@@ -161,7 +164,7 @@ internal fun AiBarInput(
                         is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = D.amber, size = 12.5.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         is AiNotice.Ask -> Txt(notice.question, color = D.amber, size = 12.5.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
                         AiNotice.Rejected -> Txt(stringResource(Res.string.term_ai_not_a_command), color = D.amber, size = 12.5.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        is AiNotice.Error -> Txt(notice.message, color = D.sunset, size = 12.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        is AiNotice.Error -> Txt(aiFailureMessage(notice.failure), color = D.sunset, size = 12.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
                     }
                     else -> {
                         if (prompt.isEmpty()) Txt(stringResource(Res.string.term_ai_ask_placeholder), color = D.dim, size = 13.sp)
@@ -194,7 +197,7 @@ internal fun AiBarInput(
                 controller.notice != null ->
                     AiActionChip(stringResource(Res.string.term_ai_dismiss), D.faint, onClick = { controller.dismiss() })
                 else -> {
-                    AiBarTag("verified_user", controller.policy.name.uppercase(), mono)
+                    AiBarTag("verified_user", labelUppercase(controller.policy.shortLabel()), mono)
                     Box(
                         Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).background(D.cyan)
                             .clickable(enabled = !controller.busy) { submit() },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
@@ -40,13 +40,13 @@ import app.skerry.ui.generated.resources.term_auth_password
 import app.skerry.ui.generated.resources.term_info_address
 import app.skerry.ui.generated.resources.term_info_auth
 import app.skerry.ui.generated.resources.term_info_cipher
-import app.skerry.ui.generated.resources.term_info_connection
 import app.skerry.ui.generated.resources.term_info_host
 import app.skerry.ui.generated.resources.term_info_jump
-import app.skerry.ui.generated.resources.term_info_live
 import app.skerry.ui.generated.resources.term_info_system
 import app.skerry.ui.generated.resources.term_info_uptime
 import app.skerry.ui.generated.resources.term_info_user
+import app.skerry.ui.generated.resources.term_system_load
+import app.skerry.ui.generated.resources.term_system_vcpu
 import app.skerry.ui.metrics.HostMetrics
 import app.skerry.ui.metrics.HostMonitorSections
 import app.skerry.ui.metrics.MetricsAvailability
@@ -146,14 +146,13 @@ private const val MOCK_SYSTEM = "Ubuntu 22.04.4 LTS\nLinux 5.15.0-105 x86_64\n4 
  * Builds the info panel's SYSTEM block from live host facts: OS, kernel, "N vCPU · load …" line.
  * Skips fields not yet available (poll pending / non-Linux). If all are empty, returns "…".
  */
+@Composable
 private fun liveSystemSummary(m: HostMetrics?): String {
-    val cpuLoad = buildString {
-        m?.cpuCount?.let { append("$it vCPU") }
-        m?.loadAverage?.let {
-            if (isNotEmpty()) append(" · ")
-            append("load $it")
-        }
-    }
+    // Parts are resolved through resources here (not concatenated from literals) so the block follows
+    // the UI language.
+    val cpu = m?.cpuCount?.let { stringResource(Res.string.term_system_vcpu, it) }
+    val load = m?.loadAverage?.let { stringResource(Res.string.term_system_load, it) }
+    val cpuLoad = listOfNotNull(cpu, load).joinToString(" · ")
     val lines = listOfNotNull(
         m?.osName,
         m?.kernel,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFailureText.kt
@@ -1,0 +1,21 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.connection.jumpProblemText
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_tunnel_error_host_missing
+import app.skerry.ui.generated.resources.conn_tunnel_error_no_credential
+import org.jetbrains.compose.resources.stringResource
+
+/** Localized reason a tunnel can't be dialled. */
+@Composable
+fun tunnelUnavailableText(reason: TunnelUnavailable): String = when (reason) {
+    TunnelUnavailable.HostNotFound -> stringResource(Res.string.conn_tunnel_error_host_missing)
+    TunnelUnavailable.NoCredential -> stringResource(Res.string.conn_tunnel_error_no_credential)
+    is TunnelUnavailable.Jump -> jumpProblemText(reason.problem)
+}
+
+/** Text under a failed tunnel row: the typed reason if there is one, else the transport message. */
+@Composable
+fun tunnelFailureText(status: TunnelStatus.Failed): String =
+    status.reason?.let { tunnelUnavailableText(it) } ?: status.message

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
@@ -3,7 +3,6 @@ package app.skerry.ui.tunnel
 import app.skerry.shared.host.Host
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.connection.JumpChainResolution
-import app.skerry.ui.connection.jumpProblemLabel
 import app.skerry.ui.connection.resolveJumpChain
 import app.skerry.ui.connection.toSshAuth
 import app.skerry.ui.connection.toTarget
@@ -53,18 +52,19 @@ fun buildTunnelDraft(
  * Resolves a saved tunnel to connection parameters (for the [TunnelManager] production lambda).
  * Host is looked up by [Tunnel.hostId], credential by [Host.credentialId] in the unlocked vault;
  * the host's ProxyJump chain (if any) is resolved too, so tunnels ride the same route as sessions.
- * Messages are generic constants without technical detail, per [TunnelResolution.Unavailable].
+ * Failures are typed ([TunnelUnavailable]) — this runs outside the composition, the view localizes.
  */
 fun resolveTunnel(
     tunnel: app.skerry.shared.tunnel.Tunnel,
     findHost: (String) -> Host?,
     findCredential: (String?) -> Credential?,
 ): TunnelResolution {
-    val host = findHost(tunnel.hostId) ?: return TunnelResolution.Unavailable("Host not found")
+    val host = findHost(tunnel.hostId) ?: return TunnelResolution.Unavailable(TunnelUnavailable.HostNotFound)
     val credential = findCredential(host.credentialId)
-        ?: return TunnelResolution.Unavailable("No saved credential")
+        ?: return TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
     val jump = when (val chain = resolveJumpChain(host, findHost, findCredential)) {
-        is JumpChainResolution.Unavailable -> return TunnelResolution.Unavailable(jumpProblemLabel(chain.problem))
+        is JumpChainResolution.Unavailable ->
+            return TunnelResolution.Unavailable(TunnelUnavailable.Jump(chain.problem))
         is JumpChainResolution.Resolved -> chain.jump
     }
     return TunnelResolution.Ready(host.toTarget(jump), credential.toSshAuth())

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
@@ -19,6 +19,7 @@ import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.tunnel.Tunnel
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.shared.tunnel.TunnelStore
+import app.skerry.ui.connection.JumpChainProblem
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ptail_err_auth_failed
 import app.skerry.ui.generated.resources.ptail_err_connection_failed
@@ -49,17 +50,28 @@ data class TunnelDraft(
     val destPort: Int? = null,
 )
 
+/**
+ * Why a saved tunnel can't be dialled. Typed, not a message string: [resolve] runs outside the
+ * composition, so the view localizes it (`tunnelFailureText`) — same rule as [JumpChainProblem].
+ */
+sealed interface TunnelUnavailable {
+    /** The tunnel's host profile was deleted. */
+    data object HostNotFound : TunnelUnavailable
+
+    /** The host has no secret bound in the vault. */
+    data object NoCredential : TunnelUnavailable
+
+    /** The host's ProxyJump chain didn't resolve. */
+    data class Jump(val problem: JumpChainProblem) : TunnelUnavailable
+}
+
 /** Resolution of a saved tunnel to connection parameters: either the host and secret are available, or not. */
 sealed interface TunnelResolution {
     /** Ready to connect: host address and auth resolved from the vault. */
     data class Ready(val target: SshTarget, val auth: SshAuth) : TunnelResolution
 
-    /**
-     * Cannot connect (host deleted, secret unbound, etc). [reason] is shown to the user as-is,
-     * bypassing [TunnelManager.friendlyError] — [resolve] implementations must keep it generic,
-     * with no file names, record ids, or system messages.
-     */
-    data class Unavailable(val reason: String) : TunnelResolution
+    /** Cannot connect (host deleted, secret unbound, broken jump chain). */
+    data class Unavailable(val reason: TunnelUnavailable) : TunnelResolution
 }
 
 /** Runtime state of a saved tunnel; config lives in [Tunnel], this is the on/off status. */
@@ -73,8 +85,11 @@ sealed interface TunnelStatus {
     /** Active; [boundPort] is the listener's actual port (assigned port when `0` was requested). */
     data class Active(val boundPort: Int) : TunnelStatus
 
-    /** Failed to come up; [message] is user-facing (no raw transport details). */
-    data class Failed(val message: String) : TunnelStatus
+    /**
+     * Failed to come up. [reason] is set when the failure was typed (config, not transport) and
+     * takes precedence in the UI; [message] is the friendly transport string otherwise.
+     */
+    data class Failed(val message: String = "", val reason: TunnelUnavailable? = null) : TunnelStatus
 }
 
 /**
@@ -203,7 +218,7 @@ class TunnelManager(
         entry.connectingJob = scope.launch {
             try {
                 when (val resolution = resolve(entry.tunnel)) {
-                    is TunnelResolution.Unavailable -> entry.status = TunnelStatus.Failed(resolution.reason)
+                    is TunnelResolution.Unavailable -> entry.status = TunnelStatus.Failed(reason = resolution.reason)
                     is TunnelResolution.Ready -> openForward(entry, resolution)
                 }
             } finally {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
@@ -81,6 +81,7 @@ import app.skerry.ui.design.D
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalTunnels
 import app.skerry.ui.design.MeterBar
@@ -286,7 +287,7 @@ private fun TunnelRowGlobal(
             }
         }
         (entry.status as? TunnelStatus.Failed)?.let {
-            Txt(it.message, color = D.sunset, size = 11.sp, font = mono, modifier = Modifier.padding(start = 16.dp, bottom = 10.dp))
+            Txt(tunnelFailureText(it), color = D.sunset, size = 11.sp, font = mono, modifier = Modifier.padding(start = 16.dp, bottom = 10.dp))
         }
     }
 }
@@ -566,7 +567,7 @@ private fun TunnelDetail() {
 
 @Composable
 private fun FieldLabel(text: String) {
-    Txt(text.uppercase(), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 5.dp))
+    Txt(labelUppercase(text), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 5.dp))
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -131,6 +131,8 @@ import app.skerry.ui.generated.resources.vault_subtitle_password
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_used_by
 import app.skerry.ui.generated.resources.vault_used_by_one
+import app.skerry.ui.generated.resources.vtail_meta_fingerprint
+import app.skerry.ui.generated.resources.vtail_meta_principals
 import app.skerry.ui.host.HostDraft
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -156,6 +158,7 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
@@ -452,7 +455,7 @@ private fun LiveSecretCard(
                     val meta = when {
                         info == null -> stringResource(Res.string.vault_meta_certificate, usedBy)
                         info.principals.isEmpty() -> stringResource(Res.string.vault_meta_any_principal, usedBy)
-                        else -> "${info.principals.joinToString(", ")} · $usedBy"
+                        else -> stringResource(Res.string.vtail_meta_principals, info.principals.joinToString(", "), usedBy)
                     }
                     Txt(meta, color = D.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
                 }
@@ -465,7 +468,11 @@ private fun LiveSecretCard(
                         Txt(credential.label, color = D.text, size = 13.5.sp, weight = FontWeight.SemiBold)
                         info?.keyTypeLabel?.let { Badge(it, bg = D.moss.copy(alpha = 0.16f), fg = D.moss, radius = 3, size = 9.5.sp) }
                     }
-                    val meta = if (info != null) "${shortFingerprint(info.fingerprintSha256)} · $usedBy" else usedBy
+                    val meta = if (info != null) {
+                        stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(info.fingerprintSha256), usedBy)
+                    } else {
+                        usedBy
+                    }
                     Txt(meta, color = D.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
                 }
             }
@@ -1053,7 +1060,7 @@ private fun KeyDetail(mono: FontFamily) {
 
 @Composable
 internal fun DetailLabel(text: String) {
-    Txt(text.uppercase(), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 6.dp))
+    Txt(labelUppercase(text), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 6.dp))
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncFailureText.kt
@@ -1,0 +1,41 @@
+package app.skerry.ui.vnc
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.vnc.VncAuthException
+import app.skerry.shared.vnc.VncProtocolException
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vnc_connect_failed
+import app.skerry.ui.generated.resources.vnc_error_auth
+import app.skerry.ui.generated.resources.vnc_error_protocol
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Why a VNC connect failed, as a localization contract. RFB wire exceptions carry English
+ * diagnostics ("truncated varint", "unsupported ZRLE subencoding 4") that are useless to a user and
+ * untranslatable, so the reason travels typed and the text is resolved in composition.
+ */
+enum class VncFailure {
+    /** Server demands an authentication scheme Skerry doesn't implement, or the secret was rejected. */
+    Auth,
+
+    /** The RFB stream was malformed or used an unsupported feature. */
+    Protocol,
+
+    /** Anything else — transport drop, refused socket, timeout. */
+    Other,
+}
+
+/** Classifies a connect exception; the cause chain is checked because the transport wraps. */
+fun vncFailureOf(e: Throwable): VncFailure = when {
+    e is VncAuthException || e.cause is VncAuthException -> VncFailure.Auth
+    e is VncProtocolException || e.cause is VncProtocolException -> VncFailure.Protocol
+    else -> VncFailure.Other
+}
+
+/** User-facing text for [failure]. */
+@Composable
+fun vncFailureText(failure: VncFailure): String = when (failure) {
+    VncFailure.Auth -> stringResource(Res.string.vnc_error_auth)
+    VncFailure.Protocol -> stringResource(Res.string.vnc_error_protocol)
+    VncFailure.Other -> stringResource(Res.string.vnc_connect_failed)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncSessionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncSessionController.kt
@@ -27,8 +27,11 @@ sealed interface VncUiState {
     /** Session is live; [screen] is the framebuffer + input bridge. */
     data class Connected(val screen: VncScreenState) : VncUiState
 
-    /** Connect failed; [message] is shown to the user (blank → the UI shows a generic localized "failed to connect"). */
-    data class Error(val message: String) : VncUiState
+    /**
+     * Connect failed. [failure] is the localization contract — the raw [detail] (wire diagnostics,
+     * always English) is for logs, never the message shown on its own.
+     */
+    data class Error(val failure: VncFailure, val detail: String = "") : VncUiState
 
     /**
      * The session closed not on our initiative (server drop / EOF). [screen] is the frozen last
@@ -90,8 +93,8 @@ class VncSessionController(
                 throw e
             } catch (e: Exception) {
                 releaseSession()
-                // Blank message → the UI substitutes a localized generic (controllers can't resolve resources).
-                uiState = VncUiState.Error(e.message ?: "")
+                // Typed reason for the UI; the wire text stays as diagnostics only.
+                uiState = VncUiState.Error(vncFailureOf(e), e.message.orEmpty())
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -58,7 +58,6 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.vnc_connect_failed
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
 import app.skerry.ui.generated.resources.vnc_quality
@@ -93,7 +92,7 @@ fun VncView(state: DesktopDesignState) {
             }
             is VncUiState.Error -> CenterNotice(
                 "error",
-                ui.message.ifBlank { stringResource(Res.string.vnc_connect_failed) },
+                vncFailureText(ui.failure),
                 color = D.sunset,
             )
             is VncUiState.Disconnected -> Box(Modifier.fillMaxSize()) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AiAssistantControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AiAssistantControllerTest.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -61,7 +60,7 @@ class AiAssistantControllerTest {
         advanceUntilIdle()
 
         assertEquals(1, c.turns.size)
-        assertNotNull(c.error)
+        assertEquals(AiFailure.UNAUTHORIZED, c.error)
         assertFalse(c.busy)
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AiStreamRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AiStreamRunnerTest.kt
@@ -54,28 +54,28 @@ class AiStreamRunnerTest {
     fun `maps AiException to a friendly message and still closes the provider`() = runTest {
         val provider = ScriptedProvider(failWith = AiException(AiException.Kind.UNAUTHORIZED, "401"))
         val runner = AiStreamRunner({ provider }, this)
-        var error: String? = null
+        var error: AiFailure? = null
         var completed: String? = null
 
         runner.launch(config, emptyList(), onDelta = { }, onComplete = { completed = it },
             onError = { error = it }, onFinally = { })
         advanceUntilIdle()
 
-        assertEquals(AiException(AiException.Kind.UNAUTHORIZED, "401").friendlyMessage(), error)
+        assertEquals(AiFailure.UNAUTHORIZED, error)
         assertNull(completed)
         assertTrue(provider.closed)
     }
 
     @Test
-    fun `maps an unexpected exception to a generic message`() = runTest {
+    fun `maps an unexpected exception to a generic failure`() = runTest {
         val runner = AiStreamRunner({ ScriptedProvider(failWith = RuntimeException("boom")) }, this)
-        var error: String? = null
+        var error: AiFailure? = null
 
         runner.launch(config, emptyList(), onDelta = { }, onComplete = { },
             onError = { error = it }, onFinally = { })
         advanceUntilIdle()
 
-        assertEquals("AI request failed: boom", error)
+        assertEquals(AiFailure.UNKNOWN, error)
     }
 
     @Test
@@ -89,7 +89,7 @@ class AiStreamRunnerTest {
             override suspend fun close() {}
         }
         val runner = AiStreamRunner({ provider }, this)
-        var error: String? = null
+        var error: AiFailure? = null
         var finallyCalled = false
 
         val job = runner.launch(config, emptyList(), onDelta = { }, onComplete = { },

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/LocalModelControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/LocalModelControllerTest.kt
@@ -86,7 +86,7 @@ class LocalModelControllerTest {
 
         c.download(model)
         advanceUntilIdle()
-        assertIs<LocalModelStatus.Failed>(c.status(model))
+        assertEquals(LocalModelFailure.NETWORK, assertIs<LocalModelStatus.Failed>(c.status(model)).failure)
 
         fail = false
         c.download(model)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
@@ -377,7 +377,7 @@ class TerminalAiControllerTest {
         c.ask("list files")
         advanceUntilIdle()
 
-        assertIs<AiNotice.Error>(c.notice)
+        assertEquals(AiFailure.UNAUTHORIZED, assertIs<AiNotice.Error>(c.notice).failure)
         assertNull(c.pending)
         assertFalse(c.busy)
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestTest.kt
@@ -56,28 +56,28 @@ class ConnectionTestTest {
     }
 
     @Test
-    fun `auth failure maps to friendly message`() = runTest {
+    fun `auth failure maps to a typed reason`() = runTest {
         val status = runConnectionTest(ProbeTransport(error = SshAuthenticationException("denied")), target, auth)
-        assertEquals(ConnectionTestStatus.Failure("Authentication failed"), status)
+        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.AuthenticationFailed), status)
     }
 
     @Test
-    fun `host key rejection maps to friendly message`() = runTest {
+    fun `host key rejection maps to a typed reason`() = runTest {
         val status = runConnectionTest(ProbeTransport(error = SshHostKeyRejectedException("bad key")), target, auth)
-        assertEquals(ConnectionTestStatus.Failure("Host key rejected"), status)
+        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected), status)
     }
 
     @Test
-    fun `connection error maps to generic message without leaking transport detail`() = runTest {
+    fun `connection error maps to a generic typed reason without leaking transport detail`() = runTest {
         // Raw exception text (address/library internals) is never surfaced in the UI — generic only.
         val status = runConnectionTest(ProbeTransport(error = SshConnectionException("no route to 10.0.0.1:22")), target, auth)
-        assertEquals(ConnectionTestStatus.Failure("Connection failed"), status)
+        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.ConnectionFailed), status)
     }
 
     @Test
-    fun `unexpected error maps to generic message`() = runTest {
+    fun `unexpected error maps to a generic typed reason`() = runTest {
         val status = runConnectionTest(ProbeTransport(error = IllegalStateException("library internals")), target, auth)
-        assertEquals(ConnectionTestStatus.Failure("Connection failed"), status)
+        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.ConnectionFailed), status)
     }
 
     // Controller: status transitions

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/LabelCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/LabelCaseTest.kt
@@ -1,0 +1,24 @@
+package app.skerry.ui.design
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Locale-aware uppercasing behind the design system's small-caps labels. */
+class LabelCaseTest {
+    @Test
+    fun latin_labels_uppercase_as_usual() {
+        assertEquals("HOST", uppercaseForLocale("Host", "en"))
+        assertEquals("ХОСТ", uppercaseForLocale("Хост", "ru-RU"))
+    }
+
+    @Test
+    fun caseless_scripts_are_untouched() {
+        assertEquals("主机", uppercaseForLocale("主机", "zh-CN"))
+    }
+
+    @Test
+    fun turkish_keeps_the_dot_on_i() {
+        assertEquals("İSTEMCİ", uppercaseForLocale("istemci", "tr-TR"))
+        assertEquals("IIK", uppercaseForLocale("ıık", "az"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.files
 
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.files.SftpFileBrowser
@@ -143,7 +144,7 @@ class FilePaneControllerTest {
         val noDotDot = object : FileBrowser {
             override val label: String get() = base.label
             override suspend fun realpath(path: String): String {
-                if (path.contains("..")) throw FileBrowserException("REALPATH with .. not supported")
+                if (path.contains("..")) throw FileBrowserException(FileBrowserFailure.Sftp)
                 return base.realpath(path)
             }
             override suspend fun list(path: String): List<FileItem> = base.list(path)
@@ -667,7 +668,7 @@ class FilePaneControllerTest {
         val noDotDot = object : FileBrowser {
             override val label: String get() = base.label
             override suspend fun realpath(path: String): String {
-                if (path.contains("..")) throw FileBrowserException("REALPATH with .. not supported")
+                if (path.contains("..")) throw FileBrowserException(FileBrowserFailure.Sftp)
                 return base.realpath(path)
             }
             override suspend fun list(path: String): List<FileItem> = base.list(path)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -167,7 +167,8 @@ class TransferCoordinatorTest {
         r.coordinator.downloadSelection()
         advanceUntilIdle()
 
-        assertIs<TransferState.Failed>(r.coordinator.transfer)
+        val failed = assertIs<TransferState.Failed>(r.coordinator.transfer)
+        assertEquals(FileTransferFailure.IllegalName, failed.failure)
         assertTrue(r.remoteFake.downloads.none { it.first.endsWith("evil.txt") })
     }
 
@@ -405,6 +406,8 @@ class TransferCoordinatorTest {
         r.coordinator.uploadSelection()
         advanceUntilIdle()
 
-        assertIs<TransferState.Failed>(r.coordinator.transfer)
+        // The library text ("disk full") never reaches the bar — only the typed reason does.
+        val failed = assertIs<TransferState.Failed>(r.coordinator.transfer)
+        assertEquals(FileTransferFailure.Transfer, failed.failure)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/ForwardDisplayTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/ForwardDisplayTest.kt
@@ -30,16 +30,19 @@ class ForwardDisplayTest {
     fun `listen port falls back to the requested port before active`() {
         val starting = entry(ForwardDirection.Local, requestedPort = 8080)
         assertEquals(8080, forwardListenPort(starting))
-        val failed = entry(ForwardDirection.Local, requestedPort = 8080, status = ForwardStatus.Failed("busy"))
+        val failed = entry(ForwardDirection.Local, requestedPort = 8080, status = ForwardStatus.Failed(ForwardFailure.RaiseFailed))
         assertEquals(8080, forwardListenPort(failed))
     }
 
     @Test
     fun `local source is on this machine, remote source is on the server`() {
+        // The `-R` source host is a localized word, so only its absence is asserted here;
+        // forwardSourceText itself is a resource lookup, verifiable only in composition.
         val local = entry(ForwardDirection.Local, bindHost = "127.0.0.1", status = ForwardStatus.Active(8080))
-        assertEquals("127.0.0.1:8080", forwardSourceText(local))
+        assertEquals("127.0.0.1", forwardSourceHost(local))
         val remote = entry(ForwardDirection.Remote, bindHost = "0.0.0.0", status = ForwardStatus.Active(9000))
-        assertEquals("server:9000", forwardSourceText(remote))
+        assertNull(forwardSourceHost(remote))
+        assertEquals(9000, forwardListenPort(remote))
     }
 
     @Test
@@ -56,11 +59,11 @@ class ForwardDisplayTest {
     }
 
     @Test
-    fun `human rate scales bytes per second across units`() {
-        assertEquals("512 B/s", humanRate(512))
-        assertEquals("42 KB/s", humanRate(42L * 1024))
-        assertEquals("1.1 MB/s", humanRate(1_200_000)) // ~1.14 MiB/s rounds down to 1.1
-        assertEquals("0 B/s", humanRate(0))
+    fun `rate parts scale bytes per second across units`() {
+        assertEquals(RateParts(RateUnit.Bytes, 512), rateParts(512))
+        assertEquals(RateParts(RateUnit.KB, 42), rateParts(42L * 1024))
+        assertEquals(RateParts(RateUnit.MB, 1, 1), rateParts(1_200_000)) // ~1.14 MiB/s truncates to 1.1
+        assertEquals(RateParts(RateUnit.Bytes, 0), rateParts(0))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/PortForwardControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/forward/PortForwardControllerTest.kt
@@ -85,7 +85,7 @@ class PortForwardControllerTest {
 
         val entry = controller.forwards.single()
         val status = assertIs<ForwardStatus.Failed>(entry.status)
-        assertEquals("port busy", status.message)
+        assertEquals(ForwardFailure.RaiseFailed, status.failure)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
@@ -35,9 +35,8 @@ class HostChipsTest {
     }
 
     @Test
-    fun chip_label_prefixes_tags_with_hash_but_keeps_all() {
-        assertEquals("All", hostChipLabel(ALL_HOSTS_CHIP))
-        assertEquals("#prod", hostChipLabel("prod"))
+    fun tag_chip_label_prefixes_with_hash() {
+        assertEquals("#prod", hostTagChipLabel("prod"))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileFilesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileFilesTest.kt
@@ -2,8 +2,11 @@ package app.skerry.ui.mobile
 
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.ui.sftp.SizeParts
+import app.skerry.ui.sftp.SizeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /** Pure logic for the mobile Files screen: screen mode, row meta/icons, path breadcrumb. */
 class MobileFilesTest {
@@ -43,11 +46,11 @@ class MobileFilesTest {
     // Row meta caption (direct projection of FileItem)
 
     @Test
-    fun row_meta_shows_human_size_for_files_and_empty_for_dirs() {
-        assertEquals("3.0 KB", mobileFileRowMeta(item("nginx.conf", FileItemType.File, size = 3072)))
-        assertEquals("112 B", mobileFileRowMeta(item("robots.txt", FileItemType.File, size = 112)))
-        // The model has no permissions or item count for directories; meta stays empty.
-        assertEquals("", mobileFileRowMeta(item("html", FileItemType.Directory)))
+    fun row_meta_shows_size_for_files_and_nothing_for_dirs() {
+        assertEquals(SizeParts(SizeUnit.KB, 3, 0), mobileFileRowMeta(item("nginx.conf", FileItemType.File, size = 3072)))
+        assertEquals(SizeParts(SizeUnit.Bytes, 112), mobileFileRowMeta(item("robots.txt", FileItemType.File, size = 112)))
+        // The model has no permissions or item count for directories; the row has no subtitle.
+        assertNull(mobileFileRowMeta(item("html", FileItemType.Directory)))
     }
 
     // Row leading icon

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileTerminalTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileTerminalTest.kt
@@ -4,6 +4,9 @@ import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.forward.RateParts
+import app.skerry.ui.forward.RateUnit
+import app.skerry.ui.forward.rateParts
 import app.skerry.ui.terminal.TerminalScreenState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -19,7 +22,7 @@ import app.skerry.ui.terminal.arrowSequence
 /** Pure logic for the mobile terminal screen: status line, Connect decision, sticky-ctrl. */
 class MobileTerminalTest {
 
-    private fun connected(): ConnectionUiState.Connected {
+    private fun screen(): TerminalScreenState {
         val session = object : TerminalSession {
             override val state: StateFlow<TerminalState> = MutableStateFlow(TerminalState.Open)
             override val output: Flow<ByteArray> = emptyFlow()
@@ -27,18 +30,26 @@ class MobileTerminalTest {
             override suspend fun resize(size: PtySize) {}
             override suspend fun close() {}
         }
-        return ConnectionUiState.Connected(TerminalScreenState(session, CoroutineScope(Job())))
+        return TerminalScreenState(session, CoroutineScope(Job()))
     }
+
+    private fun connected(): ConnectionUiState.Connected = ConnectionUiState.Connected(screen())
+
+    private fun disconnected(cleanExit: Boolean) =
+        ConnectionUiState.Disconnected(screen(), reconnecting = false, attempt = 0, cleanExit = cleanExit)
 
     // Header status line
 
     @Test
-    fun status_text_reflects_connection_state() {
-        assertEquals("connected", mobileTerminalStatusText(connected()))
-        assertEquals("connecting…", mobileTerminalStatusText(ConnectionUiState.Connecting))
-        assertEquals("disconnected", mobileTerminalStatusText(ConnectionUiState.Error("boom")))
-        assertEquals("no session", mobileTerminalStatusText(ConnectionUiState.Form))
-        assertEquals("no session", mobileTerminalStatusText(null))
+    fun status_reflects_connection_state() {
+        assertEquals(MobileTerminalStatus.Connected, mobileTerminalStatus(connected()))
+        assertEquals(MobileTerminalStatus.Connecting, mobileTerminalStatus(ConnectionUiState.Connecting))
+        assertEquals(MobileTerminalStatus.Disconnected, mobileTerminalStatus(ConnectionUiState.Error("boom")))
+        assertEquals(MobileTerminalStatus.NoSession, mobileTerminalStatus(ConnectionUiState.Form))
+        assertEquals(MobileTerminalStatus.NoSession, mobileTerminalStatus(null))
+        // Clean shell exit reads as "closed", a transport drop as "disconnected".
+        assertEquals(MobileTerminalStatus.Closed, mobileTerminalStatus(disconnected(cleanExit = true)))
+        assertEquals(MobileTerminalStatus.Disconnected, mobileTerminalStatus(disconnected(cleanExit = false)))
     }
 
     // Header status-bar metrics (RTT/throughput).
@@ -51,11 +62,10 @@ class MobileTerminalTest {
     }
 
     @Test
-    fun rate_label_humanizes_or_dash_before_first_sample() {
-        // Humanized B/s, "—" until a sample exists.
-        assertEquals("0 B/s", mobileRateLabel(0))
-        assertEquals("1 KB/s", mobileRateLabel(1024))
-        assertEquals("—", mobileRateLabel(null))
+    fun rate_parts_scale_the_header_throughput() {
+        // mobileRateLabel itself is @Composable (localized unit template), so the split is asserted here.
+        assertEquals(RateParts(RateUnit.Bytes, 0), rateParts(0))
+        assertEquals(RateParts(RateUnit.KB, 1), rateParts(1024))
     }
 
     // Decision on Connect tap

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SftpFormatTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SftpFormatTest.kt
@@ -3,28 +3,31 @@ package app.skerry.ui.sftp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/** Pure formatting for the SFTP listing: human-readable file size. */
+/**
+ * Pure size decomposition for the SFTP listing. The visible string comes from a localized template
+ * ([sizeText]), so the unit test covers the unit/digits split only.
+ */
 class SftpFormatTest {
 
     @Test
-    fun bytes_below_kib_show_raw_bytes() {
-        assertEquals("0 B", humanSize(0))
-        assertEquals("96 B", humanSize(96))
-        assertEquals("1023 B", humanSize(1023))
+    fun bytes_below_kib_stay_in_raw_bytes() {
+        assertEquals(SizeParts(SizeUnit.Bytes, 0), sizeParts(0))
+        assertEquals(SizeParts(SizeUnit.Bytes, 96), sizeParts(96))
+        assertEquals(SizeParts(SizeUnit.Bytes, 1023), sizeParts(1023))
     }
 
     @Test
     fun larger_sizes_use_one_decimal_binary_units() {
-        assertEquals("1.0 KB", humanSize(1024))
-        assertEquals("1.5 KB", humanSize(1536))
-        assertEquals("1.0 MB", humanSize(1024L * 1024))
-        assertEquals("418.0 MB", humanSize(418L * 1024 * 1024))
-        assertEquals("2.0 GB", humanSize(2L * 1024 * 1024 * 1024))
+        assertEquals(SizeParts(SizeUnit.KB, 1, 0), sizeParts(1024))
+        assertEquals(SizeParts(SizeUnit.KB, 1, 5), sizeParts(1536))
+        assertEquals(SizeParts(SizeUnit.MB, 1, 0), sizeParts(1024L * 1024))
+        assertEquals(SizeParts(SizeUnit.MB, 418, 0), sizeParts(418L * 1024 * 1024))
+        assertEquals(SizeParts(SizeUnit.GB, 2, 0), sizeParts(2L * 1024 * 1024 * 1024))
     }
 
     @Test
     fun rounding_at_a_unit_boundary_carries_into_the_next_unit() {
-        // 1048575 B = 1024 MiB - 1 B: rounding pushes it to 1024.0 KB, so we show 1.0 MB.
-        assertEquals("1.0 MB", humanSize(1024L * 1024 - 1))
+        // 1048575 B = 1024 KiB - 1 B: rounding pushes it to 1024.0 KB, so we show 1.0 MB.
+        assertEquals(SizeParts(SizeUnit.MB, 1, 0), sizeParts(1024L * 1024 - 1))
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
@@ -6,6 +6,7 @@ import app.skerry.shared.tunnel.Tunnel
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.ui.connection.JumpChainProblem
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -84,7 +85,7 @@ class TunnelFormTest {
         val r = assertIs<TunnelResolution.Unavailable>(
             resolveTunnel(tunnel, findHost = { null }, findCredential = { credential }),
         )
-        assertEquals("Host not found", r.reason)
+        assertEquals(TunnelUnavailable.HostNotFound, r.reason)
     }
 
     @Test
@@ -92,7 +93,7 @@ class TunnelFormTest {
         val r = assertIs<TunnelResolution.Unavailable>(
             resolveTunnel(tunnel, findHost = { host }, findCredential = { null }),
         )
-        assertEquals("No saved credential", r.reason)
+        assertEquals(TunnelUnavailable.NoCredential, r.reason)
     }
 
     @Test
@@ -119,6 +120,6 @@ class TunnelFormTest {
         val r = assertIs<TunnelResolution.Unavailable>(
             resolveTunnel(tunnel, findHost = { hosts[it] }, findCredential = { if (it == "c1") credential else null }),
         )
-        assertEquals("Jump host has no saved credential", r.reason)
+        assertEquals(TunnelUnavailable.Jump(JumpChainProblem.NO_CREDENTIAL), r.reason)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
@@ -127,13 +127,13 @@ class TunnelManagerTest {
     @Test
     fun `activate fails fast when resolution is unavailable and never connects`() = runTest {
         val transport = FakeTunnelTransport()
-        val manager = managerWith(transport, resolve = { TunnelResolution.Unavailable("No saved credential") })
+        val manager = managerWith(transport, resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) })
         val id = manager.save(localDraft())
 
         manager.activate(id)
 
         val status = assertIs<TunnelStatus.Failed>(manager.tunnels.single().status)
-        assertEquals("No saved credential", status.message)
+        assertEquals(TunnelUnavailable.NoCredential, status.reason)
         assertNull(transport.lastTarget) // transport untouched
     }
 
@@ -228,7 +228,7 @@ class TunnelManagerTest {
         var available = false
         val transport = FakeTunnelTransport(FakeTunnelConnection(localPort = 50030))
         val manager = managerWith(transport, resolve = {
-            if (available) TunnelResolution.Ready(target, auth) else TunnelResolution.Unavailable("No saved credential")
+            if (available) TunnelResolution.Ready(target, auth) else TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
         })
         val id = manager.save(localDraft())
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vnc/VncSessionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vnc/VncSessionControllerTest.kt
@@ -78,7 +78,8 @@ class VncSessionControllerTest {
 
         val state = controller.uiState
         assertTrue(state is VncUiState.Error)
-        assertEquals("refused", state.message)
+        assertEquals(VncFailure.Other, state.failure)
+        assertEquals("refused", state.detail)
     }
 
     @Test

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.desktop.kt
@@ -5,11 +5,14 @@ import app.skerry.shared.files.LocalFileBrowser
 import kotlinx.coroutines.Dispatchers
 import okio.FileSystem
 
-/** Desktop: real local filesystem via okio, starting in the user's home directory. */
+/**
+ * Desktop: real local filesystem via okio, starting in the user's home directory. The label is left
+ * blank on purpose — the UI substitutes the localized `ftail_local_label` (parity with Android).
+ */
 actual fun platformLocalBrowser(): FileBrowser =
     LocalFileBrowser(
         fileSystem = FileSystem.SYSTEM,
         home = System.getProperty("user.home") ?: "/",
-        label = "This computer",
+        label = "",
         ioDispatcher = Dispatchers.IO,
     )

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
@@ -1,11 +1,14 @@
 package app.skerry.ui.vault
 
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_dialog_save_as
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.getString
 
 /**
  * Desktop export via the native AWT [FileDialog] (like [app.skerry.ui.sftp.pickDownloadTarget]).
@@ -13,8 +16,10 @@ import kotlinx.coroutines.withContext
  * happens on the IO dispatcher. Cancellation (directory/name null) returns `false`.
  */
 actual suspend fun exportTextFile(suggestedName: String, content: String): Boolean {
+    // Same dialog title as the SFTP download picker, so the shared key is reused.
+    val title = getString(Res.string.sftp_dialog_save_as)
     val path = withContext(Dispatchers.Swing) {
-        val dialog = FileDialog(null as Frame?, "Save as", FileDialog.SAVE).apply {
+        val dialog = FileDialog(null as Frame?, title, FileDialog.SAVE).apply {
             file = suggestedName
             isVisible = true
         }

--- a/shared/src/androidMain/kotlin/app/skerry/shared/serial/SerialSystem.android.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/serial/SerialSystem.android.kt
@@ -48,24 +48,24 @@ actual object SerialSystem {
 
     actual fun open(config: SerialConfig): SerialPortHandle {
         val context = SerialUsbBridge.context()
-            ?: throw SerialUnavailableException("USB context unavailable (app not initialized)")
+            ?: throw SerialUnavailableException(SerialProblem.UNSUPPORTED)
         val usbManager = context.getSystemService(Context.USB_SERVICE) as? UsbManager
-            ?: throw SerialUnavailableException("USB Host API unavailable on this device")
+            ?: throw SerialUnavailableException(SerialProblem.UNSUPPORTED)
 
         val (driver, portIndex) = locate(usbManager, config.portName)
-            ?: throw SerialUnavailableException("USB device ${config.portName} not found")
+            ?: throw SerialUnavailableException(SerialProblem.PORT_NOT_FOUND, config.portName)
 
         if (!ensurePermission(context, usbManager, driver.device)) {
-            throw SerialUnavailableException("No permission to access USB device ${config.portName}")
+            throw SerialUnavailableException(SerialProblem.PERMISSION_DENIED, config.portName)
         }
 
         val connection: UsbDeviceConnection = usbManager.openDevice(driver.device)
-            ?: throw SerialUnavailableException("Failed to open USB device ${config.portName}")
+            ?: throw SerialUnavailableException(SerialProblem.OPEN_FAILED, config.portName)
 
         val port = driver.ports.getOrNull(portIndex)
             ?: run {
                 runCatching { connection.close() }
-                throw SerialUnavailableException("Port #$portIndex missing on ${config.portName}")
+                throw SerialUnavailableException(SerialProblem.PORT_NOT_FOUND, config.portName)
             }
         return try {
             port.open(connection)
@@ -79,7 +79,7 @@ actual object SerialSystem {
         } catch (e: Exception) {
             runCatching { port.close() }
             runCatching { connection.close() }
-            throw SerialUnavailableException("Failed to configure USB port ${config.portName}", e)
+            throw SerialUnavailableException(SerialProblem.CONFIGURE_FAILED, config.portName, e)
         }
     }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
@@ -64,5 +64,33 @@ interface FileBrowser {
     suspend fun rename(from: String, to: String)
 }
 
-/** File browser operation error: missing path/access, wrong object type, or source disconnect. */
-class FileBrowserException(message: String, cause: Throwable? = null) : Exception(message, cause)
+/**
+ * Typed, user-facing reason for a [FileBrowserException]. The UI maps it to a localized string;
+ * platform text (okio/sshj/OS) is never shown as the primary message.
+ */
+enum class FileBrowserFailure {
+    /** Local filesystem error: missing path, denied access, wrong object type. */
+    LocalIo,
+
+    /** Remote SFTP error: missing path, denied access, protocol/connection failure. */
+    Sftp,
+
+    /** A listing entry carries a name that is unsafe to use as a path component. */
+    IllegalName,
+
+    /** The picked source file could not be opened for reading. */
+    OpenSource,
+
+    /** The chosen save target could not be opened for writing. */
+    OpenTarget,
+}
+
+/**
+ * File browser operation error. [failure] is the user-facing reason (localized by the UI);
+ * [detail] carries raw platform text for logs and diagnostics only — never for the primary message.
+ */
+class FileBrowserException(
+    val failure: FileBrowserFailure,
+    val detail: String? = null,
+    cause: Throwable? = null,
+) : Exception(detail ?: failure.name, cause)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/LocalFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/LocalFileBrowser.kt
@@ -56,7 +56,8 @@ class LocalFileBrowser(
     }
 
     /**
-     * Run blocking I/O on [ioDispatcher], wrapping okio [IOException] in [FileBrowserException].
+     * Run blocking I/O on [ioDispatcher], wrapping okio [IOException] in [FileBrowserException]
+     * ([FileBrowserFailure.LocalIo]; the okio text is kept as diagnostic detail only).
      * [CancellationException] is rethrown explicitly (not an [IOException], but kept for consistency
      * in case the catch is broadened later).
      */
@@ -67,7 +68,7 @@ class LocalFileBrowser(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: IOException) {
-                throw FileBrowserException(e.message ?: "Filesystem error", e)
+                throw FileBrowserException(FileBrowserFailure.LocalIo, e.message, e)
             }
         }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
@@ -63,7 +63,8 @@ class SftpFileBrowser(
         try {
             block()
         } catch (e: SftpException) {
-            throw FileBrowserException(e.message ?: "SFTP error", e)
+            // The sshj/protocol text is diagnostic detail only; the UI renders [failure].
+            throw FileBrowserException(FileBrowserFailure.Sftp, e.message, e)
         }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/serial/SerialProblem.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/serial/SerialProblem.kt
@@ -1,0 +1,46 @@
+package app.skerry.shared.serial
+
+/**
+ * Why a serial port could not be opened. Platform-neutral on purpose: desktop (native port) and
+ * Android (USB-OTG) must report the same cause for the same situation, and the UI turns it into
+ * localized text (`serialProblemText`) instead of surfacing a platform message string — same rule
+ * as [app.skerry.shared.sync.SyncFailureReason].
+ */
+enum class SerialProblem {
+    /** The device has no serial support at all (no USB Host API, subsystem not initialized). */
+    UNSUPPORTED,
+
+    /** No port with the requested name — unplugged, renamed, or a port index that doesn't exist. */
+    PORT_NOT_FOUND,
+
+    /** The OS denied access to the port (Android USB permission, desktop device permissions). */
+    PERMISSION_DENIED,
+
+    /** The port exists but wouldn't open: busy, held by another program, or a driver failure. */
+    OPEN_FAILED,
+
+    /** The port opened but rejected the frame format (baud rate, data/stop bits, parity). */
+    CONFIGURE_FAILED,
+}
+
+/**
+ * Port unavailable: the platform has no serial support, or the device could not be opened.
+ * [problem] is the typed cause and [detail] the port name it refers to; [message] is an English
+ * fallback for logs — user-facing text is rendered from [problem] in the UI.
+ */
+class SerialUnavailableException(
+    val problem: SerialProblem,
+    val detail: String? = null,
+    cause: Throwable? = null,
+) : Exception(defaultMessage(problem, detail), cause)
+
+private fun defaultMessage(problem: SerialProblem, detail: String?): String {
+    val port = detail ?: "serial port"
+    return when (problem) {
+        SerialProblem.UNSUPPORTED -> "Serial ports are unavailable on this device"
+        SerialProblem.PORT_NOT_FOUND -> "Port $port not found"
+        SerialProblem.PERMISSION_DENIED -> "No permission to access port $port"
+        SerialProblem.OPEN_FAILED -> "Failed to open port $port"
+        SerialProblem.CONFIGURE_FAILED -> "Failed to configure port $port"
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/LocalFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/LocalFileBrowserTest.kt
@@ -56,7 +56,9 @@ class LocalFileBrowserTest {
 
     @Test
     fun `list of a missing directory throws FileBrowserException`() = runTest {
-        assertFailsWith<FileBrowserException> { browser().list("/nope") }
+        // The okio text is diagnostic detail only; the user-facing reason is the typed failure.
+        val e = assertFailsWith<FileBrowserException> { browser().list("/nope") }
+        assertEquals(FileBrowserFailure.LocalIo, e.failure)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
@@ -117,7 +117,9 @@ class SftpFileBrowserTest {
     fun `sftp errors are wrapped in FileBrowserException`() = runTest {
         client.failList = true
 
-        assertFailsWith<FileBrowserException> { browser().list("/d") }
+        // The sshj text is diagnostic detail only; the user-facing reason is the typed failure.
+        val e = assertFailsWith<FileBrowserException> { browser().list("/d") }
+        assertEquals(FileBrowserFailure.Sftp, e.failure)
     }
 
     @Test

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/serial/SerialSystem.desktop.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/serial/SerialSystem.desktop.kt
@@ -20,7 +20,7 @@ actual object SerialSystem {
         val port = try {
             NativePort.getCommPort(config.portName)
         } catch (e: Exception) {
-            throw SerialUnavailableException("Port ${config.portName} not found", e)
+            throw SerialUnavailableException(SerialProblem.PORT_NOT_FOUND, config.portName, e)
         }
         // Everything from parameter setup to stream acquisition is under one try: any failure
         // (invalid baud/format, driver failure, throw in getInputStream) closes the already-open
@@ -33,7 +33,7 @@ actual object SerialSystem {
             // SEMI_BLOCKING + readTimeout 0: read blocks until the first byte; -1 when the port closes.
             port.setComPortTimeouts(NativePort.TIMEOUT_READ_SEMI_BLOCKING, 0, 0)
             if (!port.openPort()) {
-                throw SerialUnavailableException("Failed to open port ${config.portName}")
+                throw SerialUnavailableException(SerialProblem.OPEN_FAILED, config.portName)
             }
             NativeSerialPortHandle(port)
         } catch (e: SerialUnavailableException) {
@@ -41,7 +41,7 @@ actual object SerialSystem {
             throw e
         } catch (e: Exception) {
             runCatching { port.closePort() }
-            throw SerialUnavailableException("Failed to configure port ${config.portName}", e)
+            throw SerialUnavailableException(SerialProblem.CONFIGURE_FAILED, config.portName, e)
         }
     }
 

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/serial/SerialTransportTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/serial/SerialTransportTest.kt
@@ -84,7 +84,7 @@ class SerialTransportTest {
 
     @Test
     fun `unavailable port surfaces as a connection exception`() = runBlocking<Unit> {
-        val transport = SerialTransport(openPort = { throw SerialUnavailableException("no port") })
+        val transport = SerialTransport(openPort = { throw SerialUnavailableException(SerialProblem.PORT_NOT_FOUND, "/dev/ttyUSB0") })
         assertFailsWith<SshConnectionException> {
             transport.connect(SshTarget(host = "/dev/ttyZZZ", port = 9600, username = ""), SshAuth.Password(""))
         }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/serial/SerialPort.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/serial/SerialPort.kt
@@ -53,6 +53,3 @@ expect object SerialSystem {
      */
     fun open(config: SerialConfig): SerialPortHandle
 }
-
-/** Port unavailable: platform has no serial support, or the device could not be opened. */
-class SerialUnavailableException(message: String, cause: Throwable? = null) : Exception(message, cause)


### PR DESCRIPTION
An i18n audit of the whole app, and the fixes for everything it turned up.

## What the audit found

The string resources were already in good shape — en/ru/zh matched, placeholders were consistent, no dangling references. The real gap was elsewhere: a large amount of user-facing text was **built outside composition** (controllers, pure helpers, `shared/`), so it bypassed the resource system entirely and reached ru/zh users in English.

## Changes

**Typed reasons instead of strings.** Controllers and `shared/` now return an enum/sealed reason and the UI resolves the text, following the pattern already used by `SyncFailureText`. New resolvers: `AiFailureMessage`, `LocalModelFailureMessage`, `SerialFailureText`, `FileFailureText`, `TunnelFailureText`, `VncFailureText`, `ConnectionTestFailureText`, `MobileTerminalStatusText`.

**Dropped the `e.message ?: stringResource(X)` idiom** (7 sites). It worked backwards — the localized resource only applied when the exception carried *no* message, so in practice the raw English text from sshj/okio always won. The localized base is now the message; the transport string survives as a parenthetical detail.

**Desktop/Android parity restored** where wording had diverged:
- biometric prompt — desktop was hardcoded English while mobile was already localized
- serial/USB errors — two different phrasings per platform, now one shared `SerialProblem`
- local filesystem label — "This computer" vs "On this device", now one resource

**Smaller fixes:** `All` chip and `Ungrouped` folder split into technical key + localized label; AI policy `enum.name` replaced with `shortLabel()`; concatenations (sizes, rates, transfer counters, vault meta) turned into parameterized templates with Russian units and comma decimals; `labelUppercase()` added because bare `uppercase()` breaks Turkish (i→İ); `androidApp` given a `res/values/strings.xml` so the manifest label is a resource rather than a literal.

**Cleanup:** 15 dead keys and seven empty locale directories removed.

## Result

en/ru/zh hold an identical set of **974 keys** with matching placeholders, zero unused, zero dangling — verified by script.

## Testing

- `./gradlew test` — green
- `:composeApp:desktopTest`, `:shared:desktopTest` — green
- `:androidApp:assembleDebug` — builds
- ~15 test files updated to the new contracts; `LabelCaseTest` added

## Deliberately out of scope

- **Mock composables** (~40 hardcoded strings). They are only reachable when `LocalSessions == null`, i.e. the offscreen render used for screenshots — and screenshots are English by project decision.
- **`SnippetShortcut`** (`Ctrl+Shift+D`) is the storage format for `Snippet.shortcut`, not UI text; modifier names are not translated in any locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)