### PR TITLE
feat(desktop): optional double-click to connect to a host

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -87,6 +87,9 @@
     <string name="settings_terminal_show_title">Показывать заголовок терминала на вкладках</string>
     <string name="settings_terminal_show_title_desc">Разрешить подключённому шеллу переименовывать вкладку (например, по запущенной программе). Выкл — вкладки всегда показывают сохранённое имя хоста.</string>
     <string name="settings_terminal_clipboard_write">Разрешить серверу писать в буфер обмена (OSC 52)</string>
+    <string name="settings_terminal_host_connect">Подключение к хосту</string>
+    <string name="settings_terminal_host_connect_single">Один клик</string>
+    <string name="settings_terminal_host_connect_double">Двойной клик</string>
     <string name="settings_terminal_clipboard_write_desc">Разрешить подключённому шеллу заменять системный буфер обмена (используется copy в tmux/vim). По умолчанию выкл — иначе вредоносный хост может подсунуть свой текст в то, что вы вставите.</string>
 
     <!-- Раздел Sync (включая карточку аккаунта и устройства — бывшая вкладка Account влита сюда) -->

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -89,7 +89,7 @@
     <string name="settings_terminal_clipboard_write">Разрешить серверу писать в буфер обмена (OSC 52)</string>
     <string name="settings_terminal_host_connect">Подключение к хосту</string>
     <string name="settings_terminal_host_connect_single">Один клик</string>
-    <string name="settings_terminal_host_connect_double">Двойной клик</string>
+    <string name="settings_terminal_host_connect_double">Двойной клик (клик выделяет)</string>
     <string name="settings_terminal_clipboard_write_desc">Разрешить подключённому шеллу заменять системный буфер обмена (используется copy в tmux/vim). По умолчанию выкл — иначе вредоносный хост может подсунуть свой текст в то, что вы вставите.</string>
 
     <!-- Раздел Sync (включая карточку аккаунта и устройства — бывшая вкладка Account влита сюда) -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -87,6 +87,9 @@
     <string name="settings_terminal_show_title">在标签页上显示终端标题</string>
     <string name="settings_terminal_show_title_desc">允许连接的终端程序重命名标签页（如运行中的程序名）。关闭——标签页始终显示保存的主机名。</string>
     <string name="settings_terminal_clipboard_write">允许服务器写入剪贴板 (OSC 52)</string>
+    <string name="settings_terminal_host_connect">连接主机方式</string>
+    <string name="settings_terminal_host_connect_single">单击</string>
+    <string name="settings_terminal_host_connect_double">双击</string>
     <string name="settings_terminal_clipboard_write_desc">允许连接的终端程序覆盖系统剪贴板（tmux/vim 的复制功能使用）。默认关闭——恶意主机可能将攻击者控制的文本插入你粘贴的内容中。</string>
 
     <!-- 同步部分 -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -89,7 +89,7 @@
     <string name="settings_terminal_clipboard_write">允许服务器写入剪贴板 (OSC 52)</string>
     <string name="settings_terminal_host_connect">连接主机方式</string>
     <string name="settings_terminal_host_connect_single">单击</string>
-    <string name="settings_terminal_host_connect_double">双击</string>
+    <string name="settings_terminal_host_connect_double">双击（单击选中）</string>
     <string name="settings_terminal_clipboard_write_desc">允许连接的终端程序覆盖系统剪贴板（tmux/vim 的复制功能使用）。默认关闭——恶意主机可能将攻击者控制的文本插入你粘贴的内容中。</string>
 
     <!-- 同步部分 -->

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -89,7 +89,7 @@
     <string name="settings_terminal_clipboard_write">Allow server clipboard writes (OSC 52)</string>
     <string name="settings_terminal_host_connect">Connect to host on</string>
     <string name="settings_terminal_host_connect_single">Single click</string>
-    <string name="settings_terminal_host_connect_double">Double click</string>
+    <string name="settings_terminal_host_connect_double">Double click (click selects)</string>
     <string name="settings_terminal_clipboard_write_desc">Let the connected shell replace your system clipboard (used by tmux/vim yank). Off by default — a malicious host could otherwise slip attacker-controlled text into what you paste.</string>
 
     <!-- Sync section (also covers the account card and linked devices — merged from the former Account tab) -->

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -87,6 +87,9 @@
     <string name="settings_terminal_show_title">Show terminal title on tabs</string>
     <string name="settings_terminal_show_title_desc">Let the connected shell rename a tab (e.g. the running program). Off — tabs always show the saved host name.</string>
     <string name="settings_terminal_clipboard_write">Allow server clipboard writes (OSC 52)</string>
