### PR TITLE
Give the new features hotkeys and list them in Settings

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/terminal/ClipboardChord.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/terminal/ClipboardChord.android.kt
@@ -1,0 +1,11 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.key
+
+/**
+ * Android Insert detection: a hardware keyboard reports `KEYCODE_INSERT`, which Compose maps to
+ * [Key.Insert]. The keypad's 0 stays a digit here (Android has no NumLock-off aliasing).
+ */
+actual fun KeyEvent.isInsertKey(): Boolean = key == Key.Insert

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -158,6 +158,10 @@
     <string name="settings_keyboard_subtitle">Горячие клавиши подстраиваются под вашу платформу. Терминальные привязки работают, когда сессия в фокусе.</string>
     <string name="settings_kb_new_connection">Новое подключение</string>
     <string name="settings_kb_command_palette">Палитра команд / поиск</string>
+    <string name="settings_kb_snippet_palette">Палитра сниппетов</string>
+    <string name="settings_kb_broadcast">Broadcast по сессиям</string>
+    <string name="settings_kb_record_session">Запись сессии (старт / стоп)</string>
+    <string name="settings_kb_play_recording">Воспроизвести запись</string>
     <string name="settings_kb_split_terminal">Разделить терминал</string>
     <string name="settings_kb_next_prev_tab">Следующая / предыдущая вкладка</string>
     <string name="settings_kb_select_tab_number">Выбрать вкладку по номеру</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -158,6 +158,10 @@
     <string name="settings_keyboard_subtitle">快捷键适配你的平台。终端快捷键在会话聚焦时生效。</string>
     <string name="settings_kb_new_connection">新建连接</string>
     <string name="settings_kb_command_palette">命令面板 / 搜索</string>
+    <string name="settings_kb_snippet_palette">片段面板</string>
+    <string name="settings_kb_broadcast">广播到多个会话</string>
+    <string name="settings_kb_record_session">录制会话（开始／停止）</string>
+    <string name="settings_kb_play_recording">播放录制</string>
     <string name="settings_kb_split_terminal">分割终端</string>
     <string name="settings_kb_next_prev_tab">下一个 / 上一个标签页</string>
     <string name="settings_kb_select_tab_number">按数字选择标签页</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -158,6 +158,10 @@
     <string name="settings_keyboard_subtitle">Shortcuts adapt to your platform. Terminal bindings apply while a session is focused.</string>
     <string name="settings_kb_new_connection">New connection</string>
     <string name="settings_kb_command_palette">Command palette / search</string>
