### PR TITLE
Pause sync while the vault is locked (issue #30)

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -433,13 +433,14 @@ class MainActivity : FragmentActivity() {
         // A missing team key (dropped by an older client's delta sync) is only fixed by a full re-pull.
         teams.onKeyMissing = { sync.recoverFullPull() }
         sync.onTeamSignal = teams::onSignal
-        // Manager reload and sync session restore on unlock (restoreSession manages its own scope).
+        // Manager reload and sync resume on unlock (the coordinator manages its own scope): the live
+        // sync paused by the lock comes back, a cold start restores the keep-connected session instead.
         onVaultUnlocked = {
             hosts.reload()
             snippets.reload()
             tunnels.reload()
             knownHosts.refresh()
-            sync.restoreSession()
+            sync.resumeAfterUnlock()
         }
         // Clears data outside the vault on reset. The vault file is already wiped and locked, so
         // credentials aren't touched here (secrets reload when a new vault is created). Host

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -470,7 +470,7 @@ fun DesktopDesignApp(
                 // and restarts the idle timer; Never (idleMs == null) turns it off.
                 autoLockIdleMs = state.autoLock.idleMs,
                 // Runs on EVERY lock, including the two automatic ones that bypass the lock action.
-                onBeforeLock = { tearDownForLock(tunnels, sessions) },
+                onBeforeLock = { tearDownForLock(tunnels, sessions, sync) },
                 onReset = onVaultReset,
                 // onPairingComplete != null (sync is present) — the create screen offers "I have a code":
                 // the coordinator creates the vault under the chosen password itself and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -286,7 +286,7 @@ fun MobileDesignApp(
                     autoLockIdleMs = state.autoLock.idleMs,
                     // Runs on EVERY lock, including the two automatic ones that bypass the lock
                     // action — Android had no teardown at all before (only onVaultReset did).
-                    onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions) },
+                    onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions, deps.sync) },
                     onReset = onVaultReset,
                     // onPairingComplete != null (sync present) — the create screen offers "I have a code":
                     // the coordinator creates the vault under the chosen password and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SyncSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SyncSection.kt