+    <string name="settings_terminal_host_connect">Connect to host on</string>
+    <string name="settings_terminal_host_connect_single">Single click</string>
+    <string name="settings_terminal_host_connect_double">Double click</string>
     <string name="settings_terminal_clipboard_write_desc">Let the connected shell replace your system clipboard (used by tmux/vim yank). Off by default — a malicious host could otherwise slip attacker-controlled text into what you paste.</string>
 
     <!-- Sync section (also covers the account card and linked devices — merged from the former Account tab) -->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -102,6 +102,28 @@ val LocalKnownHosts: ProvidableCompositionLocal<KnownHostsController?> = staticC
  */
 val LocalConnectHost: ProvidableCompositionLocal<(Host) -> Unit> = staticCompositionLocalOf { {} }
 
+/** How a host row click connects: single click or double click. Desktop-only setting. */
+enum class HostClickConnectMode(val id: String) {
+    SingleClick("single"),
+    DoubleClick("double"),
+    ;
+
+    companion object {
+        // Single click keeps the historic behavior; double click is opt-in via Settings.
+        val DEFAULT = SingleClick
+
+        fun fromId(id: String): HostClickConnectMode = entries.firstOrNull { it.id == id } ?: DEFAULT
+    }
+}
+
+/**
+ * Whether a host row connects on single or double click (Settings → Terminal → Behavior).
+ * Desktop-only; mobile always connects on tap. Supplied by [DesktopDesignApp]; default is
+ * [HostClickConnectMode.DEFAULT].
+ */
+val LocalHostClickConnectMode: ProvidableCompositionLocal<HostClickConnectMode> =
+    staticCompositionLocalOf { HostClickConnectMode.DEFAULT }
+
 /**
  * "Open host in the active tab's split pane" action: same secret resolution as [LocalConnectHost], but
  * opens a new independent secondary session alongside, rather than a new tab. Supplied by

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -157,6 +157,10 @@ class DesktopDesignState(
     private val onTerminalCursorStyleChange: (TerminalCursorStyle) -> Unit = {},
     initialShowTerminalTitleOnTabs: Boolean = false,
     private val onShowTerminalTitleOnTabsChange: (Boolean) -> Unit = {},
+    // Host-row click behavior (Settings → Terminal → Behavior): single click connects directly,
+    // double click requires a second click (protects against accidental connects). Desktop-only.
+    initialHostClickConnectMode: HostClickConnectMode = HostClickConnectMode.DEFAULT,
+    private val onHostClickConnectModeChange: (HostClickConnectMode) -> Unit = {},
     // Whether the server may write the system clipboard via OSC 52 (Terminal → "Allow server
     // clipboard write"). Off by default (like xterm/kitty). Snapshotted into new sessions via
     // [app.skerry.ui.terminal.TerminalSessionPrefs] and pushed live into open ones.
@@ -299,6 +303,7 @@ class DesktopDesignState(
 
     /** Whether to show the live OSC title on terminal tabs (Terminal → Show title on tabs). */
     var showTerminalTitleOnTabs: Boolean by mutableStateOf(initialShowTerminalTitleOnTabs); private set