+    <string name="settings_kb_snippet_palette">Snippet palette</string>
+    <string name="settings_kb_broadcast">Broadcast to sessions</string>
+    <string name="settings_kb_record_session">Record session (start / stop)</string>
+    <string name="settings_kb_play_recording">Play a recording</string>
     <string name="settings_kb_split_terminal">Split terminal</string>
     <string name="settings_kb_next_prev_tab">Next / previous tab</string>
     <string name="settings_kb_select_tab_number">Select tab by number</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -423,6 +423,21 @@ class DesktopDesignState(
     val aiBarFocusRequests: SharedFlow<Unit> = _aiBarFocusRequests
     fun requestAiBarFocus() { _aiBarFocusRequests.tryEmit(Unit) }
 
+    // Hotkeys for the toolbar buttons that own their own state (snippet palette popup, recording
+    // toggle, file picker). Same one-shot signal as the AI bar above rather than a flag on the
+    // state: a boolean would have to be reset by the button and could re-fire on recomposition.
+    private val _snippetPaletteRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val snippetPaletteRequests: SharedFlow<Unit> = _snippetPaletteRequests
+    fun requestSnippetPalette() { _snippetPaletteRequests.tryEmit(Unit) }
+
+    private val _recordingToggleRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val recordingToggleRequests: SharedFlow<Unit> = _recordingToggleRequests
+    fun requestRecordingToggle() { _recordingToggleRequests.tryEmit(Unit) }
+
+    private val _castOpenRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val castOpenRequests: SharedFlow<Unit> = _castOpenRequests
+    fun requestCastOpen() { _castOpenRequests.tryEmit(Unit) }
+
     /** Whether folder [name] is collapsed (its host list hidden). */
     fun isGroupCollapsed(name: String): Boolean = name in collapsedGroups
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -868,6 +868,10 @@ private fun runDesktopShortcut(
         }
         DesktopShortcut.Lock -> onLock()
         DesktopShortcut.Broadcast -> state.openBroadcast()
+        // These three live in toolbar buttons that own their state; the shortcut nudges them.
+        DesktopShortcut.SnippetPalette -> state.requestSnippetPalette()
+        DesktopShortcut.ToggleRecording -> state.requestRecordingToggle()
+        DesktopShortcut.PlayRecording -> state.requestCastOpen()
         // Only over a live terminal: the palette inserts into it, so with nothing to insert into the
         // key falls through (to the snippet hotkey) instead of opening a dead-end overlay.
         DesktopShortcut.CommandPalette -> {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
@@ -29,6 +29,15 @@ sealed interface DesktopShortcut {
     /** Open the broadcast panel: one command into several sessions (⌘B / Ctrl+Shift+B). */
     data object Broadcast : DesktopShortcut
 
+    /** Open the snippet palette over the active session (⌘S / Ctrl+Shift+S). */
+    data object SnippetPalette : DesktopShortcut
+
+    /** Start or stop recording the active session (⌘R / Ctrl+Shift+R). */
+    data object ToggleRecording : DesktopShortcut
+
+    /** Open a .cast recording in the player (⌘P / Ctrl+Shift+P). */
+    data object PlayRecording : DesktopShortcut
+
     /** Next tab (Ctrl+Tab). */
     data object NextTab : DesktopShortcut
 
@@ -73,6 +82,9 @@ fun matchDesktopShortcut(ctrl: Boolean, shift: Boolean, alt: Boolean, meta: Bool
         Key.L -> DesktopShortcut.Lock
         Key.K -> DesktopShortcut.CommandPalette
         Key.B -> DesktopShortcut.Broadcast
+        Key.S -> DesktopShortcut.SnippetPalette
+        Key.R -> DesktopShortcut.ToggleRecording
+        Key.P -> DesktopShortcut.PlayRecording
         Key.Slash -> DesktopShortcut.FocusAiBar
         else -> null
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -26,7 +26,11 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.settings_badge_soon
 import app.skerry.ui.generated.resources.settings_kb_accept_autocomplete
+import app.skerry.ui.generated.resources.settings_kb_broadcast
 import app.skerry.ui.generated.resources.settings_kb_command_palette
+import app.skerry.ui.generated.resources.settings_kb_play_recording
+import app.skerry.ui.generated.resources.settings_kb_record_session
+import app.skerry.ui.generated.resources.settings_kb_snippet_palette
 import app.skerry.ui.generated.resources.settings_kb_copy_selection
 import app.skerry.ui.generated.resources.settings_kb_cycle_suggestions
 import app.skerry.ui.generated.resources.settings_kb_focus_ai
@@ -63,6 +67,10 @@ internal fun KeyboardSection() {
     val global = listOf(
         KeyboardBinding(stringResource(Res.string.settings_kb_new_connection), mod("N"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_command_palette), mod("K"), live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_snippet_palette), mod("S"), live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_broadcast), mod("B"), live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_record_session), mod("R"), live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_play_recording), mod("P"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_split_terminal), mod("D"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_next_prev_tab), "${ctrl("Tab")} / ${ctrlShift("Tab")}", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_select_tab_number), if (mac) "⌥1–9" else "Alt+1–9", live = true),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -84,8 +84,10 @@ internal fun KeyboardSection() {
         KeyboardBinding(stringResource(Res.string.settings_kb_accept_autocomplete), "Tab", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_cycle_suggestions), shift("Tab"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_search_history), ctrl("R"), live = true),
-        KeyboardBinding(stringResource(Res.string.settings_kb_copy_selection), ctrlShift("C"), live = true),
-        KeyboardBinding(stringResource(Res.string.settings_kb_paste), ctrlShift("V"), live = true),
+        // Both conventions are live, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
+        // Both conventions work, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
+        KeyboardBinding(stringResource(Res.string.settings_kb_copy_selection), "${ctrlShift("C")} / ${ctrl("Insert")}", live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_paste), "${ctrlShift("V")} / ${shift("Insert")}", live = true),
     )
 
     val mono = LocalFonts.current.mono

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ClipboardChord.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ClipboardChord.kt
@@ -1,0 +1,44 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+
+/** A key chord that means copy or paste in the terminal. */
+enum class ClipboardChord { Copy, Paste }
+
+/**
+ * Recognises the terminal's clipboard chords, or `null` when the keys belong to the shell.
+ *
+ * Two conventions are supported side by side: `Ctrl+Shift+C/V` (what modern terminals use, because
+ * plain `Ctrl+C` is SIGINT and `Ctrl+V` is a control code) and `Shift+Insert` / `Ctrl+Insert` (the
+ * X11 pair, still muscle memory for many). Bare `Insert` is deliberately left alone — it is a real
+ * terminal key (CSI 2~, the shell's overwrite toggle).
+ *
+ * [insertKey] is passed in rather than compared here because "the Insert key" is not one constant:
+ * see [isInsertKey].
+ */
+fun clipboardChord(ctrl: Boolean, shift: Boolean, alt: Boolean, insertKey: Boolean, key: Key): ClipboardChord? {
+    if (alt) return null // Alt+… is Meta-prefixed input for the shell
+    if (insertKey) {
+        // Both claim Ctrl+Shift+Insert; copy is the non-destructive reading of an ambiguous chord.
+        if (ctrl) return ClipboardChord.Copy
+        if (shift) return ClipboardChord.Paste
+        return null
+    }
+    if (!ctrl || !shift) return null
+    return when (key) {
+        Key.C -> ClipboardChord.Copy
+        Key.V -> ClipboardChord.Paste
+        else -> null
+    }
+}
+
+/**
+ * Whether this event is the Insert key.
+ *
+ * Not simply `key == Key.Insert`: on the JVM the key code comes from AWT, and depending on the
+ * toolkit and layout Insert can also arrive as the numeric keypad's 0 (NumLock off). Missing those
+ * is what makes Shift+Insert silently do nothing — the key falls through to [mapTerminalKey] and the
+ * shell receives CSI 2~ instead of a paste.
+ */
+expect fun KeyEvent.isInsertKey(): Boolean

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
@@ -1,13 +1,16 @@
 package app.skerry.ui.terminal
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import app.skerry.ui.design.D
 import app.skerry.ui.design.IconBtn
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -18,23 +21,27 @@ import kotlinx.coroutines.launch
  * the first is the kind of thing that hangs a desktop app.
  */
 @Composable
