### PR TITLE
Discover listening services and open forwards in a browser

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -55,7 +55,7 @@ import app.skerry.ui.terminal.TERMINAL_SCROLLBACK_OPTIONS
 import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.tunnel.TunnelManager
-import app.skerry.ui.tunnel.resolveTunnel
+import app.skerry.ui.tunnel.resolveTunnelHost
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.ui.vault.ResetScope
 import kotlinx.coroutines.CoroutineScope
@@ -364,7 +364,7 @@ class MainActivity : FragmentActivity() {
         val tunnels = TunnelManager(
             store = VaultTunnelStore(vault),
             transport = tunnelTransport,
-            resolve = { resolveTunnel(it, findHost = hosts::find, findCredential = credentials::find) },
+            resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::find) },
             scope = scope,
         ) { UUID.randomUUID().toString() }
         // Saved command snippets: SNIPPET records in the vault (commands may contain inline

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -207,6 +207,7 @@ tasks.register<JavaExec>("screenshotDesign") {
     systemProperty("skerry.screenshot.device", providers.systemProperty("skerry.screenshot.device").getOrElse("desktop"))
     providers.systemProperty("skerry.screenshot.settingsTab").orNull?.let { systemProperty("skerry.screenshot.settingsTab", it) }
     providers.systemProperty("skerry.screenshot.termTheme").orNull?.let { systemProperty("skerry.screenshot.termTheme", it) }
+    providers.systemProperty("skerry.screenshot.portsScan").orNull?.let { systemProperty("skerry.screenshot.portsScan", it) }
     providers.systemProperty("skerry.screenshot.aiProvider").orNull?.let { systemProperty("skerry.screenshot.aiProvider", it) }
     providers.systemProperty("skerry.screenshot.updateAvailable").orNull?.let { systemProperty("skerry.screenshot.updateAvailable", it) }
     // Stub window chrome: draws the custom window buttons of the undecorated window in the titlebar.

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ports.xml
@@ -43,4 +43,17 @@
     <string name="ports_type_local_display">Локальный проброс (-L)</string>
     <string name="ports_type_remote_display">Обратный проброс (-R)</string>
     <string name="ports_type_socks_display">Динамический SOCKS (-D)</string>
+    <string name="ports_find_services">Найти сервисы</string>
+    <string name="ports_services_title">Слушающие сервисы</string>
+    <string name="ports_services_hint">Спросите хост, какие TCP-порты он слушает, и пробросьте нужный одним нажатием.</string>
+    <string name="ports_scan">Сканировать</string>
+    <string name="ports_scanning">Сканирование…</string>
+    <string name="ports_no_services">Слушающих TCP-портов не найдено</string>
+    <string name="ports_services_unsupported">У этого типа подключения нет командного канала — хост нельзя просканировать.</string>
+    <string name="ports_forward">Пробросить</string>
+    <string name="ports_already_forwarded">Проброшен</string>
+    <string name="ports_service_port">порт %1$d</string>
+    <string name="ports_pick_host_to_scan">Выберите хост для сканирования</string>
+    <string name="ports_open_in_browser">Открыть в браузере</string>
+    <string name="ports_close">Закрыть</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
@@ -43,4 +43,17 @@
     <string name="ports_type_local_display">本地转发 (-L)</string>
     <string name="ports_type_remote_display">远程转发 (-R)</string>
     <string name="ports_type_socks_display">动态 SOCKS (-D)</string>
+    <string name="ports_find_services">查找服务</string>
+    <string name="ports_services_title">监听中的服务</string>
+    <string name="ports_services_hint">询问主机正在监听哪些 TCP 端口，然后一键转发。</string>
+    <string name="ports_scan">扫描</string>
+    <string name="ports_scanning">正在扫描…</string>
+    <string name="ports_no_services">未发现监听中的 TCP 端口</string>
+    <string name="ports_services_unsupported">此连接类型没有命令通道，无法扫描该主机。</string>
+    <string name="ports_forward">转发</string>
+    <string name="ports_already_forwarded">已转发</string>
+    <string name="ports_service_port">端口 %1$d</string>
+    <string name="ports_pick_host_to_scan">选择要扫描的主机</string>
+    <string name="ports_open_in_browser">在浏览器中打开</string>
+    <string name="ports_close">关闭</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ports.xml
@@ -43,4 +43,17 @@
     <string name="ports_type_local_display">Local forward (-L)</string>
     <string name="ports_type_remote_display">Remote forward (-R)</string>
     <string name="ports_type_socks_display">Dynamic SOCKS (-D)</string>
+    <string name="ports_find_services">Find services</string>
+    <string name="ports_services_title">Listening services</string>
+    <string name="ports_services_hint">Ask a host which TCP ports it listens on, then forward one in a tap.</string>
+    <string name="ports_scan">Scan</string>
+    <string name="ports_scanning">Scanning…</string>
+    <string name="ports_no_services">No listening TCP ports found</string>
+    <string name="ports_services_unsupported">This connection type has no command channel, so the host cannot be scanned.</string>
+    <string name="ports_forward">Forward</string>
+    <string name="ports_already_forwarded">Forwarded</string>
+    <string name="ports_service_port">port %1$d</string>
+    <string name="ports_pick_host_to_scan">Pick a host to scan</string>
+    <string name="ports_open_in_browser">Open in browser</string>
+    <string name="ports_close">Close</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -122,6 +122,7 @@ import app.skerry.ui.tunnel.TunnelManager
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.ui.vault.ResetScope
 import app.skerry.ui.vault.VaultGate
+import app.skerry.ui.vault.tearDownForLock
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_this_session
 import app.skerry.ui.generated.resources.term_ai_dismiss
@@ -468,6 +469,8 @@ fun DesktopDesignApp(
                 // Idle auto-lock threshold from settings: changing it in the UI recomposes VaultGate
                 // and restarts the idle timer; Never (idleMs == null) turns it off.
                 autoLockIdleMs = state.autoLock.idleMs,
+                // Runs on EVERY lock, including the two automatic ones that bypass the lock action.
+                onBeforeLock = { tearDownForLock(tunnels, sessions) },
                 onReset = onVaultReset,
                 // onPairingComplete != null (sync is present) — the create screen offers "I have a code":
                 // the coordinator creates the vault under the chosen password itself and accepts the account key.
@@ -589,30 +592,19 @@ private fun DesktopChrome(
         { host: Host -> connectOrAsk(PendingAuth.Split(host, sessions?.activeId)) }
     }
 
-    // Locking the vault must tear down all active tunnels: their connections hold the decrypted
-    // secret, and they can't keep hanging around after locking (zero-knowledge). closeAll is
-    // idempotent; the mock path (onLock==null) has nothing to wrap.
-    val tunnels = LocalTunnels.current
-    // Locking tears down active tunnels (their connections hold the decrypted secret — zero-knowledge),
-    // but TAB SESSIONS (including split) are deliberately meant to SURVIVE a lock: terminals stay put
-    // after unlocking. Any pending password-prompt dialogs are dismissed (don't leave password entry
-    // sitting under the lock screen). Stabilized like onRootKey below: the lambda flows into TitleBar
-    // and lockAction, and without remember a new instance on every recomposition would force them to
+    // Pending password-prompt dialogs are dismissed on lock (don't leave password entry sitting under
+    // the lock screen). Stabilized like onRootKey below: the lambda flows into TitleBar and
+    // lockAction, and without remember a new instance on every recomposition would force them to
     // recompute for nothing.
-    val onLockWithTunnels: (() -> Unit)? = if (onLock == null) null else remember(onLock, tunnels, sessions, state) {
+    // Only the UI part of locking lives here. Tearing down what holds the secret is
+    // [tearDownForLock], handed to VaultGate as onBeforeLock: the background and idle auto-locks
+    // never reach this lambda, so anything security-relevant put here would be skipped by them.
+    val onLockWithTunnels: (() -> Unit)? = if (onLock == null) null else remember(onLock, state) {
         {
             pendingAuth = null
             // Also dismiss any pending disconnect/close confirmation — after unlock an action needs a
             // fresh user intent (like pendingAuth), not to "resurface" on its own.
             state.dismissClose()
-            tunnels?.closeAll()
-            // Sessions survive a lock (the open socket stays alive), but auto-reconnect after a lock
-            // would re-authenticate with a stale secret against a locked vault — forbid it by clearing
-            // the saved credentials on every session and its split panes (zero-knowledge).
-            sessions?.sessions?.forEach { s ->
-                s.controller.clearReconnectCredentials()
-                s.splitSession?.controller?.clearReconnectCredentials()
-            }
             onLock()
         }
     }
@@ -630,7 +622,7 @@ private fun DesktopChrome(
         // into the snippet editor's fields (Command/ShortcutField) or New connection would go to the
         // terminal as a command.
         val snippets = LocalSnippets.current
-        // Live lock (tears down tunnels/credentials) on the live path; state.lock is mock/preview.
+        // Live lock on the live path (teardown itself runs in VaultGate); state.lock is mock/preview.
         // Via rememberUpdatedState so onRootKey doesn't depend on the lock lambda itself changing.
         val lockAction = rememberUpdatedState(onLockWithTunnels ?: state::lock)
         // Global shell hotkeys (⌘/Ctrl+Shift — New conn/Split/SFTP/AI-bar/Lock, Ctrl+Tab — adjacent

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -57,6 +57,7 @@ import app.skerry.ui.terminal.TerminalAppearance
 import app.skerry.ui.terminal.TerminalSessionPrefs
 import app.skerry.ui.vault.ResetScope
 import app.skerry.ui.vault.VaultGate
+import app.skerry.ui.vault.tearDownForLock
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_route_team
 import org.jetbrains.compose.resources.stringResource
@@ -283,6 +284,9 @@ fun MobileDesignApp(
                     // Auto-lock threshold from settings: changing it recomposes VaultGate and restarts
                     // the idle timer; Never (idleMs == null) disables it.
                     autoLockIdleMs = state.autoLock.idleMs,
+                    // Runs on EVERY lock, including the two automatic ones that bypass the lock
+                    // action — Android had no teardown at all before (only onVaultReset did).
+                    onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions) },
                     onReset = onVaultReset,
                     // onPairingComplete != null (sync present) — the create screen offers "I have a code":
                     // the coordinator creates the vault under the chosen password and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -44,16 +45,24 @@ import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.forward.rateFraction
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.tunnel.ListeningService
+import app.skerry.ui.tunnel.ServiceScanState
 import app.skerry.ui.tunnel.TunnelEntry
 import app.skerry.ui.tunnel.TunnelFormState
 import app.skerry.ui.tunnel.TunnelManager
 import app.skerry.ui.tunnel.TunnelStatus
+import app.skerry.ui.tunnel.forwardedPorts
+import app.skerry.ui.tunnel.serviceLabel
+import app.skerry.ui.tunnel.serviceScanFailureText
+import app.skerry.ui.tunnel.serviceTunnelDraft
+import app.skerry.ui.tunnel.tunnelBrowserUrl
 import app.skerry.ui.tunnel.tunnelFailureText
 import app.skerry.ui.tunnel.badgeColors
 import app.skerry.ui.tunnel.badgeLabel
 import app.skerry.ui.tunnel.displayLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ports_add_tunnel_below
+import app.skerry.ui.generated.resources.ports_already_forwarded
 import app.skerry.ui.generated.resources.ports_changes_apply_after_restart
 import app.skerry.ui.generated.resources.ports_edit
 import app.skerry.ui.generated.resources.ports_edit_tunnel
@@ -64,15 +73,25 @@ import app.skerry.ui.generated.resources.ports_field_name
 import app.skerry.ui.generated.resources.ports_field_port
 import app.skerry.ui.generated.resources.ports_field_type
 import app.skerry.ui.generated.resources.ports_field_via_host
+import app.skerry.ui.generated.resources.ports_find_services
+import app.skerry.ui.generated.resources.ports_forward
 import app.skerry.ui.generated.resources.ports_new_tunnel
 import app.skerry.ui.generated.resources.ports_no_saved_hosts
+import app.skerry.ui.generated.resources.ports_no_services
 import app.skerry.ui.generated.resources.ports_no_tunnels_yet
 import app.skerry.ui.generated.resources.ports_ph_web_tunnel
+import app.skerry.ui.generated.resources.ports_pick_host_to_scan
 import app.skerry.ui.generated.resources.ports_port_forwarding
 import app.skerry.ui.generated.resources.ports_remove
 import app.skerry.ui.generated.resources.ports_remove_tunnel
 import app.skerry.ui.generated.resources.ports_save_tunnel
+import app.skerry.ui.generated.resources.ports_scan
+import app.skerry.ui.generated.resources.ports_scanning
 import app.skerry.ui.generated.resources.ports_select_host
+import app.skerry.ui.generated.resources.ports_service_port
+import app.skerry.ui.generated.resources.ports_services_hint
+import app.skerry.ui.generated.resources.ports_services_title
+import app.skerry.ui.generated.resources.ports_services_unsupported
 import app.skerry.ui.generated.resources.ports_socks_hint
 import app.skerry.ui.generated.resources.ports_tunnel
 import app.skerry.ui.generated.resources.ports_via
@@ -104,6 +123,9 @@ fun MobilePortsScreen(state: MobileDesignState) {
     // Open editor: null when closed, else the edited tunnel's id or "" for a new one. Kept at
     // screen level since the sheet is a full-screen overlay in the root Box.
     var editorFor by remember { mutableStateOf<String?>(null) }
+    // Discovery survives leaving and re-entering the screen (desktop does the same): the sheet
+    // reopens on whatever the scan still holds, and only closing it resets the scan.
+    var discovering by remember { mutableStateOf(manager?.services?.state != ServiceScanState.Idle) }
     Box(Modifier.fillMaxSize().background(D.bg)) {
         Column(Modifier.fillMaxSize()) {
             MobilePushHeader(stringResource(Res.string.ports_port_forwarding), onBack = state::pop, plainBack = true)
@@ -116,6 +138,7 @@ fun MobilePortsScreen(state: MobileDesignState) {
                     mono = mono,
                     onNew = { editorFor = "" },
                     onEdit = { editorFor = it },
+                    onDiscover = { discovering = true },
                 )
             }
         }
@@ -126,6 +149,14 @@ fun MobilePortsScreen(state: MobileDesignState) {
                 mono = mono,
                 existing = editorFor?.takeIf { it.isNotEmpty() }?.let { id -> manager.tunnels.firstOrNull { it.id == id } },
                 onDismiss = { editorFor = null },
+            )
+        }
+        if (manager != null && discovering) {
+            MobileServicesSheet(
+                manager = manager,
+                hosts = hosts,
+                mono = mono,
+                onDismiss = { discovering = false; manager.services.reset() },
             )
         }
     }
@@ -140,6 +171,7 @@ private fun LiveMobilePortsBody(
     mono: FontFamily,
     onNew: () -> Unit,
     onEdit: (String) -> Unit,
+    onDiscover: () -> Unit,
 ) {
     val tunnels = manager.tunnels
 
@@ -177,6 +209,7 @@ private fun LiveMobilePortsBody(
             }
         }
         MobileNewTunnelButton(onClick = onNew)
+        MobileDashedButton(stringResource(Res.string.ports_find_services), icon = "radar", onClick = onDiscover)
         Spacer(Modifier.height(30.dp))
     }
 }
