### PR TITLE
Add a command palette over the terminal history

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -10,6 +10,11 @@
     <string name="term_no_active_session">Нет активной сессии</string>
     <string name="term_run_snippet_placeholder">Запустить сниппет…</string>
     <string name="term_no_snippets_yet">Пока нет сниппетов</string>
+    <string name="term_palette_title">История команд</string>
+    <string name="term_palette_placeholder">Поиск по командам…</string>
+    <string name="term_palette_empty">Команды пока не записаны</string>
+    <string name="term_palette_hint">Enter вставит команду в терминал, но не выполнит её</string>
+    <string name="term_palette_this_host">этот хост</string>
     <string name="term_no_matches">Нет совпадений</string>
     <string name="term_untitled">Без названия</string>
     <string name="term_notice_pick_host_to_connect">Выберите хост в боковой панели, чтобы подключиться.</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -10,6 +10,11 @@
     <string name="term_no_active_session">无活动会话</string>
     <string name="term_run_snippet_placeholder">运行片段…</string>
     <string name="term_no_snippets_yet">暂无片段</string>
+    <string name="term_palette_title">命令历史</string>
+    <string name="term_palette_placeholder">搜索命令…</string>
+    <string name="term_palette_empty">尚未记录任何命令</string>
+    <string name="term_palette_hint">Enter 只会把命令插入终端，不会执行</string>
+    <string name="term_palette_this_host">当前主机</string>
     <string name="term_no_matches">无匹配</string>
     <string name="term_untitled">未命名</string>
     <string name="term_notice_pick_host_to_connect">从侧边栏选择一个主机进行连接。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -10,6 +10,11 @@
     <string name="term_no_active_session">No active session</string>
     <string name="term_run_snippet_placeholder">Run a snippet…</string>
     <string name="term_no_snippets_yet">No snippets yet</string>
+    <string name="term_palette_title">Command history</string>
+    <string name="term_palette_placeholder">Search commands…</string>
+    <string name="term_palette_empty">No commands recorded yet</string>
+    <string name="term_palette_hint">Enter inserts the command into the terminal without running it</string>
+    <string name="term_palette_this_host">this host</string>
     <string name="term_no_matches">No matches</string>
     <string name="term_untitled">Untitled</string>
     <string name="term_notice_pick_host_to_connect">Pick a host from the sidebar to connect.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.terminal.TerminalHistoryStore
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.SecurityLog
@@ -140,6 +141,13 @@ val LocalTunnels: ProvidableCompositionLocal<TunnelManager?> = staticComposition
  * Supplied by [DesktopDesignApp] (snippets are plain config, not vault-gated).
  */
 val LocalSnippets: ProvidableCompositionLocal<SnippetManager?> = staticCompositionLocalOf { null }
+
+/**
+ * Per-host terminal command history over the encrypted vault: the sessions graph writes it for
+ * autocomplete, the command palette reads every host's at once. `null` — mock path/preview without a
+ * vault, where the palette has nothing to show.
+ */
+val LocalTerminalHistory: ProvidableCompositionLocal<TerminalHistoryStore?> = staticCompositionLocalOf { null }
 
 /**
  * Snippet "Run on host" action: open/reuse a session to [Host] and run the given command right after

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -187,6 +187,9 @@ class DesktopDesignState(
 
     var locked: Boolean by mutableStateOf(false); private set
     var modalOpen: Boolean by mutableStateOf(false); private set
+
+    /** Whether the command palette (⌘K / Ctrl+Shift+K) is open over the active session. */
+    var commandPaletteOpen: Boolean by mutableStateOf(false); private set
     var settingsOpen: Boolean by mutableStateOf(false); private set
 
     /** Whether the sync setup onboarding modal is open (Settings → Sync → "Set up sync"). */
