### PR TITLE
Built-in SSH agent with forwarding into sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ Building it yourself is also easy — see [Building from source](#building-from-
 
 ## Features
 
-- **Connections** — SSH with jump hosts (ProxyJump) and SSH certificates; SFTP (dual-pane
+- **Connections** — SSH with jump hosts (ProxyJump) and SSH certificates; built-in SSH agent
+  with per-host forwarding (and `SSH_AUTH_SOCK` for local tools on desktop); SFTP (dual-pane
   commander); port forwarding: local, remote, dynamic/SOCKS; Telnet; serial (desktop and
   Android USB-OTG).
 - **Terminal** — custom grid emulation, session tabs with split view, SSH auto-reconnect,

--- a/README.ru.md
+++ b/README.ru.md
@@ -96,7 +96,8 @@ macOS)** и **Android**, паритет фич между платформами
 
 ## Возможности
 
-- **Подключения** — SSH с jump-хостами (ProxyJump) и SSH-сертификатами; SFTP (двухпанельный
+- **Подключения** — SSH с jump-хостами (ProxyJump) и SSH-сертификатами; встроенный SSH-агент
+  с пробросом по хостам (и `SSH_AUTH_SOCK` для локальных утилит на десктопе); SFTP (двухпанельный
   commander); port forwarding: local, remote, dynamic/SOCKS; Telnet; serial (desktop и
   Android USB-OTG).
 - **Терминал** — своя grid-эмуляция, вкладки со split view, авто-реконнект SSH, поиск по

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -17,6 +17,9 @@ import app.skerry.shared.ssh.FileHostKeyMismatchStore
 import app.skerry.shared.ssh.VaultKnownHostsStore
 import app.skerry.shared.ssh.ProbeHostKeyVerifier
 import app.skerry.shared.ssh.RoutingTransport
+import app.skerry.shared.agent.SshAgentActivityLog
+import app.skerry.shared.agent.SshAgentService
+import app.skerry.shared.agent.SshjAgentKeys
 import app.skerry.shared.ssh.SshjTransport
 import app.skerry.shared.ssh.TofuHostKeyVerifier
 import app.skerry.shared.snippet.VaultSnippetStore
@@ -228,6 +231,17 @@ class MainActivity : FragmentActivity() {
      * OSC 52 server clipboard-write gate (More → Appearance → Terminal): "true"/"false" in
      * `terminal_clipboard_write`. Missing/unreadable → false (off by default). Best-effort, off the UI thread.
      */
+    /** Master switch of the built-in SSH agent (per device, like the desktop pref). */
+    private fun readAgentEnabled(dir: File): Boolean = runCatching {
+        File(dir, "ssh_agent").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeAgentEnabled(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "ssh_agent").writeText(enabled.toString()) }
+        }
+    }
+
     private fun readClipboardWrite(dir: File): Boolean = runCatching {
         File(dir, "terminal_clipboard_write").readText().trim().toBoolean()
     }.getOrDefault(false)
@@ -330,10 +344,28 @@ class MainActivity : FragmentActivity() {
         val mismatchStore = FileHostKeyMismatchStore(dir.resolve("known_hosts_mismatches").toPath())
         // Live session transport: routes by connection type (SSH/Telnet/Serial). SSH carries the
         // TOFU verifier/known-hosts; Telnet/Serial are stateless (serial unsupported on Android).
+        // Built-in SSH agent: the service is wired into the session transport (and only that one —
+        // the tunnel/probe transport below must never expose keys), while its keys come from the
+        // controller assembled a few lines down, hence the var (same pattern as teamsForSync).
+        var sshAgentController: app.skerry.ui.agent.SshAgentController? = null
+        val agentKeys = SshjAgentKeys({ sshAgentController?.keyMaterial().orEmpty() })
+        val agentService = SshAgentService(agentKeys) { usage -> sshAgentController?.record(usage) }
         val transport = RoutingTransport(
             ssh = SshjTransport(
                 TofuHostKeyVerifier(knownHostsStore, mismatchStore) { Instant.now().toString() },
+                agent = agentService,
             ),
+        )
+        // Android has no SSH_AUTH_SOCK to expose (no local programs to serve), so the agent here is
+        // forwarding-only: socket = null hides that row and the controller never starts a listener.
+        sshAgentController = app.skerry.ui.agent.SshAgentController(
+            credentials = credentials,
+            isVaultUnlocked = { vault.isUnlocked },
+            socket = null,
+            dropParsedKeys = agentKeys::clear,
+            activityLog = SshAgentActivityLog(clock = { Instant.now().toString() }),
+            initialEnabled = readAgentEnabled(dir),
+            persistEnabled = { writeAgentEnabled(dir, it) },
         )
         val knownHosts = KnownHostsController(knownHostsStore, mismatchStore) { Instant.now().toString() }
         // Host profiles are HOST records in the vault; tree order lives in a layout record. The vault
@@ -440,6 +472,8 @@ class MainActivity : FragmentActivity() {
             tunnels.reload()
             knownHosts.refresh()
             sync.restoreSession()
+            // The agent's keys are vault secrets: it only starts offering them once the vault opens.
+            sshAgentController.onVaultUnlocked()
         }
         // Clears data outside the vault on reset. The vault file is already wiped and locked, so
         // credentials aren't touched here (secrets reload when a new vault is created). Host
@@ -447,6 +481,8 @@ class MainActivity : FragmentActivity() {
         // clears non-vault data and reflects the now-empty vault in the managers.
         onVaultReset = { resetScope ->
             tunnels.closeAll()
+            // The keys the agent was offering were erased with the vault; forget them.
+            sshAgentController.onVaultLocked()
             // Team keys lived in the wiped vault; team vaults can no longer be opened, so lock their in-memory trace.
             teams.lock()
             // Reset wiped the dataKey, so the biometric artifact (`vault.bio`) and the sealed sync
@@ -471,6 +507,7 @@ class MainActivity : FragmentActivity() {
                 writeClipboardWrite(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)
+                writeAgentEnabled(dir, false)
             }
             hosts.reload()
             snippets.reload()
@@ -504,6 +541,7 @@ class MainActivity : FragmentActivity() {
             teams = teams,
             securityLog = securityLog,
             localAi = localAi,
+            sshAgent = sshAgentController,
         )
     }
 

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -231,14 +231,14 @@ class MainActivity : FragmentActivity() {
      * OSC 52 server clipboard-write gate (More → Appearance → Terminal): "true"/"false" in
      * `terminal_clipboard_write`. Missing/unreadable → false (off by default). Best-effort, off the UI thread.
      */
-    /** Master switch of the built-in SSH agent (per device, like the desktop pref). */
-    private fun readAgentEnabled(dir: File): Boolean = runCatching {
-        File(dir, "ssh_agent").readText().trim().toBoolean()
+    /** Per-device switches of the built-in SSH agent, one file each (like the desktop prefs). */
+    private fun readAgentFlag(dir: File, name: String): Boolean = runCatching {
+        File(dir, name).readText().trim().toBoolean()
     }.getOrDefault(false)
 
-    private fun writeAgentEnabled(dir: File, enabled: Boolean) {
+    private fun writeAgentFlag(dir: File, name: String, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
-            runCatching { File(dir, "ssh_agent").writeText(enabled.toString()) }
+            runCatching { File(dir, name).writeText(enabled.toString()) }
         }
     }
 
@@ -349,7 +349,12 @@ class MainActivity : FragmentActivity() {
         // controller assembled a few lines down, hence the var (same pattern as teamsForSync).
         var sshAgentController: app.skerry.ui.agent.SshAgentController? = null
         val agentKeys = SshjAgentKeys({ sshAgentController?.keyMaterial().orEmpty() })
-        val agentService = SshAgentService(agentKeys) { usage -> sshAgentController?.record(usage) }
+        // No controller yet (or one that says no) means no signature: at that point the agent holds
+        // no keys either, so refusing is the honest answer.
+        val agentService = SshAgentService(
+            agentKeys,
+            confirm = { prompt -> sshAgentController?.confirmSignature(prompt) == true },
+        ) { usage -> sshAgentController?.record(usage) }
         val transport = RoutingTransport(
             ssh = SshjTransport(
                 TofuHostKeyVerifier(knownHostsStore, mismatchStore) { Instant.now().toString() },
@@ -364,8 +369,10 @@ class MainActivity : FragmentActivity() {
             socket = null,
             dropParsedKeys = agentKeys::clear,
             activityLog = SshAgentActivityLog(clock = { Instant.now().toString() }),
-            initialEnabled = readAgentEnabled(dir),
-            persistEnabled = { writeAgentEnabled(dir, it) },
+            initialEnabled = readAgentFlag(dir, "ssh_agent"),
+            persistEnabled = { writeAgentFlag(dir, "ssh_agent", it) },
+            initialConfirmSignatures = readAgentFlag(dir, "ssh_agent_confirm"),
+            persistConfirmSignatures = { writeAgentFlag(dir, "ssh_agent_confirm", it) },
         )
         val knownHosts = KnownHostsController(knownHostsStore, mismatchStore) { Instant.now().toString() }
         // Host profiles are HOST records in the vault; tree order lives in a layout record. The vault
@@ -507,7 +514,8 @@ class MainActivity : FragmentActivity() {
                 writeClipboardWrite(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)
-                writeAgentEnabled(dir, false)
+                writeAgentFlag(dir, "ssh_agent", false)
+                writeAgentFlag(dir, "ssh_agent_confirm", false)
             }
             hosts.reload()
             snippets.reload()

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
@@ -10,7 +10,7 @@
     <string name="agent_key_certificate">Сертификат</string>
     <string name="agent_socket">Сокет агента</string>
     <string name="agent_socket_desc">Обслуживать локальные программы (ssh, git, scp) через SSH_AUTH_SOCK.</string>
-    <string name="agent_socket_hint">Выполните в своей оболочке:</string>
+    <string name="agent_socket_hint">Укажите в SSH_AUTH_SOCK:</string>
     <string name="agent_socket_copy">Копировать</string>
     <string name="agent_socket_failed">Не удалось открыть сокет. Проверьте, доступен ли каталог конфигурации для записи.</string>
     <string name="agent_socket_unsupported">В этой системе нет unix-сокетов с доступом только для владельца, поэтому сокет агента недоступен.</string>
@@ -20,11 +20,13 @@
     <string name="agent_activity_listed">Запрошен список ключей</string>
     <string name="agent_activity_signed">Подпись</string>
     <string name="agent_activity_refused">Отказано</string>
-    <string name="agent_activity_denied">Сервер отклонил форвардинг</string>
+    <string name="agent_activity_denied">Сервер отклонил проброс агента</string>
     <string name="agent_origin_session">сессия к %1$s</string>
     <string name="agent_origin_socket">локальная программа</string>
     <string name="agent_more_on">Включён</string>
     <string name="agent_more_off">Выключен</string>
     <string name="agent_socket_section">ЛОКАЛЬНЫЙ ДОСТУП</string>
     <string name="agent_subtitle_mobile">Ключи остаются в хранилище, а сессия получает подпись, но не сам ключ.</string>
+    <string name="agent_socket_needs_agent">Включите агента выше, чтобы обслуживать локальные программы.</string>
+    <string name="agent_no_keys">В агенте нет ключей — добавьте ниже</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
@@ -1,0 +1,30 @@
+<resources>
+    <!-- Built-in SSH agent (AgentSection.kt · MobileAgentView.kt) -->
+    <string name="agent_title">SSH-агент</string>
+    <string name="agent_subtitle">Ключи остаются в хранилище, а сессия — или другая программа на этой машине — получает подпись, но не сам ключ.</string>
+    <string name="agent_enable">Включить агента</string>
+    <string name="agent_enable_desc">Когда выключен, агент везде отвечает пустым списком ключей.</string>
+    <string name="agent_keys">КЛЮЧИ В АГЕНТЕ</string>
+    <string name="agent_keys_empty">В связке пока нет ключей. Добавьте приватный ключ или сертификат в разделе «Хранилище».</string>
+    <string name="agent_key_private">Приватный ключ</string>
+    <string name="agent_key_certificate">Сертификат</string>
+    <string name="agent_socket">Сокет агента</string>
+    <string name="agent_socket_desc">Обслуживать локальные программы (ssh, git, scp) через SSH_AUTH_SOCK.</string>
+    <string name="agent_socket_hint">Выполните в своей оболочке:</string>
+    <string name="agent_socket_copy">Копировать</string>
+    <string name="agent_socket_failed">Не удалось открыть сокет. Проверьте, доступен ли каталог конфигурации для записи.</string>
+    <string name="agent_socket_unsupported">В этой системе нет unix-сокетов с доступом только для владельца, поэтому сокет агента недоступен.</string>
+    <string name="agent_activity">ПОСЛЕДНИЕ ОБРАЩЕНИЯ</string>
+    <string name="agent_activity_none">К агенту ещё не обращались.</string>
+    <string name="agent_activity_line">%1$s · %2$s · %3$s</string>
+    <string name="agent_activity_listed">Запрошен список ключей</string>
+    <string name="agent_activity_signed">Подпись</string>
+    <string name="agent_activity_refused">Отказано</string>
+    <string name="agent_activity_denied">Сервер отклонил форвардинг</string>
+    <string name="agent_origin_session">сессия к %1$s</string>
+    <string name="agent_origin_socket">локальная программа</string>
+    <string name="agent_more_on">Включён</string>
+    <string name="agent_more_off">Выключен</string>
+    <string name="agent_socket_section">ЛОКАЛЬНЫЙ ДОСТУП</string>
+    <string name="agent_subtitle_mobile">Ключи остаются в хранилище, а сессия получает подпись, но не сам ключ.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
@@ -29,4 +29,12 @@
     <string name="agent_subtitle_mobile">Ключи остаются в хранилище, а сессия получает подпись, но не сам ключ.</string>
     <string name="agent_socket_needs_agent">Включите агента выше, чтобы обслуживать локальные программы.</string>
     <string name="agent_no_keys">В агенте нет ключей — добавьте ниже</string>
+    <string name="agent_confirm">Подтверждать каждую подпись</string>
+    <string name="agent_confirm_desc">Спрашивать перед каждым использованием ключа, как ssh-agent -c. Запросы без ответа отклоняются.</string>
+    <string name="agent_activity_declined">Вы отклонили</string>
+    <string name="agent_prompt_title">Разрешить подпись?</string>
+    <string name="agent_prompt_body">%1$s просит подписать ключом «%2$s».</string>
+    <string name="agent_prompt_hint">Без ответа в течение двух минут запрос будет отклонён.</string>
+    <string name="agent_prompt_allow">Разрешить один раз</string>
+    <string name="agent_prompt_deny">Отклонить</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -17,8 +17,8 @@
     <string name="conn_field_tags">Теги</string>
     <string name="conn_field_jump_host">Прыжковый хост</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
-    <string name="conn_field_forward_agent">Форвардинг агента</string>
-    <string name="conn_forward_agent_desc">Разрешить этому хосту пользоваться ключами SSH-агента</string>
+    <string name="conn_field_forward_agent">Проброс агента</string>
+    <string name="conn_forward_agent_desc">Чтобы ssh/git на этом хосте прыгали дальше ключом, который остаётся здесь</string>
     <string name="conn_forward_agent_off">SSH-агент выключен — включите его в настройках</string>
     <string name="conn_field_ai_policy">Политика AI для этого подключения</string>
     <string name="conn_field_ai_policy_short">Политика AI</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -17,6 +17,9 @@
     <string name="conn_field_tags">Теги</string>
     <string name="conn_field_jump_host">Прыжковый хост</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
+    <string name="conn_field_forward_agent">Форвардинг агента</string>
+    <string name="conn_forward_agent_desc">Разрешить этому хосту пользоваться ключами SSH-агента</string>
+    <string name="conn_forward_agent_off">SSH-агент выключен — включите его в настройках</string>
     <string name="conn_field_ai_policy">Политика AI для этого подключения</string>
     <string name="conn_field_ai_policy_short">Политика AI</string>
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
@@ -3,6 +3,7 @@
     <string name="shtail_nav_ai">AI</string>
     <string name="shtail_nav_sync">Синхронизация</string>
     <string name="shtail_nav_security">Безопасность</string>
+    <string name="shtail_nav_agent">SSH-агент</string>
     <string name="shtail_nav_appearance">Оформление</string>
     <string name="shtail_nav_terminal">Терминал</string>
     <string name="shtail_nav_keyboard">Клавиатура</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -112,4 +112,7 @@
     <string name="term_broadcast_none">Нет подключённых сессий</string>
     <string name="term_broadcast_selected">Выбрано %1$s из %2$s</string>
     <string name="term_broadcast_sent">Отправлено: %1$s</string>
+    <string name="term_info_agent">Агент</string>
+    <string name="term_agent_active">проброшен</string>
+    <string name="term_agent_refused">сервер отклонил</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -113,4 +113,5 @@
     <string name="vault_reset_scope_everything_subtitle">Также удалить профили хостов, known_hosts и настройки.</string>
     <string name="vault_reset_confirm_label">Впишите %1$s для подтверждения</string>
     <string name="vault_reset_confirm_button">Сбросить безвозвратно</string>
+    <string name="vault_badge_agent">в агенте</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
@@ -10,7 +10,7 @@
     <string name="agent_key_certificate">证书</string>
     <string name="agent_socket">代理套接字</string>
     <string name="agent_socket_desc">通过 SSH_AUTH_SOCK 为本地程序（ssh、git、scp）提供服务。</string>
-    <string name="agent_socket_hint">在你的 shell 中执行：</string>
+    <string name="agent_socket_hint">将 SSH_AUTH_SOCK 指向：</string>
     <string name="agent_socket_copy">复制</string>
     <string name="agent_socket_failed">无法打开套接字。请检查配置目录是否可写。</string>
     <string name="agent_socket_unsupported">此系统不支持仅所有者可访问的 unix 套接字，因此代理套接字不可用。</string>
@@ -27,4 +27,6 @@
     <string name="agent_more_off">已关闭</string>
     <string name="agent_socket_section">本地访问</string>
     <string name="agent_subtitle_mobile">密钥留在保险库中，会话只获得签名，而不会拿到密钥本身。</string>
+    <string name="agent_socket_needs_agent">请先在上方启用代理，才能为本地程序提供服务。</string>
+    <string name="agent_no_keys">代理中没有密钥 — 请在下方添加</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
@@ -1,0 +1,30 @@
+<resources>
+    <!-- Built-in SSH agent (AgentSection.kt · MobileAgentView.kt) -->
+    <string name="agent_title">SSH 代理</string>
+    <string name="agent_subtitle">密钥留在保险库中，会话或本机上的其他程序只获得签名，而不会拿到密钥本身。</string>
+    <string name="agent_enable">启用代理</string>
+    <string name="agent_enable_desc">关闭时，代理在任何地方都返回空的密钥列表。</string>
+    <string name="agent_keys">代理中的密钥</string>
+    <string name="agent_keys_empty">密钥串中还没有密钥。请在「保险库」中添加私钥或证书。</string>
+    <string name="agent_key_private">私钥</string>
+    <string name="agent_key_certificate">证书</string>
+    <string name="agent_socket">代理套接字</string>
+    <string name="agent_socket_desc">通过 SSH_AUTH_SOCK 为本地程序（ssh、git、scp）提供服务。</string>
+    <string name="agent_socket_hint">在你的 shell 中执行：</string>
+    <string name="agent_socket_copy">复制</string>
+    <string name="agent_socket_failed">无法打开套接字。请检查配置目录是否可写。</string>
+    <string name="agent_socket_unsupported">此系统不支持仅所有者可访问的 unix 套接字，因此代理套接字不可用。</string>
+    <string name="agent_activity">最近的使用</string>
+    <string name="agent_activity_none">代理尚未被使用。</string>
+    <string name="agent_activity_line">%1$s · %2$s · %3$s</string>
+    <string name="agent_activity_listed">已列出密钥</string>
+    <string name="agent_activity_signed">已签名</string>
+    <string name="agent_activity_refused">已拒绝</string>
+    <string name="agent_activity_denied">服务器拒绝转发</string>
+    <string name="agent_origin_session">到 %1$s 的会话</string>
+    <string name="agent_origin_socket">本地程序</string>
+    <string name="agent_more_on">已启用</string>
+    <string name="agent_more_off">已关闭</string>
+    <string name="agent_socket_section">本地访问</string>
+    <string name="agent_subtitle_mobile">密钥留在保险库中，会话只获得签名，而不会拿到密钥本身。</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
@@ -29,4 +29,12 @@
     <string name="agent_subtitle_mobile">密钥留在保险库中，会话只获得签名，而不会拿到密钥本身。</string>
     <string name="agent_socket_needs_agent">请先在上方启用代理，才能为本地程序提供服务。</string>
     <string name="agent_no_keys">代理中没有密钥 — 请在下方添加</string>
+    <string name="agent_confirm">每次签名都需确认</string>
+    <string name="agent_confirm_desc">每次使用密钥前询问，类似 ssh-agent -c。未回应的请求将被拒绝。</string>
+    <string name="agent_activity_declined">你已拒绝</string>
+    <string name="agent_prompt_title">允许此次签名？</string>
+    <string name="agent_prompt_body">%1$s 请求使用密钥“%2$s”签名。</string>
+    <string name="agent_prompt_hint">两分钟内未回应将拒绝该请求。</string>
+    <string name="agent_prompt_allow">允许一次</string>
+    <string name="agent_prompt_deny">拒绝</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -18,7 +18,7 @@
     <string name="conn_field_jump_host">跳板主机</string>
     <string name="conn_field_keep_alive">保活</string>
     <string name="conn_field_forward_agent">代理转发</string>
-    <string name="conn_forward_agent_desc">允许该主机使用 SSH 代理中的密钥</string>
+    <string name="conn_forward_agent_desc">让该主机上的 ssh/git 用留在本机的密钥继续跳转</string>
     <string name="conn_forward_agent_off">SSH 代理已关闭 — 请在设置中启用</string>
     <string name="conn_field_ai_policy">此连接的 AI 策略</string>
     <string name="conn_field_ai_policy_short">AI 策略</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -17,6 +17,9 @@
     <string name="conn_field_tags">标签</string>
     <string name="conn_field_jump_host">跳板主机</string>
     <string name="conn_field_keep_alive">保活</string>
+    <string name="conn_field_forward_agent">代理转发</string>
+    <string name="conn_forward_agent_desc">允许该主机使用 SSH 代理中的密钥</string>
+    <string name="conn_forward_agent_off">SSH 代理已关闭 — 请在设置中启用</string>
     <string name="conn_field_ai_policy">此连接的 AI 策略</string>
     <string name="conn_field_ai_policy_short">AI 策略</string>
 

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
@@ -3,6 +3,7 @@
     <string name="shtail_nav_ai">AI</string>
     <string name="shtail_nav_sync">同步</string>
     <string name="shtail_nav_security">安全</string>
+    <string name="shtail_nav_agent">SSH 代理</string>
     <string name="shtail_nav_appearance">外观</string>
     <string name="shtail_nav_terminal">终端</string>
     <string name="shtail_nav_keyboard">键盘</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -112,4 +112,7 @@
     <string name="term_broadcast_none">没有已连接的会话</string>
     <string name="term_broadcast_selected">已选 %1$s / %2$s</string>
     <string name="term_broadcast_sent">已发送到 %1$s</string>
+    <string name="term_info_agent">代理</string>
+    <string name="term_agent_active">已转发</string>
+    <string name="term_agent_refused">服务器已拒绝</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -113,4 +113,5 @@
     <string name="vault_reset_scope_everything_subtitle">同时删除主机配置、known_hosts 和设置。</string>
     <string name="vault_reset_confirm_label">输入 %1$s 以确认</string>
     <string name="vault_reset_confirm_button">永久重置</string>
+    <string name="vault_badge_agent">代理中</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_agent.xml
@@ -3,14 +3,14 @@
     <string name="agent_title">SSH agent</string>
     <string name="agent_subtitle">Hold keys in the vault and let a session — or another program on this machine — sign with them, without ever handing over the key itself.</string>
     <string name="agent_enable">Enable agent</string>
-    <string name="agent_enable_desc">Off, the agent answers with an empty key list everywhere.</string>
+    <string name="agent_enable_desc">When off, the agent answers every request with an empty key list.</string>
     <string name="agent_keys">KEYS IN THE AGENT</string>
     <string name="agent_keys_empty">No keys in the keychain yet. Add a private key or certificate in Vault.</string>
     <string name="agent_key_private">Private key</string>
     <string name="agent_key_certificate">Certificate</string>
     <string name="agent_socket">Agent socket</string>
     <string name="agent_socket_desc">Serve local programs (ssh, git, scp) over SSH_AUTH_SOCK.</string>
-    <string name="agent_socket_hint">Export this in your shell:</string>
+    <string name="agent_socket_hint">Point SSH_AUTH_SOCK at:</string>
     <string name="agent_socket_copy">Copy</string>
     <string name="agent_socket_failed">The socket could not be opened. Check that the config directory is writable.</string>
     <string name="agent_socket_unsupported">This system has no unix sockets with owner-only access, so the agent socket is unavailable.</string>
@@ -27,4 +27,6 @@
     <string name="agent_more_off">Off</string>
     <string name="agent_socket_section">LOCAL ACCESS</string>
     <string name="agent_subtitle_mobile">Hold keys in the vault and let a session sign with them, without ever handing over the key itself.</string>
+    <string name="agent_socket_needs_agent">Turn the agent on above to serve local programs.</string>
+    <string name="agent_no_keys">No keys in the agent — add one below</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_agent.xml
@@ -1,0 +1,30 @@
+<resources>
+    <!-- Built-in SSH agent (AgentSection.kt · MobileAgentView.kt) -->
+    <string name="agent_title">SSH agent</string>
+    <string name="agent_subtitle">Hold keys in the vault and let a session — or another program on this machine — sign with them, without ever handing over the key itself.</string>
+    <string name="agent_enable">Enable agent</string>
+    <string name="agent_enable_desc">Off, the agent answers with an empty key list everywhere.</string>
+    <string name="agent_keys">KEYS IN THE AGENT</string>
+    <string name="agent_keys_empty">No keys in the keychain yet. Add a private key or certificate in Vault.</string>
+    <string name="agent_key_private">Private key</string>
+    <string name="agent_key_certificate">Certificate</string>
+    <string name="agent_socket">Agent socket</string>
+    <string name="agent_socket_desc">Serve local programs (ssh, git, scp) over SSH_AUTH_SOCK.</string>
+    <string name="agent_socket_hint">Export this in your shell:</string>
+    <string name="agent_socket_copy">Copy</string>
+    <string name="agent_socket_failed">The socket could not be opened. Check that the config directory is writable.</string>
+    <string name="agent_socket_unsupported">This system has no unix sockets with owner-only access, so the agent socket is unavailable.</string>
+    <string name="agent_activity">RECENT ACTIVITY</string>
+    <string name="agent_activity_none">The agent has not been used yet.</string>
+    <string name="agent_activity_line">%1$s · %2$s · %3$s</string>
+    <string name="agent_activity_listed">Keys listed</string>
+    <string name="agent_activity_signed">Signed</string>
+    <string name="agent_activity_refused">Refused</string>
+    <string name="agent_activity_denied">Server refused forwarding</string>
+    <string name="agent_origin_session">session to %1$s</string>
+    <string name="agent_origin_socket">local program</string>
+    <string name="agent_more_on">On</string>
+    <string name="agent_more_off">Off</string>
+    <string name="agent_socket_section">LOCAL ACCESS</string>
+    <string name="agent_subtitle_mobile">Hold keys in the vault and let a session sign with them, without ever handing over the key itself.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_agent.xml
@@ -29,4 +29,12 @@
     <string name="agent_subtitle_mobile">Hold keys in the vault and let a session sign with them, without ever handing over the key itself.</string>
     <string name="agent_socket_needs_agent">Turn the agent on above to serve local programs.</string>
     <string name="agent_no_keys">No keys in the agent — add one below</string>
+    <string name="agent_confirm">Confirm every signature</string>
+    <string name="agent_confirm_desc">Ask before each use of a key, like ssh-agent -c. Unanswered requests are refused.</string>
+    <string name="agent_activity_declined">Declined by you</string>
+    <string name="agent_prompt_title">Allow this signature?</string>
+    <string name="agent_prompt_body">%1$s wants to sign with the key “%2$s”.</string>
+    <string name="agent_prompt_hint">No answer within two minutes refuses the request.</string>
+    <string name="agent_prompt_allow">Allow once</string>
+    <string name="agent_prompt_deny">Refuse</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -18,7 +18,7 @@
     <string name="conn_field_jump_host">Jump host</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
     <string name="conn_field_forward_agent">Agent forwarding</string>
-    <string name="conn_forward_agent_desc">Let this host use the keys in the SSH agent</string>
+    <string name="conn_forward_agent_desc">So ssh/git on that host can hop onward with a key that stays here</string>
     <string name="conn_forward_agent_off">The SSH agent is off — turn it on in Settings</string>
     <string name="conn_field_ai_policy">AI policy for this connection</string>
     <string name="conn_field_ai_policy_short">AI policy</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -17,6 +17,9 @@
     <string name="conn_field_tags">Tags</string>
     <string name="conn_field_jump_host">Jump host</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
+    <string name="conn_field_forward_agent">Agent forwarding</string>
+    <string name="conn_forward_agent_desc">Let this host use the keys in the SSH agent</string>
+    <string name="conn_forward_agent_off">The SSH agent is off — turn it on in Settings</string>
     <string name="conn_field_ai_policy">AI policy for this connection</string>
     <string name="conn_field_ai_policy_short">AI policy</string>
 

--- a/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
@@ -3,6 +3,7 @@
     <string name="shtail_nav_ai">AI</string>
     <string name="shtail_nav_sync">Sync</string>
     <string name="shtail_nav_security">Security</string>
+    <string name="shtail_nav_agent">SSH agent</string>
     <string name="shtail_nav_appearance">Appearance</string>
     <string name="shtail_nav_terminal">Terminal</string>
     <string name="shtail_nav_keyboard">Keyboard</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -112,4 +112,7 @@
     <string name="term_broadcast_none">No connected sessions</string>
     <string name="term_broadcast_selected">%1$s of %2$s selected</string>
     <string name="term_broadcast_sent">Sent to %1$s</string>
+    <string name="term_info_agent">Agent</string>
+    <string name="term_agent_active">forwarded</string>
+    <string name="term_agent_refused">refused by server</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -113,4 +113,5 @@
     <string name="vault_reset_scope_everything_subtitle">Also delete host profiles, known_hosts and settings.</string>
     <string name="vault_reset_confirm_label">Type %1$s to confirm</string>
     <string name="vault_reset_confirm_button">Reset permanently</string>
+    <string name="vault_badge_agent">in agent</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
@@ -52,4 +52,6 @@ data class AppDependencies(
     val securityLog: SecurityLog? = null,
     /** Local AI: model store + downloader + runtime; `null` for preview/mock without the subsystem. */
     val localAi: LocalAiDeps? = null,
+    /** Built-in SSH agent (key policy, agent socket, activity); `null` if not wired up. */
+    val sshAgent: app.skerry.ui.agent.SshAgentController? = null,
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/AgentSignPrompt.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/AgentSignPrompt.kt
@@ -1,0 +1,42 @@
+package app.skerry.ui.agent
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.ui.design.ConfirmActionDialog
+import app.skerry.ui.design.D
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_origin_session
+import app.skerry.ui.generated.resources.agent_origin_socket
+import app.skerry.ui.generated.resources.agent_prompt_allow
+import app.skerry.ui.generated.resources.agent_prompt_body
+import app.skerry.ui.generated.resources.agent_prompt_deny
+import app.skerry.ui.generated.resources.agent_prompt_hint
+import app.skerry.ui.generated.resources.agent_prompt_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * "Allow this signature?" — the prompt behind Settings → SSH agent → confirm every signature.
+ *
+ * Hosted at the root of both shells, above every session, because the request comes from the
+ * forwarding coroutine rather than from anything the user is looking at. Dismissing (Esc, Refuse)
+ * is a real answer: the request is refused, and so is a prompt nobody answers in time
+ * ([SshAgentController.PROMPT_TIMEOUT_MS]).
+ */
+@Composable
+fun AgentSignPromptDialog(controller: SshAgentController?) {
+    val prompt = controller?.pendingSignature ?: return
+    val origin = when (val where = prompt.origin) {
+        is SshAgentOrigin.Session -> stringResource(Res.string.agent_origin_session, where.address)
+        SshAgentOrigin.LocalSocket -> stringResource(Res.string.agent_origin_socket)
+    }
+    ConfirmActionDialog(
+        title = stringResource(Res.string.agent_prompt_title),
+        message = stringResource(Res.string.agent_prompt_body, origin, prompt.keyComment) +
+            "\n" + stringResource(Res.string.agent_prompt_hint),
+        confirmLabel = stringResource(Res.string.agent_prompt_allow),
+        onConfirm = { controller.answerSignature(allow = true) },
+        onDismiss = { controller.answerSignature(allow = false) },
+        confirmColor = D.cyan,
+        dismissLabel = stringResource(Res.string.agent_prompt_deny),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
@@ -62,6 +62,9 @@ class SshAgentController(
     /** Whether a local agent socket is possible at all here (desktop, POSIX filesystem). */
     val socketSupported: Boolean get() = socket?.isSupported == true
 
+    /** Whether the agent would offer anything at all right now (on, unlocked, at least one key). */
+    val hasKeys: Boolean get() = keyMaterial().isNotEmpty()
+
     /** Keychain secrets that can act as agent keys — passwords cannot. */
     val agentKeys: List<Credential>
         get() = credentials.credentials.filter { it.secret !is CredentialSecret.Password }
@@ -119,7 +122,7 @@ class SshAgentController(
 
     /** Record one thing the agent did (called from the agent's own threads). */
     fun record(usage: SshAgentUsage) {
-        activity = activityLog.record(usage)
+        activityLog.record(usage) { activity = it }
     }
 
     /** Vault locked: forget parsed keys and stop serving until it is opened again. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
@@ -7,10 +7,22 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.agent.SshAgentActivity
 import app.skerry.shared.agent.SshAgentActivityLog
 import app.skerry.shared.agent.SshAgentKeyMaterial
+import app.skerry.shared.agent.SshAgentSignPrompt
 import app.skerry.shared.agent.SshAgentUsage
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.identity.CredentialManagerController
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Settings → SSH agent: which vault keys the built-in agent offers, whether it is reachable from
@@ -38,6 +50,13 @@ class SshAgentController(
     private val persistEnabled: (Boolean) -> Unit = {},
     initialSocketEnabled: Boolean = false,
     private val persistSocketEnabled: (Boolean) -> Unit = {},
+    initialConfirmSignatures: Boolean = false,
+    private val persistConfirmSignatures: (Boolean) -> Unit = {},
+    /**
+     * Where the prompt state is published. Requests arrive on the agent's IO threads, so the
+     * snapshot writes are moved onto the UI thread, as every other state this class owns is.
+     */
+    private val uiContext: CoroutineContext = Dispatchers.Main.immediate,
 ) {
     /** Master switch. Off means the agent answers with an empty key list, wherever it is asked. */
     var enabled: Boolean by mutableStateOf(initialEnabled)
@@ -53,6 +72,14 @@ class SshAgentController(
 
     /** The socket was asked for but could not be bound — shown instead of a silent no-op. */
     var socketFailed: Boolean by mutableStateOf(false)
+        private set
+
+    /** Ask the user before every signature (`ssh-agent -c`). */
+    var confirmSignatures: Boolean by mutableStateOf(initialConfirmSignatures)
+        private set
+
+    /** The signature currently waiting for an answer, rendered as a dialog over everything. */
+    var pendingSignature: SshAgentSignPrompt? by mutableStateOf(null)
         private set
 
     /** Recent agent activity, newest first. In memory only — see [SshAgentActivityLog]. */
@@ -85,6 +112,44 @@ class SshAgentController(
         // The keyring caches parsed keys by credential id; a key just removed must stop being
         // offered immediately.
         dropParsedKeys()
+    }
+
+    fun confirmEachSignature(enabled: Boolean) {
+        if (confirmSignatures == enabled) return
+        confirmSignatures = enabled
+        persistConfirmSignatures(enabled)
+        // Switching confirmation off must not leave a request hanging on a dialog nobody will see.
+        if (!enabled) answerSignature(allow = false)
+    }
+
+    /**
+     * The gate the agent asks before signing. Called from the agent's IO threads and suspends there
+     * until the user answers, the prompt times out, or the vault locks — all of which the caller
+     * turns into a protocol refusal. One prompt at a time: a second request queues behind the
+     * first, so an answer is never ambiguous about which signature it allows.
+     */
+    suspend fun confirmSignature(prompt: SshAgentSignPrompt): Boolean {
+        if (!confirmSignatures) return true
+        return promptLock.withLock {
+            val answer = CompletableDeferred<Boolean>()
+            withContext(uiContext) {
+                pending = answer
+                pendingSignature = prompt
+            }
+            try {
+                withTimeoutOrNull(PROMPT_TIMEOUT_MS) { answer.await() } ?: false
+            } finally {
+                withContext(NonCancellable + uiContext) {
+                    pending = null
+                    pendingSignature = null
+                }
+            }
+        }
+    }
+
+    /** The user's answer to [pendingSignature]; a no-op when nothing is waiting. */
+    fun answerSignature(allow: Boolean) {
+        pending?.complete(allow)
     }
 
     fun exposeSocket(enabled: Boolean) {
@@ -120,15 +185,22 @@ class SshAgentController(
         }
     }
 
-    /** Record one thing the agent did (called from the agent's own threads). */
+    /**
+     * Record one thing the agent did. Called from the agent's IO threads, so the snapshot it
+     * produces is published on the UI thread — the same rule the signature prompt follows, and the
+     * log itself keeps the ordering (the snapshot is taken under its lock).
+     */
     fun record(usage: SshAgentUsage) {
-        activityLog.record(usage) { activity = it }
+        activityLog.record(usage) { snapshot -> scope.launch { activity = snapshot } }
     }
+
 
     /** Vault locked: forget parsed keys and stop serving until it is opened again. */
     fun onVaultLocked() {
         dropParsedKeys()
         stopSocket()
+        // The prompt would otherwise sit behind the lock screen, and the key it guards is gone.
+        answerSignature(allow = false)
     }
 
     /** Vault opened: bring the socket back if the user had it on. */
@@ -148,6 +220,18 @@ class SshAgentController(
         socket?.stop()
         socketPath = null
         socketFailed = false
+    }
+
+    private val promptLock = Mutex()
+    private var pending: CompletableDeferred<Boolean>? = null
+
+    // Publishes state produced on the agent's threads onto the UI one. Lives as long as the
+    // controller does — one per app, not per session.
+    private val scope = CoroutineScope(SupervisorJob() + uiContext)
+
+    companion object {
+        /** How long an unanswered signature prompt waits before it refuses on its own. */
+        const val PROMPT_TIMEOUT_MS = 120_000L
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/agent/SshAgentController.kt
@@ -1,0 +1,163 @@
+package app.skerry.ui.agent
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.agent.SshAgentActivity
+import app.skerry.shared.agent.SshAgentActivityLog
+import app.skerry.shared.agent.SshAgentKeyMaterial
+import app.skerry.shared.agent.SshAgentUsage
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.ui.identity.CredentialManagerController
+
+/**
+ * Settings → SSH agent: which vault keys the built-in agent offers, whether it is reachable from
+ * other programs on this machine, and what it has been asked to do lately.
+ *
+ * The controller owns the *policy*; the protocol lives in `shared` ([app.skerry.shared.agent]).
+ * [keyMaterial] is the single gate between the vault and everything that can use a key — a
+ * forwarded session or the local socket — and it closes on three independent conditions: the agent
+ * switched off, the vault locked, or the key not put in the agent. Terminal sessions deliberately
+ * survive a vault lock, so the lock check is not a formality: without it a server whose session is
+ * still open could keep signing behind the lock screen.
+ *
+ * [socket] is absent on Android (no `SSH_AUTH_SOCK`, no local programs to serve) — the section then
+ * shows only forwarding.
+ */
+@Stable
+class SshAgentController(
+    private val credentials: CredentialManagerController,
+    private val isVaultUnlocked: () -> Boolean,
+    private val socket: SshAgentSocket? = null,
+    /** Forget keys already parsed into memory (the agent keyring's cache). */
+    private val dropParsedKeys: () -> Unit = {},
+    private val activityLog: SshAgentActivityLog = SshAgentActivityLog(),
+    initialEnabled: Boolean = false,
+    private val persistEnabled: (Boolean) -> Unit = {},
+    initialSocketEnabled: Boolean = false,
+    private val persistSocketEnabled: (Boolean) -> Unit = {},
+) {
+    /** Master switch. Off means the agent answers with an empty key list, wherever it is asked. */
+    var enabled: Boolean by mutableStateOf(initialEnabled)
+        private set
+
+    /** Whether the user wants the local socket; [socketPath] tells whether it is actually up. */
+    var socketEnabled: Boolean by mutableStateOf(initialSocketEnabled)
+        private set
+
+    /** Path to hand to `SSH_AUTH_SOCK`, or `null` when the socket is not listening. */
+    var socketPath: String? by mutableStateOf(null)
+        private set
+
+    /** The socket was asked for but could not be bound — shown instead of a silent no-op. */
+    var socketFailed: Boolean by mutableStateOf(false)
+        private set
+
+    /** Recent agent activity, newest first. In memory only — see [SshAgentActivityLog]. */
+    var activity: List<SshAgentActivity> by mutableStateOf(activityLog.recent())
+        private set
+
+    /** Whether a local agent socket is possible at all here (desktop, POSIX filesystem). */
+    val socketSupported: Boolean get() = socket?.isSupported == true
+
+    /** Keychain secrets that can act as agent keys — passwords cannot. */
+    val agentKeys: List<Credential>
+        get() = credentials.credentials.filter { it.secret !is CredentialSecret.Password }
+
+    fun enable(enabled: Boolean) {
+        if (this.enabled == enabled) return
+        this.enabled = enabled
+        persistEnabled(enabled)
+        // Turning the agent off must take effect now, not at the next request: drop the keys it
+        // already parsed and close the door other programs came through.
+        dropParsedKeys()
+        if (!enabled) stopSocket() else syncSocket()
+    }
+
+    /** Put a keychain key in the agent, or take it out ([Credential.agentEnabled]). */
+    fun setKeyInAgent(id: String, inAgent: Boolean) {
+        credentials.setAgentEnabled(id, inAgent)
+        // The keyring caches parsed keys by credential id; a key just removed must stop being
+        // offered immediately.
+        dropParsedKeys()
+    }
+
+    fun exposeSocket(enabled: Boolean) {
+        socketEnabled = enabled
+        persistSocketEnabled(enabled)
+        syncSocket()
+    }
+
+    /**
+     * Key material for the agent keyring. Called on the agent's IO threads for every request, so it
+     * re-reads the current state instead of trusting a snapshot taken at startup.
+     */
+    fun keyMaterial(): List<SshAgentKeyMaterial> {
+        if (!enabled || !isVaultUnlocked()) return emptyList()
+        return credentials.credentials.filter { it.agentEnabled }.mapNotNull { credential ->
+            when (val secret = credential.secret) {
+                is CredentialSecret.PrivateKey -> SshAgentKeyMaterial(
+                    id = credential.id,
+                    comment = credential.label,
+                    privateKeyPem = secret.privateKeyPem,
+                    passphrase = secret.passphrase,
+                )
+                is CredentialSecret.Certificate -> SshAgentKeyMaterial(
+                    id = credential.id,
+                    comment = credential.label,
+                    privateKeyPem = secret.privateKeyPem,
+                    passphrase = secret.passphrase,
+                    certificate = secret.certificate,
+                )
+                // A stored password is not a key: the agent protocol has nothing to do with it.
+                is CredentialSecret.Password -> null
+            }
+        }
+    }
+
+    /** Record one thing the agent did (called from the agent's own threads). */
+    fun record(usage: SshAgentUsage) {
+        activity = activityLog.record(usage)
+    }
+
+    /** Vault locked: forget parsed keys and stop serving until it is opened again. */
+    fun onVaultLocked() {
+        dropParsedKeys()
+        stopSocket()
+    }
+
+    /** Vault opened: bring the socket back if the user had it on. */
+    fun onVaultUnlocked() = syncSocket()
+
+    /** Start or stop the socket to match the current policy (agent on, socket wanted, vault open). */
+    private fun syncSocket() {
+        val wanted = socket != null && enabled && socketEnabled && isVaultUnlocked()
+        if (!wanted) return stopSocket()
+        if (socketPath != null) return
+        val path = socket?.start()
+        socketPath = path
+        socketFailed = path == null
+    }
+
+    private fun stopSocket() {
+        socket?.stop()
+        socketPath = null
+        socketFailed = false
+    }
+}
+
+/**
+ * The local agent socket, as the UI sees it. Implemented on desktop over a unix socket
+ * ([app.skerry.shared.agent.UnixSocketSshAgent]); absent on Android.
+ */
+interface SshAgentSocket {
+    /** Whether this platform can host the socket with owner-only access. */
+    val isSupported: Boolean
+
+    /** Start listening; returns the socket path, or `null` if it could not be bound. */
+    fun start(): String?
+
+    fun stop()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -202,6 +202,14 @@ val LocalTeams: ProvidableCompositionLocal<app.skerry.ui.teams.TeamsCoordinator?
 val LocalAi: ProvidableCompositionLocal<AiAssistantController?> = staticCompositionLocalOf { null }
 
 /**
+ * Built-in SSH agent (Settings → SSH agent): which vault keys it offers, the local agent socket on
+ * desktop, and its recent activity. `null` — mock path/preview or a platform build without an
+ * agent: the section renders a static layout. Supplied behind the vault gate (the keys it hands out
+ * are vault secrets).
+ */
+val LocalSshAgent: ProvidableCompositionLocal<app.skerry.ui.agent.SshAgentController?> = staticCompositionLocalOf { null }
+
+/**
  * Update-notice controller (GitHub Releases check + the "check for updates" toggle). `null` — mock
  * path/preview: the About section hides the toggle and no notice is shown. Supplied behind the
  * vault gate (the toggle is a synced SETTINGS record in the vault).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -60,7 +60,7 @@ fun SessionView.asDesktopView(): DesktopView = when (this) {
 }
 
 /** Settings panel tabs. */
-enum class SettingsTab { AI, Sync, Security, Appearance, Terminal, Keyboard, About }
+enum class SettingsTab { AI, Sync, Security, Agent, Appearance, Terminal, Keyboard, About }
 
 /**
  * Connection AI policy. Aliases the shared enum ([app.skerry.shared.host.Host.aiPolicy]) so the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -42,7 +42,7 @@ enum class MobileTab(val icon: String) {
  * Full-screen push screens over the tab navigation (tab bar hidden): terminal and host detail open
  * from Hosts, SFTP (Files) via the host card's SFTP button, and Ports/Known/Team from the More tab.
  */
-enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Ports, Known, Team, Appearance, Sync, Ai, Security, About }
+enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Ports, Known, Team, Appearance, Sync, Ai, Security, Agent, About }
 
 /** What the system back gesture should do in the mobile shell. */
 enum class MobileBackAction {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -11,6 +11,7 @@ import app.skerry.shared.serial.SerialProblem
 import app.skerry.shared.serial.SerialUnavailableException
 import app.skerry.shared.mosh.MoshSetupException
 import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.SshAgentForwarding
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
@@ -154,6 +155,14 @@ class ConnectionController(
         private set
 
     /**
+     * Whether the live session's shell got the SSH agent forwarded into it, and — the point of
+     * showing it at all — whether the server refused. Snapshot state like [cipher]: the info panel
+     * has to redraw when the session appears or resets.
+     */
+    var agentForwarding: SshAgentForwarding by mutableStateOf(SshAgentForwarding.None)
+        private set
+
+    /**
      * History key of the live session (see [terminalHistoryKey]), or `null` while not connected.
      * The command palette reads it to put this host's commands first. Snapshot state so the palette
      * sees the key appear when a session connects under it.
@@ -242,6 +251,9 @@ class ConnectionController(
             shellChannel = channel
             cipher = conn.cipher
             serverVersion = conn.serverVersion
+            // Read after openShell: the request rides the shell's session channel, so before that
+            // the connection has nothing to report.
+            agentForwarding = conn.agentForwarding
             sessionScope = sScope
             // Command history for autocomplete: load for this host and attach a snapshot-persist
             // hook on every committed command (runs on the controller's IO scope, not the UI thread).
@@ -560,6 +572,7 @@ class ConnectionController(
         shellChannel = null
         cipher = null
         serverVersion = null
+        agentForwarding = SshAgentForwarding.None
         if (sftp != null) closeSftpQuietly(sftp)
         if (conn != null) closeConnectionQuietly(conn)
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -23,7 +23,7 @@ import app.skerry.shared.vnc.VncAuth
 fun Host.toTarget(jump: SshJump? = null): SshTarget =
     SshTarget(
         host = address, port = port, username = username, connectionType = connectionType,
-        jump = jump, keepAliveSeconds = keepAliveSeconds,
+        jump = jump, keepAliveSeconds = keepAliveSeconds, forwardAgent = forwardAgent,
     )
 
 /** `user@addr:port` string — the session's tab/title label. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ConfirmActionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ConfirmActionDialog.kt
@@ -27,7 +27,8 @@ import org.jetbrains.compose.resources.stringResource
  * Confirmation dialog for a destructive action (disconnect session, close split panel, delete
  * tunnel): scrim + card, title + message + Cancel/[confirmLabel]. Same visual language as
  * [DesktopDeleteHostDialog]/[DesktopPasswordDialog]; confirm button defaults to [D.sunset].
- * [onDismiss] fires on Cancel or Esc (not on a click outside the card).
+ * [onDismiss] fires on Cancel or Esc (not on a click outside the card). [dismissLabel] renames that
+ * button where "Cancel" would understate it (refusing a signature is an answer, not a way out).
  */
 @Composable
 fun ConfirmActionDialog(
@@ -37,6 +38,7 @@ fun ConfirmActionDialog(
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
     confirmColor: Color = D.sunset,
+    dismissLabel: String? = null,
 ) {
     ModalScrim(onDismiss = onDismiss) {
         Column(
@@ -58,7 +60,7 @@ fun ConfirmActionDialog(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(Modifier.clip(RoundedCornerShape(7.dp)).clickable(onClick = onDismiss).padding(horizontal = 16.dp, vertical = 9.dp)) {
-                    Txt(stringResource(Res.string.shell_cancel), color = D.dim, size = 12.5.sp)
+                    Txt(dismissLabel ?: stringResource(Res.string.shell_cancel), color = D.dim, size = 12.5.sp)
                 }
                 PrimaryButton(confirmLabel, onClick = onConfirm, bg = confirmColor, fg = Color(0xFF1A0B07))
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -79,6 +79,7 @@ import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.JumpChainProblem
 import app.skerry.ui.connection.JumpChainResolution
+import app.skerry.ui.agent.AgentSignPromptDialog
 import app.skerry.ui.connection.JumpErrorDialog
 import app.skerry.ui.connection.jumpRouteLabel
 import app.skerry.ui.connection.resolveJumpChain
@@ -742,6 +743,9 @@ private fun DesktopChrome(
             jumpProblem?.let { problem ->
                 JumpErrorDialog(problem, onDismiss = { jumpProblem = null })
             }
+            // A forwarded session (or a local program) asking to sign, when the user chose to
+            // confirm every signature. It belongs at the root: nothing on screen raised it.
+            AgentSignPromptDialog(LocalSshAgent.current)
             // Delete-host-profile confirmation (invoked from the sidebar's context menu). The keychain
             // secret itself stays in the vault (reusable, managed from the Vault tab).
             val hosts = LocalHosts.current

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -172,6 +172,7 @@ import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSftpPrefs
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalSshAgent
 import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
@@ -318,6 +319,9 @@ fun DesktopDesignApp(
     // Update notice (GitHub Releases check + the About toggle). `null` — mock/preview: no notice,
     // the About section hides the toggle.
     updates: app.skerry.ui.update.UpdateNoticeController? = null,
+    // Built-in SSH agent (Settings → SSH agent, per-host agent forwarding). `null` — mock/preview:
+    // the section is static and no session forwards anything. Supplied behind the vault gate.
+    sshAgent: app.skerry.ui.agent.SshAgentController? = null,
     features: FeatureFlags = FeatureFlags(),
     // Called once after vault unlock, before list reload — reloads managers from decrypted records
     // and restores the sync session (supplied by desktop `main`). No-op in mock/preview.
@@ -460,6 +464,7 @@ fun DesktopDesignApp(
         LocalTeams provides teams,
         LocalAi provides ai,
         LocalUpdates provides updates,
+        LocalSshAgent provides sshAgent,
     ) {
         if (vault != null) {
             VaultGate(
@@ -470,7 +475,7 @@ fun DesktopDesignApp(
                 // and restarts the idle timer; Never (idleMs == null) turns it off.
                 autoLockIdleMs = state.autoLock.idleMs,
                 // Runs on EVERY lock, including the two automatic ones that bypass the lock action.
-                onBeforeLock = { tearDownForLock(tunnels, sessions) },
+                onBeforeLock = { tearDownForLock(tunnels, sessions, sshAgent) },
                 onReset = onVaultReset,
                 // onPairingComplete != null (sync is present) — the create screen offers "I have a code":
                 // the coordinator creates the vault under the chosen password itself and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
@@ -15,6 +15,7 @@ import app.skerry.ui.design.D
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_no_keys
 import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_forward_agent_off
@@ -40,7 +41,15 @@ private fun ForwardAgentToggle(
     titleSize: androidx.compose.ui.unit.TextUnit,
     descSize: androidx.compose.ui.unit.TextUnit,
 ) {
-    val agentOn = LocalSshAgent.current?.enabled == true
+    val agent = LocalSshAgent.current
+    val agentOn = agent?.enabled == true
+    // An agent with no keys in it forwards an empty list, and the remote falls back to a password
+    // prompt with nothing to explain it — say so where the switch is.
+    val warning = when {
+        !agentOn -> Res.string.conn_forward_agent_off
+        !agent.hasKeys -> Res.string.agent_no_keys
+        else -> null
+    }
     Row(
         Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
@@ -49,9 +58,8 @@ private fun ForwardAgentToggle(
         Column(Modifier.weight(1f)) {
             Txt(stringResource(Res.string.conn_field_forward_agent), color = D.text, size = titleSize)
             Txt(
-                if (agentOn) stringResource(Res.string.conn_forward_agent_desc)
-                else stringResource(Res.string.conn_forward_agent_off),
-                color = if (agentOn) D.dim else D.amber,
+                stringResource(warning ?: Res.string.conn_forward_agent_desc),
+                color = if (warning == null) D.dim else D.amber,
                 size = descSize,
                 modifier = Modifier.padding(top = 3.dp),
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
@@ -1,0 +1,61 @@
+package app.skerry.ui.host
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalSshAgent
+import app.skerry.ui.design.D
+import app.skerry.ui.design.Toggle
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_field_forward_agent
+import app.skerry.ui.generated.resources.conn_forward_agent_desc
+import app.skerry.ui.generated.resources.conn_forward_agent_off
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * "Agent forwarding" switch in the host form, shared by the desktop modal and the Android sheet
+ * (only the type sizes differ, like the other paired form controls).
+ *
+ * When the agent itself is off the row still works — the profile setting is remembered — but the
+ * description says so, otherwise the switch would silently do nothing at connect time.
+ */
+@Composable
+internal fun ForwardAgentRow(form: NewConnectionFormState) = ForwardAgentToggle(form, titleSize = 12.5.sp, descSize = 11.sp)
+
+/** Android variant of [ForwardAgentRow] (larger type, matching the sheet's other rows). */
+@Composable
+internal fun MobileForwardAgentRow(form: NewConnectionFormState) = ForwardAgentToggle(form, titleSize = 14.sp, descSize = 11.5.sp)
+
+@Composable
+private fun ForwardAgentToggle(
+    form: NewConnectionFormState,
+    titleSize: androidx.compose.ui.unit.TextUnit,
+    descSize: androidx.compose.ui.unit.TextUnit,
+) {
+    val agentOn = LocalSshAgent.current?.enabled == true
+    Row(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(stringResource(Res.string.conn_field_forward_agent), color = D.text, size = titleSize)
+            Txt(
+                if (agentOn) stringResource(Res.string.conn_forward_agent_desc)
+                else stringResource(Res.string.conn_forward_agent_off),
+                color = if (agentOn) D.dim else D.amber,
+                size = descSize,
+                modifier = Modifier.padding(top = 3.dp),
+            )
+        }
+        Toggle(form.forwardAgent, { form.forwardAgent = !form.forwardAgent })
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -27,6 +27,7 @@ data class HostDraft(
     val connectionType: ConnectionType = ConnectionType.SSH,
     val jumpHostId: String? = null,
     val keepAliveSeconds: Int = 30,
+    val forwardAgent: Boolean = false,
 )
 
 /**
@@ -77,6 +78,7 @@ class HostManagerController(
                 connectionType = draft.connectionType,
                 jumpHostId = draft.jumpHostId,
                 keepAliveSeconds = draft.keepAliveSeconds,
+                forwardAgent = draft.forwardAgent,
                 // Not a form field — toggled from the live VNC session; a form save must not reset it.
                 vncResizeToWindow = find(id)?.vncResizeToWindow ?: false,
             ),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -68,6 +68,9 @@ class NewConnectionFormState {
         if (port.trim() == defaultPortFor(connectionType).toString()) {
             port = defaultPortFor(type).toString()
         }
+        // Agent forwarding rides the SSH session channel, so it goes with the jump host when the
+        // profile leaves the SSH family (Mosh runs its own protocol after the bootstrap exec).
+        if (type != ConnectionType.SSH) forwardAgent = false
         if (!type.usesSshAuth) jumpHostId = null
         if (type.isVnc) dropNonVncAuth()
         connectionType = type
@@ -91,6 +94,9 @@ class NewConnectionFormState {
 
     /** Keep-alive cadence for this profile's sessions, seconds (0 = off); see [Host.keepAliveSeconds]. */
     var keepAliveSeconds: Int by mutableStateOf(30)
+
+    /** Forward the built-in SSH agent into this host's shell; see [Host.forwardAgent]. */
+    var forwardAgent: Boolean by mutableStateOf(false)
 
     // Auth: mode plus fields for each kind (kept side by side so switching doesn't lose input).
     var authMode: AuthMode by mutableStateOf(AuthMode.ASK)
@@ -201,6 +207,7 @@ class NewConnectionFormState {
         connectionType = connectionType,
         jumpHostId = jumpHostId,
         keepAliveSeconds = keepAliveSeconds,
+        forwardAgent = forwardAgent,
     )
 
     companion object {
@@ -230,6 +237,7 @@ class NewConnectionFormState {
             aiPolicy = host.aiPolicy
             jumpHostId = host.jumpHostId
             keepAliveSeconds = host.keepAliveSeconds
+            forwardAgent = host.forwardAgent
             if (host.credentialId != null) {
                 authMode = AuthMode.EXISTING
                 existingCredentialId = host.credentialId

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -92,9 +92,7 @@ import app.skerry.ui.generated.resources.conn_field_device
 import app.skerry.ui.generated.resources.conn_field_group
 import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_jump_host
-import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_field_keep_alive
-import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_field_name
 import app.skerry.ui.generated.resources.conn_field_port
 import app.skerry.ui.generated.resources.conn_field_protocol

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -92,7 +92,9 @@ import app.skerry.ui.generated.resources.conn_field_device
 import app.skerry.ui.generated.resources.conn_field_group
 import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_jump_host
+import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_field_keep_alive
+import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_field_name
 import app.skerry.ui.generated.resources.conn_field_port
 import app.skerry.ui.generated.resources.conn_field_protocol
@@ -282,6 +284,12 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                         if (form.connectionType == ConnectionType.SSH) {
                             Field(stringResource(Res.string.conn_field_keep_alive), Modifier.weight(1f)) { KeepAlivePicker(form) }
                         }
+                    }
+                    // Agent forwarding rides the SSH session channel, so it is SSH-only like
+                    // keep-alive. Off by default: the host may use every key the agent offers.
+                    if (form.connectionType == ConnectionType.SSH) {
+                        Spacer14()
+                        ForwardAgentRow(form)
                     }
                 }
                 Spacer14()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -60,9 +60,25 @@ class CredentialManagerController(
     /** Creates (if [CredentialDraft.id] == null) or updates a secret; returns the assigned id. */
     fun save(draft: CredentialDraft): String {
         val id = draft.id ?: newId()
-        store.put(Credential(id = id, label = draft.label, secret = draft.toSecret()))
+        store.put(
+            Credential(
+                id = id,
+                label = draft.label,
+                secret = draft.toSecret(),
+                // Not a form field: editing a key must not silently drop it out of (or into) the
+                // agent — that switch lives in Settings → SSH agent.
+                agentEnabled = find(id)?.agentEnabled ?: false,
+            ),
+        )
         credentials = store.all()
         return id
+    }
+
+    /** Put the key in the built-in SSH agent, or take it out ([Credential.agentEnabled]). */
+    fun setAgentEnabled(id: String, enabled: Boolean) {
+        val credential = find(id) ?: return
+        store.put(credential.copy(agentEnabled = enabled))
+        credentials = store.all()
     }
 
     fun delete(id: String) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
@@ -1,0 +1,125 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.agent.SshAgentAction
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.ui.agent.SshAgentController
+import app.skerry.ui.app.LocalSshAgent
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.design.D
+import app.skerry.ui.design.Toggle
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_activity
+import app.skerry.ui.generated.resources.agent_activity_none
+import app.skerry.ui.generated.resources.agent_enable
+import app.skerry.ui.generated.resources.agent_enable_desc
+import app.skerry.ui.generated.resources.agent_key_certificate
+import app.skerry.ui.generated.resources.agent_key_private
+import app.skerry.ui.generated.resources.agent_keys
+import app.skerry.ui.generated.resources.agent_keys_empty
+import app.skerry.ui.generated.resources.agent_subtitle_mobile
+import app.skerry.ui.generated.resources.agent_title
+import app.skerry.ui.settings.agentActivityLine
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Android counterpart of the desktop SSH agent section: master switch, which vault keys the agent
+ * offers, and recent activity. There is no local socket row — `SSH_AUTH_SOCK` has nothing to serve
+ * on Android, so agent forwarding into a session is the whole feature here.
+ */
+@Composable
+fun MobileAgentScreen(state: MobileDesignState) {
+    val controller = LocalSshAgent.current
+    Column(Modifier.fillMaxSize().background(D.bg)) {
+        MobilePushHeader(stringResource(Res.string.agent_title), onBack = state::pop)
+        Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp)) {
+            Txt(
+                stringResource(Res.string.agent_subtitle_mobile),
+                color = D.dim,
+                size = 12.5.sp,
+                lineHeight = 18.sp,
+                modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
+            )
+
+            Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Column(Modifier.weight(1f)) {
+                    Txt(stringResource(Res.string.agent_enable), color = D.text, size = 14.5.sp)
+                    Txt(stringResource(Res.string.agent_enable_desc), color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+                }
+                Toggle(controller?.enabled == true, { controller?.enable(controller.enabled != true) })
+            }
+
+            MobileSectionLabel(stringResource(Res.string.agent_keys))
+            val keys = controller?.agentKeys.orEmpty()
+            if (keys.isEmpty()) {
+                Txt(stringResource(Res.string.agent_keys_empty), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 4.dp))
+            } else {
+                keys.forEach { key -> MobileAgentKeyRow(key, controller) }
+            }
+
+            MobileSectionLabel(stringResource(Res.string.agent_activity))
+            val activity = controller?.activity.orEmpty()
+            if (activity.isEmpty()) {
+                Txt(stringResource(Res.string.agent_activity_none), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 3.dp))
+            } else {
+                activity.forEach { entry ->
+                    Row(Modifier.padding(vertical = 4.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Txt("●", color = if (entry.action == SshAgentAction.Signed) D.amber else D.moss, size = 9.sp)
+                        Txt(agentActivityLine(entry), color = D.dim, size = 12.sp)
+                    }
+                }
+            }
+            Spacer(Modifier.height(40.dp))
+        }
+    }
+}
+
+@Composable
+private fun MobileAgentKeyRow(key: Credential, controller: SshAgentController?) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(Modifier.weight(1f)) {
+            Txt(key.label, color = D.text, size = 14.5.sp)
+            Txt(
+                stringResource(
+                    if (key.secret is CredentialSecret.Certificate) Res.string.agent_key_certificate
+                    else Res.string.agent_key_private,
+                ),
+                color = D.dim,
+                size = 11.5.sp,
+                modifier = Modifier.padding(top = 3.dp),
+            )
+        }
+        Toggle(key.agentEnabled, { controller?.setKeyInAgent(key.id, !key.agentEnabled) })
+    }
+}
+
+/** Small caps group heading, matching the other mobile settings screens. */
+@Composable
+private fun MobileSectionLabel(text: String) {
+    Txt(
+        text,
+        color = D.faint,
+        size = 10.sp,
+        weight = FontWeight.SemiBold,
+        letterSpacing = 0.5.sp,
+        modifier = Modifier.padding(top = 18.dp, bottom = 8.dp),
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.agent.SshAgentAction
@@ -29,6 +28,8 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.agent_activity
 import app.skerry.ui.generated.resources.agent_activity_none
+import app.skerry.ui.generated.resources.agent_confirm
+import app.skerry.ui.generated.resources.agent_confirm_desc
 import app.skerry.ui.generated.resources.agent_enable
 import app.skerry.ui.generated.resources.agent_enable_desc
 import app.skerry.ui.generated.resources.agent_key_certificate
@@ -59,13 +60,18 @@ fun MobileAgentScreen(state: MobileDesignState) {
                 modifier = Modifier.padding(top = 2.dp, bottom = 8.dp),
             )
 
-            Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Column(Modifier.weight(1f)) {
-                    Txt(stringResource(Res.string.agent_enable), color = D.text, size = 14.5.sp)
-                    Txt(stringResource(Res.string.agent_enable_desc), color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
-                }
-                Toggle(controller?.enabled == true, { controller?.enable(controller.enabled != true) })
-            }
+            MobileAgentToggleRow(
+                stringResource(Res.string.agent_enable),
+                stringResource(Res.string.agent_enable_desc),
+                on = controller?.enabled == true,
+                onToggle = { controller?.enable(controller.enabled != true) },
+            )
+            MobileAgentToggleRow(
+                stringResource(Res.string.agent_confirm),
+                stringResource(Res.string.agent_confirm_desc),
+                on = controller?.confirmSignatures == true,
+                onToggle = { controller?.confirmEachSignature(controller.confirmSignatures != true) },
+            )
 
             MobileSectionLabel(stringResource(Res.string.agent_keys))
             val keys = controller?.agentKeys.orEmpty()
@@ -92,6 +98,18 @@ fun MobileAgentScreen(state: MobileDesignState) {
     }
 }
 
+/** One switch with its explanation, as the desktop section's [SettingToggleRow] does. */
+@Composable
+private fun MobileAgentToggleRow(title: String, description: String, on: Boolean, onToggle: () -> Unit) {
+    Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        Column(Modifier.weight(1f)) {
+            Txt(title, color = D.text, size = 14.5.sp)
+            Txt(description, color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+        }
+        Toggle(on, onToggle)
+    }
+}
+
 @Composable
 private fun MobileAgentKeyRow(key: Credential, controller: SshAgentController?) {
     Row(Modifier.fillMaxWidth().padding(vertical = 12.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -109,17 +127,4 @@ private fun MobileAgentKeyRow(key: Credential, controller: SshAgentController?) 
         }
         Toggle(key.agentEnabled, { controller?.setKeyInAgent(key.id, !key.agentEnabled) })
     }
-}
-
-/** Small caps group heading, matching the other mobile settings screens. */
-@Composable
-private fun MobileSectionLabel(text: String) {
-    Txt(
-        text,
-        color = D.faint,
-        size = 10.sp,
-        weight = FontWeight.SemiBold,
-        letterSpacing = 0.5.sp,
-        modifier = Modifier.padding(top = 18.dp, bottom = 8.dp),
-    )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -75,6 +75,7 @@ import app.skerry.ui.app.LocalOpenSftp
 import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalSshAgent
 import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
@@ -273,6 +274,8 @@ fun MobileDesignApp(
         LocalSync provides deps.sync,
         // Teams — More → "Team" push screen (sharing hosts/snippets between accounts).
         LocalTeams provides deps.teams,
+        // Built-in SSH agent — More → "SSH agent" push screen and per-host agent forwarding.
+        LocalSshAgent provides deps.sshAgent,
     ) {
         Box(Modifier.fillMaxSize().background(D.bg)) {
             val vault = deps.vault
@@ -286,7 +289,7 @@ fun MobileDesignApp(
                     autoLockIdleMs = state.autoLock.idleMs,
                     // Runs on EVERY lock, including the two automatic ones that bypass the lock
                     // action — Android had no teardown at all before (only onVaultReset did).
-                    onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions) },
+                    onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions, deps.sshAgent) },
                     onReset = onVaultReset,
                     // onPairingComplete != null (sync present) — the create screen offers "I have a code":
                     // the coordinator creates the vault under the chosen password and accepts the account key.
@@ -574,6 +577,7 @@ private fun MobileRoutePane(state: MobileDesignState, route: MobileRoute) {
         MobileRoute.Sync -> MobileSyncScreen(state)
         MobileRoute.Ai -> MobileAiScreen(state)
         MobileRoute.Security -> MobileSecurityScreen(state)
+        MobileRoute.Agent -> MobileAgentScreen(state)
         MobileRoute.About -> MobileAboutScreen(state)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -34,6 +34,7 @@ import app.skerry.shared.terminal.VaultTerminalHistoryStore
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.JumpChainProblem
 import app.skerry.ui.connection.JumpChainResolution
+import app.skerry.ui.agent.AgentSignPromptDialog
 import app.skerry.ui.connection.JumpErrorDialog
 import app.skerry.ui.connection.connectionSubtitle
 import app.skerry.ui.connection.resolveJumpChain
@@ -515,6 +516,9 @@ private fun MobileChrome(
             jumpProblem?.let { problem ->
                 JumpErrorDialog(problem, onDismiss = { jumpProblem = null })
             }
+            // A forwarded session asking to sign, when the user chose to confirm every signature.
+            // Root-level for the same reason as on desktop: nothing on screen raised it.
+            AgentSignPromptDialog(LocalSshAgent.current)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
@@ -34,6 +34,23 @@ import app.skerry.ui.design.Txt
  * source of truth instead of per-screen copies (new-connection sheet, snippets, ports, AI settings).
  */
 
+/**
+ * Group heading on a mobile settings screen ("KEYS IN THE AGENT", "MEMBERS"). Uppercased here, so a
+ * screen can pass a resource in whatever case it is written in. The desktop
+ * [app.skerry.ui.settings.SectionLabel] stays separate: same idea, denser layout.
+ */
+@Composable
+internal fun MobileSectionLabel(text: String) {
+    Txt(
+        text.uppercase(),
+        color = D.faint,
+        size = 10.5.sp,
+        weight = FontWeight.SemiBold,
+        letterSpacing = 0.6.sp,
+        modifier = Modifier.padding(top = 22.dp, bottom = 9.dp),
+    )
+}
+
 /** Field label (uppercase) + content. */
 @Composable
 internal fun MobileFormField(label: String, modifier: Modifier = Modifier, content: @Composable () -> Unit) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_more_on
+import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.shtail_host_address
 import app.skerry.ui.generated.resources.shtail_host_ask_on_connect
 import app.skerry.ui.generated.resources.shtail_host_auth
@@ -83,6 +85,8 @@ fun mobileHostDetailRows(host: Host, findHost: (String) -> Host? = { null }): Li
         mono = false,
     ),
     jumpRouteLabel(host, findHost)?.let { HostDetailRow(stringResource(Res.string.shtail_host_jump), it, mono = false) },
+    // Only when it is on: a row saying "off" on every other host would be noise.
+    if (host.forwardAgent) HostDetailRow(stringResource(Res.string.conn_field_forward_agent), stringResource(Res.string.agent_more_on), mono = false) else null,
     HostDetailRow(stringResource(Res.string.shtail_host_group), host.group?.takeIf { it.isNotBlank() } ?: ungroupedLabel(), mono = false),
 )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -39,6 +39,9 @@ import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.vault.BiometricPrompt
 import app.skerry.shared.vault.SecurityEvent
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_more_off
+import app.skerry.ui.generated.resources.agent_more_on
+import app.skerry.ui.generated.resources.agent_title
 import app.skerry.ui.generated.resources.appearance_badge_active
 import app.skerry.ui.generated.resources.appearance_default_value
 import app.skerry.ui.generated.resources.appearance_font
@@ -128,6 +131,7 @@ import app.skerry.ui.app.LocalUpdates
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalKnownHosts
 import app.skerry.ui.app.LocalSecurityLog
+import app.skerry.ui.app.LocalSshAgent
 import app.skerry.ui.app.LocalSync
 import app.skerry.ui.app.LocalTunnels
 import app.skerry.ui.app.LocalVault
@@ -188,6 +192,15 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             // "Security" section: master password, biometrics, auto-lock, event log. Live path is
             // behind the gate (vault present); in preview the row is inert (nothing to configure without a vault).
             MoreRow("shield_lock", D.cyanBright, stringResource(Res.string.settings_security_title), null, D.dim, onClick = if (preview) null else { -> state.push(MobileRoute.Security) })
+            // SSH agent: which vault keys sessions with agent forwarding may use. Live path only
+            // (there is nothing to configure without a vault).
+            val agent = LocalSshAgent.current
+            MoreRow(
+                "key", D.cyanBright, stringResource(Res.string.agent_title),
+                if (agent?.enabled == true) stringResource(Res.string.agent_more_on) else stringResource(Res.string.agent_more_off),
+                D.dim,
+                onClick = if (agent == null) null else { -> state.push(MobileRoute.Agent) },
+            )
             // About: subtitle is the current version, or an amber "Update x.y.z" when a newer
             // release is known (the passive mobile counterpart of the desktop status-bar notice).
             val updateVersion = LocalUpdates.current?.available?.versionLabel

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -72,9 +72,7 @@ import app.skerry.ui.generated.resources.conn_field_baud
 import app.skerry.ui.generated.resources.conn_field_device
 import app.skerry.ui.generated.resources.conn_field_group
 import app.skerry.ui.generated.resources.conn_field_jump_host
-import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_field_keep_alive
-import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_jump_none
 import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_name

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -47,6 +47,7 @@ import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.host.AuthMode
+import app.skerry.ui.host.MobileForwardAgentRow
 import app.skerry.ui.host.NewConnectionFormState
 import app.skerry.ui.nav.PlatformBackHandler
 import app.skerry.ui.secure.SecureScreen
@@ -71,7 +72,9 @@ import app.skerry.ui.generated.resources.conn_field_baud
 import app.skerry.ui.generated.resources.conn_field_device
 import app.skerry.ui.generated.resources.conn_field_group
 import app.skerry.ui.generated.resources.conn_field_jump_host
+import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_field_keep_alive
+import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_jump_none
 import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_name
@@ -240,6 +243,9 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                 // Keep-alive cadence (desktop parity); 0 = off. SSH-only: Mosh heartbeats on its own.
                 if (form.connectionType == ConnectionType.SSH) {
                     MobileFormField(stringResource(Res.string.conn_field_keep_alive)) { MobileKeepAlivePicker(form) }
+                    Spacer(Modifier.height(14.dp))
+                    // Agent forwarding (desktop parity): SSH-only, off by default.
+                    MobileForwardAgentRow(form)
                     Spacer(Modifier.height(14.dp))
                 }
             } else if (form.connectionType.isVnc) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -422,7 +422,7 @@ private fun MobileTeamDetail(
         if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
     }
 
-    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_members))
+    MobileSectionLabel(stringResource(Res.string.lib_teams_members))
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         members.forEach { m ->
             val modifiable = canManage && m.accountId != team.ownerAccountId && canModifyMember(team.role, m.role)
@@ -436,7 +436,7 @@ private fun MobileTeamDetail(
         }
     }
 
-    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
+    MobileSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
     sharedHosts.forEach { host ->
         MobileSharedRow(host.label, "${host.username}@${host.address}", canUnshare = canWrite) { onUnshare(host.id) }
@@ -445,7 +445,7 @@ private fun MobileTeamDetail(
         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
     }
 
-    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
+    MobileSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
     if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = D.faint, size = 11.5.sp)
     sharedSnippets.forEach { snippet ->
         MobileSharedRow(snippet.label, snippet.command, canUnshare = canWrite) { onUnshare(snippet.id) }
@@ -463,10 +463,6 @@ private fun MobileTeamDetail(
     }
 }
 
-@Composable
-private fun MobileTeamsSectionLabel(text: String) {
-    Txt(text.uppercase(), color = D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(top = 24.dp, bottom = 10.dp))
-}
 
 @Composable
 private fun MobileTeamChip(team: TeamUi, active: Boolean, onClick: () -> Unit) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -84,6 +84,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.vault.AddPasswordDialog
+import app.skerry.ui.vault.AgentBadge
 import app.skerry.ui.design.Badge
 import app.skerry.ui.vault.CertificateDetailBody
 import app.skerry.ui.design.D
@@ -391,6 +392,7 @@ private fun MobileSecretCard(credential: Credential, usedByCount: Int, mono: Fon
                     }
                     is CredentialSecret.Password -> Unit
                 }
+                AgentBadge(credential, size = 9.sp)
             }
             val meta = when (credential.secret) {
                 is CredentialSecret.PrivateKey ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
@@ -46,6 +46,7 @@ import app.skerry.ui.generated.resources.agent_socket_copy
 import app.skerry.ui.generated.resources.agent_socket_desc
 import app.skerry.ui.generated.resources.agent_socket_failed
 import app.skerry.ui.generated.resources.agent_socket_hint
+import app.skerry.ui.generated.resources.agent_socket_needs_agent
 import app.skerry.ui.generated.resources.agent_socket_section
 import app.skerry.ui.generated.resources.agent_socket_unsupported
 import app.skerry.ui.generated.resources.agent_subtitle
@@ -94,6 +95,10 @@ internal fun AgentSection(controller: SshAgentController?) {
             on = controller?.socketEnabled == true,
             onToggle = { controller?.exposeSocket(controller.socketEnabled != true) },
         )
+        // A socket switch with the agent off would sit there "on" and serve nothing.
+        if (controller?.socketEnabled == true && !controller.enabled) {
+            Txt(stringResource(Res.string.agent_socket_needs_agent), color = D.amber, size = 11.5.sp, modifier = Modifier.padding(top = 4.dp))
+        }
         controller?.socketPath?.let { path -> SocketPathRow(path) }
         if (controller?.socketFailed == true) {
             Txt(stringResource(Res.string.agent_socket_failed), color = D.storm, size = 11.5.sp, modifier = Modifier.padding(top = 4.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
@@ -27,12 +27,15 @@ import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.agent_activity
+import app.skerry.ui.generated.resources.agent_activity_declined
 import app.skerry.ui.generated.resources.agent_activity_denied
 import app.skerry.ui.generated.resources.agent_activity_line
 import app.skerry.ui.generated.resources.agent_activity_listed
 import app.skerry.ui.generated.resources.agent_activity_none
 import app.skerry.ui.generated.resources.agent_activity_refused
 import app.skerry.ui.generated.resources.agent_activity_signed
+import app.skerry.ui.generated.resources.agent_confirm
+import app.skerry.ui.generated.resources.agent_confirm_desc
 import app.skerry.ui.generated.resources.agent_enable
 import app.skerry.ui.generated.resources.agent_enable_desc
 import app.skerry.ui.generated.resources.agent_key_certificate
@@ -73,6 +76,13 @@ internal fun AgentSection(controller: SshAgentController?) {
         stringResource(Res.string.agent_enable_desc),
         on = controller?.enabled == true,
         onToggle = { controller?.enable(controller.enabled != true) },
+    )
+
+    SettingToggleRow(
+        stringResource(Res.string.agent_confirm),
+        stringResource(Res.string.agent_confirm_desc),
+        on = controller?.confirmSignatures == true,
+        onToggle = { controller?.confirmEachSignature(controller.confirmSignatures != true) },
     )
 
     SectionLabel(stringResource(Res.string.agent_keys))
@@ -170,6 +180,7 @@ internal fun agentActivityLine(entry: SshAgentActivity): String {
             SshAgentAction.Signed -> Res.string.agent_activity_signed
             SshAgentAction.Refused -> Res.string.agent_activity_refused
             SshAgentAction.ForwardingDenied -> Res.string.agent_activity_denied
+            SshAgentAction.Declined -> Res.string.agent_activity_declined
         },
     )
     val origin = when (val where = entry.origin) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
@@ -1,0 +1,187 @@
+package app.skerry.ui.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.agent.SshAgentAction
+import app.skerry.shared.agent.SshAgentActivity
+import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.securityMoment
+import app.skerry.ui.agent.SshAgentController
+import app.skerry.ui.design.D
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Toggle
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.agent_activity
+import app.skerry.ui.generated.resources.agent_activity_denied
+import app.skerry.ui.generated.resources.agent_activity_line
+import app.skerry.ui.generated.resources.agent_activity_listed
+import app.skerry.ui.generated.resources.agent_activity_none
+import app.skerry.ui.generated.resources.agent_activity_refused
+import app.skerry.ui.generated.resources.agent_activity_signed
+import app.skerry.ui.generated.resources.agent_enable
+import app.skerry.ui.generated.resources.agent_enable_desc
+import app.skerry.ui.generated.resources.agent_key_certificate
+import app.skerry.ui.generated.resources.agent_key_private
+import app.skerry.ui.generated.resources.agent_keys
+import app.skerry.ui.generated.resources.agent_keys_empty
+import app.skerry.ui.generated.resources.agent_origin_session
+import app.skerry.ui.generated.resources.agent_origin_socket
+import app.skerry.ui.generated.resources.agent_socket
+import app.skerry.ui.generated.resources.agent_socket_copy
+import app.skerry.ui.generated.resources.agent_socket_desc
+import app.skerry.ui.generated.resources.agent_socket_failed
+import app.skerry.ui.generated.resources.agent_socket_hint
+import app.skerry.ui.generated.resources.agent_socket_section
+import app.skerry.ui.generated.resources.agent_socket_unsupported
+import app.skerry.ui.generated.resources.agent_subtitle
+import app.skerry.ui.generated.resources.agent_title
+import app.skerry.ui.generated.resources.settings_time_days_ago
+import app.skerry.ui.generated.resources.settings_time_today
+import app.skerry.ui.generated.resources.settings_time_yesterday
+import app.skerry.ui.vault.copyTextToClipboard
+import org.jetbrains.compose.resources.stringResource
+
+// SSH agent section: master switch, which vault keys the agent offers, the local agent socket
+// (desktop) and what has been asking for signatures lately.
+
+/**
+ * Live SSH agent section. [controller] == null means mock/preview without a vault: the layout
+ * renders with the switches off and inert, like the other sections do.
+ */
+@Composable
+internal fun AgentSection(controller: SshAgentController?) {
+    SectionTitle(stringResource(Res.string.agent_title), stringResource(Res.string.agent_subtitle))
+
+    SettingToggleRow(
+        stringResource(Res.string.agent_enable),
+        stringResource(Res.string.agent_enable_desc),
+        on = controller?.enabled == true,
+        onToggle = { controller?.enable(controller.enabled != true) },
+    )
+
+    SectionLabel(stringResource(Res.string.agent_keys))
+    val keys = controller?.agentKeys.orEmpty()
+    if (keys.isEmpty()) {
+        Txt(stringResource(Res.string.agent_keys_empty), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 4.dp))
+    } else {
+        keys.forEach { key -> AgentKeyRow(key, controller) }
+    }
+
+    // The local socket is desktop-only and needs owner-only file permissions; where that is
+    // impossible the row still appears, explaining why rather than silently vanishing.
+    SectionLabel(stringResource(Res.string.agent_socket_section))
+    if (controller != null && !controller.socketSupported) {
+        Txt(stringResource(Res.string.agent_socket_unsupported), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 4.dp))
+    } else {
+        SettingToggleRow(
+            stringResource(Res.string.agent_socket),
+            stringResource(Res.string.agent_socket_desc),
+            on = controller?.socketEnabled == true,
+            onToggle = { controller?.exposeSocket(controller.socketEnabled != true) },
+        )
+        controller?.socketPath?.let { path -> SocketPathRow(path) }
+        if (controller?.socketFailed == true) {
+            Txt(stringResource(Res.string.agent_socket_failed), color = D.storm, size = 11.5.sp, modifier = Modifier.padding(top = 4.dp))
+        }
+    }
+
+    SectionLabel(stringResource(Res.string.agent_activity))
+    val activity = controller?.activity.orEmpty()
+    if (activity.isEmpty()) {
+        Txt(stringResource(Res.string.agent_activity_none), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 3.dp))
+    } else {
+        activity.forEach { entry ->
+            Row(Modifier.padding(vertical = 3.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Txt("●", color = if (entry.action == SshAgentAction.Signed) D.amber else D.moss, size = 9.sp)
+                Txt(agentActivityLine(entry), color = D.dim, size = 12.sp)
+            }
+        }
+    }
+}
+
+/** One keychain key with the switch that puts it in the agent. */
+@Composable
+private fun AgentKeyRow(key: Credential, controller: SshAgentController?) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(key.label, color = D.text, size = 13.sp, weight = FontWeight.Medium)
+            Txt(agentKeyKind(key), color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+        }
+        Toggle(key.agentEnabled, { controller?.setKeyInAgent(key.id, !key.agentEnabled) })
+    }
+}
+
+/** The `SSH_AUTH_SOCK` value, with a copy action — it is meant to be pasted into a shell. */
+@Composable
+private fun SocketPathRow(path: String) {
+    Column(Modifier.fillMaxWidth().padding(top = 6.dp)) {
+        Txt(stringResource(Res.string.agent_socket_hint), color = D.faint, size = 11.sp)
+        Row(
+            Modifier.padding(top = 4.dp).clip(RoundedCornerShape(6.dp)).clickable { copyTextToClipboard(path) }.padding(vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Txt(path, color = D.cyanBright, size = 12.sp)
+            Sym("content_copy", size = 13.sp, color = D.cyan)
+            Txt(stringResource(Res.string.agent_socket_copy), color = D.cyan, size = 11.sp)
+        }
+    }
+}
+
+/** Localized secret kind of an agent key (only key-shaped secrets reach this section). */
+@Composable
+private fun agentKeyKind(key: Credential): String = stringResource(
+    when (key.secret) {
+        is CredentialSecret.Certificate -> Res.string.agent_key_certificate
+        else -> Res.string.agent_key_private
+    },
+)
+
+/** Activity row: "Signed with <key> · <who> · <when>". */
+@Composable
+internal fun agentActivityLine(entry: SshAgentActivity): String {
+    val action = stringResource(
+        when (entry.action) {
+            SshAgentAction.Listed -> Res.string.agent_activity_listed
+            SshAgentAction.Signed -> Res.string.agent_activity_signed
+            SshAgentAction.Refused -> Res.string.agent_activity_refused
+            SshAgentAction.ForwardingDenied -> Res.string.agent_activity_denied
+        },
+    )
+    val origin = when (val where = entry.origin) {
+        is SshAgentOrigin.Session -> stringResource(Res.string.agent_origin_session, where.address)
+        SshAgentOrigin.LocalSocket -> stringResource(Res.string.agent_origin_socket)
+    }
+    val head = entry.keyComment?.let { "$action · $it" } ?: action
+    return stringResource(Res.string.agent_activity_line, head, origin, agentActivityTime(entry.at))
+}
+
+/** Relative time of an activity entry, sharing the security log's wording. */
+@Composable
+private fun agentActivityTime(at: String): String {
+    val moment = securityMoment(at) ?: return at
+    return when (moment.daysAgo) {
+        0 -> stringResource(Res.string.settings_time_today, moment.timeOfDay)
+        1 -> stringResource(Res.string.settings_time_yesterday, moment.timeOfDay)
+        else -> stringResource(Res.string.settings_time_days_ago, moment.daysAgo)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsNav.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsNav.kt
@@ -9,6 +9,7 @@ val SETTINGS_NAV = listOf(
     SettingsNavItem(SettingsTab.AI, "auto_awesome"),
     SettingsNavItem(SettingsTab.Sync, "sync"),
     SettingsNavItem(SettingsTab.Security, "shield_lock"),
+    SettingsNavItem(SettingsTab.Agent, "key"),
     SettingsNavItem(SettingsTab.Appearance, "palette"),
     SettingsNavItem(SettingsTab.Terminal, "terminal"),
     SettingsNavItem(SettingsTab.Keyboard, "keyboard"),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsPanel.kt
@@ -32,6 +32,7 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalFeatures
 import app.skerry.ui.app.LocalSecurityLog
+import app.skerry.ui.app.LocalSshAgent
 import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
 import app.skerry.ui.app.SettingsTab
@@ -44,6 +45,7 @@ import app.skerry.ui.design.consumeClicks
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.settings_nav_header
 import app.skerry.ui.generated.resources.shtail_nav_about
+import app.skerry.ui.generated.resources.shtail_nav_agent
 import app.skerry.ui.generated.resources.shtail_nav_ai
 import app.skerry.ui.generated.resources.shtail_nav_appearance
 import app.skerry.ui.generated.resources.shtail_nav_keyboard
@@ -53,7 +55,7 @@ import app.skerry.ui.generated.resources.shtail_nav_terminal
 import app.skerry.ui.vault.VaultGateController
 import org.jetbrains.compose.resources.stringResource
 
-/** Settings panel (760x560 modal): 200dp nav + content with 7 sections (AI/Sync/.../About). */
+/** Settings panel (760x560 modal): 200dp nav + content with 8 sections (AI/Sync/.../About). */
 @Composable
 fun SettingsPanel(state: DesktopDesignState) {
     // Live security controller over shared vault/biometrics/log: password change, biometrics
@@ -100,6 +102,7 @@ fun SettingsPanel(state: DesktopDesignState) {
                         onChangeMasterPassword = { changePwOpen = true },
                         onBiometricToggled = { securityReload++ },
                     )
+                    SettingsTab.Agent -> AgentSection(LocalSshAgent.current)
                     SettingsTab.Keyboard -> KeyboardSection()
                     SettingsTab.About -> AboutSection()
                 }
@@ -162,6 +165,7 @@ private fun SettingsTab.navLabel(): String = when (this) {
     SettingsTab.AI -> stringResource(Res.string.shtail_nav_ai)
     SettingsTab.Sync -> stringResource(Res.string.shtail_nav_sync)
     SettingsTab.Security -> stringResource(Res.string.shtail_nav_security)
+    SettingsTab.Agent -> stringResource(Res.string.shtail_nav_agent)
     SettingsTab.Appearance -> stringResource(Res.string.shtail_nav_appearance)
     SettingsTab.Terminal -> stringResource(Res.string.shtail_nav_terminal)
     SettingsTab.Keyboard -> stringResource(Res.string.shtail_nav_keyboard)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -26,6 +27,7 @@ import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.jumpRouteLabel
+import app.skerry.shared.ssh.SshAgentForwarding
 import app.skerry.ui.connection.shortCipher
 import app.skerry.ui.design.D
 import app.skerry.ui.design.Dot
@@ -37,7 +39,10 @@ import app.skerry.ui.generated.resources.term_auth_ask
 import app.skerry.ui.generated.resources.term_auth_certificate
 import app.skerry.ui.generated.resources.term_auth_identity
 import app.skerry.ui.generated.resources.term_auth_password
+import app.skerry.ui.generated.resources.term_agent_active
+import app.skerry.ui.generated.resources.term_agent_refused
 import app.skerry.ui.generated.resources.term_info_address
+import app.skerry.ui.generated.resources.term_info_agent
 import app.skerry.ui.generated.resources.term_info_auth
 import app.skerry.ui.generated.resources.term_info_cipher
 import app.skerry.ui.generated.resources.term_info_host
@@ -108,6 +113,15 @@ internal fun InfoPanel() {
             }
             InfoRow(stringResource(Res.string.term_info_auth), authValue, mono)
             InfoRow(stringResource(Res.string.term_info_cipher), if (live) (shortCipher(active?.controller?.cipher) ?: "…") else "aes256-gcm", mono)
+            // Agent forwarding is shown only when the profile asked for it: silence would leave the
+            // user guessing why `ssh` on the far side still wants a password.
+            when (if (live) active?.controller?.agentForwarding else SshAgentForwarding.None) {
+                SshAgentForwarding.Active ->
+                    InfoRow(stringResource(Res.string.term_info_agent), stringResource(Res.string.term_agent_active), mono)
+                SshAgentForwarding.Refused ->
+                    InfoRow(stringResource(Res.string.term_info_agent), stringResource(Res.string.term_agent_refused), mono, valueColor = D.sunset)
+                else -> Unit
+            }
             InfoRow(stringResource(Res.string.term_info_uptime), if (live) (liveMetrics?.uptimeSeconds?.let { formatUptime(it) } ?: "…") else "04:12:45", mono)
         }
         Column(Modifier.padding(start = 16.dp, end = 16.dp, bottom = 14.dp)) {
@@ -132,10 +146,10 @@ internal fun InfoPanel() {
 }
 
 @Composable
-private fun InfoRow(label: String, value: String, mono: FontFamily) {
+private fun InfoRow(label: String, value: String, mono: FontFamily, valueColor: Color = D.textBright) {
     Row(Modifier.fillMaxWidth().padding(vertical = 6.dp), horizontalArrangement = Arrangement.SpaceBetween) {
         Txt(label, color = D.faint, size = 11.5.sp)
-        Txt(value, color = D.textBright, size = 11.5.sp, font = mono)
+        Txt(value, color = valueColor, size = 11.5.sp, font = mono)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/AgentBadge.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/AgentBadge.kt
@@ -1,0 +1,25 @@
+package app.skerry.ui.vault
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.vault.Credential
+import app.skerry.ui.app.LocalSshAgent
+import app.skerry.ui.design.Badge
+import app.skerry.ui.design.D
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vault_badge_agent
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * "in agent" marker on a key in the keychain — the way back from Settings → SSH agent, where the
+ * text already points at the vault.
+ *
+ * Shown only while the agent is actually on: the flag lives on the key, but a key in a switched-off
+ * agent signs nothing, and a badge claiming otherwise would be the wrong thing to trust.
+ */
+@Composable
+fun AgentBadge(credential: Credential, size: androidx.compose.ui.unit.TextUnit = 9.5.sp) {
+    val agent = LocalSshAgent.current ?: return
+    if (!credential.agentEnabled || !agent.enabled) return
+    Badge(stringResource(Res.string.vault_badge_agent), bg = D.amber.copy(alpha = 0.16f), fg = D.amber, radius = 3, size = size)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.vault
 
+import app.skerry.ui.agent.SshAgentController
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.tunnel.TunnelManager
 
@@ -15,10 +16,15 @@ import app.skerry.ui.tunnel.TunnelManager
  * the tabs are still there after unlocking — but their saved credentials are cleared, because an
  * auto-reconnect after a lock would re-authenticate with a stale secret against a locked vault.
  *
+ * The SSH agent forgets every private key it had parsed and stops serving the local socket. This
+ * matters precisely because sessions survive: a server whose forwarded agent channel is still open
+ * would otherwise keep getting signatures from behind the lock screen.
+ *
  * Shared by desktop and Android so the two can't drift apart on which of these gets forgotten.
  */
-fun tearDownForLock(tunnels: TunnelManager?, sessions: SessionsController?) {
+fun tearDownForLock(tunnels: TunnelManager?, sessions: SessionsController?, agent: SshAgentController? = null) {
     tunnels?.closeAll()
+    agent?.onVaultLocked()
     sessions?.sessions?.forEach { session ->
         session.controller.clearReconnectCredentials()
         session.splitSession?.controller?.clearReconnectCredentials()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -451,6 +451,7 @@ private fun LiveSecretCard(
                         Txt(credential.label, color = D.text, size = 13.5.sp, weight = FontWeight.SemiBold)
                         info?.keyTypeLabel?.let { Badge(it, bg = D.moss.copy(alpha = 0.16f), fg = D.moss, radius = 3, size = 9.5.sp) }
                         if (info?.expired == true) Badge(stringResource(Res.string.vault_badge_expired), bg = D.sunset.copy(alpha = 0.16f), fg = D.sunset, radius = 3, size = 9.5.sp)
+                        AgentBadge(credential)
                     }
                     val meta = when {
                         info == null -> stringResource(Res.string.vault_meta_certificate, usedBy)
@@ -467,6 +468,7 @@ private fun LiveSecretCard(
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         Txt(credential.label, color = D.text, size = 13.5.sp, weight = FontWeight.SemiBold)
                         info?.keyTypeLabel?.let { Badge(it, bg = D.moss.copy(alpha = 0.16f), fg = D.moss, radius = 3, size = 9.5.sp) }
+                        AgentBadge(credential)
                     }
                     val meta = if (info != null) {
                         stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(info.fingerprintSha256), usedBy)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/agent/SshAgentControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/agent/SshAgentControllerTest.kt
@@ -1,0 +1,218 @@
+package app.skerry.ui.agent
+
+import app.skerry.shared.agent.SshAgentAction
+import app.skerry.shared.agent.SshAgentActivityLog
+import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.shared.agent.SshAgentUsage
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.MergeResult
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SyncMeta
+import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+import app.skerry.ui.identity.CredentialManagerController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private class FakeSocket(var failing: Boolean = false) : SshAgentSocket {
+    override val isSupported = true
+    var running = false
+        private set
+
+    override fun start(): String? {
+        if (failing) return null
+        running = true
+        return "/run/skerry/agent.sock"
+    }
+
+    override fun stop() {
+        running = false
+    }
+}
+
+class SshAgentControllerTest {
+
+    private val vault = FakeAgentVault()
+    private val credentials = CredentialManagerController(CredentialStore(vault)) { "generated" }
+    private var parsedKeysDropped = 0
+
+    private fun controller(socket: SshAgentSocket? = null, enabled: Boolean = true) =
+        SshAgentController(
+            credentials = credentials,
+            isVaultUnlocked = { vault.isUnlocked },
+            socket = socket,
+            dropParsedKeys = { parsedKeysDropped++ },
+            activityLog = SshAgentActivityLog(clock = { "2026-07-21T10:00:00Z" }),
+            initialEnabled = enabled,
+            initialSocketEnabled = false,
+        )
+
+    private fun addKey(id: String, label: String, inAgent: Boolean, secret: CredentialSecret = CredentialSecret.PrivateKey("pem-$id")) {
+        CredentialStore(vault).put(Credential(id = id, label = label, secret = secret, agentEnabled = inAgent))
+        credentials.reload()
+    }
+
+    @Test
+    fun `offers only the keys the user put in the agent`() {
+        addKey("a", "work", inAgent = true)
+        addKey("b", "home", inAgent = false)
+
+        assertEquals(listOf("work"), controller().keyMaterial().map { it.comment })
+    }
+
+    @Test
+    fun `passwords are never offered as agent keys`() {
+        // A password is not a key; it must not show up in the agent's list, enabled flag or not.
+        addKey("p", "server password", inAgent = true, secret = CredentialSecret.Password("s3cret"))
+
+        assertTrue(controller().keyMaterial().isEmpty())
+        assertTrue(controller().agentKeys.isEmpty())
+    }
+
+    @Test
+    fun `certificates are offered with their certificate blob`() {
+        addKey("c", "ca key", inAgent = true, secret = CredentialSecret.Certificate("pem", "ssh-ed25519-cert-v01@openssh.com AAAA"))
+
+        val material = controller().keyMaterial().single()
+        assertEquals("ssh-ed25519-cert-v01@openssh.com AAAA", material.certificate)
+    }
+
+    @Test
+    fun `a disabled agent offers nothing`() {
+        addKey("a", "work", inAgent = true)
+
+        assertTrue(controller(enabled = false).keyMaterial().isEmpty())
+    }
+
+    @Test
+    fun `a locked vault offers nothing`() {
+        // Terminal sessions survive a lock, so a forwarded channel can still ask — and must get
+        // nothing until the user unlocks again.
+        addKey("a", "work", inAgent = true)
+        val controller = controller()
+        vault.lock()
+
+        assertTrue(controller.keyMaterial().isEmpty())
+    }
+
+    @Test
+    fun `switching the agent off drops parsed keys and stops the socket`() {
+        val socket = FakeSocket()
+        val controller = controller(socket)
+        controller.exposeSocket(true)
+        assertTrue(socket.running)
+
+        controller.enable(false)
+
+        assertFalse(socket.running)
+        assertTrue(parsedKeysDropped > 0)
+        assertNull(controller.socketPath)
+    }
+
+    @Test
+    fun `changing which keys are in the agent re-parses them`() {
+        addKey("a", "work", inAgent = false)
+        val controller = controller()
+        val before = parsedKeysDropped
+
+        controller.setKeyInAgent("a", true)
+
+        assertEquals(listOf("work"), controller.keyMaterial().map { it.comment })
+        assertTrue(parsedKeysDropped > before, "parsed keys must be dropped when the key set changes")
+    }
+
+    @Test
+    fun `the socket is only started while the agent is on`() {
+        val socket = FakeSocket()
+        val controller = controller(socket, enabled = false)
+
+        controller.exposeSocket(true)
+
+        assertFalse(socket.running, "socket exposed keys while the agent was off")
+        assertNull(controller.socketPath)
+    }
+
+    @Test
+    fun `a socket that cannot be bound is reported instead of failing silently`() {
+        val socket = FakeSocket(failing = true)
+        val controller = controller(socket)
+
+        controller.exposeSocket(true)
+
+        assertTrue(controller.socketFailed)
+        assertNull(controller.socketPath)
+    }
+
+    @Test
+    fun `locking the vault stops the socket and unlocking brings it back`() {
+        val socket = FakeSocket()
+        val controller = controller(socket)
+        controller.exposeSocket(true)
+
+        controller.onVaultLocked()
+        assertFalse(socket.running)
+        assertTrue(parsedKeysDropped > 0)
+
+        controller.onVaultUnlocked()
+        assertTrue(socket.running)
+    }
+
+    @Test
+    fun `records agent use newest first and keeps the list bounded`() {
+        val controller = controller()
+        repeat(MAX + 5) {
+            controller.record(SshAgentUsage(SshAgentOrigin.Session("host-$it"), SshAgentAction.Signed, "work"))
+        }
+
+        assertEquals(MAX, controller.activity.size)
+        assertEquals("host-${MAX + 4}", (controller.activity.first().origin as SshAgentOrigin.Session).address)
+        assertEquals("2026-07-21T10:00:00Z", controller.activity.first().at)
+    }
+
+    private companion object {
+        const val MAX = SshAgentActivityLog.DEFAULT_MAX
+    }
+}
+
+/** In-memory vault that can actually lock — the agent's key access hangs off that. */
+private class FakeAgentVault : Vault {
+    private val payloads = mutableMapOf<String, ByteArray>()
+    private val records = mutableMapOf<String, VaultRecord>()
+
+    override var isUnlocked: Boolean = true
+        private set
+
+    override fun exists(): Boolean = true
+    override fun create(password: CharArray) { isUnlocked = true }
+    override fun unlock(password: CharArray): UnlockResult { isUnlocked = true; return UnlockResult.Success }
+    override fun lock() { isUnlocked = false }
+    override fun reset() { payloads.clear(); records.clear() }
+
+    override fun records(): List<VaultRecord> = records.values.toList()
+    override fun syncMeta(): SyncMeta? = null
+    override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
+    override fun openPayload(id: String): ByteArray? = records[id]?.takeIf { !it.deleted }?.let { payloads[id] }
+
+    override fun put(id: String, type: RecordType, payload: ByteArray) {
+        val version = (records[id]?.version ?: 0L) + 1
+        records[id] = VaultRecord(id, type, version, "2026-07-21T00:00:00Z", "dev", deleted = false, blob = ByteArray(0))
+        payloads[id] = payload
+    }
+
+    override fun remove(id: String) {
+        records[id] = (records[id] ?: return).copy(version = records[id]!!.version + 1, deleted = true)
+    }
+
+    override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
+    override fun verifyPassword(password: CharArray): Boolean = true
+    override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Corrupted
+    override fun exportDataKey(): DataKey? = null
+    override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/agent/SshAgentControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/agent/SshAgentControllerTest.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.agent
 import app.skerry.shared.agent.SshAgentAction
 import app.skerry.shared.agent.SshAgentActivityLog
 import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.shared.agent.SshAgentSignPrompt
 import app.skerry.shared.agent.SshAgentUsage
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
@@ -15,6 +16,13 @@ import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecord
 import app.skerry.ui.identity.CredentialManagerController
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -43,7 +51,12 @@ class SshAgentControllerTest {
     private val credentials = CredentialManagerController(CredentialStore(vault)) { "generated" }
     private var parsedKeysDropped = 0
 
-    private fun controller(socket: SshAgentSocket? = null, enabled: Boolean = true) =
+    private fun controller(
+        socket: SshAgentSocket? = null,
+        enabled: Boolean = true,
+        confirmSignatures: Boolean = false,
+        uiContext: CoroutineContext = EmptyCoroutineContext,
+    ) =
         SshAgentController(
             credentials = credentials,
             isVaultUnlocked = { vault.isUnlocked },
@@ -52,6 +65,8 @@ class SshAgentControllerTest {
             activityLog = SshAgentActivityLog(clock = { "2026-07-21T10:00:00Z" }),
             initialEnabled = enabled,
             initialSocketEnabled = false,
+            initialConfirmSignatures = confirmSignatures,
+            uiContext = uiContext,
         )
 
     private fun addKey(id: String, label: String, inAgent: Boolean, secret: CredentialSecret = CredentialSecret.PrivateKey("pem-$id")) {
@@ -165,8 +180,8 @@ class SshAgentControllerTest {
     }
 
     @Test
-    fun `records agent use newest first and keeps the list bounded`() {
-        val controller = controller()
+    fun `records agent use newest first and keeps the list bounded`() = runTest {
+        val controller = controller(uiContext = UnconfinedTestDispatcher(testScheduler))
         repeat(MAX + 5) {
             controller.record(SshAgentUsage(SshAgentOrigin.Session("host-$it"), SshAgentAction.Signed, "work"))
         }
@@ -175,6 +190,89 @@ class SshAgentControllerTest {
         assertEquals("host-${MAX + 4}", (controller.activity.first().origin as SshAgentOrigin.Session).address)
         assertEquals("2026-07-21T10:00:00Z", controller.activity.first().at)
     }
+
+    @Test
+    fun `without per-signature confirmation the agent signs straight away`() = runTest {
+        val controller = controller(confirmSignatures = false)
+
+        assertTrue(controller.confirmSignature(prompt()))
+        assertNull(controller.pendingSignature)
+    }
+
+    @Test
+    fun `a signature waits for the user and goes through once allowed`() = runTest {
+        val controller = controller(confirmSignatures = true)
+
+        val answer = async { controller.confirmSignature(prompt()) }
+        runCurrent()
+        assertEquals("work", controller.pendingSignature?.keyComment)
+
+        controller.answerSignature(allow = true)
+
+        assertTrue(answer.await())
+        assertNull(controller.pendingSignature, "the prompt outlived the answer")
+    }
+
+    @Test
+    fun `declining a signature refuses it`() = runTest {
+        val controller = controller(confirmSignatures = true)
+
+        val answer = async { controller.confirmSignature(prompt()) }
+        runCurrent()
+        controller.answerSignature(allow = false)
+
+        assertFalse(answer.await())
+        assertNull(controller.pendingSignature)
+    }
+
+    @Test
+    fun `an unanswered prompt times out as a refusal`() = runTest {
+        // The requesting channel must not hang forever on a dialog nobody is looking at.
+        val controller = controller(confirmSignatures = true)
+
+        val answer = async { controller.confirmSignature(prompt()) }
+        runCurrent()
+        advanceTimeBy(SshAgentController.PROMPT_TIMEOUT_MS + 1)
+
+        assertFalse(answer.await())
+        assertNull(controller.pendingSignature)
+    }
+
+    @Test
+    fun `locking the vault refuses whatever is waiting for an answer`() = runTest {
+        val controller = controller(confirmSignatures = true)
+
+        val answer = async { controller.confirmSignature(prompt()) }
+        runCurrent()
+        controller.onVaultLocked()
+
+        assertFalse(answer.await())
+        assertNull(controller.pendingSignature)
+    }
+
+    @Test
+    fun `a second request waits its turn instead of replacing the prompt`() = runTest {
+        // Two forwarded channels can ask at once; answering must not be ambiguous about which
+        // request the click belongs to.
+        val controller = controller(confirmSignatures = true)
+
+        val first = async { controller.confirmSignature(prompt("work")) }
+        runCurrent()
+        val second = async { controller.confirmSignature(prompt("home")) }
+        runCurrent()
+        assertEquals("work", controller.pendingSignature?.keyComment)
+
+        controller.answerSignature(allow = true)
+        runCurrent()
+        assertTrue(first.await())
+        assertEquals("home", controller.pendingSignature?.keyComment)
+
+        controller.answerSignature(allow = false)
+        assertFalse(second.await())
+    }
+
+    private fun prompt(keyComment: String = "work") =
+        SshAgentSignPrompt(SshAgentOrigin.Session("bastion.example"), keyComment)
 
     private companion object {
         const val MAX = SshAgentActivityLog.DEFAULT_MAX

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
@@ -7,6 +7,8 @@ import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 /**
  * Pure helpers wiring a host to a session (host → address/label, keychain secret → auth
@@ -34,6 +36,12 @@ class HostConnectTest {
     fun target_carries_the_keep_alive_interval() {
         assertEquals(120, host().copy(keepAliveSeconds = 120).toTarget().keepAliveSeconds)
         assertEquals(0, host().copy(keepAliveSeconds = 0).toTarget().keepAliveSeconds)
+    }
+
+    @Test
+    fun target_carries_the_agent_forwarding_flag() {
+        assertTrue(host().copy(forwardAgent = true).toTarget().forwardAgent)
+        assertFalse(host().toTarget().forwardAgent)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -91,6 +91,26 @@ class NewConnectionFormStateTest {
     }
 
     @Test
+    fun agent_forwarding_defaults_to_off_travels_the_draft_and_prefills_from_host() {
+        val f = NewConnectionFormState().apply { name = "h"; address = "a"; username = "u" }
+        assertFalse(f.forwardAgent)
+        f.forwardAgent = true
+        assertTrue(f.toDraft().forwardAgent)
+
+        val host = Host(id = "h1", label = "Web", address = "web", username = "root", forwardAgent = true)
+        assertTrue(NewConnectionFormState.fromHost(host).forwardAgent)
+    }
+
+    @Test
+    fun switching_away_from_ssh_drops_agent_forwarding() {
+        // Only an SSH session channel can carry the agent; Mosh runs its own protocol after the
+        // bootstrap, so leaving the flag on would promise something the profile cannot do.
+        val f = NewConnectionFormState().apply { forwardAgent = true }
+        f.chooseConnectionType(app.skerry.shared.ssh.ConnectionType.MOSH)
+        assertFalse(f.forwardAgent)
+    }
+
+    @Test
     fun switching_away_from_ssh_drops_the_jump_host() {
         val f = NewConnectionFormState().apply { jumpHostId = "bastion-1" }
         f.chooseConnectionType(app.skerry.shared.ssh.ConnectionType.TELNET)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
@@ -99,6 +99,26 @@ class CredentialManagerControllerTest {
         assertNull(controller.find("missing"))
         assertNull(controller.find(null))
     }
+
+    @Test
+    fun `editing a secret keeps it in the agent`() {
+        // The agent switch lives in Settings, not in the keychain form: re-saving a key there must
+        // neither drop it out of the agent nor sneak it in.
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+        val id = controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem"))
+        controller.setAgentEnabled(id, true)
+
+        controller.save(CredentialDraft(id = id, label = "Key renamed", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem2"))
+
+        assertEquals(true, controller.credentials.single().agentEnabled)
+    }
+
+    @Test
+    fun `a new secret is not in the agent`() {
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem"))
+        assertEquals(false, controller.credentials.single().agentEnabled)
+    }
 }
 
 /** In-memory [Vault] storing records (put/openPayload/records/remove, tombstone) for tests. */

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/agent/DesktopAgentSocket.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/agent/DesktopAgentSocket.kt
@@ -1,0 +1,32 @@
+package app.skerry.ui.agent
+
+import app.skerry.shared.agent.SshAgentService
+import app.skerry.shared.agent.UnixSocketSshAgent
+import java.nio.file.Path
+import kotlinx.coroutines.CoroutineScope
+
+/**
+ * Desktop [SshAgentSocket]: the `SSH_AUTH_SOCK` unix socket other programs connect to. Thin
+ * adapter — the listener itself is [UnixSocketSshAgent] in `shared` (so the socket and a forwarded
+ * channel serve the identical agent), and this only turns a failed bind into `null` for the UI to
+ * report.
+ */
+internal class DesktopAgentSocket(
+    private val directory: Path,
+    private val service: SshAgentService,
+    private val scope: CoroutineScope,
+) : SshAgentSocket {
+
+    private var listener: UnixSocketSshAgent? = null
+
+    override val isSupported: Boolean get() = UnixSocketSshAgent.isSupported
+
+    override fun start(): String? = runCatching {
+        val agent = listener ?: UnixSocketSshAgent(directory, service, scope).also { listener = it }
+        agent.start().toString()
+    }.getOrNull()
+
+    override fun stop() {
+        listener?.stop()
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -503,8 +503,8 @@ private fun seededKnownHosts(): KnownHostsController {
  */
 private fun seededAgent(credentials: CredentialManagerController): app.skerry.ui.agent.SshAgentController {
     val log = app.skerry.shared.agent.SshAgentActivityLog(clock = { "2026-07-21T09:12:00Z" })
-    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.Session("bastion.internal"), app.skerry.shared.agent.SshAgentAction.Signed, "Deploy key"))
-    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.LocalSocket, app.skerry.shared.agent.SshAgentAction.Listed, null))
+    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.Session("bastion.internal"), app.skerry.shared.agent.SshAgentAction.Signed, "Deploy key")) {}
+    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.LocalSocket, app.skerry.shared.agent.SshAgentAction.Listed, null)) {}
     val socket = object : app.skerry.ui.agent.SshAgentSocket {
         override val isSupported = true
         override fun start() = "/run/user/1000/skerry/agent/agent.sock"

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -159,6 +159,9 @@ fun main() {
     // Built once outside the content lambda: recomposition must not recreate the controller
     // (a fresh instance would restart its async check and the notice would never settle).
     val updates = if (live) seededUpdates() else null
+    // Live SSH agent so the "SSH agent" settings tab renders real key rows and activity instead of
+    // an empty layout (the section reads the keychain, so it needs the seeded credentials).
+    val sshAgent = if (live && credentials != null) seededAgent(credentials) else null
 
     // Stub window chrome (-Dskerry.screenshot.windowChrome=true): draws the custom window buttons
     // in the titlebar (as in the real undecorated window); drag/minimize/maximize are no-ops offscreen.
@@ -175,7 +178,7 @@ fun main() {
         "unlock" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopUnlockScreen(error = null, canUseBiometric = true, onUnlock = {}, onBiometric = {}, onForgotPassword = {}) } } } }
         "corrupted" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopCorruptedScreen(onReset = {}) } } } }
         "reset" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopResetScreen(onConfirm = {}, onCancel = {}) } } } }
-        else -> { { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, ai = ai, updates = updates, windowChrome = windowChrome) } }
+        else -> { { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, ai = ai, updates = updates, sshAgent = sshAgent, windowChrome = windowChrome) } }
     }
 
     val scene = ImageComposeScene(width = 1280, height = 820, density = Density(1f)) {
@@ -217,7 +220,11 @@ private fun renderMobile(out: String, viewName: String, overlay: String, live: B
     // Key generator/inspector: the Vault tab uses it to compute fingerprints of seeded keys in live mode.
     val keyGenerator = if (live) BouncyCastleSshKeyGenerator() else null
     val deps = if (hosts != null) {
-        AppDependencies(hosts = hosts, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, tunnels = seededTunnels(hosts))
+        AppDependencies(
+            hosts = hosts, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator,
+            tunnels = seededTunnels(hosts),
+            sshAgent = credentials?.let { seededAgent(it) },
+        )
     } else {
         AppDependencies()
     }
@@ -490,6 +497,30 @@ private fun seededKnownHosts(): KnownHostsController {
  * `-Dskerry.screenshot.updateAvailable=true` makes the canned newer release visible (status-bar
  * item, About notice, More-row subtitle); without the flag the check finds nothing.
  */
+/**
+ * SSH agent seeded for offscreen renders: on, with the keychain's first key in it, a socket path
+ * and a couple of activity entries, so the section shows every row it has.
+ */
+private fun seededAgent(credentials: CredentialManagerController): app.skerry.ui.agent.SshAgentController {
+    val log = app.skerry.shared.agent.SshAgentActivityLog(clock = { "2026-07-21T09:12:00Z" })
+    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.Session("bastion.internal"), app.skerry.shared.agent.SshAgentAction.Signed, "Deploy key"))
+    log.record(app.skerry.shared.agent.SshAgentUsage(app.skerry.shared.agent.SshAgentOrigin.LocalSocket, app.skerry.shared.agent.SshAgentAction.Listed, null))
+    val socket = object : app.skerry.ui.agent.SshAgentSocket {
+        override val isSupported = true
+        override fun start() = "/run/user/1000/skerry/agent/agent.sock"
+        override fun stop() = Unit
+    }
+    credentials.credentials.firstOrNull()?.let { credentials.setAgentEnabled(it.id, true) }
+    return app.skerry.ui.agent.SshAgentController(
+        credentials = credentials,
+        isVaultUnlocked = { true },
+        socket = socket,
+        activityLog = log,
+        initialEnabled = true,
+        initialSocketEnabled = true,
+    ).also { it.onVaultUnlocked() }
+}
+
 private fun seededUpdates(): app.skerry.ui.update.UpdateNoticeController {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val available = System.getProperty("skerry.screenshot.updateAvailable", "false").toBoolean()

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -193,7 +193,12 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     // is also exactly what an app that has not been unlocked yet should offer.
     var sshAgentController: app.skerry.ui.agent.SshAgentController? = null
     val agentKeys = SshjAgentKeys({ sshAgentController?.keyMaterial().orEmpty() })
-    val agentService = SshAgentService(agentKeys) { usage -> sshAgentController?.record(usage) }
+    // No controller yet (or one that says no) means no signature: at that point the agent holds no
+    // keys either, so refusing is the honest answer.
+    val agentService = SshAgentService(
+        agentKeys,
+        confirm = { prompt -> sshAgentController?.confirmSignature(prompt) == true },
+    ) { usage -> sshAgentController?.record(usage) }
     // Live session transport: routes by connection type (SSH/Telnet/Serial). SSH carries the TOFU
     // verifier/known-hosts; Telnet/Serial are stateless (created internally with defaults). Only
     // this transport gets the agent: probe/tunnel connections below must never expose keys.
@@ -298,6 +303,8 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         persistEnabled = { prefs.set("ssh_agent", it) },
         initialSocketEnabled = prefs.bool("ssh_agent_socket", false),
         persistSocketEnabled = { prefs.set("ssh_agent_socket", it) },
+        initialConfirmSignatures = prefs.bool("ssh_agent_confirm", false),
+        persistConfirmSignatures = { prefs.set("ssh_agent_confirm", it) },
     )
     // Saved snippets: the command library is SNIPPET records in the vault (commands may contain
     // inline credentials, so they share encryption and E2E sync). Run targets the active terminal.

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -23,6 +23,9 @@ import app.skerry.shared.ssh.VaultKnownHostsStore
 import app.skerry.shared.ssh.ProbeHostKeyVerifier
 import app.skerry.shared.ssh.RoutingTransport
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.agent.SshAgentActivityLog
+import app.skerry.shared.agent.SshAgentService
+import app.skerry.shared.agent.SshjAgentKeys
 import app.skerry.shared.ssh.SshjTransport
 import app.skerry.shared.ssh.TofuHostKeyVerifier
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
@@ -105,6 +108,17 @@ private fun dataDir(): Path {
 }
 
 /**
+ * Directory holding the SSH agent socket. Prefers `XDG_RUNTIME_DIR` (per-user tmpfs, wiped at
+ * logout — where sockets belong and where a stale one cannot survive a reboot); falls back to the
+ * config directory on systems that do not set it. Either way the directory itself is created 0700
+ * by the listener, which is what keeps other users away from the agent.
+ */
+private fun agentSocketDir(config: Path): Path {
+    val runtime = System.getenv("XDG_RUNTIME_DIR")?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+    return (runtime?.resolve("skerry") ?: config).resolve("agent")
+}
+
+/**
  * Stable device identifier for vault records (provenance + sync LWW). Generated once and
  * persisted to `device_id` so it survives restarts.
  */
@@ -173,11 +187,20 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     // The clock stamps firstSeen/observedAt.
     val knownHostsStore = VaultKnownHostsStore(vault)
     val mismatchStore = FileHostKeyMismatchStore(dir.resolve("known_hosts_mismatches"))
+    // Built-in SSH agent. The service is created before the transport (which forwards it into
+    // sessions) but its keys come from the controller assembled further down — hence the var, as
+    // with reloadManagers/teamsForSync below. Until the controller exists there are no keys, which
+    // is also exactly what an app that has not been unlocked yet should offer.
+    var sshAgentController: app.skerry.ui.agent.SshAgentController? = null
+    val agentKeys = SshjAgentKeys({ sshAgentController?.keyMaterial().orEmpty() })
+    val agentService = SshAgentService(agentKeys) { usage -> sshAgentController?.record(usage) }
     // Live session transport: routes by connection type (SSH/Telnet/Serial). SSH carries the TOFU
-    // verifier/known-hosts; Telnet/Serial are stateless (created internally with defaults).
+    // verifier/known-hosts; Telnet/Serial are stateless (created internally with defaults). Only
+    // this transport gets the agent: probe/tunnel connections below must never expose keys.
     val transport = RoutingTransport(
         ssh = SshjTransport(
             TofuHostKeyVerifier(knownHostsStore, mismatchStore) { Instant.now().toString() },
+            agent = agentService,
         ),
     )
     // "Test connection" from the form uses a separate transport with a read-only verifier: it
@@ -262,6 +285,20 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::find) },
         scope = tunnelScope,
     ) { UUID.randomUUID().toString() }
+    // The agent's policy side: which vault keys it offers, the local socket, recent activity. The
+    // master switch and the socket switch are per-device prefs (the socket is a property of THIS
+    // machine), while which keys are in the agent travels with the key record in the vault.
+    sshAgentController = app.skerry.ui.agent.SshAgentController(
+        credentials = credentials,
+        isVaultUnlocked = { vault.isUnlocked },
+        socket = app.skerry.ui.agent.DesktopAgentSocket(agentSocketDir(dir), agentService, tunnelScope),
+        dropParsedKeys = agentKeys::clear,
+        activityLog = SshAgentActivityLog(clock = { Instant.now().toString() }),
+        initialEnabled = prefs.bool("ssh_agent", false),
+        persistEnabled = { prefs.set("ssh_agent", it) },
+        initialSocketEnabled = prefs.bool("ssh_agent_socket", false),
+        persistSocketEnabled = { prefs.set("ssh_agent_socket", it) },
+    )
     // Saved snippets: the command library is SNIPPET records in the vault (commands may contain
     // inline credentials, so they share encryption and E2E sync). Run targets the active terminal.
     val snippets = SnippetManager(VaultSnippetStore(vault)) { UUID.randomUUID().toString() }
@@ -314,6 +351,8 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         reloadManagers()
         // keep-connected: vault opened means a dataKey exists, so the sync session can be silently restored.
         sync.restoreSession()
+        // The agent's keys live in the vault, so it only starts serving once the vault is open.
+        sshAgentController?.onVaultUnlocked()
     }
     // External cleanup on an irreversible vault reset (forgotten password / corrupted file). The
     // vault file is already erased by the controller (Vault.reset) and now locked, so
@@ -326,6 +365,8 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     // managers. The vault is locked at this point.
     val onVaultReset: (ResetScope) -> Unit = { resetScope ->
         tunnels.closeAll()
+        // The keys the agent was offering were erased with the vault; stop serving and forget them.
+        sshAgentController?.onVaultLocked()
         // Team keys lived in the erased vault, so local team vaults can no longer be opened; lock them.
         teams.lock()
         // The security log refers to the erased vault (password change/biometrics/pairing); on any
@@ -361,7 +402,7 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         snippets.reload()
         tunnels.reload()
     }
-    val deps = AppDependencies(transport = transport, hosts = hosts, vault = vault, credentials = credentials, knownHosts = knownHosts, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, snippets = snippets, sync = sync, teams = teams, localAi = localAi)
+    val deps = AppDependencies(transport = transport, hosts = hosts, vault = vault, credentials = credentials, knownHosts = knownHosts, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, snippets = snippets, sync = sync, teams = teams, localAi = localAi, sshAgent = sshAgentController)
     return DesktopGraph(
         deps = deps,
         securityLog = securityLog,
@@ -478,6 +519,7 @@ fun main(args: Array<String>) {
                     teams = deps.teams,
                     ai = graph.ai,
                     updates = graph.updates,
+                    sshAgent = deps.sshAgent,
                     onVaultUnlocked = graph.onVaultUnlocked,
                     onVaultReset = graph.onVaultReset,
                     windowChrome = windowChrome,

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentActivityLog.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentActivityLog.kt
@@ -20,11 +20,15 @@ class SshAgentActivityLog(
     private val lock = SynchronizedObject()
     private val entries = ArrayDeque<SshAgentActivity>()
 
-    /** Record one use; returns the list as it now looks (newest first), ready to publish. */
-    fun record(usage: SshAgentUsage): List<SshAgentActivity> = synchronized(lock) {
+    /**
+     * Record one use and hand the resulting list (newest first) to [publish] — still under the
+     * lock, so two concurrent requests cannot publish their snapshots out of order and leave the
+     * UI showing the older one.
+     */
+    fun record(usage: SshAgentUsage, publish: (List<SshAgentActivity>) -> Unit): Unit = synchronized(lock) {
         entries.addFirst(SshAgentActivity(usage.origin, usage.action, usage.keyComment, clock()))
         while (entries.size > max) entries.removeLast()
-        entries.toList()
+        publish(entries.toList())
     }
 
     /** Current entries, newest first. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentActivityLog.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentActivityLog.kt
@@ -1,0 +1,48 @@
+package app.skerry.shared.agent
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Bounded in-memory trace of what the agent has been asked to do — the "recent activity" list in
+ * Settings → SSH agent. Deliberately NOT persisted: which key signed for which host and when is
+ * exactly the metadata a zero-knowledge client should not leave on disk, and the list only has to
+ * answer "is something using my keys right now?".
+ *
+ * Entries arrive from the agent's IO threads (forwarded channels, socket connections) and are read
+ * from the UI thread, so the read-modify-write is synchronized (as in
+ * [app.skerry.shared.vault.FileSecurityLog]).
+ */
+class SshAgentActivityLog(
+    private val max: Int = DEFAULT_MAX,
+    private val clock: () -> String = { "" },
+) {
+    private val lock = SynchronizedObject()
+    private val entries = ArrayDeque<SshAgentActivity>()
+
+    /** Record one use; returns the list as it now looks (newest first), ready to publish. */
+    fun record(usage: SshAgentUsage): List<SshAgentActivity> = synchronized(lock) {
+        entries.addFirst(SshAgentActivity(usage.origin, usage.action, usage.keyComment, clock()))
+        while (entries.size > max) entries.removeLast()
+        entries.toList()
+    }
+
+    /** Current entries, newest first. */
+    fun recent(): List<SshAgentActivity> = synchronized(lock) { entries.toList() }
+
+    fun clear(): Unit = synchronized(lock) { entries.clear() }
+
+    companion object {
+        const val DEFAULT_MAX = 20
+    }
+}
+
+/** One entry of the activity list: what the agent did, for whom, and when. */
+data class SshAgentActivity(
+    val origin: SshAgentOrigin,
+    val action: SshAgentAction,
+    /** Comment of the key involved, when the action names one. */
+    val keyComment: String?,
+    /** ISO-8601, from the same clock as the security log. */
+    val at: String,
+)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentCodec.kt
@@ -1,0 +1,180 @@
+package app.skerry.shared.agent
+
+/**
+ * SSH agent protocol (draft-miller-ssh-agent-04) — the read-only subset Skerry serves: list the
+ * keys the vault offers and sign a challenge with one of them. Adding, removing, locking and
+ * extensions are deliberately NOT implemented: the key set is the vault's, not the client's, so a
+ * forwarded remote (or any local process on the socket) must not be able to change it.
+ *
+ * Pure codec over [ByteArray] — no sockets, no threads, no JVM types — so it lives in `commonMain`
+ * and is driven directly from tests (same split as [app.skerry.shared.vnc.RfbCodec] /
+ * [app.skerry.shared.telnet.TelnetCodec]). Framing (the uint32 length prefix in front of every
+ * message) is [frame]; reading it back belongs to the transport, which alone knows where the bytes
+ * come from.
+ *
+ * Every input here arrives from an untrusted peer: a forwarded agent channel is opened by the
+ * remote server, and the local socket is reachable by any process running as the user. Field
+ * lengths are therefore bounded by what actually arrived ([SshAgentProtocolException] otherwise)
+ * before anything is allocated.
+ */
+object SshAgentCodec {
+
+    /** Ceiling for one message, as in OpenSSH's agent. Anything larger is refused unread. */
+    const val MAX_MESSAGE_BYTES = 256 * 1024
+
+    /** Signature flags: ask an RSA key for a SHA-2 signature instead of the legacy SHA-1 one. */
+    const val FLAG_RSA_SHA2_256 = 2
+    const val FLAG_RSA_SHA2_512 = 4
+
+    private const val FAILURE = 5
+    private const val REQUEST_IDENTITIES = 11
+    private const val IDENTITIES_ANSWER = 12
+    private const val SIGN_REQUEST = 13
+    private const val SIGN_RESPONSE = 14
+
+    /**
+     * Parse one agent message (without the length prefix).
+     * @throws SshAgentProtocolException the message is empty or a known request is malformed
+     */
+    fun parseRequest(message: ByteArray): SshAgentRequest {
+        val reader = SshWireReader(message)
+        return when (val type = reader.readByte()) {
+            REQUEST_IDENTITIES -> SshAgentRequest.ListIdentities
+            SIGN_REQUEST -> SshAgentRequest.Sign(
+                keyBlob = reader.readString(),
+                data = reader.readString(),
+                // Flags are the last field: a client that omits them means "no flags" (legacy
+                // SHA-1 RSA), which is not a protocol error.
+                flags = if (reader.remaining >= 4) reader.readUInt32Bits() else 0,
+            )
+            else -> SshAgentRequest.Unsupported(type)
+        }
+    }
+
+    /** `SSH_AGENT_IDENTITIES_ANSWER`: the keys we offer, each as (blob, comment). */
+    fun identitiesAnswer(identities: List<SshAgentIdentity>): ByteArray {
+        val writer = SshWireWriter()
+        writer.putByte(IDENTITIES_ANSWER)
+        writer.putUInt32(identities.size)
+        identities.forEach { identity ->
+            writer.putString(identity.keyBlob)
+            writer.putString(identity.comment.encodeToByteArray())
+        }
+        return writer.toByteArray()
+    }
+
+    /** `SSH_AGENT_SIGN_RESPONSE`: [signature] is the ssh-wire blob `string alg || string sig`. */
+    fun signResponse(signature: ByteArray): ByteArray {
+        val writer = SshWireWriter()
+        writer.putByte(SIGN_RESPONSE)
+        writer.putString(signature)
+        return writer.toByteArray()
+    }
+
+    /** `SSH_AGENT_FAILURE` — the only refusal the protocol has; it carries no reason. */
+    fun failure(): ByteArray = byteArrayOf(FAILURE.toByte())
+
+    /** Prefix [message] with its uint32 length, the framing every agent connection uses. */
+    fun frame(message: ByteArray): ByteArray {
+        val writer = SshWireWriter()
+        writer.putUInt32(message.size)
+        writer.putRaw(message)
+        return writer.toByteArray()
+    }
+}
+
+/** One key the agent offers: ssh-wire public key blob plus the comment shown by `ssh-add -l`. */
+class SshAgentIdentity(val keyBlob: ByteArray, val comment: String)
+
+/** A parsed client request. Everything outside the served subset lands in [Unsupported]. */
+sealed interface SshAgentRequest {
+    /** `SSH_AGENTC_REQUEST_IDENTITIES`. */
+    data object ListIdentities : SshAgentRequest
+
+    /** `SSH_AGENTC_SIGN_REQUEST`: sign [data] with the key identified by [keyBlob]. */
+    class Sign(val keyBlob: ByteArray, val data: ByteArray, val flags: Int) : SshAgentRequest
+
+    /** Any other message type (add/remove/lock/extension) — answered with a failure. */
+    data class Unsupported(val type: Int) : SshAgentRequest
+}
+
+/** Malformed input from the peer: truncated message or a length prefix past the end of the data. */
+class SshAgentProtocolException(message: String) : Exception(message)
+
+/**
+ * Minimal ssh-wire reader over an already-received message. Every read is bounded by the message
+ * itself, so a hostile length prefix fails instead of allocating.
+ */
+private class SshWireReader(private val bytes: ByteArray) {
+    private var pos = 0
+
+    val remaining: Int get() = bytes.size - pos
+
+    fun readByte(): Int {
+        needAtLeast(1)
+        return bytes[pos++].toInt() and 0xFF
+    }
+
+    /** Read a uint32 as a raw 32-bit mask (agent flags), without range-checking the sign bit. */
+    fun readUInt32Bits(): Int {
+        needAtLeast(4)
+        var value = 0
+        repeat(4) { value = (value shl 8) or (bytes[pos++].toInt() and 0xFF) }
+        return value
+    }
+
+    /** Read a length-prefixed byte string. */
+    fun readString(): ByteArray {
+        val length = readUInt32Bits()
+        // Negative means the peer sent a length above 2^31 — always a lie, the message itself is
+        // capped at 256 KiB.
+        if (length < 0) throw SshAgentProtocolException("agent field length out of range")
+        needAtLeast(length)
+        val out = bytes.copyOfRange(pos, pos + length)
+        pos += length
+        return out
+    }
+
+    private fun needAtLeast(count: Int) {
+        if (remaining < count) throw SshAgentProtocolException("truncated agent message")
+    }
+}
+
+/** Minimal ssh-wire writer over a growable byte buffer. */
+private class SshWireWriter {
+    private var buffer = ByteArray(64)
+    private var size = 0
+
+    fun putByte(value: Int) {
+        ensureCapacity(1)
+        buffer[size++] = value.toByte()
+    }
+
+    fun putUInt32(value: Int) {
+        ensureCapacity(4)
+        buffer[size++] = (value ushr 24).toByte()
+        buffer[size++] = (value ushr 16).toByte()
+        buffer[size++] = (value ushr 8).toByte()
+        buffer[size++] = value.toByte()
+    }
+
+    fun putString(bytes: ByteArray) {
+        putUInt32(bytes.size)
+        putRaw(bytes)
+    }
+
+    fun putRaw(bytes: ByteArray) {
+        ensureCapacity(bytes.size)
+        bytes.copyInto(buffer, size)
+        size += bytes.size
+    }
+
+    fun toByteArray(): ByteArray = buffer.copyOf(size)
+
+    private fun ensureCapacity(extra: Int) {
+        if (size + extra <= buffer.size) return
+        var capacity = buffer.size
+        while (capacity < size + extra) capacity *= 2
+        buffer = buffer.copyOf(capacity)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentKeyMaterial.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentKeyMaterial.kt
@@ -1,0 +1,24 @@
+package app.skerry.shared.agent
+
+/**
+ * One vault secret offered to the agent, flattened to what a keyring needs. Built by the UI layer
+ * from [app.skerry.shared.vault.Credential] (the `shared` core does not reach into the vault
+ * itself), so the agent has no opinion on where keys are stored or which of them the user picked.
+ *
+ * [id] is the credential id — the cache key for an already-parsed key. [comment] is what
+ * `ssh-add -l` shows on the remote side, i.e. the credential's label; it is user-visible on the
+ * far end of a forwarded agent, so it must stay a label and never carry the secret. [certificate]
+ * is the `*-cert.pub` string when the secret is a certificate: the agent then offers the
+ * certificate blob and signs with the private key behind it.
+ *
+ * `toString` is redacted like every secret-bearing type in the vault.
+ */
+class SshAgentKeyMaterial(
+    val id: String,
+    val comment: String,
+    val privateKeyPem: String,
+    val passphrase: String? = null,
+    val certificate: String? = null,
+) {
+    override fun toString(): String = "SshAgentKeyMaterial(id=$id, secrets=redacted)"
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
@@ -31,18 +31,30 @@ class SshAgentService(
             return refuse(origin)
         }
         return when (parsed) {
-            is SshAgentRequest.ListIdentities -> {
-                val identities = keys.identities()
-                report(origin, SshAgentAction.Listed, null)
-                SshAgentCodec.identitiesAnswer(identities)
-            }
+            is SshAgentRequest.ListIdentities -> list(origin)
             is SshAgentRequest.Sign -> sign(parsed, origin)
-            is SshAgentRequest.Unsupported -> refuse(origin)
+            // Answered, but NOT reported: OpenSSH sends `session-bind@openssh.com` before every
+            // single login, so recording these would stamp a "Refused" on every successful
+            // connection and drown the entries that mean something.
+            is SshAgentRequest.Unsupported -> SshAgentCodec.failure()
         }
     }
 
     /** Record something the agent did outside a request (e.g. a server refusing forwarding). */
     fun note(origin: SshAgentOrigin, action: SshAgentAction) = report(origin, action, null)
+
+    private suspend fun list(origin: SshAgentOrigin): ByteArray {
+        // Same contract as sign(): the keyring reads the vault, and an unexpected failure there
+        // must come back as a protocol refusal rather than killing the serving coroutine.
+        val identities = try {
+            keys.identities()
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            return refuse(origin)
+        }
+        report(origin, SshAgentAction.Listed, null)
+        return SshAgentCodec.identitiesAnswer(identities)
+    }
 
     private suspend fun sign(request: SshAgentRequest.Sign, origin: SshAgentOrigin): ByteArray {
         // The keyring is the only place that decides whether a key may be used; an unknown blob

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
@@ -15,6 +15,14 @@ import kotlinx.coroutines.CancellationException
  */
 class SshAgentService(
     private val keys: SshAgentKeys,
+    /**
+     * Asked before every signature, the equivalent of `ssh-agent -c`. Suspends for as long as the
+     * user takes to answer — the requesting channel waits, which is what the protocol expects of a
+     * slow agent. `false` refuses the request. The default answers yes, i.e. behaves like a plain
+     * `ssh-agent`; the policy (and the UI) lives in the app.
+     */
+    private val confirm: suspend (SshAgentSignPrompt) -> Boolean = { true },
+    // Kept last so `SshAgentService(keys) { ... }` still reads as "report uses here".
     private val onUse: (SshAgentUsage) -> Unit = {},
 ) {
 
@@ -57,6 +65,30 @@ class SshAgentService(
     }
 
     private suspend fun sign(request: SshAgentRequest.Sign, origin: SshAgentOrigin): ByteArray {
+        // Resolve the key before asking anything: a blob we do not hold is refused outright, so a
+        // remote cannot raise confirmation prompts by naming keys at random. The listing is served
+        // from the keyring's cache, so this costs nothing per request.
+        val identity = try {
+            keys.identities().firstOrNull { it.keyBlob.contentEquals(request.keyBlob) }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        } ?: return refuse(origin)
+
+        // A broken confirmation channel (no UI to ask, prompt path failed) is not an answer, and
+        // "no answer" refuses: it must never fall through to a signature, nor throw at the peer's
+        // serving coroutine.
+        val allowed = try {
+            confirm(SshAgentSignPrompt(origin, identity.comment))
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            return refuse(origin)
+        }
+        if (!allowed) {
+            report(origin, SshAgentAction.Declined, identity.comment)
+            return SshAgentCodec.failure()
+        }
+
         // The keyring is the only place that decides whether a key may be used; an unknown blob
         // (or a key the user has not put in the agent) comes back null and is refused here.
         val signature = try {
@@ -120,7 +152,13 @@ enum class SshAgentAction {
 
     /** The server declined agent forwarding for a session that asked for it. */
     ForwardingDenied,
+
+    /** The user was asked to confirm a signature and said no (or let the prompt time out). */
+    Declined,
 }
+
+/** One signature waiting for the user's answer — who is asking, and with which key. */
+class SshAgentSignPrompt(val origin: SshAgentOrigin, val keyComment: String)
 
 /** One entry for the activity list. */
 class SshAgentUsage(

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
@@ -1,0 +1,119 @@
+package app.skerry.shared.agent
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * The agent itself: turns one request message into one response message, over whatever key source
+ * it was given. Transport-agnostic on purpose — the same instance serves forwarded agent channels
+ * (`auth-agent@openssh.com`) and the local socket (`SSH_AUTH_SOCK`), which is exactly what makes
+ * "the key never leaves the vault" true for both.
+ *
+ * Every request is attributed to an [SshAgentOrigin] and reported through [onUse], including the
+ * bare listing: a remote that only enumerates the keys leaves a trace too. The report is what the
+ * Settings → SSH agent activity list shows; nothing is written to disk (the key set is already in
+ * the vault, and an on-disk trail of which key was used where is a liability of its own).
+ */
+class SshAgentService(
+    private val keys: SshAgentKeys,
+    private val onUse: (SshAgentUsage) -> Unit = {},
+) {
+
+    /**
+     * Handle one agent message (without the length prefix) and return the reply to write back.
+     * Never throws for peer-controlled input: anything unparseable, oversized or unsupported is a
+     * plain `SSH_AGENT_FAILURE`, which is all the protocol can say anyway.
+     */
+    suspend fun handle(request: ByteArray, origin: SshAgentOrigin): ByteArray {
+        if (request.size > SshAgentCodec.MAX_MESSAGE_BYTES) return refuse(origin)
+        val parsed = try {
+            SshAgentCodec.parseRequest(request)
+        } catch (e: SshAgentProtocolException) {
+            return refuse(origin)
+        }
+        return when (parsed) {
+            is SshAgentRequest.ListIdentities -> {
+                val identities = keys.identities()
+                report(origin, SshAgentAction.Listed, null)
+                SshAgentCodec.identitiesAnswer(identities)
+            }
+            is SshAgentRequest.Sign -> sign(parsed, origin)
+            is SshAgentRequest.Unsupported -> refuse(origin)
+        }
+    }
+
+    /** Record something the agent did outside a request (e.g. a server refusing forwarding). */
+    fun note(origin: SshAgentOrigin, action: SshAgentAction) = report(origin, action, null)
+
+    private suspend fun sign(request: SshAgentRequest.Sign, origin: SshAgentOrigin): ByteArray {
+        // The keyring is the only place that decides whether a key may be used; an unknown blob
+        // (or a key the user has not put in the agent) comes back null and is refused here.
+        val signature = try {
+            keys.sign(request.keyBlob, request.data, request.flags)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            null
+        } ?: return refuse(origin)
+        report(origin, SshAgentAction.Signed, signature.keyComment)
+        return SshAgentCodec.signResponse(signature.blob)
+    }
+
+    private fun refuse(origin: SshAgentOrigin): ByteArray {
+        report(origin, SshAgentAction.Refused, null)
+        return SshAgentCodec.failure()
+    }
+
+    private fun report(origin: SshAgentOrigin, action: SshAgentAction, keyComment: String?) {
+        onUse(SshAgentUsage(origin, action, keyComment))
+    }
+}
+
+/**
+ * Key material the agent may use. Implementations live on the platform side (vault secrets are
+ * parsed with JVM crypto); the contract stays here so the service and its tests are pure.
+ */
+interface SshAgentKeys {
+    /** Keys currently offered — empty when the agent is off or the vault is locked. */
+    suspend fun identities(): List<SshAgentIdentity>
+
+    /**
+     * Sign [data] with the key identified by [keyBlob], honouring the `rsa-sha2-*` request
+     * [flags]. `null` = we do not hold that key (or may not use it), which the caller turns into a
+     * protocol failure.
+     */
+    suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature?
+}
+
+/** A produced signature: the ssh-wire blob plus the comment of the key that made it (for the audit). */
+class SshAgentSignature(val blob: ByteArray, val keyComment: String)
+
+/** Who asked the agent to do something. */
+sealed interface SshAgentOrigin {
+    /** A forwarded agent channel opened by the server of a live session to [address]. */
+    data class Session(val address: String) : SshAgentOrigin
+
+    /** A local process connected to the agent socket (`SSH_AUTH_SOCK`; desktop only). */
+    data object LocalSocket : SshAgentOrigin
+}
+
+/** What the agent did, as shown in the activity list. */
+enum class SshAgentAction {
+    /** The peer enumerated the offered keys. */
+    Listed,
+
+    /** The peer got a signature. */
+    Signed,
+
+    /** The request was refused (unknown key, unsupported or malformed message). */
+    Refused,
+
+    /** The server declined agent forwarding for a session that asked for it. */
+    ForwardingDenied,
+}
+
+/** One entry for the activity list. */
+class SshAgentUsage(
+    val origin: SshAgentOrigin,
+    val action: SshAgentAction,
+    /** Comment of the key involved, when the action names one. */
+    val keyComment: String?,
+)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
@@ -45,6 +45,11 @@ import kotlinx.serialization.Serializable
  *
  * [vncResizeToWindow] remembers the VNC session's "Resize to window" toggle across restarts.
  * VNC-only; toggled from the live session's graphics menu, not the edit form (which preserves it).
+ *
+ * [forwardAgent] forwards the built-in SSH agent into this host's shell (`ssh -A`), so an `ssh` run
+ * on the far side can hop onward with a key that stays in the local vault. SSH-only and default
+ * `false`: while the session lives, that host can use every key the agent offers, so it is a
+ * per-host trust decision — and old saved files read as "off".
  */
 @Serializable
 data class Host(
@@ -61,4 +66,5 @@ data class Host(
     val jumpHostId: String? = null,
     val keepAliveSeconds: Int = 30,
     val vncResizeToWindow: Boolean = false,
+    val forwardAgent: Boolean = false,
 )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
@@ -122,6 +122,15 @@ interface SshConnection {
     val serverVersion: String? get() = null
 
     /**
+     * Whether this session's shell got the SSH agent forwarded into it. Only meaningful once the
+     * shell is open, and only for a target that asked ([SshTarget.forwardAgent]) — a server may
+     * refuse (`AllowAgentForwarding no`), and the user has to be able to see that instead of
+     * wondering why `ssh` on the far side asks for a password. Default [SshAgentForwarding.None]
+     * (fakes/tests, other transports).
+     */
+    val agentForwarding: SshAgentForwarding get() = SshAgentForwarding.None
+
+    /**
      * Measure round-trip time to the server (ms): sends a keep-alive request and waits for a
      * response, returning `null` if the connection is dead or no reply arrives in a reasonable time.
      * Each call is one round-trip (and incidentally keeps the connection alive). Default `null`
@@ -228,6 +237,18 @@ data class ExecResult(
     val stdout: String,
     val stderr: String,
 )
+
+/** State of SSH agent forwarding for a session's shell; see [SshConnection.agentForwarding]. */
+enum class SshAgentForwarding {
+    /** Not asked for (the profile has it off, or no agent is configured). */
+    None,
+
+    /** Asked for and granted: the remote shell has an `SSH_AUTH_SOCK` pointing back here. */
+    Active,
+
+    /** Asked for and refused by the server. The session is fine; onward hops are not. */
+    Refused,
+}
 
 open class SshException(message: String, cause: Throwable? = null) : Exception(message, cause)
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
@@ -34,6 +34,12 @@ interface SshTransport {
  * [SshConnection.measureRoundTrip]). Carried inside the target (like [jump]) so auto-reconnect
  * keeps the cadence with no extra plumbing. Default 0 preserves prior call sites: ad-hoc/probe
  * targets spawn no background traffic unless asked to.
+ *
+ * [forwardAgent] asks the server to forward Skerry's built-in SSH agent into the session's shell
+ * (`ssh -A`), so an `ssh`/`git` run on the remote can authenticate onward with a key that stays in
+ * the local vault. SSH-only and off by default: the far end can use every key the agent offers for
+ * as long as the session lives, so it is a per-host decision, and it takes effect only when an
+ * agent is actually wired into the transport.
  */
 data class SshTarget(
     val host: String,
@@ -42,6 +48,7 @@ data class SshTarget(
     val connectionType: ConnectionType = ConnectionType.SSH,
     val jump: SshJump? = null,
     val keepAliveSeconds: Int = 0,
+    val forwardAgent: Boolean = false,
 )
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamShare.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamShare.kt
@@ -10,9 +10,11 @@ private val json = Json { ignoreUnknownKeys = true }
 /**
  * Host payload fields that lose meaning in team scope: `group` is a personal folder structure;
  * `credentialId` references a record in the owner's PERSONAL vault (secrets aren't shared —
- * members' references would dangle; each member connects with their own secret).
+ * members' references would dangle; each member connects with their own secret); `forwardAgent`
+ * would hand the recipient's own agent keys to a host somebody else decided to trust, which has to
+ * be each member's own decision.
  */
-val HOST_SHARE_STRIP: Set<String> = setOf("group", "credentialId")
+val HOST_SHARE_STRIP: Set<String> = setOf("group", "credentialId", "forwardAgent")
 
 /**
  * Strips fields with no meaning in team scope (e.g. a host's `group`, a personal-folder

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
@@ -57,12 +57,18 @@ sealed interface CredentialSecret {
  * [VaultRecord]'s plaintext metadata must not reveal key names or types (zero-knowledge). For the
  * same reason `toString` redacts [label] and [secret], leaving only [id] (already plaintext in
  * the metadata).
+ *
+ * [agentEnabled] marks the key as available to the built-in SSH agent (`ssh-add` for this vault):
+ * only such a key may be offered to a session with agent forwarding or to a local process on the
+ * agent socket. Meaningless for [CredentialSecret.Password]. Default `false` — the agent starts
+ * empty, so enabling it never retroactively exposes keys stored before the feature existed.
  */
 @Serializable
 data class Credential(
     val id: String,
     val label: String,
     val secret: CredentialSecret,
+    val agentEnabled: Boolean = false,
 ) {
     override fun toString(): String = "Credential(id=$id, label=redacted, secret=redacted)"
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentCodecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentCodecTest.kt
@@ -1,0 +1,116 @@
+package app.skerry.shared.agent
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/** Wire-level tests for the agent protocol codec (draft-miller-ssh-agent-04 subset). */
+class SshAgentCodecTest {
+
+    private fun message(type: Int, vararg fields: ByteArray): ByteArray {
+        val body = fields.fold(byteArrayOf(type.toByte())) { acc, field -> acc + field }
+        return body
+    }
+
+    private fun string(bytes: ByteArray): ByteArray =
+        byteArrayOf(
+            (bytes.size ushr 24).toByte(),
+            (bytes.size ushr 16).toByte(),
+            (bytes.size ushr 8).toByte(),
+            bytes.size.toByte(),
+        ) + bytes
+
+    private fun uint32(value: Int): ByteArray =
+        byteArrayOf((value ushr 24).toByte(), (value ushr 16).toByte(), (value ushr 8).toByte(), value.toByte())
+
+    @Test
+    fun `parses a request for identities`() {
+        assertIs<SshAgentRequest.ListIdentities>(SshAgentCodec.parseRequest(byteArrayOf(11)))
+    }
+
+    @Test
+    fun `parses a sign request with key, data and flags`() {
+        val request = SshAgentCodec.parseRequest(
+            message(13, string(byteArrayOf(1, 2, 3)), string(byteArrayOf(9, 9)), uint32(4)),
+        )
+        val sign = assertIs<SshAgentRequest.Sign>(request)
+        assertContentEquals(byteArrayOf(1, 2, 3), sign.keyBlob)
+        assertContentEquals(byteArrayOf(9, 9), sign.data)
+        assertEquals(SshAgentCodec.FLAG_RSA_SHA2_512, sign.flags)
+    }
+
+    @Test
+    fun `a sign request may omit the flags field`() {
+        // OpenSSH always sends flags, but the field is the last one: a client that stops short must
+        // be read as "no flags" rather than dropped, otherwise SHA-1 RSA clients break.
+        val request = SshAgentCodec.parseRequest(message(13, string(byteArrayOf(1)), string(byteArrayOf(2))))
+        assertEquals(0, assertIs<SshAgentRequest.Sign>(request).flags)
+    }
+
+    @Test
+    fun `unknown message types are reported as unsupported, not rejected`() {
+        // Add/remove/lock (17..22) and extensions (27) are answered with FAILURE by the service; the
+        // codec must classify them instead of throwing, so the audit can tell them from garbage.
+        assertEquals(SshAgentRequest.Unsupported(17), SshAgentCodec.parseRequest(byteArrayOf(17)))
+    }
+
+    @Test
+    fun `an empty message is malformed`() {
+        assertFailsWith<SshAgentProtocolException> { SshAgentCodec.parseRequest(ByteArray(0)) }
+    }
+
+    @Test
+    fun `a truncated sign request is malformed`() {
+        assertFailsWith<SshAgentProtocolException> {
+            SshAgentCodec.parseRequest(message(13, string(byteArrayOf(1, 2, 3)), byteArrayOf(0, 0, 0)))
+        }
+    }
+
+    @Test
+    fun `a field longer than the message is malformed`() {
+        // Length prefix from an untrusted peer must be bounded by what actually arrived, or the
+        // reader would try to allocate/copy 4 GiB.
+        assertFailsWith<SshAgentProtocolException> {
+            SshAgentCodec.parseRequest(message(13, uint32(Int.MAX_VALUE) + byteArrayOf(1)))
+        }
+    }
+
+    @Test
+    fun `encodes the identities answer`() {
+        val encoded = SshAgentCodec.identitiesAnswer(
+            listOf(
+                SshAgentIdentity(byteArrayOf(7, 7), "work key"),
+                SshAgentIdentity(byteArrayOf(8), "home key"),
+            ),
+        )
+        val expected = byteArrayOf(12) + uint32(2) +
+            string(byteArrayOf(7, 7)) + string("work key".encodeToByteArray()) +
+            string(byteArrayOf(8)) + string("home key".encodeToByteArray())
+        assertContentEquals(expected, encoded)
+    }
+
+    @Test
+    fun `encodes an empty identities answer`() {
+        assertContentEquals(byteArrayOf(12) + uint32(0), SshAgentCodec.identitiesAnswer(emptyList()))
+    }
+
+    @Test
+    fun `encodes a signature response`() {
+        assertContentEquals(
+            byteArrayOf(14) + string(byteArrayOf(5, 6)),
+            SshAgentCodec.signResponse(byteArrayOf(5, 6)),
+        )
+    }
+
+    @Test
+    fun `failure is a single byte`() {
+        assertContentEquals(byteArrayOf(5), SshAgentCodec.failure())
+    }
+
+    @Test
+    fun `frames a message with its length`() {
+        assertContentEquals(uint32(3) + byteArrayOf(1, 2, 3), SshAgentCodec.frame(byteArrayOf(1, 2, 3)))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
@@ -79,6 +79,17 @@ class SshAgentServiceTest {
     }
 
     @Test
+    fun `routine unsupported requests are answered but not recorded`() = runTest {
+        // OpenSSH sends session-bind@openssh.com before every login; recording it would stamp a
+        // "Refused" on every successful connection and bury the entries that matter.
+        val uses = mutableListOf<SshAgentUsage>()
+        val response = SshAgentService(FakeKeys()) { uses += it }.handle(byteArrayOf(27), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.failure(), response)
+        assertTrue(uses.isEmpty(), "routine protocol chatter was recorded: \${uses.map { it.action }}")
+    }
+
+    @Test
     fun `refuses a malformed request without throwing`() = runTest {
         val service = SshAgentService(FakeKeys())
         assertContentEquals(SshAgentCodec.failure(), service.handle(ByteArray(0), ORIGIN))

--- a/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private val ORIGIN = SshAgentOrigin.Session("bastion.example")
@@ -100,6 +102,83 @@ class SshAgentServiceTest {
     fun `refuses an oversized request without parsing it`() = runTest {
         val response = SshAgentService(FakeKeys()).handle(ByteArray(SshAgentCodec.MAX_MESSAGE_BYTES + 1), ORIGIN)
         assertContentEquals(SshAgentCodec.failure(), response)
+    }
+
+    @Test
+    fun `asks the user before signing and refuses when they decline`() = runTest {
+        val keys = FakeKeys(
+            identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")),
+            signature = SshAgentSignature(byteArrayOf(42), "work"),
+        )
+        val asked = mutableListOf<SshAgentSignPrompt>()
+        val uses = mutableListOf<SshAgentUsage>()
+        val service = SshAgentService(keys, onUse = { uses += it }, confirm = { asked += it; false })
+
+        val response = service.handle(signRequest(byteArrayOf(1), byteArrayOf(7)), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.failure(), response)
+        assertEquals(listOf(SshAgentAction.Declined), uses.map { it.action })
+        assertEquals(ORIGIN, asked.single().origin)
+        assertEquals("work", asked.single().keyComment)
+        assertNull(keys.signedData, "the key was used even though the user declined")
+    }
+
+    @Test
+    fun `signs once the user allows it`() = runTest {
+        val keys = FakeKeys(
+            identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")),
+            signature = SshAgentSignature(byteArrayOf(42), "work"),
+        )
+        val service = SshAgentService(keys, confirm = { true })
+
+        assertContentEquals(
+            SshAgentCodec.signResponse(byteArrayOf(42)),
+            service.handle(signRequest(byteArrayOf(1), byteArrayOf(7)), ORIGIN),
+        )
+    }
+
+    @Test
+    fun `a key the agent does not hold is refused without asking the user`() = runTest {
+        // Otherwise a remote could raise a confirmation dialog at will by naming keys at random.
+        val keys = FakeKeys(identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")))
+        var asked = false
+        val uses = mutableListOf<SshAgentUsage>()
+        val service = SshAgentService(keys, onUse = { uses += it }, confirm = { asked = true; true })
+
+        val response = service.handle(signRequest(byteArrayOf(2), byteArrayOf(7)), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.failure(), response)
+        assertFalse(asked, "an unknown key blob raised a confirmation prompt")
+        assertEquals(listOf(SshAgentAction.Refused), uses.map { it.action })
+    }
+
+    @Test
+    fun `a confirmation channel that breaks refuses instead of taking the connection down`() = runTest {
+        // The prompt lives in the UI; if that path fails there is no answer, and "no answer" is a
+        // refusal — not an exception thrown at the peer's serving coroutine.
+        val keys = FakeKeys(
+            identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")),
+            signature = SshAgentSignature(byteArrayOf(42), "work"),
+        )
+        val uses = mutableListOf<SshAgentUsage>()
+        val service = SshAgentService(keys, onUse = { uses += it }, confirm = { error("no UI here") })
+
+        val response = service.handle(signRequest(byteArrayOf(1), byteArrayOf(7)), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.failure(), response)
+        assertEquals(listOf(SshAgentAction.Refused), uses.map { it.action })
+        assertNull(keys.signedData, "the key was used despite the confirmation failing")
+    }
+
+    @Test
+    fun `listing keys never asks for confirmation`() = runTest {
+        // Only signing uses a key; prompting on enumeration would fire on every single login.
+        var asked = false
+        val keys = FakeKeys(identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")))
+
+        SshAgentService(keys, confirm = { asked = true; true }).handle(byteArrayOf(11), ORIGIN)
+
+        assertFalse(asked)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
@@ -1,0 +1,100 @@
+package app.skerry.shared.agent
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val ORIGIN = SshAgentOrigin.Session("bastion.example")
+
+private class FakeKeys(
+    var identities: List<SshAgentIdentity> = emptyList(),
+    var signature: SshAgentSignature? = null,
+) : SshAgentKeys {
+    var signedData: ByteArray? = null
+    var signedFlags: Int? = null
+
+    override suspend fun identities(): List<SshAgentIdentity> = identities
+
+    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? {
+        signedData = data
+        signedFlags = flags
+        return signature.takeIf { identities.any { id -> id.keyBlob.contentEquals(keyBlob) } }
+    }
+}
+
+private fun signRequest(keyBlob: ByteArray, data: ByteArray, flags: Int = 0): ByteArray {
+    fun uint32(v: Int) = byteArrayOf((v ushr 24).toByte(), (v ushr 16).toByte(), (v ushr 8).toByte(), v.toByte())
+    fun string(b: ByteArray) = uint32(b.size) + b
+    return byteArrayOf(13) + string(keyBlob) + string(data) + uint32(flags)
+}
+
+class SshAgentServiceTest {
+
+    @Test
+    fun `answers the identity list from the keyring`() = runTest {
+        val keys = FakeKeys(identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")))
+        val response = SshAgentService(keys).handle(byteArrayOf(11), ORIGIN)
+        assertContentEquals(SshAgentCodec.identitiesAnswer(keys.identities), response)
+    }
+
+    @Test
+    fun `signs with a known key and reports the use`() = runTest {
+        val keys = FakeKeys(
+            identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")),
+            signature = SshAgentSignature(byteArrayOf(42), "work"),
+        )
+        val uses = mutableListOf<SshAgentUsage>()
+        val response = SshAgentService(keys) { uses += it }
+            .handle(signRequest(byteArrayOf(1), byteArrayOf(7, 7), SshAgentCodec.FLAG_RSA_SHA2_256), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.signResponse(byteArrayOf(42)), response)
+        assertContentEquals(byteArrayOf(7, 7), keys.signedData)
+        assertEquals(SshAgentCodec.FLAG_RSA_SHA2_256, keys.signedFlags)
+        assertEquals(listOf(SshAgentAction.Signed), uses.map { it.action })
+        assertEquals("work", uses.single().keyComment)
+        assertEquals(ORIGIN, uses.single().origin)
+    }
+
+    @Test
+    fun `refuses to sign with a key the vault does not offer`() = runTest {
+        val keys = FakeKeys(identities = listOf(SshAgentIdentity(byteArrayOf(1), "work")))
+        val uses = mutableListOf<SshAgentUsage>()
+        val response = SshAgentService(keys) { uses += it }
+            .handle(signRequest(byteArrayOf(2), byteArrayOf(7)), ORIGIN)
+
+        assertContentEquals(SshAgentCodec.failure(), response)
+        assertEquals(listOf(SshAgentAction.Refused), uses.map { it.action })
+    }
+
+    @Test
+    fun `refuses mutating requests`() = runTest {
+        // Adding, removing or locking keys is the vault's business: a forwarded remote must not be
+        // able to plant a key that later sessions would offer onward.
+        val service = SshAgentService(FakeKeys())
+        listOf(17, 18, 19, 20, 21, 22, 25, 27).forEach { type ->
+            assertContentEquals(SshAgentCodec.failure(), service.handle(byteArrayOf(type.toByte()), ORIGIN), "type $type")
+        }
+    }
+
+    @Test
+    fun `refuses a malformed request without throwing`() = runTest {
+        val service = SshAgentService(FakeKeys())
+        assertContentEquals(SshAgentCodec.failure(), service.handle(ByteArray(0), ORIGIN))
+        assertContentEquals(SshAgentCodec.failure(), service.handle(byteArrayOf(13, 0, 0), ORIGIN))
+    }
+
+    @Test
+    fun `refuses an oversized request without parsing it`() = runTest {
+        val response = SshAgentService(FakeKeys()).handle(ByteArray(SshAgentCodec.MAX_MESSAGE_BYTES + 1), ORIGIN)
+        assertContentEquals(SshAgentCodec.failure(), response)
+    }
+
+    @Test
+    fun `listing keys is recorded as a use so the audit shows silent probes`() = runTest {
+        val uses = mutableListOf<SshAgentUsage>()
+        SshAgentService(FakeKeys()) { uses += it }.handle(byteArrayOf(11), ORIGIN)
+        assertTrue(uses.single().action == SshAgentAction.Listed)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
@@ -13,6 +13,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 
 class VaultHostStoreTest {
 
@@ -108,6 +109,16 @@ class VaultHostStoreTest {
         // Absent in old records -> 30 (backward compatible default, matches the pre-setting behavior).
         VaultHostStore(vault).put(host("plain"))
         assertEquals(30, VaultHostStore(vault).all().first { it.id == "plain" }.keepAliveSeconds)
+    }
+
+    @Test
+    fun `agent forwarding survives persist and reload, defaulting to off`() {
+        val vault = FakeVault()
+        VaultHostStore(vault).put(host("bastion").copy(forwardAgent = true))
+        assertTrue(VaultHostStore(vault).all().single().forwardAgent)
+        // Absent in records written before the agent existed -> off, never a silent opt-in.
+        VaultHostStore(vault).put(host("plain"))
+        assertFalse(VaultHostStore(vault).all().first { it.id == "plain" }.forwardAgent)
     }
 
     @Test

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
@@ -5,6 +5,8 @@ import java.io.IOException
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
+import java.nio.channels.SelectionKey
+import java.nio.channels.Selector
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.FileSystems
@@ -54,7 +56,20 @@ class UnixSocketSshAgent(
     private val clients = ConcurrentHashMap.newKeySet<SocketChannel>()
 
     private var channel: ServerSocketChannel? = null
+    private var selector: Selector? = null
     private var acceptJob: Job? = null
+
+    // Guards the handover of an accepted connection into [clients]. A client can be connected (the
+    // kernel completes a unix-socket connect before anything calls accept) while stop() is running:
+    // without this, it would be registered after stop() emptied the set and served on past the
+    // switch-off, holding a thread in a blocking read for the rest of the app's life.
+    private val lock = Any()
+    private var listening = false
+
+    // Which round of start()/stop() we are in. A connection accepted by the previous round's loop
+    // could otherwise be handed to a socket the user has since switched off and on again, and be
+    // served as if it belonged to the new one.
+    private var generation = 0
 
     /** Path of the socket while it is listening, `null` when stopped. */
     var socketPath: Path? = null
@@ -87,9 +102,28 @@ class UnixSocketSshAgent(
             runCatching { server.close() }
             throw e
         }
+        // Accept through a selector rather than a blocking accept(): stop() then has a wakeup() that
+        // is guaranteed to end the loop. A thread parked in a blocking accept() is only woken as a
+        // side effect of closing the channel, and while it sits there the listening descriptor stays
+        // open — a client that connected but had not been accepted yet would keep waiting for an
+        // answer from an agent that is already switched off.
+        val selector = Selector.open()
+        try {
+            server.configureBlocking(false)
+            server.register(selector, SelectionKey.OP_ACCEPT)
+        } catch (e: IOException) {
+            runCatching { selector.close() }
+            runCatching { server.close() }
+            throw e
+        }
         channel = server
+        this.selector = selector
         socketPath = path
-        acceptJob = scope.launch { accept(server) }
+        val round = synchronized(lock) {
+            listening = true
+            ++generation
+        }
+        acceptJob = scope.launch { accept(server, selector, round) }
         return path
     }
 
@@ -104,29 +138,54 @@ class UnixSocketSshAgent(
         // Then close what those coroutines are blocked on. A client that keeps its connection open
         // without sending anything (a long-lived `ssh`) sits in a read that cancellation alone does
         // not end, and would hold a thread and an fd for the rest of the app's life.
-        clients.forEach { runCatching { it.close() } }
-        clients.clear()
-        // Closing the channel is what unblocks accept(); the coroutine is already cancelled, but a
-        // blocking accept only returns once the channel is gone.
+        synchronized(lock) {
+            listening = false
+            clients.forEach { runCatching { it.close() } }
+            clients.clear()
+        }
+        // wakeup() ends the select the accept loop sits in (cancellation alone does not), and closing
+        // the listening channel releases its descriptor, which resets whatever the kernel had queued
+        // behind it — a client that connected without being accepted gets an answer, not a hang.
+        selector?.let { runCatching { it.wakeup() } }
         runCatching { channel?.close() }
+        runCatching { selector?.close() }
         channel = null
+        selector = null
         path?.let { runCatching { Files.deleteIfExists(it) } }
     }
 
-    private suspend fun accept(server: ServerSocketChannel) {
+    private suspend fun accept(server: ServerSocketChannel, selector: Selector, round: Int) {
         while (true) {
-            val client = try {
-                runInterruptible { server.accept() }
+            try {
+                runInterruptible { selector.select() }
             } catch (e: IOException) {
-                return // channel closed by stop(), or the listener died
+                return // selector or channel closed by stop()
             }
-            if (openConnections.get() >= MAX_CONNECTIONS) {
-                runCatching { client.close() }
-                continue
+            selector.selectedKeys().clear()
+            while (true) {
+                // Non-blocking: null means the batch is drained and we go back to select().
+                val client = try {
+                    server.accept() ?: break
+                } catch (e: IOException) {
+                    return // the listening channel is gone
+                }
+                val accepted = synchronized(lock) {
+                    if (!listening || generation != round || openConnections.get() >= MAX_CONNECTIONS) false
+                    else {
+                        openConnections.incrementAndGet()
+                        clients += client
+                        true
+                    }
+                }
+                if (!accepted) {
+                    // Over the ceiling, or this round is over (socket switched off, possibly back
+                    // on since) — either way the client is closed, not served.
+                    runCatching { client.close() }
+                    if (synchronized(lock) { !listening || generation != round }) return
+                    continue
+                }
+                scope.launch { serve(client) }
             }
-            openConnections.incrementAndGet()
-            clients += client
-            scope.launch { serve(client) }
         }
     }
 

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
@@ -10,11 +10,13 @@ import java.nio.channels.SocketChannel
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 
@@ -36,10 +38,20 @@ class UnixSocketSshAgent(
     private val directory: Path,
     private val service: SshAgentService,
     parentScope: CoroutineScope,
+    // Defaults to the agent's bounded slice of the IO pool ([agentDispatcher]); injectable so a
+    // test gets threads of its own instead of queueing behind another test's parked readers.
+    dispatcher: CoroutineDispatcher = agentDispatcher,
 ) {
-    // Own child scope on the IO dispatcher: accept() and the per-connection read loops are
-    // blocking, and cancelling this scope must not take the caller's scope with it.
-    private val scope = CoroutineScope(SupervisorJob(parentScope.coroutineContext[Job]) + Dispatchers.IO)
+    // Own child scope: accept() and the per-connection read loops are blocking, and cancelling this
+    // scope must not take the caller's scope with it.
+    private val scope = CoroutineScope(SupervisorJob(parentScope.coroutineContext[Job]) + dispatcher)
+
+    // Connections being served right now. Any local process can open them, and each parks a thread
+    // in a blocking read, so the listener needs its own ceiling as the forwarder has. The channels
+    // are held (not just counted) because cancelling the serving coroutine is not enough to end a
+    // read that is already blocked — closing the channel underneath it is what unblocks it.
+    private val openConnections = AtomicInteger()
+    private val clients = ConcurrentHashMap.newKeySet<SocketChannel>()
 
     private var channel: ServerSocketChannel? = null
     private var acceptJob: Job? = null
@@ -60,8 +72,13 @@ class UnixSocketSshAgent(
         PrivateConfig.ensureDir(directory)
         val path = directory.resolve(SOCKET_NAME)
         // A socket file left behind by a crash would make bind() fail with "address already in
-        // use". It is inside our own 0700 directory, so nothing else can have put it there.
-        Files.deleteIfExists(path)
+        // use", so it has to go — but only once it is certain nobody is listening on it. A second
+        // running copy of Skerry shares this path, and unlinking its socket would leave it serving
+        // an unreachable inode while new clients silently landed on a different key set.
+        if (Files.exists(path)) {
+            if (isAlive(path)) throw IOException("another SSH agent is already listening on this socket")
+            Files.deleteIfExists(path)
+        }
         val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
         try {
             server.bind(UnixDomainSocketAddress.of(path))
@@ -80,8 +97,15 @@ class UnixSocketSshAgent(
     fun stop() {
         val path = socketPath
         socketPath = null
-        acceptJob?.cancel()
         acceptJob = null
+        // Cancel the CHILDREN, not the scope: a cancelled scope could never be restarted, and the
+        // user can switch the socket back on.
+        scope.coroutineContext.cancelChildren()
+        // Then close what those coroutines are blocked on. A client that keeps its connection open
+        // without sending anything (a long-lived `ssh`) sits in a read that cancellation alone does
+        // not end, and would hold a thread and an fd for the rest of the app's life.
+        clients.forEach { runCatching { it.close() } }
+        clients.clear()
         // Closing the channel is what unblocks accept(); the coroutine is already cancelled, but a
         // blocking accept only returns once the channel is gone.
         runCatching { channel?.close() }
@@ -96,6 +120,12 @@ class UnixSocketSshAgent(
             } catch (e: IOException) {
                 return // channel closed by stop(), or the listener died
             }
+            if (openConnections.get() >= MAX_CONNECTIONS) {
+                runCatching { client.close() }
+                continue
+            }
+            openConnections.incrementAndGet()
+            clients += client
             scope.launch { serve(client) }
         }
     }
@@ -109,12 +139,22 @@ class UnixSocketSshAgent(
                 SshAgentOrigin.LocalSocket,
             )
         } finally {
+            openConnections.decrementAndGet()
+            clients -= client
             runCatching { client.close() }
         }
     }
 
+    /** Is somebody already serving this socket? A refused connection means the file is stale. */
+    private fun isAlive(path: Path): Boolean = runCatching {
+        SocketChannel.open(UnixDomainSocketAddress.of(path)).use { true }
+    }.getOrDefault(false)
+
     companion object {
         private const val SOCKET_NAME = "agent.sock"
+
+        /** Connections served at once; see [openConnections]. */
+        private const val MAX_CONNECTIONS = 8
 
         /**
          * Whether a unix socket with owner-only permissions can be created here. False on

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/agent/UnixSocketSshAgent.kt
@@ -1,0 +1,126 @@
+package app.skerry.shared.agent
+
+import app.skerry.shared.io.PrivateConfig
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+
+/**
+ * Exposes the built-in agent to other programs on this machine through a unix socket, the
+ * `SSH_AUTH_SOCK` protocol every OpenSSH tool speaks. With it, `ssh`, `git` or `scp` in the user's
+ * own terminal can authenticate with a key that never leaves Skerry's vault.
+ *
+ * Desktop only, and only where the filesystem can express POSIX permissions ([isSupported]): the
+ * socket's access control IS its directory mode. Anything that can open the socket can make the
+ * agent sign, so the socket lives alone in a 0700 directory and the socket file itself is set to
+ * 0600 — the same protection OpenSSH's own agent relies on. On Windows the OpenSSH agent is a named
+ * pipe instead, which this does not implement, so the feature reports itself unavailable rather
+ * than opening something weaker.
+ *
+ * Off by default; started only when the user asks for it in Settings → SSH agent.
+ */
+class UnixSocketSshAgent(
+    private val directory: Path,
+    private val service: SshAgentService,
+    parentScope: CoroutineScope,
+) {
+    // Own child scope on the IO dispatcher: accept() and the per-connection read loops are
+    // blocking, and cancelling this scope must not take the caller's scope with it.
+    private val scope = CoroutineScope(SupervisorJob(parentScope.coroutineContext[Job]) + Dispatchers.IO)
+
+    private var channel: ServerSocketChannel? = null
+    private var acceptJob: Job? = null
+
+    /** Path of the socket while it is listening, `null` when stopped. */
+    var socketPath: Path? = null
+        private set
+
+    /**
+     * Bind the socket and start accepting. Idempotent: a second call while listening is a no-op.
+     * @throws IOException the socket could not be bound (stale socket held by a live process,
+     *   unwritable directory, platform without unix sockets)
+     */
+    fun start(): Path {
+        socketPath?.let { return it }
+        // 0700 on the directory is what keeps other users out; do it before the socket exists, so
+        // there is no window where the socket sits in a world-traversable directory.
+        PrivateConfig.ensureDir(directory)
+        val path = directory.resolve(SOCKET_NAME)
+        // A socket file left behind by a crash would make bind() fail with "address already in
+        // use". It is inside our own 0700 directory, so nothing else can have put it there.
+        Files.deleteIfExists(path)
+        val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        try {
+            server.bind(UnixDomainSocketAddress.of(path))
+            PrivateConfig.harden(path)
+        } catch (e: IOException) {
+            runCatching { server.close() }
+            throw e
+        }
+        channel = server
+        socketPath = path
+        acceptJob = scope.launch { accept(server) }
+        return path
+    }
+
+    /** Stop listening, drop the socket file and end every connection being served. Idempotent. */
+    fun stop() {
+        val path = socketPath
+        socketPath = null
+        acceptJob?.cancel()
+        acceptJob = null
+        // Closing the channel is what unblocks accept(); the coroutine is already cancelled, but a
+        // blocking accept only returns once the channel is gone.
+        runCatching { channel?.close() }
+        channel = null
+        path?.let { runCatching { Files.deleteIfExists(it) } }
+    }
+
+    private suspend fun accept(server: ServerSocketChannel) {
+        while (true) {
+            val client = try {
+                runInterruptible { server.accept() }
+            } catch (e: IOException) {
+                return // channel closed by stop(), or the listener died
+            }
+            scope.launch { serve(client) }
+        }
+    }
+
+    private suspend fun serve(client: SocketChannel) {
+        try {
+            serveSshAgent(
+                Channels.newInputStream(client),
+                Channels.newOutputStream(client),
+                service,
+                SshAgentOrigin.LocalSocket,
+            )
+        } finally {
+            runCatching { client.close() }
+        }
+    }
+
+    companion object {
+        private const val SOCKET_NAME = "agent.sock"
+
+        /**
+         * Whether a unix socket with owner-only permissions can be created here. False on
+         * filesystems without POSIX modes (Windows), where the socket could not be protected.
+         */
+        val isSupported: Boolean
+            get() = FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshAgentStreamTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshAgentStreamTest.kt
@@ -1,0 +1,90 @@
+package app.skerry.shared.agent
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+
+/**
+ * The framing layer against a peer that behaves like a real `ssh`: several requests over ONE
+ * connection, and messages that arrive in pieces.
+ */
+class SshAgentStreamTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val identities = listOf(SshAgentIdentity(byteArrayOf(1, 2), "work key"))
+
+    @AfterTest
+    fun tearDown() = scope.cancel()
+
+    private val keys = object : SshAgentKeys {
+        override suspend fun identities() = identities
+        override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? = null
+    }
+
+    /** Wire both directions to the serving loop and hand back the peer's ends. */
+    private fun serve(): Pair<PipedOutputStream, InputStream> {
+        val toAgent = PipedOutputStream()
+        val agentInput = PipedInputStream(toAgent, 8192)
+        val agentOutput = PipedOutputStream()
+        val fromAgent = PipedInputStream(agentOutput, 8192)
+        scope.launch { serveSshAgent(agentInput, agentOutput, SshAgentService(keys), SshAgentOrigin.LocalSocket) }
+        return toAgent to fromAgent
+    }
+
+    private fun InputStream.readReply(): ByteArray {
+        val header = readNBytes(4)
+        val length = (header[0].toInt() and 0xFF shl 24) or (header[1].toInt() and 0xFF shl 16) or
+            (header[2].toInt() and 0xFF shl 8) or (header[3].toInt() and 0xFF)
+        return readNBytes(length)
+    }
+
+    @Test
+    fun `serves several requests over one connection`() = runTest {
+        // OpenSSH sends session-bind, then the listing, then the signature — all on one connection.
+        val (toAgent, fromAgent) = serve()
+        withTimeout(TIMEOUT_MILLIS) {
+            val extension = ByteArrayOutputStream().apply { write(byteArrayOf(27)) }.toByteArray()
+            toAgent.write(SshAgentCodec.frame(extension))
+            toAgent.flush()
+            assertContentEquals(SshAgentCodec.failure(), fromAgent.readReply())
+
+            toAgent.write(SshAgentCodec.frame(byteArrayOf(11)))
+            toAgent.flush()
+            assertContentEquals(SshAgentCodec.identitiesAnswer(identities), fromAgent.readReply())
+
+            toAgent.write(SshAgentCodec.frame(byteArrayOf(11)))
+            toAgent.flush()
+            assertContentEquals(SshAgentCodec.identitiesAnswer(identities), fromAgent.readReply())
+        }
+    }
+
+    @Test
+    fun `reassembles a message split across reads`() = runTest {
+        // TCP (and a pipe) may deliver the length prefix and the body separately; the reader must
+        // wait for the whole message instead of treating a short read as the end.
+        val (toAgent, fromAgent) = serve()
+        val framed = SshAgentCodec.frame(byteArrayOf(11))
+        withTimeout(TIMEOUT_MILLIS) {
+            toAgent.write(framed, 0, 2)
+            toAgent.flush()
+            toAgent.write(framed, 2, framed.size - 2)
+            toAgent.flush()
+            assertContentEquals(SshAgentCodec.identitiesAnswer(identities), fromAgent.readReply())
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_MILLIS = 10_000L
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentForwardingTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentForwardingTest.kt
@@ -1,0 +1,166 @@
+package app.skerry.shared.agent
+
+import app.skerry.shared.ssh.HostKeyVerifier
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.ssh.SshjTransport
+import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
+import app.skerry.shared.vault.SshKeyType
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.apache.sshd.agent.SshAgent
+import org.apache.sshd.agent.local.AgentServerProxy
+import org.apache.sshd.agent.local.ProxyAgentFactory
+import org.apache.sshd.common.session.ConnectionService
+import org.apache.sshd.common.session.Session
+import org.apache.sshd.server.SshServer
+import org.apache.sshd.server.forward.AcceptAllForwardingFilter
+import org.apache.sshd.server.forward.RejectAllForwardingFilter
+import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider
+import org.apache.sshd.server.shell.InteractiveProcessShellFactory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+private const val USER = "skerry"
+private const val PASSWORD = "correct horse battery staple"
+
+/**
+ * Agent forwarding against an embedded Apache MINA SSHD server that has agent forwarding enabled:
+ * the server opens `auth-agent@openssh.com` channels back to us, exactly as a remote `ssh` would,
+ * and gets answers from the in-process agent.
+ */
+class SshjAgentForwardingTest {
+
+    private lateinit var server: SshServer
+    private val generator = BouncyCastleSshKeyGenerator()
+    private val challenge = "userauth request".encodeToByteArray()
+    private val acceptAll = HostKeyVerifier { _, _, _, _ -> true }
+
+    @BeforeTest
+    fun startServer() {
+        server = SshServer.setUpDefaultServer().apply {
+            host = "127.0.0.1"
+            port = 0
+            keyPairProvider = SimpleGeneratorHostKeyProvider()
+            setPasswordAuthenticator { user, password, _ -> user == USER && password == PASSWORD }
+            shellFactory = InteractiveProcessShellFactory.INSTANCE
+            // Both are needed for the server to accept `auth-agent-req@openssh.com`; the factory
+            // also gives the test the server side of a forwarded agent — the role a remote `ssh`
+            // plays. The filter is left off in the "denied" test below.
+            agentFactory = ProxyAgentFactory()
+            forwardingFilter = AcceptAllForwardingFilter.INSTANCE
+            start()
+        }
+    }
+
+    @AfterTest
+    fun stopServer() {
+        server.stop(true)
+    }
+
+    private fun target(forwardAgent: Boolean) =
+        SshTarget(host = "127.0.0.1", port = server.port, username = USER, forwardAgent = forwardAgent)
+
+    /**
+     * The server side of a forwarded agent: opens an `auth-agent@openssh.com` channel back to the
+     * client and speaks the agent protocol over it — what `ssh` on the remote host does through
+     * `SSH_AUTH_SOCK`. Built straight from the session's connection service (MINA's factory looks
+     * its proxies up by an id that only the remote shell's environment knows).
+     */
+    private fun agentClientFor(session: Session): SshAgent =
+        AgentServerProxy(session.getService(ConnectionService::class.java)).createClient()
+
+    private fun agentOf(usages: MutableList<SshAgentUsage>, pem: String) = SshAgentService(
+        SshjAgentKeys({ listOf(SshAgentKeyMaterial(id = "c1", comment = "work key", privateKeyPem = pem)) }),
+    ) { usages += it }
+
+    @Test
+    fun `the server reaches the agent over a forwarded channel`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val usages = mutableListOf<SshAgentUsage>()
+        val connection = SshjTransport(acceptAll, agentOf(usages, generated.privateKeyPem))
+            .connect(target(forwardAgent = true), SshAuth.Password(PASSWORD))
+        try {
+            // The shell is what carries the request; without it the server has no reason to forward.
+            val shell = connection.openShell()
+            val session = server.activeSessions.single()
+            agentClientFor(session).use { agent ->
+                val identities = agent.identities.toList()
+                assertEquals(listOf("work key"), identities.map { it.value })
+
+                val signature = agent.sign(session, identities.single().key, "ssh-ed25519", challenge)
+                assertEquals("ssh-ed25519", signature.key)
+                val verifier = java.security.Signature.getInstance("Ed25519")
+                verifier.initVerify(identities.single().key)
+                verifier.update(challenge)
+                assertTrue(verifier.verify(signature.value), "forwarded signature does not verify")
+            }
+            shell.close()
+        } finally {
+            connection.disconnect()
+        }
+
+        assertEquals(listOf(SshAgentAction.Listed, SshAgentAction.Signed), usages.map { it.action })
+        // The server asked on behalf of the session we dialed — that is what the activity list shows.
+        assertTrue(usages.all { it.origin == SshAgentOrigin.Session("127.0.0.1") }, "unexpected origins: $usages")
+    }
+
+    @Test
+    fun `a host without the forwarding flag exposes no agent`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val usages = mutableListOf<SshAgentUsage>()
+        val connection = SshjTransport(acceptAll, agentOf(usages, generated.privateKeyPem))
+            .connect(target(forwardAgent = false), SshAuth.Password(PASSWORD))
+        try {
+            connection.openShell().close()
+            val session = server.activeSessions.single()
+            // No opener is registered, so sshj rejects the channel: the server cannot reach the keys
+            // even though the very same agent is configured in the app.
+            assertFailsWith<IOException> {
+                agentClientFor(session).use { it.identities.toList() }
+            }
+        } finally {
+            connection.disconnect()
+        }
+        assertTrue(usages.isEmpty(), "agent was used without the per-host flag: $usages")
+    }
+
+    @Test
+    fun `a server that refuses forwarding is recorded and the shell still opens`() = runTest {
+        // `AllowAgentForwarding no` is a common server policy; it must cost the user a note in the
+        // activity list, not the session they were opening.
+        server.forwardingFilter = RejectAllForwardingFilter.INSTANCE
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val usages = mutableListOf<SshAgentUsage>()
+        val connection = SshjTransport(acceptAll, agentOf(usages, generated.privateKeyPem))
+            .connect(target(forwardAgent = true), SshAuth.Password(PASSWORD))
+        try {
+            assertTrue(connection.openShell().isOpen)
+        } finally {
+            connection.disconnect()
+        }
+        assertEquals(listOf(SshAgentAction.ForwardingDenied), usages.map { it.action })
+    }
+
+    @Test
+    fun `disconnect stops serving the agent`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val usages = mutableListOf<SshAgentUsage>()
+        val connection = SshjTransport(acceptAll, agentOf(usages, generated.privateKeyPem))
+            .connect(target(forwardAgent = true), SshAuth.Password(PASSWORD))
+        val shell = connection.openShell()
+        val session = server.activeSessions.single()
+        shell.close()
+        connection.disconnect()
+
+        // The session is gone, so the agent must be unreachable — a server that kept a handle on the
+        // connection must not be able to sign after the user closed the tab.
+        assertFailsWith<IOException> {
+            agentClientFor(session).use { it.identities.toList() }
+        }
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
@@ -37,6 +37,16 @@ class SshjAgentKeysTest {
         val buffer = Buffer.PlainBuffer(blob)
         val algorithm = buffer.readString()
         val raw = buffer.readBytes()
+        // ECDSA on the wire is `mpint r || mpint s`, not the DER sequence JCA expects, so it is
+        // checked with the same decoder an sshj server uses rather than being re-encoded here.
+        if (algorithm.startsWith("ecdsa-")) {
+            val ecdsa = net.schmizz.sshj.signature.SignatureECDSA.Factory256().create()
+            ecdsa.initVerify(key)
+            ecdsa.update(data)
+            // extractSig wants the whole `algorithm || signature` blob, not the unwrapped half.
+            assertTrue(ecdsa.verify(blob), "signature does not verify under the offered key ($algorithm)")
+            return algorithm
+        }
         val jca = java.security.Signature.getInstance(
             when (algorithm) {
                 "ssh-ed25519" -> "Ed25519"
@@ -91,6 +101,58 @@ class SshjAgentKeysTest {
             "rsa-sha2-512",
             verify(key, challenge, assertNotNull(keys.sign(blob, challenge, SshAgentCodec.FLAG_RSA_SHA2_512)).blob),
         )
+    }
+
+    @Test
+    fun `signs a challenge with an ecdsa key`() = runTest {
+        // Skerry generates ED25519/RSA, but a user can paste an ECDSA key from elsewhere, and the
+        // agent must sign with it: the signature type comes from the PUBLIC half, because sshj
+        // classifies an EC private key as UNKNOWN and would silently refuse.
+        val (pem, publicLine) = ecdsaKey()
+        val keys = SshjAgentKeys({ listOf(material(pem)) })
+        val blob = keys.identities().single().keyBlob
+
+        assertContentEquals(publicBlob(publicLine), blob)
+        val signature = assertNotNull(keys.sign(blob, challenge, flags = 0))
+        assertEquals("ecdsa-sha2-nistp256", verify(publicKeyOf(blob), challenge, signature.blob))
+    }
+
+    @Test
+    fun `signs with a pkcs8 key, the shape sshj cannot read on its own`() = runTest {
+        // What `openssl genpkey` and most cloud consoles hand out. Before the shared loader such a
+        // key was simply invisible to the agent.
+        val pair = java.security.KeyPairGenerator.getInstance("EC")
+            .apply { initialize(java.security.spec.ECGenParameterSpec("secp256r1")) }
+            .generateKeyPair()
+        val pem = "-----BEGIN PRIVATE KEY-----\n" +
+            Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(pair.private.encoded) +
+            "\n-----END PRIVATE KEY-----\n"
+        val keys = SshjAgentKeys({ listOf(material(pem)) })
+        val blob = keys.identities().single().keyBlob
+
+        val signature = assertNotNull(keys.sign(blob, challenge, flags = 0))
+        assertEquals("ecdsa-sha2-nistp256", verify(publicKeyOf(blob), challenge, signature.blob))
+    }
+
+    /**
+     * A real P-256 key in the shape `ssh-keygen -t ecdsa` writes today: `openssh-key-v1` in an
+     * `OPENSSH PRIVATE KEY` PEM. (BouncyCastle's `encodePrivateKey` emits that container for EC —
+     * not the SEC1 DER an `EC PRIVATE KEY` header would promise, which is why the header matters.)
+     * Returned with its `authorized_keys` line, as ground truth for what the agent offers.
+     */
+    private fun ecdsaKey(): Pair<String, String> {
+        val generator = org.bouncycastle.crypto.generators.ECKeyPairGenerator().apply {
+            val curve = org.bouncycastle.asn1.x9.ECNamedCurveTable.getByName("P-256")
+            val domain = org.bouncycastle.crypto.params.ECDomainParameters(curve.curve, curve.g, curve.n, curve.h)
+            init(org.bouncycastle.crypto.params.ECKeyGenerationParameters(domain, java.security.SecureRandom()))
+        }
+        val pair = generator.generateKeyPair()
+        val der = org.bouncycastle.crypto.util.OpenSSHPrivateKeyUtil.encodePrivateKey(pair.private)
+        val pem = "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+            Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(der) +
+            "\n-----END OPENSSH PRIVATE KEY-----\n"
+        val blob = org.bouncycastle.crypto.util.OpenSSHPublicKeyUtil.encodePublicKey(pair.public)
+        return pem to "ecdsa-sha2-nistp256 ${Base64.getEncoder().encodeToString(blob)}"
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
@@ -94,6 +94,37 @@ class SshjAgentKeysTest {
     }
 
     @Test
+    fun `a certificate is offered together with the plain key behind it`() = runTest {
+        // `ssh-add` offers both: a server that trusts the CA takes the certificate, one that only
+        // has the key in authorized_keys takes the key. Offering the certificate alone would lock
+        // the user out of every host that is not CA-enrolled.
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val plain = publicBlob(generated.info.publicKeyOpenSsh)
+        val certBlob = "test certificate blob".encodeToByteArray()
+        val certificate = "ssh-ed25519-cert-v01@openssh.com " + Base64.getEncoder().encodeToString(certBlob)
+        val keys = SshjAgentKeys({
+            listOf(SshAgentKeyMaterial(id = "c1", comment = "ca key", privateKeyPem = generated.privateKeyPem, certificate = certificate))
+        })
+
+        val offered = keys.identities()
+        assertEquals(listOf("ca key", "ca key"), offered.map { it.comment })
+        assertContentEquals(certBlob, offered.first().keyBlob)
+        assertContentEquals(plain, offered.last().keyBlob)
+        // Possession is proven by the same private key whichever blob the server picked.
+        assertEquals("ssh-ed25519", verify(publicKeyOf(plain), challenge, assertNotNull(keys.sign(certBlob, challenge, 0)).blob))
+    }
+
+    @Test
+    fun `a damaged certificate costs only itself, not the key`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({
+            listOf(SshAgentKeyMaterial(id = "c1", comment = "ca key", privateKeyPem = generated.privateKeyPem, certificate = "not-a-certificate"))
+        })
+
+        assertContentEquals(publicBlob(generated.info.publicKeyOpenSsh), keys.identities().single().keyBlob)
+    }
+
+    @Test
     fun `refuses a key it does not hold`() = runTest {
         val mine = generator.generate(SshKeyType.ED25519, comment = "")
         val other = generator.generate(SshKeyType.ED25519, comment = "")

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
@@ -1,0 +1,153 @@
+package app.skerry.shared.agent
+
+import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
+import app.skerry.shared.vault.SshKeyType
+import java.security.PublicKey
+import java.util.Base64
+import kotlinx.coroutines.test.runTest
+import net.schmizz.sshj.common.Buffer
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The keyring against real generated keys: what it offers must be exactly the public key of the
+ * stored secret, and what it signs must verify under that key with the algorithm the client asked
+ * for.
+ */
+class SshjAgentKeysTest {
+
+    private val generator = BouncyCastleSshKeyGenerator()
+    private val challenge = "session id and userauth request".encodeToByteArray()
+
+    private fun material(pem: String, id: String = "c1", comment: String = "work key") =
+        SshAgentKeyMaterial(id = id, comment = comment, privateKeyPem = pem)
+
+    /** Public key blob as written in the `authorized_keys` line — the ground truth for identities. */
+    private fun publicBlob(openSshLine: String): ByteArray =
+        Base64.getDecoder().decode(openSshLine.split(" ")[1])
+
+    private fun publicKeyOf(blob: ByteArray): PublicKey = Buffer.PlainBuffer(blob).readPublicKey()
+
+    /** Verify an agent signature blob (`string algorithm || string signature`) under [key]. */
+    private fun verify(key: PublicKey, data: ByteArray, blob: ByteArray): String {
+        val buffer = Buffer.PlainBuffer(blob)
+        val algorithm = buffer.readString()
+        val raw = buffer.readBytes()
+        val jca = java.security.Signature.getInstance(
+            when (algorithm) {
+                "ssh-ed25519" -> "Ed25519"
+                "rsa-sha2-512" -> "SHA512withRSA"
+                "rsa-sha2-256" -> "SHA256withRSA"
+                "ssh-rsa" -> "SHA1withRSA"
+                else -> error("unexpected signature algorithm $algorithm")
+            },
+        )
+        jca.initVerify(key)
+        jca.update(data)
+        assertTrue(jca.verify(raw), "signature does not verify under the offered key ($algorithm)")
+        return algorithm
+    }
+
+    @Test
+    fun `offers the public key of the stored secret`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val identities = SshjAgentKeys({ listOf(material(generated.privateKeyPem)) }).identities()
+
+        assertEquals(1, identities.size)
+        assertEquals("work key", identities.single().comment)
+        assertContentEquals(publicBlob(generated.info.publicKeyOpenSsh), identities.single().keyBlob)
+    }
+
+    @Test
+    fun `signs a challenge with an ed25519 key`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({ listOf(material(generated.privateKeyPem)) })
+        val blob = keys.identities().single().keyBlob
+
+        val signature = assertNotNull(keys.sign(blob, challenge, flags = 0))
+        assertEquals("work key", signature.keyComment)
+        assertEquals("ssh-ed25519", verify(publicKeyOf(blob), challenge, signature.blob))
+    }
+
+    @Test
+    fun `honours the rsa-sha2 flags of the sign request`() = runTest {
+        // A modern server asks for rsa-sha2-*; answering with a SHA-1 signature would be rejected,
+        // and answering SHA-2 to a client that did not ask breaks old ones. Both must follow the flag.
+        val generated = generator.generate(SshKeyType.RSA_4096, comment = "")
+        val keys = SshjAgentKeys({ listOf(material(generated.privateKeyPem)) })
+        val blob = keys.identities().single().keyBlob
+        val key = publicKeyOf(blob)
+
+        assertEquals("ssh-rsa", verify(key, challenge, assertNotNull(keys.sign(blob, challenge, 0)).blob))
+        assertEquals(
+            "rsa-sha2-256",
+            verify(key, challenge, assertNotNull(keys.sign(blob, challenge, SshAgentCodec.FLAG_RSA_SHA2_256)).blob),
+        )
+        assertEquals(
+            "rsa-sha2-512",
+            verify(key, challenge, assertNotNull(keys.sign(blob, challenge, SshAgentCodec.FLAG_RSA_SHA2_512)).blob),
+        )
+    }
+
+    @Test
+    fun `refuses a key it does not hold`() = runTest {
+        val mine = generator.generate(SshKeyType.ED25519, comment = "")
+        val other = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({ listOf(material(mine.privateKeyPem)) })
+
+        assertNull(keys.sign(publicBlob(other.info.publicKeyOpenSsh), challenge, flags = 0))
+    }
+
+    @Test
+    fun `a key that cannot be parsed is skipped instead of breaking the listing`() = runTest {
+        val good = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({
+            listOf(
+                SshAgentKeyMaterial(id = "broken", comment = "damaged", privateKeyPem = "-----BEGIN OPENSSH PRIVATE KEY-----\nnope\n"),
+                material(good.privateKeyPem, id = "good", comment = "good key"),
+            )
+        })
+
+        assertEquals(listOf("good key"), keys.identities().map { it.comment })
+    }
+
+    @Test
+    fun `reflects the current key set on every request`() = runTest {
+        // The user can add or remove keys (or lock the vault) while a forwarded channel is open.
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        var offered = listOf(material(generated.privateKeyPem))
+        val keys = SshjAgentKeys({ offered })
+
+        assertEquals(1, keys.identities().size)
+        offered = emptyList()
+        assertEquals(0, keys.identities().size)
+    }
+
+    @Test
+    fun `clear drops the parsed keys`() = runTest {
+        val generated = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({ listOf(material(generated.privateKeyPem)) })
+        val blob = keys.identities().single().keyBlob
+
+        keys.clear()
+        // The material provider is what gates access after a lock; clear() only drops what was
+        // parsed, so with the provider still returning the key the agent keeps working.
+        assertNotNull(keys.sign(blob, challenge, flags = 0))
+    }
+
+    @Test
+    fun `an edited key is re-parsed instead of served from the cache`() = runTest {
+        val first = generator.generate(SshKeyType.ED25519, comment = "")
+        val second = generator.generate(SshKeyType.ED25519, comment = "")
+        var pem = first.privateKeyPem
+        val keys = SshjAgentKeys({ listOf(material(pem)) })
+
+        assertContentEquals(publicBlob(first.info.publicKeyOpenSsh), keys.identities().single().keyBlob)
+        pem = second.privateKeyPem
+        assertContentEquals(publicBlob(second.info.publicKeyOpenSsh), keys.identities().single().keyBlob)
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
@@ -11,14 +11,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 /**
  * The `SSH_AUTH_SOCK` socket, driven by a client that speaks the real agent protocol — the role
@@ -43,7 +45,9 @@ class UnixSocketSshAgentTest {
             override suspend fun identities() = identities
             override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? = null
         }
-        return UnixSocketSshAgent(dir.resolve("run"), SshAgentService(keys), scope)
+        // Own dispatcher: the shared agent one is capped and other suites in this JVM park readers
+        // on it, which would leave this listener's accept() waiting for a free thread.
+        return UnixSocketSshAgent(dir.resolve("run"), SshAgentService(keys), scope, Dispatchers.IO)
             .also { agent = it }
             .start()
     }
@@ -62,21 +66,35 @@ class UnixSocketSshAgentTest {
             input.readNBytes(length)
         }
 
-    @Test
-    fun `serves the identity list over the socket`() = runTest {
-        val identities = listOf(SshAgentIdentity(byteArrayOf(1, 2, 3), "work key"))
-        val path = start(identities)
-        val response = withTimeout(SOCKET_TIMEOUT_MILLIS) { request(path, byteArrayOf(11)) }
-        assertContentEquals(SshAgentCodec.identitiesAnswer(identities), response)
+    /**
+     * Run blocking socket work with a wall-clock deadline, so a regression fails the test instead
+     * of hanging the whole suite. Not `runTest`: its virtual clock does not advance while a thread
+     * sits in a blocking read, which makes `withTimeout` around one both useless and flaky.
+     */
+    private fun <T> withDeadline(block: () -> T): T {
+        val worker = Executors.newSingleThreadExecutor()
+        return try {
+            worker.submit(block).get(SOCKET_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+        } catch (e: TimeoutException) {
+            fail("the agent did not answer within \${SOCKET_TIMEOUT_MILLIS}ms")
+        } finally {
+            worker.shutdownNow()
+        }
     }
 
     @Test
-    fun `serves several clients in a row`() = runTest {
+    fun `serves the identity list over the socket`() {
+        val identities = listOf(SshAgentIdentity(byteArrayOf(1, 2, 3), "work key"))
+        val path = start(identities)
+        assertContentEquals(SshAgentCodec.identitiesAnswer(identities), withDeadline { request(path, byteArrayOf(11)) })
+    }
+
+    @Test
+    fun `serves several clients in a row`() {
         // `ssh` opens a new connection per invocation; one client hanging up must not end the agent.
         val path = start(emptyList())
         repeat(3) {
-            val response = withTimeout(SOCKET_TIMEOUT_MILLIS) { request(path, byteArrayOf(11)) }
-            assertContentEquals(SshAgentCodec.identitiesAnswer(emptyList()), response)
+            assertContentEquals(SshAgentCodec.identitiesAnswer(emptyList()), withDeadline { request(path, byteArrayOf(11)) })
         }
     }
 
@@ -92,6 +110,20 @@ class UnixSocketSshAgentTest {
             PosixFilePermission.entries.filter { it.name.startsWith("OWNER") }.toSet(),
             Files.getPosixFilePermissions(path.parent),
         )
+    }
+
+    @Test
+    fun `stop ends connections that are still open`() {
+        // A long-lived client (an `ssh` session on the far end of a shell) keeps its connection
+        // open with no requests; switching the socket off must not leave it holding a thread.
+        val path = start(emptyList())
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(path))
+            val input = Channels.newInputStream(channel)
+            agent?.stop()
+            val eof = withDeadline { runCatching { input.read() }.getOrDefault(-1) }
+            assertEquals(-1, eof, "connection outlived the agent")
+        }
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
@@ -127,6 +127,23 @@ class UnixSocketSshAgentTest {
     }
 
     @Test
+    fun `a client from the previous round is not served after a restart`() {
+        // Switching the socket off and straight back on is one click in Settings; a connection that
+        // belonged to the old listener must end with it, not be picked up by the new one.
+        val path = start(emptyList())
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(path))
+            val input = Channels.newInputStream(channel)
+            agent?.stop()
+            agent?.start()
+
+            val eof = withDeadline { runCatching { input.read() }.getOrDefault(-1) }
+
+            assertEquals(-1, eof, "a connection from before the restart is still being served")
+        }
+    }
+
+    @Test
     fun `stop removes the socket`() {
         val path = start(emptyList())
         assertTrue(Files.exists(path))

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
@@ -1,0 +1,116 @@
+package app.skerry.shared.agent
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The `SSH_AUTH_SOCK` socket, driven by a client that speaks the real agent protocol — the role
+ * `ssh` plays when it asks the agent for keys.
+ */
+class UnixSocketSshAgentTest {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private lateinit var dir: Path
+    private var agent: UnixSocketSshAgent? = null
+
+    @AfterTest
+    fun tearDown() {
+        agent?.stop()
+        scope.cancel()
+        if (::dir.isInitialized) Files.walk(dir).sorted(Comparator.reverseOrder()).forEach { it.toFile().delete() }
+    }
+
+    private fun start(identities: List<SshAgentIdentity>): Path {
+        dir = Files.createTempDirectory("skerry-agent-test")
+        val keys = object : SshAgentKeys {
+            override suspend fun identities() = identities
+            override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? = null
+        }
+        return UnixSocketSshAgent(dir.resolve("run"), SshAgentService(keys), scope)
+            .also { agent = it }
+            .start()
+    }
+
+    /** One agent round trip over the socket, framing included. */
+    private fun request(path: Path, message: ByteArray): ByteArray =
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(path))
+            val output = Channels.newOutputStream(channel)
+            output.write(SshAgentCodec.frame(message))
+            output.flush()
+            val input = Channels.newInputStream(channel)
+            val header = ByteArray(4).also { input.readNBytes(it, 0, 4) }
+            val length = (header[0].toInt() and 0xFF shl 24) or (header[1].toInt() and 0xFF shl 16) or
+                (header[2].toInt() and 0xFF shl 8) or (header[3].toInt() and 0xFF)
+            input.readNBytes(length)
+        }
+
+    @Test
+    fun `serves the identity list over the socket`() = runTest {
+        val identities = listOf(SshAgentIdentity(byteArrayOf(1, 2, 3), "work key"))
+        val path = start(identities)
+        val response = withTimeout(SOCKET_TIMEOUT_MILLIS) { request(path, byteArrayOf(11)) }
+        assertContentEquals(SshAgentCodec.identitiesAnswer(identities), response)
+    }
+
+    @Test
+    fun `serves several clients in a row`() = runTest {
+        // `ssh` opens a new connection per invocation; one client hanging up must not end the agent.
+        val path = start(emptyList())
+        repeat(3) {
+            val response = withTimeout(SOCKET_TIMEOUT_MILLIS) { request(path, byteArrayOf(11)) }
+            assertContentEquals(SshAgentCodec.identitiesAnswer(emptyList()), response)
+        }
+    }
+
+    @Test
+    fun `the socket is reachable only by its owner`() {
+        // The socket has no other access control: anything that can open it can make the agent sign.
+        val path = start(emptyList())
+        assertEquals(
+            setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            Files.getPosixFilePermissions(path),
+        )
+        assertEquals(
+            PosixFilePermission.entries.filter { it.name.startsWith("OWNER") }.toSet(),
+            Files.getPosixFilePermissions(path.parent),
+        )
+    }
+
+    @Test
+    fun `stop removes the socket`() {
+        val path = start(emptyList())
+        assertTrue(Files.exists(path))
+        agent?.stop()
+        assertFalse(Files.exists(path), "socket file outlived the agent")
+    }
+
+    @Test
+    fun `start replaces a socket left behind by a crash`() {
+        val path = start(emptyList())
+        agent?.stop()
+        Files.createFile(path)
+        assertEquals(path, agent?.start())
+    }
+
+    private companion object {
+        const val SOCKET_TIMEOUT_MILLIS = 10_000L
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellChannelTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellChannelTest.kt
@@ -49,7 +49,7 @@ class ShellChannelTest {
     }
 
     private suspend fun connect(): SshConnection =
-        SshjTransport { _, _, _, _ -> true }.connect(
+        SshjTransport(HostKeyVerifier { _, _, _, _ -> true }).connect(
             SshTarget(host = "127.0.0.1", port = server.port, username = USER),
             SshAuth.Password(PASSWORD),
         )

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshPemKeysTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshPemKeysTest.kt
@@ -1,0 +1,124 @@
+package app.skerry.shared.ssh
+
+import java.security.KeyPairGenerator
+import java.security.spec.ECGenParameterSpec
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.EncryptedPrivateKeyInfo
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.PBEParameterSpec
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * The PEM loader against the shapes a pasted key really has. sshj covers OpenSSH and PKCS#1 on its
+ * own; PKCS#8 (`BEGIN PRIVATE KEY`, what `openssl`, cloud consoles and Java tooling hand out) it
+ * cannot parse at all, which is what the fallback here is for.
+ */
+class SshPemKeysTest {
+
+    private fun pem(header: String, der: ByteArray) =
+        "-----BEGIN $header-----\n" +
+            Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(der) +
+            "\n-----END $header-----\n"
+
+    private fun pkcs8(algorithm: String, curve: String? = null) =
+        KeyPairGenerator.getInstance(algorithm)
+            .apply { curve?.let { initialize(ECGenParameterSpec(it)) } }
+            .generateKeyPair()
+
+    @Test
+    fun `loads a pkcs8 ecdsa key and recovers its public half`() {
+        val original = pkcs8("EC", "secp256r1")
+
+        val loaded = loadSshKeyPair(pem("PRIVATE KEY", original.private.encoded), passphrase = null)
+
+        assertEquals(original.public, loaded.public)
+        assertEquals("ecdsa-sha2-nistp256", net.schmizz.sshj.common.KeyType.fromKey(loaded.public).toString())
+    }
+
+    @Test
+    fun `loads a pkcs8 rsa key`() {
+        val original = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+
+        val loaded = loadSshKeyPair(pem("PRIVATE KEY", original.private.encoded), passphrase = null)
+
+        assertEquals(original.public, loaded.public)
+    }
+
+    @Test
+    fun `loads a pkcs8 ed25519 key`() {
+        val original = pkcs8("Ed25519")
+
+        val loaded = loadSshKeyPair(pem("PRIVATE KEY", original.private.encoded), passphrase = null)
+
+        assertEquals("ssh-ed25519", net.schmizz.sshj.common.KeyType.fromKey(loaded.public).toString())
+    }
+
+    @Test
+    fun `loads an encrypted pkcs8 key with its passphrase`() {
+        val original = pkcs8("EC", "secp256r1")
+
+        val loaded = loadSshKeyPair(pem("ENCRYPTED PRIVATE KEY", encrypt(original.private.encoded, "hunter2")), "hunter2")
+
+        assertEquals(original.public, loaded.public)
+    }
+
+    @Test
+    fun `a wrong passphrase fails instead of returning a broken key`() {
+        val original = pkcs8("EC", "secp256r1")
+        val encrypted = pem("ENCRYPTED PRIVATE KEY", encrypt(original.private.encoded, "hunter2"))
+
+        assertFailsWith<java.io.IOException> { loadSshKeyPair(encrypted, "wrong") }
+    }
+
+    @Test
+    fun `an openssh key still goes through sshj`() {
+        val generated = app.skerry.shared.vault.BouncyCastleSshKeyGenerator()
+            .generate(app.skerry.shared.vault.SshKeyType.ED25519, comment = "")
+
+        val loaded = loadSshKeyPair(generated.privateKeyPem, passphrase = null)
+
+        assertTrue(net.schmizz.sshj.common.KeyType.fromKey(loaded.public) == net.schmizz.sshj.common.KeyType.ED25519)
+    }
+
+    @Test
+    fun `an unreadable key is named as such, not reported as a dropped connection`() {
+        // What the user sees when a key cannot be opened must point at the key: "the connection
+        // dropped" sends them looking at the network for a wrong-passphrase typo.
+        val failure = assertFailsWith<SshAuthenticationException> {
+            loadAuthKey("-----BEGIN PRIVATE KEY-----\nnope\n", passphrase = null)
+        }
+
+        assertTrue(failure.message!!.contains("key", ignoreCase = true), "message does not mention the key: ${failure.message}")
+    }
+
+    @Test
+    fun `a readable key comes back as a usable pair`() {
+        val original = pkcs8("EC", "secp256r1")
+
+        assertEquals(original.public, loadAuthKey(pem("PRIVATE KEY", original.private.encoded), null).public)
+    }
+
+    @Test
+    fun `garbage is reported, not returned`() {
+        assertFailsWith<java.io.IOException> { loadSshKeyPair("-----BEGIN PRIVATE KEY-----\nnope\n", null) }
+    }
+
+    /**
+     * Wrap a key as `ENCRYPTED PRIVATE KEY`. PBES1 here only because it is what the JDK can build an
+     * AlgorithmId for in a test; decryption reads the algorithm out of the blob, so a real PBES2 key
+     * from `openssl` goes through the same path.
+     */
+    private fun encrypt(pkcs8Der: ByteArray, passphrase: String): ByteArray {
+        val algorithm = "PBEWithMD5AndDES"
+        val parameters = java.security.AlgorithmParameters.getInstance(algorithm)
+            .apply { init(PBEParameterSpec(ByteArray(8) { it.toByte() }, 10_000)) }
+        val key = SecretKeyFactory.getInstance(algorithm).generateSecret(PBEKeySpec(passphrase.toCharArray()))
+        val cipher = Cipher.getInstance(algorithm).apply { init(Cipher.ENCRYPT_MODE, key, parameters) }
+        return EncryptedPrivateKeyInfo(parameters, cipher.doFinal(pkcs8Der)).encoded
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/vault/BouncyCastleSshKeyGeneratorTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/vault/BouncyCastleSshKeyGeneratorTest.kt
@@ -79,4 +79,22 @@ class BouncyCastleSshKeyGeneratorTest {
         assertNull(gen.inspect("not a pem at all"))
         assertNull(gen.inspect(""))
     }
+
+    @Test
+    fun `inspects a pkcs8 key instead of calling it damaged`() {
+        // A pasted `BEGIN PRIVATE KEY` must show its type and fingerprint like any other key; sshj
+        // alone cannot parse it, so this covers the shared loader's fallback.
+        val pair = java.security.KeyPairGenerator.getInstance("EC")
+            .apply { initialize(java.security.spec.ECGenParameterSpec("secp256r1")) }
+            .generateKeyPair()
+        val pem = "-----BEGIN PRIVATE KEY-----\n" +
+            Base64.getMimeEncoder(64, "\n".toByteArray()).encodeToString(pair.private.encoded) +
+            "\n-----END PRIVATE KEY-----\n"
+
+        val info = gen.inspect(pem, passphrase = null)
+
+        assertEquals("ECDSA-SHA2-NISTP256", info?.keyTypeLabel)
+        assertTrue(info!!.publicKeyOpenSsh.startsWith("ecdsa-sha2-nistp256 "))
+        assertTrue(info.fingerprintSha256.startsWith("SHA256:"))
+    }
 }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
@@ -3,7 +3,26 @@ package app.skerry.shared.agent
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runInterruptible
+
+/**
+ * Threads the agent may take from the shared IO pool, across every carrier and every session.
+ *
+ * Each served connection parks one thread in a blocking read for as long as the peer keeps it open,
+ * and the peers are untrusted: a server the user forwards to can open agent channels and then go
+ * quiet. Without a ceiling those reads would eat `Dispatchers.IO`, which the whole app shares with
+ * SFTP, tunnels and every other session — so a single hostile host could stall features that have
+ * nothing to do with the agent. A deadline is not an option instead: a legitimate `ssh` holds its
+ * agent connection open, idle, for the life of the remote shell.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal val agentDispatcher: CoroutineDispatcher = Dispatchers.IO.limitedParallelism(MAX_AGENT_THREADS)
+
+/** See [agentDispatcher]. Generous next to what one user's own tooling opens, tiny next to the pool. */
+private const val MAX_AGENT_THREADS = 16
 
 /**
  * Serve the agent protocol over one byte stream pair until the peer goes away. Shared by both

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
@@ -1,0 +1,59 @@
+package app.skerry.shared.agent
+
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlinx.coroutines.runInterruptible
+
+/**
+ * Serve the agent protocol over one byte stream pair until the peer goes away. Shared by both
+ * carriers — a forwarded `auth-agent@openssh.com` channel and the local `SSH_AUTH_SOCK` socket —
+ * so framing and refusal behaviour cannot drift apart between them.
+ *
+ * The peer is untrusted in both cases: a length that is absurd or a message the codec cannot parse
+ * ends the connection rather than resynchronising, because there is no way to find the next message
+ * boundary in a stream once the length prefix is not to be trusted.
+ *
+ * Blocking reads run under [runInterruptible], so cancelling the serving coroutine (session
+ * teardown, vault lock, app exit) actually interrupts a read that is waiting for the next request
+ * instead of leaking a thread until the peer closes.
+ */
+internal suspend fun serveSshAgent(
+    input: InputStream,
+    output: OutputStream,
+    service: SshAgentService,
+    origin: SshAgentOrigin,
+) {
+    try {
+        while (true) {
+            val header = runInterruptible { input.readFullyOrNull(HEADER_BYTES) } ?: return
+            val length = (header[0].toInt() and 0xFF shl 24) or
+                (header[1].toInt() and 0xFF shl 16) or
+                (header[2].toInt() and 0xFF shl 8) or
+                (header[3].toInt() and 0xFF)
+            if (length <= 0 || length > SshAgentCodec.MAX_MESSAGE_BYTES) return
+            val request = runInterruptible { input.readFullyOrNull(length) } ?: return
+            val response = service.handle(request, origin)
+            runInterruptible {
+                output.write(SshAgentCodec.frame(response))
+                output.flush()
+            }
+        }
+    } catch (e: IOException) {
+        // Peer closed mid-message (session torn down, `ssh` exited): nothing to report.
+    }
+}
+
+private const val HEADER_BYTES = 4
+
+/** Read exactly [count] bytes, or `null` at end of stream. */
+private fun InputStream.readFullyOrNull(count: Int): ByteArray? {
+    val buffer = ByteArray(count)
+    var read = 0
+    while (read < count) {
+        val n = read(buffer, read, count - read)
+        if (n < 0) return null
+        read += n
+    }
+    return buffer
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
@@ -3,8 +3,8 @@ package app.skerry.shared.agent
 import java.io.IOException
 import java.nio.charset.Charset
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -15,12 +15,19 @@ import net.schmizz.sshj.connection.ConnectionException
 import net.schmizz.sshj.connection.channel.direct.SessionChannel
 import net.schmizz.sshj.connection.channel.forwarded.AbstractForwardedChannel
 import net.schmizz.sshj.connection.channel.forwarded.ForwardedChannelOpener
+import net.schmizz.sshj.connection.channel.OpenFailException
 
 /** Channel type the server opens back to us to reach the agent (OpenSSH's name). */
 private const val AGENT_CHANNEL_TYPE = "auth-agent@openssh.com"
 
 /** Session request that asks the server to set `SSH_AUTH_SOCK` for the remote shell. */
 private const val AGENT_REQUEST_TYPE = "auth-agent-req@openssh.com"
+
+/**
+ * Agent channels one session may have open at once. A remote running several `ssh` processes in
+ * parallel needs a handful; a server that opens more than this is not doing anything a shell does.
+ */
+private const val MAX_CHANNELS_PER_SESSION = 8
 
 /**
  * Session channel that can ask for agent forwarding. sshj has no agent support at all (0.40), and
@@ -61,21 +68,28 @@ internal class SshjAgentForwarder(
 
     // Own scope, not a session scope passed in: this object is created inside the transport, below
     // the UI layer, and each channel is a blocking read loop that must be cancellable as a group.
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    // The dispatcher is the agent's bounded slice of the IO pool (see [agentDispatcher]).
+    private val scope = CoroutineScope(SupervisorJob() + agentDispatcher)
+
+    // How many of this server's agent channels are being served right now. The server decides how
+    // many to open, so it needs a ceiling of its own: without one, a single session could take the
+    // agent's whole thread budget and starve the other sessions (and the local socket).
+    private val openChannels = AtomicInteger()
 
     override fun getChannelType(): String = AGENT_CHANNEL_TYPE
 
     /**
      * Ask the server to forward the agent to [session]. A server with `AllowAgentForwarding no`
      * answers CHANNEL_FAILURE, which must not cost the user their shell: the refusal is recorded
-     * for the activity list and the session continues without an agent.
+     * for the activity list, reported to the session (info panel) and the shell opens anyway.
+     * @return whether the server granted it
      */
-    fun requestOn(session: AgentSessionChannel) {
-        try {
-            session.requestAgentForwarding()
-        } catch (e: IOException) {
-            service.note(origin, SshAgentAction.ForwardingDenied)
-        }
+    fun requestOn(session: AgentSessionChannel): Boolean = try {
+        session.requestAgentForwarding()
+        true
+    } catch (e: IOException) {
+        service.note(origin, SshAgentAction.ForwardingDenied)
+        false
     }
 
     override fun handleOpen(buf: SSHPacket) {
@@ -84,6 +98,13 @@ internal class SshjAgentForwarder(
         } catch (e: Buffer.BufferException) {
             throw ConnectionException(e)
         }
+        // Over the ceiling: refuse before confirming, so the server learns it cannot open more
+        // instead of holding a channel we never read.
+        if (openChannels.get() >= MAX_CHANNELS_PER_SESSION) {
+            runCatching { channel.reject(OpenFailException.Reason.RESOURCE_SHORTAGE, "too many agent channels") }
+            return
+        }
+        openChannels.incrementAndGet()
         // confirm() attaches the channel and sends the open confirmation; data can arrive the moment
         // it returns, so the serving coroutine starts right after.
         channel.confirm()
@@ -91,6 +112,7 @@ internal class SshjAgentForwarder(
             try {
                 serveSshAgent(channel.inputStream, channel.outputStream, service, origin)
             } finally {
+                openChannels.decrementAndGet()
                 runCatching { channel.close() }
             }
         }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
@@ -1,0 +1,120 @@
+package app.skerry.shared.agent
+
+import java.io.IOException
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import net.schmizz.sshj.common.Buffer
+import net.schmizz.sshj.common.SSHPacket
+import net.schmizz.sshj.connection.Connection
+import net.schmizz.sshj.connection.ConnectionException
+import net.schmizz.sshj.connection.channel.direct.SessionChannel
+import net.schmizz.sshj.connection.channel.forwarded.AbstractForwardedChannel
+import net.schmizz.sshj.connection.channel.forwarded.ForwardedChannelOpener
+
+/** Channel type the server opens back to us to reach the agent (OpenSSH's name). */
+private const val AGENT_CHANNEL_TYPE = "auth-agent@openssh.com"
+
+/** Session request that asks the server to set `SSH_AUTH_SOCK` for the remote shell. */
+private const val AGENT_REQUEST_TYPE = "auth-agent-req@openssh.com"
+
+/**
+ * Session channel that can ask for agent forwarding. sshj has no agent support at all (0.40), and
+ * `SSHClient.startSession()` hands back a `Session` whose only channel requests are PTY/shell/exec —
+ * `sendChannelRequest` is `protected`. Subclassing is the supported way in: this is exactly what
+ * `startSession()` builds, plus one extra request.
+ *
+ * The request must go out BEFORE `shell`/`exec` (sshj marks the channel used up afterwards, and
+ * OpenSSH expects the same order).
+ */
+internal class AgentSessionChannel(conn: Connection, charset: Charset) : SessionChannel(conn, charset) {
+    /**
+     * Ask the server to forward the agent to this session.
+     * @throws ConnectionException the server refused (agent forwarding disabled) or the channel broke
+     */
+    fun requestAgentForwarding() {
+        sendChannelRequest(AGENT_REQUEST_TYPE, true, null)
+            .await(conn.timeoutMs.toLong(), TimeUnit.MILLISECONDS)
+    }
+}
+
+/**
+ * Serves agent requests coming back from a server over `auth-agent@openssh.com` channels. Every
+ * channel the server opens is answered by the in-process [SshAgentService], so the private key
+ * itself never leaves this machine — the remote only ever gets signatures, and only for keys the
+ * user put in the agent.
+ *
+ * Registered on the connection for the whole session (a remote `ssh` may open a channel per
+ * connection attempt) and torn down with it via [stop]: sshj does not track third-party openers, so
+ * forgetting it is our job, and the scope must die with the session or a wedged channel would
+ * outlive the terminal tab.
+ */
+internal class SshjAgentForwarder(
+    private val conn: Connection,
+    private val service: SshAgentService,
+    private val origin: SshAgentOrigin,
+) : ForwardedChannelOpener {
+
+    // Own scope, not a session scope passed in: this object is created inside the transport, below
+    // the UI layer, and each channel is a blocking read loop that must be cancellable as a group.
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    override fun getChannelType(): String = AGENT_CHANNEL_TYPE
+
+    /**
+     * Ask the server to forward the agent to [session]. A server with `AllowAgentForwarding no`
+     * answers CHANNEL_FAILURE, which must not cost the user their shell: the refusal is recorded
+     * for the activity list and the session continues without an agent.
+     */
+    fun requestOn(session: AgentSessionChannel) {
+        try {
+            session.requestAgentForwarding()
+        } catch (e: IOException) {
+            service.note(origin, SshAgentAction.ForwardingDenied)
+        }
+    }
+
+    override fun handleOpen(buf: SSHPacket) {
+        val channel = try {
+            AgentChannel(conn, buf.readUInt32AsInt(), buf.readUInt32(), buf.readUInt32())
+        } catch (e: Buffer.BufferException) {
+            throw ConnectionException(e)
+        }
+        // confirm() attaches the channel and sends the open confirmation; data can arrive the moment
+        // it returns, so the serving coroutine starts right after.
+        channel.confirm()
+        scope.launch {
+            try {
+                serveSshAgent(channel.inputStream, channel.outputStream, service, origin)
+            } finally {
+                runCatching { channel.close() }
+            }
+        }
+    }
+
+    /** De-register from the connection and stop serving. Idempotent. */
+    fun stop() {
+        conn.forget(this)
+        scope.cancel()
+    }
+
+    /** An agent channel opened by the server; unlike `x11` it carries no originator address. */
+    private class AgentChannel(
+        conn: Connection,
+        recipient: Int,
+        remoteWindowSize: Long,
+        remoteMaxPacketSize: Long,
+    ) : AbstractForwardedChannel(
+        conn,
+        AGENT_CHANNEL_TYPE,
+        recipient,
+        remoteWindowSize,
+        remoteMaxPacketSize,
+        "",
+        0,
+    )
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
@@ -1,19 +1,18 @@
 package app.skerry.shared.agent
 
 import app.skerry.shared.ssh.ensureCryptoProvider
+import app.skerry.shared.ssh.loadSshKeyPair
 import com.hierynomus.sshj.signature.SignatureEdDSA
 import java.security.PrivateKey
 import java.util.Base64
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.common.Buffer
 import net.schmizz.sshj.common.KeyType
 import net.schmizz.sshj.signature.Signature
 import net.schmizz.sshj.signature.SignatureECDSA
 import net.schmizz.sshj.signature.SignatureRSA
-import net.schmizz.sshj.userauth.password.PasswordUtils
 
 /**
  * [SshAgentKeys] over the vault's keys, parsed with the same stack the transport authenticates
@@ -90,13 +89,10 @@ class SshjAgentKeys(
         // Android's system BouncyCastle is stripped down and cannot parse PEM keys; register the
         // full provider first (idempotent, no-op on desktop) — as the transport and key generator do.
         ensureCryptoProvider()
-        val pwdf = entry.passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
-        // SSHClient opens no connection here; `use` just frees the parsing resources (as in
-        // BouncyCastleSshKeyGenerator.inspect). Both key halves are taken inside the block.
-        val (privateKey, publicKey) = SSHClient().use { client ->
-            val keys = client.loadKeys(entry.privateKeyPem, null, pwdf)
-            keys.private to keys.public
-        }
+        // Every stored shape goes through the shared loader, PKCS#8 included ([loadSshKeyPair]).
+        val pair = loadSshKeyPair(entry.privateKeyPem, entry.passphrase)
+        val privateKey = pair.private
+        val publicKey = pair.public
         val publicBlob = Buffer.PlainBuffer().putPublicKey(publicKey).compactData
         LoadedKey(
             id = entry.id,

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
@@ -39,10 +39,10 @@ class SshjAgentKeys(
     private var epoch = 0
 
     override suspend fun identities(): List<SshAgentIdentity> =
-        load().map { SshAgentIdentity(it.keyBlob, it.comment) }
+        load().flatMap { key -> key.keyBlobs.map { SshAgentIdentity(it, key.comment) } }
 
     override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? {
-        val key = load().firstOrNull { it.keyBlob.contentEquals(keyBlob) } ?: return null
+        val key = load().firstOrNull { key -> key.keyBlobs.any { it.contentEquals(keyBlob) } } ?: return null
         return withContext(dispatcher) {
             val signature = signatureFor(key.type, flags) ?: return@withContext null
             runCatching {
@@ -93,19 +93,25 @@ class SshjAgentKeys(
         val pwdf = entry.passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
         // SSHClient opens no connection here; `use` just frees the parsing resources (as in
         // BouncyCastleSshKeyGenerator.inspect). Both key halves are taken inside the block.
-        val (privateKey, publicBlob) = SSHClient().use { client ->
+        val (privateKey, publicKey) = SSHClient().use { client ->
             val keys = client.loadKeys(entry.privateKeyPem, null, pwdf)
-            keys.private to Buffer.PlainBuffer().putPublicKey(keys.public).compactData
+            keys.private to keys.public
         }
+        val publicBlob = Buffer.PlainBuffer().putPublicKey(publicKey).compactData
         LoadedKey(
             id = entry.id,
             comment = entry.comment,
-            // A certificate credential offers the certificate itself: its base64 field already IS
-            // the ssh-wire public blob, so it needs no re-encoding. Possession is still proven with
-            // the private key below.
-            keyBlob = entry.certificate?.let { certificateBlob(it) } ?: publicBlob,
+            // A certificate credential offers BOTH identities, as `ssh-add` does: the certificate
+            // (its base64 field already IS the ssh-wire blob, no re-encoding needed) and the plain
+            // key behind it. Offering only the certificate would lock the user out of every server
+            // that knows the key but does not trust the CA. A certificate that cannot be parsed
+            // costs only itself — the plain key is still offered.
+            keyBlobs = listOfNotNull(entry.certificate?.let { runCatching { certificateBlob(it) }.getOrNull() }, publicBlob),
             privateKey = privateKey,
-            type = KeyType.fromKey(privateKey),
+            // Type comes from the PUBLIC half: sshj can classify a private key for RSA/Ed25519 but
+            // not always for EC (a provider that reports the algorithm differently drops it to
+            // UNKNOWN), and an unclassified key would silently refuse to sign.
+            type = KeyType.fromKey(publicKey),
             pem = entry.privateKeyPem,
             passphrase = entry.passphrase,
             certificate = entry.certificate,
@@ -124,9 +130,11 @@ class SshjAgentKeys(
      * the agent answers what was asked for, it does not pick the policy.
      */
     private fun signatureFor(type: KeyType, flags: Int): Signature? = when (type) {
+        // SHA-256 is tested first, as OpenSSH's own agent does: a client that (wrongly) sets both
+        // flags gets the algorithm it names in the userauth request, not the other one.
         KeyType.RSA -> when {
-            flags and SshAgentCodec.FLAG_RSA_SHA2_512 != 0 -> SignatureRSA.FactoryRSASHA512().create()
             flags and SshAgentCodec.FLAG_RSA_SHA2_256 != 0 -> SignatureRSA.FactoryRSASHA256().create()
+            flags and SshAgentCodec.FLAG_RSA_SHA2_512 != 0 -> SignatureRSA.FactoryRSASHA512().create()
             else -> SignatureRSA.FactorySSHRSA().create()
         }
         KeyType.ED25519 -> SignatureEdDSA.Factory().create()
@@ -140,7 +148,8 @@ class SshjAgentKeys(
     private class LoadedKey(
         val id: String,
         val comment: String,
-        val keyBlob: ByteArray,
+        /** Wire blobs this key answers to: the certificate (if any) first, then the plain key. */
+        val keyBlobs: List<ByteArray>,
         val privateKey: PrivateKey,
         val type: KeyType,
         private val pem: String,

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
@@ -1,0 +1,157 @@
+package app.skerry.shared.agent
+
+import app.skerry.shared.ssh.ensureCryptoProvider
+import com.hierynomus.sshj.signature.SignatureEdDSA
+import java.security.PrivateKey
+import java.util.Base64
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.common.Buffer
+import net.schmizz.sshj.common.KeyType
+import net.schmizz.sshj.signature.Signature
+import net.schmizz.sshj.signature.SignatureECDSA
+import net.schmizz.sshj.signature.SignatureRSA
+import net.schmizz.sshj.userauth.password.PasswordUtils
+
+/**
+ * [SshAgentKeys] over the vault's keys, parsed with the same stack the transport authenticates
+ * with (sshj + BouncyCastle) so a key that works for a direct connection works through the agent.
+ *
+ * [material] is re-read on every request instead of being captured once: the user can add a key
+ * to the agent, remove one, or lock the vault while a forwarded channel is open, and the next
+ * request must see that. Parsed keys are cached by credential id (a passphrase-protected key costs
+ * a bcrypt KDF round to open, and `ssh` asks the agent on every connection), but the cache is
+ * checked against the current PEM/passphrase, so editing a key in place does not serve the old one.
+ *
+ * [clear] drops every parsed private key — called when the vault locks, so agent keys do not
+ * outlive the vault they came from. A load that was already in flight cannot repopulate the cache
+ * afterwards ([epoch] guard).
+ */
+class SshjAgentKeys(
+    private val material: () -> List<SshAgentKeyMaterial>,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : SshAgentKeys {
+
+    private val lock = Any()
+    private var cache: Map<String, LoadedKey> = emptyMap()
+    private var epoch = 0
+
+    override suspend fun identities(): List<SshAgentIdentity> =
+        load().map { SshAgentIdentity(it.keyBlob, it.comment) }
+
+    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? {
+        val key = load().firstOrNull { it.keyBlob.contentEquals(keyBlob) } ?: return null
+        return withContext(dispatcher) {
+            val signature = signatureFor(key.type, flags) ?: return@withContext null
+            runCatching {
+                signature.initSign(key.privateKey)
+                signature.update(data)
+                // Agent wire format for a signature is `string algorithm || string blob` — the same
+                // shape sshj builds for userauth (KeyedAuthMethod.putSig), minus the outer string
+                // the userauth packet adds.
+                val blob = Buffer.PlainBuffer()
+                    .putString(signature.signatureName)
+                    .putBytes(signature.encode(signature.sign()))
+                    .compactData
+                SshAgentSignature(blob, key.comment)
+            }.getOrNull()
+        }
+    }
+
+    /** Forget every parsed key (vault locked / agent switched off). */
+    fun clear() = synchronized(lock) {
+        cache = emptyMap()
+        epoch++
+    }
+
+    private suspend fun load(): List<LoadedKey> = withContext(dispatcher) {
+        val wanted = material()
+        val (snapshot, startedAt) = synchronized(lock) { cache to epoch }
+        val loaded = wanted.mapNotNull { entry ->
+            snapshot[entry.id]?.takeIf { it.matches(entry) } ?: parse(entry)
+        }
+        synchronized(lock) {
+            // A clear() in the meantime (vault locked) wins: publishing here would restore keys the
+            // lock was supposed to drop.
+            if (epoch == startedAt) cache = loaded.associateBy { it.id }
+        }
+        loaded
+    }
+
+    /**
+     * Parse one secret into a usable key. A key that cannot be opened (wrong passphrase, damaged
+     * PEM, unsupported type) is silently skipped rather than failing the whole listing: the agent
+     * offers what it can, exactly as `ssh-add` does, and the user sees the key missing from the
+     * Settings list.
+     */
+    private fun parse(entry: SshAgentKeyMaterial): LoadedKey? = runCatching {
+        // Android's system BouncyCastle is stripped down and cannot parse PEM keys; register the
+        // full provider first (idempotent, no-op on desktop) — as the transport and key generator do.
+        ensureCryptoProvider()
+        val pwdf = entry.passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
+        // SSHClient opens no connection here; `use` just frees the parsing resources (as in
+        // BouncyCastleSshKeyGenerator.inspect). Both key halves are taken inside the block.
+        val (privateKey, publicBlob) = SSHClient().use { client ->
+            val keys = client.loadKeys(entry.privateKeyPem, null, pwdf)
+            keys.private to Buffer.PlainBuffer().putPublicKey(keys.public).compactData
+        }
+        LoadedKey(
+            id = entry.id,
+            comment = entry.comment,
+            // A certificate credential offers the certificate itself: its base64 field already IS
+            // the ssh-wire public blob, so it needs no re-encoding. Possession is still proven with
+            // the private key below.
+            keyBlob = entry.certificate?.let { certificateBlob(it) } ?: publicBlob,
+            privateKey = privateKey,
+            type = KeyType.fromKey(privateKey),
+            pem = entry.privateKeyPem,
+            passphrase = entry.passphrase,
+            certificate = entry.certificate,
+        )
+    }.getOrNull()
+
+    private fun certificateBlob(certificate: String): ByteArray {
+        val fields = certificate.trim().split(Regex("\\s+"))
+        require(fields.size >= 2) { "expected format '<type> <base64> [comment]'" }
+        return Base64.getDecoder().decode(fields[1])
+    }
+
+    /**
+     * Signature algorithm for a key. RSA honours the client's `rsa-sha2-*` flags; with no flags it
+     * falls back to `ssh-rsa` (SHA-1), which modern servers refuse but old ones still require —
+     * the agent answers what was asked for, it does not pick the policy.
+     */
+    private fun signatureFor(type: KeyType, flags: Int): Signature? = when (type) {
+        KeyType.RSA -> when {
+            flags and SshAgentCodec.FLAG_RSA_SHA2_512 != 0 -> SignatureRSA.FactoryRSASHA512().create()
+            flags and SshAgentCodec.FLAG_RSA_SHA2_256 != 0 -> SignatureRSA.FactoryRSASHA256().create()
+            else -> SignatureRSA.FactorySSHRSA().create()
+        }
+        KeyType.ED25519 -> SignatureEdDSA.Factory().create()
+        KeyType.ECDSA256 -> SignatureECDSA.Factory256().create()
+        KeyType.ECDSA384 -> SignatureECDSA.Factory384().create()
+        KeyType.ECDSA521 -> SignatureECDSA.Factory521().create()
+        else -> null
+    }
+
+    /** A parsed key held in memory while the vault is unlocked. */
+    private class LoadedKey(
+        val id: String,
+        val comment: String,
+        val keyBlob: ByteArray,
+        val privateKey: PrivateKey,
+        val type: KeyType,
+        private val pem: String,
+        private val passphrase: String?,
+        private val certificate: String?,
+    ) {
+        /** Still the same secret? An edited key must be re-parsed, not served from the cache. */
+        fun matches(entry: SshAgentKeyMaterial): Boolean =
+            pem == entry.privateKeyPem &&
+                passphrase == entry.passphrase &&
+                certificate == entry.certificate &&
+                comment == entry.comment
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshPemKeys.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshPemKeys.kt
@@ -1,0 +1,107 @@
+package app.skerry.shared.ssh
+
+import java.io.IOException
+import java.security.KeyFactory
+import java.security.KeyPair
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.EncryptedPrivateKeyInfo
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.userauth.password.PasswordUtils
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters
+import org.bouncycastle.crypto.params.ECPrivateKeyParameters
+import org.bouncycastle.crypto.params.RSAKeyParameters
+import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters
+import org.bouncycastle.crypto.params.ECPublicKeyParameters
+import org.bouncycastle.crypto.util.PrivateKeyFactory
+import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory
+
+/**
+ * One way in for every stored private key, whichever shape the user pasted.
+ *
+ * sshj reads OpenSSH (`openssh-key-v1`) and the OpenSSL PKCS#1/SEC1 PEMs, which covers keys made by
+ * `ssh-keygen`. It cannot read PKCS#8 (`BEGIN PRIVATE KEY`) — its parser fails with an index error
+ * deep inside — and that is exactly what `openssl genpkey`, cloud consoles and Java tooling produce,
+ * so such a key would look "damaged" to the user for no reason. PKCS#8 (plain and encrypted) is
+ * therefore parsed here instead, and the public half is derived from the private one, since PKCS#8
+ * carries no public key of its own.
+ */
+fun loadSshKeyPair(pem: String, passphrase: String?): KeyPair {
+    // Android's system BouncyCastle is stripped down and cannot parse PEM keys (idempotent, no-op
+    // on desktop) — as the transport, the generator and the agent keyring do.
+    ensureCryptoProvider()
+    val viaSshj = runCatching {
+        val finder = passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
+        SSHClient().use { client ->
+            val keys = client.loadKeys(pem, null, finder)
+            KeyPair(keys.public, keys.private)
+        }
+    }.getOrNull()
+    if (viaSshj != null) return viaSshj
+    return pkcs8KeyPair(pem, passphrase)
+        ?: throw IOException("unsupported or damaged private key")
+}
+
+/**
+ * [loadSshKeyPair] for the authentication path, where the failure has to reach the user as what it
+ * is. A key that cannot be opened (wrong passphrase, unsupported or damaged PEM) is not a transport
+ * problem, and reporting it as one sends the user looking at the network for a typo.
+ */
+internal fun loadAuthKey(pem: String, passphrase: String?): KeyPair =
+    runCatching { loadSshKeyPair(pem, passphrase) }.getOrElse {
+        throw SshAuthenticationException("The stored SSH key could not be read (wrong passphrase or unsupported format)", it)
+    }
+
+private fun pkcs8KeyPair(pem: String, passphrase: String?): KeyPair? = runCatching {
+    val header = PKCS8_HEADER.find(pem) ?: return null
+    val encrypted = header.groupValues[1] == "ENCRYPTED "
+    val body = pem.substringAfter(header.value).substringBefore("-----END").filterNot { it.isWhitespace() }
+    val der = Base64.getDecoder().decode(body)
+    val pkcs8 = if (encrypted) decrypt(der, passphrase ?: return null) else der
+    val parameters = PrivateKeyFactory.createKey(pkcs8)
+    val factory = KeyFactory.getInstance(algorithmOf(parameters))
+    KeyPair(publicKeyOf(parameters, factory), factory.generatePrivate(PKCS8EncodedKeySpec(pkcs8)) as PrivateKey)
+}.getOrNull()
+
+/**
+ * Undo the PBES wrapper of an `ENCRYPTED PRIVATE KEY`. The algorithm (and its parameters) are named
+ * in the blob itself, so whatever produced the key decides the KDF — we only supply the passphrase.
+ */
+private fun decrypt(der: ByteArray, passphrase: String): ByteArray {
+    val info = EncryptedPrivateKeyInfo(der)
+    val key = SecretKeyFactory.getInstance(info.algName).generateSecret(PBEKeySpec(passphrase.toCharArray()))
+    val cipher = Cipher.getInstance(info.algName).apply { init(Cipher.DECRYPT_MODE, key, info.algParameters) }
+    return cipher.doFinal(info.encryptedData)
+}
+
+/**
+ * The public half, computed from the private key: RSA carries its public exponent, an EC private
+ * scalar gives the point back as `d·G`, and Ed25519 derives it by hashing. Encoded through
+ * SubjectPublicKeyInfo so one JCA path covers all three.
+ */
+private fun publicKeyOf(parameters: AsymmetricKeyParameter, factory: KeyFactory): PublicKey {
+    val public = when (parameters) {
+        is RSAPrivateCrtKeyParameters -> RSAKeyParameters(false, parameters.modulus, parameters.publicExponent)
+        is ECPrivateKeyParameters ->
+            ECPublicKeyParameters(parameters.parameters.g.multiply(parameters.d).normalize(), parameters.parameters)
+        is Ed25519PrivateKeyParameters -> parameters.generatePublicKey()
+        else -> throw IOException("unsupported key type")
+    }
+    return factory.generatePublic(X509EncodedKeySpec(SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(public).encoded))
+}
+
+private fun algorithmOf(parameters: AsymmetricKeyParameter): String = when (parameters) {
+    is RSAKeyParameters -> "RSA"
+    is ECPrivateKeyParameters -> "EC"
+    is Ed25519PrivateKeyParameters -> "Ed25519"
+    else -> throw IOException("unsupported key type")
+}
+
+private val PKCS8_HEADER = Regex("-----BEGIN (ENCRYPTED )?PRIVATE KEY-----")

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
@@ -10,6 +10,7 @@ import java.io.InputStream
 import java.net.InetSocketAddress
 import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
@@ -39,6 +40,12 @@ internal class SshjConnection(
 
     override val isConnected: Boolean
         get() = client.isConnected && client.isAuthenticated
+
+    // Written on the IO thread that opens the shell, read from the UI (info panel) — hence the
+    // atomic reference rather than a plain field.
+    private val agentForwardingState = AtomicReference(SshAgentForwarding.None)
+
+    override val agentForwarding: SshAgentForwarding get() = agentForwardingState.get()
 
     override suspend fun exec(command: String): ExecResult = withContext(Dispatchers.IO) {
         try {
@@ -111,7 +118,8 @@ internal class SshjConnection(
         val forwarder = agentForwarder ?: return client.startSession()
         val session = AgentSessionChannel(client.connection, client.remoteCharset)
         session.open()
-        forwarder.requestOn(session)
+        val granted = forwarder.requestOn(session)
+        agentForwardingState.set(if (granted) SshAgentForwarding.Active else SshAgentForwarding.Refused)
         return session
     }
 

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
@@ -1,5 +1,7 @@
 package app.skerry.shared.ssh
 
+import app.skerry.shared.agent.AgentSessionChannel
+import app.skerry.shared.agent.SshjAgentForwarder
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SshjSftpClient
 import java.io.ByteArrayOutputStream
@@ -22,12 +24,17 @@ import net.schmizz.sshj.transport.TransportException
  * Live sshj connection: exec/shell/SFTP/forwards over one authenticated client. [upstream] holds
  * the ProxyJump hop clients this connection is tunneled through (entry point first, empty for a
  * direct connection); they only live to carry [client]'s traffic and are closed with it.
+ *
+ * [agentForwarder] is present when this target asked for SSH agent forwarding: the interactive
+ * shell then requests it and the forwarder answers the server's agent channels. It dies with the
+ * connection ([disconnect]) — the agent must not stay reachable from a server whose session is gone.
  */
 internal class SshjConnection(
     private val client: SSHClient,
     override val cipher: String?,
     override val serverVersion: String?,
     private val upstream: List<SSHClient> = emptyList(),
+    private val agentForwarder: SshjAgentForwarder? = null,
 ) : SshConnection {
 
     override val isConnected: Boolean
@@ -86,11 +93,27 @@ internal class SshjConnection(
     override suspend fun openShell(size: PtySize, term: String): ShellChannel =
         withContext(Dispatchers.IO) {
             try {
-                openShellChannel(client.startSession(), size, term)
+                openShellChannel(newSession(), size, term)
             } catch (e: IOException) {
                 throw SshConnectionException("Failed to open shell channel", e)
             }
         }
+
+    /**
+     * A session channel for the interactive shell. Without agent forwarding this is sshj's own
+     * `startSession()`; with it, the same channel plus an `auth-agent-req@openssh.com` request,
+     * which has to be sent before the PTY/shell requests (see [AgentSessionChannel]).
+     *
+     * Only the shell gets the agent — one-shot [exec] channels (metrics polling, service scan, the
+     * Mosh bootstrap) run without it, so background machinery can never hand keys to a server.
+     */
+    private fun newSession(): Session {
+        val forwarder = agentForwarder ?: return client.startSession()
+        val session = AgentSessionChannel(client.connection, client.remoteCharset)
+        session.open()
+        forwarder.requestOn(session)
+        return session
+    }
 
     override suspend fun openSftp(): SftpClient = withContext(Dispatchers.IO) {
         try {
@@ -135,6 +158,9 @@ internal class SshjConnection(
         // already-dead socket (full TCP buffer) could hang indefinitely, and this is called from the UI
         // thread on tab close. On timeout, just force-close the client.
         withContext(Dispatchers.IO) {
+            // Before the transport goes down: stop answering agent channels and drop the opener, so
+            // no serving coroutine survives the session that authorized it.
+            agentForwarder?.let { runCatching { it.stop() } }
             withTimeoutOrNull(DISCONNECT_TIMEOUT_MILLIS) { runInterruptible { client.disconnect() } }
                 ?: runCatching { client.close() }
             // ProxyJump hops die with the session: closing the target client only closes its

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -19,7 +19,6 @@ import net.schmizz.sshj.common.Buffer
 import net.schmizz.sshj.common.KeyType
 import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.UserAuthException
-import net.schmizz.sshj.userauth.password.PasswordUtils
 
 /**
  * Desktop implementation of [SshTransport] over sshj (JVM).
@@ -173,11 +172,9 @@ class SshjTransport(
             when (auth) {
                 is SshAuth.Password -> client.authPassword(username, auth.secret)
                 is SshAuth.PublicKey -> {
-                    // loadKeys treats the strings as key content (not a path); passphrase is a
-                    // one-off PasswordFinder. sshj detects the format (OpenSSH/PKCS) itself.
-                    val pwdf = auth.passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
-                    val keys = client.loadKeys(auth.privateKeyPem, null, pwdf)
-                    client.authPublickey(username, keys)
+                    // The shared loader takes the PEM as key content (not a path) and covers every
+                    // stored shape, PKCS#8 included ([loadSshKeyPair]).
+                    client.authPublickey(username, keyProvider(loadAuthKey(auth.privateKeyPem, auth.passphrase)))
                 }
                 is SshAuth.Certificate -> {
                     // Cert auth: possession is proven by the private key from PEM, while the
@@ -185,8 +182,7 @@ class SshjTransport(
                     // sshj doesn't stitch these together from strings on its own (only from
                     // sibling files), so we build the KeyProvider by hand: private from PEM,
                     // public as Certificate, type as *_CERT.
-                    val pwdf = auth.passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
-                    val keys = client.loadKeys(auth.privateKeyPem, null, pwdf)
+                    val keys = loadAuthKey(auth.privateKeyPem, auth.passphrase)
                     client.authPublickey(username, certificateKeyProvider(keys, auth.certificate))
                 }
             }
@@ -259,7 +255,14 @@ internal fun ensureCryptoProvider() {
  * type). The type is taken from the string's first field (`ssh-…-cert-v01@openssh.com`) — that's
  * `*_CERT`, and sshj uses it to send the server the cert blob.
  */
-private fun certificateKeyProvider(privateKeys: KeyProvider, certificate: String): KeyProvider {
+/** sshj's view of an already-parsed pair: type comes from the public half (EC needs that). */
+private fun keyProvider(pair: java.security.KeyPair): KeyProvider = object : KeyProvider {
+    override fun getPrivate(): PrivateKey = pair.private
+    override fun getPublic(): PublicKey = pair.public
+    override fun getType(): KeyType = KeyType.fromKey(pair.public)
+}
+
+private fun certificateKeyProvider(privateKeys: java.security.KeyPair, certificate: String): KeyProvider {
     val fields = certificate.trim().split(Regex("\\s+"))
     // A malformed/truncated cert string (missing second field, invalid base64, garbage wire data)
     // must not escape as an unhandled IndexOutOfBounds/IllegalArgument past the auth handlers —

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -1,5 +1,8 @@
 package app.skerry.shared.ssh
 
+import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.shared.agent.SshAgentService
+import app.skerry.shared.agent.SshjAgentForwarder
 import java.io.IOException
 import java.security.MessageDigest
 import java.security.PrivateKey
@@ -18,9 +21,17 @@ import net.schmizz.sshj.userauth.keyprovider.KeyProvider
 import net.schmizz.sshj.userauth.UserAuthException
 import net.schmizz.sshj.userauth.password.PasswordUtils
 
-/** Desktop implementation of [SshTransport] over sshj (JVM). */
+/**
+ * Desktop implementation of [SshTransport] over sshj (JVM).
+ *
+ * [agent] is the built-in SSH agent; when a target asks for [SshTarget.forwardAgent] and an agent
+ * is present, the session's shell gets agent forwarding. Null (the default) means no agent is
+ * configured — probe/tunnel transports pass nothing, so "test connection" and background tunnels
+ * never expose keys.
+ */
 class SshjTransport(
     private val hostKeyVerifier: HostKeyVerifier,
+    private val agent: SshAgentService? = null,
 ) : SshTransport {
 
     override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection =
@@ -62,7 +73,20 @@ class SshjTransport(
         // `SSH-2.0-` too — substring(8) is the same either way; cosmetic only.)
         val serverVersion = runCatching { client.transport.serverVersion }
             .getOrNull()?.takeIf { it.isNotBlank() }?.let { "SSH-2.0-$it" }
-        return SshjConnection(client, negotiatedCipher.get(), serverVersion, upstream = opened.dropLast(1))
+        // Agent forwarding is registered only after authentication: an unauthenticated server has no
+        // business opening channels back to our keys. The origin is the address the user dialed, so
+        // the activity list can name who asked (in memory only — see SshAgentService).
+        val agentForwarder = agent?.takeIf { target.forwardAgent }?.let { service ->
+            SshjAgentForwarder(client.connection, service, SshAgentOrigin.Session(target.host))
+                .also { client.connection.attach(it) }
+        }
+        return SshjConnection(
+            client,
+            negotiatedCipher.get(),
+            serverVersion,
+            upstream = opened.dropLast(1),
+            agentForwarder = agentForwarder,
+        )
     }
 
     /**

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/vault/BouncyCastleSshKeyGenerator.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/vault/BouncyCastleSshKeyGenerator.kt
@@ -1,10 +1,9 @@
 package app.skerry.shared.vault
 
 import app.skerry.shared.ssh.ensureCryptoProvider
-import net.schmizz.sshj.SSHClient
+import app.skerry.shared.ssh.loadSshKeyPair
 import net.schmizz.sshj.common.Buffer
 import net.schmizz.sshj.common.KeyType
-import net.schmizz.sshj.userauth.password.PasswordUtils
 import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator
 import org.bouncycastle.crypto.generators.RSAKeyPairGenerator
 import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters
@@ -22,7 +21,7 @@ import java.util.Base64
  * JVM SSH key generator on BouncyCastle (lightweight crypto API), shared by desktop and Android.
  * Encodes the pair in the format sshj reads on connect ([SshjTransport]):
  *  - ED25519 → private key as `openssh-key-v1` (PEM `OPENSSH PRIVATE KEY`);
- *  - RSA-4096 → PKCS#1 (PEM `RSA PRIVATE KEY`) — both parsed by [SSHClient.loadKeys].
+ *  - RSA-4096 → PKCS#1 (PEM `RSA PRIVATE KEY`) — both parsed by [loadSshKeyPair].
  *
  * The public part (`authorized_keys` line + SHA256 fingerprint) is derived from the ssh-wire
  * encoding of the public key, matching OpenSSH's fingerprint. Keys are generated without a
@@ -64,9 +63,9 @@ class BouncyCastleSshKeyGenerator(
         // sshj loadKeys goes through the JCE "BC" provider, stripped down on Android, which breaks
         // PEM parsing. Register the full provider before parsing (idempotent).
         ensureCryptoProvider()
-        val pwdf = passphrase?.let { PasswordUtils.createOneOff(it.toCharArray()) }
-        // SSHClient is Closeable; loadKeys opens no connection but resources are freed via use.
-        val publicKey = SSHClient().use { it.loadKeys(privateKeyPem, null, pwdf).public }
+        // Shared loader, so a key the vault accepts is a key the transport and the agent can use —
+        // PKCS#8 included, which sshj alone cannot read ([loadSshKeyPair]).
+        val publicKey = loadSshKeyPair(privateKeyPem, passphrase).public
         val publicBlob = Buffer.PlainBuffer().putPublicKey(publicKey).compactData
         SshPublicKeyInfo(
             // The PEM comment isn't recoverable; line has no trailing comment.


### PR DESCRIPTION
Keys stay in the vault; a session — or another program on this machine — only ever gets a signature.

## What this adds

- **Agent core** (`shared/commonMain/agent`): the SSH agent protocol as a pure codec. Only requests that cannot change the key set are served — listing and signing; add/remove/lock/extension get `SSH_AGENT_FAILURE`, because the key set is the vault's, not the peer's. Every field length is bounded by what actually arrived.
- **Signing** (`jvmSharedMain`): vault keys parsed with the same stack the transport authenticates with (sshj + BouncyCastle). `rsa-sha2-256/512` flags honoured; a certificate credential is offered together with the plain key behind it, as `ssh-add` does.
- **Forwarding**: sshj 0.40 has no agent support at all, so both halves are hand-built — a `SessionChannel` subclass sends `auth-agent-req@openssh.com` before the PTY, and a `ForwardedChannelOpener` answers the server's `auth-agent@openssh.com` channels. Shell only: `exec` channels (metrics, service scan, the Mosh bootstrap) never carry keys.
- **`SSH_AUTH_SOCK`** (desktop): a unix socket under `$XDG_RUNTIME_DIR`, 0700 directory and 0600 socket. Android has nothing to serve, so the row is absent there rather than faked.
- **UI**: Settings → SSH agent (master switch, which keys are in the agent, the socket, recent activity) on both platforms, plus a per-host "Agent forwarding" toggle.

## Exposure gates

Three independent ones: the agent off, the vault locked, or the key not put in the agent. Forwarding is per host and off by default — while the session lives, that host can use every key the agent offers. Sessions deliberately survive a vault lock, so the lock drops parsed keys and closes the socket. `forwardAgent` is stripped when a host is shared to a team: trusting a host with your own keys is each member's decision.

## Review

Four independent reviews (security, Kotlin/concurrency, protocol conformance vs OpenSSH, UX/i18n/parity) ran before this PR; their findings are fixed in the second commit — see its message. Known follow-ups, deliberately not in scope: per-signature confirmation (`ssh-agent -c` style), an ECDSA signing test (the fixture, not the path — sshj reads a narrow set of EC PEM formats), and a badge in the Vault section showing which keys are in the agent.

## Verification

`./gradlew build` green with lint on desktop and Android. 39 new tests, including an end-to-end run against an embedded Apache MINA SSHD server: it opens the agent channel, gets the identity list and an Ed25519 signature that verifies under the offered key; sibling tests prove a host without the flag is refused the channel, and that disconnecting ends the agent. Screens checked visually via the offscreen renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)