### PR TITLE
Run local model inference in an isolated process

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -28,6 +28,13 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Local model inference runs in its own process: llama.cpp aborts the process instead of
+             throwing (issue #37), and here that costs one answer rather than the app with every open
+             SSH session. Not exported — only this app binds it. -->
+        <service
+            android:name="app.skerry.shared.ai.local.LlmHostService"
+            android:exported="false"
+            android:process=":llm" />
     </application>
 
 </manifest>

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -8,8 +8,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
-import app.skerry.shared.ai.local.LlamatikRuntime
+import app.skerry.shared.ai.local.IsolatedLlmRuntime
 import app.skerry.shared.ai.local.LocalModelStore
+import app.skerry.shared.ai.local.ServiceLlmHostLauncher
 import app.skerry.shared.ai.local.ModelDownloader
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.ssh.FileHostKeyMismatchStore
@@ -476,13 +477,14 @@ class MainActivity : FragmentActivity() {
             tunnels.reload()
         }
         // Local AI: GGUF models in the private filesDir/models (allowBackup=false so gigabyte-sized
-        // weights don't break cloud backup); inference via Llamatik/llama.cpp arm64. ctx 2048 keeps the
+        // weights don't break cloud backup); inference via Llamatik/llama.cpp arm64 in the ":llm"
+        // process (LlmHostService) so a native abort doesn't take the app down. ctx 2048 keeps the
         // KV cache within a few hundred MiB on phone-class RAM.
         val localModelStore = LocalModelStore(FileSystem.SYSTEM, dir.resolve("models").absolutePath.toPath())
         val localAi = LocalAiDeps(
             store = localModelStore,
             downloader = ModelDownloader(FileSystem.SYSTEM, localModelStore),
-            runtime = LlamatikRuntime(contextLength = 2048),
+            runtime = IsolatedLlmRuntime(ServiceLlmHostLauncher(this, contextLength = 2048)),
         )
         return AppDependencies(
             transport = transport,

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -61,6 +61,7 @@
     <string name="settings_ai_error_invalid_request">Провайдер отклонил запрос (проверьте модель и параметры).</string>
     <string name="settings_ai_error_protocol">Неожиданный ответ от провайдера ИИ.</string>
     <string name="settings_ai_error_unknown">Не удалось выполнить запрос к ИИ. Попробуйте ещё раз.</string>
+    <string name="settings_ai_error_engine_crashed">Движок локальной модели аварийно завершился. Попробуйте ещё раз.</string>
     <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">Очищать секреты перед отправкой</string>
     <string name="settings_ai_sanitize_desc">Вырезать очевидные пароли, токены и ключи из запросов до отправки внешним провайдерам.</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -61,6 +61,7 @@
     <string name="settings_ai_error_invalid_request">提供商拒绝了该请求（请检查模型和参数）。</string>
     <string name="settings_ai_error_protocol">AI 提供商返回了意外的响应。</string>
     <string name="settings_ai_error_unknown">AI 请求失败。请重试。</string>
+    <string name="settings_ai_error_engine_crashed">本地模型引擎意外停止。请重试。</string>
     <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">发送前清除敏感信息</string>
     <string name="settings_ai_sanitize_desc">在发送到外部提供商前，从提示中移除明显的密码、令牌和密钥。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -61,6 +61,7 @@
     <string name="settings_ai_error_invalid_request">The provider rejected the request (check model/params).</string>
     <string name="settings_ai_error_protocol">Unexpected response from the AI provider.</string>
     <string name="settings_ai_error_unknown">AI request failed. Try again.</string>
+    <string name="settings_ai_error_engine_crashed">The local model engine stopped unexpectedly. Try again.</string>
     <string name="settings_ai_model_meta">%1$s · %2$s</string>
     <string name="settings_ai_sanitize">Sanitize secrets before sending</string>
     <string name="settings_ai_sanitize_desc">Strip obvious passwords, tokens and keys from prompts before they reach external providers.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiFailureMessage.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiFailureMessage.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.ai
 
 import androidx.compose.runtime.Composable
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.settings_ai_error_engine_crashed
 import app.skerry.ui.generated.resources.settings_ai_error_invalid_request
 import app.skerry.ui.generated.resources.settings_ai_error_network
 import app.skerry.ui.generated.resources.settings_ai_error_protocol
@@ -22,6 +23,7 @@ fun aiFailureMessage(failure: AiFailure): String = stringResource(
         AiFailure.NETWORK -> Res.string.settings_ai_error_network
         AiFailure.INVALID_REQUEST -> Res.string.settings_ai_error_invalid_request
         AiFailure.PROTOCOL -> Res.string.settings_ai_error_protocol
+        AiFailure.ENGINE_CRASHED -> Res.string.settings_ai_error_engine_crashed
         AiFailure.UNKNOWN -> Res.string.settings_ai_error_unknown
     },
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiStreamRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiStreamRunner.kt
@@ -21,6 +21,9 @@ enum class AiFailure {
     NETWORK,
     INVALID_REQUEST,
     PROTOCOL,
+
+    /** The isolated local-inference host died; the rest of the app is unaffected. */
+    ENGINE_CRASHED,
     UNKNOWN,
 }
 
@@ -31,6 +34,7 @@ internal fun AiException.toFailure(): AiFailure = when (kind) {
     AiException.Kind.NETWORK -> AiFailure.NETWORK
     AiException.Kind.INVALID_REQUEST -> AiFailure.INVALID_REQUEST
     AiException.Kind.PROTOCOL -> AiFailure.PROTOCOL
+    AiException.Kind.ENGINE_CRASHED -> AiFailure.ENGINE_CRASHED
 }
 
 /**

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -39,7 +39,10 @@ import app.skerry.shared.sync.KtorSyncClient
 import app.skerry.shared.tunnel.VaultTunnelStore
 import app.skerry.ui.sync.FileSyncConfigStore
 import app.skerry.shared.ai.AiSettingsStore
-import app.skerry.shared.ai.local.LlamatikRuntime
+import app.skerry.shared.ai.local.IsolatedLlmRuntime
+import app.skerry.shared.ai.local.LlmHostCommandLine
+import app.skerry.shared.ai.local.LlmHostMain
+import app.skerry.shared.ai.local.ProcessLlmHostLauncher
 import app.skerry.shared.ai.local.LocalModelStore
 import app.skerry.shared.ai.local.ModelDownloader
 import app.skerry.ui.ai.LocalAiDeps
@@ -271,7 +274,10 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val localAi = LocalAiDeps(
         store = localModelStore,
         downloader = ModelDownloader(FileSystem.SYSTEM, localModelStore),
-        runtime = LlamatikRuntime(contextLength = 4096),
+        // Inference runs in a child JVM: llama.cpp aborts the process on some inputs and corrupts
+        // memory when loaded next to Skia/AWT (issue #37). Out of process, a native crash costs one
+        // answer instead of every open SSH session.
+        runtime = IsolatedLlmRuntime(ProcessLlmHostLauncher(contextLength = 4096)),
     )
     val ai = AiAssistantController(
         initialSettings = aiSettingsStore.load(),
@@ -369,7 +375,11 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     )
 }
 
-fun main() {
+fun main(args: Array<String>) {
+    // Started as the isolated inference host (issue #37): serve llama.cpp and nothing else — no
+    // vault, no window. A packaged build has no bundled `java` to spawn, so the app re-launches its
+    // own launcher with this flag; the branch must come before anything touches AWT or Skia.
+    if (LlmHostCommandLine.isHostRun(args)) return LlmHostMain.main(args)
     // libsodium (ionspin) requires async init before the first VaultCrypto call; on desktop startup
     // this is done blocking so the dependency graph is already built and ready.
     runBlocking { initializeVaultCrypto() }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/LocalAiIsolationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/LocalAiIsolationTest.kt
@@ -1,0 +1,56 @@
+package app.skerry.ui.ai
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import app.skerry.shared.ai.local.IsolatedLlmRuntime
+import app.skerry.shared.ai.local.ProcessLlmHostLauncher
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlinx.coroutines.withTimeout
+
+/**
+ * Regression test for issue #37. Loading `libllama_jni.so` into a process that already has Skia and
+ * AWT in it corrupts memory: generation aborts the whole JVM (`free(): invalid pointer`, always
+ * inside the same `std::regex` bracket matcher), and often the `System.load` itself segfaults.
+ * Ordering is the trigger — the very same library is fine in a bare JVM.
+ *
+ * So this test sets up exactly the deadly environment and then generates through
+ * [IsolatedLlmRuntime]: the native library is loaded in the child host, and the app survives.
+ * Before the fix, this test did not fail — it killed the test worker with exit code 134.
+ *
+ *     SKERRY_LOCAL_AI_MODEL=~/.local/share/skerry/models/qwen2.5-coder-1.5b-instruct-q4_k_m.gguf \
+ *         ./gradlew :composeApp:desktopTest --tests '*LocalAiIsolationTest*'
+ */
+class LocalAiIsolationTest {
+
+    @Test
+    fun `generation survives with skia and awt loaded in the app process`() = runBlocking {
+        val modelPath = System.getenv("SKERRY_LOCAL_AI_MODEL")?.takeIf { it.isNotBlank() }
+            ?: return@runBlocking // not an e2e run: regular CI has no multi-gigabyte weights
+
+        org.jetbrains.skia.Surface.makeRasterN32Premul(64, 64).canvas.clear(0)
+        java.awt.Toolkit.getDefaultToolkit()
+
+        val runtime = IsolatedLlmRuntime(ProcessLlmHostLauncher(contextLength = 4096))
+        val request = AiChatRequest(
+            model = "local-it",
+            messages = listOf(
+                AiMessage(AiRole.SYSTEM, "You are a terse shell assistant."),
+                AiMessage(AiRole.USER, "Say OK."),
+            ),
+            maxOutputTokens = 24,
+        )
+
+        val text = withTimeout(5.minutes) {
+            runtime.generate(modelPath.toPath(), request).toList().joinToString("") { it.text }
+        }
+        runtime.close()
+
+        assertTrue(text.isNotBlank(), "the isolated host produced no output")
+    }
+}

--- a/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/LlmHostService.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/LlmHostService.kt
@@ -9,13 +9,14 @@ import android.os.IBinder
 import android.os.Message
 import android.os.Messenger
 import android.os.ParcelFileDescriptor
+import android.util.Log
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import java.io.FileOutputStream
 
 /**
  * The isolated inference host on Android: declared with `android:process=":llm"`, so llama.cpp
@@ -28,7 +29,13 @@ import java.io.FileOutputStream
  */
 class LlmHostService : Service() {
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // The point of this process is to absorb failures: a bug in the plumbing here must end the
+    // connection (the app sees a dead host and retries), not take the process down by itself.
+    private val scope = CoroutineScope(
+        SupervisorJob() + Dispatchers.IO + CoroutineExceptionHandler { _, e ->
+            Log.e("SkerryLlmHost", "inference connection failed", e)
+        },
+    )
     private var serving: Job? = null
     private var handlerThread: HandlerThread? = null
 
@@ -44,9 +51,12 @@ class LlmHostService : Service() {
         val (host, client) = pair[0] to pair[1]
         serving?.cancel()
         serving = scope.launch {
-            // Both ends are sockets: reading and writing go over the same descriptor.
+            // The socket is full duplex, but each stream must own its own descriptor: two wrappers
+            // over one ParcelFileDescriptor would close it twice. The dup is closed with its stream.
             ParcelFileDescriptor.AutoCloseInputStream(host).use { input ->
-                FileOutputStream(host.fileDescriptor).use { output ->
+                ParcelFileDescriptor.AutoCloseOutputStream(host.dup()).use { output ->
+                    // A runtime per connection: the process is torn down with the last unbind, so
+                    // this is also the lifetime of the loaded model.
                     LlmHostServer.serve(input, output, LlamatikRuntime(message.arg1))
                 }
             }

--- a/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/LlmHostService.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/LlmHostService.kt
@@ -1,0 +1,75 @@
+package app.skerry.shared.ai.local
+
+import android.app.Service
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.Message
+import android.os.Messenger
+import android.os.ParcelFileDescriptor
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.FileOutputStream
+
+/**
+ * The isolated inference host on Android: declared with `android:process=":llm"`, so llama.cpp
+ * lives in its own process and a native abort (issue #37) costs one answer instead of the app and
+ * every open SSH session. The counterpart of the child JVM that [ProcessLlmHostLauncher] starts on
+ * desktop; both run the same [LlmHostServer].
+ *
+ * Binding gives the client a socket pair rather than a per-message Binder API: the same line
+ * protocol then works on both platforms, and the app sees a dead host as a closed stream.
+ */
+class LlmHostService : Service() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var serving: Job? = null
+    private var handlerThread: HandlerThread? = null
+
+    override fun onBind(intent: Intent?): IBinder {
+        val thread = handlerThread ?: HandlerThread("llm-host-bind").also { it.start(); handlerThread = it }
+        return Messenger(Handler(thread.looper) { message -> handle(message) }).binder
+    }
+
+    private fun handle(message: Message): Boolean {
+        if (message.what != MSG_OPEN) return false
+        val reply = message.replyTo ?: return true
+        val pair = ParcelFileDescriptor.createSocketPair()
+        val (host, client) = pair[0] to pair[1]
+        serving?.cancel()
+        serving = scope.launch {
+            // Both ends are sockets: reading and writing go over the same descriptor.
+            ParcelFileDescriptor.AutoCloseInputStream(host).use { input ->
+                FileOutputStream(host.fileDescriptor).use { output ->
+                    LlmHostServer.serve(input, output, LlamatikRuntime(message.arg1))
+                }
+            }
+        }
+        val answer = Message.obtain(null, MSG_OPEN).apply {
+            data = Bundle().apply { putParcelable(KEY_CHANNEL, client) }
+        }
+        runCatching { reply.send(answer) }
+        // The descriptor was duplicated into the client process during the transaction.
+        runCatching { client.close() }
+        return true
+    }
+
+    override fun onDestroy() {
+        serving?.cancel()
+        scope.cancel()
+        handlerThread?.quitSafely()
+        super.onDestroy()
+    }
+
+    companion object {
+        /** Asks for a channel to the host; `arg1` is the context length, `replyTo` receives the socket. */
+        const val MSG_OPEN = 1
+        const val KEY_CHANNEL = "channel"
+    }
+}

--- a/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
@@ -1,0 +1,105 @@
+package app.skerry.shared.ai.local
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Build
+import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.IBinder
+import android.os.Message
+import android.os.Messenger
+import android.os.ParcelFileDescriptor
+import app.skerry.shared.ai.AiException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.FileOutputStream
+
+/**
+ * Binds [LlmHostService] in the `:llm` process and takes the socket it hands back. The service is
+ * started on demand — a user who never asks the local model anything never pays for the process —
+ * and is released together with the link, so a crashed host is simply replaced by a fresh one.
+ */
+class ServiceLlmHostLauncher(
+    context: Context,
+    private val contextLength: Int,
+) : LlmHostLauncher {
+
+    private val appContext = context.applicationContext
+
+    override suspend fun launch(): LlmHostLink = withContext(Dispatchers.IO) {
+        val binder = CompletableDeferred<IBinder?>()
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                binder.complete(service)
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                binder.complete(null) // the host died before it could hand over the channel
+            }
+        }
+
+        val intent = Intent(appContext, LlmHostService::class.java)
+        if (!appContext.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+            runCatching { appContext.unbindService(connection) }
+            fail("could not start the inference service")
+        }
+        try {
+            val service = withTimeoutOrNull(BIND_TIMEOUT_MILLIS) { binder.await() }
+                ?: fail("the inference service did not start")
+            val channel = openChannel(Messenger(service)) ?: fail("the inference service gave no channel")
+            StreamLlmHostLink(
+                input = ParcelFileDescriptor.AutoCloseInputStream(channel),
+                output = FileOutputStream(channel.fileDescriptor),
+            ) {
+                runCatching { appContext.unbindService(connection) }
+            }
+        } catch (e: Throwable) {
+            runCatching { appContext.unbindService(connection) }
+            throw e
+        }
+    }
+
+    /** Asks the service for a socket pair and waits for the descriptor to come back. */
+    private suspend fun openChannel(service: Messenger): ParcelFileDescriptor? {
+        val answer = CompletableDeferred<ParcelFileDescriptor?>()
+        val thread = HandlerThread("llm-host-reply").also { it.start() }
+        try {
+            val replyTo = Messenger(
+                Handler(thread.looper) { message ->
+                    answer.complete(message.data?.channel())
+                    true
+                },
+            )
+            val request = Message.obtain(null, LlmHostService.MSG_OPEN).apply {
+                arg1 = contextLength
+                this.replyTo = replyTo
+            }
+            service.send(request)
+            return withTimeoutOrNull(BIND_TIMEOUT_MILLIS) { answer.await() }
+        } finally {
+            thread.quitSafely()
+        }
+    }
+
+    @Suppress("DEPRECATION") // the typed getParcelable overload only exists from API 33
+    private fun Bundle.channel(): ParcelFileDescriptor? {
+        classLoader = ParcelFileDescriptor::class.java.classLoader
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getParcelable(LlmHostService.KEY_CHANNEL, ParcelFileDescriptor::class.java)
+        } else {
+            getParcelable(LlmHostService.KEY_CHANNEL)
+        }
+    }
+
+    private fun fail(reason: String): Nothing =
+        throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host: $reason")
+
+    private companion object {
+        const val BIND_TIMEOUT_MILLIS = 30_000L
+    }
+}

--- a/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import java.io.FileOutputStream
 
 /**
  * Binds [LlmHostService] in the `:llm` process and takes the socket it hands back. The service is
@@ -38,8 +37,10 @@ class ServiceLlmHostLauncher(
                 binder.complete(service)
             }
 
+            // Only matters before the handshake: once the socket exists, a dead host is detected by
+            // the stream ending, the same way as on desktop.
             override fun onServiceDisconnected(name: ComponentName?) {
-                binder.complete(null) // the host died before it could hand over the channel
+                binder.complete(null)
             }
         }
 
@@ -53,8 +54,10 @@ class ServiceLlmHostLauncher(
                 ?: fail("the inference service did not start")
             val channel = openChannel(Messenger(service)) ?: fail("the inference service gave no channel")
             StreamLlmHostLink(
+                // One descriptor per stream (see LlmHostService): the socket is full duplex, but a
+                // ParcelFileDescriptor must not be closed twice.
                 input = ParcelFileDescriptor.AutoCloseInputStream(channel),
-                output = FileOutputStream(channel.fileDescriptor),
+                output = ParcelFileDescriptor.AutoCloseOutputStream(channel.dup()),
             ) {
                 runCatching { appContext.unbindService(connection) }
             }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/AiProvider.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/AiProvider.kt
@@ -51,7 +51,8 @@ interface AiProvider {
     suspend fun close()
 }
 
-/** AI provider error: network, auth, rate limit, invalid request, or protocol. */
+/** AI provider error: network, auth, rate limit, invalid request, protocol, or a dead local engine. */
 class AiException(val kind: Kind, message: String, cause: Throwable? = null) : Exception(message, cause) {
-    enum class Kind { NETWORK, UNAUTHORIZED, RATE_LIMITED, INVALID_REQUEST, PROTOCOL }
+    /** [ENGINE_CRASHED] is local-only: the isolated inference host died (see `IsolatedLlmRuntime`). */
+    enum class Kind { NETWORK, UNAUTHORIZED, RATE_LIMITED, INVALID_REQUEST, PROTOCOL, ENGINE_CRASHED }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntime.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntime.kt
@@ -1,0 +1,136 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiDelta
+import app.skerry.shared.ai.AiException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.Path
+
+/**
+ * [LocalLlmRuntime] that runs inference in a separate process (see [LlmHostLauncher]) instead of
+ * loading llama.cpp into the app. The native library aborts the whole process on some inputs and
+ * corrupts memory when it is loaded after Skia/AWT (issue #37) — out of process, such a crash costs
+ * one answer instead of every open SSH session, and the host is a clean headless JVM, which is the
+ * configuration where the library behaves.
+ *
+ * The host stays alive between requests, so the GGUF is loaded once. Generations are serialized by
+ * [mutex] — the host handles one at a time. A host that died is dropped and replaced: silently when
+ * it went away between requests, with [AiException.Kind.ENGINE_CRASHED] when it died mid-answer.
+ */
+class IsolatedLlmRuntime(
+    private val launcher: LlmHostLauncher,
+) : LocalLlmRuntime {
+
+    private val mutex = Mutex()
+    private var link: LlmHostLink? = null
+
+    override fun generate(modelPath: Path, request: AiChatRequest): Flow<AiDelta> = flow {
+        mutex.withLock {
+            val start = LlmHostProtocol.encode(LlmHostCommand.Generate(modelPath.toString(), request))
+            // A host that quietly went away between requests is not a user-visible failure: the
+            // command never reached it, so a fresh host can run the same request from scratch.
+            val live = reuseOrLaunch(start) ?: launchFresh().also { it.send(start) }
+            stream(live)
+        }
+    }
+
+    /** Shuts the host down; the next request starts a new one. */
+    suspend fun close() {
+        mutex.withLock { release() }
+    }
+
+    /** Sends [start] on the existing host, or returns null if there is none or it is already gone. */
+    private suspend fun reuseOrLaunch(start: String): LlmHostLink? {
+        val existing = link ?: return null
+        return try {
+            existing.send(start)
+            existing
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            release()
+            null
+        }
+    }
+
+    private suspend fun launchFresh(): LlmHostLink = try {
+        launcher.launch().also { link = it }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: AiException) {
+        throw e
+    } catch (e: Exception) {
+        throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host did not start: ${e.message}", e)
+    }
+
+    /** Relays events until the host reports the end of the answer. */
+    private suspend fun FlowCollector<AiDelta>.stream(live: LlmHostLink) {
+        var finished = false
+        try {
+            while (true) {
+                val line = live.receive() ?: crashed()
+                when (val event = LlmHostProtocol.decodeEvent(line)) {
+                    is LlmHostEvent.Delta -> emit(AiDelta(event.text))
+                    LlmHostEvent.Done -> {
+                        finished = true
+                        return
+                    }
+                    is LlmHostEvent.Failure -> {
+                        finished = true
+                        throw AiException(event.kind, event.message)
+                    }
+                }
+            }
+        } finally {
+            if (!finished) withContext(NonCancellable) { stopGeneration(live) }
+        }
+    }
+
+    /**
+     * The collector walked away mid-answer: tell the host to stop and wait for the tail of the
+     * stream, so the next request starts on a quiet host. A host that ignores the cancel is not
+     * trustworthy any more and gets replaced.
+     */
+    private suspend fun stopGeneration(live: LlmHostLink) {
+        val drained = runCatching {
+            withTimeoutOrNull(CANCEL_DRAIN_MILLIS) {
+                live.send(LlmHostProtocol.encode(LlmHostCommand.Cancel))
+                var tailSeen = false
+                while (!tailSeen) {
+                    val line = live.receive() ?: break
+                    val event = LlmHostProtocol.decodeEvent(line)
+                    tailSeen = event is LlmHostEvent.Done || event is LlmHostEvent.Failure
+                }
+                tailSeen
+            }
+        }.getOrNull()
+        if (drained != true) release()
+    }
+
+    private suspend fun crashed(): Nothing {
+        release()
+        throw AiException(
+            AiException.Kind.ENGINE_CRASHED,
+            "Local inference host stopped before finishing the answer",
+        )
+    }
+
+    private suspend fun release() {
+        val gone = link ?: return
+        link = null
+        runCatching { gone.close() }
+    }
+
+    private companion object {
+        /** Cancel is a flag polled between tokens, so the tail arrives fast or the host is stuck. */
+        const val CANCEL_DRAIN_MILLIS = 5_000L
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntime.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntime.kt
@@ -4,14 +4,17 @@ import app.skerry.shared.ai.AiChatRequest
 import app.skerry.shared.ai.AiDelta
 import app.skerry.shared.ai.AiException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import okio.Path
 
 /**
@@ -27,6 +30,7 @@ import okio.Path
  */
 class IsolatedLlmRuntime(
     private val launcher: LlmHostLauncher,
+    private val cancelDrainMillis: Long = CANCEL_DRAIN_MILLIS,
 ) : LocalLlmRuntime {
 
     private val mutex = Mutex()
@@ -37,7 +41,7 @@ class IsolatedLlmRuntime(
             val start = LlmHostProtocol.encode(LlmHostCommand.Generate(modelPath.toString(), request))
             // A host that quietly went away between requests is not a user-visible failure: the
             // command never reached it, so a fresh host can run the same request from scratch.
-            val live = reuseOrLaunch(start) ?: launchFresh().also { it.send(start) }
+            val live = reuseOrLaunch(start) ?: startFresh(start)
             stream(live)
         }
     }
@@ -61,14 +65,27 @@ class IsolatedLlmRuntime(
         }
     }
 
-    private suspend fun launchFresh(): LlmHostLink = try {
-        launcher.launch().also { link = it }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: AiException) {
-        throw e
-    } catch (e: Exception) {
-        throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host did not start: ${e.message}", e)
+    /** Starts a host and hands it [start]; a host that dies right away is released, not cached. */
+    private suspend fun startFresh(start: String): LlmHostLink {
+        val fresh = try {
+            launcher.launch()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: AiException) {
+            throw e
+        } catch (e: Exception) {
+            throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host did not start: ${e.message}", e)
+        }
+        link = fresh
+        try {
+            fresh.send(start)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            release() // it never took the request; leaving it cached would fail the next one too
+            throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host died on start-up", e)
+        }
+        return fresh
     }
 
     /** Relays events until the host reports the end of the answer. */
@@ -100,19 +117,27 @@ class IsolatedLlmRuntime(
      * trustworthy any more and gets replaced.
      */
     private suspend fun stopGeneration(live: LlmHostLink) {
-        val drained = runCatching {
-            withTimeoutOrNull(CANCEL_DRAIN_MILLIS) {
-                live.send(LlmHostProtocol.encode(LlmHostCommand.Cancel))
-                var tailSeen = false
-                while (!tailSeen) {
-                    val line = live.receive() ?: break
-                    val event = LlmHostProtocol.decodeEvent(line)
-                    tailSeen = event is LlmHostEvent.Done || event is LlmHostEvent.Failure
-                }
-                tailSeen
-            }
-        }.getOrNull()
-        if (drained != true) release()
+        // A deadline alone cannot stop a read that is already blocked inside the OS, and this
+        // cleanup runs uncancellable while holding [mutex] — so the watchdog closes the transport
+        // instead, which is what actually releases the read. Without it, a wedged host would hold
+        // the lock forever and local AI would stay dead for the rest of the session.
+        val watchdog = CoroutineScope(Dispatchers.Default).launch {
+            delay(cancelDrainMillis)
+            runCatching { live.close() }
+        }
+        val drained = runCatching { drain(live) }.getOrDefault(false)
+        watchdog.cancel()
+        if (!drained) release()
+    }
+
+    /** Reads to the end of the cancelled answer; false if the host went away instead. */
+    private suspend fun drain(live: LlmHostLink): Boolean {
+        live.send(LlmHostProtocol.encode(LlmHostCommand.Cancel))
+        while (true) {
+            val line = live.receive() ?: return false
+            val event = LlmHostProtocol.decodeEvent(line)
+            if (event is LlmHostEvent.Done || event is LlmHostEvent.Failure) return true
+        }
     }
 
     private suspend fun crashed(): Nothing {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/LlmHostLink.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/LlmHostLink.kt
@@ -1,0 +1,23 @@
+package app.skerry.shared.ai.local
+
+/**
+ * A live connection to an inference host — the process that owns the native llama.cpp library.
+ * Line-oriented on purpose: the transport differs per platform (a child JVM over a Unix socket on
+ * desktop, a `:llm` service over a socket pair on Android), the framing does not.
+ */
+interface LlmHostLink {
+
+    /** Sends one [LlmHostProtocol] frame. Throws when the host is gone. */
+    suspend fun send(line: String)
+
+    /** Next frame from the host, or `null` once the host is gone (exit or native crash). */
+    suspend fun receive(): String?
+
+    /** Stops the host and releases the transport. Idempotent. */
+    suspend fun close()
+}
+
+/** Starts an inference host and connects to it. */
+fun interface LlmHostLauncher {
+    suspend fun launch(): LlmHostLink
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/LlmHostProtocol.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/local/LlmHostProtocol.kt
@@ -1,0 +1,129 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiException
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Wire protocol between the app and the isolated inference host (see [IsolatedLlmRuntime]): one
+ * JSON object per line, commands app -> host, events host -> app. JSON escaping keeps a frame on a
+ * single line even when model output contains newlines, so the reader can split on `\n`.
+ *
+ * The domain types ([AiChatRequest] and friends) stay serialization-free; the DTOs below are the
+ * only place that knows the wire shape.
+ */
+sealed interface LlmHostCommand {
+    /** Run one generation. A host handles one at a time; the caller serializes. */
+    data class Generate(val modelPath: String, val request: AiChatRequest) : LlmHostCommand
+
+    /** Stop the generation in flight. Ignored by the host when nothing is running. */
+    data object Cancel : LlmHostCommand
+}
+
+sealed interface LlmHostEvent {
+    /** Next chunk of assistant text. */
+    data class Delta(val text: String) : LlmHostEvent
+
+    /** Generation finished (including after a [LlmHostCommand.Cancel]). */
+    data object Done : LlmHostEvent
+
+    /** Generation failed; [kind] is carried over so the UI keeps its typed failure. */
+    data class Failure(val kind: AiException.Kind, val message: String) : LlmHostEvent
+}
+
+object LlmHostProtocol {
+
+    fun encode(command: LlmHostCommand): String = when (command) {
+        is LlmHostCommand.Generate -> json.encodeToString(
+            CommandDto.serializer(),
+            CommandDto(
+                type = GENERATE,
+                modelPath = command.modelPath,
+                model = command.request.model,
+                messages = command.request.messages.map { MessageDto(it.role, it.content) },
+                temperature = command.request.temperature,
+                maxOutputTokens = command.request.maxOutputTokens,
+            ),
+        )
+        LlmHostCommand.Cancel -> json.encodeToString(CommandDto.serializer(), CommandDto(type = CANCEL))
+    }
+
+    fun decodeCommand(line: String): LlmHostCommand {
+        val dto = decode(CommandDto.serializer(), line)
+        return when (dto.type) {
+            CANCEL -> LlmHostCommand.Cancel
+            GENERATE -> LlmHostCommand.Generate(
+                modelPath = dto.modelPath ?: malformed("generate without a model path"),
+                request = AiChatRequest(
+                    model = dto.model ?: malformed("generate without a model id"),
+                    messages = dto.messages.map { AiMessage(it.role, it.content) },
+                    temperature = dto.temperature,
+                    maxOutputTokens = dto.maxOutputTokens,
+                ),
+            )
+            else -> malformed("unknown command '${dto.type}'")
+        }
+    }
+
+    fun encode(event: LlmHostEvent): String = json.encodeToString(
+        EventDto.serializer(),
+        when (event) {
+            is LlmHostEvent.Delta -> EventDto(type = DELTA, text = event.text)
+            LlmHostEvent.Done -> EventDto(type = DONE)
+            is LlmHostEvent.Failure -> EventDto(type = FAILURE, kind = event.kind, message = event.message)
+        },
+    )
+
+    fun decodeEvent(line: String): LlmHostEvent {
+        val dto = decode(EventDto.serializer(), line)
+        return when (dto.type) {
+            DELTA -> LlmHostEvent.Delta(dto.text.orEmpty())
+            DONE -> LlmHostEvent.Done
+            FAILURE -> LlmHostEvent.Failure(dto.kind ?: AiException.Kind.PROTOCOL, dto.message.orEmpty())
+            else -> malformed("unknown event '${dto.type}'")
+        }
+    }
+
+    private fun <T> decode(serializer: kotlinx.serialization.KSerializer<T>, line: String): T =
+        try {
+            json.decodeFromString(serializer, line)
+        } catch (e: Exception) {
+            malformed("unreadable frame", e)
+        }
+
+    private fun malformed(what: String, cause: Throwable? = null): Nothing =
+        throw AiException(AiException.Kind.PROTOCOL, "Local inference host: $what", cause)
+
+    private const val GENERATE = "generate"
+    private const val CANCEL = "cancel"
+    private const val DELTA = "delta"
+    private const val DONE = "done"
+    private const val FAILURE = "failure"
+
+    private val json = Json { encodeDefaults = false }
+
+    @Serializable
+    private data class MessageDto(val role: AiRole, val content: String)
+
+    @Serializable
+    private data class CommandDto(
+        val type: String,
+        @SerialName("path") val modelPath: String? = null,
+        val model: String? = null,
+        val messages: List<MessageDto> = emptyList(),
+        val temperature: Double? = null,
+        @SerialName("maxTokens") val maxOutputTokens: Int? = null,
+    )
+
+    @Serializable
+    private data class EventDto(
+        val type: String,
+        val text: String? = null,
+        val kind: AiException.Kind? = null,
+        val message: String? = null,
+    )
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeTest.kt
@@ -21,7 +21,11 @@ class IsolatedLlmRuntimeTest {
     private val request = AiChatRequest("local", listOf(AiMessage(AiRole.USER, "hi")))
 
     /** Scripted host: [answers] are the event lines it replies with, per generation. */
-    private class FakeLink(private val answers: MutableList<List<LlmHostEvent>>) : LlmHostLink {
+    private class FakeLink(
+        private val answers: MutableList<List<LlmHostEvent>>,
+        /** Mimics a host wedged in a native call: it never answers and never closes the socket. */
+        private val mute: Boolean = false,
+    ) : LlmHostLink {
         val sent = mutableListOf<LlmHostCommand>()
         var closed = false
         var sendFails = false
@@ -34,13 +38,16 @@ class IsolatedLlmRuntimeTest {
             if (command !is LlmHostCommand.Generate) return
             val events = answers.removeFirstOrNull() ?: listOf(LlmHostEvent.Done)
             events.forEach { pending.send(LlmHostProtocol.encode(it)) }
-            if (events.none { it is LlmHostEvent.Done || it is LlmHostEvent.Failure }) pending.send(null) // host died
+            if (!mute && events.none { it is LlmHostEvent.Done || it is LlmHostEvent.Failure }) {
+                pending.send(null) // host died
+            }
         }
 
-        override suspend fun receive(): String? = pending.receive()
+        override suspend fun receive(): String? = pending.receiveCatching().getOrNull()
 
         override suspend fun close() {
             closed = true
+            pending.close() // a closed transport releases a read that is waiting on it
         }
     }
 
@@ -135,6 +142,33 @@ class IsolatedLlmRuntimeTest {
         assertTrue(LlmHostCommand.Cancel in link.sent, "the host must be told to stop generating")
         assertEquals(listOf(AiDelta("next")), runtime.generate(modelPath, request).toList())
         assertEquals(1, launcher.launches)
+    }
+
+    @Test
+    fun `a host that never answers the cancel is dropped instead of blocking every later request`() = runTest {
+        val wedged = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("one"))), mute = true)
+        val fresh = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("next"), LlmHostEvent.Done)))
+        val launcher = FakeLauncher(wedged, fresh)
+        val runtime = IsolatedLlmRuntime(launcher, cancelDrainMillis = 100)
+
+        assertEquals(AiDelta("one"), runtime.generate(modelPath, request).first()) // abandons the stream
+
+        assertTrue(wedged.closed, "a host that ignores cancel must be torn down")
+        // The runtime is usable afterwards, i.e. the lock was not left held by the cleanup.
+        assertEquals(listOf(AiDelta("next")), runtime.generate(modelPath, request).toList())
+        assertEquals(2, launcher.launches)
+    }
+
+    @Test
+    fun `a host that dies before the request reaches it is reported and released`() = runTest {
+        val stillborn = FakeLink(mutableListOf()).apply { sendFails = true }
+        val launcher = FakeLauncher(stillborn)
+        val runtime = IsolatedLlmRuntime(launcher)
+
+        val error = assertFailsWith<AiException> { runtime.generate(modelPath, request).toList() }
+
+        assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+        assertTrue(stillborn.closed, "a host that never took the request must not stay cached")
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeTest.kt
@@ -1,0 +1,150 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiDelta
+import app.skerry.shared.ai.AiException
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class IsolatedLlmRuntimeTest {
+
+    private val modelPath = "/models/m.gguf".toPath()
+    private val request = AiChatRequest("local", listOf(AiMessage(AiRole.USER, "hi")))
+
+    /** Scripted host: [answers] are the event lines it replies with, per generation. */
+    private class FakeLink(private val answers: MutableList<List<LlmHostEvent>>) : LlmHostLink {
+        val sent = mutableListOf<LlmHostCommand>()
+        var closed = false
+        var sendFails = false
+        private val pending = Channel<String?>(Channel.UNLIMITED)
+
+        override suspend fun send(line: String) {
+            if (sendFails) throw AiException(AiException.Kind.PROTOCOL, "broken pipe")
+            val command = LlmHostProtocol.decodeCommand(line)
+            sent += command
+            if (command !is LlmHostCommand.Generate) return
+            val events = answers.removeFirstOrNull() ?: listOf(LlmHostEvent.Done)
+            events.forEach { pending.send(LlmHostProtocol.encode(it)) }
+            if (events.none { it is LlmHostEvent.Done || it is LlmHostEvent.Failure }) pending.send(null) // host died
+        }
+
+        override suspend fun receive(): String? = pending.receive()
+
+        override suspend fun close() {
+            closed = true
+        }
+    }
+
+    private class FakeLauncher(private vararg val links: FakeLink) : LlmHostLauncher {
+        var launches = 0
+        override suspend fun launch(): LlmHostLink = links[launches++.coerceAtMost(links.lastIndex)]
+    }
+
+    @Test
+    fun `streams deltas from the host until done`() = runTest {
+        val link = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("he"), LlmHostEvent.Delta("llo"), LlmHostEvent.Done)))
+        val runtime = IsolatedLlmRuntime(FakeLauncher(link))
+
+        val deltas = runtime.generate(modelPath, request).toList()
+
+        assertEquals(listOf(AiDelta("he"), AiDelta("llo")), deltas)
+        assertEquals(LlmHostCommand.Generate(modelPath.toString(), request), link.sent.single())
+    }
+
+    @Test
+    fun `the host stays alive between generations so the model is loaded once`() = runTest {
+        val link = FakeLink(
+            mutableListOf(
+                listOf(LlmHostEvent.Delta("a"), LlmHostEvent.Done),
+                listOf(LlmHostEvent.Delta("b"), LlmHostEvent.Done),
+            ),
+        )
+        val launcher = FakeLauncher(link)
+        val runtime = IsolatedLlmRuntime(launcher)
+
+        runtime.generate(modelPath, request).toList()
+        runtime.generate(modelPath, request).toList()
+
+        assertEquals(1, launcher.launches)
+    }
+
+    @Test
+    fun `a failure event keeps its kind`() = runTest {
+        val link = FakeLink(
+            mutableListOf(listOf(LlmHostEvent.Failure(AiException.Kind.INVALID_REQUEST, "no such model"))),
+        )
+        val runtime = IsolatedLlmRuntime(FakeLauncher(link))
+
+        val error = assertFailsWith<AiException> { runtime.generate(modelPath, request).toList() }
+
+        assertEquals(AiException.Kind.INVALID_REQUEST, error.kind)
+    }
+
+    @Test
+    fun `a host that dies mid-stream surfaces an engine failure and does not kill the caller`() = runTest {
+        val dying = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("half"))))
+        val fresh = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("whole"), LlmHostEvent.Done)))
+        val launcher = FakeLauncher(dying, fresh)
+        val runtime = IsolatedLlmRuntime(launcher)
+
+        val error = assertFailsWith<AiException> { runtime.generate(modelPath, request).toList() }
+        assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+        assertTrue(dying.closed, "the dead host must be released")
+
+        // The next request recovers on a fresh host instead of staying broken forever.
+        assertEquals(listOf(AiDelta("whole")), runtime.generate(modelPath, request).toList())
+        assertEquals(2, launcher.launches)
+    }
+
+    @Test
+    fun `a host that died while idle is replaced without surfacing an error`() = runTest {
+        val stale = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("a"), LlmHostEvent.Done)))
+        val fresh = FakeLink(mutableListOf(listOf(LlmHostEvent.Delta("b"), LlmHostEvent.Done)))
+        val launcher = FakeLauncher(stale, fresh)
+        val runtime = IsolatedLlmRuntime(launcher)
+
+        runtime.generate(modelPath, request).toList()
+        stale.sendFails = true // the host went away between requests
+
+        assertEquals(listOf(AiDelta("b")), runtime.generate(modelPath, request).toList())
+        assertEquals(2, launcher.launches)
+    }
+
+    @Test
+    fun `abandoning the stream cancels generation on the host and keeps it usable`() = runTest {
+        val link = FakeLink(
+            mutableListOf(
+                listOf(LlmHostEvent.Delta("one"), LlmHostEvent.Delta("two"), LlmHostEvent.Done),
+                listOf(LlmHostEvent.Delta("next"), LlmHostEvent.Done),
+            ),
+        )
+        val launcher = FakeLauncher(link)
+        val runtime = IsolatedLlmRuntime(launcher)
+
+        assertEquals(AiDelta("one"), runtime.generate(modelPath, request).first()) // first() cancels the flow
+
+        assertTrue(LlmHostCommand.Cancel in link.sent, "the host must be told to stop generating")
+        assertEquals(listOf(AiDelta("next")), runtime.generate(modelPath, request).toList())
+        assertEquals(1, launcher.launches)
+    }
+
+    @Test
+    fun `close shuts the host down`() = runTest {
+        val link = FakeLink(mutableListOf(listOf(LlmHostEvent.Done)))
+        val runtime = IsolatedLlmRuntime(FakeLauncher(link))
+        runtime.generate(modelPath, request).toList()
+
+        runtime.close()
+
+        assertTrue(link.closed)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/LlmHostProtocolTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ai/local/LlmHostProtocolTest.kt
@@ -1,0 +1,69 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiException
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class LlmHostProtocolTest {
+
+    private val request = AiChatRequest(
+        model = "qwen2.5-coder-1.5b",
+        messages = listOf(
+            AiMessage(AiRole.SYSTEM, "You are terse."),
+            AiMessage(AiRole.USER, "line one\nline two"),
+        ),
+        temperature = 0.2,
+        maxOutputTokens = 64,
+    )
+
+    @Test
+    fun `generate command survives a round trip`() {
+        val line = LlmHostProtocol.encode(LlmHostCommand.Generate("/models/m.gguf", request))
+
+        assertEquals(LlmHostCommand.Generate("/models/m.gguf", request), LlmHostProtocol.decodeCommand(line))
+    }
+
+    @Test
+    fun `cancel command survives a round trip`() {
+        assertEquals(LlmHostCommand.Cancel, LlmHostProtocol.decodeCommand(LlmHostProtocol.encode(LlmHostCommand.Cancel)))
+    }
+
+    @Test
+    fun `events survive a round trip`() {
+        val events = listOf(
+            LlmHostEvent.Delta("hello"),
+            LlmHostEvent.Done,
+            LlmHostEvent.Failure(AiException.Kind.INVALID_REQUEST, "no such model"),
+        )
+
+        events.forEach { assertEquals(it, LlmHostProtocol.decodeEvent(LlmHostProtocol.encode(it))) }
+    }
+
+    @Test
+    fun `a frame is a single line even when the payload has newlines`() {
+        val encoded = listOf(
+            LlmHostProtocol.encode(LlmHostCommand.Generate("/m.gguf", request)),
+            LlmHostProtocol.encode(LlmHostEvent.Delta("first\nsecond\r\nthird")),
+        )
+
+        encoded.forEach { assertTrue(it.none { c -> c == '\n' || c == '\r' }, "frame must stay on one line: $it") }
+    }
+
+    @Test
+    fun `newlines in a delta are preserved`() {
+        val decoded = LlmHostProtocol.decodeEvent(LlmHostProtocol.encode(LlmHostEvent.Delta("a\nb")))
+
+        assertEquals(LlmHostEvent.Delta("a\nb"), decoded)
+    }
+
+    @Test
+    fun `a malformed frame is rejected, not silently ignored`() {
+        assertFailsWith<AiException> { LlmHostProtocol.decodeEvent("not json at all") }
+        assertFailsWith<AiException> { LlmHostProtocol.decodeCommand("""{"type":"nope"}""") }
+    }
+}

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostCommandLine.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostCommandLine.kt
@@ -1,0 +1,53 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiException
+
+/**
+ * How to start the isolated inference host, given how this app itself was started.
+ *
+ * A packaged build has no `java` to spawn — jpackage strips the launchers out of the bundled
+ * runtime — so the app re-launches **itself** with [HOST_FLAG] and branches into [LlmHostMain]
+ * before any UI exists. A development run is started by `java` and simply gets a second JVM on the
+ * same classpath.
+ */
+object LlmHostCommandLine {
+
+    /** Marks a run as "be the inference host, not the app". First argument of the child. */
+    const val HOST_FLAG = "--llm-host"
+
+    private const val HOST_MAIN_CLASS = "app.skerry.shared.ai.local.LlmHostMain"
+
+    /** True when this process was started to serve inference. */
+    fun isHostRun(args: Array<String>): Boolean = args.firstOrNull() == HOST_FLAG
+
+    /**
+     * @param selfCommand the executable that started this process (`ProcessHandle.current()`).
+     * @param classpath used only when [selfCommand] is a `java` binary.
+     */
+    fun build(
+        selfCommand: String?,
+        classpath: String,
+        socketPath: String,
+        contextLength: Int,
+        heapMegabytes: Int,
+    ): List<String> {
+        val self = selfCommand?.takeIf { it.isNotBlank() }
+            ?: fail("cannot tell how this app was started")
+        val tail = listOf(HOST_FLAG, socketPath, contextLength.toString())
+        if (!self.substringAfterLast('/').substringAfterLast('\\').removeSuffix(".exe").equals("java", true)) {
+            return listOf(self) + tail // packaged app: its own launcher, with the host flag
+        }
+        if (classpath.isBlank()) fail("the app classpath is empty")
+        return listOf(
+            self,
+            "-Djava.awt.headless=true", // the crash being isolated from needs AWT/Skia in the process
+            "-Xmx${heapMegabytes}m", // weights are native, mmapped memory — the JVM side is tiny
+            "-cp",
+            classpath,
+            HOST_MAIN_CLASS,
+        ) + tail
+    }
+
+    private fun fail(reason: String): Nothing =
+        throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host: $reason")
+}

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostMain.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostMain.kt
@@ -1,0 +1,53 @@
+package app.skerry.shared.ai.local
+
+import kotlinx.coroutines.runBlocking
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+/**
+ * Entry point of the isolated inference host on desktop: a bare JVM that owns llama.cpp and
+ * nothing else. Started by [ProcessLlmHostLauncher], which passes the Unix socket to connect back
+ * to and the context length; the protocol then runs over that socket ([LlmHostServer]).
+ *
+ * Native logging from llama.cpp keeps going to the inherited stdout/stderr — the protocol is on the
+ * socket precisely so a chatty native library cannot corrupt it.
+ */
+object LlmHostMain {
+
+    /**
+     * @param args `--llm-host <socket-path> <context-length>` — the same flag the app checks before
+     * building any UI, since a packaged build re-launches its own launcher to get a host.
+     */
+    @JvmStatic
+    fun main(args: Array<String>) {
+        // AWT must never initialize here: the app process proves what happens when llama.cpp is
+        // loaded next to it. Set before anything can touch a graphics class.
+        System.setProperty("java.awt.headless", "true")
+        val rest = if (LlmHostCommandLine.isHostRun(args)) args.drop(1) else args.toList()
+        val socketPath = rest.getOrNull(0) ?: fail("usage: --llm-host <socket-path> <context-length>")
+        val contextLength = rest.getOrNull(1)?.toIntOrNull() ?: fail("context length must be a number")
+
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(Path.of(socketPath)))
+            runBlocking {
+                LlmHostServer.serve(
+                    input = Channels.newInputStream(channel),
+                    output = Channels.newOutputStream(channel),
+                    runtime = LlamatikRuntime(contextLength),
+                )
+            }
+        }
+        // The app closed the socket: nothing left to serve. Exit hard — the native library keeps
+        // non-daemon threads around and a plain return would leave the process hanging.
+        exitProcess(0)
+    }
+
+    private fun fail(message: String): Nothing {
+        System.err.println("skerry-llm-host: $message")
+        exitProcess(2)
+    }
+}

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
@@ -14,6 +14,7 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.deleteIfExists
 
 /**
@@ -47,7 +48,10 @@ class ProcessLlmHostLauncher(
                 input = Channels.newInputStream(channel),
                 output = Channels.newOutputStream(channel),
             ) {
+                // A host wedged in a native call may never act on a polite termination, and this is
+                // the path taken exactly when it looks stuck, so escalate rather than leak it.
                 process.destroy()
+                if (!process.waitFor(EXIT_GRACE_MILLIS, TimeUnit.MILLISECONDS)) process.destroyForcibly()
                 cleanUp(server, socketPath, directory)
             }
         } catch (e: Throwable) {
@@ -91,6 +95,7 @@ class ProcessLlmHostLauncher(
     private companion object {
         const val SOCKET_NAME = "host.sock"
         const val START_TIMEOUT_MILLIS = 60_000L
+        const val EXIT_GRACE_MILLIS = 2_000L
 
         /** The host holds protocol strings only; the model itself is native, mmapped memory. */
         const val DEFAULT_HEAP_MB = 256

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
@@ -1,0 +1,98 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+
+/**
+ * Starts the desktop inference host: a second process running [LlmHostMain] — a plain JVM on this
+ * app's classpath in a development run, the app's own launcher in a packaged build (see
+ * [LlmHostCommandLine]).
+ *
+ * The two talk over a Unix socket in a private temp directory rather than the child's stdin/stdout:
+ * llama.cpp and the Llamatik binding both print to the standard streams, and a stray line there
+ * would corrupt the protocol. stdout/stderr stay inherited, so native logs still reach the console.
+ *
+ * The child exits by itself when the socket closes, so it cannot outlive the app.
+ */
+class ProcessLlmHostLauncher(
+    private val contextLength: Int,
+    private val selfCommand: String? = ProcessHandle.current().info().command().orElse(null),
+    private val classpath: String = System.getProperty("java.class.path").orEmpty(),
+    private val heapMegabytes: Int = DEFAULT_HEAP_MB,
+) : LlmHostLauncher {
+
+    override suspend fun launch(): LlmHostLink = withContext(Dispatchers.IO) {
+        val directory = Files.createTempDirectory("skerry-llm-")
+        val socketPath = directory.resolve(SOCKET_NAME)
+        val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        var process: Process? = null
+        try {
+            server.bind(UnixDomainSocketAddress.of(socketPath))
+            process = startChild(socketPath)
+            val channel = accept(server, process) ?: fail("the inference host did not start")
+            StreamLlmHostLink(
+                input = Channels.newInputStream(channel),
+                output = Channels.newOutputStream(channel),
+            ) {
+                process.destroy()
+                cleanUp(server, socketPath, directory)
+            }
+        } catch (e: Throwable) {
+            process?.destroyForcibly()
+            cleanUp(server, socketPath, directory)
+            throw e
+        }
+    }
+
+    private fun startChild(socketPath: Path): Process = ProcessBuilder(
+        LlmHostCommandLine.build(selfCommand, classpath, socketPath.toString(), contextLength, heapMegabytes),
+    )
+        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+        .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .start()
+
+    /** Waits for the child to connect back; gives up early if it died instead. */
+    private suspend fun accept(server: ServerSocketChannel, process: Process): SocketChannel? = coroutineScope {
+        withTimeoutOrNull(START_TIMEOUT_MILLIS) {
+            val watchdog = launch {
+                runInterruptible(Dispatchers.IO) { process.waitFor() }
+                runCatching { server.close() } // unblocks accept()
+            }
+            try {
+                runCatching { runInterruptible(Dispatchers.IO) { server.accept() } }.getOrNull()
+            } finally {
+                watchdog.cancel()
+            }
+        }
+    }
+
+    private fun cleanUp(server: ServerSocketChannel, socketPath: Path, directory: Path) {
+        runCatching { server.close() }
+        runCatching { socketPath.deleteIfExists() }
+        runCatching { directory.deleteIfExists() }
+    }
+
+    private fun fail(reason: String): Nothing =
+        throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host: $reason")
+
+    private companion object {
+        const val SOCKET_NAME = "host.sock"
+        const val START_TIMEOUT_MILLIS = 60_000L
+
+        /** The host holds protocol strings only; the model itself is native, mmapped memory. */
+        const val DEFAULT_HEAP_MB = 256
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeBlockingLinkTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/IsolatedLlmRuntimeBlockingLinkTest.kt
@@ -1,0 +1,85 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiDelta
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import okio.Path.Companion.toPath
+import java.util.concurrent.CountDownLatch
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The real transport is a blocking socket read, and a coroutine deadline cannot interrupt one — a
+ * host that goes quiet can only be released by closing the transport. This fake reproduces that
+ * property (an in-memory channel would not: its reads are cancellable), so it covers the case where
+ * the cleanup after an abandoned answer would otherwise hold the runtime's lock forever and take
+ * local AI down for the rest of the session.
+ */
+class IsolatedLlmRuntimeBlockingLinkTest {
+
+    private val modelPath = "/models/m.gguf".toPath()
+    private val request = AiChatRequest("local", listOf(AiMessage(AiRole.USER, "hi")))
+
+    /** Answers one delta, then blocks in a way only [close] can release. */
+    private class WedgedLink : LlmHostLink {
+        private val released = CountDownLatch(1)
+        private var answered = false
+        var closed = false
+            private set
+
+        override suspend fun send(line: String) = Unit
+
+        override suspend fun receive(): String? = withContext(Dispatchers.IO) {
+            if (!answered) {
+                answered = true
+                LlmHostProtocol.encode(LlmHostEvent.Delta("one"))
+            } else {
+                released.await() // a blocking read: cancelling the coroutine does not end it
+                null
+            }
+        }
+
+        override suspend fun close() {
+            closed = true
+            released.countDown()
+        }
+    }
+
+    private class HealthyLink : LlmHostLink {
+        private val events = ArrayDeque(
+            listOf(LlmHostEvent.Delta("next"), LlmHostEvent.Done).map(LlmHostProtocol::encode),
+        )
+
+        override suspend fun send(line: String) = Unit
+        override suspend fun receive(): String? = events.removeFirstOrNull()
+        override suspend fun close() = Unit
+    }
+
+    @Test
+    fun `abandoning an answer on a wedged host does not lock local ai up for good`() = runBlocking {
+        val wedged = WedgedLink()
+        val links = ArrayDeque<LlmHostLink>(listOf(wedged, HealthyLink()))
+        val runtime = IsolatedLlmRuntime(
+            launcher = { links.removeFirst() },
+            cancelDrainMillis = 200,
+        )
+
+        withTimeout(30.seconds) {
+            assertEquals(AiDelta("one"), runtime.generate(modelPath, request).first()) // walks away
+
+            // Before the fix this second request never returned: the cleanup was still waiting on a
+            // read that no deadline could interrupt, with the runtime's lock in hand.
+            assertEquals(listOf(AiDelta("next")), runtime.generate(modelPath, request).toList())
+        }
+        assertTrue(wedged.closed, "the wedged host must be torn down")
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostCommandLineTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostCommandLineTest.kt
@@ -1,0 +1,80 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LlmHostCommandLineTest {
+
+    @Test
+    fun `a development run spawns a second jvm on the same classpath`() {
+        val command = LlmHostCommandLine.build(
+            selfCommand = "/opt/jdk-21/bin/java",
+            classpath = "a.jar:b.jar",
+            socketPath = "/tmp/x/host.sock",
+            contextLength = 4096,
+            heapMegabytes = 256,
+        )
+
+        assertEquals(
+            listOf(
+                "/opt/jdk-21/bin/java",
+                "-Djava.awt.headless=true",
+                "-Xmx256m",
+                "-cp",
+                "a.jar:b.jar",
+                "app.skerry.shared.ai.local.LlmHostMain",
+                "--llm-host",
+                "/tmp/x/host.sock",
+                "4096",
+            ),
+            command,
+        )
+    }
+
+    @Test
+    fun `a packaged app relaunches its own launcher, because jpackage ships no java binary`() {
+        val command = LlmHostCommandLine.build(
+            selfCommand = "/app/skerry/bin/Skerry",
+            classpath = "",
+            socketPath = "/tmp/x/host.sock",
+            contextLength = 2048,
+            heapMegabytes = 256,
+        )
+
+        assertEquals(listOf("/app/skerry/bin/Skerry", "--llm-host", "/tmp/x/host.sock", "2048"), command)
+    }
+
+    @Test
+    fun `windows java is recognised as a jvm launch`() {
+        val command = LlmHostCommandLine.build(
+            selfCommand = """C:\Program Files\Java\bin\java.exe""",
+            classpath = "a.jar",
+            socketPath = """C:\Temp\host.sock""",
+            contextLength = 4096,
+            heapMegabytes = 256,
+        )
+
+        assertTrue("-cp" in command, "a java launcher needs the classpath: $command")
+    }
+
+    @Test
+    fun `an unknown launcher and an empty classpath are reported, not guessed`() {
+        assertFailsWith<AiException> {
+            LlmHostCommandLine.build(null, "a.jar", "/tmp/s", 4096, 256)
+        }
+        assertFailsWith<AiException> {
+            LlmHostCommandLine.build("/opt/jdk-21/bin/java", "  ", "/tmp/s", 4096, 256)
+        }
+    }
+
+    @Test
+    fun `the host flag tells a host run from an app run`() {
+        assertTrue(LlmHostCommandLine.isHostRun(arrayOf("--llm-host", "/tmp/s", "4096")))
+        assertFalse(LlmHostCommandLine.isHostRun(emptyArray()))
+        assertFalse(LlmHostCommandLine.isHostRun(arrayOf("/tmp/s")))
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostServerTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostServerTest.kt
@@ -1,0 +1,144 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiDelta
+import app.skerry.shared.ai.AiException
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.Path
+import java.io.BufferedReader
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import java.io.Writer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The inference host as seen from the app side: commands in, events out. Uses real pipes because
+ * the point of the host is that it survives on the other side of a process boundary.
+ */
+class LlmHostServerTest {
+
+    private val request = AiChatRequest("local", listOf(AiMessage(AiRole.USER, "hi")))
+
+    private class Harness(runtime: LocalLlmRuntime) : AutoCloseable {
+        private val commands = PipedOutputStream()
+        private val events = PipedInputStream()
+        val writer: Writer = commands.writer()
+        val reader: BufferedReader = events.bufferedReader()
+        // Both pipe ends are connected before the host starts: a PipedInputStream that connects
+        // after its writer is closed never learns about it and blocks forever.
+        private val hostIn = PipedInputStream(commands)
+        private val hostOut = PipedOutputStream(events)
+        private val scope = CoroutineScope(Dispatchers.IO)
+        val served: Job = scope.launch { LlmHostServer.serve(hostIn, hostOut, runtime) }
+
+        fun send(command: LlmHostCommand) {
+            writer.write(LlmHostProtocol.encode(command) + "\n")
+            writer.flush()
+        }
+
+        fun next(): LlmHostEvent = LlmHostProtocol.decodeEvent(reader.readLine() ?: error("host closed the stream"))
+
+        override fun close() {
+            runCatching { writer.close() }
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `relays deltas and reports completion`() = runBlocking {
+        val runtime = FakeRuntime(flow { emit(AiDelta("he")); emit(AiDelta("llo")) })
+        Harness(runtime).use { host ->
+            host.send(LlmHostCommand.Generate("/m.gguf", request))
+
+            withTimeout(10.seconds) {
+                assertEquals(LlmHostEvent.Delta("he"), host.next())
+                assertEquals(LlmHostEvent.Delta("llo"), host.next())
+                assertEquals(LlmHostEvent.Done, host.next())
+            }
+            assertEquals("/m.gguf", runtime.lastPath?.toString())
+            assertEquals(request, runtime.lastRequest)
+        }
+    }
+
+    @Test
+    fun `reports a failure with its kind instead of dying`() = runBlocking {
+        val runtime = FakeRuntime(flow { throw AiException(AiException.Kind.INVALID_REQUEST, "no such model") })
+        Harness(runtime).use { host ->
+            host.send(LlmHostCommand.Generate("/m.gguf", request))
+
+            withTimeout(10.seconds) {
+                assertEquals(
+                    LlmHostEvent.Failure(AiException.Kind.INVALID_REQUEST, "no such model"),
+                    host.next(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `cancel stops the generation and the host keeps serving`() = runBlocking {
+        val blocked = CompletableDeferred<Unit>()
+        val cancelled = CompletableDeferred<Unit>()
+        val runtime = FakeRuntime(
+            flow {
+                emit(AiDelta("start"))
+                try {
+                    blocked.await() // never completes: the request is only ended by cancellation
+                } finally {
+                    cancelled.complete(Unit)
+                }
+            },
+            flow { emit(AiDelta("after")) },
+        )
+        Harness(runtime).use { host ->
+            host.send(LlmHostCommand.Generate("/m.gguf", request))
+            withTimeout(10.seconds) { assertEquals(LlmHostEvent.Delta("start"), host.next()) }
+
+            host.send(LlmHostCommand.Cancel)
+
+            withTimeout(10.seconds) {
+                cancelled.await()
+                assertEquals(LlmHostEvent.Done, host.next())
+
+                host.send(LlmHostCommand.Generate("/m.gguf", request))
+                assertEquals(LlmHostEvent.Delta("after"), host.next())
+                assertEquals(LlmHostEvent.Done, host.next())
+            }
+        }
+    }
+
+    @Test
+    fun `stops when the app closes the command stream`() = runBlocking {
+        val host = Harness(FakeRuntime(flow { }))
+        host.writer.close()
+
+        withTimeout(10.seconds) { host.served.join() }
+        assertTrue(host.served.isCompleted)
+    }
+
+    private class FakeRuntime(private vararg val answers: Flow<AiDelta>) : LocalLlmRuntime {
+        var lastPath: Path? = null
+        var lastRequest: AiChatRequest? = null
+        private var call = 0
+
+        override fun generate(modelPath: Path, request: AiChatRequest): Flow<AiDelta> {
+            lastPath = modelPath
+            lastRequest = request
+            return answers[call++.coerceAtMost(answers.lastIndex)]
+        }
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
@@ -1,0 +1,50 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiException
+import app.skerry.shared.ai.AiMessage
+import app.skerry.shared.ai.AiRole
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * The real desktop host: a child JVM is started, connects back over its Unix socket and answers.
+ * Deliberately uses a model path that does not exist — the answer travels the full pipeline
+ * (spawn -> socket -> protocol -> typed failure) without needing multi-gigabyte weights, and the
+ * native library never has to load.
+ */
+class ProcessLlmHostLauncherTest {
+
+    private val request = AiChatRequest("local-it", listOf(AiMessage(AiRole.USER, "Say OK.")), maxOutputTokens = 8)
+
+    @Test
+    fun `reports a missing model through a real child process`() = runBlocking {
+        val runtime = IsolatedLlmRuntime(ProcessLlmHostLauncher(contextLength = 512))
+
+        val error = withTimeout(2.minutes) {
+            assertFailsWith<AiException> {
+                runtime.generate("/nonexistent/model.gguf".toPath(), request).toList()
+            }
+        }
+
+        assertEquals(AiException.Kind.INVALID_REQUEST, error.kind)
+        runtime.close()
+    }
+
+    @Test
+    fun `a missing runtime fails as an engine error instead of hanging`() = runBlocking {
+        val runtime = IsolatedLlmRuntime(
+            ProcessLlmHostLauncher(contextLength = 512, selfCommand = "/nonexistent/bin/java"),
+        )
+
+        val error = assertFailsWith<AiException> { runtime.generate("/m.gguf".toPath(), request).toList() }
+
+        assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlamatikRuntime.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlamatikRuntime.kt
@@ -19,7 +19,13 @@ import okio.Path
 
 /**
  * [LocalLlmRuntime] over Llamatik (llama.cpp, GGUF), one implementation shared by desktop and
- * Android (the KMP artifact bundles both natives). `LlamaBridge` is a global singleton native
+ * Android (the KMP artifact bundles both natives).
+ *
+ * **Runs inside the isolated inference host, never in the app process** — see [IsolatedLlmRuntime]
+ * and issue #37: the native library corrupts memory when it is loaded after Skia/AWT, and it aborts
+ * the process rather than throwing. The app talks to it across a process boundary.
+ *
+ * `LlamaBridge` is a global singleton native
  * library with a single loaded model and global generation state, so:
  * - one runtime instance per process (the model stays resident between requests, reloaded only
  *   on file change);
@@ -45,8 +51,10 @@ class LlamatikRuntime(
         withContext(Dispatchers.IO) {
             mutex.withLock {
                 try {
-                    ensureLoaded(modelPath)
+                    // Params first: contextLength/numThreads are read when the context is built,
+                    // so setting them after the load would only take effect on the next model.
                     applyParams(request)
+                    ensureLoaded(modelPath)
                     val prompt = renderPrompt(request.messages)
                     var failure: String? = null
                     LlamaBridge.generateStream(

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlmHostServer.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlmHostServer.kt
@@ -1,0 +1,112 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.ai.AiException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import okio.Path.Companion.toPath
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.Writer
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * The other side of [IsolatedLlmRuntime]: reads [LlmHostCommand]s and drives a real
+ * [LocalLlmRuntime], reporting back as [LlmHostEvent]s. Runs inside the isolated host — a child JVM
+ * on desktop, the `:llm` process on Android — so a native abort in llama.cpp takes down this loop
+ * and nothing else.
+ *
+ * One generation at a time (the app serializes), but reading never stops: a `cancel` has to be
+ * heard while an answer is streaming.
+ */
+object LlmHostServer {
+
+    suspend fun serve(input: InputStream, output: OutputStream, runtime: LocalLlmRuntime) {
+        // Explicit UTF-8: the app and the host may run with different platform defaults.
+        val reader = input.bufferedReader(Charsets.UTF_8)
+        val writer = output.writer(Charsets.UTF_8)
+        val out = SerialWriter(writer)
+        coroutineScope {
+            var generation: Generation? = null
+            while (true) {
+                val line = runInterruptible(Dispatchers.IO) { reader.readLineOrNull() } ?: break
+                when (val command = decode(line, out) ?: continue) {
+                    LlmHostCommand.Cancel -> generation?.job?.cancel()
+                    is LlmHostCommand.Generate -> {
+                        // Every request gets exactly one closing frame, so a request that arrives
+                        // while an answer is still running must not close the new one with the old
+                        // one's `done`. The app serializes requests, but the protocol shouldn't
+                        // desync if it ever stops.
+                        generation?.supersede()
+                        generation = Generation().also { it.job = launch { runGeneration(command, runtime, out, it) } }
+                    }
+                }
+            }
+            generation?.supersede()
+        }
+    }
+
+    /** One answer in flight; [silenced] survives the cancellation that stops the job. */
+    private class Generation {
+        lateinit var job: Job
+        var silenced = false
+            private set
+
+        suspend fun supersede() {
+            silenced = true
+            job.cancelAndJoin()
+        }
+    }
+
+    private suspend fun runGeneration(
+        command: LlmHostCommand.Generate,
+        runtime: LocalLlmRuntime,
+        out: SerialWriter,
+        generation: Generation,
+    ) {
+        try {
+            runtime.generate(command.modelPath.toPath(), command.request).collect {
+                out.write(LlmHostEvent.Delta(it.text))
+            }
+            out.write(LlmHostEvent.Done)
+        } catch (_: CancellationException) {
+            // The app asked to stop: the answer is over, not failed — it expects the closing frame.
+            if (!generation.silenced) out.write(LlmHostEvent.Done)
+        } catch (e: AiException) {
+            out.write(LlmHostEvent.Failure(e.kind, e.message.orEmpty()))
+        } catch (e: Exception) {
+            out.write(LlmHostEvent.Failure(AiException.Kind.PROTOCOL, "Local inference failed: ${e.message}"))
+        }
+    }
+
+    /** A frame we cannot parse is reported, not acted on: staying silent would hang the app. */
+    private fun decode(line: String, out: SerialWriter): LlmHostCommand? =
+        try {
+            LlmHostProtocol.decodeCommand(line)
+        } catch (e: AiException) {
+            out.write(LlmHostEvent.Failure(e.kind, e.message.orEmpty()))
+            null
+        }
+
+    private fun BufferedReader.readLineOrNull(): String? = runCatching { readLine() }.getOrNull()
+
+    /** Frames are written from the generation coroutine and from the reader loop — one at a time. */
+    private class SerialWriter(private val writer: Writer) {
+        private val lock = ReentrantLock()
+
+        fun write(event: LlmHostEvent) = lock.withLock {
+            runCatching {
+                writer.write(LlmHostProtocol.encode(event))
+                writer.write("\n")
+                writer.flush()
+            }
+            Unit
+        }
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlmHostServer.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LlmHostServer.kt
@@ -44,7 +44,11 @@ object LlmHostServer {
                         // one's `done`. The app serializes requests, but the protocol shouldn't
                         // desync if it ever stops.
                         generation?.supersede()
-                        generation = Generation().also { it.job = launch { runGeneration(command, runtime, out, it) } }
+                        generation = Generation().also {
+                            // Explicit dispatcher: the caller may drive serve() from a single-thread
+                            // event loop (the desktop host does), and answering must not sit on it.
+                            it.job = launch(Dispatchers.IO) { runGeneration(command, runtime, out, it) }
+                        }
                     }
                 }
             }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/StreamLlmHostLink.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/StreamLlmHostLink.kt
@@ -1,0 +1,50 @@
+package app.skerry.shared.ai.local
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * [LlmHostLink] over a pair of byte streams — a Unix socket to a child JVM on desktop, a socket
+ * pair to the `:llm` service on Android. [stop] tears the host itself down (destroy the process,
+ * unbind the service) and runs once, after the streams are closed.
+ *
+ * A dead host shows up as a closed stream: [receive] answers `null` instead of throwing, which is
+ * exactly what [IsolatedLlmRuntime] treats as a crash.
+ */
+class StreamLlmHostLink(
+    input: InputStream,
+    output: OutputStream,
+    private val stop: () -> Unit,
+) : LlmHostLink {
+
+    private val reader = input.bufferedReader(Charsets.UTF_8)
+    private val writer = output.writer(Charsets.UTF_8)
+    private val sending = Mutex()
+    private var closed = false
+
+    override suspend fun send(line: String) = withContext(Dispatchers.IO) {
+        sending.withLock {
+            writer.write(line)
+            writer.write("\n")
+            writer.flush()
+        }
+    }
+
+    override suspend fun receive(): String? = withContext(Dispatchers.IO) {
+        runCatching { reader.readLine() }.getOrNull()
+    }
+
+    override suspend fun close() {
+        withContext(Dispatchers.IO) {
+            if (closed) return@withContext
+            closed = true
+            runCatching { writer.close() }
+            runCatching { reader.close() }
+            runCatching { stop() }
+        }
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/StreamLlmHostLink.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/StreamLlmHostLink.kt
@@ -1,6 +1,8 @@
 package app.skerry.shared.ai.local
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -24,24 +26,32 @@ class StreamLlmHostLink(
     private val reader = input.bufferedReader(Charsets.UTF_8)
     private val writer = output.writer(Charsets.UTF_8)
     private val sending = Mutex()
+
+    @Volatile
     private var closed = false
 
-    override suspend fun send(line: String) = withContext(Dispatchers.IO) {
+    // runInterruptible, not a plain withContext: these are blocking calls with no suspension point,
+    // so without it a timeout around them could not stop waiting for a host that went quiet.
+    override suspend fun send(line: String) {
         sending.withLock {
-            writer.write(line)
-            writer.write("\n")
-            writer.flush()
+            runInterruptible(Dispatchers.IO) {
+                writer.write(line)
+                writer.write("\n")
+                writer.flush()
+            }
         }
     }
 
-    override suspend fun receive(): String? = withContext(Dispatchers.IO) {
+    override suspend fun receive(): String? = runInterruptible(Dispatchers.IO) {
         runCatching { reader.readLine() }.getOrNull()
     }
 
     override suspend fun close() {
-        withContext(Dispatchers.IO) {
+        withContext(NonCancellable + Dispatchers.IO) {
             if (closed) return@withContext
             closed = true
+            // Closing the transport is also how a read that is already blocked gets released:
+            // both a socket channel (desktop) and an Android fd report the asynchronous close.
             runCatching { writer.close() }
             runCatching { reader.close() }
             runCatching { stop() }


### PR DESCRIPTION
Fixes #37.

## Root cause

`libllama_jni.so` corrupts memory when it is loaded into a process that already has **Skia or AWT** in it. Load order is the trigger — the same library, the same model and the same code are fine in a bare JVM, which is why no headless harness ever reproduced it.

Reproduced deterministically in ~10 s per case:

| in-process setup before generating | result |
|---|---|
| bare JVM (headless) | works |
| libstdc++ preloaded | works |
| **AWT Toolkit → llama** | SIGSEGV |
| **Skia Surface → llama** | SIGSEGV |
| **llama → Skia + AWT → generate** | works |

Both the reported `free(): invalid pointer` and the `System.load` segfault land in the same symbol inside the library — `std::__detail::_BracketMatcher<std::__cxx11::regex_traits<char>>::_M_ready()`; the address from the issue (`+0x235df7`) is `_M_ready+0x4d7`. There is no upstream fix: 1.9.0 is the latest release, and its `main` differs only in CI files.

## What changed

Inference no longer runs in the app process. It runs in an isolated host that speaks a one-JSON-object-per-line protocol over a socket:

- **desktop** — a second process (Unix socket, headless, small heap). A packaged build has no bundled `java` to spawn (jpackage strips the launchers out of the runtime image), so the app re-launches **its own launcher** with `--llm-host` and branches before any UI exists.
- **Android** — a bound service in the `:llm` process, handed a socket pair.

A native abort now costs one answer and a typed error (`AiFailure.ENGINE_CRASHED`, localized en/ru/zh) instead of the client with every open SSH session. The host is also exactly the bare-JVM configuration where the library behaves, so local AI works again rather than merely failing safely.

Also fixed on the way: `contextLength`/`numThreads` were applied *after* the model load, so they were ignored on first load (Android's 2048 in particular).

## Verification

- `LocalAiIsolationTest` — sets up the deadly environment (Skia + AWT in-process) and generates through the isolated runtime. Before the fix this did not "fail", it killed the test worker with exit 134.
- `ProcessLlmHostLauncherTest` — a real child process, spawn → socket → protocol → typed failure.
- The **packaged** build was driven through the protocol directly: the jpackage launcher connects back as a host, loads the GGUF and answers.
- `IsolatedLlmRuntimeBlockingLinkTest` — regression test for the cleanup deadlock found in review: it hangs without the watchdog, passes with it.
- Full suite green (2045 tests); Android debug build installed on a device, service merged into the manifest with `android:process=":llm"`.

Reviewed by two independent reviewers before this PR; their HIGH/CRITICAL findings (blocking-read deadlock, stillborn host left cached, descriptor double-close on Android, missing forced kill) are fixed in the second commit.