+    var hostClickConnectMode: HostClickConnectMode by mutableStateOf(initialHostClickConnectMode); private set
 
     /**
      * Whether a server may write the system clipboard via OSC 52 (Terminal → Allow server clipboard
@@ -612,6 +617,13 @@ class DesktopDesignState(
     fun toggleShowTerminalTitleOnTabs() {
         showTerminalTitleOnTabs = !showTerminalTitleOnTabs
         onShowTerminalTitleOnTabsChange(showTerminalTitleOnTabs)
+    }
+
+    /** Choose how host rows connect (single/double click) and report outward (for persistence). */
+    fun chooseHostClickConnectMode(mode: HostClickConnectMode) {
+        if (mode == hostClickConnectMode) return
+        hostClickConnectMode = mode
+        onHostClickConnectModeChange(mode)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -166,6 +166,8 @@ import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.app.LocalFeatures
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.LocalHostClickConnectMode
+import app.skerry.ui.app.HostClickConnectMode
 import app.skerry.ui.app.LocalKnownHosts
 import app.skerry.ui.app.LocalRunSnippetOnHost
 import app.skerry.ui.app.LocalSecurityLog
@@ -255,6 +257,9 @@ fun DesktopDesignApp(
     onTerminalCursorStyleChange: (TerminalCursorStyle) -> Unit = {},
     initialShowTerminalTitleOnTabs: Boolean = false,
     onShowTerminalTitleOnTabsChange: (Boolean) -> Unit = {},
+    // Host-row click behavior (Settings → Terminal → Behavior) — persisted externally (desktop main).
+    initialHostClickConnectMode: HostClickConnectMode = HostClickConnectMode.DEFAULT,
+    onHostClickConnectModeChange: (HostClickConnectMode) -> Unit = {},
     // OSC 52 server clipboard-write gate (Settings → Terminal) — persisted externally (desktop main).
     initialAllowServerClipboardWrite: Boolean = false,
     onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
@@ -279,6 +284,7 @@ fun DesktopDesignApp(
             initialTerminalScrollback, onTerminalScrollbackChange,
             initialTerminalCursorStyle, onTerminalCursorStyleChange,
             initialShowTerminalTitleOnTabs, onShowTerminalTitleOnTabsChange,
+            initialHostClickConnectMode, onHostClickConnectModeChange,
             initialAllowServerClipboardWrite, onAllowServerClipboardWriteChange,
             initialTerminalTheme, onTerminalThemeChange,
             initialAutoLock, onAutoLockChange,
@@ -614,6 +620,7 @@ private fun DesktopChrome(
         LocalConnectSplit provides connectSplitHost,
         LocalRunSnippetOnHost provides runSnippetOnHost,
         LocalCredentials provides credentials,
+        LocalHostClickConnectMode provides state.hostClickConnectMode,
     ) {
         // Global snippet hotkey: preview events flow from the root down to focus, so the root Box
         // intercepts the chord before the terminal does. If a saved shortcut matches and there's a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -179,7 +179,9 @@ internal fun TerminalSection(state: DesktopDesignState) {
     // click (protects against accidental connects when just browsing the catalog). Desktop-only.
     Row(Modifier.fillMaxWidth().padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
         Column(Modifier.weight(1f)) { Txt(stringResource(Res.string.settings_terminal_host_connect), color = D.text, size = 13.sp, weight = FontWeight.Medium) }
-        Box(Modifier.width(160.dp)) { HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode) }
+        // No fixed-width Box: DropdownField sizes itself to the longest option, matching the
+        // neighbouring CursorStylePicker.
+        HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode)
     }
     HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.HostClickConnectMode
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.D
 import app.skerry.ui.design.DropdownField
@@ -51,6 +52,9 @@ import app.skerry.ui.generated.resources.settings_terminal_show_title
 import app.skerry.ui.generated.resources.settings_terminal_show_title_desc
 import app.skerry.ui.generated.resources.settings_terminal_subtitle
 import app.skerry.ui.generated.resources.settings_terminal_title
+import app.skerry.ui.generated.resources.settings_terminal_host_connect
+import app.skerry.ui.generated.resources.settings_terminal_host_connect_single
+import app.skerry.ui.generated.resources.settings_terminal_host_connect_double
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
@@ -171,6 +175,13 @@ internal fun TerminalSection(state: DesktopDesignState) {
         onToggle = state::toggleShowTerminalTitleOnTabs,
     )
     HLine()
+    // Host-row click behavior: single click connects directly, double click requires a second
+    // click (protects against accidental connects when just browsing the catalog). Desktop-only.
+    Row(Modifier.fillMaxWidth().padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
+        Column(Modifier.weight(1f)) { Txt(stringResource(Res.string.settings_terminal_host_connect), color = D.text, size = 13.sp, weight = FontWeight.Medium) }
+        Box(Modifier.width(160.dp)) { HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode) }
+    }
+    HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from
     // silently overwriting the system clipboard. Applies to new and already-open sessions.
     SettingToggleRow(
@@ -258,6 +269,21 @@ private fun ScrollbackPicker(current: Int, onPick: (Int) -> Unit) {
 @Composable
 private fun CursorStylePicker(current: TerminalCursorStyle, onPick: (TerminalCursorStyle) -> Unit) {
     DropdownField(current, TerminalCursorStyle.entries, label = { it.cursorStyleLabel() }, onPick = onPick)
+}
+
+/** Localized host-connect-mode label for the dropdown and its trigger. */
+@Composable
+internal fun HostClickConnectMode.hostConnectModeLabel(): String = stringResource(
+    when (this) {
+        HostClickConnectMode.SingleClick -> Res.string.settings_terminal_host_connect_single
+        HostClickConnectMode.DoubleClick -> Res.string.settings_terminal_host_connect_double
+    },
+)
+
+/** Dropdown for host-row connect click behavior (single/double click). */
+@Composable
+private fun HostConnectModePicker(current: HostClickConnectMode, onPick: (HostClickConnectMode) -> Unit) {
+    DropdownField(current, HostClickConnectMode.entries, label = { it.hostConnectModeLabel() }, onPick = onPick)
 }
 
 /** "10000" -> "10 000" (space between thousands) for readable line counts. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -35,6 +35,11 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
@@ -107,12 +112,34 @@ import org.jetbrains.compose.resources.stringResource
 /**
  * Host-row connect click behavior from Settings → Terminal → Behavior: single click connects
  * directly, double click requires a second click. Desktop-only (mobile always connects on tap).
+ *
+ * Double-click mode keeps two affordances:
+ * - A single mouse click still *does* something: [onSingleClick] runs when provided (live catalog
+ *   rows use it for selection highlight); otherwise combinedClickable's press feedback shows the
+ *   row isn't inert.
+ * - Keyboard activation (Enter/Space) connects directly — the double-click requirement applies to
+ *   the mouse only, so keyboard-only users can always connect.
  */
 @Composable
-private fun Modifier.hostConnectClick(onClick: () -> Unit): Modifier =
+private fun Modifier.hostConnectClick(
+    onClick: () -> Unit,
+    onSingleClick: (() -> Unit)? = null,
+): Modifier =
     when (LocalHostClickConnectMode.current) {
         HostClickConnectMode.SingleClick -> clickable(onClick = onClick)
-        HostClickConnectMode.DoubleClick -> combinedClickable(onClick = { }, onDoubleClick = onClick)
+        HostClickConnectMode.DoubleClick -> combinedClickable(
+            onClick = { onSingleClick?.invoke() },
+            onDoubleClick = onClick,
+        ).onKeyEvent { event ->
+            if (event.type == KeyEventType.KeyDown &&
+                (event.key == Key.Enter || event.key == Key.Spacebar)
+            ) {
+                onClick()
+                true
+            } else {
+                false
+            }
+        }
     }
 
 @Composable
@@ -121,6 +148,10 @@ internal fun HostsSidebar(state: DesktopDesignState) {
     val liveHosts = LocalHosts.current
     // Manual reorder (drag-and-drop) state for the live catalog; unused on the mock path.
     val dragState = remember { HostDragState() }
+    // Selected host in the live catalog — drives the single-click highlight in double-click
+    // connect mode (file-manager convention: click selects, double-click opens). Also updated on
+    // connect so the row that just opened reads as selected. Null = no selection.
+    var selectedHostId by remember { mutableStateOf<String?>(null) }
     // Active filter chip (tag); live catalog only, chips are static on the mock path.
     var activeChip by remember { mutableStateOf(ALL_HOSTS_CHIP) }
     val chips = liveHosts?.let { remember(it.hosts) { hostTagChips(it.hosts) } } ?: emptyList()
@@ -218,7 +249,7 @@ internal fun HostsSidebar(state: DesktopDesignState) {
                 folders.forEach { folder ->
                     key(folder.name) {
                         if (folder.name == folderLineBefore) DropLine()
-                        LiveHostFolder(folder, state, mono, dragState, liveHosts) { foldersUpdated.value }
+                        LiveHostFolder(folder, state, mono, dragState, liveHosts, selectedHostId, { selectedHostId = it }) { foldersUpdated.value }
                     }
                 }
                 if (folderLineIndex != null && folderLineIndex == otherFolders.size) DropLine()
@@ -513,6 +544,8 @@ private fun LiveHostFolder(
     mono: FontFamily,
     dragState: HostDragState,
     controller: HostManagerController,
+    selectedHostId: String?,
+    onSelectHost: (String) -> Unit,
     foldersProvider: () -> List<HostFolder>,
 ) {
     val sessions = LocalSessions.current
@@ -562,6 +595,7 @@ private fun LiveHostFolder(
                     // Stabilizes lambdas on (host, ...): otherwise every folder recomposition would
                     // recreate them and force the row to redraw (nullable functions are unstable).
                     val onClick = remember(host, connect) { { connect(host) } }
+                    val onSelect = remember(host) { { onSelectHost(host.id) } }
                     val onEdit = remember(host, state) { { state.openEditModal(host) } }
                     val onDelete = remember(host, state) { { state.requestDeleteHost(host) } }
                     // Forgets the row's geometry once the host leaves the list (deleted/filtered out).
@@ -576,13 +610,14 @@ private fun LiveHostFolder(
                     ) {
                         HostEntryRow(
                             label = host.label,
-                            // Active-tab host highlight removed: with a split view two hosts can be
-                            // active, so highlighting one would mislead. The status dot on the right
-                            // still reflects live connection state.
-                            selected = false,
+                            // Selection highlight: marks the row clicked in double-click mode (and
+                            // the most recently connected one in single-click mode). Distinct from
+                            // the live-connection status dot on the right.
+                            selected = host.id == selectedHostId,
                             dot = sessionDotColor(sessions?.statusFor(host.id)),
                             badge = null,
                             onClick = onClick,
+                            onSelect = onSelect,
                             mono = mono,
                             icon = host.connectionType.icon,
                             // Host object, for the "Run snippet..." menu item (runs a snippet on this host).
@@ -647,6 +682,7 @@ private fun HostEntryRow(
     mono: FontFamily,
     icon: String,
     host: Host? = null,
+    onSelect: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
     onDelete: (() -> Unit)? = null,
 ) {
@@ -661,7 +697,15 @@ private fun HostEntryRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(5.dp))
             .background(if (selected) D.cyan10 else Color.Transparent)
-            .hostConnectClick(onClick)
+            .hostConnectClick(
+                onClick = {
+                    // Connecting also marks the row selected (single-click mode too — it reads as
+                    // "the host you just opened"), then opens the session.
+                    onSelect?.invoke()
+                    onClick()
+                },
+                onSingleClick = onSelect,
+            )
             .padding(start = 8.dp, end = 2.dp, top = 5.dp, bottom = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.terminal
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -48,6 +49,8 @@ import app.skerry.shared.host.Host
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.HostClickConnectMode
+import app.skerry.ui.app.LocalHostClickConnectMode
 import app.skerry.ui.app.LocalRunSnippetOnHost
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
@@ -100,6 +103,17 @@ import org.jetbrains.compose.resources.stringResource
 
 // Terminal view host sidebar: search, tag filters, catalog folders (live drag-and-drop or mock
 // preview), a RECENT section, and the "New connection" button.
+
+/**
+ * Host-row connect click behavior from Settings → Terminal → Behavior: single click connects
+ * directly, double click requires a second click. Desktop-only (mobile always connects on tap).
+ */
+@Composable
+private fun Modifier.hostConnectClick(onClick: () -> Unit): Modifier =
+    when (LocalHostClickConnectMode.current) {
+        HostClickConnectMode.SingleClick -> clickable(onClick = onClick)
+        HostClickConnectMode.DoubleClick -> combinedClickable(onClick = { }, onDoubleClick = onClick)
+    }
 
 @Composable
 internal fun HostsSidebar(state: DesktopDesignState) {
@@ -419,7 +433,7 @@ private fun TeamHostRow(host: Host, mono: FontFamily) {
             .fillMaxWidth()
             .padding(start = 16.dp)
             .clip(RoundedCornerShape(5.dp))
-            .clickable(onClick = onClick)
+            .hostConnectClick(onClick)
             .padding(horizontal = 8.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -448,7 +462,7 @@ private fun RecentHostRow(host: Host, mono: FontFamily) {
             .fillMaxWidth()
             .padding(start = 16.dp)
             .clip(RoundedCornerShape(5.dp))
-            .clickable(onClick = onClick)
+            .hostConnectClick(onClick)
             .padding(horizontal = 8.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -647,7 +661,7 @@ private fun HostEntryRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(5.dp))
             .background(if (selected) D.cyan10 else Color.Transparent)
-            .clickable(onClick = onClick)
+            .hostConnectClick(onClick)
             .padding(start = 8.dp, end = 2.dp, top = 5.dp, bottom = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
@@ -127,19 +127,27 @@ private fun Modifier.hostConnectClick(
 ): Modifier =
     when (LocalHostClickConnectMode.current) {
         HostClickConnectMode.SingleClick -> clickable(onClick = onClick)
-        HostClickConnectMode.DoubleClick -> combinedClickable(
-            onClick = { onSingleClick?.invoke() },
-            onDoubleClick = onClick,
-        ).onKeyEvent { event ->
-            if (event.type == KeyEventType.KeyDown &&
-                (event.key == Key.Enter || event.key == Key.Spacebar)
-            ) {
-                onClick()
-                true
-            } else {
-                false
-            }
-        }
+        HostClickConnectMode.DoubleClick ->
+            // onPreviewKeyEvent must sit *outer* to combinedClickable: key events travel
+            // root→focused on the preview pass, and combinedClickable consumes Enter/Space itself
+            // (routing them to onClick = select), so a descendant onKeyEvent never fires. The
+            // preview handler intercepts first, making Enter/Space connect while the mouse still
+            // requires a double click (same pattern as TerminalScreen/CommandPalette).
+            Modifier
+                .onPreviewKeyEvent { event ->
+                    if (event.type == KeyEventType.KeyDown &&
+                        (event.key == Key.Enter || event.key == Key.Spacebar)
+                    ) {
+                        onClick()
+                        true
+                    } else {
+                        false
+                    }
+                }
+                .combinedClickable(
+                    onClick = { onSingleClick?.invoke() },
+                    onDoubleClick = onClick,
+                )
     }
 
 @Composable

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -70,6 +70,7 @@ import app.skerry.ui.terminal.TerminalThemes
 import app.skerry.ui.tunnel.TunnelManager
 import app.skerry.ui.tunnel.resolveTunnelHost
 import app.skerry.ui.vault.AutoLockDuration
+import app.skerry.ui.app.HostClickConnectMode
 import app.skerry.ui.vault.ResetScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -454,6 +455,8 @@ fun main(args: Array<String>) {
                     onTerminalCursorStyleChange = { prefs.set("terminal_cursor_style", it.id) },
                     initialShowTerminalTitleOnTabs = prefs.bool("terminal_show_title", false),
                     onShowTerminalTitleOnTabsChange = { prefs.set("terminal_show_title", it) },
+                    initialHostClickConnectMode = prefs.id("host_click_connect", HostClickConnectMode.DEFAULT, HostClickConnectMode::fromId),
+                    onHostClickConnectModeChange = { prefs.set("host_click_connect", it.id) },
                     initialAllowServerClipboardWrite = prefs.bool("terminal_clipboard_write", false),
                     onAllowServerClipboardWriteChange = { prefs.set("terminal_clipboard_write", it) },
                     initialAutoLock = prefs.id("auto_lock", AutoLockDuration.DEFAULT, AutoLockDuration::fromId),


### PR DESCRIPTION
Hi! 😊

Host rows in the terminal sidebar connect on a **single click** today. When you're just browsing the catalog it's easy to accidentally open a session on a production machine — one stray click and you're connected.

This PR adds **Settings → Terminal → Behavior → "Connect to host on"** with two options:

- **Single click** (default) — the current behavior, unchanged
- **Double click** — the file-manager convention: click selects, double-click opens

Details:

- `HostClickConnectMode` persisted to prefs; the default keeps single click so existing users see no behavior change
- The three host-row types in `HostsSidebar` (team / recent / catalog) switch between `clickable` and `combinedClickable(onClick={}, onDoubleClick=...)` via a small `Modifier.hostConnectClick` helper
- Mobile is unaffected (always connects on tap)
- i18n: en / zh / ru

Verified with `:composeApp:compileKotlinDesktop`.