### PR TITLE
Built-in file viewer/editor in the SFTP panel (F3/F4)

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.android.kt
@@ -1,6 +1,6 @@
 package app.skerry.ui.files
 
-import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.LocalFileBrowser
 import app.skerry.ui.sftp.SafBridge
 import kotlinx.coroutines.Dispatchers
@@ -16,7 +16,7 @@ import okio.FileSystem
  * Context comes from [SafBridge] (set by the Activity in `onCreate`); falls back to the external
  * storage root before that. `getExternalFilesDir` creates the directory on first access.
  */
-actual fun platformLocalBrowser(): FileBrowser {
+actual fun platformLocalBrowser(): FileContentBrowser {
     val ctx = SafBridge.context()
     val home = ctx?.getExternalFilesDir(null)?.absolutePath
         ?: ctx?.filesDir?.absolutePath

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
@@ -11,6 +11,8 @@
     <string name="ftail_fkey_delete">Удалить</string>
     <string name="ftail_fkey_refresh">Обновить</string>
     <string name="ftail_fkey_quit">Выход</string>
+    <string name="ftail_fkey_save">Сохранить</string>
+    <string name="ftail_fkey_search">Поиск</string>
 
     <!-- Резервные сообщения об ошибках контроллеров/эффектов -->
     <string name="ftail_open_failed">Не удалось открыть SFTP</string>
@@ -24,6 +26,13 @@
     <string name="ftail_err_illegal_name">Недопустимое имя в списке файлов</string>
     <string name="ftail_err_open_source">Не удалось открыть выбранный файл</string>
     <string name="ftail_err_open_target">Не удалось открыть файл для записи</string>
+    <string name="ftail_err_too_large">Файл слишком большой, чтобы открыть его</string>
+
+    <!-- Ошибки просмотрщика/редактора (F3/F4) -->
+    <string name="ftail_edit_err_read">Не удалось прочитать файл</string>
+    <string name="ftail_edit_err_too_large">Файл слишком большой для редактора</string>
+    <string name="ftail_edit_err_binary">Двоичный файл — его нельзя править как текст</string>
+    <string name="ftail_edit_err_write">Не удалось сохранить файл</string>
 
     <!-- Локальная файловая система: подпись панели и «хлебных крошек» -->
     <string name="ftail_local_label">Это устройство</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -179,6 +179,11 @@
     <string name="settings_kb_paste">Вставить</string>
     <string name="settings_kb_global">ОБЩИЕ</string>
     <string name="settings_kb_terminal_group">ТЕРМИНАЛ И АВТОДОПОЛНЕНИЕ</string>
+    <string name="settings_kb_files_group">ФАЙЛОВАЯ ПАНЕЛЬ</string>
+    <string name="settings_kb_editor_group">ПРОСМОТР И ПРАВКА ФАЙЛА</string>
+    <string name="settings_kb_files_switch_pane">Переключить панель</string>
+    <string name="settings_kb_files_hidden">Показывать скрытые файлы</string>
+    <string name="settings_kb_files_save">Сохранить редактируемый файл</string>
     <string name="settings_badge_soon">СКОРО</string>
 
     <!-- Раздел About -->

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -61,4 +61,18 @@
     <string name="sftp_overwrite_one">%1$s уже есть в каталоге-приёмнике.</string>
     <string name="sftp_overwrite_many">В каталоге-приёмнике уже есть объектов: %1$d — они будут перезаписаны.</string>
     <string name="sftp_overwrite">Перезаписать</string>
+
+    <!-- Встроенный просмотрщик/редактор (F3/F4) -->
+    <string name="sftp_edit_title">Правка</string>
+    <string name="sftp_edit_title_view">Просмотр</string>
+    <string name="sftp_edit_readonly">только чтение</string>
+    <string name="sftp_edit_modified">изменён</string>
+    <string name="sftp_edit_saving">Сохранение…</string>
+    <string name="sftp_edit_find">Найти:</string>
+    <string name="sftp_edit_not_found">не найдено</string>
+    <string name="sftp_edit_discard_q">Отменить изменения?</string>
+    <string name="sftp_edit_discard_body">В «%1$s» есть несохранённые изменения. Если закрыть сейчас, они пропадут.</string>
+    <string name="sftp_edit_discard">Отменить</string>
+    <string name="sftp_edit_conflict_q">Файл изменился в источнике?</string>
+    <string name="sftp_edit_conflict_body">«%1$s» изменился после того, как вы его открыли. Сохранение перезапишет эти изменения вашей версией.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
@@ -11,6 +11,8 @@
     <string name="ftail_fkey_delete">删除</string>
     <string name="ftail_fkey_refresh">刷新</string>
     <string name="ftail_fkey_quit">退出</string>
+    <string name="ftail_fkey_save">保存</string>
+    <string name="ftail_fkey_search">搜索</string>
 
     <!-- 控制器 / 副作用错误回退 -->
     <string name="ftail_open_failed">打开 SFTP 失败</string>
@@ -24,6 +26,13 @@
     <string name="ftail_err_illegal_name">列表中的文件名不安全</string>
     <string name="ftail_err_open_source">无法打开所选文件</string>
     <string name="ftail_err_open_target">无法打开保存目标</string>
+    <string name="ftail_err_too_large">文件太大，无法打开</string>
+
+    <!-- 查看器/编辑器（F3/F4）失败原因 -->
+    <string name="ftail_edit_err_read">读取文件失败</string>
+    <string name="ftail_edit_err_too_large">文件太大，编辑器无法打开</string>
+    <string name="ftail_edit_err_binary">二进制文件 — 无法按文本编辑</string>
+    <string name="ftail_edit_err_write">保存文件失败</string>
 
     <!-- 本地文件系统：面板标题与路径导航中的名称 -->
     <string name="ftail_local_label">本设备</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -179,6 +179,11 @@
     <string name="settings_kb_paste">粘贴</string>
     <string name="settings_kb_global">全局</string>
     <string name="settings_kb_terminal_group">终端和自动补全</string>
+    <string name="settings_kb_files_group">文件面板</string>
+    <string name="settings_kb_editor_group">文件查看与编辑</string>
+    <string name="settings_kb_files_switch_pane">切换面板</string>
+    <string name="settings_kb_files_hidden">显示隐藏文件</string>
+    <string name="settings_kb_files_save">保存正在编辑的文件</string>
     <string name="settings_badge_soon">即将推出</string>
 
     <!-- 关于部分 -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -61,4 +61,18 @@
     <string name="sftp_overwrite_one">%1$s 在目标位置已存在。</string>
     <string name="sftp_overwrite_many">%1$d 个项目在目标位置已存在，将被覆盖。</string>
     <string name="sftp_overwrite">覆盖</string>
+
+    <!-- 内置查看器/编辑器（F3/F4） -->
+    <string name="sftp_edit_title">编辑</string>
+    <string name="sftp_edit_title_view">查看</string>
+    <string name="sftp_edit_readonly">只读</string>
+    <string name="sftp_edit_modified">已修改</string>
+    <string name="sftp_edit_saving">正在保存…</string>
+    <string name="sftp_edit_find">查找：</string>
+    <string name="sftp_edit_not_found">未找到</string>
+    <string name="sftp_edit_discard_q">放弃更改？</string>
+    <string name="sftp_edit_discard_body">「%1$s」有未保存的更改，现在关闭将会丢失。</string>
+    <string name="sftp_edit_discard">放弃</string>
+    <string name="sftp_edit_conflict_q">文件在源端已被修改？</string>
+    <string name="sftp_edit_conflict_body">「%1$s」在你打开之后发生了变化。保存将用你的版本覆盖这些更改。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
@@ -11,6 +11,8 @@
     <string name="ftail_fkey_delete">Delete</string>
     <string name="ftail_fkey_refresh">Refresh</string>
     <string name="ftail_fkey_quit">Quit</string>
+    <string name="ftail_fkey_save">Save</string>
+    <string name="ftail_fkey_search">Search</string>
 
     <!-- Controller / effect error fallbacks -->
     <string name="ftail_open_failed">Failed to open SFTP</string>
@@ -24,6 +26,13 @@
     <string name="ftail_err_illegal_name">Unsafe name in the listing</string>
     <string name="ftail_err_open_source">Failed to open the selected file</string>
     <string name="ftail_err_open_target">Failed to open the save target</string>
+    <string name="ftail_err_too_large">File is too large to open</string>
+
+    <!-- Viewer/editor (F3/F4) failures -->
+    <string name="ftail_edit_err_read">Failed to read the file</string>
+    <string name="ftail_edit_err_too_large">File is too large for the editor</string>
+    <string name="ftail_edit_err_binary">Binary file — cannot be edited as text</string>
+    <string name="ftail_edit_err_write">Failed to save the file</string>
 
     <!-- Local filesystem source, shown in the pane header and breadcrumbs -->
     <string name="ftail_local_label">This device</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -179,6 +179,11 @@
     <string name="settings_kb_paste">Paste</string>
     <string name="settings_kb_global">GLOBAL</string>
     <string name="settings_kb_terminal_group">TERMINAL &amp; AUTOCOMPLETE</string>
+    <string name="settings_kb_files_group">FILE PANEL</string>
+    <string name="settings_kb_editor_group">FILE VIEWER / EDITOR</string>
+    <string name="settings_kb_files_switch_pane">Switch pane</string>
+    <string name="settings_kb_files_hidden">Show hidden files</string>
+    <string name="settings_kb_files_save">Save the file being edited</string>
     <string name="settings_badge_soon">SOON</string>
 
     <!-- About section -->

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -61,4 +61,18 @@
     <string name="sftp_overwrite_one">%1$s already exists in the destination.</string>
     <string name="sftp_overwrite_many">%1$d items already exist in the destination and will be overwritten.</string>
     <string name="sftp_overwrite">Overwrite</string>
+
+    <!-- Built-in viewer/editor (F3/F4) -->
+    <string name="sftp_edit_title">Edit</string>
+    <string name="sftp_edit_title_view">View</string>
+    <string name="sftp_edit_readonly">read-only</string>
+    <string name="sftp_edit_modified">modified</string>
+    <string name="sftp_edit_saving">Saving…</string>
+    <string name="sftp_edit_find">Search:</string>
+    <string name="sftp_edit_not_found">not found</string>
+    <string name="sftp_edit_discard_q">Discard changes?</string>
+    <string name="sftp_edit_discard_body">«%1$s» has unsaved changes. Closing now loses them.</string>
+    <string name="sftp_edit_discard">Discard</string>
+    <string name="sftp_edit_conflict_q">File changed on the source?</string>
+    <string name="sftp_edit_conflict_body">«%1$s» changed after you opened it. Saving overwrites those changes with your version.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.serial.SerialProblem
@@ -351,7 +351,7 @@ class ConnectionController(
      * second one), and the non-volatile cache fields are published safely under the lock.
      * @throws IllegalStateException the session isn't connected (no live connection)
      */
-    suspend fun openTransferCoordinator(localBrowser: FileBrowser, hostLabel: String): TransferCoordinator =
+    suspend fun openTransferCoordinator(localBrowser: FileContentBrowser, hostLabel: String): TransferCoordinator =
         sftpMutex.withLock {
             transferCoordinator ?: run {
                 val client = (connection ?: error("No active connection for SFTP")).openSftp()
@@ -547,6 +547,7 @@ class ConnectionController(
         portForwards = null
         val sftp = sftpClient
         sftpClient = null
+        val coordinator = transferCoordinator
         transferCoordinator = null
         metrics?.stop()
         metrics = null
@@ -560,7 +561,7 @@ class ConnectionController(
         shellChannel = null
         cipher = null
         serverVersion = null
-        if (sftp != null) closeSftpQuietly(sftp)
+        if (sftp != null) closeSftpQuietly(sftp, coordinator)
         if (conn != null) closeConnectionQuietly(conn)
     }
 
@@ -569,8 +570,17 @@ class ConnectionController(
         scope.launch(NonCancellable) { runCatching { conn.disconnect() } }
     }
 
-    /** Closes the SFTP channel in the background under [NonCancellable] (the SSH connection closes separately after). */
-    private fun closeSftpQuietly(client: SftpClient) {
-        scope.launch(NonCancellable) { runCatching { client.close() } }
+    /**
+     * Closes the SFTP channel in the background under [NonCancellable] (the SSH connection closes
+     * separately after). A file being saved in the built-in editor is written on the same scope and
+     * outlives the editor UI, so the channel is closed only once that write is done
+     * ([TransferCoordinator.awaitEditorWrites]) — otherwise closing the tab right after Save would
+     * leave the remote file truncated (the write is an in-place truncate).
+     */
+    private fun closeSftpQuietly(client: SftpClient, coordinator: TransferCoordinator?) {
+        scope.launch(NonCancellable) {
+            runCatching { coordinator?.awaitEditorWrites() }
+            runCatching { client.close() }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FKeyBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FKeyBar.kt
@@ -1,0 +1,83 @@
+package app.skerry.ui.files
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.D
+import app.skerry.ui.design.Txt
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * One cell of the mc-style bottom key bar: function key [n] and what it does. [enabled] greys the
+ * cell out when the action isn't available in the current context (nothing to save, no session yet);
+ * [done] marks a label that is only a placeholder — such a cell carries a visible "*".
+ */
+internal data class FKeyDef(
+    val n: Int,
+    val label: StringResource,
+    val done: Boolean = true,
+    val enabled: Boolean = true,
+)
+
+/**
+ * Bottom hotkey bar (mc/Total Commander): a row of "F3 View … F10 Quit" cells spanning the width.
+ * Shared by the file panel and the built-in editor, which swap their own [keys] in — the bar is the
+ * screen's key legend, so it has to follow whatever currently owns the keyboard. A cell click and
+ * the matching key press both go through [onKey].
+ */
+@Composable
+internal fun FKeyBar(keys: List<FKeyDef>, onKey: (Int) -> Unit, mono: FontFamily) {
+    Row(
+        Modifier.fillMaxWidth().background(D.surface2).padding(horizontal = 6.dp, vertical = 5.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        keys.forEach { def ->
+            FKeyCell(def, mono, onClick = { onKey(def.n) }, modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+@Composable
+private fun FKeyCell(def: FKeyDef, mono: FontFamily, onClick: () -> Unit, modifier: Modifier) {
+    Row(
+        modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(D.panel)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                enabled = def.enabled,
+                onClick = onClick,
+            )
+            .padding(horizontal = 8.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        Txt("F${def.n}", color = if (def.enabled) D.cyanBright else D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, font = mono)
+        Txt(
+            stringResource(def.label),
+            color = if (def.enabled) D.text else D.faint,
+            size = 11.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        // "*" marks a non-working stub.
+        if (!def.done) Txt("*", color = D.sunset, size = 11.sp, weight = FontWeight.SemiBold)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditController.kt
@@ -1,0 +1,319 @@
+package app.skerry.ui.files
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileContentBrowser
+import app.skerry.shared.files.FileItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Size cap for the built-in viewer/editor (F3/F4). The whole file is held in memory twice (bytes +
+ * decoded buffer) and rendered by a single text field, so this is deliberately far below the SFTP
+ * client's transport-level read cap: config files, scripts and logs fit, disk images don't.
+ */
+const val MAX_EDIT_BYTES: Long = 1L * 1024 * 1024
+
+/** Typed, user-facing reason the viewer/editor couldn't open or save a file; localized by the UI. */
+enum class FileEditFailure {
+    /** The file couldn't be read (missing, no permission, transport failure). */
+    Read,
+
+    /** The file is over [MAX_EDIT_BYTES]. */
+    TooLarge,
+
+    /** The content isn't editable text: NUL bytes or not valid UTF-8. */
+    Binary,
+
+    /** The buffer couldn't be written back. */
+    Write,
+}
+
+/** Viewer/editor state for one file. */
+sealed interface FileEditState {
+    /** The file is being read. */
+    data object Loading : FileEditState
+
+    /** Content loaded; [text] is the current buffer with `\n` line endings. */
+    data class Ready(val text: String) : FileEditState
+
+    /** The file couldn't be opened; [failure] is the typed reason, localized by the UI. */
+    data class Failed(val failure: FileEditFailure) : FileEditState
+}
+
+/**
+ * Controller behind F3 View / F4 Edit for a single file of one pane's source, local or remote alike
+ * ([FileContentBrowser]). Reads the file whole (capped at [maxBytes]), decodes it as strict UTF-8,
+ * hands the UI an editable buffer and writes it back on [save].
+ *
+ * Refusals are explicit rather than best-effort: content with NUL bytes or invalid UTF-8 is reported
+ * as [FileEditFailure.Binary] instead of being decoded leniently — lenient decoding would replace
+ * the offending bytes with U+FFFD and silently corrupt the file the moment it's saved. A UTF-8 BOM
+ * is deliberately left in the buffer as the character it is, so saving writes the file back with the
+ * BOM it came with.
+ *
+ * Overwriting is guarded: if the file's size/mtime changed between [open] and [save], the write is
+ * held back and [conflict] is raised for the UI to confirm ([confirmOverwrite]/[dismissConflict]).
+ * A failed save never discards the buffer — [saveFailure] is reported and the text stays editable.
+ *
+ * [scope] must outlive the editor UI (the session scope): a write in flight has to finish even if
+ * the view leaves composition, otherwise the file is left truncated. For the same reason the write
+ * runs inside [writeGuard] — the owner (the transfer coordinator) holds the transport open until it
+ * returns, so closing the tab mid-save can't pull the channel out from under a half-written file.
+ * [onSaved] fires after each successful write, for the pane to refresh its listing.
+ *
+ * Operations are serialized via [busy]; like the other file-panel controllers this is a plain flag,
+ * safe only because the scope is main-confined.
+ */
+@Stable
+class FileEditController(
+    private val source: FileContentBrowser,
+    private val item: FileItem,
+    readOnly: Boolean,
+    private val scope: CoroutineScope,
+    private val maxBytes: Long = MAX_EDIT_BYTES,
+    private val onSaved: () -> Unit = {},
+    private val writeGuard: suspend (suspend () -> Unit) -> Unit = { it() },
+) {
+    /**
+     * Whether the buffer is view-only (opened with F3). Not fixed for the editor's lifetime: F4
+     * turns viewing into editing in place ([enableEditing]), the way mc does, so the user doesn't
+     * have to close and re-open the file to change one line.
+     */
+    var readOnly: Boolean by mutableStateOf(readOnly)
+        private set
+
+    /** File name for the editor header. */
+    val name: String get() = item.name
+
+    /** Absolute path in the source's namespace, for the header subtitle. */
+    val path: String get() = item.path
+
+    var state: FileEditState by mutableStateOf(FileEditState.Loading)
+        private set
+
+    /** A save is in flight: the UI disables editing and the Save action. */
+    var saving: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Reason the last save failed, shown alongside the (preserved) buffer. Cleared when the next
+     * save starts or the buffer is edited again.
+     */
+    var saveFailure: FileEditFailure? by mutableStateOf(null)
+        private set
+
+    /**
+     * The file changed on the source since it was opened, and a save is waiting for confirmation.
+     * The buffer is untouched while this is set.
+     */
+    var conflict: Boolean by mutableStateOf(false)
+        private set
+
+    /** Content as loaded (or last saved), for [dirty] and for restoring on cancel. */
+    private var baseline: String by mutableStateOf("")
+
+    /** Line ending the file used when it was read; restored on save. */
+    private var lineEnding: LineEnding = LineEnding.Lf
+
+    /** Size/mtime of the file when it was read (or last written), for conflict detection. */
+    private var snapshot: FileItem? = null
+
+    private var busy = false
+
+    /** Whether the buffer differs from what's on the source. */
+    val dirty: Boolean get() = (state as? FileEditState.Ready)?.text?.let { it != baseline } == true
+
+    /** F4 in view mode: makes the loaded buffer editable. */
+    fun enableEditing() {
+        readOnly = false
+    }
+
+    /** Reads the file. Call once when the editor opens. */
+    fun open() {
+        if (busy) return
+        busy = true
+        scope.launch {
+            try {
+                val bytes = source.readFile(item.path, maxBytes)
+                val decoded = decodeEditableText(bytes)
+                if (decoded == null) {
+                    state = FileEditState.Failed(FileEditFailure.Binary)
+                    return@launch
+                }
+                lineEnding = detectLineEnding(decoded)
+                baseline = normalizeLineEndings(decoded)
+                snapshot = runCatching { source.stat(item.path) }.getOrNull() ?: item
+                state = FileEditState.Ready(baseline)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: FileBrowserException) {
+                state = FileEditState.Failed(
+                    if (e.failure == FileBrowserFailure.TooLarge) FileEditFailure.TooLarge else FileEditFailure.Read,
+                )
+            } catch (_: Exception) {
+                // Anything the source didn't wrap still has to land somewhere: an unhandled type
+                // would otherwise leave the editor spinning on Loading with no explanation.
+                state = FileEditState.Failed(FileEditFailure.Read)
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    /**
+     * Buffer edit from the text field. Ignored in read-only mode, while a save is in flight, and
+     * while a [conflict] is pending — the pending write is of the buffer as it was when the
+     * conflict was raised, so it must not shift underneath the confirmation.
+     */
+    fun edit(value: String) {
+        if (readOnly || saving || conflict) return
+        val ready = state as? FileEditState.Ready ?: return
+        if (ready.text == value) return
+        saveFailure = null
+        state = FileEditState.Ready(value)
+    }
+
+    /**
+     * Writes the buffer back. No-op when read-only, unchanged, or already busy. If the file changed
+     * on the source since [open], nothing is written and [conflict] is raised instead.
+     */
+    fun save() {
+        if (readOnly || !dirty || busy) return
+        busy = true
+        scope.launch {
+            try {
+                val current = runCatching { source.stat(item.path) }.getOrNull()
+                if (changedUnderneath(current)) {
+                    conflict = true
+                    return@launch
+                }
+                write()
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    /** Confirms the [conflict] dialog: writes the buffer over the changed file. */
+    fun confirmOverwrite() {
+        if (!conflict) return
+        conflict = false
+        if (readOnly || !dirty || busy) return
+        busy = true
+        scope.launch {
+            try {
+                write()
+            } finally {
+                busy = false
+            }
+        }
+    }
+
+    /** Cancels the [conflict] dialog, keeping the buffer unsaved. */
+    fun dismissConflict() {
+        conflict = false
+    }
+
+    /**
+     * Whether the file on the source differs from the snapshot taken when it was read. An
+     * unreadable/vanished stat isn't treated as a conflict: the write itself will fail with a real
+     * error, which is more informative than a spurious "changed on the server".
+     */
+    private fun changedUnderneath(current: FileItem?): Boolean {
+        val base = snapshot ?: return false
+        if (current == null) return false
+        return current.size != base.size || current.modifiedEpochSeconds != base.modifiedEpochSeconds
+    }
+
+    /** Encodes and writes the buffer, re-baselining on success. Callers own the [busy] flag. */
+    private suspend fun write() {
+        val text = (state as? FileEditState.Ready)?.text ?: return
+        saving = true
+        saveFailure = null
+        try {
+            writeGuard {
+                source.writeFile(item.path, restoreLineEndings(text, lineEnding).encodeToByteArray())
+                baseline = text
+                // Re-baseline against what's actually on the source now, so the next save doesn't
+                // see our own write (new size/mtime) as someone else's change. If that stat fails,
+                // the previous snapshot is kept rather than dropped: a stale snapshot costs at most
+                // one spurious "changed on the source?" prompt, while a null one would silently
+                // disable conflict detection for the rest of the session.
+                snapshot = runCatching { source.stat(item.path) }.getOrNull() ?: snapshot
+            }
+            onSaved()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: FileBrowserException) {
+            saveFailure = FileEditFailure.Write
+        } finally {
+            saving = false
+        }
+    }
+}
+
+/** Line ending a file uses; the buffer always holds `\n` and the original is restored on save. */
+internal enum class LineEnding { Lf, Crlf, Cr }
+
+/**
+ * Decodes [bytes] as editable text, or null if the content isn't text. Strict UTF-8 (a malformed
+ * sequence is a refusal, not a replacement character) plus a NUL-byte check, since NUL is the
+ * classic binary marker and valid UTF-8 all the same.
+ */
+internal fun decodeEditableText(bytes: ByteArray): String? {
+    if (bytes.any { it == 0.toByte() }) return null
+    return try {
+        bytes.decodeToString(throwOnInvalidSequence = true)
+    } catch (_: CharacterCodingException) {
+        null
+    }
+}
+
+/**
+ * Line ending of [text]: CRLF when every `\n` is preceded by `\r`, CR for a classic-Mac file with
+ * bare `\r` and no `\n` at all, LF otherwise. A file mixing endings counts as LF and is normalized
+ * throughout on save — rare enough to prefer one consistent ending over reproducing the mixture
+ * line by line.
+ */
+internal fun detectLineEnding(text: String): LineEnding {
+    val lf = text.count { it == '\n' }
+    val crlf = countOccurrences(text, "\r\n")
+    val cr = text.count { it == '\r' }
+    return when {
+        crlf > 0 && crlf == lf && crlf == cr -> LineEnding.Crlf
+        lf == 0 && cr > 0 -> LineEnding.Cr
+        else -> LineEnding.Lf
+    }
+}
+
+/**
+ * Puts [text] into the editor's own form: every ending becomes `\n`. Bare `\r` is translated too,
+ * not just `\r\n` — a stray carriage return left in the buffer renders and moves the caret in ways
+ * a text field doesn't define.
+ */
+internal fun normalizeLineEndings(text: String): String =
+    if ('\r' in text) text.replace("\r\n", "\n").replace('\r', '\n') else text
+
+/** Converts the buffer's `\n` endings back to the file's own [ending]. */
+internal fun restoreLineEndings(text: String, ending: LineEnding): String =
+    when (ending) {
+        LineEnding.Lf -> text
+        LineEnding.Crlf -> text.replace("\n", "\r\n")
+        LineEnding.Cr -> text.replace('\n', '\r')
+    }
+
+private fun countOccurrences(text: String, needle: String): Int {
+    var count = 0
+    var index = text.indexOf(needle)
+    while (index >= 0) {
+        count++
+        index = text.indexOf(needle, index + needle.length)
+    }
+    return count
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
@@ -1,0 +1,407 @@
+package app.skerry.ui.files
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.D
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_fkey_edit
+import app.skerry.ui.generated.resources.ftail_fkey_quit
+import app.skerry.ui.generated.resources.ftail_fkey_save
+import app.skerry.ui.generated.resources.ftail_fkey_search
+import app.skerry.ui.generated.resources.sftp_edit_conflict_body
+import app.skerry.ui.generated.resources.sftp_edit_conflict_q
+import app.skerry.ui.generated.resources.sftp_edit_discard
+import app.skerry.ui.generated.resources.sftp_edit_discard_body
+import app.skerry.ui.generated.resources.sftp_edit_discard_q
+import app.skerry.ui.generated.resources.sftp_edit_find
+import app.skerry.ui.generated.resources.sftp_edit_modified
+import app.skerry.ui.generated.resources.sftp_edit_not_found
+import app.skerry.ui.generated.resources.sftp_edit_readonly
+import app.skerry.ui.generated.resources.sftp_edit_saving
+import app.skerry.ui.generated.resources.sftp_edit_title
+import app.skerry.ui.generated.resources.sftp_edit_title_view
+import app.skerry.ui.generated.resources.sftp_loading
+import app.skerry.ui.generated.resources.sftp_overwrite
+import app.skerry.ui.nav.PlatformBackHandler
+import app.skerry.ui.sftp.ConfirmDangerDialog
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Built-in file viewer/editor (F3/F4). It takes over the file panel's own screen rather than opening
+ * a window of its own: same chrome, same bottom key bar, only the keys change to the editor's
+ * (F2 Save, F4 Edit, F7 Search, F10 Quit) — mc's arrangement, and the one the panel already teaches.
+ *
+ * Closing with unsaved changes asks first, as does an overwrite conflict raised by the controller;
+ * those two stay modal dialogs (the app's convention for a yes/no that must not be missed).
+ * [showKeyBar] is off on touch, where the header's buttons stand in for the function keys.
+ * [onClose] is called once the editor is actually free to go.
+ */
+@Composable
+fun FileEditorScreen(
+    controller: FileEditController,
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+    showKeyBar: Boolean = true,
+) {
+    val mono = LocalFonts.current.mono
+    var confirmDiscard by remember(controller) { mutableStateOf(false) }
+    var searching by remember(controller) { mutableStateOf(false) }
+    var query by remember(controller) { mutableStateOf("") }
+    var notFound by remember(controller) { mutableStateOf(false) }
+    // Caret and selection live here, not in the controller (which owns only the content): Tab needs
+    // the caret to insert a tab, and search needs it to know where to continue from.
+    var value by remember(controller) { mutableStateOf(TextFieldValue()) }
+
+    val requestClose = { if (controller.dirty) confirmDiscard = true else onClose() }
+    val findNext = {
+        val hit = findNextMatch(value.text, query, value.selection.max)
+        notFound = hit == null
+        if (hit != null) value = value.copy(selection = TextRange(hit.first, hit.last + 1))
+    }
+    val onKey: (Int) -> Unit = { n ->
+        when (n) {
+            2 -> controller.save()
+            4 -> controller.enableEditing()
+            7 -> if (searching) findNext() else { searching = true; notFound = false }
+            10 -> requestClose()
+        }
+    }
+
+    // Android's system back closes the editor, not the whole file screen behind it — and goes
+    // through the same unsaved-changes confirmation F10/Esc do. Disabled while a dialog of ours is
+    // up: back should dismiss that first (handlers are LIFO, the dialog registers its own).
+    PlatformBackHandler(enabled = !confirmDiscard && !controller.conflict) {
+        if (searching) searching = false else requestClose()
+    }
+
+    val focus = remember(controller) { FocusRequester() }
+    val overlaid = searching || confirmDiscard || controller.conflict
+    val ready = controller.state is FileEditState.Ready
+    // The editor owns the keyboard from the moment it opens, and takes it back when a dialog or the
+    // search bar above it closes — otherwise F2/F10 would fall through to the panel underneath.
+    LaunchedEffect(controller, ready, overlaid) {
+        if (!overlaid && !ready) runCatching { focus.requestFocus() }
+    }
+
+    Column(
+        modifier
+            .background(D.bg)
+            .imePadding()
+            .focusRequester(focus)
+            .onPreviewKeyEvent { event ->
+                if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                when {
+                    event.key == Key.F2 -> { onKey(2); true }
+                    event.key == Key.F4 -> { onKey(4); true }
+                    event.key == Key.F7 -> { onKey(7); true }
+                    event.key == Key.F10 -> { onKey(10); true }
+                    event.key == Key.Escape -> { requestClose(); true }
+                    // Ctrl/⌘+S next to mc's F2: the chord every other editor has trained people on.
+                    (event.isCtrlPressed || event.isMetaPressed) && event.key == Key.S -> {
+                        controller.save()
+                        true
+                    }
+                    else -> false
+                }
+            }
+            .focusable(),
+    ) {
+        EditorHeader(controller, mono, showButtons = !showKeyBar, onSave = { controller.save() }, onClose = requestClose)
+        HLine()
+        controller.saveFailure?.let { failure ->
+            EditorStrip("error", fileEditFailureText(failure), D.sunset)
+            HLine()
+        }
+        if (searching) {
+            EditorSearchBar(
+                query = query,
+                notFound = notFound,
+                mono = mono,
+                onQueryChange = { query = it; notFound = false },
+                onSubmit = findNext,
+                onDismiss = { searching = false; notFound = false },
+            )
+            HLine()
+        }
+        Box(Modifier.weight(1f).fillMaxWidth()) {
+            when (val st = controller.state) {
+                FileEditState.Loading -> EditorNotice("sync", stringResource(Res.string.sftp_loading), D.faint)
+                is FileEditState.Failed -> EditorNotice("error", fileEditFailureText(st.failure), D.sunset)
+                is FileEditState.Ready -> EditorBuffer(
+                    controller = controller,
+                    state = st,
+                    mono = mono,
+                    value = value,
+                    onValueChange = { value = it },
+                    focusEditor = !overlaid,
+                )
+            }
+        }
+        if (showKeyBar) {
+            HLine()
+            FKeyBar(editorKeys(controller), onKey, mono)
+        }
+    }
+
+    if (confirmDiscard) {
+        ConfirmDangerDialog(
+            title = stringResource(Res.string.sftp_edit_discard_q),
+            body = stringResource(Res.string.sftp_edit_discard_body, controller.name),
+            confirmLabel = stringResource(Res.string.sftp_edit_discard),
+            onConfirm = { confirmDiscard = false; onClose() },
+            onDismiss = { confirmDiscard = false },
+        )
+    }
+
+    if (controller.conflict) {
+        ConfirmDangerDialog(
+            title = stringResource(Res.string.sftp_edit_conflict_q),
+            body = stringResource(Res.string.sftp_edit_conflict_body, controller.name),
+            confirmLabel = stringResource(Res.string.sftp_overwrite),
+            onConfirm = controller::confirmOverwrite,
+            onDismiss = controller::dismissConflict,
+        )
+    }
+}
+
+/**
+ * The editor's own key legend, replacing the panel's while it is open. Save is greyed out with
+ * nothing to write; in view mode F4 turns the buffer editable (mc's F3 → F4 path) and F2 stays dead
+ * until it does.
+ */
+private fun editorKeys(controller: FileEditController): List<FKeyDef> = listOf(
+    FKeyDef(2, Res.string.ftail_fkey_save, enabled = !controller.readOnly && controller.dirty && !controller.saving),
+    FKeyDef(4, Res.string.ftail_fkey_edit, enabled = controller.readOnly),
+    FKeyDef(7, Res.string.ftail_fkey_search, enabled = controller.state is FileEditState.Ready),
+    FKeyDef(10, Res.string.ftail_fkey_quit),
+)
+
+/**
+ * Editor header: mode icon, file name, path, and the read-only/modified/saving state. On touch
+ * ([showButtons]) it also carries Save and Close, which the function keys cover elsewhere.
+ */
+@Composable
+private fun EditorHeader(
+    controller: FileEditController,
+    mono: FontFamily,
+    showButtons: Boolean,
+    onSave: () -> Unit,
+    onClose: () -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().background(D.surface2).padding(start = 16.dp, end = 6.dp, top = 9.dp, bottom = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Sym(if (controller.readOnly) "visibility" else "edit_note", size = 18.sp, color = D.cyanBright)
+        Txt(
+            if (controller.readOnly) stringResource(Res.string.sftp_edit_title_view) else stringResource(Res.string.sftp_edit_title),
+            color = D.text,
+            size = 13.sp,
+            weight = FontWeight.SemiBold,
+        )
+        Txt(controller.name, color = D.textBright, size = 12.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Txt(
+            controller.path,
+            color = D.faint,
+            size = 11.sp,
+            font = mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        when {
+            controller.saving -> Txt(stringResource(Res.string.sftp_edit_saving), color = D.cyan, size = 11.sp)
+            controller.readOnly -> Txt(stringResource(Res.string.sftp_edit_readonly), color = D.faint, size = 11.sp)
+            controller.dirty -> Txt(stringResource(Res.string.sftp_edit_modified), color = D.sunset, size = 11.sp)
+        }
+        if (showButtons) {
+            if (!controller.readOnly) {
+                IconBtn(
+                    "save",
+                    onClick = onSave,
+                    box = 26,
+                    icon = 16.sp,
+                    tint = if (controller.dirty && !controller.saving) D.cyanBright else D.faint,
+                )
+            }
+            IconBtn("close", onClick = onClose, box = 26, icon = 16.sp)
+        }
+    }
+}
+
+/**
+ * The buffer: a monospace field that scrolls itself, so the caret stays in view while typing.
+ * [focusEditor] hands the keyboard over while nothing is layered on top (search bar, a dialog).
+ */
+@Composable
+private fun EditorBuffer(
+    controller: FileEditController,
+    state: FileEditState.Ready,
+    mono: FontFamily,
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    focusEditor: Boolean,
+) {
+    val focus = remember(controller) { FocusRequester() }
+    // The controller can replace the content on its own (initial load, an edit rejected while a
+    // conflict is pending): adopt it, but never on the echo of our own keystroke.
+    LaunchedEffect(state.text) {
+        // Caret at the top, not at the end: a file opens at its beginning, the way every editor and
+        // pager on the platform opens one.
+        if (value.text != state.text) onValueChange(TextFieldValue(state.text, TextRange.Zero))
+    }
+    LaunchedEffect(controller, focusEditor) { if (focusEditor) runCatching { focus.requestFocus() } }
+    val editable = !controller.readOnly && !controller.saving
+    BasicTextField(
+        value = value,
+        onValueChange = { next ->
+            onValueChange(next)
+            controller.edit(next.text)
+        },
+        readOnly = !editable,
+        textStyle = TextStyle(color = D.textBright, fontSize = 12.5.sp, fontFamily = mono),
+        cursorBrush = SolidColor(D.cyan),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(14.dp)
+            .focusRequester(focus)
+            .onPreviewKeyEvent { event ->
+                // Tab types a tab (this is a file editor, and config files are full of them);
+                // without this Compose would move focus out of the buffer instead.
+                if (event.type != KeyEventType.KeyDown || event.key != Key.Tab || !editable) {
+                    return@onPreviewKeyEvent false
+                }
+                val selection = value.selection
+                val next = value.text.replaceRange(selection.min, selection.max, "\t")
+                onValueChange(TextFieldValue(next, TextRange(selection.min + 1)))
+                controller.edit(next)
+                true
+            },
+    )
+}
+
+/**
+ * F7 search bar: type and press Enter (or F7 again) to jump to the next match, Esc to close. The hit
+ * is selected in the buffer rather than highlighted separately — the field scrolls to its own
+ * selection, so the match lands in view.
+ */
+@Composable
+private fun EditorSearchBar(
+    query: String,
+    notFound: Boolean,
+    mono: FontFamily,
+    onQueryChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { runCatching { focus.requestFocus() } }
+    Row(
+        Modifier.fillMaxWidth().background(D.panel).padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Sym("search", size = 15.sp, color = D.cyanBright)
+        Txt(stringResource(Res.string.sftp_edit_find), color = D.faint, size = 11.5.sp)
+        BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            singleLine = true,
+            textStyle = TextStyle(color = D.textBright, fontSize = 12.sp, fontFamily = mono),
+            cursorBrush = SolidColor(D.cyan),
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focus)
+                .onPreviewKeyEvent { event ->
+                    if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                    when (event.key) {
+                        Key.Enter, Key.NumPadEnter, Key.F7 -> { onSubmit(); true }
+                        Key.Escape -> { onDismiss(); true }
+                        else -> false
+                    }
+                },
+        )
+        if (notFound) Txt(stringResource(Res.string.sftp_edit_not_found), color = D.sunset, size = 11.sp)
+    }
+}
+
+/** One-line notice strip under the header (a failed save keeps the buffer, so it isn't a full screen). */
+@Composable
+private fun EditorStrip(icon: String, text: String, color: Color) {
+    Row(
+        Modifier.fillMaxWidth().background(D.surface2).padding(horizontal = 16.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Sym(icon, size = 15.sp, color = color)
+        Txt(text, color = color, size = 11.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+    }
+}
+
+/** Centered notice in the buffer area (loading / failed to open). */
+@Composable
+private fun EditorNotice(icon: String, text: String, color: Color) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Sym(icon, size = 26.sp, color = color)
+            Txt(text, color = D.text, size = 12.5.sp)
+        }
+    }
+}
+
+/**
+ * Next occurrence of [query] in [text] at or after [from], wrapping around to the start (so repeated
+ * F7 cycles through the file). Case-insensitive; a blank query never matches.
+ */
+internal fun findNextMatch(text: String, query: String, from: Int): IntRange? {
+    if (query.isEmpty()) return null
+    val start = from.coerceIn(0, text.length)
+    val ahead = text.indexOf(query, start, ignoreCase = true)
+    val at = if (ahead >= 0) ahead else text.indexOf(query, 0, ignoreCase = true)
+    return if (at < 0) null else at until (at + query.length)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
@@ -4,11 +4,16 @@ import androidx.compose.runtime.Composable
 import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_delete_source_failed
+import app.skerry.ui.generated.resources.ftail_edit_err_binary
+import app.skerry.ui.generated.resources.ftail_edit_err_read
+import app.skerry.ui.generated.resources.ftail_edit_err_too_large
+import app.skerry.ui.generated.resources.ftail_edit_err_write
 import app.skerry.ui.generated.resources.ftail_err_illegal_name
 import app.skerry.ui.generated.resources.ftail_err_local_io
 import app.skerry.ui.generated.resources.ftail_err_open_source
 import app.skerry.ui.generated.resources.ftail_err_open_target
 import app.skerry.ui.generated.resources.ftail_err_sftp
+import app.skerry.ui.generated.resources.ftail_err_too_large
 import app.skerry.ui.generated.resources.ftail_transfer_error
 import org.jetbrains.compose.resources.stringResource
 
@@ -21,6 +26,18 @@ fun fileBrowserFailureText(failure: FileBrowserFailure): String = stringResource
         FileBrowserFailure.IllegalName -> Res.string.ftail_err_illegal_name
         FileBrowserFailure.OpenSource -> Res.string.ftail_err_open_source
         FileBrowserFailure.OpenTarget -> Res.string.ftail_err_open_target
+        FileBrowserFailure.TooLarge -> Res.string.ftail_err_too_large
+    },
+)
+
+/** Localized text for a viewer/editor failure ([FileEditState.Failed] / [FileEditController.saveFailure]). */
+@Composable
+fun fileEditFailureText(failure: FileEditFailure): String = stringResource(
+    when (failure) {
+        FileEditFailure.Read -> Res.string.ftail_edit_err_read
+        FileEditFailure.TooLarge -> Res.string.ftail_edit_err_too_large
+        FileEditFailure.Binary -> Res.string.ftail_edit_err_binary
+        FileEditFailure.Write -> Res.string.ftail_edit_err_write
     },
 )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.kt
@@ -1,10 +1,10 @@
 package app.skerry.ui.files
 
-import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
 
 /**
  * Platform local file browser for the left pane of the two-pane SFTP view. Desktop returns
  * `LocalFileBrowser` over `FileSystem.SYSTEM` starting at the user's home directory; Android
  * returns a stub over shared storage root (used only by the desktop shell currently).
  */
-expect fun platformLocalBrowser(): FileBrowser
+expect fun platformLocalBrowser(): FileContentBrowser

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.sftp.SftpClient
@@ -15,6 +16,8 @@ import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sftp.UploadSource
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -45,7 +48,8 @@ private fun FileBrowserFailure.toTransferFailure(): FileTransferFailure = when (
     FileBrowserFailure.IllegalName -> FileTransferFailure.IllegalName
     FileBrowserFailure.OpenSource -> FileTransferFailure.OpenSource
     FileBrowserFailure.OpenTarget -> FileTransferFailure.OpenTarget
-    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp -> FileTransferFailure.Transfer
+    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp, FileBrowserFailure.TooLarge ->
+        FileTransferFailure.Transfer
 }
 
 /** Cross-pane batch transfer state, for the bottom transfer bar. */
@@ -93,9 +97,9 @@ class OverwriteConflict(val names: List<String>, val proceed: () -> Unit)
 class TransferCoordinator(
     private val sftp: SftpClient,
     val local: FilePaneController,
-    private val localBrowser: FileBrowser,
+    private val localBrowser: FileContentBrowser,
     val remote: FilePaneController,
-    private val remoteBrowser: FileBrowser,
+    private val remoteBrowser: FileContentBrowser,
     private val scope: CoroutineScope,
 ) {
     var transfer: TransferState by mutableStateOf(TransferState.Idle)
@@ -115,6 +119,19 @@ class TransferCoordinator(
      * as [FilePaneController].
      */
     private var busy = false
+
+    /**
+     * Held for the duration of an editor's write ([openEditor]). The session's teardown waits on it
+     * ([awaitEditorWrites]) before closing the SFTP channel: an editor save runs on this scope and
+     * outlives the editor UI, so closing the tab mid-save would otherwise cut the channel with the
+     * remote file already truncated and the new content only half written.
+     */
+    private val editorWrites = Mutex()
+
+    /** Suspends until no editor write is in flight. Called before the transport is closed. */
+    suspend fun awaitEditorWrites() {
+        editorWrites.withLock { }
+    }
 
     /**
      * Uploads the local pane's selection into the remote pane's current directory. Files are
@@ -269,6 +286,29 @@ class TransferCoordinator(
             transfer = TransferState.Idle
             remote.refresh()
         }
+    }
+
+    /**
+     * Editor/viewer (F3/F4) over [item] of the [fromLocal] pane's source. The controller runs on the
+     * coordinator's scope (the session's), so a save in flight survives the editor UI leaving
+     * composition — a cancelled write would leave the file truncated. The pane reloads after each
+     * successful save so the listing shows the new size/mtime.
+     */
+    fun openEditor(fromLocal: Boolean, item: FileItem, readOnly: Boolean): FileEditController? {
+        val pane = if (fromLocal) local else remote
+        // Path rebuilt from the pane's directory + a validated name, never the listing's own
+        // `item.path`: on the remote side that value is server-controlled, and trusting it would let
+        // a hostile listing redirect the read — and the save — to another file entirely. An entry
+        // whose name isn't usable as a path component simply doesn't open.
+        if (isUnsafeListingName(item.name)) return null
+        return FileEditController(
+            writeGuard = { write -> editorWrites.withLock { write() } },
+            source = if (fromLocal) localBrowser else remoteBrowser,
+            item = item.copy(path = childPath(pane.path, item.name)),
+            readOnly = readOnly,
+            scope = scope,
+            onSaved = { pane.refresh() },
+        ).also { it.open() }
     }
 
     /** Closes the transfer bar (resets to [TransferState.Idle]); doesn't touch an active transfer. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -40,6 +40,8 @@ import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.files.FileEditController
+import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.PathJumpField
@@ -50,6 +52,8 @@ import app.skerry.ui.files.platformLocalBrowser
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_file_fallback
+import app.skerry.ui.generated.resources.ftail_fkey_edit
+import app.skerry.ui.generated.resources.ftail_fkey_view
 import app.skerry.ui.generated.resources.ftail_local_label
 import app.skerry.ui.generated.resources.ftail_open_failed
 import app.skerry.ui.generated.resources.sftp_connecting
@@ -136,6 +140,9 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
     var openError by remember(controller) { mutableStateOf<String?>(null) }
     var creatingFolder by remember(controller) { mutableStateOf(false) }
     var fabOpen by remember(controller) { mutableStateOf(false) }
+    // Built-in viewer/editor over the cursored file (long-press menu). The controller comes from the
+    // coordinator (session scope), so closing the modal never cancels a save in flight.
+    var editor by remember(controller) { mutableStateOf<FileEditController?>(null) }
     // UI scope only for the native file picker (FAB Upload); the transfer itself lives on the
     // session scope inside the coordinator and survives the view leaving composition.
     val uiScope = rememberCoroutineScope()
@@ -154,6 +161,19 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
     }
 
     val c = coord
+    val openEditor = editor
+    // Built-in viewer/editor (long-press → View/Edit): takes over the screen instead of opening a
+    // dialog, so it gets the full height and the same chrome as the file list.
+    if (openEditor != null) {
+        FileEditorScreen(
+            controller = openEditor,
+            onClose = { editor = null },
+            modifier = Modifier.fillMaxSize(),
+            // No function keys on touch: Save/Close sit in the header instead.
+            showKeyBar = false,
+        )
+        return
+    }
     Box(Modifier.fillMaxSize().background(D.bg)) {
         Column(Modifier.fillMaxSize()) {
             MobileFilesTitle(onBack)
@@ -187,11 +207,18 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                         pane.label.ifBlank { stringResource(Res.string.ftail_local_label) },
                         pane.path,
                         mono, onGoToPath = pane::goToPath)
+                    // View/Edit a remote file in place (parity with desktop F3/F4).
+                    val openEditor = remember(c) {
+                        { item: FileItem, readOnly: Boolean ->
+                            editor = c.openEditor(fromLocal = false, item = item, readOnly = readOnly)
+                        }
+                    }
                     MobileLivePane(
                         pane = pane,
                         mono = mono,
                         onTransfer = onTransfer,
                         onDownloadHere = downloadHere,
+                        onOpenEditor = openEditor,
                         modifier = Modifier.weight(1f),
                     )
                     MobileTransferCard(c.transfer, mono, onDismiss = c::clearTransfer)
@@ -269,6 +296,7 @@ private fun MobileLivePane(
     mono: FontFamily,
     onTransfer: (FileItem) -> Unit,
     onDownloadHere: ((FileItem) -> Unit)?,
+    onOpenEditor: (FileItem, Boolean) -> Unit,
     modifier: Modifier,
 ) {
     var renaming by remember(pane) { mutableStateOf<FileItem?>(null) }
@@ -304,6 +332,7 @@ private fun MobileLivePane(
                             mono = mono,
                             onClick = { if (isDir) pane.open(entry) else onTransfer(entry) },
                             onDownloadHere = if (!isDir && onDownloadHere != null) ({ onDownloadHere(entry) }) else null,
+                            onOpenEditor = if (entry.type == FileItemType.File) ({ readOnly -> onOpenEditor(entry, readOnly) }) else null,
                             onRename = { renaming = entry },
                             onDelete = { deleting = entry },
                         )
@@ -344,6 +373,7 @@ private fun MobileFileRow(
     mono: FontFamily,
     onClick: () -> Unit,
     onDownloadHere: (() -> Unit)?,
+    onOpenEditor: ((Boolean) -> Unit)?,
     onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -372,6 +402,10 @@ private fun MobileFileRow(
             actions = buildList {
                 onDownloadHere?.let { dl ->
                     add(MobileSheetAction(stringResource(Res.string.sftp_download_to_device), onClick = dl, icon = "download"))
+                }
+                onOpenEditor?.let { open ->
+                    add(MobileSheetAction(stringResource(Res.string.ftail_fkey_view), onClick = { open(true) }, icon = "visibility"))
+                    add(MobileSheetAction(stringResource(Res.string.ftail_fkey_edit), onClick = { open(false) }, icon = "edit_note"))
                 }
                 add(MobileSheetAction(stringResource(Res.string.sftp_rename), onClick = onRename, icon = "edit"))
                 add(MobileSheetAction(stringResource(Res.string.sftp_delete), onClick = onDelete, icon = "delete", danger = true))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -24,15 +24,28 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_fkey_copy
+import app.skerry.ui.generated.resources.ftail_fkey_delete
+import app.skerry.ui.generated.resources.ftail_fkey_edit
+import app.skerry.ui.generated.resources.ftail_fkey_mkdir
+import app.skerry.ui.generated.resources.ftail_fkey_move
+import app.skerry.ui.generated.resources.ftail_fkey_quit
+import app.skerry.ui.generated.resources.ftail_fkey_refresh
+import app.skerry.ui.generated.resources.ftail_fkey_rename
+import app.skerry.ui.generated.resources.ftail_fkey_save
+import app.skerry.ui.generated.resources.ftail_fkey_search
+import app.skerry.ui.generated.resources.ftail_fkey_view
 import app.skerry.ui.generated.resources.settings_badge_soon
 import app.skerry.ui.generated.resources.settings_kb_accept_autocomplete
 import app.skerry.ui.generated.resources.settings_kb_broadcast
+import app.skerry.ui.generated.resources.settings_kb_editor_group
 import app.skerry.ui.generated.resources.settings_kb_command_palette
-import app.skerry.ui.generated.resources.settings_kb_play_recording
-import app.skerry.ui.generated.resources.settings_kb_record_session
-import app.skerry.ui.generated.resources.settings_kb_snippet_palette
 import app.skerry.ui.generated.resources.settings_kb_copy_selection
 import app.skerry.ui.generated.resources.settings_kb_cycle_suggestions
+import app.skerry.ui.generated.resources.settings_kb_files_group
+import app.skerry.ui.generated.resources.settings_kb_files_hidden
+import app.skerry.ui.generated.resources.settings_kb_files_save
+import app.skerry.ui.generated.resources.settings_kb_files_switch_pane
 import app.skerry.ui.generated.resources.settings_kb_focus_ai
 import app.skerry.ui.generated.resources.settings_kb_global
 import app.skerry.ui.generated.resources.settings_kb_lock
@@ -40,8 +53,11 @@ import app.skerry.ui.generated.resources.settings_kb_new_connection
 import app.skerry.ui.generated.resources.settings_kb_next_prev_tab
 import app.skerry.ui.generated.resources.settings_kb_open_sftp
 import app.skerry.ui.generated.resources.settings_kb_paste
+import app.skerry.ui.generated.resources.settings_kb_play_recording
+import app.skerry.ui.generated.resources.settings_kb_record_session
 import app.skerry.ui.generated.resources.settings_kb_search_history
 import app.skerry.ui.generated.resources.settings_kb_select_tab_number
+import app.skerry.ui.generated.resources.settings_kb_snippet_palette
 import app.skerry.ui.generated.resources.settings_kb_split_terminal
 import app.skerry.ui.generated.resources.settings_kb_terminal_group
 import app.skerry.ui.generated.resources.settings_keyboard_subtitle
@@ -90,11 +106,42 @@ internal fun KeyboardSection() {
         KeyboardBinding(stringResource(Res.string.settings_kb_paste), "${ctrlShift("V")} / ${shift("Insert")}", live = true),
     )
 
+    // File panel (SFTP view) F-keys, mc/Total Commander style — the same labels the bottom bar uses.
+    // Ctrl+S belongs to the built-in editor opened by F4.
+    val files = listOf(
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_rename), "F2", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_view), "F3", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_edit), "F4", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_copy), "F5", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_move), "F6", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_mkdir), "F7", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_delete), "F8", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_refresh), "F9", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_quit), "F10", live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_files_switch_pane), "Tab", live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_files_hidden), ctrl("H"), live = true),
+    )
+    // The built-in viewer/editor (F3/F4) opens inside the file panel and redefines the same bar of
+    // function keys while it is there, so its keys are listed as their own group.
+    val editor = listOf(
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_save), "F2", live = true),
+        // The editor takes ⌘S on macOS (what a mac user reaches for) and Ctrl+S elsewhere — not the
+        // app-wide mod() chord, which is Ctrl+Shift+ on Linux/Windows.
+        KeyboardBinding(stringResource(Res.string.settings_kb_files_save), if (mac) "⌘S" else "Ctrl+S", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_edit), "F4", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_search), "F7", live = true),
+        KeyboardBinding(stringResource(Res.string.ftail_fkey_quit), "F10 / Esc", live = true),
+    )
+
     val mono = LocalFonts.current.mono
     KeyboardGroupLabel(stringResource(Res.string.settings_kb_global), top = 4.dp)
     global.forEach { KeyboardRow(it, mono) }
     KeyboardGroupLabel(stringResource(Res.string.settings_kb_terminal_group), top = 18.dp)
     terminal.forEach { KeyboardRow(it, mono) }
+    KeyboardGroupLabel(stringResource(Res.string.settings_kb_files_group), top = 18.dp)
+    files.forEach { KeyboardRow(it, mono) }
+    KeyboardGroupLabel(stringResource(Res.string.settings_kb_editor_group), top = 18.dp)
+    editor.forEach { KeyboardRow(it, mono) }
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -62,6 +62,10 @@ import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.files.FileEditController
+import app.skerry.ui.files.FKeyBar
+import app.skerry.ui.files.FKeyDef
+import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.PathJumpField
@@ -228,6 +232,9 @@ private fun LiveSftpView(
     var copyTarget by remember(controller) { mutableStateOf<FilePaneController?>(null) }
     // F2 Rename target — a (pane, cursored row) pair at press time. null — dialog closed.
     var renameTarget by remember(controller) { mutableStateOf<Pair<FilePaneController, FileItem>?>(null) }
+    // F3 View / F4 Edit — the open file editor. null — no editor. The controller comes from the
+    // coordinator (session scope), so closing the modal never cancels a save in flight.
+    var editor by remember(controller) { mutableStateOf<FileEditController?>(null) }
     // A pane's path bar is being edited (type-to-jump). While true the Column's key handler steps aside
     // (preview events fire parent-first) so arrows/Enter reach the focused path field, not the listing.
     var editingPath by remember(controller) { mutableStateOf(false) }
@@ -267,12 +274,21 @@ private fun LiveSftpView(
 
     // Single point for F-keys: both a key press and a click on a bottom-pane row come here. Operations
     // act on the active pane, the target is its operands() (selection or the cursored row, mc-style).
-    // F3 View / F4 Edit are stubs (need file reading in the FileBrowser contract).
     val fKey: (Int) -> Unit = remember(c) { fKey@{ n ->
         val coord = c ?: return@fKey
         val pane = if (active == ActivePane.Local) coord.local else coord.remote
+        // F3 View / F4 Edit: the cursored row only (never the selection — one editor, one file);
+        // directories/symlinks have nothing to show.
+        val openEditor = { readOnly: Boolean ->
+            pane.cursoredItem()?.takeIf { it.type == FileItemType.File }?.let { item ->
+                editor = coord.openEditor(fromLocal = pane === coord.local, item = item, readOnly = readOnly)
+            }
+            Unit
+        }
         when (n) {
             2 -> pane.cursoredItem()?.let { renameTarget = pane to it } // Rename the cursored row
+            3 -> openEditor(true) // View: read-only
+            4 -> openEditor(false) // Edit
             5 -> { // Copy: active pane's selection/cursor to the other (upload/download), with confirmation
                 ensureOperandSelection(pane)
                 if (pane.operands().isNotEmpty()) copyTarget = pane
@@ -288,7 +304,7 @@ private fun LiveSftpView(
             }
             9 -> { coord.local.refresh(); coord.remote.refresh() } // Refresh both panes
             10 -> onQuit() // Quit: back to this tab's terminal
-            else -> {} // F3 View / F4 Edit — stub
+            else -> {}
         }
     } }
 
@@ -301,6 +317,8 @@ private fun LiveSftpView(
                 if (c == null || event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                 // Path bar has focus (type-to-jump): let its own handler take arrows/Enter/Esc.
                 if (editingPath) return@onPreviewKeyEvent false
+                // The editor is open: it owns every key, including the F-keys it redefines.
+                if (editor != null) return@onPreviewKeyEvent false
                 // Ctrl+H — show/hide hidden entries (dotfiles); toggle the persistent setting, and the
                 // LaunchedEffect below applies it to both panes (single source of truth).
                 if (event.isCtrlPressed && event.key == Key.H) {
@@ -339,39 +357,36 @@ private fun LiveSftpView(
             }
             .focusable(),
     ) {
-        // Header: "File transfer" + subtitle on the left, Upload + New folder on the right.
-        Row(
-            Modifier.fillMaxWidth().background(D.surface2).padding(horizontal = 18.dp, vertical = 9.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                Sym("drive_file_move", size = 18.sp, color = D.cyanBright)
-                Txt(stringResource(Res.string.sftp_title), color = D.text, size = 13.sp, weight = FontWeight.SemiBold)
-                Txt(stringResource(Res.string.sftp_subtitle_host, subtitle), color = D.faint, size = 11.5.sp, font = mono)
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                // Upload: if there's a local file selection → transfer it; otherwise fall back to the
-                // native file picker → upload into the remote pane's current directory. New folder — in remote.
-                GhostButton(
-                    stringResource(Res.string.sftp_upload),
-                    onClick = {
-                        val coord = c
-                        if (coord != null) {
-                            if (coord.local.selection.isNotEmpty()) {
-                                coord.uploadSelection()
-                            } else {
-                                uiScope.launch { pickUploadSource()?.let { coord.uploadSource(it) } }
-                            }
+        // The panel's header is hidden while the editor is open: the editor brings its own, and two
+        // stacked bars over one file — the upper one offering Upload/New folder that do nothing
+        // there — are noise.
+        if (editor == null) {
+            LivePaneHeader(
+                subtitle = subtitle,
+                mono = mono,
+                onUpload = {
+                    val coord = c
+                    if (coord != null) {
+                        if (coord.local.selection.isNotEmpty()) {
+                            coord.uploadSelection()
+                        } else {
+                            uiScope.launch { pickUploadSource()?.let { coord.uploadSource(it) } }
                         }
-                    },
-                    icon = "upload",
-                )
-                GhostButton(stringResource(Res.string.sftp_new_folder), onClick = { if (c != null) creatingFolder = true }, icon = "create_new_folder")
-            }
+                    }
+                },
+                onNewFolder = { if (c != null) creatingFolder = true },
+            )
+            HLine()
         }
-        HLine()
+        val openEditor = editor
         when {
+            // F3/F4: the editor takes over the panel area and the key bar, in this same window —
+            // the panel's chrome stays, only what the function keys do changes.
+            openEditor != null -> FileEditorScreen(
+                controller = openEditor,
+                onClose = { editor = null; focus.requestFocus() },
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+            )
             openError != null -> Box(Modifier.weight(1f).fillMaxWidth()) {
                 PaneNotice("error", stringResource(Res.string.sftp_unavailable), openError, D.sunset)
             }
@@ -403,8 +418,12 @@ private fun LiveSftpView(
                 LiveTransferStrip(c.transfer, mono, onDismiss = c::clearTransfer)
             }
         }
-        HLine()
-        FKeyBar(enabled = c != null, onKey = fKey, mono = mono)
+        // The editor brings its own key bar (Save/Edit/Search/Quit) — the panel's would be a legend
+        // for keys that aren't listening.
+        if (openEditor == null) {
+            HLine()
+            FKeyBar(PANEL_FKEYS.map { it.copy(enabled = c != null) }, fKey, mono)
+        }
     }
 
     if (creatingFolder && c != null) {
@@ -508,6 +527,35 @@ private fun LiveSftpView(
 }
 
 /**
+ * The two-pane screen's header: "File transfer" + the session's subtitle on the left, Upload and
+ * New folder on the right. [onUpload] transfers the local pane's selection, or falls back to the
+ * native picker; [onNewFolder] creates a directory in the active pane.
+ */
+@Composable
+private fun LivePaneHeader(
+    subtitle: String,
+    mono: FontFamily,
+    onUpload: () -> Unit,
+    onNewFolder: () -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth().background(D.surface2).padding(horizontal = 18.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Sym("drive_file_move", size = 18.sp, color = D.cyanBright)
+            Txt(stringResource(Res.string.sftp_title), color = D.text, size = 13.sp, weight = FontWeight.SemiBold)
+            Txt(stringResource(Res.string.sftp_subtitle_host, subtitle), color = D.faint, size = 11.5.sp, font = mono)
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            GhostButton(stringResource(Res.string.sftp_upload), onClick = onUpload, icon = "upload")
+            GhostButton(stringResource(Res.string.sftp_new_folder), onClick = onNewFolder, icon = "create_new_folder")
+        }
+    }
+}
+
+/**
  * Target of the active pane's batch F-operations: if nothing is marked — select the cursored row (mc
  * copies/moves/deletes the cursored item when there's no selection). On ".."/empty — no-op.
  */
@@ -515,70 +563,18 @@ private fun ensureOperandSelection(pane: FilePaneController) {
     if (pane.selection.isEmpty()) pane.cursoredItem()?.let { pane.selectOnly(it) }
 }
 
-/**
- * mc-style bottom F-key bar layout (classic, adapted for Skerry).
- * [done] = the key actually does something; false — a stub. Non-working ones are marked "*" in the bar
- * so it's visible what's wired and what isn't.
- */
-private data class FKeyDef(val n: Int, val label: StringResource, val done: Boolean)
-
-private val FKEY_LABELS = listOf(
-    FKeyDef(2, Res.string.ftail_fkey_rename, done = true),
-    FKeyDef(3, Res.string.ftail_fkey_view, done = false),
-    FKeyDef(4, Res.string.ftail_fkey_edit, done = false),
-    FKeyDef(5, Res.string.ftail_fkey_copy, done = true),
-    FKeyDef(6, Res.string.ftail_fkey_move, done = true),
-    FKeyDef(7, Res.string.ftail_fkey_mkdir, done = true),
-    FKeyDef(8, Res.string.ftail_fkey_delete, done = true),
-    FKeyDef(9, Res.string.ftail_fkey_refresh, done = true),
-    FKeyDef(10, Res.string.ftail_fkey_quit, done = true),
+/** The file panel's own key legend (mc/Total Commander order, adapted for Skerry). */
+private val PANEL_FKEYS = listOf(
+    FKeyDef(2, Res.string.ftail_fkey_rename),
+    FKeyDef(3, Res.string.ftail_fkey_view),
+    FKeyDef(4, Res.string.ftail_fkey_edit),
+    FKeyDef(5, Res.string.ftail_fkey_copy),
+    FKeyDef(6, Res.string.ftail_fkey_move),
+    FKeyDef(7, Res.string.ftail_fkey_mkdir),
+    FKeyDef(8, Res.string.ftail_fkey_delete),
+    FKeyDef(9, Res.string.ftail_fkey_refresh),
+    FKeyDef(10, Res.string.ftail_fkey_quit),
 )
-
-/**
- * Bottom hotkey bar (mc/Total Commander): a row of cells "F3 View … F10 Quit". Both a cell click and an
- * F-key press go through the shared [onKey]. [enabled] disables the bar until the SFTP coordinator is open.
- */
-@Composable
-private fun FKeyBar(enabled: Boolean, onKey: (Int) -> Unit, mono: FontFamily) {
-    Row(
-        Modifier.fillMaxWidth().background(D.surface2).padding(horizontal = 6.dp, vertical = 5.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        FKEY_LABELS.forEach { def ->
-            FKeyCell(def, enabled, mono, onClick = { onKey(def.n) }, modifier = Modifier.weight(1f))
-        }
-    }
-}
-
-@Composable
-private fun FKeyCell(
-    def: FKeyDef,
-    enabled: Boolean,
-    mono: FontFamily,
-    onClick: () -> Unit,
-    modifier: Modifier,
-) {
-    Row(
-        modifier
-            .clip(RoundedCornerShape(4.dp))
-            .background(D.panel)
-            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, enabled = enabled, onClick = onClick)
-            .padding(horizontal = 8.dp, vertical = 5.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(5.dp),
-    ) {
-        Txt("F${def.n}", color = if (enabled) D.cyanBright else D.faint, size = 10.5.sp, weight = FontWeight.SemiBold, font = mono)
-        Txt(
-            stringResource(def.label),
-            color = if (enabled) D.text else D.faint,
-            size = 11.sp,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
-        // "*" marks a non-working stub (F3 View / F4 Edit).
-        if (!def.done) Txt("*", color = D.sunset, size = 11.sp, weight = FontWeight.SemiBold)
-    }
-}
 
 /**
  * One live pane over [FilePaneController]: header [label] + path (no toolbar — up-navigation via the

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -1,6 +1,6 @@
 package app.skerry.ui.connection
 
-import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntry
@@ -721,7 +721,7 @@ private class RecordingSftpClient : SftpClient {
     override suspend fun list(path: String): List<SftpEntry> = emptyList()
     override suspend fun stat(path: String): SftpEntry? = null
     override suspend fun realpath(path: String): String = "/"
-    override suspend fun read(path: String): ByteArray = ByteArray(0)
+    override suspend fun read(path: String, maxBytes: Long): ByteArray = ByteArray(0)
     override suspend fun write(path: String, data: ByteArray) = Unit
     override suspend fun download(remotePath: String, localPath: String, onProgress: SftpProgress) = Unit
     override suspend fun upload(localPath: String, remotePath: String, onProgress: SftpProgress) = Unit
@@ -735,13 +735,16 @@ private class RecordingSftpClient : SftpClient {
 }
 
 /** Local file browser stub for the coordinator's left pane: only identity matters. */
-private class FakeFileBrowser : FileBrowser {
+private class FakeFileBrowser : FileContentBrowser {
     override val label: String = "local"
     override suspend fun realpath(path: String): String = "/"
     override suspend fun list(path: String): List<FileItem> = emptyList()
     override suspend fun mkdir(path: String) = Unit
     override suspend fun delete(item: FileItem) = Unit
     override suspend fun rename(from: String, to: String) = Unit
+    override suspend fun stat(path: String): FileItem? = null
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray = ByteArray(0)
+    override suspend fun writeFile(path: String, data: ByteArray) = Unit
 }
 
 /** Counts openShell calls — verifies a repeated connect doesn't open a second shell. */

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditControllerTest.kt
@@ -1,0 +1,336 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileContentBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val PATH = "/etc/nginx/nginx.conf"
+
+/**
+ * Editor controller tests over an in-memory [FakeContentBrowser]. [UnconfinedTestDispatcher] runs
+ * the controller's launches immediately, so state is settled after [advanceUntilIdle].
+ */
+class FileEditControllerTest {
+
+    private val browser = FakeContentBrowser()
+    private var savedCount = 0
+
+    private fun TestScope.opened(
+        content: ByteArray = "server {\n}\n".encodeToByteArray(),
+        readOnly: Boolean = false,
+        size: Long = content.size.toLong(),
+        modified: Long = 100,
+    ): FileEditController {
+        browser.contents[PATH] = content
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, size, modified)
+        val c = FileEditController(
+            source = browser,
+            item = FileItem("nginx.conf", PATH, FileItemType.File, size, modified),
+            readOnly = readOnly,
+            scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler)),
+            onSaved = { savedCount++ },
+        )
+        c.open()
+        advanceUntilIdle()
+        return c
+    }
+
+    @Test
+    fun `open loads the file into a clean buffer`() = runTest {
+        val c = opened()
+
+        assertEquals("server {\n}\n", assertIs<FileEditState.Ready>(c.state).text)
+        assertFalse(c.dirty)
+        assertEquals("nginx.conf", c.name)
+    }
+
+    @Test
+    fun `editing marks the buffer dirty and returning to the original clears it`() = runTest {
+        val c = opened()
+
+        c.edit("server { }\n")
+        assertTrue(c.dirty)
+
+        c.edit("server {\n}\n")
+        assertFalse(c.dirty)
+    }
+
+    @Test
+    fun `save writes the buffer and clears dirty`() = runTest {
+        val c = opened()
+
+        c.edit("worker_processes 4;\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals("worker_processes 4;\n", browser.contents.getValue(PATH).decodeToString())
+        assertFalse(c.dirty)
+        assertEquals(1, savedCount)
+        assertNull(c.saveFailure)
+    }
+
+    @Test
+    fun `save is a no-op with an unchanged buffer`() = runTest {
+        val c = opened()
+
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals(0, browser.writes)
+        assertEquals(0, savedCount)
+    }
+
+    @Test
+    fun `a read-only editor never writes`() = runTest {
+        val c = opened(readOnly = true)
+
+        c.edit("tampered")
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals(0, browser.writes)
+        assertEquals("server {\n}\n", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `CRLF line endings are normalized for editing and restored on save`() = runTest {
+        val c = opened(content = "a\r\nb\r\n".encodeToByteArray())
+
+        // The buffer the user sees has no stray \r — Compose text fields don't handle them.
+        assertEquals("a\nb\n", assertIs<FileEditState.Ready>(c.state).text)
+
+        c.edit("a\nb\nc\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals("a\r\nb\r\nc\r\n", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `LF line endings are kept as-is`() = runTest {
+        val c = opened(content = "a\nb\n".encodeToByteArray())
+
+        c.edit("a\nb\nc\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals("a\nb\nc\n", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `a file with NUL bytes is refused as binary`() = runTest {
+        val c = opened(content = byteArrayOf(0x7F, 0x45, 0x4C, 0x46, 0x00, 0x01))
+
+        assertEquals(FileEditFailure.Binary, assertIs<FileEditState.Failed>(c.state).failure)
+    }
+
+    @Test
+    fun `a file that is not valid UTF-8 is refused as binary`() = runTest {
+        // Lone 0xFF: decoding it leniently would silently replace bytes and corrupt the file on save.
+        val c = opened(content = byteArrayOf(0x61, 0xFF.toByte(), 0x62))
+
+        assertEquals(FileEditFailure.Binary, assertIs<FileEditState.Failed>(c.state).failure)
+    }
+
+    @Test
+    fun `a file over the cap is refused`() = runTest {
+        browser.failure = FileBrowserFailure.TooLarge
+        val c = opened()
+
+        assertEquals(FileEditFailure.TooLarge, assertIs<FileEditState.Failed>(c.state).failure)
+    }
+
+    @Test
+    fun `a read error is surfaced as a failed state`() = runTest {
+        browser.failure = FileBrowserFailure.Sftp
+        val c = opened()
+
+        assertEquals(FileEditFailure.Read, assertIs<FileEditState.Failed>(c.state).failure)
+    }
+
+    @Test
+    fun `a write error keeps the buffer and reports the failure`() = runTest {
+        val c = opened()
+        c.edit("changed\n")
+        browser.failure = FileBrowserFailure.Sftp
+
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals(FileEditFailure.Write, c.saveFailure)
+        assertEquals("changed\n", assertIs<FileEditState.Ready>(c.state).text)
+        assertTrue(c.dirty)
+        assertEquals(0, savedCount)
+    }
+
+    @Test
+    fun `a file changed underneath the editor raises a conflict instead of overwriting`() = runTest {
+        val c = opened()
+        c.edit("changed\n")
+        // Someone else wrote the file while it was open.
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, 999, 500)
+
+        c.save()
+        advanceUntilIdle()
+
+        assertTrue(c.conflict)
+        assertEquals(0, browser.writes)
+        assertEquals("server {\n}\n", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `confirming a conflict overwrites the file`() = runTest {
+        val c = opened()
+        c.edit("changed\n")
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, 999, 500)
+        c.save()
+        advanceUntilIdle()
+
+        c.confirmOverwrite()
+        advanceUntilIdle()
+
+        assertFalse(c.conflict)
+        assertEquals("changed\n", browser.contents.getValue(PATH).decodeToString())
+        assertFalse(c.dirty)
+    }
+
+    @Test
+    fun `dismissing a conflict leaves the file and the buffer untouched`() = runTest {
+        val c = opened()
+        c.edit("changed\n")
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, 999, 500)
+        c.save()
+        advanceUntilIdle()
+
+        c.dismissConflict()
+
+        assertFalse(c.conflict)
+        assertEquals(0, browser.writes)
+        assertEquals("changed\n", assertIs<FileEditState.Ready>(c.state).text)
+        assertTrue(c.dirty)
+    }
+
+    @Test
+    fun `a second save after a successful one sees the new baseline and does not conflict`() = runTest {
+        val c = opened()
+
+        c.edit("one\n")
+        c.save()
+        advanceUntilIdle()
+        c.edit("two\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertFalse(c.conflict)
+        assertEquals("two\n", browser.contents.getValue(PATH).decodeToString())
+        assertEquals(2, savedCount)
+    }
+
+    @Test
+    fun `classic Mac CR line endings are normalized for editing and restored on save`() = runTest {
+        val c = opened(content = "a\rb\r".encodeToByteArray())
+
+        assertEquals("a\nb\n", assertIs<FileEditState.Ready>(c.state).text)
+
+        c.edit("a\nb\nc\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertEquals("a\rb\rc\r", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `a buffer with mixed endings is not left with stray carriage returns`() = runTest {
+        val c = opened(content = "a\r\nb\nc\r".encodeToByteArray())
+
+        assertEquals("a\nb\nc\n", assertIs<FileEditState.Ready>(c.state).text)
+    }
+
+    @Test
+    fun `editing is ignored while a conflict is awaiting confirmation`() = runTest {
+        val c = opened()
+        c.edit("mine\n")
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, 999, 500)
+        c.save()
+        advanceUntilIdle()
+
+        c.edit("typed into the buffer behind the dialog\n")
+
+        // The pending write is of the buffer as it was when the conflict was raised.
+        assertEquals("mine\n", assertIs<FileEditState.Ready>(c.state).text)
+        c.confirmOverwrite()
+        advanceUntilIdle()
+        assertEquals("mine\n", browser.contents.getValue(PATH).decodeToString())
+    }
+
+    @Test
+    fun `a failed stat after saving keeps conflict detection armed`() = runTest {
+        val c = opened()
+        c.edit("one\n")
+        browser.statFails = true
+        c.save()
+        advanceUntilIdle()
+        browser.statFails = false
+
+        // The file changed on the source afterwards: the next save must still stop and ask.
+        browser.stats[PATH] = FileItem("nginx.conf", PATH, FileItemType.File, 4242, 777)
+        c.edit("two\n")
+        c.save()
+        advanceUntilIdle()
+
+        assertTrue(c.conflict)
+        assertEquals("one\n", browser.contents.getValue(PATH).decodeToString())
+    }
+}
+
+/** In-memory [FileContentBrowser]; navigation isn't exercised by the editor. */
+private class FakeContentBrowser : FileContentBrowser, FileBrowser {
+    override val label = "prod-web-01"
+    val contents = mutableMapOf<String, ByteArray>()
+    val stats = mutableMapOf<String, FileItem>()
+    var writes = 0
+
+    /** When set, the next read/write fails with this reason. */
+    var failure: FileBrowserFailure? = null
+
+    /** When set, [stat] fails — the editor must not lose its conflict baseline over it. */
+    var statFails = false
+
+    override suspend fun realpath(path: String) = path
+    override suspend fun list(path: String): List<FileItem> = emptyList()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+
+    override suspend fun stat(path: String): FileItem? {
+        if (statFails) throw FileBrowserException(FileBrowserFailure.Sftp)
+        return stats[path]
+    }
+
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray {
+        failure?.let { throw FileBrowserException(it) }
+        return contents[path] ?: throw FileBrowserException(FileBrowserFailure.Sftp)
+    }
+
+    override suspend fun writeFile(path: String, data: ByteArray) {
+        failure?.let { throw FileBrowserException(it) }
+        writes++
+        contents[path] = data
+        // A real source bumps mtime/size on write; the editor must re-baseline on it.
+        stats[path] = FileItem(path.substringAfterLast('/'), path, FileItemType.File, data.size.toLong(), 900)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditorSearchTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditorSearchTest.kt
@@ -1,0 +1,41 @@
+package app.skerry.ui.files
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** F7 search in the built-in editor: match order, wrap-around, and what never matches. */
+class FileEditorSearchTest {
+
+    private val text = "server {\n  listen 443;\n  server_name skerry.app;\n}\n"
+
+    @Test
+    fun `finds the first match at or after the caret`() {
+        assertEquals(0 until 6, findNextMatch(text, "server", from = 0))
+        assertEquals(text.indexOf("server_name") until text.indexOf("server_name") + 6, findNextMatch(text, "server", from = 6))
+    }
+
+    @Test
+    fun `wraps around to the start after the last match`() {
+        val last = text.indexOf("server_name")
+
+        assertEquals(0 until 6, findNextMatch(text, "server", from = last + 1))
+    }
+
+    @Test
+    fun `matching ignores case`() {
+        val listen = text.indexOf("listen")
+        assertEquals(listen until listen + 6, findNextMatch(text, "LISTEN", from = 0))
+    }
+
+    @Test
+    fun `a missing needle and a blank query do not match`() {
+        assertNull(findNextMatch(text, "nginx", from = 0))
+        assertNull(findNextMatch(text, "", from = 0))
+    }
+
+    @Test
+    fun `a caret past the end is clamped instead of failing`() {
+        assertEquals(0 until 6, findNextMatch(text, "server", from = text.length + 100))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -9,6 +9,7 @@ import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sftp.UploadSource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -16,7 +17,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private const val LHOME = "/local/home"
@@ -409,5 +412,82 @@ class TransferCoordinatorTest {
         // The library text ("disk full") never reaches the bar — only the typed reason does.
         val failed = assertIs<TransferState.Failed>(r.coordinator.transfer)
         assertEquals(FileTransferFailure.Transfer, failed.failure)
+    }
+
+    @Test
+    fun `openEditor loads the cursored remote file through the pane's source`() = runTest {
+        val remote = remoteFake().apply { seedContent("$RHOME/nginx.conf", "server {}\n") }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+
+        val editor = r.coordinator.openEditor(fromLocal = false, item = r.remote.entry("nginx.conf"), readOnly = false)
+        advanceUntilIdle()
+
+        assertNotNull(editor)
+        assertEquals("server {}\n", (editor.state as FileEditState.Ready).text)
+    }
+
+    @Test
+    fun `openEditor rebuilds the path from the pane directory instead of the listing path`() = runTest {
+        // A hostile server can put any path in a listing entry; the editor must read (and later
+        // write) the file under the directory actually being browsed.
+        val remote = remoteFake().apply {
+            seedContent("$RHOME/nginx.conf", "real\n")
+            seedDir("/etc")
+            seedContent("/etc/shadow", "secret\n")
+        }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+        val forged = r.remote.entry("nginx.conf").copy(path = "/etc/shadow")
+        remote.contentCalls.clear()
+
+        val editor = r.coordinator.openEditor(fromLocal = false, item = forged, readOnly = false)
+        advanceUntilIdle()
+
+        assertEquals("real\n", (editor!!.state as FileEditState.Ready).text)
+        assertTrue(remote.contentCalls.none { it.endsWith("/etc/shadow") }, "must not touch the forged path")
+
+        editor.edit("changed\n")
+        editor.save()
+        advanceUntilIdle()
+
+        assertEquals("changed\n", remote.contentOf("$RHOME/nginx.conf"))
+        assertEquals("secret\n", remote.contentOf("/etc/shadow"))
+    }
+
+    @Test
+    fun `openEditor refuses a listing entry whose name is not a plain path component`() = runTest {
+        val r = rig()
+        val hostile = r.remote.entry("r.txt").copy(name = "../../etc/shadow")
+
+        assertNull(r.coordinator.openEditor(fromLocal = false, item = hostile, readOnly = false))
+    }
+
+    @Test
+    fun `awaitEditorWrites suspends until the editor's save has finished`() = runTest {
+        // Session teardown closes the SFTP channel; an editor save runs on the session scope and
+        // outlives the editor UI, so the close must wait — an interrupted write truncates the file.
+        val remote = remoteFake().apply { seedContent("$RHOME/nginx.conf", "before\n") }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+        val editor = r.coordinator.openEditor(fromLocal = false, item = r.remote.entry("nginx.conf"), readOnly = false)!!
+        advanceUntilIdle()
+        editor.edit("after\n")
+        remote.writeGate = CompletableDeferred()
+
+        editor.save()
+        advanceUntilIdle()
+
+        var released = false
+        val waiter = scope().launch { r.coordinator.awaitEditorWrites(); released = true }
+        advanceUntilIdle()
+        assertFalse(released, "teardown must not proceed while a save is in flight")
+
+        remote.writeGate!!.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(released)
+        assertEquals("after\n", remote.contentOf("$RHOME/nginx.conf"))
+        waiter.cancel()
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.CompletableDeferred
 /**
  * In-memory [SftpClient] for panel controller tests: models a directory/file tree with POSIX
  * path semantics (`.`/`..` normalization, `/` separator). Covers the operations the panel calls
- * ([list]/[realpath]/[stat]/[mkdir]/[rmdir]/[remove]/[rename]); [read]/[write] are stubs (the
- * directory panel controller doesn't use download/upload). Not thread-safe; tests run it on a
- * single test dispatcher.
+ * ([list]/[realpath]/[stat]/[mkdir]/[rmdir]/[remove]/[rename]) plus whole-file [read]/[write] over
+ * an in-memory content map (seeded with [seedContent]). Not thread-safe; tests run it on a single
+ * test dispatcher.
  *
  * Seeded via [seedDir]/[seedFile] after construction; the start directory [startDir] exists
  * immediately (init creates it and its ancestors), and [realpath] of `.` resolves to it.
@@ -54,9 +54,42 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
 
     override suspend fun realpath(path: String): String = realpathSync(path)
 
-    override suspend fun read(path: String): ByteArray = throw UnsupportedOperationException()
+    /** File contents for [read]/[write]; a seeded file with no content reads as empty. */
+    private val contents = mutableMapOf<String, ByteArray>()
 
-    override suspend fun write(path: String, data: ByteArray): Unit = throw UnsupportedOperationException()
+    /** Paths passed to [read]/[write], in order — for asserting which file an editor touched. */
+    val contentCalls = mutableListOf<String>()
+
+    /** Seeds [path] with [text] (and registers the file), for whole-file read tests. */
+    fun seedContent(path: String, text: String) {
+        val norm = realpathSync(path)
+        val bytes = text.encodeToByteArray()
+        seedFile(norm, size = bytes.size.toLong())
+        contents[norm] = bytes
+    }
+
+    /** Current content of [path], as written by [write]. */
+    fun contentOf(path: String): String? = contents[realpathSync(path)]?.decodeToString()
+
+    override suspend fun read(path: String, maxBytes: Long): ByteArray {
+        val norm = realpathSync(path)
+        contentCalls += "read:$norm"
+        val entry = children[parentOf(norm)]?.get(nameOf(norm)) ?: throw SftpException("No file $path")
+        if (entry.type == SftpEntryType.Directory) throw SftpException("$path is a directory, not a file")
+        return contents[norm] ?: ByteArray(0)
+    }
+
+    /** When set, [write] blocks until it completes — lets a test observe a save in flight. */
+    var writeGate: CompletableDeferred<Unit>? = null
+
+    override suspend fun write(path: String, data: ByteArray) {
+        writeGate?.await()
+        val norm = realpathSync(path)
+        contentCalls += "write:$norm"
+        if (children[parentOf(norm)] == null) throw SftpException("No parent for $path")
+        contents[norm] = data
+        seedFile(norm, size = data.size.toLong())
+    }
 
     /** Last download call: (remotePath, localPath). For controller test assertions. */
     var lastDownload: Pair<String, String>? = null

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -5,7 +5,21 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.unit.Density
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.files.FileContentBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
 import app.skerry.shared.host.Host
+import app.skerry.ui.design.D
+import app.skerry.ui.files.FileEditController
+import app.skerry.ui.files.FileEditorScreen
 import app.skerry.shared.host.HostStore
 import app.skerry.ui.terminal.TerminalThemes
 import app.skerry.shared.sftp.SftpClient
@@ -175,6 +189,9 @@ fun main() {
         "unlock" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopUnlockScreen(error = null, canUseBiometric = true, onUnlock = {}, onBiometric = {}, onForgotPassword = {}) } } } }
         "corrupted" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopCorruptedScreen(onReset = {}) } } } }
         "reset" -> { { GateScreenPreview { LockWindowChrome(windowChrome) { DesktopResetScreen(onConfirm = {}, onCancel = {}) } } } }
+        // The F4 editor is a modal opened by a key press, which an offscreen render can't send, and
+        // a Dialog has no platform layer here — so its card ([FileEditorPanel]) is rendered directly.
+        "editor" -> { { GateScreenPreview { EditorPreview() } } }
         else -> { { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions, knownHosts = knownHosts, credentials = credentials, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, ai = ai, updates = updates, windowChrome = windowChrome) } }
     }
 
@@ -292,6 +309,44 @@ private fun seedFakeHome() {
 }
 
 /** Design font provider for standalone screen renders, bypassing [DesktopDesignApp]. */
+/** Canned nginx.conf for the [FileEditorPanel] preview, over an in-memory source. */
+@Composable
+private fun EditorPreview() {
+    val scope = rememberCoroutineScope()
+    val controller = remember {
+        val text = """
+            server {
+                listen 443 ssl http2;
+                server_name skerry.app;
+
+                ssl_certificate     /etc/letsencrypt/live/skerry.app/fullchain.pem;
+                ssl_certificate_key /etc/letsencrypt/live/skerry.app/privkey.pem;
+
+                location / {
+                    proxy_pass http://127.0.0.1:8080;
+                    proxy_set_header Host ${'$'}host;
+                }
+            }
+        """.trimIndent()
+        val item = FileItem("nginx.conf", "/etc/nginx/sites-enabled/nginx.conf", FileItemType.File, text.length.toLong(), 0)
+        FileEditController(PreviewFileSource(item, text), item, readOnly = false, scope = scope).also { it.open() }
+    }
+    FileEditorScreen(controller, onClose = {}, modifier = Modifier.fillMaxSize())
+}
+
+/** In-memory single-file source for [EditorPreview]. */
+private class PreviewFileSource(private val item: FileItem, private val text: String) : FileContentBrowser {
+    override val label = "prod-web-01"
+    override suspend fun realpath(path: String) = path
+    override suspend fun list(path: String): List<FileItem> = emptyList()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+    override suspend fun stat(path: String): FileItem = item
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray = text.encodeToByteArray()
+    override suspend fun writeFile(path: String, data: ByteArray) = Unit
+}
+
 @Composable
 private fun GateScreenPreview(body: @Composable () -> Unit) {
     val fonts = DesignFonts(
@@ -694,7 +749,7 @@ private class FakeSftpClient : SftpClient {
     override suspend fun list(path: String): List<SftpEntry> = listing
     override suspend fun stat(path: String): SftpEntry? = null
     override suspend fun realpath(path: String): String = "/var/www"
-    override suspend fun read(path: String): ByteArray = ByteArray(0)
+    override suspend fun read(path: String, maxBytes: Long): ByteArray = ByteArray(0)
     override suspend fun write(path: String, data: ByteArray) = Unit
     override suspend fun download(remotePath: String, localPath: String, onProgress: SftpProgress) = Unit
     override suspend fun upload(localPath: String, remotePath: String, onProgress: SftpProgress) = Unit

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/files/PlatformLocalBrowser.desktop.kt
@@ -1,6 +1,6 @@
 package app.skerry.ui.files
 
-import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.LocalFileBrowser
 import kotlinx.coroutines.Dispatchers
 import okio.FileSystem
@@ -9,7 +9,7 @@ import okio.FileSystem
  * Desktop: real local filesystem via okio, starting in the user's home directory. The label is left
  * blank on purpose — the UI substitutes the localized `ftail_local_label` (parity with Android).
  */
-actual fun platformLocalBrowser(): FileBrowser =
+actual fun platformLocalBrowser(): FileContentBrowser =
     LocalFileBrowser(
         fileSystem = FileSystem.SYSTEM,
         home = System.getProperty("user.home") ?: "/",

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
@@ -65,6 +65,37 @@ interface FileBrowser {
 }
 
 /**
+ * A [FileBrowser] that can also read and write a whole file — what the built-in viewer/editor
+ * (F3/F4) needs on top of navigation. Split from [FileBrowser] because the panel controller works
+ * with navigation alone; both production sources (local FS and SFTP) implement this.
+ */
+interface FileContentBrowser : FileBrowser {
+
+    /**
+     * Metadata for one object, or `null` if [path] doesn't exist. Used to detect a file changed
+     * underneath the editor (size/mtime) before overwriting it.
+     * @throws FileBrowserException if the source can't be queried at all (connection/access)
+     */
+    suspend fun stat(path: String): FileItem?
+
+    /**
+     * Reads file [path] entirely into memory, refusing anything over [maxBytes]
+     * ([FileBrowserFailure.TooLarge]). The cap is checked against the reported size *and* the bytes
+     * actually read, so a source understating the size can't blow up memory.
+     * @throws FileBrowserException if the path is missing, is a directory, access is denied, or the file is too large
+     */
+    suspend fun readFile(path: String, maxBytes: Long): ByteArray
+
+    /**
+     * Writes [data] to file [path], creating or truncating it in place (the parent must exist).
+     * In place, not write-to-temp-and-rename: the inode survives, so permissions/owner/hard links
+     * are preserved and SFTP servers that refuse `rename` onto an existing path still work.
+     * @throws FileBrowserException if access is denied, the parent is missing, or [path] is a directory
+     */
+    suspend fun writeFile(path: String, data: ByteArray)
+}
+
+/**
  * Typed, user-facing reason for a [FileBrowserException]. The UI maps it to a localized string;
  * platform text (okio/sshj/OS) is never shown as the primary message.
  */
@@ -83,6 +114,9 @@ enum class FileBrowserFailure {
 
     /** The chosen save target could not be opened for writing. */
     OpenTarget,
+
+    /** The file is larger than the caller's cap (whole-file read for the viewer/editor). */
+    TooLarge,
 }
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/LocalFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/LocalFileBrowser.kt
@@ -20,7 +20,7 @@ class LocalFileBrowser(
     private val home: String,
     override val label: String,
     private val ioDispatcher: CoroutineDispatcher,
-) : FileBrowser {
+) : FileContentBrowser {
 
     /** Path normalization is pure (no I/O), so it doesn't run on [ioDispatcher]. */
     override suspend fun realpath(path: String): String =
@@ -53,6 +53,38 @@ class LocalFileBrowser(
 
     override suspend fun rename(from: String, to: String): Unit = io {
         fileSystem.atomicMove(from.toPath(), to.toPath())
+    }
+
+    override suspend fun stat(path: String): FileItem? = io {
+        val p = path.toPath()
+        fileSystem.metadataOrNull(p)?.let { md ->
+            FileItem(
+                name = p.name,
+                path = p.toString(),
+                type = md.toItemType(),
+                size = md.size ?: 0L,
+                modifiedEpochSeconds = (md.lastModifiedAtMillis ?: 0L) / 1000L,
+            )
+        }
+    }
+
+    /** The size is checked before opening the file, so an oversized one is never read into memory. */
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray = io {
+        val p = path.toPath()
+        val size = fileSystem.metadataOrNull(p)?.size
+        if (size != null && size > maxBytes) {
+            throw FileBrowserException(FileBrowserFailure.TooLarge, detail = "$size > $maxBytes")
+        }
+        val data = fileSystem.read(p) { readByteArray() }
+        // Size unreported (or the file grew between the check and the read) — enforce the cap on the bytes.
+        if (data.size > maxBytes) {
+            throw FileBrowserException(FileBrowserFailure.TooLarge, detail = "${data.size} > $maxBytes")
+        }
+        data
+    }
+
+    override suspend fun writeFile(path: String, data: ByteArray): Unit = io {
+        fileSystem.write(path.toPath()) { write(data) }
     }
 
     /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
@@ -15,7 +15,7 @@ import app.skerry.shared.sftp.SftpException
 class SftpFileBrowser(
     private val sftp: SftpClient,
     override val label: String,
-) : FileBrowser {
+) : FileContentBrowser {
 
     override suspend fun realpath(path: String): String = guard { sftp.realpath(path) }
 
@@ -58,6 +58,28 @@ class SftpFileBrowser(
     }
 
     override suspend fun rename(from: String, to: String): Unit = guard { sftp.rename(from, to) }
+
+    override suspend fun stat(path: String): FileItem? = guard { sftp.stat(path)?.toFileItem() }
+
+    /**
+     * The server's reported size is checked first, so an oversized file is never fetched, and the cap
+     * is passed down to [SftpClient.read] which also enforces it while streaming — the size is
+     * server-controlled, so a missing/understated one must not turn into an unbounded allocation.
+     * The final check on the returned bytes covers a client that ignores the limit.
+     */
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray = guard {
+        val reported = sftp.stat(path)?.size
+        if (reported != null && reported > maxBytes) {
+            throw FileBrowserException(FileBrowserFailure.TooLarge, detail = "$reported > $maxBytes")
+        }
+        val data = sftp.read(path, maxBytes)
+        if (data.size > maxBytes) {
+            throw FileBrowserException(FileBrowserFailure.TooLarge, detail = "${data.size} > $maxBytes")
+        }
+        data
+    }
+
+    override suspend fun writeFile(path: String, data: ByteArray): Unit = guard { sftp.write(path, data) }
 
     private suspend fun <T> guard(block: suspend () -> T): T =
         try {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sftp/SftpClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sftp/SftpClient.kt
@@ -32,10 +32,12 @@ interface SftpClient {
     suspend fun realpath(path: String): String
 
     /**
-     * Reads file [path] entirely into memory (small files only).
-     * @throws SftpException path doesn't exist, is a directory, or lacks permission
+     * Reads file [path] entirely into memory (small files only), refusing anything over [maxBytes].
+     * The limit is enforced while streaming, not just against the size the server reports: a server
+     * is free to understate the size (or report `0`, as special files do) and then keep sending.
+     * @throws SftpException path doesn't exist, is a directory, lacks permission, or exceeds [maxBytes]
      */
-    suspend fun read(path: String): ByteArray
+    suspend fun read(path: String, maxBytes: Long = SFTP_MAX_READ_BYTES): ByteArray
 
     /**
      * Writes [data] to file [path], creating or truncating it. The parent directory must exist.
@@ -122,6 +124,12 @@ data class SftpEntry(
     val modifiedEpochSeconds: Long,
     val permissions: Int,
 )
+
+/**
+ * Default whole-file read cap ([SftpClient.read]), 64 MiB: a backstop against reading a huge file
+ * into memory when the caller doesn't set its own, smaller limit.
+ */
+const val SFTP_MAX_READ_BYTES: Long = 64L * 1024 * 1024
 
 /** SFTP operation error: missing path/permission, wrong object type, or channel failure. */
 class SftpException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/LocalFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/LocalFileBrowserTest.kt
@@ -127,4 +127,60 @@ class LocalFileBrowserTest {
 
         assertFailsWith<FileBrowserException> { browser().delete(item) }
     }
+
+    @Test
+    fun `stat returns metadata for a file and null for a missing path`() = runTest {
+        fs.createDirectories("/dir".toPath())
+        fs.write("/dir/a.txt".toPath()) { writeUtf8("hello") }
+
+        val item = browser().stat("/dir/a.txt")
+
+        assertEquals("a.txt", item?.name)
+        assertEquals("/dir/a.txt", item?.path)
+        assertEquals(5, item?.size)
+        assertEquals(FileItemType.File, item?.type)
+        assertNull(browser().stat("/dir/missing"))
+    }
+
+    @Test
+    fun `readFile returns the file bytes`() = runTest {
+        fs.createDirectories("/dir".toPath())
+        fs.write("/dir/a.txt".toPath()) { writeUtf8("hello") }
+
+        assertEquals("hello", browser().readFile("/dir/a.txt", maxBytes = 1024).decodeToString())
+    }
+
+    @Test
+    fun `readFile refuses a file larger than the cap`() = runTest {
+        fs.createDirectories("/dir".toPath())
+        fs.write("/dir/big.log".toPath()) { write(ByteArray(5_000)) }
+
+        val e = assertFailsWith<FileBrowserException> { browser().readFile("/dir/big.log", maxBytes = 1024) }
+
+        assertEquals(FileBrowserFailure.TooLarge, e.failure)
+    }
+
+    @Test
+    fun `readFile of a missing path throws FileBrowserException`() = runTest {
+        val e = assertFailsWith<FileBrowserException> { browser().readFile("/dir/nope", maxBytes = 1024) }
+
+        assertEquals(FileBrowserFailure.LocalIo, e.failure)
+    }
+
+    @Test
+    fun `writeFile creates and truncates the file`() = runTest {
+        fs.createDirectories("/dir".toPath())
+        fs.write("/dir/a.txt".toPath()) { writeUtf8("a longer previous content") }
+
+        browser().writeFile("/dir/a.txt", "new".encodeToByteArray())
+
+        assertEquals("new", fs.read("/dir/a.txt".toPath()) { readUtf8() })
+    }
+
+    @Test
+    fun `writeFile into a missing directory throws FileBrowserException`() = runTest {
+        val e = assertFailsWith<FileBrowserException> { browser().writeFile("/nope/a.txt", ByteArray(1)) }
+
+        assertEquals(FileBrowserFailure.LocalIo, e.failure)
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -114,6 +115,56 @@ class SftpFileBrowserTest {
     }
 
     @Test
+    fun `stat maps an entry and reports a missing path as null`() = runTest {
+        client.stats["/d/a.txt"] = SftpEntry("a.txt", "/d/a.txt", SftpEntryType.File, 42, 200, 0)
+
+        val item = browser().stat("/d/a.txt")
+
+        assertEquals("a.txt", item?.name)
+        assertEquals(42, item?.size)
+        assertEquals(200, item?.modifiedEpochSeconds)
+        assertEquals(FileItemType.File, item?.type)
+        assertNull(browser().stat("/d/missing"))
+    }
+
+    @Test
+    fun `readFile returns the file bytes`() = runTest {
+        client.contents["/d/a.txt"] = "hello".encodeToByteArray()
+
+        assertEquals("hello", browser().readFile("/d/a.txt", maxBytes = 1024).decodeToString())
+    }
+
+    @Test
+    fun `readFile refuses a file larger than the cap without reading it`() = runTest {
+        client.stats["/d/big.log"] = SftpEntry("big.log", "/d/big.log", SftpEntryType.File, 5_000, 0, 0)
+        client.contents["/d/big.log"] = ByteArray(5_000)
+
+        val e = assertFailsWith<FileBrowserException> { browser().readFile("/d/big.log", maxBytes = 1024) }
+
+        assertEquals(FileBrowserFailure.TooLarge, e.failure)
+        assertFalse("read:/d/big.log" in client.calls)
+    }
+
+    @Test
+    fun `readFile refuses oversized content even when the server understated the size`() = runTest {
+        // A server may report any size it likes: the cap must also hold against the bytes actually read.
+        client.stats["/d/liar"] = SftpEntry("liar", "/d/liar", SftpEntryType.File, 1, 0, 0)
+        client.contents["/d/liar"] = ByteArray(5_000)
+
+        val e = assertFailsWith<FileBrowserException> { browser().readFile("/d/liar", maxBytes = 1024) }
+
+        assertEquals(FileBrowserFailure.TooLarge, e.failure)
+    }
+
+    @Test
+    fun `writeFile is delegated`() = runTest {
+        browser().writeFile("/d/a.txt", "new".encodeToByteArray())
+
+        assertTrue("write:/d/a.txt" in client.calls)
+        assertEquals("new", client.contents["/d/a.txt"]?.decodeToString())
+    }
+
+    @Test
     fun `sftp errors are wrapped in FileBrowserException`() = runTest {
         client.failList = true
 
@@ -136,6 +187,8 @@ private class RecordingSftp : SftpClient {
     val calls = mutableListOf<String>()
     var listResult: List<SftpEntry> = emptyList()
     val listings = mutableMapOf<String, List<SftpEntry>>()
+    val stats = mutableMapOf<String, SftpEntry>()
+    val contents = mutableMapOf<String, ByteArray>()
     var failList = false
     var cancelList = false
 
@@ -146,14 +199,25 @@ private class RecordingSftp : SftpClient {
         return listings[path] ?: listResult
     }
 
-    override suspend fun stat(path: String): SftpEntry? = null
+    override suspend fun stat(path: String): SftpEntry? {
+        calls += "stat:$path"
+        return stats[path] ?: contents[path]?.let { SftpEntry(path.substringAfterLast('/'), path, SftpEntryType.File, it.size.toLong(), 0, 0) }
+    }
+
     override suspend fun realpath(path: String): String {
         calls += "realpath:$path"
         return "/resolved$path"
     }
 
-    override suspend fun read(path: String): ByteArray = ByteArray(0)
-    override suspend fun write(path: String, data: ByteArray) {}
+    override suspend fun read(path: String, maxBytes: Long): ByteArray {
+        calls += "read:$path"
+        return contents[path] ?: throw SftpException("No file $path")
+    }
+
+    override suspend fun write(path: String, data: ByteArray) {
+        calls += "write:$path"
+        contents[path] = data
+    }
     override suspend fun download(remotePath: String, localPath: String, onProgress: SftpProgress) {}
     override suspend fun upload(localPath: String, remotePath: String, onProgress: SftpProgress) {}
     override suspend fun mkdir(path: String) { calls += "mkdir:$path" }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
@@ -133,6 +133,37 @@ class SshjSftpClientTest {
     }
 
     @Test
+    fun `read refuses a file over the caller's cap`() = runTest {
+        withSftp { sftp ->
+            val e = assertFailsWith<SftpException> { sftp.read("/readme.txt", maxBytes = 4) }
+            assertTrue("too large" in (e.message ?: ""), "unexpected message: ${e.message}")
+        }
+    }
+
+    @Test
+    fun `the streaming read stops at the cap when the source outruns its reported size`() {
+        // A server can report any size (or 0, as special files do) and then keep sending; the guard
+        // has to hold on the bytes themselves, not on the metadata that preceded them.
+        val endless = object : java.io.InputStream() {
+            override fun read(): Int = 0
+            override fun read(b: ByteArray, off: Int, len: Int): Int = len
+        }
+
+        val e = assertFailsWith<SftpException> { readAtMost(endless, cap = 64 * 1024, label = "/dev/zero") }
+
+        assertTrue("read limit" in (e.message ?: ""), "unexpected message: ${e.message}")
+    }
+
+    @Test
+    fun `the streaming read returns content that exactly fills the cap`() {
+        val body = ByteArray(1024) { 'x'.code.toByte() }
+
+        val read = readAtMost(java.io.ByteArrayInputStream(body), cap = 1024, label = "/exact")
+
+        assertContentEquals(body, read)
+    }
+
+    @Test
     fun `write creates a file that reads back identically`() = runTest {
         val payload = "uploaded by skerry\n".encodeToByteArray()
         withSftp { sftp ->

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sftp/SshjSftpClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sftp/SshjSftpClient.kt
@@ -1,6 +1,8 @@
 package app.skerry.shared.sftp
 
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Dispatchers
@@ -21,9 +23,10 @@ import net.schmizz.sshj.xfer.TransferListener
  * (`SFTPException`) and disconnects (`IOException`) are wrapped in [SftpException]; the one
  * exception is [stat], where "no such file" is `null`, not an error.
  *
- * [maxReadBytes] caps [read] by the file's **reported** size, guarding against OOM from
- * accidentally opening a multi-gigabyte file. Special files reporting size zero (`/dev/zero`
- * etc.) aren't covered by this — that needs a streaming limit, not implemented yet.
+ * [maxReadBytes] is the channel's own ceiling for [read]; the effective limit is the smaller of it
+ * and the caller's `maxBytes`. It is enforced both against the reported size (so an honestly-large
+ * file isn't fetched at all) and while streaming (so a server understating the size — `0` for
+ * `/dev/zero` and friends — can't grow the buffer without bound).
  */
 internal class SshjSftpClient(
     private val sftp: SFTPClient,
@@ -61,13 +64,14 @@ internal class SshjSftpClient(
         sftp.canonicalize(path)
     }
 
-    override suspend fun read(path: String): ByteArray = io("Failed to read file $path") {
+    override suspend fun read(path: String, maxBytes: Long): ByteArray = io("Failed to read file $path") {
+        val cap = minOf(maxBytes, maxReadBytes)
         sftp.open(path).use { file ->
             val size = file.length()
-            if (size > maxReadBytes) {
-                throw SftpException("File $path is too large to read whole: $size B (limit $maxReadBytes B)")
+            if (size > cap) {
+                throw SftpException("File $path is too large to read whole: $size B (limit $cap B)")
             }
-            file.RemoteFileInputStream().use { it.readBytes() }
+            file.RemoteFileInputStream().use { readAtMost(it, cap, path) }
         }
     }
 
@@ -165,9 +169,28 @@ internal class SshjSftpClient(
         }
 
     private companion object {
-        /** Default read cap for [read] (64 MiB). */
-        const val DEFAULT_MAX_READ_BYTES = 64L * 1024 * 1024
+        /** Default channel-level read cap for [read]; the shared contract's [SFTP_MAX_READ_BYTES]. */
+        const val DEFAULT_MAX_READ_BYTES = SFTP_MAX_READ_BYTES
     }
+}
+
+/**
+ * Reads [input] fully but never past [cap] bytes, so a source that understates its size (or streams
+ * endlessly, as a special file does) can't grow the buffer without bound. Overshooting is an error,
+ * not a truncation: silently returning a cut-off file would be corruption the moment it's saved back.
+ */
+internal fun readAtMost(input: InputStream, cap: Long, label: String): ByteArray {
+    val out = ByteArrayOutputStream()
+    val chunk = ByteArray(64 * 1024)
+    var total = 0L
+    while (true) {
+        val n = input.read(chunk)
+        if (n < 0) break
+        total += n
+        if (total > cap) throw SftpException("File $label is larger than the read limit of $cap B")
+        out.write(chunk, 0, n)
+    }
+    return out.toByteArray()
 }
 
 /** sshj listing entry to [SftpEntry] (name and path come from the server response). */


### PR DESCRIPTION
Adds a file viewer and editor to the SFTP panel: `F3` opens the file under the cursor read-only, `F4` opens it for editing and writes it back over the same SFTP connection. Works in both panes — remote host and local machine — and on Android from the file's long-press menu.

## Where it opens

Inside the panel, not in a separate window. The file takes over the panel area, the panel's header is hidden while it is there, and the bottom function-key bar switches to the editor's keys:

| Key | Action |
|---|---|
| `F2`, `Ctrl`/`⌘`+`S` | Save |
| `F4` | Switch from viewing to editing, without reopening the file |
| `F7` | Search: Enter or F7 jumps to the next match, wrapping around at the end |
| `F10`, `Esc` | Quit — asks first if there are unsaved changes |

`Tab` types a tab character instead of moving focus out of the buffer. The header shows the mode, the file name and its full path, and whether the buffer is read-only, modified or being saved. On Android there are no function keys: Save and Close are buttons in the header, and the system Back button closes the editor.

## Behaviour

**Opening.** The file is read whole, up to 1 MiB — this is an editor for configs, scripts and short logs, not for dumps. Content with NUL bytes or invalid UTF-8 is reported as a binary file and does not open as text; decoding it leniently would replace those bytes with `U+FFFD` and corrupt the file on the first save. CRLF and classic-Mac CR files are edited with plain `\n` and written back in their original form, so changing one line does not rewrite every line.

**Saving.** The write truncates the file in place rather than writing a temporary file and renaming over it: permissions, owner and hard links are preserved, and it works with SFTP servers that refuse to rename onto an existing path. Before writing, the file's size and mtime are compared against what they were when it was opened — if something changed it underneath, the save stops and asks instead of overwriting silently. A failed write keeps the buffer intact and reports the reason in a strip under the header. The write itself runs on the session's scope and outlives the editor UI, and the SFTP channel is not closed until it finishes — an interrupted in-place write would leave a truncated file on the server.

**Untrusted server.** The path being read and written is rebuilt from the pane's current directory plus a validated file name, never taken from the server's listing entry. The read cap is enforced on the bytes as they arrive, not only against the size the server reports.

## Also in this PR

`FileContentBrowser` — a separate contract for whole-file read/write, implemented by the local and SFTP sources; the pane controller keeps working with the navigation-only `FileBrowser`. The new keys are documented in Settings → Keyboard ("File panel" and "File viewer / editor"), and all strings ship in en/ru/zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
