### PR TITLE
Let a host use only the agent keys it needs

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_agent.xml
@@ -37,4 +37,5 @@
     <string name="agent_prompt_hint">Без ответа в течение двух минут запрос будет отклонён.</string>
     <string name="agent_prompt_allow">Разрешить один раз</string>
     <string name="agent_prompt_deny">Отклонить</string>
+    <string name="agent_keys_desc">Это то, что держит агент. Какие из них достанутся конкретному хосту, выбирается в самом хосте.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -102,4 +102,7 @@
     <string name="conn_serial_err_permission">Доступ к порту %1$s запрещён.</string>
     <string name="conn_serial_err_open">Не удалось открыть порт %1$s — возможно, он занят другой программой.</string>
     <string name="conn_serial_err_configure">Порт %1$s не принял выбранную скорость или формат кадра.</string>
+    <string name="conn_agent_keys_all">Все ключи агента</string>
+    <string name="conn_agent_keys_title">Ключи, доступные этому хосту</string>
+    <string name="conn_agent_keys_hint">Проброс отдаёт удалённой стороне живого агента. Оставьте только те ключи, которые нужны этому хосту.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_agent.xml
@@ -37,4 +37,5 @@
     <string name="agent_prompt_hint">两分钟内未回应将拒绝该请求。</string>
     <string name="agent_prompt_allow">允许一次</string>
     <string name="agent_prompt_deny">拒绝</string>
+    <string name="agent_keys_desc">这些是代理持有的密钥。转发时具体主机可用哪些，在主机设置中选择。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -102,4 +102,7 @@
     <string name="conn_serial_err_permission">访问端口 %1$s 被拒绝。</string>
     <string name="conn_serial_err_open">无法打开端口 %1$s — 它可能正被其他程序占用。</string>
     <string name="conn_serial_err_configure">端口 %1$s 拒绝了所选的速率或帧格式。</string>
+    <string name="conn_agent_keys_all">代理中的全部密钥</string>
+    <string name="conn_agent_keys_title">此主机可用的密钥</string>
+    <string name="conn_agent_keys_hint">转发相当于把可用的代理交给远端。请只保留该主机确实需要的密钥。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_agent.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_agent.xml
@@ -37,4 +37,5 @@
     <string name="agent_prompt_hint">No answer within two minutes refuses the request.</string>
     <string name="agent_prompt_allow">Allow once</string>
     <string name="agent_prompt_deny">Refuse</string>
+    <string name="agent_keys_desc">This is what the agent holds. Which of these a forwarded host may use is chosen in the host itself.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -102,4 +102,7 @@
     <string name="conn_serial_err_permission">Access to port %1$s was denied.</string>
     <string name="conn_serial_err_open">Port %1$s could not be opened — it may be in use by another program.</string>
     <string name="conn_serial_err_configure">Port %1$s rejected the selected speed or frame format.</string>