@@ -352,6 +355,8 @@ class DesktopDesignState(
     fun requestCloseSplit(parentId: String) { pendingClose = PendingClose.Split(parentId) }
     fun dismissClose() { pendingClose = null }
     fun choosePolicy(p: AiPolicy) { modalPolicy = p }
+    fun openCommandPalette() { commandPaletteOpen = true }
+    fun closeCommandPalette() { commandPaletteOpen = false }
     fun openSettings() { settingsOpen = true }
     fun closeSettings() { settingsOpen = false }
     fun openSyncSetup() { syncSetupOpen = true }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -153,6 +153,14 @@ class ConnectionController(
     var serverVersion: String? by mutableStateOf(null)
         private set
 
+    /**
+     * History key of the live session (see [terminalHistoryKey]), or `null` while not connected.
+     * The command palette reads it to put this host's commands first. Snapshot state so the palette
+     * sees the key appear when a session connects under it.
+     */
+    var historyKey: String? by mutableStateOf(null)
+        private set
+
     private var connectJob: Job? = null
     // Target/auth of the last connect — used by auto-reconnect after a drop (reconnects to the same target).
     private var lastTarget: SshTarget? = null
@@ -240,6 +248,7 @@ class ConnectionController(
             val historyKey = terminalHistoryKey(
                 target.connectionType.name, target.username, target.host, target.port,
             )
+            this.historyKey = historyKey
             val loadedHistory = history?.load(historyKey).orEmpty()
             // Snapshot terminal settings at connect time: they apply to the new session.
             val prefs = terminalPrefs()
@@ -253,8 +262,10 @@ class ConnectionController(
                 clipboardWriteEnabled = prefs.clipboardWriteEnabled,
                 onHistoryChanged = history?.let { store ->
                     // Moves the write off the UI thread onto the controller's scope (Default):
-                    // commands are infrequent and the write is small.
-                    { snapshot -> scope.launch { store.save(historyKey, snapshot) } }
+                    // commands are infrequent and the write is small. The label rides along so the
+                    // command palette can name the host a command came from.
+                    val label = "${target.username}@${target.host}"
+                    { snapshot -> scope.launch { store.save(historyKey, snapshot, label) } }
                 },
             )
             // Keep-alive per the profile's cadence (0 = off, SSH-only): pings run from the moment

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -73,6 +73,7 @@ import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.VaultBiometrics
+import app.skerry.shared.terminal.TerminalHistoryStore
 import app.skerry.shared.terminal.VaultTerminalHistoryStore
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
@@ -99,6 +100,7 @@ import androidx.compose.runtime.collectAsState
 import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.sync.SyncIndicatorLevel
 import app.skerry.ui.sync.syncIndicatorLocalized
+import app.skerry.ui.terminal.CommandPalette
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
@@ -160,6 +162,7 @@ import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSftpPrefs
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalSync
@@ -341,10 +344,11 @@ fun DesktopDesignApp(
     // built from the live transport — one shell per tab, like in [app.skerry.ui.mobile.MobileApp].
     // We close our own graph on dispose; an externally-owned one belongs to the caller and is left alone.
     val scope = rememberCoroutineScope()
+    // Per-host terminal command history persistence (autocomplete + the command palette) on top of
+    // the encrypted vault. Hoisted out of the sessions factory: the palette reads it directly.
+    val termHistory = remember(vault) { vault?.let { VaultTerminalHistoryStore(it) } }
     val liveSessions = sessions ?: remember(transport, vncTransport, scope, vault) {
         transport?.let { t ->
-            // Per-host terminal command history persistence (for autocomplete) on top of the encrypted vault.
-            val termHistory = vault?.let { VaultTerminalHistoryStore(it) }
             var counter = 0
             SessionsController(
                 newId = { "sess-${counter++}" },
@@ -430,6 +434,7 @@ fun DesktopDesignApp(
         LocalTestTransport provides (testTransport ?: transport),
         LocalTunnels provides tunnels,
         LocalSnippets provides snippets,
+        LocalTerminalHistory provides termHistory,
         LocalFeatures provides features,
         LocalSftpPrefs provides sftpPrefs,
         // Terminal appearance from settings: font + size, read by [app.skerry.ui.terminal.TerminalScreen].
@@ -492,6 +497,7 @@ private fun DesktopChrome(
     customGroupsProvider: () -> List<String>,
     windowChrome: WindowChrome? = null,
 ) {
+    val termHistory = LocalTerminalHistory.current
     // Keychain secrets live in the open vault — behind the master-password gate we first fire
     // [onVaultUnlocked], then reload (secrets + synced empty folders).
     LaunchedEffect(credentials) {
@@ -626,7 +632,7 @@ private fun DesktopChrome(
         val onRootKey = remember(snippets, sessions, state) {
             { event: KeyEvent ->
                 if (event.type != KeyEventType.KeyDown) false
-                else if (state.appOverlay != null || state.modalOpen || state.settingsOpen) false
+                else if (state.appOverlay != null || state.modalOpen || state.settingsOpen || state.commandPaletteOpen) false
                 else {
                     val shortcut = matchDesktopShortcut(
                         event.isCtrlPressed, event.isShiftPressed, event.isAltPressed, event.isMetaPressed, event.key,
@@ -647,6 +653,18 @@ private fun DesktopChrome(
                 }
                 HLine()
                 StatusBar()
+            }
+            if (state.commandPaletteOpen) {
+                val liveTerminal = (sessions?.active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
+                CommandPalette(
+                    history = termHistory,
+                    currentKey = sessions?.active?.controller?.historyKey,
+                    onPick = { command ->
+                        liveTerminal?.applyHistoryCommand(command)
+                        state.closeCommandPalette()
+                    },
+                    onDismiss = state::closeCommandPalette,
+                )
             }
             if (state.modalOpen) NewConnectionModal(state, editHost = state.editingHost)
             if (state.settingsOpen) SettingsPanel(state)
@@ -812,6 +830,12 @@ private fun runDesktopShortcut(
             state.showView(DesktopView.Sftp)
         }
         DesktopShortcut.Lock -> onLock()
+        // Only over a live terminal: the palette inserts into it, so with nothing to insert into the
+        // key falls through (to the snippet hotkey) instead of opening a dead-end overlay.
+        DesktopShortcut.CommandPalette -> {
+            if (sessions?.active?.controller?.uiState !is ConnectionUiState.Connected) return false
+            state.openCommandPalette()
+        }
         DesktopShortcut.FocusAiBar -> state.requestAiBarFocus()
     }
     return true

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
@@ -23,6 +23,9 @@ sealed interface DesktopShortcut {
     /** Lock the vault (⌘L / Ctrl+Shift+L). */
     data object Lock : DesktopShortcut
 
+    /** Open the command palette over the active session (⌘K / Ctrl+Shift+K). */
+    data object CommandPalette : DesktopShortcut
+
     /** Next tab (Ctrl+Tab). */
     data object NextTab : DesktopShortcut
 
@@ -65,6 +68,7 @@ fun matchDesktopShortcut(ctrl: Boolean, shift: Boolean, alt: Boolean, meta: Bool
         Key.D -> DesktopShortcut.SplitTerminal
         Key.F -> DesktopShortcut.OpenSftp
         Key.L -> DesktopShortcut.Lock
+        Key.K -> DesktopShortcut.CommandPalette
         Key.Slash -> DesktopShortcut.FocusAiBar
         else -> null
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileCommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileCommandPalette.kt
@@ -1,0 +1,98 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.terminal.TerminalHistoryRecord
+import app.skerry.shared.terminal.TerminalHistoryStore
+import app.skerry.shared.terminal.commandSuggestions
+import app.skerry.ui.design.D
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_palette_empty
+import app.skerry.ui.generated.resources.term_palette_hint
+import app.skerry.ui.generated.resources.term_palette_placeholder
+import app.skerry.ui.generated.resources.term_palette_this_host
+import app.skerry.ui.generated.resources.term_palette_title
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Command palette on mobile: the desktop overlay ([app.skerry.ui.terminal.CommandPalette]) as a
+ * bottom sheet, over the same [commandSuggestions]. Tapping a command inserts it into the terminal
+ * without running it — the last keystroke stays the user's.
+ */
+@Composable
+internal fun MobileCommandPaletteSheet(
+    history: TerminalHistoryStore?,
+    currentKey: String?,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    var query by remember { mutableStateOf("") }
+    var records by remember { mutableStateOf<List<TerminalHistoryRecord>?>(null) }
+    // Reading history decrypts vault records — disk work, kept off the UI thread.
+    LaunchedEffect(history) {
+        records = withContext(Dispatchers.Default) { history?.all().orEmpty() }
+    }
+    val suggestions = remember(records, query, currentKey) {
+        records?.let { commandSuggestions(it, currentKey, query) }.orEmpty()
+    }
+
+    MobileBottomSheet(onDismiss = onDismiss, maxHeightFraction = 0.75f) {
+        Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Txt(stringResource(Res.string.term_palette_title), color = D.text, size = 18.sp, weight = FontWeight.Bold)
+            MobileFormInput(query, { query = it }, stringResource(Res.string.term_palette_placeholder))
+            if (records != null && suggestions.isEmpty()) {
+                Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 13.sp)
+            }
+            suggestions.forEach { suggestion ->
+                key(suggestion.command) {
+                    val onClick = remember(suggestion.command) { { onPick(suggestion.command) } }
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(D.card)
+                            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+                            .padding(horizontal = 12.dp, vertical = 11.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Txt(suggestion.command, color = D.text, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+                        val origin = if (suggestion.fromCurrentHost) stringResource(Res.string.term_palette_this_host) else suggestion.hostLabel
+                        if (origin != null) Txt(origin, color = if (suggestion.fromCurrentHost) D.cyanBright else D.faint, size = 10.sp)
+                    }
+                }
+            }
+            Txt(stringResource(Res.string.term_palette_hint), color = D.faint, size = 11.sp)
+            Spacer(Modifier.height(4.dp))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -69,6 +69,7 @@ import app.skerry.ui.app.LocalOpenSftp
 import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalSync
@@ -124,10 +125,11 @@ fun MobileDesignApp(
     // the live transport — one shell per session.
     // Dispose our own graph; an externally supplied one is the caller's, leave it alone.
     val scope = rememberCoroutineScope()
+    // Per-host terminal command history over the encrypted vault: autocomplete writes it, the
+    // command palette reads every host's. Hoisted out of the sessions factory so both can see it.
+    val termHistory = remember(deps.vault) { deps.vault?.let { VaultTerminalHistoryStore(it) } }
     val liveSessions = sessions ?: remember(deps.transport, scope, deps.vault) {
         deps.transport?.let { t ->
-            // Per-host terminal command history persistence (for autocomplete) over the encrypted vault.
-            val termHistory = deps.vault?.let { VaultTerminalHistoryStore(it) }
             var counter = 0
             SessionsController(
                 newId = { "sess-${counter++}" },
@@ -256,6 +258,7 @@ fun MobileDesignApp(
         LocalTunnels provides deps.tunnels,
         // Saved snippets — Snippets tab (command library + run into the active terminal).
         LocalSnippets provides deps.snippets,
+        LocalTerminalHistory provides termHistory,
         // Vault + biometrics — for the More screen's "unlock with biometrics" toggle (enable/reconfigure).
         LocalVault provides deps.vault,
         LocalVaultBiometrics provides deps.biometrics,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -68,6 +68,7 @@ import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_mobile_title_fallback
 import app.skerry.ui.generated.resources.term_monitor_title
+import app.skerry.ui.generated.resources.term_palette_title
 import app.skerry.ui.generated.resources.term_no_active_session
 import app.skerry.ui.generated.resources.term_mobile_open_host_connect
 import app.skerry.ui.generated.resources.term_connecting
@@ -92,6 +93,7 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
@@ -176,6 +178,8 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     var menuOpen by remember(active?.id) { mutableStateOf(false) }
     // Host monitor sheet (desktop info-panel parity) — raised from the same menu, connected only.
     var monitorOpen by remember(active?.id) { mutableStateOf(false) }
+    // Command history palette (desktop ⌘K parity) — same menu, connected only.
+    var historyOpen by remember(active?.id) { mutableStateOf(false) }
     val snippets = LocalSnippets.current
     val activeTerminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     val canRunSnippet = snippets != null && activeTerminal != null
@@ -277,6 +281,14 @@ fun MobileTerminalScreen(state: MobileDesignState) {
         if (monitorOpen && active?.controller != null && activeTerminal != null) {
             MobileHostMonitorSheet(active.controller, onDismiss = { monitorOpen = false })
         }
+        if (historyOpen && activeTerminal != null) {
+            MobileCommandPaletteSheet(
+                history = LocalTerminalHistory.current,
+                currentKey = active?.controller?.historyKey,
+                onPick = { command -> activeTerminal.applyHistoryCommand(command); historyOpen = false },
+                onDismiss = { historyOpen = false },
+            )
+        }
         if (menuOpen && onDisconnect != null) {
             MobileBottomSheet(
                 onDismiss = { menuOpen = false },
@@ -291,6 +303,13 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             onClick = { menuOpen = false; monitorOpen = true },
                             modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
                             icon = "monitoring",
+                            filled = false,
+                        )
+                        MobileSheetButton(
+                            label = stringResource(Res.string.term_palette_title),
+                            onClick = { menuOpen = false; historyOpen = true },
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                            icon = "history",
                             filled = false,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -62,7 +62,7 @@ internal fun KeyboardSection() {
 
     val global = listOf(
         KeyboardBinding(stringResource(Res.string.settings_kb_new_connection), mod("N"), live = true),
-        KeyboardBinding(stringResource(Res.string.settings_kb_command_palette), mod("K"), live = false),
+        KeyboardBinding(stringResource(Res.string.settings_kb_command_palette), mod("K"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_split_terminal), mod("D"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_next_prev_tab), "${ctrl("Tab")} / ${ctrlShift("Tab")}", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_select_tab_number), if (mac) "⌥1–9" else "Alt+1–9", live = true),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
@@ -1,0 +1,168 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.terminal.CommandSuggestion
+import app.skerry.shared.terminal.TerminalHistoryRecord
+import app.skerry.shared.terminal.TerminalHistoryStore
+import app.skerry.shared.terminal.commandSuggestions
+import app.skerry.ui.design.D
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.ModalScrim
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_palette_empty
+import app.skerry.ui.generated.resources.term_palette_hint
+import app.skerry.ui.generated.resources.term_palette_placeholder
+import app.skerry.ui.generated.resources.term_palette_this_host
+import app.skerry.ui.generated.resources.term_palette_title
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Command palette (⌘K / Ctrl+Shift+K): fuzzy search over the command history of every host, with
+ * the current session's commands first. Picking one *inserts* it into the terminal without running
+ * it ([TerminalScreenState.applyHistoryCommand]) — these are real commands against real servers, so
+ * the last keystroke stays the user's.
+ *
+ * History is read once per opening, off the UI thread: decrypting the vault records is disk work
+ * and would jank the terminal underneath.
+ */
+@Composable
+internal fun CommandPalette(
+    history: TerminalHistoryStore?,
+    currentKey: String?,
+    onPick: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    var query by remember { mutableStateOf("") }
+    var records by remember { mutableStateOf<List<TerminalHistoryRecord>?>(null) }
+    LaunchedEffect(history) {
+        records = withContext(Dispatchers.Default) { history?.all().orEmpty() }
+    }
+    val suggestions = remember(records, query, currentKey) {
+        records?.let { commandSuggestions(it, currentKey, query) }.orEmpty()
+    }
+    val searchFocus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { searchFocus.requestFocus() }
+
+    ModalScrim(onDismiss = onDismiss, contentAlignment = Alignment.TopCenter) {
+        Column(
+            Modifier
+                .padding(top = 90.dp)
+                .width(560.dp)
+                .consumeClicks()
+                .clip(RoundedCornerShape(10.dp))
+                .background(D.surface2)
+                .border(1.dp, D.lineStrong, RoundedCornerShape(10.dp))
+                .padding(8.dp)
+                // Enter on the first hit: the palette is meant to be driven without the mouse.
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown && event.key == Key.Enter) {
+                        suggestions.firstOrNull()?.let { onPick(it.command) }
+                        true
+                    } else {
+                        false
+                    }
+                },
+        ) {
+            Txt(stringResource(Res.string.term_palette_title), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(start = 4.dp, bottom = 6.dp))
+            PaletteSearch(query, { query = it }, mono, searchFocus)
+            Column(Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState()).padding(top = 6.dp)) {
+                if (records == null) {
+                    // Still loading; an empty box beats flashing "no commands" for a frame.
+                } else if (suggestions.isEmpty()) {
+                    Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 11.5.sp, font = mono, modifier = Modifier.padding(8.dp))
+                } else {
+                    suggestions.forEach { suggestion ->
+                        key(suggestion.command) {
+                            CommandRow(suggestion, mono) { onPick(suggestion.command) }
+                        }
+                    }
+                }
+            }
+            Txt(stringResource(Res.string.term_palette_hint), color = D.faint, size = 10.sp, modifier = Modifier.padding(start = 4.dp, top = 8.dp, bottom = 2.dp))
+        }
+    }
+}
+
+@Composable
+private fun PaletteSearch(value: String, onValueChange: (String) -> Unit, mono: FontFamily, focus: FocusRequester) {
+    val style = remember(mono) { TextStyle(color = D.text, fontSize = 13.sp, fontFamily = mono) }
+    Row(
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.line, RoundedCornerShape(7.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Sym("search", size = 16.sp, color = D.faint)
+        Box(Modifier.weight(1f)) {
+            if (value.isEmpty()) Txt(stringResource(Res.string.term_palette_placeholder), color = D.faint, size = 13.sp, font = mono)
+            BasicTextField(
+                value = value,
+                onValueChange = onValueChange,
+                singleLine = true,
+                textStyle = style,
+                cursorBrush = SolidColor(D.cyan),
+                modifier = Modifier.fillMaxWidth().focusRequester(focus),
+            )
+        }
+    }
+}
+
+@Composable
+private fun CommandRow(suggestion: CommandSuggestion, mono: FontFamily, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).clickable(onClick = onClick).padding(horizontal = 9.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Txt(suggestion.command, color = D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+        val origin = when {
+            suggestion.fromCurrentHost -> stringResource(Res.string.term_palette_this_host)
+            else -> suggestion.hostLabel
+        }
+        if (origin != null) {
+            Txt(origin, color = if (suggestion.fromCurrentHost) D.cyanBright else D.faint, size = 10.sp)
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -34,6 +34,14 @@ class DesktopShortcutsTest {
     }
 
     @Test
+    fun `the command palette is on the app modifier plus K`() {
+        assertEquals(DesktopShortcut.CommandPalette, match(meta = true, key = Key.K))
+        assertEquals(DesktopShortcut.CommandPalette, match(ctrl = true, shift = true, key = Key.K))
+        // Plain Ctrl+K stays with the terminal (readline kill-line).
+        assertNull(match(ctrl = true, key = Key.K))
+    }
+
+    @Test
     fun `app modifier on macOS is Cmd alone`() {
         assertEquals(DesktopShortcut.NewConnection, match(meta = true, key = Key.N))
         assertEquals(DesktopShortcut.SplitTerminal, match(meta = true, key = Key.D))

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CommandSuggestions.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CommandSuggestions.kt
@@ -1,0 +1,42 @@
+package app.skerry.shared.terminal
+
+/**
+ * One row of the command palette: the [command], the host it came from ([hostLabel], `null` for
+ * records written before labels existed), whether that host is the session the palette was opened
+ * from, and the fuzzy-matched character [positions] for highlighting.
+ */
+data class CommandSuggestion(
+    val command: String,
+    val hostLabel: String?,
+    val fromCurrentHost: Boolean,
+    val positions: List<Int> = emptyList(),
+)
+
+/**
+ * Build the palette list from every host's history: commands of the session in [currentKey] first
+ * (newest-first), then everyone else's, deduplicated by command text — a command known to both the
+ * current host and another is attributed to the current one, since that's where it can be run
+ * without thinking. [query] then filters and reorders the result fuzzily ([fuzzyRank]); a blank
+ * query keeps the recency order. Capped at [limit].
+ *
+ * Pure function: the caller supplies the records, so the palette is testable without a vault.
+ */
+fun commandSuggestions(
+    records: List<TerminalHistoryRecord>,
+    currentKey: String?,
+    query: String,
+    limit: Int = 200,
+): List<CommandSuggestion> {
+    val (current, others) = records.partition { currentKey != null && it.key == currentKey }
+    val seen = LinkedHashMap<String, CommandSuggestion>()
+    for ((record, isCurrent) in (current.map { it to true } + others.map { it to false })) {
+        for (command in record.commands) {
+            val trimmed = command.trim()
+            if (trimmed.isEmpty() || trimmed in seen) continue
+            seen[trimmed] = CommandSuggestion(trimmed, record.label, isCurrent)
+        }
+    }
+    return fuzzyRank(seen.values.toList(), query) { it.command }
+        .take(limit)
+        .map { hit -> hit.item.copy(positions = hit.positions) }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/FuzzyMatch.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/FuzzyMatch.kt
@@ -1,0 +1,65 @@
+package app.skerry.shared.terminal
+
+/**
+ * One scored fuzzy match: [score] (higher is better) and the matched character [positions] in the
+ * candidate, for highlighting. Positions are empty for a blank query, which matches everything.
+ */
+data class FuzzyHit<T>(val item: T, val score: Int, val positions: List<Int>)
+
+/**
+ * Score [candidate] against [query] as a subsequence match (like a command palette, not a substring
+ * search): every query character must appear in order, case-insensitively. Returns `null` when it
+ * doesn't match at all.
+ *
+ * Scoring favours what a person means by "closest": runs of consecutive characters, matches at word
+ * starts (string start or after a separator), and — all else equal — shorter candidates. Pure and
+ * deterministic; the greedy left-to-right scan is O(candidate) rather than an optimal alignment,
+ * which is enough for history-sized inputs and keeps the result easy to reason about.
+ */
+fun fuzzyScore(candidate: String, query: String): FuzzyHit<String>? {
+    val needle = query.trim()
+    if (needle.isEmpty()) return FuzzyHit(candidate, 0, emptyList())
+
+    val positions = ArrayList<Int>(needle.length)
+    var score = 0
+    var at = 0
+    var previousMatch = -2
+    for (wanted in needle) {
+        val found = candidate.indexOfIgnoringCase(wanted, at) ?: return null
+        score += CHARACTER_BONUS
+        if (found == previousMatch + 1) score += CONSECUTIVE_BONUS
+        if (found == 0 || candidate[found - 1].isSeparator()) score += WORD_START_BONUS
+        score -= (found - at).coerceAtMost(MAX_GAP_PENALTY)
+        positions += found
+        previousMatch = found
+        at = found + 1
+    }
+    // Break ties towards shorter candidates: "df -h" over "df -h | sort … | head -20".
+    score -= (candidate.length - needle.length).coerceAtMost(MAX_LENGTH_PENALTY)
+    return FuzzyHit(candidate, score, positions)
+}
+
+/**
+ * Rank [items] against [query] by [text], dropping non-matches. Ties keep input order, so a
+ * newest-first history stays newest-first among equally good matches. A blank query returns
+ * everything untouched.
+ */
+fun <T> fuzzyRank(items: List<T>, query: String, text: (T) -> String): List<FuzzyHit<T>> {
+    if (query.isBlank()) return items.map { FuzzyHit(it, 0, emptyList()) }
+    return items
+        .mapNotNull { item -> fuzzyScore(text(item), query)?.let { FuzzyHit(item, it.score, it.positions) } }
+        .sortedByDescending { it.score } // sortedByDescending is stable, so ties keep input order
+}
+
+private const val CHARACTER_BONUS = 8
+private const val CONSECUTIVE_BONUS = 10
+private const val WORD_START_BONUS = 6
+private const val MAX_GAP_PENALTY = 5
+private const val MAX_LENGTH_PENALTY = 6
+
+private fun Char.isSeparator(): Boolean = this == ' ' || this == '-' || this == '_' || this == '/' || this == '.'
+
+private fun String.indexOfIgnoringCase(char: Char, from: Int): Int? {
+    for (i in from until length) if (this[i].equals(char, ignoreCase = true)) return i
+    return null
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalHistoryStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalHistoryStore.kt
@@ -19,8 +19,15 @@ interface TerminalHistoryStore {
     /** History for [key], newest-first; empty if nothing saved or the vault is locked. */
     fun load(key: String): List<String>
 
-    /** Save [commands] (newest-first) for [key]; silent no-op on a locked vault. */
-    fun save(key: String, commands: List<String>)
+    /**
+     * Save [commands] (newest-first) for [key]; silent no-op on a locked vault. [label] is the
+     * human-readable host name shown next to a command in the palette; `null` keeps whatever label
+     * is already stored, so a caller that doesn't know it can't erase it.
+     */
+    fun save(key: String, commands: List<String>, label: String? = null)
+
+    /** Every host's history, for cross-host search. Empty on a locked vault. */
+    fun all(): List<TerminalHistoryRecord>
 }
 
 /**
@@ -42,9 +49,16 @@ class VaultTerminalHistoryStore(
         return codec.get(idOf(key))?.commands ?: emptyList()
     }
 
-    override fun save(key: String, commands: List<String>) {
+    override fun save(key: String, commands: List<String>, label: String?) {
         if (!vault.isUnlocked) return
-        codec.put(idOf(key), TerminalHistoryRecord(key, commands.take(cap)))
+        val id = idOf(key)
+        val keptLabel = label ?: codec.get(id)?.label
+        codec.put(id, TerminalHistoryRecord(key, commands.take(cap), keptLabel))
+    }
+
+    override fun all(): List<TerminalHistoryRecord> {
+        if (!vault.isUnlocked) return emptyList()
+        return codec.list()
     }
 
     private fun idOf(key: String): String = "$ID_PREFIX$key"
@@ -54,9 +68,17 @@ class VaultTerminalHistoryStore(
     }
 }
 
-/** History record payload: host [key] + commands newest-first. */
+/**
+ * History record payload: host [key] + commands newest-first, plus the human-readable host [label]
+ * shown in the command palette. [label] is nullable because records written before the palette
+ * existed don't carry one.
+ */
 @Serializable
-data class TerminalHistoryRecord(val key: String, val commands: List<String>)
+data class TerminalHistoryRecord(
+    val key: String,
+    val commands: List<String>,
+    val label: String? = null,
+)
 
 /** Stable history key for a target host: protocol|account@address:port (see `SshTarget`). */
 fun terminalHistoryKey(connectionType: String, username: String, host: String, port: Int): String =

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CommandSuggestionsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CommandSuggestionsTest.kt
@@ -1,0 +1,79 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CommandSuggestionsTest {
+
+    private val alpha = TerminalHistoryRecord("k-alpha", listOf("docker ps", "uptime"), label = "root@alpha")
+    private val beta = TerminalHistoryRecord("k-beta", listOf("docker compose up", "uptime"), label = "dev@beta")
+
+    @Test
+    fun merges_history_from_every_host() {
+        val all = commandSuggestions(listOf(alpha, beta), currentKey = null, query = "")
+
+        assertEquals(
+            setOf("docker ps", "uptime", "docker compose up"),
+            all.map { it.command }.toSet(),
+        )
+    }
+
+    @Test
+    fun the_current_host_comes_first_and_is_marked() {
+        val all = commandSuggestions(listOf(alpha, beta), currentKey = "k-beta", query = "")
+
+        assertEquals("docker compose up", all.first().command)
+        assertTrue(all.first().fromCurrentHost)
+        assertTrue(all.last().fromCurrentHost.not())
+    }
+
+    @Test
+    fun a_command_shared_by_two_hosts_is_listed_once_and_attributed_to_the_current_one() {
+        val all = commandSuggestions(listOf(alpha, beta), currentKey = "k-beta", query = "uptime")
+
+        val uptime = all.single { it.command == "uptime" }
+        assertEquals("dev@beta", uptime.hostLabel)
+        assertTrue(uptime.fromCurrentHost)
+    }
+
+    @Test
+    fun a_shared_command_falls_back_to_the_first_host_when_none_is_current() {
+        val all = commandSuggestions(listOf(alpha, beta), currentKey = null, query = "uptime")
+
+        assertEquals("root@alpha", all.single { it.command == "uptime" }.hostLabel)
+    }
+
+    @Test
+    fun query_filters_and_ranks_fuzzily() {
+        val all = commandSuggestions(listOf(alpha, beta), currentKey = null, query = "dcu")
+
+        assertEquals(listOf("docker compose up"), all.map { it.command })
+    }
+
+    @Test
+    fun carries_match_positions_for_highlighting() {
+        val hit = commandSuggestions(listOf(alpha), currentKey = null, query = "dps").single()
+
+        assertEquals(listOf(0, 7, 8), hit.positions)
+    }
+
+    @Test
+    fun respects_the_limit() {
+        val many = TerminalHistoryRecord("k", (1..50).map { "cmd$it" })
+
+        assertEquals(10, commandSuggestions(listOf(many), currentKey = null, query = "", limit = 10).size)
+    }
+
+    @Test
+    fun blank_and_duplicate_commands_are_dropped() {
+        val messy = TerminalHistoryRecord("k", listOf("ls", "   ", "ls"))
+
+        assertEquals(listOf("ls"), commandSuggestions(listOf(messy), currentKey = null, query = "").map { it.command })
+    }
+
+    @Test
+    fun no_history_yields_nothing() {
+        assertEquals(emptyList(), commandSuggestions(emptyList(), currentKey = null, query = "x"))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/FuzzyMatchTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/FuzzyMatchTest.kt
@@ -1,0 +1,93 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FuzzyMatchTest {
+
+    @Test
+    fun matches_a_subsequence_not_only_a_substring() {
+        assertNotNull(fuzzyScore("docker compose up", "dcu"))
+        assertNotNull(fuzzyScore("systemctl status nginx", "sysngx"))
+    }
+
+    @Test
+    fun rejects_when_a_query_character_is_missing_or_out_of_order() {
+        assertNull(fuzzyScore("docker ps", "dockerz"))
+        assertNull(fuzzyScore("docker ps", "psd"))
+    }
+
+    @Test
+    fun is_case_insensitive() {
+        assertNotNull(fuzzyScore("Docker PS", "docker ps"))
+        assertNotNull(fuzzyScore("docker ps", "DOCKER"))
+    }
+
+    @Test
+    fun blank_query_matches_everything_with_a_neutral_score() {
+        val hit = fuzzyScore("anything", "  ")
+
+        assertNotNull(hit)
+        assertEquals(emptyList(), hit.positions)
+    }
+
+    @Test
+    fun reports_matched_positions_for_highlighting() {
+        val hit = assertNotNull(fuzzyScore("docker ps", "dps"))
+
+        assertEquals(listOf(0, 7, 8), hit.positions)
+    }
+
+    @Test
+    fun consecutive_matches_beat_scattered_ones() {
+        val tight = assertNotNull(fuzzyScore("git push", "push"))
+        val loose = assertNotNull(fuzzyScore("p-u-s-h-x", "push"))
+
+        assertTrue(tight.score > loose.score, "tight=${tight.score} loose=${loose.score}")
+    }
+
+    @Test
+    fun word_starts_beat_mid_word_matches() {
+        val wordStart = assertNotNull(fuzzyScore("docker system prune", "dsp"))
+        val midWord = assertNotNull(fuzzyScore("xdxsxpx", "dsp"))
+
+        assertTrue(wordStart.score > midWord.score, "wordStart=${wordStart.score} midWord=${midWord.score}")
+    }
+
+    @Test
+    fun a_shorter_candidate_wins_when_the_match_is_otherwise_equal() {
+        val short = assertNotNull(fuzzyScore("df -h", "df"))
+        val long = assertNotNull(fuzzyScore("df -h | sort -k5 -r | head -20", "df"))
+
+        assertTrue(short.score > long.score)
+    }
+
+    @Test
+    fun rank_orders_by_score_and_drops_non_matches() {
+        val items = listOf("apt update", "docker ps", "docker compose up")
+
+        val ranked = fuzzyRank(items, "docker") { it }
+
+        assertEquals(listOf("docker ps", "docker compose up"), ranked.map { it.item })
+    }
+
+    @Test
+    fun rank_keeps_input_order_when_scores_tie() {
+        // Input is newest-first, so an equal-scoring older command must not jump ahead.
+        val items = listOf("ls /tmp", "ls /var")
+
+        val ranked = fuzzyRank(items, "ls /") { it }
+
+        assertEquals(items, ranked.map { it.item })
+    }
+
+    @Test
+    fun rank_with_a_blank_query_returns_everything_in_order() {
+        val items = listOf("b", "a", "c")
+
+        assertEquals(items, fuzzyRank(items, "") { it }.map { it.item })
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/VaultTerminalHistoryStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/VaultTerminalHistoryStoreTest.kt
@@ -50,6 +50,40 @@ class VaultTerminalHistoryStoreTest {
     }
 
     @Test
+    fun `all returns every host's history for cross-host search`() {
+        val vault = FakeVault()
+        val store = VaultTerminalHistoryStore(vault)
+        store.save("h1", listOf("uptime"), label = "root@alpha")
+        store.save("h2", listOf("whoami"))
+
+        val all = store.all()
+
+        assertEquals(setOf("h1", "h2"), all.map { it.key }.toSet())
+        assertEquals("root@alpha", all.single { it.key == "h1" }.label)
+        assertEquals(null, all.single { it.key == "h2" }.label)
+    }
+
+    @Test
+    fun `all is empty on a locked vault`() {
+        val vault = FakeVault()
+        VaultTerminalHistoryStore(vault).save("h1", listOf("uptime"))
+        vault.locked = true
+
+        assertEquals(emptyList(), VaultTerminalHistoryStore(vault).all())
+    }
+
+    @Test
+    fun `saving without a label keeps the one already stored`() {
+        val vault = FakeVault()
+        val store = VaultTerminalHistoryStore(vault)
+        store.save("h1", listOf("uptime"), label = "root@alpha")
+
+        store.save("h1", listOf("ls", "uptime"))
+
+        assertEquals("root@alpha", store.all().single().label)
+    }
+
+    @Test
     fun `terminal history never syncs regardless of flags`() {
         assertFalse(SyncSettings(syncHosts = true, syncSnippets = true).shouldSync(RecordType.TERMINAL_HISTORY))
         assertTrue(SyncSettings().shouldSync(RecordType.SETTINGS)) // control: settings still syncs

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -13,8 +13,11 @@ internal class FakeVault : Vault {
 
     private val entries = mutableMapOf<String, Entry>()
 
+    /** Flip to exercise the locked-vault path of a store; unlocked by default. */
+    var locked: Boolean = false
+
     override fun exists(): Boolean = true
-    override val isUnlocked: Boolean = true
+    override val isUnlocked: Boolean get() = !locked
     override fun create(password: CharArray) = Unit
     override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
     override fun lock() = Unit


### PR DESCRIPTION
⌘K / Ctrl+Shift+K over a live terminal opens a fuzzy search across the command history of every host. Idea from the second tier of `docs/feature-ideas.md`.

## What changed

- **`FuzzyMatch.kt`** (shared): subsequence matcher with match positions. Ranks consecutive runs and word starts above scattered hits, breaks ties towards shorter commands, and keeps input order on equal scores so newest-first history stays newest-first.
- **`CommandSuggestions.kt`** (shared): merges every host's history, deduplicates by command text, attributes a shared command to the current host, caps the list.
- **`TerminalHistoryStore.all()`**: cross-host read. `TerminalHistoryRecord` gained a nullable `label` (the `user@host` a command came from) — `ConnectionController` passes it on save; `null` on save keeps whatever label is stored, so a caller that doesn't know it can't erase it.
- **UI**: `CommandPalette` on `ModalScrim` (Esc, ModalPresence, focus return) for desktop; `MobileCommandPaletteSheet` from the terminal menu for parity. The ⌘K row in Settings → Keyboard lost its SOON badge.

The recording side already existed — history has been persisted per host for autocomplete, behind the same `echoSuppressed` gate that keeps password prompts out.

## Decisions taken without you

1. **Picking a command inserts it, never runs it** (`applyHistoryCommand`, Ctrl-U then type). These are real commands against real servers; a fuzzy match one row off would otherwise execute something unintended. The hint line under the palette says so.
2. **History still does not sync.** `SyncSettings` excludes `TERMINAL_HISTORY` deliberately ("large, sensitive, device-specific"), and command arguments regularly carry tokens and passwords. Turning it on would also need a server whitelist entry and a new toggle. "Across all hosts" is delivered; "across all devices" is not, and I'd rather you decide that one — the idea file asked for it, so this is a knowing deviation.
3. **⌘K / Ctrl+Shift+K, not plain Ctrl+K.** Plain Ctrl+K is readline kill-line and belongs to the terminal. This matches the existing appMod scheme, and the binding was already reserved in Settings.
4. **The hotkey falls through when no session is connected** rather than opening an empty overlay with nowhere to insert.
5. **History is read once per opening, off the UI thread** (`Dispatchers.Default`) — decrypting vault records is disk work and would jank the terminal underneath. While loading, the list is blank rather than flashing "no commands".
6. **`FakeVault` gained a `locked` flag** so the locked-vault path of a store is testable; it was hardcoded unlocked.

## Tests

New: `FuzzyMatchTest` (11 cases), `CommandSuggestionsTest` (9). Extended: `VaultTerminalHistoryStoreTest` (cross-host read, locked vault, label retention), `DesktopShortcutsTest` (⌘K, and that plain Ctrl+K stays with the terminal).

Gate: `./gradlew build` (lint on) and `:androidApp:compileDebugKotlin` — both green, no pipe.

## Check by eye

Behind the vault gate, so no screenshot from me. Connect a host, run a few commands, connect a second host, run different ones. Ctrl+Shift+K → both hosts' commands, this host's first and marked; type `dcu` and watch `docker compose up` surface. Enter inserts the top hit into the shell without executing; Esc closes. On Android: terminal → ⋯ → Command history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)