### PR TITLE
Fix what the review found in today's five features

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -44,6 +44,7 @@
     <string name="lib_snippets_add_tag">добавить тег…</string>
     <string name="lib_snippets_press_keys">Нажмите клавиши…</string>
     <string name="lib_snippets_shortcut_conflict">Уже используется в \"%1$s\"</string>
+    <string name="lib_snippets_shortcut_reserved">Занято горячей клавишей Skerry (Настройки → Клавиатура)</string>
     <string name="lib_snippets_select_or_create">Выберите сниппет или создайте новый.</string>
     <string name="lib_snippets_save">Сохранить</string>
     <string name="lib_snippets_delete">Удалить</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -44,6 +44,7 @@
     <string name="lib_snippets_add_tag">添加标签…</string>
     <string name="lib_snippets_press_keys">按键…</string>
     <string name="lib_snippets_shortcut_conflict">已被 \"%1$s\" 使用</string>
+    <string name="lib_snippets_shortcut_reserved">已被 Skerry 快捷键占用（设置 → 键盘）</string>
     <string name="lib_snippets_select_or_create">选择一个片段或新建一个。</string>
     <string name="lib_snippets_save">保存</string>
     <string name="lib_snippets_delete">删除</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -44,6 +44,7 @@
     <string name="lib_snippets_add_tag">add tag…</string>
     <string name="lib_snippets_press_keys">Press keys…</string>
     <string name="lib_snippets_shortcut_conflict">Already used by \"%1$s\"</string>