+    <string name="conn_agent_keys_all">All keys in the agent</string>
+    <string name="conn_agent_keys_title">Keys this host may use</string>
+    <string name="conn_agent_keys_hint">Forwarding hands the far side a live agent. Limit it to the keys this host actually needs.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -24,6 +24,7 @@ fun Host.toTarget(jump: SshJump? = null): SshTarget =
     SshTarget(
         host = address, port = port, username = username, connectionType = connectionType,
         jump = jump, keepAliveSeconds = keepAliveSeconds, forwardAgent = forwardAgent,
+        agentKeyIds = agentKeyIds,
     )
 
 /** `user@addr:port` string — the session's tab/title label. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
@@ -1,5 +1,8 @@
 package app.skerry.ui.host
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,10 +15,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.app.LocalSshAgent
 import app.skerry.ui.design.D
+import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.agent_no_keys
+import app.skerry.ui.generated.resources.conn_agent_keys_all
+import app.skerry.ui.generated.resources.conn_agent_keys_hint
+import app.skerry.ui.generated.resources.conn_agent_keys_title
 import app.skerry.ui.generated.resources.conn_field_forward_agent
 import app.skerry.ui.generated.resources.conn_forward_agent_desc
 import app.skerry.ui.generated.resources.conn_forward_agent_off
@@ -65,5 +72,61 @@ private fun ForwardAgentToggle(
             )
         }
         Toggle(form.forwardAgent, { form.forwardAgent = !form.forwardAgent })
+    }
+    // Which keys go with the forwarding is part of the same decision, so it belongs here rather
+    // than in Settings — where the user cannot see which host they are deciding for.
+    if (form.forwardAgent && agentOn) AgentKeyPicker(form, titleSize, descSize)
+}
+
+/**
+ * Per-host key set. Empty selection in the profile means "every key in the agent" — what a profile
+ * made before this setting existed says, and what OpenSSH does, since its agent has no per-host
+ * sets at all. Ticking any key narrows the host to exactly those.
+ */
+@Composable
+private fun AgentKeyPicker(
+    form: NewConnectionFormState,
+    titleSize: androidx.compose.ui.unit.TextUnit,
+    descSize: androidx.compose.ui.unit.TextUnit,
+) {
+    val keys = LocalSshAgent.current?.agentKeys.orEmpty().filter { it.agentEnabled }
+    if (keys.isEmpty()) return
+    val chosen = form.agentKeyIds
+    Column(Modifier.fillMaxWidth().padding(top = 10.dp)) {
+        Txt(stringResource(Res.string.conn_agent_keys_title), color = D.text, size = titleSize)
+        Txt(
+            stringResource(Res.string.conn_agent_keys_hint),
+            color = D.dim,
+            size = descSize,
+            modifier = Modifier.padding(top = 3.dp, bottom = 6.dp),
+        )
+        AgentKeyChoice(
+            label = stringResource(Res.string.conn_agent_keys_all),
+            checked = chosen.isEmpty(),
+            size = descSize,
+            onClick = { form.agentKeyIds = emptyList() },
+        )
+        keys.forEach { key ->
+            AgentKeyChoice(
+                label = key.label,
+                checked = key.id in chosen,
+                size = descSize,
+                onClick = {
+                    form.agentKeyIds = if (key.id in chosen) chosen - key.id else chosen + key.id
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun AgentKeyChoice(label: String, checked: Boolean, size: androidx.compose.ui.unit.TextUnit, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).clickable(onClick = onClick).padding(vertical = 5.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Sym(if (checked) "check_box" else "check_box_outline_blank", size = 16.sp, color = if (checked) D.cyan else D.faint)
+        Txt(label, color = if (checked) D.text else D.dim, size = size)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ForwardAgentField.kt
@@ -89,7 +89,10 @@ private fun AgentKeyPicker(
     titleSize: androidx.compose.ui.unit.TextUnit,
     descSize: androidx.compose.ui.unit.TextUnit,
 ) {
-    val keys = LocalSshAgent.current?.agentKeys.orEmpty().filter { it.agentEnabled }
+    val agent = LocalSshAgent.current
+    // Every key-shaped secret in the vault, not just the ones already in the agent: ticking one
+    // here puts it in the agent, so the user never has to go to Settings and back.
+    val keys = agent?.agentKeys.orEmpty()
     if (keys.isEmpty()) return
     val chosen = form.agentKeyIds
     Column(Modifier.fillMaxWidth().padding(top = 10.dp)) {
@@ -111,9 +114,7 @@ private fun AgentKeyPicker(
                 label = key.label,
                 checked = key.id in chosen,
                 size = descSize,
-                onClick = {
-                    form.agentKeyIds = if (key.id in chosen) chosen - key.id else chosen + key.id
-                },
+                onClick = { form.toggleAgentKey(key.id) { agent?.setKeyInAgent(it, true) } },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -28,6 +28,7 @@ data class HostDraft(
     val jumpHostId: String? = null,
     val keepAliveSeconds: Int = 30,
     val forwardAgent: Boolean = false,
+    val agentKeyIds: List<String> = emptyList(),
 )
 
 /**
@@ -79,6 +80,7 @@ class HostManagerController(
                 jumpHostId = draft.jumpHostId,
                 keepAliveSeconds = draft.keepAliveSeconds,
                 forwardAgent = draft.forwardAgent,
+                agentKeyIds = draft.agentKeyIds,
                 // Not a form field — toggled from the live VNC session; a form save must not reset it.
                 vncResizeToWindow = find(id)?.vncResizeToWindow ?: false,
             ),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -101,6 +101,21 @@ class NewConnectionFormState {
     /** Vault keys this host may use through the agent; empty = every key in it ([Host.agentKeyIds]). */
     var agentKeyIds: List<String> by mutableStateOf(emptyList())
 
+    /**
+     * Tick or untick one key for this host. Ticking also puts it in the agent ([addToAgent]) —
+     * otherwise the profile would name a key the agent does not hold, and forwarding would quietly
+     * offer nothing. Unticking leaves the agent alone: other hosts (and the local socket) may still
+     * be using that key.
+     */
+    fun toggleAgentKey(id: String, addToAgent: (String) -> Unit) {
+        agentKeyIds = if (id in agentKeyIds) {
+            agentKeyIds - id
+        } else {
+            addToAgent(id)
+            agentKeyIds + id
+        }
+    }
+
     // Auth: mode plus fields for each kind (kept side by side so switching doesn't lose input).
     var authMode: AuthMode by mutableStateOf(AuthMode.ASK)
     var existingCredentialId: String? by mutableStateOf(null)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -98,6 +98,9 @@ class NewConnectionFormState {
     /** Forward the built-in SSH agent into this host's shell; see [Host.forwardAgent]. */
     var forwardAgent: Boolean by mutableStateOf(false)
 
+    /** Vault keys this host may use through the agent; empty = every key in it ([Host.agentKeyIds]). */
+    var agentKeyIds: List<String> by mutableStateOf(emptyList())
+
     // Auth: mode plus fields for each kind (kept side by side so switching doesn't lose input).
     var authMode: AuthMode by mutableStateOf(AuthMode.ASK)
     var existingCredentialId: String? by mutableStateOf(null)
@@ -208,6 +211,7 @@ class NewConnectionFormState {
         jumpHostId = jumpHostId,
         keepAliveSeconds = keepAliveSeconds,
         forwardAgent = forwardAgent,
+        agentKeyIds = agentKeyIds,
     )
 
     companion object {
@@ -238,6 +242,7 @@ class NewConnectionFormState {
             jumpHostId = host.jumpHostId
             keepAliveSeconds = host.keepAliveSeconds
             forwardAgent = host.forwardAgent
+            agentKeyIds = host.agentKeyIds
             if (host.credentialId != null) {
                 authMode = AuthMode.EXISTING
                 existingCredentialId = host.credentialId

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAgentView.kt
@@ -35,6 +35,7 @@ import app.skerry.ui.generated.resources.agent_enable_desc
 import app.skerry.ui.generated.resources.agent_key_certificate
 import app.skerry.ui.generated.resources.agent_key_private
 import app.skerry.ui.generated.resources.agent_keys
+import app.skerry.ui.generated.resources.agent_keys_desc
 import app.skerry.ui.generated.resources.agent_keys_empty
 import app.skerry.ui.generated.resources.agent_subtitle_mobile
 import app.skerry.ui.generated.resources.agent_title
@@ -74,6 +75,7 @@ fun MobileAgentScreen(state: MobileDesignState) {
             )
 
             MobileSectionLabel(stringResource(Res.string.agent_keys))
+            Txt(stringResource(Res.string.agent_keys_desc), color = D.faint, size = 11.sp, modifier = Modifier.padding(bottom = 6.dp))
             val keys = controller?.agentKeys.orEmpty()
             if (keys.isEmpty()) {
                 Txt(stringResource(Res.string.agent_keys_empty), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 4.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AgentSection.kt
@@ -41,6 +41,7 @@ import app.skerry.ui.generated.resources.agent_enable_desc
 import app.skerry.ui.generated.resources.agent_key_certificate
 import app.skerry.ui.generated.resources.agent_key_private
 import app.skerry.ui.generated.resources.agent_keys
+import app.skerry.ui.generated.resources.agent_keys_desc
 import app.skerry.ui.generated.resources.agent_keys_empty
 import app.skerry.ui.generated.resources.agent_origin_session
 import app.skerry.ui.generated.resources.agent_origin_socket
@@ -86,6 +87,7 @@ internal fun AgentSection(controller: SshAgentController?) {
     )
 
     SectionLabel(stringResource(Res.string.agent_keys))
+    Txt(stringResource(Res.string.agent_keys_desc), color = D.faint, size = 11.sp, modifier = Modifier.padding(bottom = 6.dp))
     val keys = controller?.agentKeys.orEmpty()
     if (keys.isEmpty()) {
         Txt(stringResource(Res.string.agent_keys_empty), color = D.faint, size = 12.sp, modifier = Modifier.padding(vertical = 4.dp))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -397,4 +397,30 @@ class NewConnectionFormStateTest {
         assertEquals(listOf("deploy"), NewConnectionFormState.fromHost(host).agentKeyIds)
         assertEquals(emptyList(), NewConnectionFormState.fromHost(host.copy(agentKeyIds = emptyList())).agentKeyIds)
     }
+
+    @Test
+    fun `choosing a key for a host also puts it in the agent`() {
+        // Otherwise the profile would name a key the agent does not hold, and forwarding would
+        // quietly offer nothing — the user would have to guess that Settings needs a second visit.
+        val form = NewConnectionFormState()
+        val putInAgent = mutableListOf<String>()
+
+        form.toggleAgentKey("deploy") { putInAgent += it }
+
+        assertEquals(listOf("deploy"), form.agentKeyIds)
+        assertEquals(listOf("deploy"), putInAgent)
+    }
+
+    @Test
+    fun `unticking a key leaves it in the agent for everyone else`() {
+        // Other hosts and the local socket may still be using it; this host just stops naming it.
+        val form = NewConnectionFormState()
+        val putInAgent = mutableListOf<String>()
+        form.toggleAgentKey("deploy") { putInAgent += it }
+
+        form.toggleAgentKey("deploy") { putInAgent += it }
+
+        assertTrue(form.agentKeyIds.isEmpty())
+        assertEquals(listOf("deploy"), putInAgent, "unticking must not touch the agent")
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -374,4 +374,27 @@ class NewConnectionFormStateTest {
         val f = NewConnectionFormState.fromHost(host)
         assertEquals(listOf("prod", "db"), f.tags)
     }
+
+    @Test
+    fun `keeps the host's agent key set through save and reopen`() {
+        // The set is the host's, not the agent's: reopening the profile must show what was chosen,
+        // and an untouched profile must keep meaning "every key in the agent".
+        val form = NewConnectionFormState().apply {
+            name = "bastion"
+            address = "10.0.0.1"
+            username = "ops"
+            forwardAgent = true
+            agentKeyIds = listOf("deploy")
+        }
+
+        val draft = form.toDraft(credentialId = null)
+        assertEquals(listOf("deploy"), draft.agentKeyIds)
+
+        val host = Host(
+            id = "h1", label = draft.label, address = draft.address, username = draft.username,
+            forwardAgent = draft.forwardAgent, agentKeyIds = draft.agentKeyIds,
+        )
+        assertEquals(listOf("deploy"), NewConnectionFormState.fromHost(host).agentKeyIds)
+        assertEquals(emptyList(), NewConnectionFormState.fromHost(host.copy(agentKeyIds = emptyList())).agentKeyIds)
+    }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/agent/SshAgentService.kt
@@ -31,7 +31,11 @@ class SshAgentService(
      * Never throws for peer-controlled input: anything unparseable, oversized or unsupported is a
      * plain `SSH_AGENT_FAILURE`, which is all the protocol can say anyway.
      */
-    suspend fun handle(request: ByteArray, origin: SshAgentOrigin): ByteArray {
+    suspend fun handle(
+        request: ByteArray,
+        origin: SshAgentOrigin,
+        scope: SshAgentScope = SshAgentScope.All,
+    ): ByteArray {
         if (request.size > SshAgentCodec.MAX_MESSAGE_BYTES) return refuse(origin)
         val parsed = try {
             SshAgentCodec.parseRequest(request)
@@ -39,8 +43,8 @@ class SshAgentService(
             return refuse(origin)
         }
         return when (parsed) {
-            is SshAgentRequest.ListIdentities -> list(origin)
-            is SshAgentRequest.Sign -> sign(parsed, origin)
+            is SshAgentRequest.ListIdentities -> list(origin, scope)
+            is SshAgentRequest.Sign -> sign(parsed, origin, scope)
             // Answered, but NOT reported: OpenSSH sends `session-bind@openssh.com` before every
             // single login, so recording these would stamp a "Refused" on every successful
             // connection and drown the entries that mean something.
@@ -51,11 +55,11 @@ class SshAgentService(
     /** Record something the agent did outside a request (e.g. a server refusing forwarding). */
     fun note(origin: SshAgentOrigin, action: SshAgentAction) = report(origin, action, null)
 
-    private suspend fun list(origin: SshAgentOrigin): ByteArray {
+    private suspend fun list(origin: SshAgentOrigin, scope: SshAgentScope): ByteArray {
         // Same contract as sign(): the keyring reads the vault, and an unexpected failure there
         // must come back as a protocol refusal rather than killing the serving coroutine.
         val identities = try {
-            keys.identities()
+            keys.identities(scope)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             return refuse(origin)
@@ -64,12 +68,12 @@ class SshAgentService(
         return SshAgentCodec.identitiesAnswer(identities)
     }
 
-    private suspend fun sign(request: SshAgentRequest.Sign, origin: SshAgentOrigin): ByteArray {
+    private suspend fun sign(request: SshAgentRequest.Sign, origin: SshAgentOrigin, scope: SshAgentScope): ByteArray {
         // Resolve the key before asking anything: a blob we do not hold is refused outright, so a
         // remote cannot raise confirmation prompts by naming keys at random. The listing is served
         // from the keyring's cache, so this costs nothing per request.
         val identity = try {
-            keys.identities().firstOrNull { it.keyBlob.contentEquals(request.keyBlob) }
+            keys.identities(scope).firstOrNull { it.keyBlob.contentEquals(request.keyBlob) }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             null
@@ -92,7 +96,7 @@ class SshAgentService(
         // The keyring is the only place that decides whether a key may be used; an unknown blob
         // (or a key the user has not put in the agent) comes back null and is refused here.
         val signature = try {
-            keys.sign(request.keyBlob, request.data, request.flags)
+            keys.sign(request.keyBlob, request.data, request.flags, scope)
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             null
@@ -117,14 +121,38 @@ class SshAgentService(
  */
 interface SshAgentKeys {
     /** Keys currently offered — empty when the agent is off or the vault is locked. */
-    suspend fun identities(): List<SshAgentIdentity>
+    suspend fun identities(scope: SshAgentScope = SshAgentScope.All): List<SshAgentIdentity>
 
     /**
      * Sign [data] with the key identified by [keyBlob], honouring the `rsa-sha2-*` request
      * [flags]. `null` = we do not hold that key (or may not use it), which the caller turns into a
      * protocol failure.
      */
-    suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature?
+    suspend fun sign(
+        keyBlob: ByteArray,
+        data: ByteArray,
+        flags: Int,
+        scope: SshAgentScope = SshAgentScope.All,
+    ): SshAgentSignature?
+}
+
+/**
+ * Which of the agent's keys a caller may reach.
+ *
+ * A forwarded session gets the set its host profile allows; the local socket and anything that does
+ * not narrow it get [All]. Restricting per host matters because forwarding hands the far side a
+ * live agent: without this, every server the user forwards to could ask for a signature by ANY key
+ * in the agent, and see the names of all of them.
+ *
+ * [allowedKeyIds] is `null` for "no restriction" — an EMPTY set would be a host allowed nothing,
+ * which is a different (and legitimate) answer.
+ */
+data class SshAgentScope(val allowedKeyIds: Set<String>? = null) {
+    fun allows(keyId: String): Boolean = allowedKeyIds?.contains(keyId) ?: true
+
+    companion object {
+        val All = SshAgentScope()
+    }
 }
 
 /** A produced signature: the ssh-wire blob plus the comment of the key that made it (for the audit). */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
@@ -67,4 +67,10 @@ data class Host(
     val keepAliveSeconds: Int = 30,
     val vncResizeToWindow: Boolean = false,
     val forwardAgent: Boolean = false,
+    /**
+     * Which vault keys this host may use through the forwarded agent (credential ids). Empty means
+     * every key in the agent, which is what a profile made before this setting existed says — and
+     * what OpenSSH does, since its agent has no per-host sets at all.
+     */
+    val agentKeyIds: List<String> = emptyList(),
 )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
@@ -49,6 +49,11 @@ data class SshTarget(
     val jump: SshJump? = null,
     val keepAliveSeconds: Int = 0,
     val forwardAgent: Boolean = false,
+    /**
+     * Vault key ids this host may reach through the forwarded agent; empty = every key in the
+     * agent. See [app.skerry.shared.agent.SshAgentScope].
+     */
+    val agentKeyIds: List<String> = emptyList(),
 )
 
 /**

--- a/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/agent/SshAgentServiceTest.kt
@@ -16,10 +16,14 @@ private class FakeKeys(
 ) : SshAgentKeys {
     var signedData: ByteArray? = null
     var signedFlags: Int? = null
+    var listedScope: SshAgentScope? = null
 
-    override suspend fun identities(): List<SshAgentIdentity> = identities
+    override suspend fun identities(scope: SshAgentScope): List<SshAgentIdentity> {
+        listedScope = scope
+        return identities
+    }
 
-    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? {
+    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int, scope: SshAgentScope): SshAgentSignature? {
         signedData = data
         signedFlags = flags
         return signature.takeIf { identities.any { id -> id.keyBlob.contentEquals(keyBlob) } }
@@ -179,6 +183,28 @@ class SshAgentServiceTest {
         SshAgentService(keys, confirm = { asked = true; true }).handle(byteArrayOf(11), ORIGIN)
 
         assertFalse(asked)
+    }
+
+
+    @Test
+    fun `passes the host's key set down to the keyring`() = runTest {
+        // Which keys a host may use is the host's setting; the service only carries it through, so
+        // the keyring stays the single place that decides what a key request can reach.
+        val scope = SshAgentScope(setOf("deploy"))
+        val keys = FakeKeys()
+
+        SshAgentService(keys).handle(byteArrayOf(11), ORIGIN, scope)
+
+        assertEquals(scope, keys.listedScope)
+    }
+
+    @Test
+    fun `a request with no host restriction sees every key in the agent`() = runTest {
+        val keys = FakeKeys()
+
+        SshAgentService(keys).handle(byteArrayOf(11), ORIGIN)
+
+        assertEquals(SshAgentScope.All, keys.listedScope)
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshAgentStreamTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshAgentStreamTest.kt
@@ -28,8 +28,8 @@ class SshAgentStreamTest {
     fun tearDown() = scope.cancel()
 
     private val keys = object : SshAgentKeys {
-        override suspend fun identities() = identities
-        override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? = null
+        override suspend fun identities(scope: SshAgentScope) = identities
+        override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int, scope: SshAgentScope): SshAgentSignature? = null
     }
 
     /** Wire both directions to the serving loop and hand back the peer's ends. */

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/SshjAgentKeysTest.kt
@@ -187,6 +187,30 @@ class SshjAgentKeysTest {
     }
 
     @Test
+    fun `a host restricted to one key sees only that key`() = runTest {
+        // Forwarding hands the far side a live agent. A host limited to its deploy key must not be
+        // able to enumerate — let alone use — the rest of the keyring.
+        val deploy = generator.generate(SshKeyType.ED25519, comment = "")
+        val personal = generator.generate(SshKeyType.ED25519, comment = "")
+        val keys = SshjAgentKeys({
+            listOf(
+                material(deploy.privateKeyPem, id = "deploy", comment = "deploy key"),
+                material(personal.privateKeyPem, id = "personal", comment = "personal key"),
+            )
+        })
+        val scope = SshAgentScope(setOf("deploy"))
+
+        assertEquals(listOf("deploy key"), keys.identities(scope).map { it.comment })
+        assertNotNull(keys.sign(publicBlob(deploy.info.publicKeyOpenSsh), challenge, 0, scope))
+        assertNull(
+            keys.sign(publicBlob(personal.info.publicKeyOpenSsh), challenge, 0, scope),
+            "a key outside the host's set was used",
+        )
+        // The same keyring still serves everything to a caller that was not narrowed.
+        assertEquals(2, keys.identities().size)
+    }
+
+    @Test
     fun `refuses a key it does not hold`() = runTest {
         val mine = generator.generate(SshKeyType.ED25519, comment = "")
         val other = generator.generate(SshKeyType.ED25519, comment = "")

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/agent/UnixSocketSshAgentTest.kt
@@ -42,8 +42,8 @@ class UnixSocketSshAgentTest {
     private fun start(identities: List<SshAgentIdentity>): Path {
         dir = Files.createTempDirectory("skerry-agent-test")
         val keys = object : SshAgentKeys {
-            override suspend fun identities() = identities
-            override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? = null
+            override suspend fun identities(scope: SshAgentScope) = identities
+            override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int, scope: SshAgentScope): SshAgentSignature? = null
         }
         // Own dispatcher: the shared agent one is capped and other suites in this JVM park readers
         // on it, which would leave this listener's accept() waiting for a free thread.

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshAgentStream.kt
@@ -42,6 +42,7 @@ internal suspend fun serveSshAgent(
     output: OutputStream,
     service: SshAgentService,
     origin: SshAgentOrigin,
+    scope: SshAgentScope = SshAgentScope.All,
 ) {
     try {
         while (true) {
@@ -52,7 +53,7 @@ internal suspend fun serveSshAgent(
                 (header[3].toInt() and 0xFF)
             if (length <= 0 || length > SshAgentCodec.MAX_MESSAGE_BYTES) return
             val request = runInterruptible { input.readFullyOrNull(length) } ?: return
-            val response = service.handle(request, origin)
+            val response = service.handle(request, origin, scope)
             runInterruptible {
                 output.write(SshAgentCodec.frame(response))
                 output.flush()

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentForwarding.kt
@@ -64,6 +64,8 @@ internal class SshjAgentForwarder(
     private val conn: Connection,
     private val service: SshAgentService,
     private val origin: SshAgentOrigin,
+    // Which of the agent's keys this session may reach — the host profile's setting.
+    private val keyScope: SshAgentScope = SshAgentScope.All,
 ) : ForwardedChannelOpener {
 
     // Own scope, not a session scope passed in: this object is created inside the transport, below
@@ -110,7 +112,7 @@ internal class SshjAgentForwarder(
         channel.confirm()
         scope.launch {
             try {
-                serveSshAgent(channel.inputStream, channel.outputStream, service, origin)
+                serveSshAgent(channel.inputStream, channel.outputStream, service, origin, keyScope)
             } finally {
                 openChannels.decrementAndGet()
                 runCatching { channel.close() }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/agent/SshjAgentKeys.kt
@@ -37,11 +37,11 @@ class SshjAgentKeys(
     private var cache: Map<String, LoadedKey> = emptyMap()
     private var epoch = 0
 
-    override suspend fun identities(): List<SshAgentIdentity> =
-        load().flatMap { key -> key.keyBlobs.map { SshAgentIdentity(it, key.comment) } }
+    override suspend fun identities(scope: SshAgentScope): List<SshAgentIdentity> =
+        load(scope).flatMap { key -> key.keyBlobs.map { SshAgentIdentity(it, key.comment) } }
 
-    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int): SshAgentSignature? {
-        val key = load().firstOrNull { key -> key.keyBlobs.any { it.contentEquals(keyBlob) } } ?: return null
+    override suspend fun sign(keyBlob: ByteArray, data: ByteArray, flags: Int, scope: SshAgentScope): SshAgentSignature? {
+        val key = load(scope).firstOrNull { key -> key.keyBlobs.any { it.contentEquals(keyBlob) } } ?: return null
         return withContext(dispatcher) {
             val signature = signatureFor(key.type, flags) ?: return@withContext null
             runCatching {
@@ -65,8 +65,13 @@ class SshjAgentKeys(
         epoch++
     }
 
-    private suspend fun load(): List<LoadedKey> = withContext(dispatcher) {
-        val wanted = material()
+    /**
+     * Parsed keys this caller may use. The cache is keyed by credential id and shared by every
+     * caller; [scope] filters what comes OUT of it, so narrowing one host's set never costs another
+     * host a re-parse.
+     */
+    private suspend fun load(scope: SshAgentScope): List<LoadedKey> = withContext(dispatcher) {
+        val wanted = material().filter { scope.allows(it.id) }
         val (snapshot, startedAt) = synchronized(lock) { cache to epoch }
         val loaded = wanted.mapNotNull { entry ->
             snapshot[entry.id]?.takeIf { it.matches(entry) } ?: parse(entry)

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.ssh
 
 import app.skerry.shared.agent.SshAgentOrigin
+import app.skerry.shared.agent.SshAgentScope
 import app.skerry.shared.agent.SshAgentService
 import app.skerry.shared.agent.SshjAgentForwarder
 import java.io.IOException
@@ -76,7 +77,13 @@ class SshjTransport(
         // business opening channels back to our keys. The origin is the address the user dialed, so
         // the activity list can name who asked (in memory only — see SshAgentService).
         val agentForwarder = agent?.takeIf { target.forwardAgent }?.let { service ->
-            SshjAgentForwarder(client.connection, service, SshAgentOrigin.Session(target.host))
+            SshjAgentForwarder(
+                client.connection,
+                service,
+                SshAgentOrigin.Session(target.host),
+                // Empty means the profile never narrowed the set, which is "every key in the agent".
+                SshAgentScope(target.agentKeyIds.takeIf { it.isNotEmpty() }?.toSet()),
+            )
                 .also { client.connection.attach(it) }
         }
         return SshjConnection(


### PR DESCRIPTION
Builds on #46 (base branch is `feat/ssh-agent-forwarding`, so this merges after it).

## Why

Agent forwarding hands the far side a live agent. Until now that meant **every** key in it: any host with forwarding on could ask for a signature by any key, and could see the names of all of them. Per-signature confirmation helps, but it is off by default and does not hide the listing.

## What

- A host profile carries the vault keys it may reach (`Host.agentKeyIds`). Empty means every key — what existing profiles say, and what OpenSSH does, since its agent has no per-host sets.
- The set travels with `SshTarget` into the forwarder and down to the keyring (`SshAgentScope`), which filters what comes out of its shared cache, so narrowing one host costs no other host a re-parse.
- The picker sits under the forwarding switch in the host form, not in Settings — that is where the user can see which host they are deciding for.

## Notes

- Sync-safe: `Host` is JSON with `ignoreUnknownKeys`, so an older client keeps the profile intact and simply behaves as "all keys".
- The local agent socket is unaffected — it is not a host and keeps the full set.

## Tests

`:shared:desktopTest` + `:composeApp:desktopTest` green; Android compiles. New: keyring honours a restricted set (and still serves everything to an unrestricted caller), service carries the set through, profile round-trips the selection.

Not verified by hand yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)