@@ -212,6 +245,20 @@ private fun LiveTunnelCard(
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Badge(t.direction.badgeLabel(), bg = bg, fg = fg, radius = 4, size = 9.5.sp)
             Txt(stringResource(Res.string.ports_via, via), color = D.dim, size = 11.sp, font = mono, modifier = Modifier.weight(1f))
+            // Only a live local forward has something to open; -R listens on the server, -D is SOCKS.
+            tunnelBrowserUrl(entry)?.let { url ->
+                val uriHandler = LocalUriHandler.current
+                Sym(
+                    "open_in_new",
+                    size = 18.sp,
+                    color = D.cyanBright,
+                    // A failing system handler must not throw into the composition.
+                    modifier = Modifier.clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { runCatching { uriHandler.openUri(url) } }.padding(end = 4.dp),
+                )
+            }
             TunnelStatusControl(entry, onToggle)
         }
         Spacer(Modifier.height(10.dp))
@@ -380,6 +427,128 @@ private fun MobileTunnelEditorSheet(
         }
 }
 
+/**
+ * Bottom sheet for service discovery: pick a saved host, scan it for listening TCP ports, forward
+ * one in a tap (saved and raised right away). Mirrors the desktop Services panel.
+ */
+@Composable
+private fun MobileServicesSheet(
+    manager: TunnelManager,
+    hosts: HostManagerController?,
+    mono: FontFamily,
+    onDismiss: () -> Unit,
+) {
+    val scan = manager.services
+    val hostList = hosts?.hosts ?: emptyList()
+    var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
+    val hostName = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
+        ?: stringResource(Res.string.ports_select_host)
+
+    MobileBottomSheet(
+        onDismiss = onDismiss,
+        panelModifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .padding(start = 22.dp, end = 22.dp, bottom = 30.dp),
+    ) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Sym("radar", size = 22.sp, color = D.cyanBright)
+                Txt(stringResource(Res.string.ports_services_title), color = D.text, size = 20.sp, weight = FontWeight.Bold)
+            }
+            Sym(
+                "close",
+                size = 24.sp,
+                color = D.dim,
+                modifier = Modifier.clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onDismiss),
+            )
+        }
+        Spacer(Modifier.height(10.dp))
+        Txt(stringResource(Res.string.ports_services_hint), color = D.faint, size = 12.sp, lineHeight = 17.sp)
+        Spacer(Modifier.height(16.dp))
+        MobileFormField(stringResource(Res.string.ports_field_via_host)) {
+            MobileHostPicker(hostName, hostList.map { it.id to it.label }) { hostId = it }
+        }
+        Spacer(Modifier.height(14.dp))
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(14.dp))
+                .background(if (hostId != null) D.cyan else D.cyan.copy(alpha = 0.4f))
+                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                    hostId?.let { scan.scan(it) }
+                }
+                .padding(15.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Txt(stringResource(Res.string.ports_scan), color = D.ink, size = 16.sp, weight = FontWeight.Bold)
+        }
+        Spacer(Modifier.height(16.dp))
+        when (val state = scan.state) {
+            ServiceScanState.Idle -> MobileScanNote(stringResource(Res.string.ports_pick_host_to_scan), D.faint)
+            ServiceScanState.Scanning -> MobileScanNote(stringResource(Res.string.ports_scanning), D.amber)
+            ServiceScanState.Unsupported -> MobileScanNote(stringResource(Res.string.ports_services_unsupported), D.dim)
+            is ServiceScanState.Failed -> MobileScanNote(serviceScanFailureText(state), D.sunset)
+            is ServiceScanState.Ready -> {
+                val scanned = scan.scannedHostId
+                if (state.services.isEmpty() || scanned == null) {
+                    MobileScanNote(stringResource(Res.string.ports_no_services), D.faint)
+                } else {
+                    val taken = forwardedPorts(manager.tunnels.map { it.tunnel }, scanned)
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        state.services.forEach { service ->
+                            MobileServiceRow(
+                                service = service,
+                                mono = mono,
+                                forwarded = service.port in taken,
+                                onForward = { label -> manager.activate(manager.save(serviceTunnelDraft(service, scanned, label))) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MobileScanNote(text: String, color: Color) {
+    Txt(text, color = color, size = 13.sp, lineHeight = 18.sp)
+}
+
+/** One discovered service in the sheet: port, owning process, and the one-tap forward action. */
+@Composable
+private fun MobileServiceRow(service: ListeningService, mono: FontFamily, forwarded: Boolean, onForward: (String) -> Unit) {
+    // Name for the tunnel when the host didn't disclose the process; localized here, since the
+    // draft is built outside the composition.
+    val fallback = stringResource(Res.string.ports_service_port, service.port)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(D.card)
+            .border(1.dp, D.cyan08, RoundedCornerShape(12.dp))
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Txt("${service.port}", color = D.textBright, size = 14.sp, font = mono, modifier = Modifier.width(58.dp))
+        Txt(serviceLabel(service), color = D.dim, size = 13.sp, modifier = Modifier.weight(1f))
+        if (forwarded) {
+            Txt(stringResource(Res.string.ports_already_forwarded), color = D.moss, size = 12.sp)
+        } else {
+            Txt(
+                stringResource(Res.string.ports_forward),
+                color = D.cyanBright,
+                size = 13.sp,
+                weight = FontWeight.SemiBold,
+                modifier = Modifier
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) { onForward(fallback) }
+                    .padding(horizontal = 4.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
 /** Host picker in the sheet: menu opens directly below the trigger, matching its width (via [AnchoredDropdown]). */
 @Composable
 private fun MobileHostPicker(current: String, options: List<Pair<String, String>>, onPick: (String) -> Unit) {
@@ -473,9 +642,9 @@ private fun PortTypeSelect(direction: TunnelDirection, onPick: (TunnelDirection)
 
 // New tunnel button.
 
-/** Dashed "New tunnel" button (cyan border, add icon). */
+/** Outlined full-width action under the tunnel list (cyan border, leading icon). */
 @Composable
-private fun MobileNewTunnelButton(onClick: () -> Unit) {
+private fun MobileDashedButton(label: String, icon: String, onClick: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()
@@ -486,10 +655,14 @@ private fun MobileNewTunnelButton(onClick: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
     ) {
-        Sym("add", size = 19.sp, color = D.cyanBright)
-        Txt(stringResource(Res.string.ports_new_tunnel), color = D.cyanBright, size = 14.sp, weight = FontWeight.Medium)
+        Sym(icon, size = 19.sp, color = D.cyanBright)
+        Txt(label, color = D.cyanBright, size = 14.sp, weight = FontWeight.Medium)
     }
 }
+
+@Composable
+private fun MobileNewTunnelButton(onClick: () -> Unit) =
+    MobileDashedButton(stringResource(Res.string.ports_new_tunnel), icon = "add", onClick = onClick)
 
 /** Throughput row in the editor sheet: arrow + bar + text. */
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScan.kt
@@ -1,0 +1,166 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.tunnel.Tunnel
+import app.skerry.shared.tunnel.TunnelDirection
+
+// Discovery of listening TCP services on a host, and the tunnel draft that forwards one of them.
+// Pure, kept out of Compose for UI-free testability (same split as TunnelForm).
+
+/**
+ * One TCP port the remote host listens on. [bindAddress] is the listen address as reported by the
+ * host (a wildcard, loopback, or one specific interface) — it decides which destination the forward
+ * has to aim at; [process] is the owning program when the host disclosed it (needs privileges).
+ */
+data class ListeningService(val port: Int, val bindAddress: String, val process: String?)
+
+/** Process names come from an untrusted host: capped and stripped before they reach the UI. */
+const val SERVICE_NAME_MAX_LEN = 40
+
+/** Upper bound on reported services, so a hostile or huge answer can't flood the list. */
+const val SERVICE_SCAN_MAX_ROWS = 200
+
+/**
+ * One command, one round-trip. `ss` is the modern tool and the only one that reports process names
+ * without privileges; `netstat` is the fallback for hosts that lack iproute2, and its `-p` form is
+ * tried first for the same reason. Both print the listen socket in the same shape, so
+ * [parseListeningServices] reads either.
+ *
+ * `-W` comes before plain `-p` because net-tools truncates the address column to a fixed width by
+ * default, which can cut into the port digits of a long IPv6 address and yield a wrong-but-valid
+ * port; older builds without the flag simply fall through to the next branch. A host where every
+ * branch fails (no iproute2, and a BSD `netstat` that has no `-l`) exits non-zero with no output —
+ * [ServiceScanController] reports that as unsupported rather than "nothing is listening".
+ */
+const val SERVICE_SCAN_COMMAND: String =
+    "ss -ltnp 2>/dev/null || netstat -ltnpW 2>/dev/null || netstat -ltnp 2>/dev/null || " +
+        "netstat -ltn 2>/dev/null"
+
+private val WHITESPACE = Regex("\\s+")
+
+// ss: users:(("nginx",pid=901,fd=6),…) — the first name is enough, the rest are worker clones.
+private val SS_PROCESS = Regex("users:\\(\\(\"([^\"]*)\"")
+
+// netstat -p: the PID/Program name column, e.g. 733/redis-server.
+private val NETSTAT_PROCESS = Regex("^\\d+/(\\S+)$")
+
+// Listen addresses only: IPv4/IPv6 literals and `*`. Anything else in that column is malformed (or
+// hostile) output and the row is skipped rather than guessed at.
+private val ADDRESS_CHARS = Regex("^[0-9A-Fa-f.:*-]+$")
+
+// A zone id is an interface name (fe80::1%eth0), so it carries letters outside the hex range the
+// address itself is limited to.
+private val ZONE_ID = Regex("^[0-9A-Za-z._-]+$")
+
+private const val IPV4_LOOPBACK = "127.0.0.1"
+private const val IPV6_LOOPBACK = "::1"
+
+/**
+ * Parses `ss -ltn`/`netstat -ltn` output into the ports the host listens on, lowest first. Header
+ * and noise lines are skipped; a port listening on several addresses collapses into one row keeping
+ * the most reachable address (wildcard over loopback over a single interface), since that is what
+ * decides whether a forward can reach it.
+ */
+fun parseListeningServices(raw: String): List<ListeningService> {
+    val byPort = LinkedHashMap<Int, ListeningService>()
+    for (line in raw.lineSequence()) {
+        val tokens = line.trim().split(WHITESPACE)
+        // The listen socket is the first token shaped like address:port — its column index differs
+        // between ss and netstat, and shifts again with -p.
+        val socket = tokens.firstNotNullOfOrNull(::parseSocket) ?: continue
+        val candidate = ListeningService(socket.second, socket.first, parseProcessName(line, tokens))
+        byPort[socket.second] = merge(byPort[socket.second], candidate)
+    }
+    return byPort.values.sortedBy { it.port }.take(SERVICE_SCAN_MAX_ROWS)
+}
+
+/** Splits `addr:port` (including `[::1]:6379` and netstat's `:::80`), or `null` if it isn't one. */
+private fun parseSocket(token: String): Pair<String, Int>? {
+    val colon = token.lastIndexOf(':')
+    if (colon <= 0) return null
+    val port = token.substring(colon + 1).toIntOrNull()?.takeIf { it in 1..65535 } ?: return null
+    val address = token.substring(0, colon).removePrefix("[").removeSuffix("]")
+    if (!isPlausibleAddress(address)) return null
+    return address to port
+}
+
+/** A listen address, optionally scoped by an interface (`fe80::1%eth0`). */
+private fun isPlausibleAddress(address: String): Boolean {
+    val percent = address.indexOf('%')
+    if (percent < 0) return ADDRESS_CHARS.matches(address)
+    return ADDRESS_CHARS.matches(address.take(percent)) && ZONE_ID.matches(address.substring(percent + 1))
+}
+
+private fun parseProcessName(line: String, tokens: List<String>): String? {
+    val raw = SS_PROCESS.find(line)?.groupValues?.get(1)
+        ?: tokens.firstNotNullOfOrNull { NETSTAT_PROCESS.find(it)?.groupValues?.get(1) }
+        ?: return null
+    // Stricter than the host monitor's sanitizer, which only drops C0/DEL: this name is not just
+    // drawn, it becomes the saved tunnel's label and syncs to the rest of the vault. Format
+    // characters (bidi overrides, zero-width) would let a host spoof how that label reads.
+    return raw
+        .filter { it.code >= 0x20 && it.code != 0x7F && it.category != CharCategory.FORMAT }
+        .take(SERVICE_NAME_MAX_LEN)
+        .trim()
+        .ifEmpty { null }
+}
+
+/** Keeps the more reachable of two rows for the same port, and any process name either one carried. */
+private fun merge(existing: ListeningService?, candidate: ListeningService): ListeningService {
+    if (existing == null) return candidate
+    val candidateWins = reachability(candidate.bindAddress) > reachability(existing.bindAddress)
+    val winner = if (candidateWins) candidate else existing
+    val loser = if (candidateWins) existing else candidate
+    // The winner's own name first: two different programs can hold the same port on different
+    // interfaces, and the row is about the address that won, not the one listed first.
+    return winner.copy(process = winner.process ?: loser.process)
+}
+
+private fun reachability(address: String): Int = when {
+    isWildcard(address) -> 2
+    isLoopback(address) -> 1
+    else -> 0
+}
+
+private fun isWildcard(address: String): Boolean =
+    address.isEmpty() || address == "0.0.0.0" || address == "::" || address == "*"
+
+private fun isLoopback(address: String): Boolean =
+    address == IPV6_LOOPBACK || address.startsWith("127.")
+
+/**
+ * Ports below this need privileges to bind on Unix, so mirroring the remote port locally would fail
+ * for the ones discovery surfaces most often (22, 80, 443).
+ */
+private const val FIRST_UNPRIVILEGED_PORT = 1024
+
+/**
+ * Builds the local forward for a discovered service: same port locally, aimed at the host's own
+ * loopback — that is where a wildcard listener answers from the server's side. A service bound to
+ * one specific interface is aimed at that address instead, since loopback would not reach it.
+ * A privileged remote port binds to `0` (assigned by the OS) rather than failing on a port the app
+ * may not claim; the actual port shows up in the row once the forward is up.
+ * [fallbackLabel] names the tunnel when the host didn't disclose the process (localized by the caller).
+ */
+fun serviceTunnelDraft(service: ListeningService, hostId: String, fallbackLabel: String): TunnelDraft = TunnelDraft(
+    label = service.process ?: fallbackLabel,
+    hostId = hostId,
+    direction = TunnelDirection.Local,
+    bindHost = IPV4_LOOPBACK,
+    bindPort = if (service.port < FIRST_UNPRIVILEGED_PORT) 0 else service.port,
+    destHost = destinationFor(service.bindAddress),
+    destPort = service.port,
+)
+
+private fun destinationFor(bindAddress: String): String = when {
+    bindAddress == "::" -> IPV6_LOOPBACK
+    isWildcard(bindAddress) -> IPV4_LOOPBACK
+    else -> bindAddress
+}
+
+/**
+ * Ports of [hostId] that a saved local forward already covers, so discovery can mark them instead
+ * of offering a duplicate. Only `-L` counts: `-R` runs the other way and `-D` has no destination.
+ */
+fun forwardedPorts(tunnels: List<Tunnel>, hostId: String): Set<Int> = tunnels
+    .filter { it.hostId == hostId && it.direction == TunnelDirection.Local }
+    .mapNotNullTo(mutableSetOf()) { it.destPort }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScanController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScanController.kt
@@ -1,0 +1,133 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshTransport
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.coroutineContext
+
+/** Result of scanning a host for listening services. */
+sealed interface ServiceScanState {
+    /** Nothing scanned yet (or the result was cleared). */
+    data object Idle : ServiceScanState
+
+    /** Connecting to the host and asking it what it listens on. */
+    data object Scanning : ServiceScanState
+
+    /** Scan finished; [services] is empty when the host listens on nothing reachable. */
+    data class Ready(val services: List<ListeningService>) : ServiceScanState
+
+    /** The host can never answer: its connection type has no command channel (telnet, serial). */
+    data object Unsupported : ServiceScanState
+
+    /**
+     * The scan didn't happen. [reason] is set when the failure was typed (config, not transport)
+     * and takes precedence in the UI; [message] is the friendly transport string otherwise —
+     * same split as [TunnelStatus.Failed].
+     */
+    data class Failed(val message: String = "", val reason: TunnelUnavailable? = null) : ServiceScanState
+}
+
+/**
+ * Scans a saved host for listening TCP ports so they can be forwarded in one tap. Owned by
+ * [TunnelManager] and dialling the same way its tunnels do — through [resolve] (host, secret and
+ * ProxyJump chain from the vault) and [transport] — because the tunnel panel is global: the host
+ * being scanned usually has no open session to borrow a connection from.
+ *
+ * The scan is a single exec round-trip on its own connection, which it closes again; nothing here
+ * outlives [scan]. A host whose transport has no exec channel is a verdict
+ * ([ServiceScanState.Unsupported]), not a retryable failure — the same rule as host monitoring.
+ */
+@Stable
+class ServiceScanController(
+    private val transport: SshTransport,
+    private val resolve: (String) -> TunnelResolution,
+    private val scope: CoroutineScope,
+) {
+    var state: ServiceScanState by mutableStateOf(ServiceScanState.Idle)
+        private set
+
+    /** Host the current [state] belongs to, so the view can't attribute a result to another host. */
+    var scannedHostId: String? by mutableStateOf(null)
+        private set
+
+    private var job: Job? = null
+
+    // Only the newest scan may publish. Cancellation alone isn't enough: a superseded scan whose
+    // exec already returned would otherwise overwrite the newer result on its way out.
+    private var epoch = 0
+
+    /** Scans [hostId], superseding any scan already in flight. */
+    fun scan(hostId: String) {
+        job?.cancel()
+        val mine = ++epoch
+        scannedHostId = hostId
+        state = ServiceScanState.Scanning
+        job = scope.launch { run(mine, hostId) }
+    }
+
+    /** Cancels an in-flight scan and clears the result (host list closed, vault locked). */
+    fun reset() {
+        job?.cancel()
+        job = null
+        epoch++
+        scannedHostId = null
+        state = ServiceScanState.Idle
+    }
+
+    private suspend fun run(mine: Int, hostId: String) {
+        when (val resolution = resolve(hostId)) {
+            is TunnelResolution.Unavailable -> publish(mine, ServiceScanState.Failed(reason = resolution.reason))
+            is TunnelResolution.Ready -> probe(mine, resolution)
+        }
+    }
+
+    private suspend fun probe(mine: Int, resolution: TunnelResolution.Ready) {
+        var conn: SshConnection? = null
+        try {
+            // resolution.auth carries the secret as a String (not zeroed on JVM); it lives on the
+            // coroutine stack until connect, as in TunnelManager.openForward.
+            conn = transport.connect(resolution.target, resolution.auth)
+            coroutineContext.ensureActive()
+            val output = conn.exec(SERVICE_SCAN_COMMAND)
+            val services = parseListeningServices(output.stdout)
+            // Nothing parsed *and* every branch of the command failed means the host has no tool
+            // that can answer (a BSD netstat rejects the Linux flags outright) — a verdict, not an
+            // empty list, which would claim the host listens on nothing.
+            publish(
+                mine,
+                if (services.isEmpty() && output.exitCode != 0) {
+                    ServiceScanState.Unsupported
+                } else {
+                    ServiceScanState.Ready(services)
+                },
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: UnsupportedOperationException) {
+            publish(mine, ServiceScanState.Unsupported)
+        } catch (e: Exception) {
+            publish(mine, ServiceScanState.Failed(friendlyTunnelError(e)))
+        } finally {
+            closeQuietly(conn)
+        }
+    }
+
+    private fun publish(mine: Int, next: ServiceScanState) {
+        if (mine == epoch) state = next
+    }
+
+    // Launched on the manager's scope, not the scan's: the scan may be finishing because it was
+    // cancelled, and its connection still has to be handed back.
+    private fun closeQuietly(conn: SshConnection?) {
+        if (conn == null) return
+        scope.launch { runCatching { conn.disconnect() } }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScanText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/ServiceScanText.kt
@@ -1,0 +1,16 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_service_port
+import org.jetbrains.compose.resources.stringResource
+
+/** Text under a failed scan: the typed reason if there is one, else the transport message. */
+@Composable
+fun serviceScanFailureText(state: ServiceScanState.Failed): String =
+    state.reason?.let { tunnelUnavailableText(it) } ?: state.message
+
+/** Name of a discovered service: the owning process, or the port when the host didn't disclose it. */
+@Composable
+fun serviceLabel(service: ListeningService): String =
+    service.process ?: stringResource(Res.string.ports_service_port, service.port)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelBrowserLink.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelBrowserLink.kt
@@ -1,0 +1,51 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.tunnel.TunnelDirection
+import app.skerry.ui.terminal.isSafeLinkUri
+
+// Browser link for a live forward. Pure, kept out of Compose for UI-free testability.
+
+// Ports where a plain http:// link would be answered with a TLS handshake. Deliberately a short
+// list of the conventional ones — guessing wider would send the browser to a broken scheme more
+// often than it would help.
+private val TLS_PORTS = setOf(443, 8443)
+
+// Hostnames and IPv4 literals; an IPv6 literal takes the bracket path instead. bindHost is free-form
+// user input, so anything outside this gets no link rather than a mangled URL.
+private val PLAIN_HOST = Regex("^[A-Za-z0-9.-]+$")
+private val IPV6_LITERAL = Regex("^[0-9A-Fa-f:]+$")
+
+/**
+ * The URL that opens an active local forward in a browser, or `null` when there's nothing to open:
+ * `-R` listens on the server, `-D` is a SOCKS proxy, and an inactive tunnel has no bound port.
+ */
+fun tunnelBrowserUrl(entry: TunnelEntry): String? {
+    val active = entry.status as? TunnelStatus.Active ?: return null
+    return localForwardUrl(entry.tunnel.direction, entry.tunnel.bindHost, active.boundPort)
+}
+
+/**
+ * URL for a local forward listening on [bindHost]:[port], or `null` when it isn't browsable. A
+ * wildcard listen address is browsed through loopback — `0.0.0.0` is where the listener binds, not
+ * an address a browser can connect to. The result passes the same gate as terminal hyperlinks.
+ */
+fun localForwardUrl(direction: TunnelDirection, bindHost: String, port: Int): String? {
+    if (direction != TunnelDirection.Local) return null
+    if (port !in 1..65535) return null
+    val host = browsableHost(bindHost) ?: return null
+    val scheme = if (port in TLS_PORTS) "https" else "http"
+    return "$scheme://$host:$port".takeIf { isSafeLinkUri(it) }
+}
+
+private fun browsableHost(bindHost: String): String? {
+    val host = bindHost.trim().removePrefix("[").removeSuffix("]")
+    return when {
+        host.isEmpty() || host == "0.0.0.0" || host == "*" -> "127.0.0.1"
+        host == "::" -> "[::1]"
+        // A zone id (fe80::1%eth0) would need percent-encoding to survive a URL — not worth it for
+        // a loopback listener, so it gets no link.
+        ':' in host -> if (IPV6_LITERAL.matches(host)) "[$host]" else null
+        PLAIN_HOST.matches(host) -> host
+        else -> null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
@@ -1,0 +1,26 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.ssh.PortForwardException
+import app.skerry.shared.ssh.SshAuthenticationException
+import app.skerry.shared.ssh.SshConnectionException
+import app.skerry.shared.ssh.SshHostKeyRejectedException
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ptail_err_auth_failed
+import app.skerry.ui.generated.resources.ptail_err_connection_failed
+import app.skerry.ui.generated.resources.ptail_err_forward_failed
+import app.skerry.ui.generated.resources.ptail_err_host_not_trusted
+import org.jetbrains.compose.resources.getString
+
+/**
+ * Friendly message for a failure while dialling a host on the tunnel path (raising a forward or
+ * scanning for services). Raw exception text (addresses, sshj internals) is never shown in the UI,
+ * only generic messages, as in runConnectionTest. Host key rejection is called out separately:
+ * tunnels use the probe verifier, so this is the expected outcome for a not-yet-trusted host.
+ */
+internal suspend fun friendlyTunnelError(e: Throwable): String = when (e) {
+    is SshHostKeyRejectedException -> getString(Res.string.ptail_err_host_not_trusted)
+    is SshAuthenticationException -> getString(Res.string.ptail_err_auth_failed)
+    is PortForwardException -> getString(Res.string.ptail_err_forward_failed)
+    is SshConnectionException -> getString(Res.string.ptail_err_connection_failed)
+    else -> getString(Res.string.ptail_err_connection_failed)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
@@ -49,17 +49,17 @@ fun buildTunnelDraft(
 }
 
 /**
- * Resolves a saved tunnel to connection parameters (for the [TunnelManager] production lambda).
- * Host is looked up by [Tunnel.hostId], credential by [Host.credentialId] in the unlocked vault;
- * the host's ProxyJump chain (if any) is resolved too, so tunnels ride the same route as sessions.
+ * Resolves a host to connection parameters (for the [TunnelManager] production lambda). The host is
+ * looked up by id, its credential by [Host.credentialId] in the unlocked vault; the host's ProxyJump
+ * chain (if any) is resolved too, so tunnels and service scans ride the same route as sessions.
  * Failures are typed ([TunnelUnavailable]) — this runs outside the composition, the view localizes.
  */
-fun resolveTunnel(
-    tunnel: app.skerry.shared.tunnel.Tunnel,
+fun resolveTunnelHost(
+    hostId: String,
     findHost: (String) -> Host?,
     findCredential: (String?) -> Credential?,
 ): TunnelResolution {
-    val host = findHost(tunnel.hostId) ?: return TunnelResolution.Unavailable(TunnelUnavailable.HostNotFound)
+    val host = findHost(hostId) ?: return TunnelResolution.Unavailable(TunnelUnavailable.HostNotFound)
     val credential = findCredential(host.credentialId)
         ?: return TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
     val jump = when (val chain = resolveJumpChain(host, findHost, findCredential)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
@@ -7,31 +7,21 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.LocalForwardSpec
 import app.skerry.shared.ssh.PortForward
-import app.skerry.shared.ssh.PortForwardException
 import app.skerry.shared.ssh.RemoteForwardSpec
 import app.skerry.shared.ssh.SshAuth
-import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnection
-import app.skerry.shared.ssh.SshConnectionException
-import app.skerry.shared.ssh.SshHostKeyRejectedException
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.tunnel.Tunnel
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.shared.tunnel.TunnelStore
 import app.skerry.ui.connection.JumpChainProblem
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ptail_err_auth_failed
-import app.skerry.ui.generated.resources.ptail_err_connection_failed
-import app.skerry.ui.generated.resources.ptail_err_forward_failed
-import app.skerry.ui.generated.resources.ptail_err_host_not_trusted
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import org.jetbrains.compose.resources.getString
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.coroutineContext
 
@@ -146,13 +136,16 @@ class TunnelEntry internal constructor(tunnel: Tunnel) {
 class TunnelManager(
     private val store: TunnelStore,
     private val transport: SshTransport,
-    private val resolve: (Tunnel) -> TunnelResolution,
+    private val resolve: (String) -> TunnelResolution,
     private val scope: CoroutineScope,
     private val pollIntervalMillis: Long = 1000,
     private val newId: () -> String,
 ) {
     var tunnels: List<TunnelEntry> by mutableStateOf(store.all().map { TunnelEntry(it) })
         private set
+
+    /** Discovery of listening services on a host, for forwarding one of them in a tap. */
+    val services: ServiceScanController = ServiceScanController(transport, resolve, scope)
 
     init {
         // Polls telemetry for active tunnels: samples counters and computes rate from the delta.
@@ -217,7 +210,7 @@ class TunnelManager(
         // deactivate can cancel it.
         entry.connectingJob = scope.launch {
             try {
-                when (val resolution = resolve(entry.tunnel)) {
+                when (val resolution = resolve(entry.tunnel.hostId)) {
                     is TunnelResolution.Unavailable -> entry.status = TunnelStatus.Failed(reason = resolution.reason)
                     is TunnelResolution.Ready -> openForward(entry, resolution)
                 }
@@ -246,7 +239,7 @@ class TunnelManager(
             throw e
         } catch (e: Exception) {
             closeQuietly(conn)
-            entry.status = TunnelStatus.Failed(friendlyError(e))
+            entry.status = TunnelStatus.Failed(friendlyTunnelError(e))
         }
     }
 
@@ -290,9 +283,10 @@ class TunnelManager(
         }
     }
 
-    /** Deactivates all tunnels. */
+    /** Deactivates all tunnels and drops any scan result (vault lock, shutdown). */
     fun closeAll() {
         tunnels.forEach { deactivate(it.id) }
+        services.reset()
     }
 
     internal fun pollTelemetry() {
@@ -312,16 +306,5 @@ class TunnelManager(
     private fun closeQuietly(conn: SshConnection?) {
         if (conn == null) return
         scope.launch { runCatching { conn.disconnect() } }
-    }
-
-    // Raw exception text (addresses/sshj internals) is never shown in the UI, only generic
-    // messages, as in runConnectionTest. Host key rejection is called out separately: tunnels use
-    // the probe verifier, so this is the expected outcome for a not-yet-trusted host.
-    private suspend fun friendlyError(e: Exception): String = when (e) {
-        is SshHostKeyRejectedException -> getString(Res.string.ptail_err_host_not_trusted)
-        is SshAuthenticationException -> getString(Res.string.ptail_err_auth_failed)
-        is PortForwardException -> getString(Res.string.ptail_err_forward_failed)
-        is SshConnectionException -> getString(Res.string.ptail_err_connection_failed)
-        else -> getString(Res.string.ptail_err_connection_failed)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -45,6 +46,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ports_active_tunnel_one
 import app.skerry.ui.generated.resources.ports_active_tunnels_other
 import app.skerry.ui.generated.resources.ports_add_tunnel_right
+import app.skerry.ui.generated.resources.ports_already_forwarded
 import app.skerry.ui.generated.resources.ports_changes_apply_after_restart
 import app.skerry.ui.generated.resources.ports_col_active
 import app.skerry.ui.generated.resources.ports_col_destination
@@ -59,10 +61,15 @@ import app.skerry.ui.generated.resources.ports_field_name
 import app.skerry.ui.generated.resources.ports_field_port
 import app.skerry.ui.generated.resources.ports_field_type
 import app.skerry.ui.generated.resources.ports_field_via_host
+import app.skerry.ui.generated.resources.ports_find_services
+import app.skerry.ui.generated.resources.ports_forward
 import app.skerry.ui.generated.resources.ports_new_tunnel
 import app.skerry.ui.generated.resources.ports_no_saved_hosts
+import app.skerry.ui.generated.resources.ports_no_services
 import app.skerry.ui.generated.resources.ports_no_tunnels_yet
+import app.skerry.ui.generated.resources.ports_open_in_browser
 import app.skerry.ui.generated.resources.ports_ph_web_tunnel
+import app.skerry.ui.generated.resources.ports_pick_host_to_scan
 import app.skerry.ui.generated.resources.ports_port_forwarding
 import app.skerry.ui.generated.resources.ports_remove
 import app.skerry.ui.generated.resources.ports_remove_active_message
@@ -70,7 +77,13 @@ import app.skerry.ui.generated.resources.ports_remove_confirm_title
 import app.skerry.ui.generated.resources.ports_remove_inactive_message
 import app.skerry.ui.generated.resources.ports_save
 import app.skerry.ui.generated.resources.ports_saved_tunnels_subtitle
+import app.skerry.ui.generated.resources.ports_scan
+import app.skerry.ui.generated.resources.ports_scanning
 import app.skerry.ui.generated.resources.ports_select_host
+import app.skerry.ui.generated.resources.ports_service_port
+import app.skerry.ui.generated.resources.ports_services_hint
+import app.skerry.ui.generated.resources.ports_services_title
+import app.skerry.ui.generated.resources.ports_services_unsupported
 import app.skerry.ui.generated.resources.ports_socks_hint
 import app.skerry.ui.generated.resources.ports_tunnel_detail
 import org.jetbrains.compose.resources.stringResource
@@ -115,9 +128,13 @@ fun TunnelsView() {
     val manager = LocalTunnels.current
     val hosts = LocalHosts.current
 
-    // Right-panel state: selected tunnel and "create new" mode (New tunnel button).
+    // Right-panel state: selected tunnel, "create new" mode (New tunnel button), and service
+    // discovery, which takes over the same panel.
     var selectedId by remember { mutableStateOf<String?>(null) }
     var adding by remember { mutableStateOf(false) }
+    // Discovery survives leaving and re-entering the section: the panel reopens on whatever the
+    // scan still holds, and only closing it (which resets the scan) puts the editor back.
+    var discovering by remember { mutableStateOf(manager?.services?.state != ServiceScanState.Idle) }
 
     Column(Modifier.fillMaxSize().background(D.bg)) {
         Row(
@@ -132,7 +149,14 @@ fun TunnelsView() {
                     color = D.dim, size = 12.sp, modifier = Modifier.padding(top = 2.dp),
                 )
             }
-            PrimaryButton(stringResource(Res.string.ports_new_tunnel), onClick = { adding = true; selectedId = null }, icon = "add")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                GhostButton(stringResource(Res.string.ports_find_services), onClick = { discovering = true }, icon = "radar")
+                PrimaryButton(
+                    stringResource(Res.string.ports_new_tunnel),
+                    onClick = { adding = true; selectedId = null; discovering = false },
+                    icon = "add",
+                )
+            }
         }
         HLine()
         Box(Modifier.weight(1f).fillMaxWidth()) {
@@ -144,12 +168,14 @@ fun TunnelsView() {
                     hosts = hosts,
                     mono = mono,
                     adding = adding,
+                    discovering = discovering,
                     selectedId = selectedId,
-                    onSelect = { selectedId = it; adding = false },
+                    onSelect = { selectedId = it; adding = false; discovering = false },
+                    onCloseDiscovery = { discovering = false; manager.services.reset() },
                     // After deletion, returns to "New tunnel" mode instead of jumping to an
                     // arbitrary remaining tunnel: selectedId still holds the removed id, and
                     // without resetting it, selected would resolve via firstOrNull().
-                    onNew = { selectedId = null; adding = true },
+                    onNew = { selectedId = null; adding = true; discovering = false },
                 )
             }
         }
@@ -164,8 +190,10 @@ private fun GlobalTunnelsBody(
     hosts: HostManagerController?,
     mono: FontFamily,
     adding: Boolean,
+    discovering: Boolean,
     selectedId: String?,
     onSelect: (String) -> Unit,
+    onCloseDiscovery: () -> Unit,
     onNew: () -> Unit,
 ) {
     val tunnels = manager.tunnels
@@ -221,14 +249,18 @@ private fun GlobalTunnelsBody(
                 }
             }
             VLine(D.line)
-            TunnelEditor(
-                manager = manager,
-                hosts = hosts,
-                mono = mono,
-                existing = if (showNew) null else selected,
-                onSaved = { onSelect(it) },
-                onRequestRemove = { selected?.let { pendingRemove = it } },
-            )
+            if (discovering) {
+                ServicesPanel(manager = manager, hosts = hosts, mono = mono, onClose = onCloseDiscovery)
+            } else {
+                TunnelEditor(
+                    manager = manager,
+                    hosts = hosts,
+                    mono = mono,
+                    existing = if (showNew) null else selected,
+                    onSaved = { onSelect(it) },
+                    onRequestRemove = { selected?.let { pendingRemove = it } },
+                )
+            }
         }
         pendingRemove?.let { entry ->
             ConfirmActionDialog(
@@ -282,7 +314,8 @@ private fun TunnelRowGlobal(
             Box(Modifier.width(20.dp)) { Sym(arrow, size = 16.sp, color = D.faint) }
             Txt(dest ?: stringResource(Res.string.ports_dynamic_proxy), color = if (dest == null || dim) D.dim else D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
             Txt(via, color = D.dim, size = 11.5.sp, font = mono, modifier = Modifier.width(110.dp))
-            Box(Modifier.width(56.dp), contentAlignment = Alignment.CenterEnd) {
+            Row(Modifier.width(84.dp), horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End), verticalAlignment = Alignment.CenterVertically) {
+                OpenInBrowserAction(entry)
                 ActiveCellGlobal(entry, onToggle)
             }
         }
@@ -298,6 +331,23 @@ private fun sourceText(entry: TunnelEntry): String {
     return "${entry.tunnel.bindHost}:$port"
 }
 
+/**
+ * Opens a live local forward in the browser. Only shown when there is something to open: `-R`
+ * listens on the server and `-D` is a SOCKS proxy, so neither gets a link.
+ */
+@Composable
+private fun OpenInBrowserAction(entry: TunnelEntry) {
+    val url = tunnelBrowserUrl(entry) ?: return
+    val uriHandler = LocalUriHandler.current
+    Sym(
+        "open_in_new",
+        size = 15.sp,
+        color = D.cyanBright,
+        // A failing system handler must not throw into the composition (see AboutSection).
+        modifier = Modifier.clickable { runCatching { uriHandler.openUri(url) } },
+    )
+}
+
 /** ACTIVE cell: on toggle when active, hourglass while connecting, otherwise off toggle (activate/retry). */
 @Composable
 private fun ActiveCellGlobal(entry: TunnelEntry, onToggle: () -> Unit) {
@@ -305,6 +355,108 @@ private fun ActiveCellGlobal(entry: TunnelEntry, onToggle: () -> Unit) {
         is TunnelStatus.Active -> Toggle(on = true, onToggle = onToggle)
         TunnelStatus.Connecting -> Sym("hourglass_top", size = 16.sp, color = D.amber)
         else -> Toggle(on = false, onToggle = onToggle)
+    }
+}
+
+/**
+ * Service discovery panel: pick a saved host, scan it for listening TCP ports, and forward one in a
+ * tap (a local forward is created and activated right away). Occupies the editor's column — the two
+ * are alternative uses of the same panel, never both at once.
+ */
+@Composable
+private fun ServicesPanel(
+    manager: TunnelManager,
+    hosts: HostManagerController?,
+    mono: FontFamily,
+    onClose: () -> Unit,
+) {
+    val scan = manager.services
+    val hostList = hosts?.hosts ?: emptyList()
+    var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
+    val hostLabel = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
+        ?: stringResource(Res.string.ports_select_host)
+
+    Column(
+        Modifier.width(308.dp).fillMaxHeight().background(D.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp),
+    ) {
+        Row(Modifier.fillMaxWidth().padding(bottom = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Sym("radar", size = 16.sp, color = D.cyanBright)
+                Txt(stringResource(Res.string.ports_services_title), color = D.text, size = 13.sp, weight = FontWeight.SemiBold)
+            }
+            Sym("close", size = 16.sp, color = D.faint, modifier = Modifier.clickable(onClick = onClose))
+        }
+        Txt(stringResource(Res.string.ports_services_hint), color = D.faint, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(bottom = 14.dp))
+        FieldLabel(stringResource(Res.string.ports_field_via_host))
+        HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { hostId = it })
+        Box(Modifier.padding(bottom = 12.dp))
+        PrimaryButton(
+            label = stringResource(Res.string.ports_scan),
+            onClick = { hostId?.let { scan.scan(it) } },
+            modifier = Modifier.fillMaxWidth(),
+            icon = "radar",
+            bg = if (hostId != null) D.cyan else Color(0x14FFFFFF),
+            fg = if (hostId != null) Color(0xFF0A1A26) else D.faint,
+        )
+        Box(Modifier.padding(bottom = 14.dp))
+        when (val state = scan.state) {
+            ServiceScanState.Idle -> ScanNote(stringResource(Res.string.ports_pick_host_to_scan), D.faint)
+            ServiceScanState.Scanning -> ScanNote(stringResource(Res.string.ports_scanning), D.amber)
+            ServiceScanState.Unsupported -> ScanNote(stringResource(Res.string.ports_services_unsupported), D.dim)
+            is ServiceScanState.Failed -> ScanNote(serviceScanFailureText(state), D.sunset)
+            is ServiceScanState.Ready -> {
+                val scanned = scan.scannedHostId
+                if (state.services.isEmpty() || scanned == null) {
+                    ScanNote(stringResource(Res.string.ports_no_services), D.faint)
+                } else {
+                    val taken = forwardedPorts(manager.tunnels.map { it.tunnel }, scanned)
+                    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        state.services.forEach { service ->
+                            ServiceRow(
+                                service = service,
+                                mono = mono,
+                                forwarded = service.port in taken,
+                                // Saved and raised in one go — the point of the panel is not to
+                                // land in the editor with fields pre-filled.
+                                onForward = { label -> manager.activate(manager.save(serviceTunnelDraft(service, scanned, label))) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanNote(text: String, color: Color) {
+    Txt(text, color = color, size = 11.5.sp, lineHeight = 16.sp)
+}
+
+/** One discovered service: port, owning process, and the one-tap forward action. */
+@Composable
+private fun ServiceRow(service: ListeningService, mono: FontFamily, forwarded: Boolean, onForward: (String) -> Unit) {
+    // Name for the tunnel when the host didn't disclose the process; localized here, since the
+    // draft is built outside the composition.
+    val fallback = stringResource(Res.string.ports_service_port, service.port)
+    Row(
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(D.bg).border(1.dp, D.cyan08, RoundedCornerShape(7.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Txt("${service.port}", color = D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.width(46.dp))
+        Txt(serviceLabel(service), color = D.dim, size = 11.5.sp, modifier = Modifier.weight(1f))
+        if (forwarded) {
+            Txt(stringResource(Res.string.ports_already_forwarded), color = D.moss, size = 10.5.sp)
+        } else {
+            Txt(
+                stringResource(Res.string.ports_forward),
+                color = D.cyanBright,
+                size = 10.5.sp,
+                weight = FontWeight.SemiBold,
+                modifier = Modifier.clickable { onForward(fallback) }.padding(horizontal = 4.dp, vertical = 2.dp),
+            )
+        }
     }
 }
 
@@ -364,6 +516,18 @@ private fun TunnelEditor(
             Txt(stringResource(Res.string.ports_socks_hint), color = D.faint, size = 11.sp, lineHeight = 15.sp)
         }
         if (existing != null && existing.status is TunnelStatus.Active) {
+            tunnelBrowserUrl(existing)?.let { url ->
+                val uriHandler = LocalUriHandler.current
+                Box(Modifier.padding(bottom = 14.dp))
+                GhostButton(
+                    stringResource(Res.string.ports_open_in_browser),
+                    onClick = { runCatching { uriHandler.openUri(url) } },
+                    icon = "open_in_new",
+                    fg = D.cyanBright,
+                    border = D.cyan20,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
             Box(Modifier.padding(bottom = 16.dp))
             FieldLabel(stringResource(Res.string.ports_field_live_throughput))
             ThroughputRow("arrow_upward", D.cyanBright, rateFraction(existing.upRate), humanRate(existing.upRate), mono)
@@ -495,7 +659,7 @@ private fun TunnelHeaderRow() {
         Box(Modifier.width(20.dp))
         HeaderCell(stringResource(Res.string.ports_col_destination), Modifier.weight(1f))
         HeaderCell(stringResource(Res.string.ports_col_via_host), Modifier.width(110.dp))
-        HeaderCell(stringResource(Res.string.ports_col_active), Modifier.width(56.dp), end = true)
+        HeaderCell(stringResource(Res.string.ports_col_active), Modifier.width(84.dp), end = true)
     }
 }
 
@@ -521,7 +685,7 @@ private fun TunnelRow(rule: TunnelRule) {
         Box(Modifier.width(20.dp)) { Sym(rule.arrow, size = 16.sp, color = D.faint) }
         Txt(rule.dest, color = if (rule.destDim) D.dim else D.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
         Txt(rule.via, color = D.dim, size = 11.5.sp, font = mono, modifier = Modifier.width(110.dp))
-        Box(Modifier.width(56.dp), contentAlignment = Alignment.CenterEnd) {
+        Box(Modifier.width(84.dp), contentAlignment = Alignment.CenterEnd) {
             Toggle(rule.active, onToggle = {})
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -1,0 +1,26 @@
+package app.skerry.ui.vault
+
+import app.skerry.ui.session.SessionsController
+import app.skerry.ui.tunnel.TunnelManager
+
+/**
+ * Drops everything that still holds a decrypted secret when the vault locks. Passed to
+ * [VaultGate] as `onBeforeLock`, so it covers the manual lock and both automatic ones (background
+ * and idle timer) — the automatic paths call the gate controller directly and never see the
+ * caller's lock action.
+ *
+ * Tunnels are closed outright: each holds its own SSH connection opened with the secret, and a
+ * saved tunnel is meaningless behind a lock screen. This also cancels an in-flight service scan
+ * ([TunnelManager.closeAll]). Terminal SESSIONS deliberately survive — their sockets stay open and
+ * the tabs are still there after unlocking — but their saved credentials are cleared, because an
+ * auto-reconnect after a lock would re-authenticate with a stale secret against a locked vault.
+ *
+ * Shared by desktop and Android so the two can't drift apart on which of these gets forgotten.
+ */
+fun tearDownForLock(tunnels: TunnelManager?, sessions: SessionsController?) {
+    tunnels?.closeAll()
+    sessions?.sessions?.forEach { session ->
+        session.controller.clearReconnectCredentials()
+        session.splitSession?.controller?.clearReconnectCredentials()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
@@ -127,6 +127,11 @@ fun VaultGate(
     // (deviceMandatesAutoLock).
     autoLockIdleMs: Long? = AUTO_LOCK_IDLE_MS,
     modifier: Modifier = Modifier,
+    // Teardown of everything holding the decrypted secret, run immediately before EVERY transition to
+    // locked — manual lock, background (`ON_STOP`) and the idle timer alike. It lives here rather than
+    // in the caller's lock action because the two automatic paths call the controller directly and
+    // would otherwise bypass it (they did: tunnels survived an idle auto-lock on both platforms).
+    onBeforeLock: () -> Unit = {},
     // External cleanup on reset (hosts/known_hosts/settings per the chosen [ResetScope]). Called after the
     // vault is erased; the platform wiring (desktop `main`) supplies the real implementation.
     onReset: (ResetScope) -> Unit = {},
@@ -229,6 +234,11 @@ fun VaultGate(
         subtitle = stringResource(Res.string.vtail_bio_unlock_subtitle),
     )
 
+    // Single door into the locked state: every path goes through the teardown first. Kept fresh via
+    // rememberUpdatedState so the DisposableEffect observer below doesn't capture a stale lambda.
+    val currentOnBeforeLock by rememberUpdatedState(onBeforeLock)
+    val lockNow = { currentOnBeforeLock(); controller.lock() }
+
     // Background auto-lock: other hands on an unlocked device must not get an open vault after minimizing.
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner, controller) {
@@ -240,7 +250,7 @@ fun VaultGate(
                 !controller.biometricInFlight &&
                 deviceMandatesAutoLock()
             ) {
-                controller.lock()
+                lockNow()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -252,7 +262,7 @@ fun VaultGate(
     if (controller.state == VaultGateState.Unlocked && autoLockIdleMs != null) {
         LaunchedEffect(controller.activityTick, autoLockIdleMs) {
             delay(autoLockIdleMs)
-            controller.lock()
+            lockNow()
         }
     }
 
@@ -316,7 +326,7 @@ fun VaultGate(
                     }
                 },
             ) {
-                content { controller.lock() }
+                content { lockNow() }
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/ServiceScanControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/ServiceScanControllerTest.kt
@@ -1,0 +1,209 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.sftp.SftpClient
+import app.skerry.shared.ssh.DynamicForwardSpec
+import app.skerry.shared.ssh.ExecResult
+import app.skerry.shared.ssh.LocalForwardSpec
+import app.skerry.shared.ssh.PortForward
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.ssh.RemoteForwardSpec
+import app.skerry.shared.ssh.ShellChannel
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshAuthenticationException
+import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.ssh.SshTransport
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ptail_err_auth_failed
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.getString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServiceScanControllerTest {
+
+    private val target = SshTarget(host = "h", port = 22, username = "u")
+    private val auth = SshAuth.Password("pw")
+
+    private fun controllerWith(
+        transport: SshTransport,
+        resolve: (String) -> TunnelResolution = { TunnelResolution.Ready(target, auth) },
+    ) = ServiceScanController(transport, resolve, TestScope(UnconfinedTestDispatcher()))
+
+    @Test
+    fun `scan lists the listening services of the host`() = runTest {
+        val conn = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*\nLISTEN 0 128 127.0.0.1:5432 0.0.0.0:*")
+        val controller = controllerWith(FakeScanTransport(conn))
+
+        controller.scan("h1")
+
+        val ready = assertIs<ServiceScanState.Ready>(controller.state)
+        assertEquals(listOf(22, 5432), ready.services.map { it.port })
+        assertEquals("h1", controller.scannedHostId)
+    }
+
+    @Test
+    fun `scan closes its connection after one exec round-trip`() = runTest {
+        val conn = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*")
+        val controller = controllerWith(FakeScanTransport(conn))
+
+        controller.scan("h1")
+
+        assertEquals(1, conn.execCalls) // one command, one round-trip
+        assertTrue(conn.disconnected) // the scan owns the connection and gives it back
+    }
+
+    @Test
+    fun `a host that answers nothing reports an empty result, not a failure`() = runTest {
+        val controller = controllerWith(FakeScanTransport(FakeScanConnection(stdout = "")))
+
+        controller.scan("h1")
+
+        assertEquals(emptyList(), assertIs<ServiceScanState.Ready>(controller.state).services)
+    }
+
+    @Test
+    fun `a host where every branch of the command failed is unsupported, not empty`() = runTest {
+        // BSD netstat rejects the Linux flags outright: no output and a non-zero exit. Claiming
+        // "nothing is listening" there would be a lie.
+        val conn = FakeScanConnection(stdout = "", exitCode = 1)
+        val controller = controllerWith(FakeScanTransport(conn))
+
+        controller.scan("h1")
+
+        assertEquals(ServiceScanState.Unsupported, controller.state)
+    }
+
+    @Test
+    fun `a non-zero exit is ignored when the host still listed services`() = runTest {
+        // The chain ends on a branch that failed after an earlier one printed: the output is what
+        // matters, not the exit code of the last attempt.
+        val conn = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*", exitCode = 1)
+        val controller = controllerWith(FakeScanTransport(conn))
+
+        controller.scan("h1")
+
+        assertEquals(listOf(22), assertIs<ServiceScanState.Ready>(controller.state).services.map { it.port })
+    }
+
+    @Test
+    fun `a transport without a command channel is reported as unsupported`() = runTest {
+        // telnet/serial: exec can never answer, so this is a verdict, not a retryable failure.
+        val conn = FakeScanConnection(execError = UnsupportedOperationException("telnet has no exec"))
+        val controller = controllerWith(FakeScanTransport(conn))
+
+        controller.scan("h1")
+
+        assertEquals(ServiceScanState.Unsupported, controller.state)
+        assertTrue(conn.disconnected)
+    }
+
+    @Test
+    fun `an unresolvable host fails with a typed reason and never connects`() = runTest {
+        val transport = FakeScanTransport(FakeScanConnection())
+        val controller = controllerWith(transport, resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) })
+
+        controller.scan("h1")
+
+        val failed = assertIs<ServiceScanState.Failed>(controller.state)
+        assertEquals(TunnelUnavailable.NoCredential, failed.reason)
+        assertEquals(0, transport.connects)
+    }
+
+    @Test
+    fun `a rejected login is reported with a friendly message`() = runTest {
+        val transport = FakeScanTransport(FakeScanConnection(), connectError = SshAuthenticationException("nope"))
+        val controller = controllerWith(transport)
+
+        controller.scan("h1")
+
+        val failed = assertIs<ServiceScanState.Failed>(controller.state)
+        // Localized from the resource, so the test doesn't depend on the machine locale.
+        assertEquals(getString(Res.string.ptail_err_auth_failed), failed.message)
+    }
+
+    @Test
+    fun `a second scan supersedes the first and never leaks its connection`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val slow = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*", execGate = gate)
+        val transport = FakeScanTransport(slow)
+        val controller = controllerWith(transport)
+
+        controller.scan("h1")
+        assertEquals(ServiceScanState.Scanning, controller.state)
+
+        val fresh = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:80 0.0.0.0:*")
+        transport.connection = fresh
+        controller.scan("h2")
+        gate.complete(Unit) // the superseded scan wakes up after the new one already finished
+
+        assertEquals(listOf(80), assertIs<ServiceScanState.Ready>(controller.state).services.map { it.port })
+        assertTrue(slow.disconnected) // cancelled scan closed its own connection
+    }
+
+    @Test
+    fun `reset cancels an in-flight scan and clears the result`() = runTest {
+        val gate = CompletableDeferred<Unit>()
+        val conn = FakeScanConnection(stdout = "LISTEN 0 128 0.0.0.0:22 0.0.0.0:*", execGate = gate)
+        val controller = controllerWith(FakeScanTransport(conn))
+        controller.scan("h1")
+
+        controller.reset()
+        gate.complete(Unit)
+
+        assertEquals(ServiceScanState.Idle, controller.state)
+        assertTrue(conn.disconnected)
+    }
+}
+
+private class FakeScanTransport(
+    var connection: FakeScanConnection,
+    private val connectError: Throwable? = null,
+) : SshTransport {
+    var connects = 0
+        private set
+
+    override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection {
+        connects++
+        connectError?.let { throw it }
+        return connection
+    }
+}
+
+private class FakeScanConnection(
+    private val stdout: String = "",
+    private val exitCode: Int = 0,
+    private val execError: Throwable? = null,
+    private val execGate: CompletableDeferred<Unit>? = null,
+) : SshConnection {
+    var execCalls = 0
+        private set
+    var disconnected = false
+        private set
+
+    override val isConnected: Boolean get() = !disconnected
+
+    override suspend fun exec(command: String): ExecResult {
+        execCalls++
+        execGate?.await()
+        execError?.let { throw it }
+        return ExecResult(exitCode, stdout, "")
+    }
+
+    override suspend fun openShell(size: PtySize, term: String): ShellChannel = throw UnsupportedOperationException()
+    override suspend fun openSftp(): SftpClient = throw UnsupportedOperationException()
+    override suspend fun forwardLocal(spec: LocalForwardSpec): PortForward = throw UnsupportedOperationException()
+    override suspend fun forwardRemote(spec: RemoteForwardSpec): PortForward = throw UnsupportedOperationException()
+    override suspend fun forwardDynamic(spec: DynamicForwardSpec): PortForward = throw UnsupportedOperationException()
+
+    override suspend fun disconnect() {
+        disconnected = true
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/ServiceScanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/ServiceScanTest.kt
@@ -1,0 +1,220 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.tunnel.Tunnel
+import app.skerry.shared.tunnel.TunnelDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ServiceScanTest {
+
+    private val ssOutput = """
+        State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+        LISTEN 0      4096         127.0.0.1:5432      0.0.0.0:*    users:(("postgres",pid=812,fd=5))
+        LISTEN 0      511            0.0.0.0:80        0.0.0.0:*    users:(("nginx",pid=901,fd=6),("nginx",pid=902,fd=6))
+        LISTEN 0      128            0.0.0.0:22        0.0.0.0:*    users:(("sshd",pid=640,fd=3))
+        LISTEN 0      511               [::]:80           [::]:*    users:(("nginx",pid=901,fd=7))
+    """.trimIndent()
+
+    private val netstatOutput = """
+        Active Internet connections (only servers)
+        Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
+        tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      640/sshd
+        tcp        0      0 127.0.0.1:6379          0.0.0.0:*               LISTEN      733/redis-server
+        tcp6       0      0 :::8080                 :::*                    LISTEN      1204/java
+    """.trimIndent()
+
+    @Test
+    fun `parses ss output into ports with process names`() {
+        val services = parseListeningServices(ssOutput)
+
+        assertEquals(listOf(22, 80, 5432), services.map { it.port })
+        assertEquals(listOf("sshd", "nginx", "postgres"), services.map { it.process })
+    }
+
+    @Test
+    fun `parses netstat output including its ipv6 form`() {
+        val services = parseListeningServices(netstatOutput)
+
+        assertEquals(listOf(22, 6379, 8080), services.map { it.port })
+        assertEquals(listOf("sshd", "redis-server", "java"), services.map { it.process })
+        // ":::8080" is netstat's IPv6 wildcard — the address must not swallow the port.
+        assertEquals("::", services.single { it.port == 8080 }.bindAddress)
+    }
+
+    @Test
+    fun `collapses the same port bound on several addresses and prefers the wildcard`() {
+        // ss lists nginx twice (0.0.0.0:80 and [::]:80) — one row, reachable address kept.
+        val services = parseListeningServices(ssOutput)
+
+        assertEquals(1, services.count { it.port == 80 })
+        assertEquals("0.0.0.0", services.single { it.port == 80 }.bindAddress)
+    }
+
+    @Test
+    fun `keeps a loopback-only service marked as loopback`() {
+        val services = parseListeningServices(ssOutput)
+
+        assertEquals("127.0.0.1", services.single { it.port == 5432 }.bindAddress)
+    }
+
+    @Test
+    fun `keeps a link-local address scoped by an interface name`() {
+        // Zone ids are interface names, so they carry letters outside the hex range an address is
+        // otherwise limited to; rejecting them dropped the whole row silently.
+        val scoped = "LISTEN 0 128 [fe80::1%eth0]:8080 [::]:* users:((\"testsvc\",pid=1,fd=3))"
+
+        val service = parseListeningServices(scoped).single()
+        assertEquals(8080, service.port)
+        assertEquals("fe80::1%eth0", service.bindAddress)
+    }
+
+    @Test
+    fun `the process name follows the address that won, not the row listed first`() {
+        // Two programs can hold the same port on different interfaces: the row describes the
+        // wildcard listener, so it must not be labelled with the other one's name.
+        val contested = """
+            LISTEN 0 128 10.0.0.5:8080 0.0.0.0:* users:(("mgmt-agent",pid=1,fd=3))
+            LISTEN 0 128  0.0.0.0:8080 0.0.0.0:* users:(("real-app",pid=2,fd=3))
+        """.trimIndent()
+
+        val service = parseListeningServices(contested).single()
+        assertEquals("0.0.0.0", service.bindAddress)
+        assertEquals("real-app", service.process)
+    }
+
+    @Test
+    fun `a winning address with no process name borrows the other row's`() {
+        val partial = """
+            LISTEN 0 128 10.0.0.5:8080 0.0.0.0:* users:(("mgmt-agent",pid=1,fd=3))
+            LISTEN 0 128  0.0.0.0:8080 0.0.0.0:*
+        """.trimIndent()
+
+        assertEquals("mgmt-agent", parseListeningServices(partial).single().process)
+    }
+
+    @Test
+    fun `ignores headers, blank lines and rows without a port`() {
+        val noise = """
+
+            State  Recv-Q Send-Q Local Address:Port
+            command not found
+            LISTEN 0      128            0.0.0.0:*         0.0.0.0:*
+        """.trimIndent()
+
+        assertTrue(parseListeningServices(noise).isEmpty())
+    }
+
+    @Test
+    fun `rejects out-of-range ports`() {
+        val bogus = "LISTEN 0 128 0.0.0.0:70000 0.0.0.0:*\nLISTEN 0 128 0.0.0.0:0 0.0.0.0:*"
+
+        assertTrue(parseListeningServices(bogus).isEmpty())
+    }
+
+    @Test
+    fun `caps process names and strips control characters from remote output`() {
+        // A process name is remote text: an escape sequence would repaint the panel, a long one
+        // would push the row off screen.
+        val withEscape = "LISTEN 0 128 0.0.0.0:9000 0.0.0.0:* users:((\"\u001B[31mngin${"x".repeat(200)}\",pid=1,fd=3))"
+
+        val process = parseListeningServices(withEscape).single().process!!
+        assertTrue(process.length <= SERVICE_NAME_MAX_LEN, "process name not capped: ${process.length}")
+        assertTrue(process.none { it.code < 0x20 }, "control characters survived")
+    }
+
+    @Test
+    fun `strips bidi overrides from a process name`() {
+        // The name becomes the saved tunnel's label and syncs onward: a bidi override or a
+        // zero-width space would let a host control how that label reads, not just what it says.
+        val spoofed = "LISTEN 0 128 0.0.0.0:9001 0.0.0.0:* users:((\"nginx\u202Elive\u200B\",pid=1,fd=3))"
+
+        assertEquals("nginxlive", parseListeningServices(spoofed).single().process)
+    }
+
+    @Test
+    fun `caps the number of reported services`() {
+        val many = (1..500).joinToString("\n") { "LISTEN 0 128 0.0.0.0:$it 0.0.0.0:*" }
+
+        assertEquals(SERVICE_SCAN_MAX_ROWS, parseListeningServices(many).size)
+    }
+
+    // Draft built from a discovered service.
+
+    @Test
+    fun `draft forwards a wildcard service through loopback on the same port`() {
+        val service = ListeningService(port = 5432, bindAddress = "0.0.0.0", process = "postgres")
+
+        val draft = serviceTunnelDraft(service, hostId = "h1", fallbackLabel = "port 5432")
+
+        assertEquals(TunnelDirection.Local, draft.direction)
+        assertEquals("h1", draft.hostId)
+        assertEquals("postgres", draft.label)
+        assertEquals("127.0.0.1", draft.bindHost)
+        assertEquals(5432, draft.bindPort)
+        assertEquals("127.0.0.1", draft.destHost)
+        assertEquals(5432, draft.destPort)
+        assertNull(draft.id) // a new tunnel, not an edit
+    }
+
+    @Test
+    fun `draft lets the OS assign the local port for a privileged remote port`() {
+        // Binding 127.0.0.1:80 needs privileges the app does not have; the forward would fail on
+        // exactly the ports discovery surfaces most often.
+        val service = ListeningService(port = 80, bindAddress = "0.0.0.0", process = "nginx")
+
+        val draft = serviceTunnelDraft(service, hostId = "h1", fallbackLabel = "port 80")
+
+        assertEquals(0, draft.bindPort)
+        assertEquals(80, draft.destPort) // the remote side is untouched
+    }
+
+    @Test
+    fun `draft mirrors an unprivileged remote port locally`() {
+        val service = ListeningService(port = 1024, bindAddress = "0.0.0.0", process = null)
+
+        assertEquals(1024, serviceTunnelDraft(service, hostId = "h1", fallbackLabel = "port 1024").bindPort)
+    }
+
+    @Test
+    fun `draft keeps a specific bind address as the destination`() {
+        // Bound to one interface only: loopback would not reach it from the server's side.
+        val service = ListeningService(port = 8086, bindAddress = "10.0.0.5", process = null)
+
+        val draft = serviceTunnelDraft(service, hostId = "h1", fallbackLabel = "port 8086")
+
+        assertEquals("10.0.0.5", draft.destHost)
+        assertEquals("port 8086", draft.label) // no process name — caller's localized fallback
+    }
+
+    @Test
+    fun `draft routes an ipv6 wildcard service through ipv6 loopback`() {
+        val service = ListeningService(port = 8080, bindAddress = "::", process = "java")
+
+        val draft = serviceTunnelDraft(service, hostId = "h1", fallbackLabel = "port 8080")
+
+        assertEquals("::1", draft.destHost)
+    }
+
+    // Which discovered services already have a saved tunnel.
+
+    @Test
+    fun `reports ports already forwarded for the scanned host only`() {
+        val saved = listOf(
+            tunnelOf("a", hostId = "h1", direction = TunnelDirection.Local, destPort = 5432),
+            tunnelOf("b", hostId = "h2", direction = TunnelDirection.Local, destPort = 6379),
+            tunnelOf("c", hostId = "h1", direction = TunnelDirection.Remote, destPort = 9000),
+            tunnelOf("d", hostId = "h1", direction = TunnelDirection.Dynamic, destPort = null),
+        )
+
+        // Only local forwards of the scanned host count: a remote forward goes the other way.
+        assertEquals(setOf(5432), forwardedPorts(saved, hostId = "h1"))
+    }
+}
+
+private fun tunnelOf(id: String, hostId: String, direction: TunnelDirection, destPort: Int?) = Tunnel(
+    id = id, label = id, hostId = hostId, direction = direction,
+    bindHost = "127.0.0.1", bindPort = destPort ?: 1080,
+    destHost = destPort?.let { "127.0.0.1" }, destPort = destPort,
+)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelBrowserLinkTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelBrowserLinkTest.kt
@@ -1,0 +1,77 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.tunnel.TunnelDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class TunnelBrowserLinkTest {
+
+    private fun url(
+        direction: TunnelDirection = TunnelDirection.Local,
+        bindHost: String = "127.0.0.1",
+        port: Int = 8080,
+    ) = localForwardUrl(direction, bindHost, port)
+
+    @Test
+    fun `local forward opens on its bound port over http`() {
+        assertEquals("http://127.0.0.1:8080", url())
+    }
+
+    @Test
+    fun `a wildcard bind address is browsed through loopback`() {
+        // 0.0.0.0 is a listen address, not something a browser can connect to.
+        assertEquals("http://127.0.0.1:9000", url(bindHost = "0.0.0.0", port = 9000))
+        assertEquals("http://127.0.0.1:9000", url(bindHost = "", port = 9000))
+        assertEquals("http://[::1]:9000", url(bindHost = "::", port = 9000))
+    }
+
+    @Test
+    fun `ipv6 literals are bracketed`() {
+        assertEquals("http://[::1]:3000", url(bindHost = "::1", port = 3000))
+    }
+
+    @Test
+    fun `tls ports get the https scheme`() {
+        assertEquals("https://127.0.0.1:443", url(port = 443))
+        assertEquals("https://127.0.0.1:8443", url(port = 8443))
+    }
+
+    @Test
+    fun `remote and dynamic forwards have nothing to open`() {
+        // -R listens on the server; -D is a SOCKS proxy, not an http endpoint.
+        assertNull(url(direction = TunnelDirection.Remote))
+        assertNull(url(direction = TunnelDirection.Dynamic))
+    }
+
+    @Test
+    fun `a port that was never bound has no link`() {
+        assertNull(url(port = 0))
+        assertNull(url(port = 70000))
+    }
+
+    @Test
+    fun `a bind address that would break the url is refused`() {
+        // bindHost is free-form user input; anything that doesn't survive the link gate is dropped
+        // rather than handed to the system browser.
+        assertNull(url(bindHost = "127.0.0.1 evil"))
+        assertNull(url(bindHost = "host\nname"))
+        assertNull(url(bindHost = "a/b"))
+    }
+
+    @Test
+    fun `an entry only offers a link while it is active`() {
+        val entry = TunnelEntry(
+            app.skerry.shared.tunnel.Tunnel(
+                id = "t1", label = "web", hostId = "h1", direction = TunnelDirection.Local,
+                bindHost = "127.0.0.1", bindPort = 0, destHost = "10.0.0.5", destPort = 80,
+            ),
+        )
+
+        assertNull(tunnelBrowserUrl(entry))
+
+        // Bound port, not the requested one: 0 means "assigned by the OS".
+        entry.status = TunnelStatus.Active(50123)
+        assertEquals("http://127.0.0.1:50123", tunnelBrowserUrl(entry))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
@@ -73,7 +73,7 @@ class TunnelFormTest {
     @Test
     fun `resolve returns Ready with target and auth`() {
         val r = assertIs<TunnelResolution.Ready>(
-            resolveTunnel(tunnel, findHost = { host }, findCredential = { credential }),
+            resolveTunnelHost(tunnel.hostId, findHost = { host }, findCredential = { credential }),
         )
         assertEquals("10.0.0.5", r.target.host)
         assertEquals("deploy", r.target.username)
@@ -83,7 +83,7 @@ class TunnelFormTest {
     @Test
     fun `resolve reports missing host`() {
         val r = assertIs<TunnelResolution.Unavailable>(
-            resolveTunnel(tunnel, findHost = { null }, findCredential = { credential }),
+            resolveTunnelHost(tunnel.hostId, findHost = { null }, findCredential = { credential }),
         )
         assertEquals(TunnelUnavailable.HostNotFound, r.reason)
     }
@@ -91,7 +91,7 @@ class TunnelFormTest {
     @Test
     fun `resolve reports missing credential`() {
         val r = assertIs<TunnelResolution.Unavailable>(
-            resolveTunnel(tunnel, findHost = { host }, findCredential = { null }),
+            resolveTunnelHost(tunnel.hostId, findHost = { host }, findCredential = { null }),
         )
         assertEquals(TunnelUnavailable.NoCredential, r.reason)
     }
@@ -106,7 +106,7 @@ class TunnelFormTest {
             "c2" to Credential("c2", "gate@bastion", CredentialSecret.Password("jump-pw")),
         )
         val r = assertIs<TunnelResolution.Ready>(
-            resolveTunnel(tunnel, findHost = { hosts[it] }, findCredential = { creds[it] }),
+            resolveTunnelHost(tunnel.hostId, findHost = { hosts[it] }, findCredential = { creds[it] }),
         )
         assertEquals("bastion.example.com", r.target.jump?.host)
         assertEquals("gate", r.target.jump?.username)
@@ -118,7 +118,7 @@ class TunnelFormTest {
         val jumped = host.copy(jumpHostId = "j1")
         val hosts = mapOf("h1" to jumped, "j1" to bastion)
         val r = assertIs<TunnelResolution.Unavailable>(
-            resolveTunnel(tunnel, findHost = { hosts[it] }, findCredential = { if (it == "c1") credential else null }),
+            resolveTunnelHost(tunnel.hostId, findHost = { hosts[it] }, findCredential = { if (it == "c1") credential else null }),
         )
         assertEquals(TunnelUnavailable.Jump(JumpChainProblem.NO_CREDENTIAL), r.reason)
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
@@ -41,7 +41,7 @@ class TunnelManagerTest {
     private fun managerWith(
         transport: SshTransport,
         store: TunnelStore = FakeTunnelStore(),
-        resolve: (Tunnel) -> TunnelResolution = { TunnelResolution.Ready(target, auth) },
+        resolve: (String) -> TunnelResolution = { TunnelResolution.Ready(target, auth) },
         ids: List<String> = List(20) { "id-$it" },
     ): TunnelManager {
         val scope = TestScope(UnconfinedTestDispatcher())
@@ -220,6 +220,20 @@ class TunnelManagerTest {
         manager.closeAll()
 
         assertTrue(manager.tunnels.all { it.status == TunnelStatus.Inactive })
+    }
+
+    @Test
+    fun `closeAll also drops the service scan`() = runTest {
+        // closeAll is what a vault lock calls: a scan result left behind would keep listing a host's
+        // services behind the lock screen, and an in-flight one holds a connection opened with the
+        // decrypted secret.
+        val manager = managerWith(FakeTunnelTransport(FakeTunnelConnection(localPort = 50040)))
+        manager.services.scan("h1")
+
+        manager.closeAll()
+
+        assertEquals(ServiceScanState.Idle, manager.services.state)
+        assertNull(manager.services.scannedHostId)
     }
 
     @Test

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -27,6 +27,13 @@ import app.skerry.shared.ssh.KnownHostsStore
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.tunnel.Tunnel
+import app.skerry.shared.tunnel.TunnelDirection
+import app.skerry.shared.tunnel.TunnelStore
+import app.skerry.ui.tunnel.SERVICE_SCAN_COMMAND
+import app.skerry.ui.tunnel.TunnelManager
+import app.skerry.ui.tunnel.TunnelResolution
+import app.skerry.ui.tunnel.TunnelUnavailable
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
 import app.skerry.shared.vault.SshjCertificateInspector
 import app.skerry.shared.vault.CredentialStore
@@ -147,6 +154,7 @@ fun main() {
         sessions?.setActiveView(SessionView.Sftp)
     }
     val knownHosts = if (live) seededKnownHosts() else null
+    val tunnels = if (live && hosts != null) seededTunnels(hosts) else null
     val ai = if (live) seededAi() else null
     // Built once outside the content lambda: recomposition must not recreate the controller
     // (a fresh instance would restart its async check and the notice would never settle).
@@ -167,7 +175,7 @@ fun main() {
         "unlock" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopUnlockScreen(error = null, canUseBiometric = true, onUnlock = {}, onBiometric = {}, onForgotPassword = {}) } } } }
         "corrupted" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopCorruptedScreen(onReset = {}) } } } }
         "reset" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopResetScreen(onConfirm = {}, onCancel = {}) } } } }
-        else -> { { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, certificateInspector = certificateInspector, ai = ai, updates = updates, windowChrome = windowChrome) } }
+        else -> { { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, ai = ai, updates = updates, windowChrome = windowChrome) } }
     }
 
     val scene = ImageComposeScene(width = 1280, height = 820, density = Density(1f)) {
@@ -209,7 +217,7 @@ private fun renderMobile(out: String, viewName: String, overlay: String, live: B
     // Key generator/inspector: the Vault tab uses it to compute fingerprints of seeded keys in live mode.
     val keyGenerator = if (live) BouncyCastleSshKeyGenerator() else null
     val deps = if (hosts != null) {
-        AppDependencies(hosts = hosts, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator)
+        AppDependencies(hosts = hosts, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, tunnels = seededTunnels(hosts))
     } else {
         AppDependencies()
     }
@@ -391,6 +399,47 @@ private class InMemoryVault : Vault {
 }
 
 /**
+ * Tunnel manager over an in-memory store and the fake transport, so the offscreen Ports render
+ * shows the live table (one active forward with its browser link) and a real service scan against
+ * [FakeSshConnection]'s canned `ss` output.
+ */
+private fun seededTunnels(hosts: HostManagerController): TunnelManager {
+    val store = object : TunnelStore {
+        private val entries = mutableListOf<Tunnel>()
+        override fun all(): List<Tunnel> = entries.toList()
+        override fun put(tunnel: Tunnel) {
+            val i = entries.indexOfFirst { it.id == tunnel.id }
+            if (i >= 0) entries[i] = tunnel else entries += tunnel
+        }
+        override fun remove(id: String) { entries.removeAll { it.id == id } }
+    }
+    val hostIds = hosts.hosts.map { it.id }
+    fun hostAt(i: Int) = hostIds.getOrElse(i) { hostIds.first() }
+    store.put(Tunnel("t1", "web tunnel", hostAt(0), TunnelDirection.Local, "127.0.0.1", 8080, "10.0.0.5", 80))
+    store.put(Tunnel("t2", "app callback", hostAt(1), TunnelDirection.Remote, "0.0.0.0", 9000, "localhost", 3000))
+    store.put(Tunnel("t3", "socks", hostAt(2), TunnelDirection.Dynamic, "127.0.0.1", 1080, null, null))
+    var next = 0
+    val manager = TunnelManager(
+        store = store,
+        transport = fakeTransport(),
+        resolve = { hostId ->
+            val host = hosts.find(hostId)
+            if (host == null) {
+                TunnelResolution.Unavailable(TunnelUnavailable.HostNotFound)
+            } else {
+                TunnelResolution.Ready(host.toTarget(), SshAuth.Password("demo"))
+            }
+        },
+        scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    ) { "seed-${next++}" }
+    manager.activate("t1")
+    // -Dskerry.screenshot.portsScan=true renders the Services panel instead of the tunnel editor
+    // (the offscreen scene can't press Find services / Scan itself).
+    if (System.getProperty("skerry.screenshot.portsScan", "false").toBoolean()) manager.services.scan(hostAt(0))
+    return manager
+}
+
+/**
  * Known-hosts manager with demo keys and one unresolved key-change event, so the offscreen render
  * shows a live table (firstSeen/Verified), a warning, and a fingerprint comparison panel with real
  * components ([KnownHostsController] -> [KnownHostsView]). In-memory, no files.
@@ -523,6 +572,15 @@ private fun seededSessions(hosts: HostManagerController): SessionsController {
     return sessions
 }
 
+private val SEEDED_SS_OUTPUT = """
+    State  Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+    LISTEN 0      128            0.0.0.0:22        0.0.0.0:*    users:(("sshd",pid=640,fd=3))
+    LISTEN 0      511            0.0.0.0:80        0.0.0.0:*    users:(("nginx",pid=901,fd=6))
+    LISTEN 0      4096         127.0.0.1:5432      0.0.0.0:*    users:(("postgres",pid=812,fd=5))
+    LISTEN 0      511          127.0.0.1:6379      0.0.0.0:*    users:(("redis-server",pid=733,fd=7))
+    LISTEN 0      128             0.0.0.0:8080     0.0.0.0:*    users:(("java",pid=1204,fd=41))
+""".trimIndent()
+
 /** Fake SSH transport: the shell emits a canned banner+listing, then hangs until cancelled. */
 private fun fakeTransport(): SshTransport = object : SshTransport {
     override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection = FakeConnection(target)
@@ -539,6 +597,9 @@ private class FakeConnection(private val target: SshTarget) : SshConnection {
     private var polls = 0
 
     override suspend fun exec(command: String): ExecResult {
+        // Service discovery asks a different question than the metrics poll; answer it with canned
+        // `ss -ltnp` output so the offscreen Ports render shows a real scan result.
+        if (command == SERVICE_SCAN_COMMAND) return ExecResult(0, SEEDED_SS_OUTPUT, "")
         val tick = polls++
         return ExecResult(
             exitCode = 0,

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -68,7 +68,7 @@ import app.skerry.ui.terminal.TerminalCursorStyle
 import app.skerry.ui.terminal.TerminalFont
 import app.skerry.ui.terminal.TerminalThemes
 import app.skerry.ui.tunnel.TunnelManager
-import app.skerry.ui.tunnel.resolveTunnel
+import app.skerry.ui.tunnel.resolveTunnelHost
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.ui.vault.ResetScope
 import kotlinx.coroutines.CoroutineScope
@@ -259,7 +259,7 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val tunnels = TunnelManager(
         store = VaultTunnelStore(vault),
         transport = tunnelTransport,
-        resolve = { resolveTunnel(it, findHost = hosts::find, findCredential = credentials::find) },
+        resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::find) },
         scope = tunnelScope,
     ) { UUID.randomUUID().toString() }
     // Saved snippets: the command library is SNIPPET records in the vault (commands may contain


### PR DESCRIPTION
Closes the "Services" item from the tunnel-panel plan: port forwarding stops being a form you fill in from memory.

## What this adds

**Service discovery.** Pick a saved host, scan it for listening TCP ports, forward one in a tap (saved and raised right away). One exec round-trip — `ss`, falling back to `netstat` — on a connection dialled the same way tunnels are (host, secret and ProxyJump chain from the vault), because the panel is global and the host usually has no open session to borrow from. Ports that already have a forward are marked instead of offered twice.

**Browser link.** An active local forward gets an "open in browser" action. A wildcard listen address is browsed through loopback (`0.0.0.0` is where a listener binds, not somewhere a browser can connect), TLS ports get `https`, and the URL passes the same gate as terminal hyperlinks. `-R` listens on the server and `-D` is a SOCKS proxy, so neither offers one.

Desktop and Android at parity: a panel beside the tunnel table, a bottom sheet on the phone.

## Honest edges

- **Untrusted input.** Scan output is remote text. Addresses are restricted to literals before they can reach a tunnel's destination; process names — which become the saved tunnel's label and sync onward — are stripped of control *and* format characters (a bidi override would let a host control how the label reads) and capped.
- **Privileged ports.** Discovery mostly surfaces 22/80/443. Mirroring those locally would fail on permissions, so a privileged remote port binds to an OS-assigned local port; the real one shows up in the row once the forward is up.
- **Verdicts, not silence.** A transport with no command channel (telnet, serial) says so. So does a host where every branch of the command failed — a BSD `netstat` has no `-l`, and claiming "nothing is listening" there would be a lie. Actual BSD support needs a second parser (its addresses use a dot before the port) and is not in this PR.
- **`netstat` truncation.** net-tools cuts the address column to a fixed width by default, which can slice into the port digits of a long IPv6 address, so `-W` is tried first; older builds fall through.

## Second commit: vault lock

Reviewing the above turned up that locking only tore down tunnels on the *manual* lock. Background and idle auto-lock call the gate controller directly and never reached that code, so an idle auto-lock left tunnels running on both platforms — and Android had no wrapper at all, so even a deliberate "Lock Skerry" left them up. The teardown moved into `VaultGate`, which every lock path goes through, shared by both platforms. Pre-existing, not introduced here, but the scan adds another live-connection surface on top of it.

## Verification

- 1127 tests green (28 new); desktop and Android debug APK build
- Both platforms checked visually via the offscreen renderer — the tunnel table with its browser link, the services panel, and the mobile card and sheet
- Reviewed by three passes: security/correctness, parser behaviour against real `ss`/`netstat`/BusyBox formats, and DI/lifecycle. Every finding is fixed in this branch
- **Not verified by eye:** the lock scenario itself — the offscreen renderer cannot reproduce it

🤖 Generated with [Claude Code](https://claude.com/claude-code)