+    <string name="lib_snippets_shortcut_reserved">Reserved by a Skerry shortcut (Settings → Keyboard)</string>
     <string name="lib_snippets_select_or_create">Select a snippet or create a new one.</string>
     <string name="lib_snippets_save">Save</string>
     <string name="lib_snippets_delete">Delete</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -423,6 +423,9 @@ class ConnectionController(
         lastTarget = null
         // Cancelled before Connected — discard the not-yet-fired one-shot action (Run on host).
         pendingOnConnected = null
+        // Stop pointing at the disconnected host: a palette opened later must not attribute its
+        // commands to a session that is gone.
+        historyKey = null
         releaseSessionResources()
         uiState = ConnectionUiState.Form
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.text.AnnotatedString
 
 /**
  * Base text on the UI font (Space Grotesk by default). Thin wrapper over [BasicText] so
@@ -88,6 +89,28 @@ fun Txt(
             lineHeight = lineHeight,
             textAlign = align,
         ),
+    )
+}
+
+/** [Txt] for pre-styled text (search-match highlighting): same defaults, spans of the string win. */
+@Composable
+fun Txt(
+    text: AnnotatedString,
+    modifier: Modifier = Modifier,
+    color: Color = D.text,
+    size: TextUnit = 13.sp,
+    weight: FontWeight = FontWeight.Normal,
+    font: FontFamily? = null,
+    maxLines: Int = Int.MAX_VALUE,
+    overflow: TextOverflow = TextOverflow.Clip,
+) {
+    val family = font ?: LocalFonts.current.ui
+    BasicText(
+        text = text,
+        modifier = modifier,
+        maxLines = maxLines,
+        overflow = overflow,
+        style = TextStyle(color = color, fontSize = size, fontWeight = weight, fontFamily = family),
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.desktop
 
 import androidx.compose.ui.input.key.Key
+import app.skerry.ui.snippet.SnippetShortcut
 
 /**
  * A global hotkey of the desktop shell (titlebar/rail/sessions), recognized from a key chord.
@@ -88,6 +89,24 @@ fun matchDesktopShortcut(ctrl: Boolean, shift: Boolean, alt: Boolean, meta: Bool
         Key.Slash -> DesktopShortcut.FocusAiBar
         else -> null
     }
+}
+
+/**
+ * The shell hotkey a [SnippetShortcut]-formatted chord ("Ctrl+Shift+R") stands for, or `null` if the
+ * chord is free. The root key handler runs shell shortcuts before snippet ones and consumes the
+ * event, so a snippet bound to a reserved chord would never fire: the editor warns instead of
+ * letting the binding die silently.
+ */
+fun matchDesktopShortcut(combo: String): DesktopShortcut? {
+    val parts = combo.split('+')
+    val key = SnippetShortcut.keyFor(parts.last()) ?: return null
+    return matchDesktopShortcut(
+        ctrl = "Ctrl" in parts,
+        shift = "Shift" in parts,
+        alt = "Alt" in parts,
+        meta = "Meta" in parts,
+        key = key,
+    )
 }
 
 /** Tab index (0-based) for the top-row digit key 1..9, else `null`. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileCommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileCommandPalette.kt
@@ -10,9 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,6 +39,9 @@ import app.skerry.ui.generated.resources.term_palette_title
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.terminal.highlightMatches
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyColumn
 
 /**
  * Command palette on mobile: the desktop overlay ([app.skerry.ui.terminal.CommandPalette]) as a
@@ -66,33 +67,41 @@ internal fun MobileCommandPaletteSheet(
     }
 
     MobileBottomSheet(onDismiss = onDismiss, maxHeightFraction = 0.75f) {
-        Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            Txt(stringResource(Res.string.term_palette_title), color = D.text, size = 18.sp, weight = FontWeight.Bold)
-            MobileFormInput(query, { query = it }, stringResource(Res.string.term_palette_placeholder))
-            if (records != null && suggestions.isEmpty()) {
-                Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 13.sp)
+        // Lazy, not a scrolling Column: the list runs to [commandSuggestions]'s cap of 200 and is
+        // rebuilt on every keystroke, so only the visible rows should be laid out.
+        LazyColumn(Modifier.fillMaxWidth().padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            item {
+                Txt(stringResource(Res.string.term_palette_title), color = D.text, size = 18.sp, weight = FontWeight.Bold)
             }
-            suggestions.forEach { suggestion ->
-                key(suggestion.command) {
-                    val onClick = remember(suggestion.command) { { onPick(suggestion.command) } }
-                    Row(
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(10.dp))
-                            .background(D.card)
-                            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
-                            .padding(horizontal = 12.dp, vertical = 11.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Txt(suggestion.command, color = D.text, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
-                        val origin = if (suggestion.fromCurrentHost) stringResource(Res.string.term_palette_this_host) else suggestion.hostLabel
-                        if (origin != null) Txt(origin, color = if (suggestion.fromCurrentHost) D.cyanBright else D.faint, size = 10.sp)
-                    }
+            item {
+                MobileFormInput(query, { query = it }, stringResource(Res.string.term_palette_placeholder))
+            }
+            if (records != null && suggestions.isEmpty()) {
+                item {
+                    Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 13.sp)
                 }
             }
-            Txt(stringResource(Res.string.term_palette_hint), color = D.faint, size = 11.sp)
-            Spacer(Modifier.height(4.dp))
+            items(suggestions, key = { it.command }) { suggestion ->
+                val onClick = remember(suggestion.command) { { onPick(suggestion.command) } }
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(10.dp))
+                        .background(D.card)
+                        .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+                        .padding(horizontal = 12.dp, vertical = 11.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Txt(highlightMatches(suggestion), color = D.text, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+                    val origin = if (suggestion.fromCurrentHost) stringResource(Res.string.term_palette_this_host) else suggestion.hostLabel
+                    if (origin != null) Txt(origin, color = if (suggestion.fromCurrentHost) D.cyanBright else D.faint, size = 10.sp)
+                }
+            }
+            item {
+                Txt(stringResource(Res.string.term_palette_hint), color = D.faint, size = 11.sp)
+                Spacer(Modifier.height(4.dp))
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -363,15 +363,17 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             label = stringResource(if (recording) Res.string.term_record_stop else Res.string.term_record_start),
                             onClick = {
                                 menuOpen = false
-                                if (!recording) {
-                                    activeTerminal.startRecording(active?.displayTitle ?: active?.subtitle)
-                                } else {
-                                    val truncated = activeTerminal.recordingTruncated
-                                    val cast = activeTerminal.stopRecording()
-                                    if (cast == null || !cast.contains('\n')) {
-                                        recordingNotice = RecordingOutcome.Empty
+                                // Start/stop go through the terminal's command loop, so both run in
+                                // a coroutine rather than inline in the click.
+                                scope.launch {
+                                    if (!recording) {
+                                        activeTerminal.startRecording(active?.displayTitle ?: active?.subtitle)
                                     } else {
-                                        scope.launch {
+                                        val truncated = activeTerminal.recordingTruncated
+                                        val cast = activeTerminal.stopRecording()
+                                        if (cast == null || !cast.contains('\n')) {
+                                            recordingNotice = RecordingOutcome.Empty
+                                        } else {
                                             val name = castFileName(active?.displayTitle.orEmpty().ifBlank { active?.subtitle.orEmpty() }, recordingStamp())
                                             val saved = exportTextFile(name, cast)
                                             recordingNotice = when {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.setValue
 
 /**
  * One session a broadcast can address: its [id], the [label] shown in the picker, and [send] —
- * writing to that session's terminal. The controller never touches [Session] itself, so broadcasting
- * is testable without a live transport.
+ * writing to that session's terminal, returning whether the session was still live enough to take it.
+ * The controller never touches [Session] itself, so broadcasting is testable without a live transport.
  */
 data class BroadcastTarget(
     val id: String,
     val label: String,
-    val send: (String) -> Unit,
+    val send: (String) -> Boolean,
 )
 
 /**
@@ -59,7 +59,9 @@ class BroadcastController {
         var delivered = 0
         for (target in targets) {
             if (target.id !in selectedIds) continue
-            runCatching { target.send(text + "\n") }.onSuccess { delivered++ }
+            // The target reports it: a write into the terminal's outbound queue always succeeds, so
+            // counting the call itself would report a host whose transport just died as reached.
+            if (runCatching { target.send(text + "\n") }.getOrDefault(false)) delivered++
         }
         return delivered
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.ChipButton
 import app.skerry.ui.design.D
@@ -75,7 +76,14 @@ internal fun broadcastTargets(sessions: SessionsController?): List<BroadcastTarg
                 BroadcastTarget(
                     id = candidate.id,
                     label = candidate.displayTitle.ifBlank { candidate.subtitle },
-                    send = { text -> it.typeInput(text) },
+                    send = { text ->
+                        // Delivery is judged on the session's state, not on the write: typeInput
+                        // hands bytes to an unbounded queue and never fails, so a host whose
+                        // transport dropped a moment ago would still be counted as reached.
+                        val live = it.state.value is TerminalState.Open
+                        if (live) it.typeInput(text)
+                        live
+                    },
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibrarySidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibrarySidebar.kt
@@ -44,6 +44,7 @@ import app.skerry.ui.generated.resources.lib_snippets_search
 import app.skerry.ui.generated.resources.lib_snippets_starter_pack
 import app.skerry.ui.generated.resources.lib_snippets_untitled
 import org.jetbrains.compose.resources.stringResource
+import androidx.compose.runtime.key
 
 /**
  * Snippet library sidebar: search, category chips and the snippet list grouped into collapsible
@@ -112,15 +113,19 @@ private fun SnippetChipRow(chips: List<String>, library: SnippetLibraryState) {
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         chips.forEach { chip ->
-            val active = chip == library.activeChip
-            ChipButton(
-                label = snippetChipLabel(chip),
-                color = if (active) D.cyan else D.dim,
-                filled = active,
-                size = 11.sp,
-                verticalPadding = 4.dp,
-                onClick = { library.activeChip = chip },
-            )
+            // Keyed like the mobile row: categories are sorted, so editing tags reorders the chips
+            // and unkeyed slots would carry the previous chip's interaction state.
+            key(chip) {
+                val active = chip == library.activeChip
+                ChipButton(
+                    label = snippetChipLabel(chip),
+                    color = if (active) D.cyan else D.dim,
+                    filled = active,
+                    size = 11.sp,
+                    verticalPadding = 4.dp,
+                    onClick = { library.activeChip = chip },
+                )
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryState.kt
@@ -36,8 +36,20 @@ class SnippetLibraryState {
     fun visible(all: List<SnippetEntry>): List<SnippetEntry> =
         filterSnippets(all, activeChip = effectiveChip(all), query = query)
 
-    /** Sections to render for [all], already narrowed by [visible]. */
-    fun categories(all: List<SnippetEntry>): List<SnippetCategory> = groupSnippetsByCategory(visible(all))
+    /**
+     * Sections to render for [all], already narrowed by [visible]. With a chip active the view *is*
+     * one category, so it renders as a single section: re-grouping the filtered list would split a
+     * snippet that carries several tags back out under its other tags and show it twice.
+     */
+    fun categories(all: List<SnippetEntry>): List<SnippetCategory> {
+        val chip = effectiveChip(all)
+        val shown = filterSnippets(all, activeChip = chip, query = query)
+        return when {
+            chip == ALL_SNIPPETS_CHIP -> groupSnippetsByCategory(shown)
+            shown.isEmpty() -> emptyList()
+            else -> listOf(SnippetCategory(chip, shown))
+        }
+    }
 
     /** Chips to render: `All` plus the categories present in [all] (unaffected by the search text). */
     fun chips(all: List<SnippetEntry>): List<String> = snippetCategoryChips(all)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetShortcut.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetShortcut.kt
@@ -41,4 +41,11 @@ object SnippetShortcut {
 
     private fun keyName(key: Key): String? =
         letters[key] ?: digits[key] ?: functionKeys[key]
+
+    private val byName: Map<String, Key> by lazy {
+        (letters + digits + functionKeys).entries.associate { (k, name) -> name to k }
+    }
+
+    /** The [Key] a [format]ted name stands for, or `null` if it isn't one Skerry can bind. */
+    fun keyFor(name: String): Key? = byName[name]
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
@@ -75,6 +75,8 @@ import app.skerry.ui.generated.resources.lib_snippets_save
 import app.skerry.ui.generated.resources.lib_snippets_search
 import app.skerry.ui.generated.resources.lib_snippets_select_or_create
 import app.skerry.ui.generated.resources.lib_snippets_shortcut_conflict
+import app.skerry.ui.generated.resources.lib_snippets_shortcut_reserved
+import app.skerry.ui.desktop.matchDesktopShortcut
 import app.skerry.ui.generated.resources.lib_snippets_untitled
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.AnchoredDropdown
@@ -224,11 +226,20 @@ private fun SnippetEditor(
                 FieldLabelSnip(stringResource(Res.string.lib_snippets_field_shortcut))
                 // Conflict is checked against other snippets (this one's own shortcut isn't a
                 // conflict); the UI prevents assigning the same chord twice, which
-                // [SnippetManager.forShortcut] doesn't guarantee on read.
+                // [SnippetManager.forShortcut] doesn't guarantee on read. Shell hotkeys are checked
+                // too: they run first and consume the event, so a snippet on one would never fire.
                 val conflict = remember(manager.snippets, form.shortcut, entry?.id) {
                     form.shortcut?.let { manager.shortcutConflict(it, entry?.id) }
                 }
-                ShortcutField(form.shortcut, mono, conflictLabel = conflict?.snippet?.label) { form.shortcut = it }
+                val reserved = remember(form.shortcut) {
+                    form.shortcut?.let { matchDesktopShortcut(it) != null } == true
+                }
+                val conflictText = when {
+                    reserved -> stringResource(Res.string.lib_snippets_shortcut_reserved)
+                    conflict != null -> stringResource(Res.string.lib_snippets_shortcut_conflict, conflict.snippet.label)
+                    else -> null
+                }
+                ShortcutField(form.shortcut, mono, conflictText = conflictText) { form.shortcut = it }
             }
             Row(Modifier.padding(top = 24.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
                 PrimaryButton(
@@ -345,10 +356,10 @@ private fun SnipTagPill(tag: String, onRemove: () -> Unit) {
 // --- Snippet hotkey capture ---
 
 @Composable
-private fun ShortcutField(value: String?, mono: FontFamily, conflictLabel: String?, onCapture: (String?) -> Unit) {
+private fun ShortcutField(value: String?, mono: FontFamily, conflictText: String?, onCapture: (String?) -> Unit) {
     var focused by remember { mutableStateOf(false) }
     val requester = remember { FocusRequester() }
-    val hasConflict = conflictLabel != null
+    val hasConflict = conflictText != null
     Column {
         Box(
             Modifier
@@ -377,11 +388,11 @@ private fun ShortcutField(value: String?, mono: FontFamily, conflictLabel: Strin
             val text = value ?: if (focused) stringResource(Res.string.lib_snippets_press_keys) else "—"
             Txt(text, color = if (value != null) D.text else D.faint, size = 13.sp, font = mono)
         }
-        // The chord may already be assigned to another snippet; the assignment still takes
-        // effect, we just warn — saving is never blocked.
-        if (conflictLabel != null) {
+        // The chord may already be taken (by another snippet or by the shell); the assignment still
+        // takes effect, we just warn — saving is never blocked.
+        if (conflictText != null) {
             Txt(
-                stringResource(Res.string.lib_snippets_shortcut_conflict, conflictLabel),
+                conflictText,
                 color = D.storm, size = 11.sp,
                 modifier = Modifier.padding(top = 6.dp),
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
@@ -51,7 +51,10 @@ import org.jetbrains.compose.resources.stringResource
  */
 @Composable
 fun CastPlayerOverlay(cast: Asciicast, onDismiss: () -> Unit) {
-    val scope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Main) }
+    // Default, not Main, exactly like a live session ([ConnectionController]): the terminal state
+    // feeds the ANSI parser from this scope, and a seek hands it every event up to the target in one
+    // chunk. On the main dispatcher that parse freezes the UI (an ANR on Android) for a long take.
+    val scope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
     val player = remember(cast) { CastPlayer(cast, scope) }
     val terminal = remember(player) { TerminalScreenState(player, scope) }
     DisposableEffect(player) { onDispose { scope.cancel() } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
@@ -11,10 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -57,6 +55,11 @@ import app.skerry.ui.generated.resources.term_palette_title
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.LazyColumn
 
 /**
  * Command palette (⌘K / Ctrl+Shift+K): fuzzy search over the command history of every host, with
@@ -108,16 +111,18 @@ internal fun CommandPalette(
         ) {
             Txt(stringResource(Res.string.term_palette_title), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(start = 4.dp, bottom = 6.dp))
             PaletteSearch(query, { query = it }, mono, searchFocus)
-            Column(Modifier.heightIn(max = 360.dp).verticalScroll(rememberScrollState()).padding(top = 6.dp)) {
+            // Lazy, not a scrolling Column: the list runs to [commandSuggestions]'s cap of 200 and
+            // is rebuilt on every keystroke, so only the visible rows should be laid out.
+            LazyColumn(Modifier.heightIn(max = 360.dp).padding(top = 6.dp)) {
                 if (records == null) {
                     // Still loading; an empty box beats flashing "no commands" for a frame.
                 } else if (suggestions.isEmpty()) {
-                    Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 11.5.sp, font = mono, modifier = Modifier.padding(8.dp))
+                    item {
+                        Txt(stringResource(Res.string.term_palette_empty), color = D.faint, size = 11.5.sp, font = mono, modifier = Modifier.padding(8.dp))
+                    }
                 } else {
-                    suggestions.forEach { suggestion ->
-                        key(suggestion.command) {
-                            CommandRow(suggestion, mono) { onPick(suggestion.command) }
-                        }
+                    items(suggestions, key = { it.command }) { suggestion ->
+                        CommandRow(suggestion, mono) { onPick(suggestion.command) }
                     }
                 }
             }
@@ -149,6 +154,19 @@ private fun PaletteSearch(value: String, onValueChange: (String) -> Unit, mono: 
     }
 }
 
+/**
+ * The command with the characters the query matched picked out — what makes a fuzzy hit readable
+ * ("dcp" matching `docker compose pull`). Positions come from the matcher, which is the only thing
+ * that knows which characters they were.
+ */
+internal fun highlightMatches(suggestion: CommandSuggestion): AnnotatedString = buildAnnotatedString {
+    append(suggestion.command)
+    val hit = SpanStyle(color = D.cyanBright, fontWeight = FontWeight.SemiBold)
+    for (i in suggestion.positions) {
+        if (i in suggestion.command.indices) addStyle(hit, i, i + 1)
+    }
+}
+
 @Composable
 private fun CommandRow(suggestion: CommandSuggestion, mono: FontFamily, onClick: () -> Unit) {
     Row(
@@ -156,7 +174,7 @@ private fun CommandRow(suggestion: CommandSuggestion, mono: FontFamily, onClick:
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Txt(suggestion.command, color = D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+        Txt(highlightMatches(suggestion), color = D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
         val origin = when {
             suggestion.fromCurrentHost -> stringResource(Res.string.term_palette_this_host)
             else -> suggestion.hostLabel

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -34,19 +34,21 @@ fun RecordSessionButton(
     val terminal = (session?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     val scope = rememberCoroutineScope()
     val recording = terminal?.recording == true
-    val toggle = onClick@{
-            val live = terminal ?: return@onClick
-            if (!live.recording) {
-                live.startRecording(session.displayTitle.ifBlank { session.subtitle })
-                return@onClick
-            }
-            val truncated = live.recordingTruncated
-            val cast = live.stopRecording()
-            if (cast == null || live.recordingWasEmpty(cast)) {
-                onDone(RecordingOutcome.Empty)
-                return@onClick
-            }
+    // Start/stop go through the terminal's command loop (it owns the recorder), so the whole toggle
+    // runs in a coroutine rather than inline in the click.
+    val toggle = {
             scope.launch {
+                val live = terminal ?: return@launch
+                if (!live.recording) {
+                    live.startRecording(session.displayTitle.ifBlank { session.subtitle })
+                    return@launch
+                }
+                val truncated = live.recordingTruncated
+                val cast = live.stopRecording()
+                if (cast == null || live.recordingWasEmpty(cast)) {
+                    onDone(RecordingOutcome.Empty)
+                    return@launch
+                }
                 val name = castFileName(session.displayTitle.ifBlank { session.subtitle }, recordingStamp())
                 val saved = exportTextFile(name, cast)
                 onDone(
@@ -57,6 +59,7 @@ fun RecordSessionButton(
                     },
                 )
             }
+            Unit
         }
     // The hotkey does exactly what a click does. rememberUpdatedState so a collector started for an
     // earlier session doesn't keep toggling a terminal that is no longer on screen.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -26,7 +26,9 @@ import app.skerry.shared.terminal.encodeMouseReport
 import app.skerry.shared.terminal.lineSelectionAt
 import app.skerry.shared.terminal.wordSelectionAt
 import kotlin.concurrent.Volatile
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
@@ -139,9 +141,11 @@ class TerminalScreenState(
     var selection: TerminalSelection? by mutableStateOf(null)
         private set
 
-    // Session recording (asciinema v2). Written only by the single output collector below; the UI
-    // reads [recording] to draw the indicator. Held in memory until the user exports it — see
-    // [SessionRecorder] on why it is bounded rather than streamed to disk.
+    // Session recording (asciinema v2). Touched only by the command loop below, the same coroutine
+    // that owns the emulator: start/stop arrive from the UI thread while PTY output is still
+    // streaming in, and SessionRecorder is not thread-safe. The UI reads the two state flags instead
+    // of the recorder. Held in memory until the user exports it — see [SessionRecorder] on why it is
+    // bounded rather than streamed to disk.
     private var recorder: SessionRecorder? = null
 
     /** Whether this session is being recorded. */
@@ -149,34 +153,35 @@ class TerminalScreenState(
         private set
 
     /** Whether the running recording hit its size limit and stopped collecting. */
-    val recordingTruncated: Boolean get() = recorder?.truncated == true
+    var recordingTruncated: Boolean by mutableStateOf(false)
+        private set
 
     /**
      * Start recording this session's output. [title] names the recording in the asciicast header
      * (the host label). Recording while already recording keeps the existing take.
      */
     fun startRecording(title: String?) {
-        if (recorder != null) return
-        val startedAt = epochMillis()
-        recorder = SessionRecorder(
-            columns = cols,
-            rows = rows,
-            startedAtEpochSeconds = startedAt / 1000,
-            title = title,
-            now = ::epochMillis,
-        )
+        if (recording) return
+        val queued = commands.trySend(TerminalCommand.StartRecording(title, epochMillis(), cols, rows))
+        // The queue is closed once the session's output ends: there is nothing left to record.
+        if (queued.isFailure) return
         recording = true
+        recordingTruncated = false
     }
 
     /**
      * Stop recording and return the asciicast, or `null` if nothing was being recorded. The caller
-     * exports it; nothing is written to disk here.
+     * exports it; nothing is written to disk here. Suspends until the command loop hands the
+     * recording over, so every chunk queued before the stop is in the file.
      */
-    fun stopRecording(): String? {
-        val cast = recorder?.finish()
-        recorder = null
+    suspend fun stopRecording(): String? {
+        if (!recording) return null
         recording = false
-        return cast
+        val cast = CompletableDeferred<String?>()
+        // The queue is closed once the session's output ends; then no owner is left to answer, and
+        // the take goes with it rather than hanging the caller.
+        if (commands.trySend(TerminalCommand.StopRecording(cast)).isFailure) return null
+        return cast.await()
     }
 
     /**
@@ -265,10 +270,7 @@ class TerminalScreenState(
         // in `for (cmd in commands)`.
         scope.launch {
             try {
-                session.output.collect { chunk ->
-                    recorder?.record(chunk)
-                    commands.send(TerminalCommand.Feed(chunk))
-                }
+                session.output.collect { chunk -> commands.send(TerminalCommand.Feed(chunk)) }
             } finally {
                 commands.close()
             }
@@ -279,13 +281,22 @@ class TerminalScreenState(
         // it per chunk is expensive (freezes/GC, especially on Android). When the queue is empty,
         // behavior is unchanged (snapshot right away), so interactive latency does not grow.
         scope.launch {
-            for (cmd in commands) {
-                applyCommand(cmd)
-                while (true) {
-                    val next = commands.tryReceive().getOrNull() ?: break
-                    applyCommand(next)
+            try {
+                for (cmd in commands) {
+                    applyCommand(cmd)
+                    while (true) {
+                        val next = commands.tryReceive().getOrNull() ?: break
+                        applyCommand(next)
+                    }
+                    publishSnapshot()
                 }
-                publishSnapshot()
+            } finally {
+                // Cancellation can leave a stop-recording queued with nobody to answer it; hand the
+                // take over here rather than leave the exporting caller awaiting forever.
+                while (true) {
+                    val left = commands.tryReceive().getOrNull() ?: break
+                    if (left is TerminalCommand.StopRecording) left.cast.complete(recorder?.finish())
+                }
             }
         }
         // Sole consumer of outbound bytes: guarantees FIFO write order to the PTY regardless of how
@@ -298,7 +309,30 @@ class TerminalScreenState(
     /** Apply one command to the emulator (does not publish a snapshot; the caller batches that). */
     private suspend fun applyCommand(cmd: TerminalCommand) {
         when (cmd) {
-            is TerminalCommand.Feed -> emulator.feed(cmd.chunk)
+            is TerminalCommand.Feed -> {
+                recorder?.let {
+                    it.record(cmd.chunk)
+                    if (it.truncated && !recordingTruncated) recordingTruncated = true
+                }
+                emulator.feed(cmd.chunk)
+            }
+            is TerminalCommand.StartRecording -> {
+                // Elapsed time comes off a monotonic source: a wall clock can step backwards (NTP,
+                // suspend/resume) and take the event timeline with it. The epoch stamp is only the
+                // header's "when was this recorded".
+                val started = TimeSource.Monotonic.markNow()
+                recorder = SessionRecorder(
+                    columns = cmd.columns,
+                    rows = cmd.rows,
+                    startedAtEpochSeconds = cmd.startedAtMillis / 1000,
+                    title = cmd.title,
+                    now = { started.elapsedNow().inWholeMilliseconds },
+                )
+            }
+            is TerminalCommand.StopRecording -> {
+                cmd.cast.complete(recorder?.finish())
+                recorder = null
+            }
             is TerminalCommand.SetCursorDefault -> emulator.applyCursorDefault(cmd.shape, cmd.blink)
             is TerminalCommand.SetMaxScrollback -> emulator.applyMaxScrollback(cmd.lines)
             is TerminalCommand.SetClipboardWriteEnabled -> emulator.applyClipboardWrite(cmd.enabled)
@@ -690,6 +724,17 @@ class TerminalScreenState(
 private sealed interface TerminalCommand {
     /** Raw PTY output chunk to feed to the parser. */
     class Feed(val chunk: ByteArray) : TerminalCommand
+
+    /** Begin recording. Carries the grid size and epoch stamp for the asciicast header. */
+    class StartRecording(
+        val title: String?,
+        val startedAtMillis: Long,
+        val columns: Int,
+        val rows: Int,
+    ) : TerminalCommand
+
+    /** End recording; [cast] receives the asciicast (or `null` if nothing was being recorded). */
+    class StopRecording(val cast: CompletableDeferred<String?>) : TerminalCommand
 
     /** New grid size: applied to the emulator and forwarded to the PTY. */
     class Resize(val size: PtySize) : TerminalCommand

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -108,4 +108,19 @@ class DesktopShortcutsTest {
         assertNull(match(key = Key.One))
         assertNull(match(shift = true, key = Key.D))
     }
+
+    @Test
+    fun `a formatted chord is recognized as reserved by the shell`() {
+        // What the snippet editor stores, matched back against the shell's own shortcuts.
+        assertEquals(DesktopShortcut.ToggleRecording, matchDesktopShortcut("Ctrl+Shift+R"))
+        assertEquals(DesktopShortcut.SnippetPalette, matchDesktopShortcut("Meta+S"))
+        assertEquals(DesktopShortcut.SelectTab(0), matchDesktopShortcut("Alt+1"))
+    }
+
+    @Test
+    fun `a free chord is not reserved`() {
+        assertNull(matchDesktopShortcut("Ctrl+Shift+X"))
+        assertNull(matchDesktopShortcut("Ctrl+G"))
+        assertNull(matchDesktopShortcut("nonsense"))
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
@@ -14,7 +14,10 @@ class BroadcastControllerTest {
     private fun targets(vararg ids: String): Pair<List<BroadcastTarget>, Map<String, Recorder>> {
         val recorders = ids.associateWith { Recorder() }
         val list = ids.map { id ->
-            BroadcastTarget(id = id, label = "host-$id", send = { text -> recorders.getValue(id).sent += text })
+            BroadcastTarget(id = id, label = "host-$id", send = { text ->
+                recorders.getValue(id).sent += text
+                true
+            })
         }
         return list to recorders
     }
@@ -103,7 +106,22 @@ class BroadcastControllerTest {
         val recorder = Recorder()
         val all = listOf(
             BroadcastTarget("bad", "host-bad", send = { error("channel is gone") }),
-            BroadcastTarget("good", "host-good", send = { recorder.sent += it }),
+            BroadcastTarget("good", "host-good", send = { recorder.sent += it; true }),
+        )
+        c.selectAll(all)
+
+        assertEquals(1, c.send("ls", all))
+        assertEquals(listOf("ls\n"), recorder.sent)
+    }
+
+    @Test
+    fun a_target_that_did_not_take_the_command_is_not_counted_as_delivered() {
+        val c = BroadcastController()
+        val recorder = Recorder()
+        val all = listOf(
+            // Transport dropped a moment ago: the session is still on screen but takes nothing.
+            BroadcastTarget("dead", "host-dead", send = { false }),
+            BroadcastTarget("live", "host-live", send = { recorder.sent += it; true }),
         )
         c.selectAll(all)
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -238,6 +238,45 @@ class SessionsControllerTest {
     }
 
     @Test
+    fun `broadcastTargets covers connected tabs and their split panes`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val a = sessions.open(hostId = "host-a", title = "alpha")
+        sessions.open(hostId = "host-b", title = "beta")
+        sessions.activate(a)
+        sessions.toggleSplit()
+        sessions.connectSplit(parentId = a, hostId = "host-c")
+
+        val targets = broadcastTargets(sessions)
+
+        // Each pane is its own shell, so the split is a target in its own right.
+        assertEquals(3, targets.size)
+        assertEquals(listOf("alpha", "beta"), targets.map { it.label }.filter { it == "alpha" || it == "beta" })
+        assertTrue(targets.map { it.id }.contains(sessions.active!!.splitSession!!.id))
+        scope.cancel()
+    }
+
+    @Test
+    fun `broadcastTargets skips a session that is not connected`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val a = sessions.open(hostId = "host-a")
+        sessions.toggleSplit() // split area open but nothing connected into it
+
+        assertEquals(listOf(a), broadcastTargets(sessions).map { it.id })
+        scope.cancel()
+    }
+
+    @Test
+    fun `broadcastTargets excludes VNC tabs and an absent controller`() = runTest {
+        val vncTransport = FakeVncTransport()
+        val (sessions, scope) = sessionsWithVnc(vncTransport)
+        sessions.openVnc(hostId = "host-a") // no shell to type into
+
+        assertTrue(broadcastTargets(sessions).isEmpty())
+        assertTrue(broadcastTargets(null).isEmpty())
+        scope.cancel()
+    }
+
+    @Test
     fun `connectSplit does not add the secondary session to the tab list`() = runTest {
         val (sessions, scope) = sessionsWith(FakeTransport())
         val a = sessions.open(hostId = "host-a")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetLibraryStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetLibraryStateTest.kt
@@ -53,6 +53,20 @@ class SnippetLibraryStateTest {
     }
 
     @Test
+    fun a_chip_shows_one_section_even_when_a_snippet_carries_other_tags() {
+        val multi = listOf(
+            entry("Deploy", listOf("prod", "db")),
+            entry("Dump", listOf("db")),
+        )
+        val s = SnippetLibraryState()
+        s.activeChip = "prod"
+
+        // Grouping the filtered list again would split "Deploy" back out under "db" and show it twice.
+        assertEquals(listOf("prod"), s.categories(multi).map { it.name })
+        assertEquals(listOf("Deploy"), s.categories(multi).single().snippets.map { it.snippet.label })
+    }
+
+    @Test
     fun toggle_collapses_and_expands_a_category() {
         val s = SnippetLibraryState()
 

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.vault
 
+import app.skerry.shared.io.PrivateConfig
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_dialog_save_as
 import java.awt.FileDialog
@@ -27,6 +28,13 @@ actual suspend fun exportTextFile(suggestedName: String, content: String): Boole
         val name = dialog.file ?: return@withContext null
         File(dir, name).absolutePath
     } ?: return false
-    withContext(Dispatchers.IO) { File(path).writeText(content) }
+    withContext(Dispatchers.IO) {
+        val file = File(path)
+        file.writeText(content)
+        // A session recording holds whatever the server printed — tokens, key material echoed by a
+        // careless command. Default umask leaves it 0644, readable by every local account, so it
+        // gets the same 0600 as every other private file Skerry writes.
+        PrivateConfig.harden(file.toPath())
+    }
     return true
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SessionRecorder.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SessionRecorder.kt
@@ -10,10 +10,11 @@ import kotlinx.serialization.json.JsonPrimitive
  * The whole recording is held in memory and written out once on [finish] — a growing file would mean
  * streaming appends from the PTY collector, and terminal output is untrusted, unbounded traffic
  * (`cat` a big file and it never stops). [maxEvents]/[maxBytes] bound it instead: past either limit
- * recording stops and [truncated] says so, rather than the app quietly eating memory.
+ * recording stops and [truncated] says so, rather than the app quietly eating memory. [maxBytes] is
+ * measured on the escaped form actually held in memory, not on the source text.
  *
- * Not thread-safe by itself: it is fed from the terminal's single output collector, which is the
- * only writer.
+ * Not thread-safe by itself: every call must come from the single coroutine that owns it (in the app,
+ * the terminal's command loop — start, stop and output all reach it from there).
  *
  * Recordings contain whatever the server printed — tokens, file contents, key material echoed by a
  * careless command. They are never written anywhere on their own: the user exports one explicitly.
@@ -30,6 +31,11 @@ class SessionRecorder(
     private val startedAtMillis: Long = now()
     private val events = StringBuilder()
     private var bytes = 0
+
+    // Last timestamp written. [now] can step backwards (NTP correction, suspend/resume), and an
+    // asciicast whose time goes back stalls players. [parseAsciicast] repairs that on read; the
+    // writer must not produce a file that needs the repair in the first place.
+    private var lastElapsed = 0L
 
     var eventCount: Int = 0
         private set
@@ -57,14 +63,23 @@ class SessionRecorder(
     /** Append an output [chunk]. Blank chunks and anything past the limits are dropped. */
     fun record(chunk: String) {
         if (chunk.isEmpty() || truncated) return
-        if (eventCount >= maxEvents || bytes + chunk.length > maxBytes) {
+        if (eventCount >= maxEvents) {
             truncated = true
             return
         }
-        val elapsed = (now() - startedAtMillis).coerceAtLeast(0L)
-        events.append('[').append(secondsLiteral(elapsed)).append(",\"o\",")
-            .append(JsonPrimitive(chunk).toString()).append("]\n")
-        bytes += chunk.length
+        // The cap is measured on the escaped UTF-8 form — what the buffer actually holds. Counting
+        // source characters would let it grow several times past [maxBytes]: an ESC is one character
+        // but six once escaped, and a box-drawing or CJK glyph is one character but three bytes.
+        val escaped = JsonPrimitive(chunk).toString()
+        val size = utf8Length(escaped)
+        if (bytes + size > maxBytes) {
+            truncated = true
+            return
+        }
+        val elapsed = (now() - startedAtMillis).coerceAtLeast(lastElapsed)
+        lastElapsed = elapsed
+        events.append('[').append(secondsLiteral(elapsed)).append(",\"o\",").append(escaped).append("]\n")
+        bytes += size
         eventCount++
     }
 
@@ -106,6 +121,22 @@ private fun secondsLiteral(millis: Long): String {
         fraction % 10 == 0 -> "$whole.${(fraction / 10).toString().padStart(2, '0')}"
         else -> "$whole.${fraction.toString().padStart(3, '0')}"
     }
+}
+
+/** UTF-8 byte length of [s], counted without allocating an encoded copy. */
+private fun utf8Length(s: String): Int {
+    var n = 0
+    for (ch in s) {
+        val c = ch.code
+        n += when {
+            c < 0x80 -> 1
+            c < 0x800 -> 2
+            // Half of a surrogate pair: two halves make the four bytes of an astral character.
+            c in 0xD800..0xDFFF -> 2
+            else -> 3
+        }
+    }
+    return n
 }
 
 /**

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SessionRecorderTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SessionRecorderTest.kt
@@ -94,6 +94,40 @@ class SessionRecorderTest {
     }
 
     @Test
+    fun the_byte_cap_counts_the_escaped_form_not_source_characters() {
+        val r = recorder(Clock(), maxBytes = 16)
+
+        r.record("\u001b\u001b\u001b\u001b") // four characters, 24 once escaped
+
+        assertTrue(r.truncated)
+        assertEquals(0, r.eventCount)
+    }
+
+    @Test
+    fun the_byte_cap_counts_utf8_bytes_of_multibyte_text() {
+        val r = recorder(Clock(), maxBytes = 8)
+
+        r.record("шшшш") // four characters, eight UTF-8 bytes plus quotes
+
+        assertTrue(r.truncated)
+        assertEquals(0, r.eventCount)
+    }
+
+    @Test
+    fun a_clock_that_steps_backwards_never_moves_an_event_back_in_time() {
+        val clock = Clock(1_000L)
+        val r = recorder(clock)
+
+        r.record("first")
+        clock.now = 1_500L
+        r.record("second")
+        clock.now = 1_100L // NTP step back mid-recording
+        r.record("third")
+
+        assertEquals("[0.5,\"o\",\"third\"]", r.finish().lines()[3])
+    }
+
+    @Test
     fun a_fresh_recorder_is_neither_truncated_nor_populated() {
         val r = recorder(Clock())
 


### PR DESCRIPTION
Six reviewers went over everything merged into `main` today (#36, #38–#42) — nothing in that batch had been reviewed before merging. This fixes all ten findings plus three minor ones. Every claim was verified against the code before it was acted on.

## Blockers

- **Recording had two writers.** `startRecording`/`stopRecording` ran on the UI thread while the PTY collector wrote chunks into the same `SessionRecorder` on `Dispatchers.Default`. Stopping a recording on a busy session (`tail -f`, build logs) could corrupt the `.cast`. The recorder now lives on the command loop that already owns the emulator; stop waits for it, so every chunk queued before the stop is in the file.
- **Playback ran on the main dispatcher.** `CastPlayerOverlay` fed the ANSI parser from `Dispatchers.Main` while live sessions use `Default`. Seeking near the end of a long take froze the UI — ANR-class on Android.
- **The size cap counted the wrong thing.** `bytes += chunk.length` counted source UTF-16 units while the buffer holds the JSON-escaped form (an `ESC` is 1 character and 6 escaped; a CJK glyph is 3 bytes). On TUI-heavy output the buffer grew several times past the intended 32 MB.

## The rest

- Exported `.cast` files were written at the default umask (`-rw-r--r--`). They hold whatever the server printed; they now get the same 0600 as every other private file Skerry writes.
- Broadcast reported "sent to N" from a queue write that never fails, so a host whose transport had just dropped counted as reached. Delivery is judged on `TerminalState` now, and `broadcastTargets` — the function deciding which shells a broadcast reaches — has tests for the first time.
- `Ctrl+Shift+S/R/P` became reserved by the shell in #42, silently killing any snippet already bound to them. The editor now warns.
- A category chip showed multi-tagged snippets twice, once under each of their other tags.
- Both command palettes laid out up to 200 rows eagerly on every keystroke; they are lazy now, and the fuzzy matcher's match positions — computed, carried to the UI, then dropped — highlight the match.
- `historyKey` kept pointing at a disconnected host; the desktop chip row was unkeyed.

## Tests

Nine new tests, written before the fixes: escape/UTF-8 accounting and a backwards clock step in the recorder, undelivered broadcast targets, `broadcastTargets` coverage (split panes in, unconnected and VNC out), multi-tag chip grouping, reserved-chord matching.

`:composeApp:desktopTest` and `:shared:desktopTest` pass; desktop and Android targets both compile.

**Not verified by eye yet** — worth a look before merging: match highlighting in the palette, the reserved-chord warning in the snippet editor, and the mobile palette, whose list structure changed when it became a `LazyColumn`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)