@@ -207,10 +207,13 @@ private fun LinkedDevices(sync: app.skerry.ui.sync.SyncCoordinator, onLink: () -
     var reload by remember { mutableStateOf(0) }
     LaunchedEffect(sync, reload) {
         loading = true
-        // Revoked devices are hidden (server keeps the row with revoked=true); current device first
-        // (sortedByDescending is stable, so the rest keep their order).
-        devices = sync.listDevices().filter { !it.revoked }.sortedByDescending { it.current }
-        loading = false
+        try {
+            // Revoked devices are hidden (server keeps the row with revoked=true); current device first
+            // (sortedByDescending is stable, so the rest keep their order).
+            devices = sync.listDevices().filter { !it.revoked }.sortedByDescending { it.current }
+        } finally {
+            loading = false // never strand the spinner, whichever way the load ends
+        }
     }
 
     Txt(stringResource(Res.string.settings_linked_devices), color = D.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 18.dp, bottom = 10.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PairingPayload.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PairingPayload.kt
@@ -89,9 +89,11 @@ class PairingPayload(
         }
 
         /**
-         * `http(s)://` followed by a non-empty authority. The scheme alone isn't enough: a truncation
-         * can leave a bare `https://`, which would sail through to [SyncCoordinator.claimPairing] and
-         * surface as an unactionable network error instead of "doesn't look like a pairing code".
+         * `http(s)://` followed by an authority that actually names a host. The scheme alone isn't
+         * enough: a truncation can leave a bare `https://`, which would sail through to
+         * [SyncCoordinator.claimPairing] and surface as an unactionable network error instead of
+         * "doesn't look like a pairing code". Userinfo and port are stripped before the check, so
+         * `https://:8443` and `https://user@` fail it too; an IPv6 literal keeps its bracket and passes.
          */
         private fun hasHttpHost(url: String): Boolean {
             val authority = when {
@@ -99,7 +101,7 @@ class PairingPayload(
                 url.startsWith("http://") -> url.removePrefix("http://")
                 else -> return false
             }
-            return authority.substringBefore('/').isNotEmpty()
+            return authority.substringBefore('/').substringAfterLast('@').substringBefore(':').isNotBlank()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PairingPayload.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/PairingPayload.kt
@@ -83,9 +83,23 @@ class PairingPayload(
                 // would burn a one-time code on a truncated QR. A wrong key length or invalid URL
                 // scheme (a tampered QR) is a decode failure, not a burned code.
                 if (transferKey.size != TRANSFER_KEY_SIZE) return@runCatching null
-                if (!serverUrl.startsWith("http://") && !serverUrl.startsWith("https://")) return@runCatching null
+                if (!hasHttpHost(serverUrl)) return@runCatching null
                 PairingPayload(serverUrl, code, transferKey)
             }.getOrNull()
+        }
+
+        /**
+         * `http(s)://` followed by a non-empty authority. The scheme alone isn't enough: a truncation
+         * can leave a bare `https://`, which would sail through to [SyncCoordinator.claimPairing] and
+         * surface as an unactionable network error instead of "doesn't look like a pairing code".
+         */
+        private fun hasHttpHost(url: String): Boolean {
+            val authority = when {
+                url.startsWith("https://") -> url.removePrefix("https://")
+                url.startsWith("http://") -> url.removePrefix("http://")
+                else -> return false
+            }
+            return authority.substringBefore('/').isNotEmpty()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/ServerHealthMonitor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/ServerHealthMonitor.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.sync
 
 import app.skerry.shared.sync.SyncClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
@@ -56,7 +57,16 @@ internal class ServerHealthMonitor(
                         return@collectLatest
                     }
                     while (true) {
-                        val ok = runCatching { clientFor(url).ping() }.getOrDefault(false)
+                        // Not runCatching: it would swallow CancellationException and report a cancelled
+                        // ping (scope teardown, target change) as "server down" — on a StateFlow that
+                        // outlives the scope, so the indicator would stay stuck on it.
+                        val ok = try {
+                            clientFor(url).ping()
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            false
+                        }
                         _reachable.value =
                             if (ok) ServerReachable.REACHABLE else ServerReachable.UNREACHABLE
                         delay(pollMs)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -532,6 +532,13 @@ class SyncCoordinator(
         // startWatch/startLocalPush have cancelled and joined the subscriptions that were using it, and
         // under syncMutex so it can't be closed out from under an in-flight sync.
         if (superseded != null) syncMutex.withLock { runCatching { superseded.close() } }
+        // The vault may have locked while this operation held opMutex: [pauseForLock] then ran first,
+        // found no session to stop and left the flag for us. Undo the live half right here — otherwise
+        // the subscriptions just published would outlive the lock with nothing left to cancel them.
+        if (lockPaused) {
+            stopSubscriptions()
+            _status.value = SyncStatus.Configured(config.serverUrl, config.accountId)
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -291,6 +291,12 @@ class SyncCoordinator(
     @Volatile
     private var pushJob: Job? = null
 
+    // Set by [pauseForLock], cleared by [resumeAfterUnlock]: which of the two the coordinator should end
+    // up obeying when they queue up behind a long operation holding [opMutex], regardless of the order
+    // their coroutines get dispatched in.
+    @Volatile
+    private var lockPaused = false
+
     // Serializes all sync cycles: launched by activateSession, manual syncNow, WS live-pull (watchJob),
     // and auto-push of local edits (pushJob) — on Dispatchers.Default they'd otherwise run in parallel
     // and race on the cursor ([syncState]) and [_status] (two engines read cursor=N, both write
@@ -512,6 +518,7 @@ class SyncCoordinator(
         config: SyncConfig,
         resetCursor: Boolean,
     ) {
+        val superseded = client?.takeIf { it !== syncClient }
         client = syncClient
         session = newSession
         if (resetCursor) syncState.setCursor(config.accountId, 0)
@@ -520,6 +527,11 @@ class SyncCoordinator(
         runSync()
         startWatch()
         startLocalPush()
+        // Reconnecting over a live session (switching accounts, a confirmed password replace) leaves the
+        // previous Ktor client with its socket pool: only disconnect used to close one. Closed last, once
+        // startWatch/startLocalPush have cancelled and joined the subscriptions that were using it, and
+        // under syncMutex so it can't be closed out from under an in-flight sync.
+        if (superseded != null) syncMutex.withLock { runCatching { superseded.close() } }
     }
 
     /**
@@ -958,15 +970,9 @@ class SyncCoordinator(
         // tears down its result entirely (invariant: no live client after disconnect).
         scope.launch {
             opMutex.withLock {
-                // First cancel both live subscriptions and wait for them to stop: cancel() only sends a
-                // signal, and their collect might be mid-runSync() — without join its finishing runSync
-                // would write Online after the Disabled set below (status stuck on Online with client==null).
-                watchJob?.cancel()
-                pushJob?.cancel()
-                watchJob?.join()
-                pushJob?.join()
-                watchJob = null
-                pushJob = null
+                // First cancel both live subscriptions and wait for them to stop, so a finishing runSync
+                // can't write Online after the Disabled set below (status stuck on Online, client==null).
+                stopSubscriptions()
                 // close() and nulling client/session under syncMutex: manual syncNow() launches runSync()
                 // and isn't tracked/cancelled anywhere, so without the lock disconnect could close the Ktor
                 // client during its own in-flight request. withLock waits for the current runSync; the next
@@ -988,6 +994,71 @@ class SyncCoordinator(
                 _status.value = SyncStatus.Disabled
             }
         }
+    }
+
+    /**
+     * Suspend live sync for the duration of a vault lock (from `onBeforeLock`, so it covers the manual
+     * lock and both automatic ones): stop the WS live-pull and the local-push subscription. Everything
+     * needed to come back — the client, the session, the saved link — is kept, so [resumeAfterUnlock]
+     * doesn't ask for a password. This is NOT [disconnect]: that one erases the link.
+     *
+     * Without it both subscriptions keep running against a vault that can no longer decrypt: every WS
+     * signal drives a [runSync] that throws inside the vault, the status parks on Failed, and the WS
+     * retry loop keeps reconnecting on a 60s backoff for nothing. The health ping deliberately keeps
+     * running (see [ServerHealthMonitor]) — reachability doesn't depend on the vault.
+     */
+    fun pauseForLock() {
+        // Set synchronously, before the launch: [resumeAfterUnlock] clears it, so an unlock that beats
+        // this coroutine to opMutex (a long connect holding the lock across lock+unlock) cancels the
+        // pause instead of tearing down the session the resume just kept.
+        lockPaused = true
+        // No early return on a null session: a connect in flight holds opMutex and would publish its
+        // subscriptions after the lock, with nothing left to stop them. Queueing behind it stops them.
+        scope.launch {
+            opMutex.withLock {
+                if (!lockPaused || session == null) return@withLock
+                stopSubscriptions()
+                // The link is intact, only the live half is gone: Configured is exactly that state.
+                configStore.load()?.let { _status.value = SyncStatus.Configured(it.serverUrl, it.accountId) }
+            }
+        }
+    }
+
+    /**
+     * Bring sync back after the vault is unlocked. A session paused by [pauseForLock] is still in
+     * memory — resubscribe and pull what was missed; otherwise (cold start) fall back to
+     * [restoreSession]. Called from `onVaultUnlocked` on both platforms.
+     */
+    fun resumeAfterUnlock() {
+        lockPaused = false
+        if (session == null) {
+            restoreSession()
+            return
+        }
+        scope.launch {
+            opMutex.withLock {
+                // A disconnect or a fresh connect may have run while we waited for the mutex; a
+                // reconnect has already restarted the subscriptions itself.
+                if (lockPaused || session == null || watchJob != null) return@withLock
+                runSync()
+                startWatch()
+                startLocalPush()
+            }
+        }
+    }
+
+    /**
+     * Cancel and await both live subscriptions. cancel() only signals — a collect might be mid-[runSync],
+     * and without the join its finishing cycle would write a status after the caller set its own.
+     * Under [opMutex] like every other write to these fields.
+     */
+    private suspend fun stopSubscriptions() {
+        watchJob?.cancel()
+        pushJob?.cancel()
+        watchJob?.join()
+        pushJob?.join()
+        watchJob = null
+        pushJob = null
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -158,10 +159,25 @@ fun SyncOnboardingScreen(sync: SyncCoordinator, onDone: () -> Unit) {
                     Spacer(Modifier.height(8.dp))
                     SyncStatusNotice("sync", D.cyanBright, stringResource(Res.string.sync_connecting), stringResource(Res.string.sync_connecting_sub))
                 }
+                // Connecting hit an existing account under a different password (issue #28): the connect
+                // is paused until the user decides. Without this the form here just snapped back to idle
+                // — no notice, no buttons, nothing explaining why nothing happened (issue #30).
+                // Shown above the form rather than replacing it, so the typed server/account survive a
+                // decline; submit is disabled meanwhile, like during Busy.
+                val pendingReplace = status as? SyncStatus.NeedsPasswordReplaceConfirm
+                if (pendingReplace != null) {
+                    // No dismiss callback to hang the decline on (this is a full screen, not a modal), so
+                    // leaving onboarding declines: a pending replace left behind keeps the typed password
+                    // in memory and strands the status.
+                    DisposableEffect(Unit) { onDispose { sync.cancelPasswordReplace() } }
+                    Spacer(Modifier.height(8.dp))
+                    PasswordReplaceConfirm(sync, pendingReplace.accountId)
+                    Spacer(Modifier.height(16.dp))
+                }
                 SyncSetupBody(
                     sync,
                     errorMessage = (status as? SyncStatus.Failed)?.let { syncFailureText(it) },
-                    busy = busy,
+                    busy = busy || pendingReplace != null,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.vault
 
 import app.skerry.ui.session.SessionsController
+import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.tunnel.TunnelManager
 
 /**
@@ -15,12 +16,17 @@ import app.skerry.ui.tunnel.TunnelManager
  * the tabs are still there after unlocking — but their saved credentials are cleared, because an
  * auto-reconnect after a lock would re-authenticate with a stale secret against a locked vault.
  *
+ * Sync is paused, not disconnected ([SyncCoordinator.pauseForLock] — the link and the session stay, only
+ * the live subscriptions stop): behind a lock every sync cycle would throw inside the vault while the WS
+ * kept retrying. [SyncCoordinator.resumeAfterUnlock] is the other half, wired to `onVaultUnlocked`.
+ *
  * Shared by desktop and Android so the two can't drift apart on which of these gets forgotten.
  */
-fun tearDownForLock(tunnels: TunnelManager?, sessions: SessionsController?) {
+fun tearDownForLock(tunnels: TunnelManager?, sessions: SessionsController?, sync: SyncCoordinator?) {
     tunnels?.closeAll()
     sessions?.sessions?.forEach { session ->
         session.controller.clearReconnectCredentials()
         session.splitSession?.controller?.clearReconnectCredentials()
     }
+    sync?.pauseForLock()
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/PairingPayloadTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/PairingPayloadTest.kt
@@ -72,6 +72,24 @@ class PairingPayloadTest {
         assertNull(PairingPayload.decode(PairingPayload("https://", "code", ByteArray(32) { 1 }).encode()))
         assertNull(PairingPayload.decode(PairingPayload("http://", "code", ByteArray(32) { 1 }).encode()))
         assertNull(PairingPayload.decode(PairingPayload("https:///pairing", "code", ByteArray(32) { 1 }).encode()))
+        // Same hole, one character wider: an authority made only of separators or blanks names no host.
+        assertNull(PairingPayload.decode(PairingPayload("https:// ", "code", ByteArray(32) { 1 }).encode()))
+        assertNull(PairingPayload.decode(PairingPayload("https://:8443", "code", ByteArray(32) { 1 }).encode()))
+        assertNull(PairingPayload.decode(PairingPayload("https://user@", "code", ByteArray(32) { 1 }).encode()))
+    }
+
+    @Test
+    fun `decode accepts the address forms a real server can have`() {
+        listOf(
+            "https://sync.example.com",
+            "https://sync.example.com:8443/base",
+            "http://192.168.1.5:8080",
+            "https://[::1]:8443",
+            "https://user@sync.example.com",
+        ).forEach { url ->
+            val payload = PairingPayload(url, "code", ByteArray(32) { 1 })
+            assertEquals(payload, PairingPayload.decode(payload.encode()), url)
+        }
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/PairingPayloadTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/PairingPayloadTest.kt
@@ -66,6 +66,15 @@ class PairingPayloadTest {
     }
 
     @Test
+    fun `decode rejects a server url without a host`() {
+        // A truncated QR can leave a bare scheme. The prefix check alone accepts it, and the claim
+        // then dies on a network error the user can't act on instead of the honest "not a pairing code".
+        assertNull(PairingPayload.decode(PairingPayload("https://", "code", ByteArray(32) { 1 }).encode()))
+        assertNull(PairingPayload.decode(PairingPayload("http://", "code", ByteArray(32) { 1 }).encode()))
+        assertNull(PairingPayload.decode(PairingPayload("https:///pairing", "code", ByteArray(32) { 1 }).encode()))
+    }
+
+    @Test
     fun `toString does not leak the transfer key or code`() {
         val s = PairingPayload("https://h", "secret-code", ByteArray(32) { 1 }).toString()
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
@@ -22,8 +22,10 @@ import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
 import app.skerry.shared.vault.VaultRecord
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -73,8 +75,29 @@ class SyncCoordinatorHealthTest {
         withTimeout(3_000) { sut.serverReachable.first { it == ServerReachable.UNKNOWN } }
     }
 
+    @Test
+    fun shutdown_during_a_ping_does_not_report_the_server_down() = runBlocking {
+        val client = HangingPingClient()
+        val sut = SyncCoordinator({ client }, StubCrypto(), StubVault(), configStore = configuredStore())
+        withTimeout(3_000) { client.pinging.first { it } }
+        // Cancelling the scope cancels the in-flight ping. Cancellation is not "the server is down":
+        // swallowing it here would leave the indicator (a StateFlow outliving the scope) on UNREACHABLE.
+        sut.close()
+        delay(200)
+        assertEquals(ServerReachable.UNKNOWN, sut.serverReachable.value)
+    }
+
     private fun configuredStore() = InMemorySyncConfigStore().apply {
         save(SyncConfig(serverUrl = "https://sync.test", accountId = "maya", deviceId = "dev-1"))
+    }
+}
+
+/** Client whose [ping] never answers, so it is still in flight when the scope is cancelled. */
+private class HangingPingClient : SyncClient by FakePingClient(reachable = true) {
+    val pinging = MutableStateFlow(false)
+    override suspend fun ping(): Boolean {
+        pinging.value = true
+        awaitCancellation()
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -312,8 +312,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val onVaultUnlocked: () -> Unit = {
         // Vault opened, so reload managers (including AI BYOK settings) from decrypted records.
         reloadManagers()
-        // keep-connected: vault opened means a dataKey exists, so the sync session can be silently restored.
-        sync.restoreSession()
+        // Resume the live sync paused by the lock, or — on a cold start with keep-connected — silently
+        // restore the session (the open vault means a dataKey to unseal the refresh token with).
+        sync.resumeAfterUnlock()
     }
     // External cleanup on an irreversible vault reset (forgotten password / corrupted file). The
     // vault file is already erased by the controller (Vault.reset) and now locked, so

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -47,10 +48,14 @@ class SyncCoordinatorLockPauseTest {
     private val account = "maya"
     private val password = "vault-A"
 
-    /** Registers any account and reports how many live-pull subscriptions are collecting right now. */
-    private class WatchCountingClient : SyncClient {
+    /**
+     * Registers any account and reports how many live-pull subscriptions are collecting right now.
+     * [registerGate], when given, holds `register` open so a connect can be caught mid-flight.
+     */
+    private class WatchCountingClient(private val registerGate: CompletableDeferred<Unit>? = null) : SyncClient {
         val watchers = AtomicInteger(0)
         val peakWatchers = AtomicInteger(0)
+        val registering = CompletableDeferred<Unit>()
 
         override fun changes(session: SyncSession): Flow<SyncSignal> = flow {
             watchers.incrementAndGet()
@@ -62,8 +67,11 @@ class SyncCoordinatorLockPauseTest {
             }
         }
 
-        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
+            registering.complete(Unit)
+            registerGate?.await()
+            return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+        }
 
         override suspend fun ping(): Boolean = true
         override suspend fun close() {}
@@ -117,6 +125,54 @@ class SyncCoordinatorLockPauseTest {
             withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
             withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
             assertEquals(1, client.peakWatchers.get(), "resume must not stack a second live-pull subscription")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `locking during a connect stops the subscriptions that connect publishes`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = WatchCountingClient(registerGate = gate)
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { client.registering.await() } // the connect now holds opMutex
+
+            // The vault locks mid-connect. The pause queues behind the connect on opMutex and tears down
+            // what it published; without that, live sync survives the lock unnoticed.
+            vault.lock()
+            sut.pauseForLock()
+            gate.complete(Unit)
+
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Configured } }
+            withTimeout(5_000) { while (client.watchers.get() != 0) delay(10) }
+            delay(200) // and it stays down: nothing restarts them behind the lock screen
+            assertEquals(0, client.watchers.get())
+            assertTrue(sut.status.value is SyncStatus.Configured)
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `a connect that starts after the pause does not publish a live session`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = WatchCountingClient()
+        val sut = coordinator(vault, client)
+        try {
+            // The other ordering of the same race: the pause wins opMutex first and finds no session to
+            // stop, so the connect behind it has to undo its own live half — nothing else is left to.
+            sut.pauseForLock()
+            delay(100) // let the pause run to completion, so it cannot tear the connect down for us
+            sut.connect(serverUrl, account, password.toCharArray())
+
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Configured } }
+            delay(200)
+            assertEquals(0, client.watchers.get(), "no live-pull may survive behind a locked vault")
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
@@ -1,0 +1,146 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #30 — sync must stop while the vault is locked and come back once it is unlocked.
+ *
+ * Locking leaves the WS live-pull and the local-push subscription running against a vault that can no
+ * longer decrypt anything: every signal retries a sync that is guaranteed to throw, the status parks on
+ * Failed, and nothing repairs it after unlocking (the session survived, so there is nothing to
+ * "restore"). [SyncCoordinator.pauseForLock] / [SyncCoordinator.resumeAfterUnlock] are the two halves.
+ *
+ * Real vault and crypto (the connect path derives keys with Argon2id); only the network is faked.
+ */
+class SyncCoordinatorLockPauseTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    /** Registers any account and reports how many live-pull subscriptions are collecting right now. */
+    private class WatchCountingClient : SyncClient {
+        val watchers = AtomicInteger(0)
+        val peakWatchers = AtomicInteger(0)
+
+        override fun changes(session: SyncSession): Flow<SyncSignal> = flow {
+            watchers.incrementAndGet()
+            peakWatchers.updateAndGet { maxOf(it, watchers.get()) }
+            try {
+                awaitCancellation()
+            } finally {
+                watchers.decrementAndGet()
+            }
+        }
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+
+        override suspend fun ping(): Boolean = true
+        override suspend fun close() {}
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
+        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
+        override suspend fun refresh(session: SyncSession): SyncSession = nope()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()
+        private fun nope(): Nothing = throw NotImplementedError("the lock/unlock flow should not call this")
+    }
+
+    private fun localVault(): Vault {
+        val file = Files.createTempFile("skerry-issue30", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "dev-local", fileSystem = FileSystem.SYSTEM, now = { "2026-07-21T00:00:00Z" })
+            .also { it.create(password.toCharArray()) }
+    }
+
+    private fun coordinator(vault: Vault, client: SyncClient): SyncCoordinator = SyncCoordinator(
+        clientFactory = { client },
+        crypto = crypto,
+        vault = vault,
+        engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
+    )
+
+    @Test
+    fun `locking stops live sync and unlocking brings it back`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = WatchCountingClient()
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
+
+            // Lock: no live subscription may survive it — otherwise the WS keeps retrying against a
+            // vault that can't decrypt, and the status parks on Failed.
+            vault.lock()
+            sut.pauseForLock()
+            withTimeout(5_000) { sut.status.first { it is SyncStatus.Configured } }
+            withTimeout(5_000) { while (client.watchers.get() != 0) delay(10) }
+
+            // Unlock: sync resumes on its own, no password retyped and no manual "Sync".
+            assertTrue(vault.unlock(password.toCharArray()) is UnlockResult.Success)
+            sut.resumeAfterUnlock()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
+            assertEquals(1, client.peakWatchers.get(), "resume must not stack a second live-pull subscription")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `unlocking without a preceding pause leaves the live session alone`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = WatchCountingClient()
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
+
+            // A stray unlock callback (biometric re-prompt, gate recomposition) must not tear down or
+            // duplicate a healthy session.
+            sut.resumeAfterUnlock()
+            delay(300)
+            assertTrue(sut.status.value is SyncStatus.Online)
+            assertEquals(1, client.peakWatchers.get(), "no second subscription")
+        } finally {
+            sut.close()
+        }
+    }
+}


### PR DESCRIPTION
Closes #30 (the confirmed findings — see the comment there for the two that did not hold up).

## The main one: sync doesn't survive a lock

Locking closed tunnels and cleared reconnect credentials but never touched `SyncCoordinator`. The WS live-pull kept retrying on its 60s backoff, and every signal drove a sync cycle that throws inside a locked vault, parking the status on `Failed`. Unlocking didn't repair it either — `restoreSession()` bails when a session is already present, so there was nothing to "restore" and sync stayed dead until the next server signal or a manual "Sync".

`pauseForLock()` stops both live subscriptions and keeps the client, the session and the saved link, so `resumeAfterUnlock()` brings sync back without asking for a password. `disconnect()` is deliberately **not** reused here: it erases the link, which would destroy keep-connected on the first lock. The health ping keeps running — reachability doesn't depend on the vault. Both are wired into the shared `tearDownForLock` / `onVaultUnlocked`, so they cover the manual lock and both automatic ones on desktop and Android.

A lock landing while a connect holds `opMutex` has two orderings; `activateSession` honours the pause flag itself so neither leaves a live session behind a lock screen. Both are tested.

## The rest

- **`ServerHealthMonitor` swallowed `CancellationException`** — a ping cancelled by scope teardown was reported as "server down" on a `StateFlow` that outlives the scope.
- **Sync onboarding ignored `NeedsPasswordReplaceConfirm`** — hitting the A/B password split during initial setup snapped the form back to idle with no notice and no way to proceed. Now shown above the form so the typed fields survive a decline; leaving onboarding declines the pending replace, as it already did on the mobile sync screen.
- **`PairingPayload` accepted a bare scheme as a server URL**, turning a truncated QR into an unactionable network error instead of "doesn't look like a pairing code".
- **`activateSession` leaked the superseded Ktor client** when reconnecting over a live session; only `disconnect` used to close one.
- The linked-devices spinner now clears in a `finally`.

## Not changed

Two findings in the report didn't survive checking against the code: the stuck device-list spinner (the `remember` slot dies with the composable, so returning re-runs the effect) and the `restoreSession`/`connect` race (the recheck under `opMutex` is already there).

## Verification

`./gradlew :composeApp:desktopTest :shared:desktopTest` green (1131 tests + the new ones), Android compiles. Each new test was confirmed to fail with its fix reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
