### PR TITLE
Exclude revoked devices from the tombstone watermark

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidSyncConfigStore.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidSyncConfigStore.kt
@@ -31,6 +31,7 @@ class AndroidSyncConfigStore(private val file: File) : SyncConfigStore {
                 deviceId = device,
                 keepConnected = map["keepConnected"] == "true",
                 sealedRefreshToken = map["sealedRefreshToken"]?.takeIf { it.isNotEmpty() },
+                pendingReconcile = map["pendingReconcile"] == "true", // absent in older files → false
             )
         }.getOrNull()
     }
@@ -42,6 +43,7 @@ class AndroidSyncConfigStore(private val file: File) : SyncConfigStore {
             appendLine("deviceId=${URLEncoder.encode(config.deviceId, "UTF-8")}")
             appendLine("keepConnected=${config.keepConnected}")
             config.sealedRefreshToken?.let { appendLine("sealedRefreshToken=${URLEncoder.encode(it, "UTF-8")}") }
+            if (config.pendingReconcile) appendLine("pendingReconcile=true")
         }
         // Atomic write: write to a temp file then rename, so a process kill mid-write can't leave a truncated sync.json.
         val tmp = File(file.parentFile, "${file.name}.tmp")

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -55,6 +55,14 @@ data class SyncConfig(
     val deviceId: String,
     val keepConnected: Boolean = false,
     val sealedRefreshToken: String? = null,
+    /**
+     * Durable "this device must rebuild from the server before pushing" marker for the revoked→reactivated
+     * flow. The server clears revocation on the SRP verify that reports `reactivated`, so it never reports
+     * it again; persisting the intent here (set before the vault is cleared, cleared only after the first
+     * sync succeeds) means an interrupted reconcile is retried on the next connect/restore instead of
+     * silently resurrecting a purged record. Default `false`; older config files without the key load as `false`.
+     */
+    val pendingReconcile: Boolean = false,
 )
 
 class InMemorySyncConfigStore : SyncConfigStore {
@@ -487,12 +495,17 @@ class SyncCoordinator(
             // (onVaultReset) and adoptedKey.
             // A reactivated (formerly revoked) device forces a full re-pull like an adopted key, and first
             // discards its pre-revocation records so a stale live copy can't re-push a server-purged record.
+            // The server reports `reactivated` only once (it clears revocation on this verify), so we also
+            // honor a durable pendingReconcile from a previously interrupted reconcile — otherwise a crash
+            // mid-reconcile would drop the signal and let the stale records push on the next connect.
+            val pendingReconcile = configStore.load()?.takeIf { it.accountId == accountId }?.pendingReconcile == true
+            val mustReconcile = reactivated || pendingReconcile
             activateSession(
                 syncClient,
                 newSession,
                 SyncConfig(serverUrl, accountId, deviceId, keepConnected, sealed),
-                resetCursor = adoptedKey || reactivated,
-                clearLocalRecords = reactivated,
+                resetCursor = adoptedKey || mustReconcile,
+                clearLocalRecords = mustReconcile,
             )
         } catch (e: CancellationException) {
             throw e // don't swallow cancellation — it would break structured concurrency
@@ -533,18 +546,37 @@ class SyncCoordinator(
         val superseded = client?.takeIf { it !== syncClient }
         client = syncClient
         session = newSession
-        // Reactivation reconcile: drop the sync-eligible local records BEFORE resetting the cursor and
-        // running the first sync, so the following full re-pull rebuilds them from the server snapshot and
-        // the subsequent push can't resurrect a record the server purged while this device was revoked.
-        // Scoped to currently-synced types (what the push would send), so device-local data survives.
+        // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the first
+        // sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
+        // push can't resurrect a record the server purged while this device was revoked.
+        //
+        // The drop set is EVERY sync-capable type, NOT the currently-enabled ones: the push after the
+        // reconciling pull filters by the SERVER's "what syncs" settings (the pull applies them), which can
+        // differ from this device's stale local settings. If we gated the clear by the local settings, a
+        // type disabled locally but enabled on the server would keep its stale record through the clear and
+        // then be pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the
+        // maximal (everything-on) filter covers any server settings; only never-synced, device-local types
+        // (terminal history) are kept.
         if (clearLocalRecords) {
-            val filter = settingsStore.load()
-            vault.clearRecords(RecordType.entries.filter { filter.shouldSync(it) }.toSet())
+            // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
+            // verify that reported `reactivated` and never reports it again, so a crash between here and the
+            // first successful sync would otherwise lose the signal and let the stale records push. The
+            // marker is cleared only after runSync succeeds below, so an interrupted reconcile is retried.
+            configStore.save(config.copy(pendingReconcile = true))
+            val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
+            vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
+            syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
+        } else {
+            if (resetCursor) syncState.setCursor(config.accountId, 0)
+            configStore.save(config)
         }
-        if (resetCursor) syncState.setCursor(config.accountId, 0)
-        configStore.save(config)
         health.setTarget(config.serverUrl)
         runSync()
+        // The reconcile is complete only once the first full re-pull actually succeeded (status Online);
+        // until then keep the marker so an interrupted or failed reconcile is redone on the next connect.
+        if (clearLocalRecords && _status.value is SyncStatus.Online) {
+            configStore.save(config.copy(pendingReconcile = false))
+        }
         startWatch()
         startLocalPush()
         // Reconnecting over a live session (switching accounts, a confirmed password replace) leaves the
@@ -1113,12 +1145,17 @@ class SyncCoordinator(
                     }
                     val syncClient = clientFactory(cfg.serverUrl)
                     val newSession = syncClient.refresh(SyncSession(cfg.accountId, "", refreshToken))
+                    // A reconcile interrupted before it finished (pendingReconcile) must still run on this
+                    // silent restore — refresh carries no `reactivated` signal, so the durable marker is the
+                    // only thing that redoes it before the first push.
+                    val reconcile = cfg.pendingReconcile
                     // refresh rotates the token — re-save it sealed under the dataKey (inside activation).
                     activateSession(
                         syncClient,
                         newSession,
                         cfg.copy(sealedRefreshToken = tokens.seal(dataKey, newSession.refreshToken)),
-                        resetCursor = false,
+                        resetCursor = reconcile,
+                        clearLocalRecords = reconcile,
                     )
                 } catch (e: CancellationException) {
                     throw e

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -16,6 +16,7 @@ import app.skerry.shared.sync.SyncSettings
 import app.skerry.shared.sync.SyncSettingsStore
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.MasterKey
+import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
@@ -401,6 +402,10 @@ class SyncCoordinator(
             // vault salt; a rare user-initiated connect, so the extra derivation is acceptable.
             val matchesVault = vault.verifyPassword(masterPassword.copyOf())
             var adoptedKey = false
+            // Set when the server reports this device was revoked and this login reactivated it: the vault
+            // may still hold records the server purged while we were locked out, so we must re-mirror the
+            // server before the first push (see [activateSession]'s clearLocalRecords).
+            var reactivated = false
             val newSession: SyncSession = if (matchesVault) {
                 // Establish the account under the vault's own password: register a new one (publishes our
                 // dataKey), or on CONFLICT log into our existing account and adopt its key. Adopting here
@@ -410,6 +415,7 @@ class SyncCoordinator(
                 } catch (e: SyncException) {
                     if (e.kind != SyncException.Kind.CONFLICT) throw e
                     val s = syncClient.login(accountId, ak, device)
+                    reactivated = s.reactivated
                     // Same password on both sides: nothing to re-wrap, only a possible key change.
                     adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf()) == KeyAdoption.Adopted
                     s
@@ -442,6 +448,7 @@ class SyncCoordinator(
                 // Confirmed ([confirmPasswordReplace]): log into the existing account and adopt its key,
                 // re-keying this vault to the account password (the intended, consented password change).
                 val s = syncClient.login(accountId, ak, device)
+                reactivated = s.reactivated
                 when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
                     KeyAdoption.Adopted -> adoptedKey = true
                     // The account key already IS ours (registered here, then the vault password was changed
@@ -478,11 +485,14 @@ class SyncCoordinator(
             // The cursor is now persistent ([FileSyncStateStore]), so a process restart also continues
             // incrementally; the reset path is doubly guarded — cursor reset in [disconnect]
             // (onVaultReset) and adoptedKey.
+            // A reactivated (formerly revoked) device forces a full re-pull like an adopted key, and first
+            // discards its pre-revocation records so a stale live copy can't re-push a server-purged record.
             activateSession(
                 syncClient,
                 newSession,
                 SyncConfig(serverUrl, accountId, deviceId, keepConnected, sealed),
-                resetCursor = adoptedKey,
+                resetCursor = adoptedKey || reactivated,
+                clearLocalRecords = reactivated,
             )
         } catch (e: CancellationException) {
             throw e // don't swallow cancellation — it would break structured concurrency
@@ -504,9 +514,10 @@ class SyncCoordinator(
 
     /**
      * Shared tail of activating a session (from [doConnect]/[doClaimPairing]/[restoreSession]):
-     * publish client/session, optionally reset the cursor ([resetCursor] — full re-pull cases: adopted
-     * account key, freshly paired device), save the link, point the health ping at its server, and
-     * start the initial sync + live subscriptions (watch/push).
+     * publish client/session, optionally drop pre-revocation records ([clearLocalRecords] — a reactivated
+     * device rebuilds from the server), reset the cursor ([resetCursor] — full re-pull cases: adopted
+     * account key, freshly paired device, reactivation), save the link, point the health ping at its
+     * server, and start the initial sync + live subscriptions (watch/push).
      *
      * Call only under [opMutex]: assigning client/session and cancel/join/replacing subscriptions race
      * with [disconnect] — the mutex serializes activation and teardown as a whole. For [restoreSession]
@@ -517,10 +528,19 @@ class SyncCoordinator(
         newSession: SyncSession,
         config: SyncConfig,
         resetCursor: Boolean,
+        clearLocalRecords: Boolean = false,
     ) {
         val superseded = client?.takeIf { it !== syncClient }
         client = syncClient
         session = newSession
+        // Reactivation reconcile: drop the sync-eligible local records BEFORE resetting the cursor and
+        // running the first sync, so the following full re-pull rebuilds them from the server snapshot and
+        // the subsequent push can't resurrect a record the server purged while this device was revoked.
+        // Scoped to currently-synced types (what the push would send), so device-local data survives.
+        if (clearLocalRecords) {
+            val filter = settingsStore.load()
+            vault.clearRecords(RecordType.entries.filter { filter.shouldSync(it) }.toSet())
+        }
         if (resetCursor) syncState.setCursor(config.accountId, 0)
         configStore.save(config)
         health.setTarget(config.serverUrl)

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileSyncConfigStore.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileSyncConfigStore.kt
@@ -33,6 +33,7 @@ class FileSyncConfigStore(private val path: Path) : SyncConfigStore {
                 deviceId = device,
                 keepConnected = map["keepConnected"] == "true",
                 sealedRefreshToken = map["sealedRefreshToken"]?.takeIf { it.isNotEmpty() },
+                pendingReconcile = map["pendingReconcile"] == "true", // absent in older files → false
             )
         }.getOrNull()
     }
@@ -44,6 +45,7 @@ class FileSyncConfigStore(private val path: Path) : SyncConfigStore {
             appendLine("deviceId=${encode(config.deviceId)}")
             appendLine("keepConnected=${config.keepConnected}")
             config.sealedRefreshToken?.let { appendLine("sealedRefreshToken=${encode(it)}") }
+            if (config.pendingReconcile) appendLine("pendingReconcile=true")
         }
         PrivateConfig.atomicWrite(path, text.encodeToByteArray())
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -9,6 +9,8 @@ import app.skerry.shared.sync.RemoteRecord
 import app.skerry.shared.sync.SyncClient
 import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSettings
+import app.skerry.shared.sync.SyncSettingsStore
 import app.skerry.shared.sync.SyncSignal
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
@@ -24,6 +26,7 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -32,7 +35,8 @@ import kotlin.test.assertTrue
  * tombstone while a revoked device still holds the record LIVE (it never pulled the tombstone). On
  * reactivation that device's full push would re-upload the record (the server has no row for it → resurrected)
  * and it would spread back to every peer. The coordinator closes this window: when the login reports the
- * device was reactivated, it rebuilds the vault from the server snapshot before the first push.
+ * device was reactivated — or a previously interrupted reconcile is still pending — it rebuilds the vault
+ * from the server snapshot before the first push.
  *
  * Real [FileVault] + real [IonspinVaultCrypto] (the reconcile is the whole point) and the REAL [SyncEngine]
  * runs so the push path is genuinely exercised; only the network is stubbed.
@@ -46,17 +50,20 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * This device's own account after a server-side purge: `register` collides (account exists), `login`
-     * reports the device was reactivated, the served wrap is this vault's OWN key (so the connect adopts
-     * nothing — isolating the reactivation path), and the server no longer holds `r1`, so `pull` returns
+     * reports [reactivated], the served wrap is this vault's OWN key (so the connect adopts nothing —
+     * isolating the reactivation path), and the server no longer holds `r1` (purged), so `pull` returns
      * nothing. `push` records exactly what the client sent.
      */
-    private inner class ReactivatingClient(private val ownWrappedKey: ByteArray) : SyncClient {
+    private inner class ReactivatingClient(
+        private val ownWrappedKey: ByteArray,
+        private val reactivated: Boolean = true,
+    ) : SyncClient {
         val pushed = mutableListOf<RemoteRecord>()
 
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
             throw SyncException(SyncException.Kind.CONFLICT, "account exists")
         override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = true)
+            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = reactivated)
         override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = RecordPage(emptyList(), 1)
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
@@ -73,33 +80,92 @@ class SyncCoordinatorReactivationTest {
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
     }
 
-    @Test
-    fun `reactivated device drops its stale record and does not re-push a purged one`() = runBlocking {
-        initializeVaultCrypto()
+    /** A fresh unlocked account vault under [password], with its own random dataKey. */
+    private fun freshVault(): Vault {
         val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()
         FileSystem.SYSTEM.delete(file) // FileVault creates it
-        val vault: Vault = FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-22T00:00:00Z" })
+        return FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-22T00:00:00Z" })
             .also { it.create(password.toCharArray()) }
+    }
+
+    /** This vault's own dataKey wrapped under the account (= vault) password, so the connect adopts nothing. */
+    private fun ownWrap(vault: Vault): ByteArray {
+        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
+        val dk = vault.exportDataKey()!!
+        val wrapped = crypto.wrapDataKey(mk, dk)
+        mk.zeroize(); dk.zeroize()
+        return wrapped
+    }
+
+    @Test
+    fun `reactivated device drops its stale record, does not re-push it, and clears the pending marker`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
         // The device still holds r1 LIVE — it was revoked before it could pull the tombstone.
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        // The account key IS this vault's own key, wrapped under the account (= vault) password: the connect
-        // adopts nothing, so only the reactivation reconcile can change the vault.
-        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
-        val dk = vault.exportDataKey()!!
-        val ownWrapped = crypto.wrapDataKey(mk, dk)
-        mk.zeroize(); dk.zeroize()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val config = InMemorySyncConfigStore()
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
+            assertFalse(vault.records().any { it.id == "r1" }, "a reactivated device must discard its pre-revocation records")
+            assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
+            // The durable marker is cleared once the reconcile's first sync succeeded.
+            assertEquals(false, config.load()?.pendingReconcile, "a completed reconcile clears the pending marker")
+        } finally {
+            sut.close()
+        }
+    }
 
-        val client = ReactivatingClient(ownWrapped)
+    @Test
+    fun `a pending reconcile from an interrupted run is redone even when the login is not a reactivation`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        // A previous reactivation was interrupted after the server cleared revocation but before the vault
+        // was rebuilt: the durable marker survived. This login is NOT a reactivation (server already sees
+        // the device as live), so only the marker can drive the reconcile.
+        val config = InMemorySyncConfigStore()
+        config.save(SyncConfig(serverUrl, account, deviceId = "devA", pendingReconcile = true))
+        val client = ReactivatingClient(ownWrap(vault), reactivated = false)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online, "reconnect should come Online")
+            assertFalse(vault.records().any { it.id == "r1" }, "a pending reconcile must still rebuild the vault")
+            assertFalse(client.pushed.any { it.id == "r1" }, "a pending reconcile must not let the stale record push")
+            assertEquals(false, config.load()?.pendingReconcile, "the redone reconcile clears the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `reactivation clears a record whose type is locally disabled but may be enabled on the server`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        // This device has "sync hosts" turned OFF locally, so its stale HOST record is not in the local
+        // push filter. But the account may have hosts sync ON: after the reconciling pull applies the
+        // server's settings, the push filter flips on and the stale record would resurrect — unless the
+        // clear covers every sync-capable type regardless of the (stale) local toggle. It must.
+        SyncSettingsStore(vault).save(SyncSettings(syncHosts = false))
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
             assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
-            // The stale live record is gone locally…
-            assertFalse(vault.records().any { it.id == "r1" }, "a reactivated device must discard its pre-revocation records")
-            // …and was never pushed back to the server, so it can't resurrect and spread to peers.
-            assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
+            assertFalse(
+                vault.records().any { it.id == "r1" },
+                "the clear must not be gated by the stale local sync toggles — a locally-disabled type must be cleared too",
+            )
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -1,0 +1,107 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * PR #51, the second half: excluding revoked devices from the tombstone watermark lets the account purge a
+ * tombstone while a revoked device still holds the record LIVE (it never pulled the tombstone). On
+ * reactivation that device's full push would re-upload the record (the server has no row for it → resurrected)
+ * and it would spread back to every peer. The coordinator closes this window: when the login reports the
+ * device was reactivated, it rebuilds the vault from the server snapshot before the first push.
+ *
+ * Real [FileVault] + real [IonspinVaultCrypto] (the reconcile is the whole point) and the REAL [SyncEngine]
+ * runs so the push path is genuinely exercised; only the network is stubbed.
+ */
+class SyncCoordinatorReactivationTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    /**
+     * This device's own account after a server-side purge: `register` collides (account exists), `login`
+     * reports the device was reactivated, the served wrap is this vault's OWN key (so the connect adopts
+     * nothing — isolating the reactivation path), and the server no longer holds `r1`, so `pull` returns
+     * nothing. `push` records exactly what the client sent.
+     */
+    private inner class ReactivatingClient(private val ownWrappedKey: ByteArray) : SyncClient {
+        val pushed = mutableListOf<RemoteRecord>()
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            throw SyncException(SyncException.Kind.CONFLICT, "account exists")
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
+            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = true)
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = RecordPage(emptyList(), 1)
+        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
+            pushed += records
+            return RecordPage(emptyList(), 1)
+        }
+        override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
+        override suspend fun ping(): Boolean = true
+        override suspend fun close() {}
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
+        override suspend fun refresh(session: SyncSession): SyncSession = throw NotImplementedError()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
+    }
+
+    @Test
+    fun `reactivated device drops its stale record and does not re-push a purged one`() = runBlocking {
+        initializeVaultCrypto()
+        val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        val vault: Vault = FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-22T00:00:00Z" })
+            .also { it.create(password.toCharArray()) }
+        // The device still holds r1 LIVE — it was revoked before it could pull the tombstone.
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        // The account key IS this vault's own key, wrapped under the account (= vault) password: the connect
+        // adopts nothing, so only the reactivation reconcile can change the vault.
+        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
+        val dk = vault.exportDataKey()!!
+        val ownWrapped = crypto.wrapDataKey(mk, dk)
+        mk.zeroize(); dk.zeroize()
+
+        val client = ReactivatingClient(ownWrapped)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
+            // The stale live record is gone locally…
+            assertFalse(vault.records().any { it.id == "r1" }, "a reactivated device must discard its pre-revocation records")
+            // …and was never pushed back to the server, so it can't resurrect and spread to peers.
+            assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
+        } finally {
+            sut.close()
+        }
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/db/TombstoneWatermark.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TombstoneWatermark.kt
@@ -7,17 +7,24 @@ import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 
 /**
- * Tombstone propagation watermark: the minimum cursor across all of an account's devices.
- * Records with `serverSeq <= watermark` have been read by every device, so only those are safe
- * to compact/purge; otherwise a lagging device would resurrect the record on its next pull. A
+ * Tombstone propagation watermark: the minimum cursor across all of an account's ACTIVE devices.
+ * Records with `serverSeq <= watermark` have been read by every active device, so only those are
+ * safe to compact/purge; otherwise a lagging device would resurrect the record on its next pull. A
  * device with no cursor (null/never synced) pins the watermark to 0, blocking compaction; an
- * account with no devices gets watermark = MAX (nothing left to resurrect). Shared by
+ * account with no active devices gets watermark = MAX (nothing left to resurrect). Revoked devices
+ * are excluded: a revoked device can never pull again (the server rejects its auth), so its frozen
+ * cursor must not pin the watermark forever — with it included, one revoked-and-never-synced device
+ * blocks tombstone compaction for the account permanently. If the device is re-activated
+ * (re-authentication clears revocation, see DeviceRepository), its cursor is stale relative to
+ * purged tombstones, which is safe: the tombstone's target record is long gone from every peer, and
+ * the device's next delta pull simply never sees a deletion for a record it may still hold — the
+ * same end state as a device that was offline past the team-scope age purge. Shared by
  * [RecordRepository.compactedTombstoneIds] and [AdminRepository.purgeTombstones].
  * Call only inside an open transaction.
  */
 internal fun tombstoneWatermark(accountId: String): Long {
     val cursors = Devices.selectAll()
-        .where { Devices.accountId eq accountId }
+        .where { (Devices.accountId eq accountId) and (Devices.revoked eq false) }
         .map { it[Devices.lastSyncVersion] ?: 0L }
     return if (cursors.isEmpty()) Long.MAX_VALUE else cursors.min()
 }

--- a/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
@@ -122,6 +122,8 @@ fun Route.authRoutes(services: Services) {
                 m2 = verified.m2,
                 accessToken = services.tokens.issueAccess(verified.accountId, req.deviceId),
                 refreshToken = services.tokens.issueRefresh(verified.accountId, req.deviceId),
+                // Tell the client a revoked device just came back so it re-mirrors the server before pushing.
+                reactivated = reactivated,
             ),
         )
         }

--- a/server/src/test/kotlin/app/skerry/server/db/AdminRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/AdminRepositoryTest.kt
@@ -120,6 +120,28 @@ class AdminRepositoryTest {
     }
 
     @Test
+    fun `a revoked device does not pin the watermark`() = withTestDb { db ->
+        seedAccount(db)
+        val devices = DeviceRepository(db)
+        val records = RecordRepository(db)
+        val admin = AdminRepository(db)
+
+        // Active device is fully caught up; a revoked device is stuck at cursor 1 (e.g. an old
+        // phone that was re-paired and then revoked). The tombstone is past the active cursor,
+        // so excluding the revoked device it is safe to purge.
+        devices.register("alice@example.com", "devA", "Laptop")
+        devices.register("alice@example.com", "devOld", "Old phone")
+        records.upsert("alice@example.com", listOf(rec("r1", 1)))
+        records.upsert("alice@example.com", listOf(rec("r1", 2, deleted = true))) // tombstone at serverSeq 3
+        devices.touch("alice@example.com", "devA", syncVersion = 3)
+        devices.touch("alice@example.com", "devOld", syncVersion = 1)
+        devices.revoke("alice@example.com", "devOld")
+
+        assertEquals(1, admin.purgeTombstones("alice@example.com"))
+        assertEquals(0, admin.accountSummaries().single().tombstones)
+    }
+
+    @Test
     fun `compacted tombstone ids are those at or below the slowest device cursor`() = withTestDb { db ->
         seedAccount(db)
         val devices = DeviceRepository(db)

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withTimeout
 import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class RoutesTest {
@@ -166,6 +167,7 @@ class RoutesTest {
         assertEquals(HttpStatusCode.OK, verify.status)
         val vr: VerifyResponse = verify.body()
         sc.step3(BigInteger(vr.m2, 16)) // not throwing means the server is authentic
+        assertFalse(vr.reactivated, "a normal login of a live device is not a reactivation")
 
         // wrong password
         val bad = srpClient(accountId, "nope")
@@ -233,6 +235,8 @@ class RoutesTest {
         assertEquals(HttpStatusCode.OK, client.get("/vault/keys") { bearerAuth(fresh.accessToken) }.status)
         val after: DevicesResponse = client.get("/devices") { bearerAuth(fresh.accessToken) }.body()
         assertEquals(false, after.devices.single { it.id == "devA" }.revoked)
+        // The response flags the reactivation so the client rebuilds its vault from the server before pushing.
+        assertTrue(fresh.reactivated, "re-login of a revoked device must be reported as a reactivation")
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
@@ -9,8 +9,18 @@ import kotlinx.coroutines.flow.Flow
  */
 data class DeviceInfo(val id: String, val name: String, val platform: String? = null)
 
-/** Active session with the sync server: accountId and a token pair (see design doc §4). */
-data class SyncSession(val accountId: String, val accessToken: String, val refreshToken: String)
+/**
+ * Active session with the sync server: accountId and a token pair (see design doc §4). [reactivated] is a
+ * transient signal from the [login] that produced this session — `true` only when this device was revoked
+ * and this login cleared the revocation; the coordinator uses it to rebuild the vault from the server before
+ * its first push. Not part of session identity: [refresh] and [register] carry the default `false`.
+ */
+data class SyncSession(
+    val accountId: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val reactivated: Boolean = false,
+)
 
 /**
  * Encrypted record as sent over the wire: metadata is plaintext, [blob] is XChaCha20-Poly1305

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
@@ -352,6 +352,19 @@ class FileVault(
         commit(currentMeta, updated)
     }
 
+    override fun clearRecords(types: Set<RecordType>): Unit = synchronized(lock) {
+        requireUnlocked()
+        if (types.isEmpty()) return@synchronized
+        val currentMeta = session()
+        // Keep records of other types (device-local or currently not synced): they never resurrect a
+        // purged record because they're not pushed, and dropping them would lose local-only data.
+        val kept = records.filterNot { it.type in types }
+        if (kept.size == records.size) return@synchronized // nothing of these types — leave the file untouched
+        // Hard drop, no tombstone (see [Vault.clearRecords]) and no _localChanges: the caller re-pulls
+        // the server snapshot, so records still on the server return and purged ones stay gone.
+        commit(currentMeta, kept)
+    }
+
     override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = synchronized(lock) {
         try {
             val currentMeta = meta

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
@@ -218,10 +218,15 @@ interface Vault {
      * Unlike [remove] it does NOT tombstone the dropped records (a tombstone would re-inflate the very
      * tombstones a server-side purge just removed) and does NOT emit [localChanges] (there's nothing to
      * push — the caller repopulates from the server). Unlike [reset] the vault stays unlocked with the
-     * same dataKey and file. The caller scopes [types] to the sync-eligible types so device-local data
-     * (e.g. terminal history, or a type currently excluded from sync) survives. Unknown/unparsed records
-     * are left untouched — they never push, so they carry no resurrection risk, and the re-pull restores
-     * the server's copy. No-op by default (fakes); the file vault overrides it. Requires an unlocked vault.
+     * same dataKey and file. The caller scopes [types] to the sync-capable types so device-local data
+     * (e.g. terminal history) survives. Unknown/unparsed records are left untouched — they never push, so
+     * they carry no resurrection risk, and the re-pull restores the server's copy.
+     *
+     * This drops matching records indiscriminately — live AND local tombstones. A deletion this device made
+     * but never managed to push is therefore reverted (the record returns live on the re-pull if the server
+     * still holds it). That is the intended contract for reactivation: a revoked device could not push
+     * anyway, so its unsynced edits — additions and deletions alike — are discarded in favor of the server
+     * snapshot. No-op by default (fakes); the file vault overrides it. Requires an unlocked vault.
      */
     fun clearRecords(types: Set<RecordType>) {}
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
@@ -211,6 +211,21 @@ interface Vault {
     fun compact(ids: List<String>) {}
 
     /**
+     * Physically drops every record whose [RecordType] is in [types], keeping the key, metadata, and
+     * unlock state — a soft reset used when a revoked device is reactivated and must become a fresh
+     * mirror of the server ([app.skerry.shared.sync.SyncCoordinator] follows this with a full re-pull).
+     *
+     * Unlike [remove] it does NOT tombstone the dropped records (a tombstone would re-inflate the very
+     * tombstones a server-side purge just removed) and does NOT emit [localChanges] (there's nothing to
+     * push — the caller repopulates from the server). Unlike [reset] the vault stays unlocked with the
+     * same dataKey and file. The caller scopes [types] to the sync-eligible types so device-local data
+     * (e.g. terminal history, or a type currently excluded from sync) survives. Unknown/unparsed records
+     * are left untouched — they never push, so they carry no resurrection risk, and the re-pull restores
+     * the server's copy. No-op by default (fakes); the file vault overrides it. Requires an unlocked vault.
+     */
+    fun clearRecords(types: Set<RecordType>) {}
+
+    /**
      * Changes the master password: rewraps the same `dataKey` under the new password (records aren't
      * re-encrypted). `false` if [oldPassword] is wrong. Requires an unlocked vault.
      */

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
@@ -876,6 +876,46 @@ class FileVaultTest {
     }
 
     @Test
+    fun `clearRecords drops the given types, keeps others, and leaves the vault unlocked under the same key`() = vaultTest {
+        val v = vault()
+        v.create("m".toCharArray())
+        v.put("h1", RecordType.HOST, "host".encodeToByteArray())
+        v.put("s1", RecordType.SNIPPET, "snip".encodeToByteArray())
+        v.put("t1", RecordType.TERMINAL_HISTORY, "hist".encodeToByteArray()) // device-local: must survive
+
+        v.clearRecords(setOf(RecordType.HOST, RecordType.SNIPPET))
+
+        // The named types are physically gone, NOT tombstoned — a leftover tombstone would be pushed and
+        // could resurrect a record the server just purged.
+        assertEquals(listOf("t1"), v.records().map { it.id })
+        assertFalse(v.records().any { it.deleted })
+        // Same key, still unlocked: the surviving record decrypts and a re-put bumps its version normally.
+        assertTrue(v.isUnlocked)
+        assertContentEquals("hist".encodeToByteArray(), v.openPayload("t1"))
+        // Persisted: a fresh handle unlocks with the same password and sees the same surviving record.
+        val reopened = vault()
+        assertEquals(UnlockResult.Success, reopened.unlock("m".toCharArray()))
+        assertEquals(listOf("t1"), reopened.records().map { it.id })
+    }
+
+    @Test
+    fun `clearRecords emits no local change`() = runTest {
+        initializeVaultCrypto()
+        val v = vault()
+        v.create("m".toCharArray())
+        v.put("h1", RecordType.HOST, "host".encodeToByteArray())
+        val seen = mutableListOf<Unit>()
+        val job = backgroundScope.launch { v.localChanges.collect { seen += Unit } }
+        runCurrent()
+
+        v.clearRecords(setOf(RecordType.HOST)) // reconcile re-pulls from the server — nothing to push
+        runCurrent()
+
+        assertTrue(seen.isEmpty())
+        job.cancel()
+    }
+
+    @Test
     fun `failed atomic write cleans up the tmp file`() = vaultTest {
         // Write target is an existing directory: atomicMove into it fails, and atomicWriteUtf8 must
         // clean up the tmp file (not leave an orphaned copy of secrets on disk).

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -139,7 +139,7 @@ class KtorSyncClient(
         } catch (e: SRP6Exception) {
             throw SyncException(SyncException.Kind.PROTOCOL, "server SRP proof (M2) invalid", e)
         }
-        return SyncSession(accountId, verify.accessToken, verify.refreshToken)
+        return SyncSession(accountId, verify.accessToken, verify.refreshToken, reactivated = verify.reactivated)
     }
 
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
@@ -39,8 +39,19 @@ data class VerifyRequest(
     val platform: String? = null,
 )
 
+/**
+ * SRP login response. [reactivated] is `true` only when this device was revoked and this correct-password
+ * login cleared the revocation (server-computed, see the device re-enroll audit event). The client uses it
+ * to rebuild its vault from the server snapshot before its first push, so a record purged while the device
+ * was revoked isn't resurrected by a stale local copy. Default `false` keeps old servers/clients wire-compatible.
+ */
 @Serializable
-data class VerifyResponse(val m2: String, val accessToken: String, val refreshToken: String)
+data class VerifyResponse(
+    val m2: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val reactivated: Boolean = false,
+)
 
 @Serializable
 data class RefreshRequest(val refreshToken: String)


### PR DESCRIPTION
Found while using the admin console on my own account: with every active device fully caught up, "Purge tombstones" still reported nothing to purge. Turned out the watermark counted **revoked** devices too — an old phone I had re-paired and revoked was pinning it forever at its frozen cursor.

**Root cause** — `tombstoneWatermark()` takes `min(lastSyncVersion)` over *all* of an account's devices. A revoked device can never pull again (the server rejects its auth), so its cursor never advances, and any tombstone above it stays unpurgeable for the account's lifetime (the team-scope age purge doesn't cover account records).

**Fix** — exclude `revoked = true` from the watermark. A revoked device carries no resurrection risk because it can never pull. If it is ever re-activated (re-authentication clears revocation per `DeviceRepository`), its next pull simply never sees tombstones purged while it was revoked — the same end state as a device that was offline past the team-scope age purge, and the record itself is long gone from every peer.

**Test** — regression test in `AdminRepositoryTest`: active device caught up + revoked device stuck at an old cursor → tombstone purges. Full `:server:test` suite green.

Real-world numbers from my account before the fix: 6 devices (2 active at cursor 59, 4 revoked at cursors 1/41/43/44), 6 tombstones at seq 6–43, watermark = 1 → 0 purgeable. After the fix: watermark = 59 → all 6 purgeable. (•̀ᴗ•́)و