### PR TITLE
Play recordings in a session tab instead of a modal overlay

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ImportFile.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ImportFile.android.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.vault
 
+import android.provider.OpenableColumns
 import app.skerry.ui.sftp.SafBridge
 import java.io.ByteArrayOutputStream
 import kotlinx.coroutines.Dispatchers
@@ -13,11 +14,17 @@ import kotlinx.coroutines.withContext
  * `content://` provider can report anything (or nothing), so the limit is enforced while reading and
  * an oversized file yields `null` instead of an out-of-memory crash.
  */
-actual suspend fun importTextFile(maxBytes: Int): String? {
+actual suspend fun importTextFile(maxBytes: Int): ImportedFile? {
     val ctx = SafBridge.context() ?: return null
     val uri = SafBridge.openDocument() ?: return null
     return withContext(Dispatchers.IO) {
         runCatching {
+            // Display name for labels: a content:// Uri has no path to take a file name from, so it
+            // is queried; providers may omit the column, hence the last-segment fallback.
+            val name = ctx.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                ?.use { cursor -> if (cursor.moveToFirst()) cursor.getString(0) else null }
+                ?: uri.lastPathSegment?.substringAfterLast('/')
+                ?: ""
             ctx.contentResolver.openInputStream(uri)?.use { stream ->
                 val buffer = ByteArray(64 * 1024)
                 val collected = ByteArrayOutputStream()
@@ -27,7 +34,7 @@ actual suspend fun importTextFile(maxBytes: Int): String? {
                     if (collected.size() + read > maxBytes) return@use null
                     collected.write(buffer, 0, read)
                 }
-                collected.toString(Charsets.UTF_8.name())
+                ImportedFile(name, collected.toString(Charsets.UTF_8.name()))
             }
         }.getOrNull()
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -55,8 +55,10 @@ fun DesktopView.asSessionView(): SessionView = when (this) {
 fun SessionView.asDesktopView(): DesktopView = when (this) {
     SessionView.Terminal -> DesktopView.Terminal
     SessionView.Sftp -> DesktopView.Sftp
-    // VNC has no dedicated rail item (it's a work-area view, like Terminal); don't highlight one.
+    // VNC and the recording player have no dedicated rail item (they're work-area views, like
+    // Terminal); don't highlight one.
     SessionView.Vnc -> DesktopView.Terminal
+    SessionView.Player -> DesktopView.Terminal
 }
 
 /** Settings panel tabs. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -658,7 +658,8 @@ private fun DesktopChrome(
                 HLine()
                 StatusBar()
             }
-            // The player owns the whole work area while it is open; Esc (via ModalScrim) closes it.
+            // Mock/preview only: with live sessions a recording opens in its own tab (SessionView.Player),
+            // and this state is never set. Esc (via ModalScrim) closes the overlay.
             state.castRecording?.let { cast -> CastPlayerOverlay(cast, onDismiss = state::closeCast) }
             if (state.castInvalid) {
                 NoticeDialog(
@@ -1004,7 +1005,10 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                     val focused = if (s.splitOpen && s.focusedSplit) s.splitSession ?: s else s
                     SessionTabChip(
                         name = focused.tabTitle(state.showTerminalTitleOnTabs),
-                        dot = sessionDotColor(focused.controller.uiState),
+                        // A recording tab has no connection: its dot and accent are sunset, so it
+                        // never reads as a live (or dead) session.
+                        dot = if (s.isPlayer) D.sunset else sessionDotColor(focused.controller.uiState),
+                        accent = if (s.isPlayer) D.sunset else D.cyan,
                         split = s.splitOpen,
                         active = s.id == sessions.activeId,
                         onClick = { sessions.activate(s.id) },
@@ -1076,6 +1080,9 @@ private fun SessionTabChip(
     onClose: () -> Unit,
     split: Boolean = false,
     dragging: Boolean = false,
+    // Chip accent (strip/border/background tint). Sessions use cyan; a recording tab is sunset, so a
+    // replay is never mistaken for a live shell at a glance.
+    accent: Color = D.cyan,
     modifier: Modifier = Modifier,
 ) {
     val shape = RoundedCornerShape(8.dp)
@@ -1083,6 +1090,10 @@ private fun SessionTabChip(
     val interaction = remember { MutableInteractionSource() }
     val hovered by interaction.collectIsHoveredAsState()
     val showClose = active || hovered
+    // Accent tints: the same 10%/20% steps the cyan tokens use, so a non-default accent keeps the
+    // chip's weight instead of turning into a solid block.
+    val accentBg = accent.copy(alpha = 0.10f)
+    val accentBorder = accent.copy(alpha = 0.20f)
     Row(
         modifier
             // Dim a dragged chip (alpha) so it reads as "lifted" out of the row.
@@ -1091,17 +1102,17 @@ private fun SessionTabChip(
             .clip(shape)
             .background(
                 when {
-                    active -> D.cyan10
+                    active -> accentBg
                     hovered -> Color(0x1FFFFFFF)
                     else -> D.card
                 },
             )
-            .border(1.dp, if (active) D.cyan20 else D.line, shape)
+            .border(1.dp, if (active) accentBorder else D.line, shape)
             // Accent strip on the active tab's top edge (editor tab style). drawBehind renders over the
             // background/border but under content; doesn't inflate the chip's width.
             .then(
                 if (active) {
-                    Modifier.drawBehind { drawRect(D.cyan, size = Size(size.width, 2.dp.toPx())) }
+                    Modifier.drawBehind { drawRect(accent, size = Size(size.width, 2.dp.toPx())) }
                 } else {
                     Modifier
                 },
@@ -1113,7 +1124,7 @@ private fun SessionTabChip(
     ) {
         Dot(dot)
         // Split marker: the tab holds two panes.
-        if (split) Sym("splitscreen_right", size = 13.sp, color = if (active) D.cyan else D.faint)
+        if (split) Sym("splitscreen_right", size = 13.sp, color = if (active) accent else D.faint)
         Txt(
             name,
             color = if (active) D.text else D.dim,
@@ -1155,8 +1166,11 @@ private fun IconRail(state: DesktopDesignState) {
         // Collapse/expand toggle for the terminal's hosts sidebar: lives on the rail (not in the
         // sidebar header) and only while the terminal view is on screen. Deliberately shorter than
         // the 38dp view buttons — an auxiliary control, not a view. VNC maps to the same rail item
-        // but drives its own slide-over drawer (closed by default, overlays the framebuffer).
-        if (state.appOverlay == null && currentSessionView == DesktopView.Terminal) {
+        // but drives its own slide-over drawer (closed by default, overlays the framebuffer). A
+        // player tab has no sidebar at all — there is no host behind a recording.
+        if (state.appOverlay == null && currentSessionView == DesktopView.Terminal &&
+            sessions?.active?.view != SessionView.Player
+        ) {
             if (sessions?.active?.view == SessionView.Vnc) {
                 SidebarToggle(hidden = !state.vncSidebar, onToggle = state::toggleVncSidebar)
             } else {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
@@ -9,6 +9,7 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.sftp.SftpView
 import app.skerry.ui.snippet.SnippetsView
 import app.skerry.ui.teams.TeamsView
+import app.skerry.ui.terminal.CastPlayerView
 import app.skerry.ui.terminal.TerminalView
 import app.skerry.ui.tunnel.TunnelsView
 import app.skerry.ui.vault.VaultView
@@ -36,6 +37,7 @@ fun Viewport(state: DesktopDesignState) {
                 SessionView.Terminal -> TerminalView(state)
                 SessionView.Sftp -> SftpView()
                 SessionView.Vnc -> VncView(state)
+                SessionView.Player -> CastPlayerView()
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -6,18 +6,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.terminal.Asciicast
 import app.skerry.shared.vnc.VncAuth
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.terminal.CastPlayback
 import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.vnc.VncSessionController
 
 /**
  * Sub-view of a session (tab-scoped): what's shown in its work area. Tunnels are not included here;
  * they're a global section, see [app.skerry.ui.app.DesktopView.isAppLevel]. [Vnc] is a
- * framebuffer tab (remote desktop) — it has no terminal/SFTP sub-views.
+ * framebuffer tab (remote desktop) and [Player] a recording being replayed — neither has
+ * terminal/SFTP sub-views.
  */
-enum class SessionView { Terminal, Sftp, Vnc }
+enum class SessionView { Terminal, Sftp, Vnc, Player }
 
 /**
  * One open session — a titlebar tab. Owns its own [ConnectionController] (one shell per session).
@@ -43,12 +46,21 @@ class Session(
      * so the many `session.controller` read-sites (split/status/close) stay total. See [isVnc].
      */
     val vncController: VncSessionController? = null,
+    /**
+     * Set only for player tabs (a recording being watched): when non-null, this tab replays a
+     * `.cast` instead of holding a connection, and [controller] is an idle, unused terminal
+     * controller kept so the many `session.controller` read-sites stay total. See [isPlayer].
+     */
+    val playback: CastPlayback? = null,
 ) {
     var hostId: String? by mutableStateOf(hostId)
         private set
 
     /** Whether this is a VNC (remote-desktop) tab rather than a terminal one. */
     val isVnc: Boolean get() = vncController != null
+
+    /** Whether this tab replays a recording rather than holding a session. */
+    val isPlayer: Boolean get() = playback != null
     var title: String by mutableStateOf(title)
         private set
     var subtitle: String by mutableStateOf(subtitle)
@@ -77,7 +89,8 @@ class Session(
      * [ConnectionUiState.Form]). Created by the "+" button; the first connection fills it. A tab
      * with a host already bound does not become blank again after [ConnectionController.disconnect].
      */
-    val isBlank: Boolean get() = hostId == null && vncController == null && controller.uiState is ConnectionUiState.Form
+    val isBlank: Boolean get() = hostId == null && vncController == null && playback == null &&
+        controller.uiState is ConnectionUiState.Form
 
     internal fun setView(v: SessionView) { view = v }
 
@@ -253,10 +266,29 @@ class SessionsController(
         return session.id
     }
 
-    /** Switch the active tab's sub-view (Terminal/SFTP); no-op on a VNC tab or with no active tab. */
+    /**
+     * Open a recording in its own tab (never reuses a blank one), locked to [SessionView.Player].
+     * A player tab lives beside the sessions instead of over them, so a shell stays reachable while
+     * a recording is watched. [title] is the tab label, resolved by the caller (the recording's own
+     * title, else a localized default). Returns the new tab's id.
+     */
+    fun openPlayer(title: String, cast: Asciicast): String {
+        // An idle terminal controller keeps `session.controller` non-null for the shared read-sites.
+        val session = Session(
+            newId(), hostId = null, title = title, subtitle = "", controllerFactory(),
+            playback = CastPlayback(cast),
+        )
+        session.setView(SessionView.Player)
+        sessions = sessions + session
+        activeId = session.id
+        return session.id
+    }
+
+    /** Switch the active tab's sub-view (Terminal/SFTP); no-op on a VNC/player tab or with none active. */
     fun setActiveView(view: SessionView) {
         val tab = active ?: return
-        if (tab.isVnc) return // VNC tabs are locked to the framebuffer view
+        // VNC and player tabs are locked to their own view — there is no shell behind them.
+        if (tab.isVnc || tab.isPlayer) return
         tab.setView(view)
     }
 
@@ -320,6 +352,7 @@ class SessionsController(
         if (index < 0) return
         sessions[index].controller.disconnect()
         sessions[index].vncController?.disconnect()
+        sessions[index].playback?.stop()
         sessions[index].splitSession?.controller?.disconnect()
         val remaining = sessions.toMutableList().apply { removeAt(index) }
         if (activeId == id) {
@@ -338,6 +371,7 @@ class SessionsController(
         sessions.forEach {
             it.controller.disconnect()
             it.vncController?.disconnect()
+            it.playback?.stop()
             it.splitSession?.controller?.disconnect()
         }
         sessions = emptyList()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastOpen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastOpen.kt
@@ -8,7 +8,8 @@ import kotlinx.coroutines.withContext
 
 /** What came back from "Play a recording": a recording, nothing (cancelled), or an unusable file. */
 sealed interface CastOpenResult {
-    data class Loaded(val cast: Asciicast) : CastOpenResult
+    /** [fileName] is the picked file's name — the player tab is labelled with it. */
+    data class Loaded(val cast: Asciicast, val fileName: String) : CastOpenResult
 
     data object Cancelled : CastOpenResult
 
@@ -21,7 +22,7 @@ sealed interface CastOpenResult {
  * recording is megabytes of JSON lines, and the picker returns on the UI dispatcher.
  */
 suspend fun openCastFile(): CastOpenResult {
-    val text = importTextFile() ?: return CastOpenResult.Cancelled
-    val cast = withContext(Dispatchers.Default) { parseAsciicast(text) } ?: return CastOpenResult.Invalid
-    return CastOpenResult.Loaded(cast)
+    val file = importTextFile() ?: return CastOpenResult.Cancelled
+    val cast = withContext(Dispatchers.Default) { parseAsciicast(file.text) } ?: return CastOpenResult.Invalid
+    return CastOpenResult.Loaded(cast, file.name)
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayback.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayback.kt
@@ -1,0 +1,53 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Stable
+import app.skerry.shared.terminal.Asciicast
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+/**
+ * A recording open for playback: the [CastPlayer] and the terminal it feeds, kept together so a
+ * player tab ([app.skerry.ui.session.Session.playback]) can own them for as long as the tab lives.
+ *
+ * The scope is owned here, not by the composable: switching to another tab unmounts the player's UI
+ * and must not tear the replay down (nor restart it on the way back). [stop] is therefore mandatory
+ * when the tab closes, or the replay coroutine keeps feeding a screen nobody looks at.
+ *
+ * Default, not Main, exactly like a live session ([app.skerry.ui.connection.ConnectionController]):
+ * a seek hands the emulator every event up to the target in one chunk, and on the main dispatcher
+ * that parse freezes the UI (an ANR on Android) for a long recording.
+ */
+@Stable
+class CastPlayback(
+    val cast: Asciicast,
+    // Injected only by tests; the playback owns whatever scope it is given and cancels it in [stop].
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    val player = CastPlayer(cast, scope)
+    val terminal = TerminalScreenState(player, scope)
+
+    /** Whether [stop] has been called (scope cancelled, nothing left to render). */
+    var stopped: Boolean = false
+        private set
+
+    private var started = false
+
+    /**
+     * Start playing the first time the recording is shown — opening it is the request to watch it.
+     * Re-entering the tab resumes what was there instead of replaying from the top.
+     */
+    fun start() {
+        if (started || stopped) return
+        started = true
+        player.play()
+    }
+
+    /** Cancel the replay coroutine; called when the player tab closes. */
+    fun stop() {
+        if (stopped) return
+        stopped = true
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,7 +25,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.Asciicast
+import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.design.D
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.ModalScrim
@@ -35,31 +38,21 @@ import app.skerry.ui.generated.resources.term_player_empty
 import app.skerry.ui.generated.resources.term_player_speed
 import app.skerry.ui.generated.resources.term_player_title
 import app.skerry.ui.generated.resources.term_player_truncated
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Plays a recording over the current screen: the same terminal renderer a live session uses, plus
- * a transport bar (play/pause, replay, seekable progress, speed).
+ * Plays a recording over the current screen (mobile, and the desktop mock without live sessions):
+ * the same terminal renderer a live session uses, plus a transport bar.
  *
- * Playback is driven by a [CastPlayer] posing as the session, so nothing here knows it isn't live.
- * The player's scope is owned by this composable and cancelled on dispose — closing the overlay
- * must stop the replay coroutine, not leave it feeding a screen nobody looks at.
+ * The playback is owned by this composable and stopped on dispose — closing the overlay must stop
+ * the replay coroutine, not leave it feeding a screen nobody looks at. On the desktop a recording
+ * opens in its own tab instead, where the session owns it ([CastPlayerView]).
  */
 @Composable
 fun CastPlayerOverlay(cast: Asciicast, onDismiss: () -> Unit) {
-    // Default, not Main, exactly like a live session ([ConnectionController]): the terminal state
-    // feeds the ANSI parser from this scope, and a seek hands it every event up to the target in one
-    // chunk. On the main dispatcher that parse freezes the UI (an ANR on Android) for a long take.
-    val scope = remember { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
-    val player = remember(cast) { CastPlayer(cast, scope) }
-    val terminal = remember(player) { TerminalScreenState(player, scope) }
-    DisposableEffect(player) { onDispose { scope.cancel() } }
-    // Start playing as soon as the recording is on screen — opening it is the request to watch it.
-    LaunchedEffect(player) { player.play() }
+    val playback = remember(cast) { CastPlayback(cast) }
+    DisposableEffect(playback) { onDispose { playback.stop() } }
+    LaunchedEffect(playback) { playback.start() }
 
     ModalScrim(onDismiss = onDismiss) {
         Column(
@@ -71,31 +64,65 @@ fun CastPlayerOverlay(cast: Asciicast, onDismiss: () -> Unit) {
                 .background(D.surface)
                 .border(1.dp, D.lineStrong, RoundedCornerShape(10.dp)),
         ) {
-            Row(
-                Modifier.fillMaxWidth().padding(start = 14.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Txt(cast.title ?: stringResource(Res.string.term_player_title), color = D.textBright, size = 13.sp, weight = FontWeight.SemiBold)
-                    if (cast.truncated) Txt(stringResource(Res.string.term_player_truncated), color = D.amber, size = 11.sp)
-                }
-                IconBtn("close", onClick = onDismiss)
-            }
-            Box(Modifier.weight(1f).fillMaxWidth().background(D.terminalBg)) {
-                if (cast.events.isEmpty()) {
-                    Txt(
-                        stringResource(Res.string.term_player_empty),
-                        color = D.faint,
-                        size = 12.sp,
-                        modifier = Modifier.align(Alignment.Center),
-                    )
-                } else {
-                    TerminalScreen(terminal, Modifier.fillMaxSize())
-                }
-            }
-            TransportBar(player)
+            CastPlayerContent(playback, onClose = onDismiss)
         }
     }
+}
+
+/**
+ * A recording as a work-area view: the player tab's content ([app.skerry.ui.session.SessionView.Player]).
+ * Playback lives on the tab ([app.skerry.ui.session.Session.playback]), so switching tabs pauses
+ * nothing and coming back continues where the recording stood; closing the tab stops it.
+ */
+@Composable
+fun CastPlayerView() {
+    val playback = LocalSessions.current?.active?.playback ?: return
+    // Start on first display only ([CastPlayback.start]) — returning to the tab must not rewind.
+    LaunchedEffect(playback) { playback.start() }
+    Column(Modifier.fillMaxSize().background(D.surface)) {
+        CastPlayerContent(playback, onClose = null)
+    }
+}
+
+/**
+ * Title strip, the replayed terminal and the transport bar. [onClose] draws a close button (the
+ * overlay's only way out); in a tab the chip's own cross closes it, so it is `null` there.
+ *
+ * Playback is driven by a [CastPlayer] posing as the session, so nothing here knows it isn't live.
+ */
+@Composable
+private fun ColumnScope.CastPlayerContent(playback: CastPlayback, onClose: (() -> Unit)?) {
+    val cast = playback.cast
+    Row(
+        Modifier.fillMaxWidth().padding(start = 14.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(cast.title ?: stringResource(Res.string.term_player_title), color = D.textBright, size = 13.sp, weight = FontWeight.SemiBold)
+            if (cast.truncated) Txt(stringResource(Res.string.term_player_truncated), color = D.amber, size = 11.sp)
+        }
+        if (onClose != null) IconBtn("close", onClick = onClose)
+    }
+    Box(Modifier.weight(1f).fillMaxWidth().background(D.terminalBg)) {
+        if (cast.events.isEmpty()) {
+            Txt(
+                stringResource(Res.string.term_player_empty),
+                color = D.faint,
+                size = 12.sp,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        } else {
+            // Pinned to the geometry the recording was taken at, with the font scaled to fill the
+            // pane: re-flowing a recording would leave empty columns in a wide window and wrap its
+            // lines in a narrow one.
+            TerminalScreen(
+                playback.terminal,
+                Modifier.fillMaxSize(),
+                fixedGrid = PtySize(cols = cast.columns, rows = cast.rows),
+            )
+        }
+    }
+    TransportBar(playback.player)
 }
 
 /** Play/pause, replay, seekable progress and speed — everything the player is driven by. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGeometry.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGeometry.kt
@@ -15,6 +15,34 @@ data class TerminalMetrics(
     val cellHeight: Float,
 )
 
+/** Bounds for [fitFontScale]: a recording is never blown up or shrunk past readability. */
+private val FIT_FONT_SCALE_RANGE = 0.3f..4f
+
+/**
+ * Font scale that makes a fixed [cols]×[rows] grid fill the viewport, given [metrics] measured at
+ * the unscaled font size. Used by the recording player: a recording has the geometry it was taken
+ * at, so instead of re-flowing it into the pane (empty columns on the right in a wide window,
+ * wrapped lines in a narrow one) the glyphs are scaled and the grid is kept.
+ *
+ * The smaller of the two axis ratios wins — the whole grid has to fit — and the result is clamped
+ * to [FIT_FONT_SCALE_RANGE]. A viewport or grid that isn't measured yet gives 1 (no scaling).
+ */
+fun fitFontScale(
+    viewportWidthPx: Float,
+    viewportHeightPx: Float,
+    paddingPx: Float,
+    metrics: TerminalMetrics,
+    cols: Int,
+    rows: Int,
+): Float {
+    if (cols <= 0 || rows <= 0 || metrics.cellWidth <= 0f || metrics.cellHeight <= 0f) return 1f
+    val contentW = viewportWidthPx - 2 * paddingPx
+    val contentH = viewportHeightPx - 2 * paddingPx
+    if (contentW <= 0f || contentH <= 0f) return 1f
+    val scale = minOf(contentW / (cols * metrics.cellWidth), contentH / (rows * metrics.cellHeight))
+    return scale.coerceIn(FIT_FONT_SCALE_RANGE.start, FIT_FONT_SCALE_RANGE.endInclusive)
+}
+
 /**
  * Columns and rows that fit in the terminal viewport. Padding on both sides ([paddingPx]) is
  * subtracted from the viewport size, and the remainder is divided by cell size (floored — a partial

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -76,6 +76,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalTextToolbar
 import androidx.compose.ui.platform.LocalUriHandler
+import app.skerry.shared.ssh.PtySize
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextMeasurer
@@ -90,6 +91,7 @@ import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -157,13 +159,44 @@ private const val HANDLE_TOUCH_RADIUS_DP = 22
  * [imeTransform] (IME path only) post-processes a non-empty [imeDeltaToPty] result before sending —
  * the mobile key panel routes it through sticky-ctrl ([app.skerry.ui.mobile.applyStickyCtrl]) so
  * Ctrl+<letter> works from the soft keyboard too, not just from panel keys.
+ *
+ * [fixedGrid] pins the grid to a given size and scales the font to fill the viewport instead of
+ * fitting the grid to the viewport. It exists for the recording player: a recording was taken at a
+ * geometry of its own, and re-flowing it would leave empty columns in a wide pane and wrap its
+ * lines in a narrow one. A live session leaves this `null`.
  */
+/**
+ * Cell size of [style], measured with [measurer].
+ *
+ * cellWidth is the font's real advance, which drawText uses to lay out ASCII runs. Measured on a
+ * long string and divided by its length: size.width is an integer (rounds to ~0.5px), which at 10
+ * chars gave error up to ~0.05px/char and drifted the ASCII run off the cw-grid by ~1 cell near the
+ * row's right edge (highlight/cursor/mouse use the grid, text uses advance). At 200 chars the error
+ * is negligible and the grid matches drawText's layout.
+ *
+ * cellHeight is rounded to a whole pixel: rows tile edge-to-edge (top = r*cellHeight), and a
+ * fractional height (e.g. line-height multiplier 1.38 → 13×1.38 = 17.94px, or fractional display
+ * scale) puts adjacent background rects' borders on fractional pixels — Skia antialiases the seam,
+ * showing horizontal banding every row on solid backgrounds (e.g. mc panels). Integer height removes
+ * the seam. Width cannot be rounded the same way (its fractional advance is intentional, see above),
+ * but height can: each row's text is drawn independent of its top, so no drift accumulates.
+ */
+private fun terminalMetrics(measurer: TextMeasurer, style: TextStyle, density: Density): TerminalMetrics {
+    val sampleLen = 200
+    val sample = measurer.measure(AnnotatedString("M".repeat(sampleLen)), style)
+    return TerminalMetrics(
+        cellWidth = sample.size.width / sampleLen.toFloat(),
+        cellHeight = with(density) { style.lineHeight.toPx() }.roundToInt().toFloat(),
+    )
+}
+
 @Composable
 fun TerminalScreen(
     state: TerminalScreenState,
     modifier: Modifier = Modifier,
     imeInput: Boolean = false,
     imeTransform: ((String) -> String)? = null,
+    fixedGrid: PtySize? = null,
 ) {
     // Terminal font/size from Appearance settings ([LocalTerminalAppearance]); defaults to Hack 13px
     // where no provider is set (mobile target/preview/connection screen). Ligatures always disabled
@@ -177,11 +210,18 @@ fun TerminalScreen(
     val selectionBg = termTheme.selection
     val handleColor = termTheme.cursor
     val mono = rememberTerminalFontFamily(appearance.font)
+    val density = LocalDensity.current
+    // A full TUI screen redraws hundreds of distinct glyph runs per frame; the default layout cache
+    // (8 entries) thrashes and re-lays-out every run every frame. Sized to hold a busy screen's runs.
+    // Color is passed at draw time (see drawGlyphText), so cache hits stay theme-safe.
+    val measurer = rememberTextMeasurer(cacheSize = 1024)
+    val paddingPx = with(density) { PADDING_DP.dp.toPx() }
+    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
     // Keyed on appearance itself (@Immutable data class, structural equality): changes exactly when
     // font/size changes. FontFamily is not a reliable key — equality of two built instances depends
     // on compose-resources Font.equals, so reference-equality would invalidate textStyle/metrics on
     // every recomposition. mono is captured by the lambda and stays consistent with appearance.font.
-    val textStyle = remember(appearance, termTheme) {
+    val baseStyle = remember(appearance, termTheme) {
         TextStyle(
             fontFamily = mono,
             fontFeatureSettings = NO_LIGATURES,
@@ -192,6 +232,24 @@ fun TerminalScreen(
             letterSpacing = appearance.letterSpacingSp.sp,
             color = termTheme.foreground,
         )
+    }
+    // With a pinned grid ([fixedGrid]) the font is scaled so that grid fills the viewport; the scale
+    // is derived from metrics measured at the unscaled size, so the style has to be built twice.
+    val baseMetrics = remember(baseStyle, density) { terminalMetrics(measurer, baseStyle, density) }
+    val fontScale = if (fixedGrid == null) 1f else fitFontScale(
+        viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, baseMetrics,
+        fixedGrid.cols, fixedGrid.rows,
+    )
+    val textStyle = remember(baseStyle, fontScale) {
+        if (fontScale == 1f) {
+            baseStyle
+        } else {
+            baseStyle.copy(
+                fontSize = baseStyle.fontSize * fontScale,
+                lineHeight = baseStyle.lineHeight * fontScale,
+                letterSpacing = baseStyle.letterSpacing * fontScale,
+            )
+        }
     }
     val sessionState by state.state.collectAsState()
     val closed = sessionState is TerminalState.Closed
@@ -234,31 +292,7 @@ fun TerminalScreen(
     // Monospace cell size in pixels is the single source of truth for geometry: glyphs, background,
     // selection, cursor, mouse, and handles are all derived from it via col*cellWidth /
     // row*cellHeight, so everything stays consistent across fonts and system scale.
-    val density = LocalDensity.current
-    // A full TUI screen redraws hundreds of distinct glyph runs per frame; the default layout cache
-    // (8 entries) thrashes and re-lays-out every run every frame. Sized to hold a busy screen's runs.
-    // Color is passed at draw time (see drawGlyphText), so cache hits stay theme-safe.
-    val measurer = rememberTextMeasurer(cacheSize = 1024)
-    val metrics = remember(textStyle, density) {
-        // cellWidth is the font's real advance, which drawText uses to lay out ASCII runs. Measured on
-        // a long string and divided by its length: size.width is an integer (rounds to ~0.5px), which
-        // at 10 chars gave error up to ~0.05px/char and drifted the ASCII run off the cw-grid by ~1
-        // cell near the row's right edge (highlight/cursor/mouse use the grid, text uses advance). At
-        // 200 chars the error is negligible and the grid matches drawText's layout.
-        val sampleLen = 200
-        val sample = measurer.measure(AnnotatedString("M".repeat(sampleLen)), textStyle)
-        TerminalMetrics(
-            cellWidth = sample.size.width / sampleLen.toFloat(),
-            // cellHeight is rounded to a whole pixel: rows tile edge-to-edge (top = r*cellHeight), and a
-            // fractional height (e.g. line-height multiplier 1.38 → 13×1.38 = 17.94px, or fractional
-            // display scale) puts adjacent background rects' borders on fractional pixels — Skia
-            // antialiases the seam, showing horizontal banding every row on solid backgrounds (e.g. mc
-            // panels). Integer height removes the seam. Width cannot be rounded the same way (its
-            // fractional advance is intentional, see above), but height can: each row's text is drawn
-            // independent of its top, so no drift accumulates.
-            cellHeight = with(density) { textStyle.lineHeight.toPx() }.roundToInt().toFloat(),
-        )
-    }
+    val metrics = remember(textStyle, density) { terminalMetrics(measurer, textStyle, density) }
     val handleRadiusPx = with(density) { HANDLE_RADIUS_DP.dp.toPx() }
     val handleTouchRadiusPx = with(density) { HANDLE_TOUCH_RADIUS_DP.dp.toPx() }
 
@@ -314,9 +348,7 @@ fun TerminalScreen(
     // Viewport size in cells is pushed to the PTY/emulator on first layout and on window resize;
     // without this the grid stays at the default 80x24 and wide output wraps. state.resize dedupes on
     // its own. Measured on the outer Box (viewport), not the scrollable Text, whose size is the full
-    // content height.
-    val paddingPx = with(density) { PADDING_DP.dp.toPx() }
-    var viewportSize by remember { mutableStateOf(IntSize.Zero) }
+    // content height. ([paddingPx]/[viewportSize] are declared above — the font scale needs them.)
     // Glyphs/cursor stay hidden until the grid has been fitted to the viewport at least once: otherwise
     // the shell's first output would land on the default 80x24 and then "re-flow" on resize — a visible
     // jump on open. Until then only the terminal background is visible, then the final layout appears.
@@ -333,7 +365,10 @@ fun TerminalScreen(
         // pending one, so this fires once the size has settled. The very first resize (sized=false, terminal
         // opening) happens instantly, without a delay.
         if (sized) delay(150)
-        state.resize(gridSizeFor(viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, metrics))
+        // With a pinned grid the emulator keeps the recording's geometry (the font was scaled to it
+        // instead); only the content pixel size follows the viewport.
+        val content = gridSizeFor(viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, metrics)
+        state.resize(if (fixedGrid == null) content else fixedGrid.copy(widthPx = content.widthPx, heightPx = content.heightPx))
         sized = true
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -65,6 +65,7 @@ import app.skerry.ui.generated.resources.term_connecting
 import app.skerry.ui.generated.resources.term_connection_failed
 import app.skerry.ui.generated.resources.term_connection_lost
 import app.skerry.ui.generated.resources.term_no_active_session
+import app.skerry.ui.generated.resources.term_player_title
 import app.skerry.ui.generated.resources.term_no_host_selected
 import app.skerry.ui.generated.resources.term_no_hosts_in_catalog
 import app.skerry.ui.generated.resources.term_notice_not_connected
@@ -105,9 +106,21 @@ private fun SessionActions(state: DesktopDesignState, modifier: Modifier = Modif
         SnippetPaletteButton(active, state.snippetPaletteRequests)
         // Asciinema recording of this session; the stop click offers a Save-As for the .cast.
         RecordSessionButton(active, state.recordingToggleRequests) { state.showRecordingNotice(it) }
-        // Plays a .cast back over the shell. Not tied to a session (a recording is watched, not run),
-        // which is why it sits here rather than behind a connected-only guard.
-        PlayRecordingButton(state.castOpenRequests) { state.showCast(it) }
+        // Plays a .cast back. Not tied to a session (a recording is watched, not run), which is why
+        // it sits here rather than behind a connected-only guard. Live mode opens the recording in
+        // its own tab, so the shells stay reachable while it plays; the mock/preview path (no
+        // session manager) has no tabs and falls back to the overlay.
+        val playerTabTitle = stringResource(Res.string.term_player_title)
+        PlayRecordingButton(state.castOpenRequests) { result ->
+            if (result is CastOpenResult.Loaded && sessions != null) {
+                state.clearOverlay()
+                // The file name labels the tab: it says "recording", and two recordings of the same
+                // host stay apart (their in-file titles are both just the host name).
+                sessions.openPlayer(result.fileName.ifBlank { playerTabTitle }, result.cast)
+            } else {
+                state.showCast(result)
+            }
+        }
         // Lit while the info panel is open — the only action here with a visible on/off state.
         IconBtn("info", onClick = state::toggleInfo, tint = if (state.infoPanel) D.cyanBright else D.dim)
         // Power: closes the active session (live path) with a confirmation prompt

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ImportFile.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ImportFile.kt
@@ -7,8 +7,11 @@ package app.skerry.ui.vault
  */
 const val MAX_IMPORT_BYTES = 32 * 1024 * 1024
 
+/** A file the user picked: its display name (for labels) and contents. */
+data class ImportedFile(val name: String, val text: String)
+
 /**
  * Reads a text file chosen by the user in the native picker, as UTF-8. Returns `null` on cancel, on
  * a read failure, or when the file is larger than [maxBytes] — nothing is imported silently.
  */
-expect suspend fun importTextFile(maxBytes: Int = MAX_IMPORT_BYTES): String?
+expect suspend fun importTextFile(maxBytes: Int = MAX_IMPORT_BYTES): ImportedFile?

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -12,6 +12,8 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.terminal.Asciicast
+import app.skerry.shared.terminal.CastEvent
 import app.skerry.shared.vnc.VncAuth
 import app.skerry.shared.vnc.VncFramebuffer
 import app.skerry.shared.vnc.VncPointerEvent
@@ -589,6 +591,68 @@ class SessionsControllerTest {
 
         assertTrue(sessions.sessions.isEmpty())
         assertTrue(vncTransport.sessions.single().closed)
+        scope.cancel()
+    }
+
+    // Player tabs
+
+    private val cast = Asciicast(80, 24, "deploy", listOf(CastEvent(0.0, "hi")))
+
+    @Test
+    fun `openPlayer opens a player tab locked to the Player view`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+
+        val id = sessions.openPlayer("deploy", cast)
+
+        assertEquals(id, sessions.activeId)
+        val tab = sessions.active!!
+        assertTrue(tab.isPlayer)
+        assertFalse(tab.isBlank) // a player tab is not an empty tab waiting for a connection
+        assertEquals(SessionView.Player, tab.view)
+        assertEquals(cast, tab.playback?.cast)
+
+        sessions.setActiveView(SessionView.Sftp) // no-op on a player tab
+        assertEquals(SessionView.Player, tab.view)
+        sessions.close(id)
+        scope.cancel()
+    }
+
+    @Test
+    fun `openPlayer opens a fresh tab instead of reusing a blank one`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val blank = sessions.openBlank()
+
+        val id = sessions.openPlayer("deploy", cast)
+
+        assertTrue(id != blank)
+        assertEquals(2, sessions.sessions.size)
+        sessions.close(id)
+        scope.cancel()
+    }
+
+    @Test
+    fun `closing a player tab stops its playback`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val id = sessions.openPlayer("deploy", cast)
+        val playback = sessions.active!!.playback!!
+
+        sessions.close(id)
+
+        assertTrue(sessions.sessions.isEmpty())
+        assertTrue(playback.stopped)
+        scope.cancel()
+    }
+
+    @Test
+    fun `disconnectAll stops playback too`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        sessions.openPlayer("deploy", cast)
+        val playback = sessions.active!!.playback!!
+
+        sessions.disconnectAll()
+
+        assertTrue(sessions.sessions.isEmpty())
+        assertTrue(playback.stopped)
         scope.cancel()
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGeometryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGeometryTest.kt
@@ -16,6 +16,44 @@ class TerminalGeometryTest {
     private val metrics = TerminalMetrics(cellWidth = 8f, cellHeight = 18f)
 
     @Test
+    fun `fit scale grows the font when the pane is wider than the recording`() {
+        // 80 cols x 24 rows at 8x18 px = 640x432; a 1280x864 pane (no padding) fits it twice over.
+        val scale = fitFontScale(1280f, 864f, paddingPx = 0f, metrics = metrics, cols = 80, rows = 24)
+        assertEquals(2f, scale)
+    }
+
+    @Test
+    fun `fit scale takes the tighter axis and honors padding`() {
+        // Width alone would allow 2x, height only 1.5x — the whole grid has to fit.
+        // Content area 1280x648: width allows 1280/640 = 2x, height only 648/432 = 1.5x.
+        val scale = fitFontScale(1290f, 658f, paddingPx = 5f, metrics = metrics, cols = 80, rows = 24)
+        assertEquals(1.5f, scale)
+    }
+
+    @Test
+    fun `fit scale shrinks the font when the pane is narrower than the recording`() {
+        // A 138-col recording in a 640px-wide pane: scaled down instead of wrapping its lines.
+        val scale = fitFontScale(640f, 2000f, paddingPx = 0f, metrics = metrics, cols = 138, rows = 24)
+        assertTrue(scale < 1f, "expected a shrink, got $scale")
+        assertTrue(138 * metrics.cellWidth * scale <= 640f)
+    }
+
+    @Test
+    fun `fit scale is 1 before the viewport or grid is known`() {
+        assertEquals(1f, fitFontScale(0f, 0f, paddingPx = 0f, metrics = metrics, cols = 80, rows = 24))
+        assertEquals(1f, fitFontScale(800f, 600f, paddingPx = 0f, metrics = metrics, cols = 0, rows = 0))
+        // Padding larger than the pane leaves no content area.
+        assertEquals(1f, fitFontScale(10f, 10f, paddingPx = 20f, metrics = metrics, cols = 80, rows = 24))
+    }
+
+    @Test
+    fun `fit scale is clamped for extreme geometries`() {
+        // A 1x1 "recording" in a huge pane would otherwise blow the font up past any usable size.
+        assertEquals(4f, fitFontScale(10_000f, 10_000f, paddingPx = 0f, metrics = metrics, cols = 1, rows = 1))
+        assertEquals(0.3f, fitFontScale(100f, 100f, paddingPx = 0f, metrics = metrics, cols = 1000, rows = 500))
+    }
+
+    @Test
     fun `offset inside the first cell maps to origin`() {
         assertEquals(TerminalPos(0, 0), cellAtOffset(x = 1f, y = 2f, metrics = metrics))
     }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -21,6 +21,8 @@ import app.skerry.ui.design.D
 import app.skerry.ui.files.FileEditController
 import app.skerry.ui.files.FileEditorScreen
 import app.skerry.shared.host.HostStore
+import app.skerry.shared.terminal.Asciicast
+import app.skerry.shared.terminal.CastEvent
 import app.skerry.ui.terminal.TerminalThemes
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntry
@@ -167,6 +169,8 @@ fun main() {
         seedFakeHome()
         sessions?.setActiveView(SessionView.Sftp)
     }
+    // A recording plays in its own tab, so it can't be reached through the rail: open one directly.
+    if (viewName == "Player") sessions?.openPlayer("deploy.cast", seededCast())
     val knownHosts = if (live) seededKnownHosts() else null
     val tunnels = if (live && hosts != null) seededTunnels(hosts) else null
     val ai = if (live) seededAi() else null
@@ -452,6 +456,22 @@ private class InMemoryVault : Vault {
     override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
     override fun verifyPassword(password: CharArray): Boolean = true
 }
+
+/** A short canned recording for the player render (`view=Player`). */
+private fun seededCast(): Asciicast = Asciicast(
+    columns = 138,
+    rows = 30,
+    title = "deploy.cast",
+    events = listOf(
+        CastEvent(0.0, "\u001b[36mroot@prod-web-01\u001b[0m:~# ./deploy.sh\r\n"),
+        CastEvent(0.2, "  \u001b[32m✓\u001b[0m build      12.4s\r\n"),
+        CastEvent(0.4, "  \u001b[32m✓\u001b[0m tests      31.2s\r\n"),
+        CastEvent(0.6, "  \u001b[32m✓\u001b[0m rollout     4.8s\r\n"),
+        CastEvent(0.8, "\r\ndeployed \u001b[1mv0.1.9\u001b[0m to 3 nodes\r\n"),
+        // Full-width rule: shows at a glance whether the recording fills the pane edge to edge.
+        CastEvent(1.0, "\u001b[2m" + "\u2500".repeat(138) + "\u001b[0m"),
+    ),
+)
 
 /**
  * Tunnel manager over an in-memory store and the fake transport, so the offscreen Ports render

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ImportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ImportFile.desktop.kt
@@ -15,7 +15,7 @@ import org.jetbrains.compose.resources.getString
  * The modal dialog runs a nested EDT event loop, so it is shown on [Dispatchers.Swing] and the read
  * happens on IO. A file over [maxBytes] is rejected before it is read.
  */
-actual suspend fun importTextFile(maxBytes: Int): String? {
+actual suspend fun importTextFile(maxBytes: Int): ImportedFile? {
     val title = getString(Res.string.term_player_open)
     val path = withContext(Dispatchers.Swing) {
         val dialog = FileDialog(null as Frame?, title, FileDialog.LOAD).apply { isVisible = true }
@@ -26,7 +26,7 @@ actual suspend fun importTextFile(maxBytes: Int): String? {
     return withContext(Dispatchers.IO) {
         runCatching {
             val file = File(path)
-            if (file.length() > maxBytes) null else file.readText()
+            if (file.length() > maxBytes) null else ImportedFile(file.name, file.readText())
         }.getOrNull()
     }
 }


### PR DESCRIPTION
Opens a `.cast` recording as its own titlebar tab instead of an overlay covering the work area — the shells stay reachable while a recording plays.

**Where:** the play button in the terminal toolbar (⌘P / Ctrl+Shift+P), same as before. Desktop only; mobile has no tabs and keeps the full-screen overlay.

**Behaviour**
- The recording gets a tab of its own (`SessionView.Player`), labelled with the `.cast` file name and accented sunset so it never reads as a live session. It never reuses a blank tab.
- Playback is owned by the tab, not the composable: switching tabs neither stops the replay nor rewinds it, and closing the tab cancels the playback scope.
- The tab is locked to the player view (no Terminal/SFTP sub-views), has no hosts sidebar, and is not a broadcast target.

**Fixed: recording geometry**
The recording is now pinned to the geometry it was taken at (`TerminalScreen.fixedGrid`) and the font is scaled to fill the pane. Before, the grid was fitted to the pane instead: a window wider than the recording left empty columns on the right, and a narrower one wrapped the recording's lines and broke the picture.

**Also in this PR**
- The file picker returns the picked file's name alongside its contents (`ImportedFile`), so the tab can be labelled with it — desktop via `File.name`, Android via SAF `DISPLAY_NAME`.
- `SessionTabChip` takes an `accent` colour (cyan for sessions, sunset for recordings).
- Cell-metric measurement extracted from `TerminalScreen`'s body into `terminalMetrics()`; it now runs twice on the player path (base style → scale → final style).
- Offscreen screenshot harness gained a `view=Player` mode with a canned recording.

**Tests:** `SessionsControllerTest` covers opening a player tab, its locked view, no blank-tab reuse, and playback stopping on close/`disconnectAll`; `TerminalGeometryTest` covers `fitFontScale` (grow, tighter axis with padding, shrink instead of wrap, unmeasured viewport, clamps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)