-fun PlayRecordingButton(onOpened: (CastOpenResult) -> Unit) {
+fun PlayRecordingButton(requests: SharedFlow<Unit>? = null, onOpened: (CastOpenResult) -> Unit) {
     val scope = rememberCoroutineScope()
     var opening by remember { mutableStateOf(false) }
+    val open = {
+        if (!opening) {
+            opening = true
+            scope.launch {
+                try {
+                    onOpened(openCastFile())
+                } finally {
+                    opening = false
+                }
+            }
+        }
+    }
+    val currentOpen by rememberUpdatedState(open)
+    // Hotkey channel (⌘P / Ctrl+Shift+P) — same action as the click.
+    LaunchedEffect(requests) { requests?.collect { currentOpen() } }
     IconBtn(
         "play_circle",
         tint = if (opening) D.faint else D.dim,
-        onClick = {
-            if (!opening) {
-                opening = true
-                scope.launch {
-                    try {
-                        onOpened(openCastFile())
-                    } finally {
-                        opening = false
-                    }
-                }
-            }
-        },
+        onClick = { open() },
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -1,7 +1,10 @@
 package app.skerry.ui.terminal
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.getValue
 import app.skerry.shared.terminal.castFileName
 import app.skerry.shared.terminal.recordingStamp
 import app.skerry.ui.design.D
@@ -9,6 +12,7 @@ import app.skerry.ui.design.IconBtn
 import app.skerry.ui.session.Session
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.vault.exportTextFile
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -17,16 +21,20 @@ import kotlinx.coroutines.launch
  *
  * Nothing is written until the user picks a file: a recording holds whatever the server printed, so
  * it must not land on disk as a side effect of clicking a toolbar button.
+ *
+ * [requests] is the hotkey channel (⌘R / Ctrl+Shift+R): the shell can't toggle recording itself,
+ * because start/stop lives on the terminal state this button holds.
  */
 @Composable
-fun RecordSessionButton(session: Session?, onDone: (RecordingOutcome) -> Unit) {
+fun RecordSessionButton(
+    session: Session?,
+    requests: SharedFlow<Unit>? = null,
+    onDone: (RecordingOutcome) -> Unit,
+) {
     val terminal = (session?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     val scope = rememberCoroutineScope()
     val recording = terminal?.recording == true
-    IconBtn(
-        name = if (recording) "stop_circle" else "radio_button_checked",
-        tint = if (recording) D.sunset else D.dim,
-        onClick = onClick@{
+    val toggle = onClick@{
             val live = terminal ?: return@onClick
             if (!live.recording) {
                 live.startRecording(session.displayTitle.ifBlank { session.subtitle })
@@ -49,7 +57,15 @@ fun RecordSessionButton(session: Session?, onDone: (RecordingOutcome) -> Unit) {
                     },
                 )
             }
-        },
+        }
+    // The hotkey does exactly what a click does. rememberUpdatedState so a collector started for an
+    // earlier session doesn't keep toggling a terminal that is no longer on screen.
+    val currentToggle by rememberUpdatedState(toggle)
+    LaunchedEffect(requests) { requests?.collect { currentToggle() } }
+    IconBtn(
+        name = if (recording) "stop_circle" else "radio_button_checked",
+        tint = if (recording) D.sunset else D.dim,
+        onClick = toggle,
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.LocalSnippets
+import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.D
 import app.skerry.ui.design.IconBtn
@@ -61,11 +62,14 @@ import org.jetbrains.compose.resources.stringResource
 // Snippet palette: quickly run a saved command in the active terminal directly from the toolbar.
 
 @Composable
-internal fun SnippetPaletteButton(active: Session?) {
+internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
     val manager = LocalSnippets.current
     val terminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     // Keyed on active: switching tabs must not leave the palette open over a different toolbar.
     var open by remember(active) { mutableStateOf(false) }
+    // Hotkey channel (⌘S / Ctrl+Shift+S). It only opens: with nothing to run into, the palette would
+    // be a dead-end popup, so the key falls through to whatever else wants it.
+    LaunchedEffect(requests, terminal) { requests?.collect { if (terminal != null) open = true } }
     if (manager == null) return
     Box {
         // Nowhere to run without a connected session — the button is dimmed and doesn't open.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -683,16 +683,20 @@ fun TerminalScreen(
                     state.cycleSuggestion()
                     return@onPreviewKeyEvent true
                 }
-                // Ctrl+Shift+C — copy the selection (Ctrl+C stays SIGINT for the shell).
-                if (event.isCtrlPressed && event.isShiftPressed && event.key == Key.C) {
-                    copySelection()
-                    return@onPreviewKeyEvent true
-                }
-                // Ctrl+Shift+V and Shift+Insert — paste from the clipboard (bracketed-paste if the app enabled it).
-                if ((event.isCtrlPressed && event.isShiftPressed && event.key == Key.V) ||
-                    (event.isShiftPressed && event.key == Key.Insert)
-                ) {
-                    pasteFromClipboard()
+                // Clipboard chords: Ctrl+Shift+C/V and the X11 pair Ctrl+Insert / Shift+Insert.
+                // Plain Ctrl+C stays SIGINT and bare Insert stays CSI 2~ — see [clipboardChord].
+                val clipboard = clipboardChord(
+                    ctrl = event.isCtrlPressed,
+                    shift = event.isShiftPressed,
+                    alt = event.isAltPressed,
+                    insertKey = event.isInsertKey(),
+                    key = event.key,
+                )
+                if (clipboard != null) {
+                    when (clipboard) {
+                        ClipboardChord.Copy -> copySelection()
+                        ClipboardChord.Paste -> pasteFromClipboard()
+                    }
                     return@onPreviewKeyEvent true
                 }
                 val bytes = mapTerminalKey(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -102,12 +102,12 @@ private fun SessionActions(state: DesktopDesignState, modifier: Modifier = Modif
         // Tunnels is a global section, always opens as an overlay.
         IconBtn("lan", onClick = { state.showView(DesktopView.Ports) })
         // Quick snippet launch into the active session without leaving for the Snippets section.
-        SnippetPaletteButton(active)
+        SnippetPaletteButton(active, state.snippetPaletteRequests)
         // Asciinema recording of this session; the stop click offers a Save-As for the .cast.
-        RecordSessionButton(active) { state.showRecordingNotice(it) }
+        RecordSessionButton(active, state.recordingToggleRequests) { state.showRecordingNotice(it) }
         // Plays a .cast back over the shell. Not tied to a session (a recording is watched, not run),
         // which is why it sits here rather than behind a connected-only guard.
-        PlayRecordingButton { state.showCast(it) }
+        PlayRecordingButton(state.castOpenRequests) { state.showCast(it) }
         // Lit while the info panel is open — the only action here with a visible on/off state.
         IconBtn("info", onClick = state::toggleInfo, tint = if (state.infoPanel) D.cyanBright else D.dim)
         // Power: closes the active session (live path) with a confirmation prompt

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -49,6 +49,28 @@ class DesktopShortcutsTest {
     }
 
     @Test
+    fun `the snippet palette is on the app modifier plus S`() {
+        assertEquals(DesktopShortcut.SnippetPalette, match(meta = true, key = Key.S))
+        assertEquals(DesktopShortcut.SnippetPalette, match(ctrl = true, shift = true, key = Key.S))
+        assertNull(match(ctrl = true, key = Key.S)) // plain Ctrl+S is the terminal's flow control
+    }
+
+    @Test
+    fun `session recording is on the app modifier plus R`() {
+        assertEquals(DesktopShortcut.ToggleRecording, match(meta = true, key = Key.R))
+        assertEquals(DesktopShortcut.ToggleRecording, match(ctrl = true, shift = true, key = Key.R))
+        // Plain Ctrl+R is reverse history search in the shell — it must not be stolen.
+        assertNull(match(ctrl = true, key = Key.R))
+    }
+
+    @Test
+    fun `the recording player is on the app modifier plus P`() {
+        assertEquals(DesktopShortcut.PlayRecording, match(meta = true, key = Key.P))
+        assertEquals(DesktopShortcut.PlayRecording, match(ctrl = true, shift = true, key = Key.P))
+        assertNull(match(ctrl = true, key = Key.P))
+    }
+
+    @Test
     fun `app modifier on macOS is Cmd alone`() {
         assertEquals(DesktopShortcut.NewConnection, match(meta = true, key = Key.N))
         assertEquals(DesktopShortcut.SplitTerminal, match(meta = true, key = Key.D))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ClipboardChordTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ClipboardChordTest.kt
@@ -1,0 +1,65 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.input.key.Key
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ClipboardChordTest {
+
+    private fun chord(
+        ctrl: Boolean = false,
+        shift: Boolean = false,
+        alt: Boolean = false,
+        insert: Boolean = false,
+        key: Key = Key.Unknown,
+    ) = clipboardChord(ctrl, shift, alt, insert, key)
+
+    @Test
+    fun `Ctrl plus Shift plus V pastes`() {
+        assertEquals(ClipboardChord.Paste, chord(ctrl = true, shift = true, key = Key.V))
+    }
+
+    @Test
+    fun `Shift plus Insert pastes`() {
+        // The X11 convention, and what a keyboard's Insert key produces regardless of how Compose
+        // names it — the caller resolves "is this the Insert key" per platform.
+        assertEquals(ClipboardChord.Paste, chord(shift = true, insert = true))
+    }
+
+    @Test
+    fun `Ctrl plus Shift plus C copies`() {
+        assertEquals(ClipboardChord.Copy, chord(ctrl = true, shift = true, key = Key.C))
+    }
+
+    @Test
+    fun `Ctrl plus Insert copies`() {
+        assertEquals(ClipboardChord.Copy, chord(ctrl = true, insert = true))
+    }
+
+    @Test
+    fun `plain Insert is left to the terminal`() {
+        // Bare Insert is a real terminal key (CSI 2~) — the shell's overwrite toggle lives on it.
+        assertNull(chord(insert = true))
+    }
+
+    @Test
+    fun `Alt plus Insert is not a clipboard chord`() {
+        assertNull(chord(shift = true, alt = true, insert = true))
+        assertNull(chord(ctrl = true, alt = true, insert = true))
+    }
+
+    @Test
+    fun `Ctrl plus Shift plus Insert prefers copy over paste`() {
+        // Both conventions claim it; copying is the non-destructive reading.
+        assertEquals(ClipboardChord.Copy, chord(ctrl = true, shift = true, insert = true))
+    }
+
+    @Test
+    fun `unmodified letters are not clipboard chords`() {
+        assertNull(chord(key = Key.V))
+        assertNull(chord(ctrl = true, key = Key.V)) // Ctrl+V is a terminal control code
+        assertNull(chord(ctrl = true, key = Key.C)) // Ctrl+C must stay SIGINT
+        assertNull(chord(shift = true, key = Key.V))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/terminal/ClipboardChord.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/terminal/ClipboardChord.desktop.kt
@@ -1,0 +1,20 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.key
+import java.awt.event.KeyEvent as AwtKeyEvent
+
+/**
+ * Desktop Insert detection. Compose's [Key] comes from the AWT key code, and normally that is
+ * `Key.Insert`; the raw AWT code is checked as a fallback so a toolkit or layout that names the key
+ * differently still pastes on Shift+Insert.
+ *
+ * `Key.NumPad0` is deliberately NOT treated as Insert: with NumLock on it is the digit zero, and
+ * claiming it would swallow `Shift+0` from the keypad.
+ */
+actual fun KeyEvent.isInsertKey(): Boolean {
+    if (key == Key.Insert) return true
+    val awt = nativeKeyEvent as? AwtKeyEvent ?: return false
+    return awt.keyCode == AwtKeyEvent.VK_INSERT
+}


### PR DESCRIPTION
Follow-up to #38–#41. Broadcast shipped with a hotkey that appears nowhere in the UI, and the snippet palette, the record toggle and the player had no hotkey at all. Settings → Keyboard is the only place these are discoverable.

## What changed

- **New shortcuts** (`matchDesktopShortcut`): `⌘S` snippet palette, `⌘R` start/stop recording, `⌘P` open a recording — `Ctrl+Shift+…` off macOS, same scheme as the rest.
- **Settings → Keyboard** now lists snippet palette, broadcast (`⌘B`, existing), record and play, all `live = true`, with `en` / `ru` / `zh` strings.
- **Signal plumbing**: those three actions live inside toolbar buttons that own their state (popup open, recording on/off, file picker), so the shell can't perform them. Each button collects a one-shot `SharedFlow` from `DesktopDesignState` — the idiom already used for AI-bar focus. A boolean flag would have to be reset by the button and could re-fire on recomposition.

### Terminal clipboard chords (second commit)

Copy/paste were two ad-hoc conditions inlined in the key handler, and `Shift+Insert` worked only if Compose named the key exactly `Key.Insert`. They are now one tested rule, `clipboardChord()`, plus an `expect/actual isInsertKey()` — desktop also accepts AWT's `VK_INSERT`, so a layout that reports the key differently still pastes. `Ctrl+Insert` now copies, completing the X11 pair; Settings → Keyboard lists both conventions on the copy and paste rows.

`NumPad0` is deliberately *not* treated as Insert: with NumLock on it is the digit, and claiming it would swallow `Shift+0` from the keypad. Bare `Insert` stays a terminal key (CSI 2~) and plain `Ctrl+C` stays SIGINT.

## Decisions taken without you

1. **Letters picked to stay clear of the shell.** Plain `Ctrl+R` is reverse history search and `Ctrl+S` is flow control; the app modifier requires Shift on the Ctrl path, so both keep working in the terminal. Tests assert exactly that.
2. **`⌘S` only opens the snippet palette, never closes it** — with no connected session there is nothing to run into, so the key falls through instead of opening a dead-end popup.
3. **No mobile change.** Android has no hardware-key scheme here; the actions stay in the `⋯` menu and More.
4. **Recording keeps its Save-As**: `⌘R` on a running recording stops it and opens the file dialog, exactly like clicking the button.

## Tests

`DesktopShortcutsTest` +3 cases (S/R/P on both modifier paths, plus the plain-`Ctrl` fall-through) and a new `ClipboardChordTest` (8 cases: both conventions, bare Insert left alone, Alt+Insert ignored, `Ctrl+Shift+Insert` resolving to copy, and unmodified letters staying with the shell). Gate: `./gradlew build` (lint on) and `:androidApp:compileDebugKotlin` — green, no pipe.

## Check by eye

Settings → Keyboard: five new rows, no SOON badge, and the labels switch with the UI language. Then in a session: `Ctrl+Shift+S` raises the snippet palette, `Ctrl+Shift+R` starts recording (button turns red) and again stops it into a Save-As, `Ctrl+Shift+P` opens the file picker for a `.cast`. In the shell, plain `Ctrl+R` must still be reverse search and `Ctrl+S` must still freeze output (`Ctrl+Q` to resume). Clipboard: `Shift+Insert` pastes, `Ctrl+Insert` copies the selection, and bare `Insert` still reaches the shell (in `vim`, it enters insert mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
