### PR TITLE
Change account password: rotate the sync master password

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -157,6 +157,14 @@
     <string name="settings_change_pw_submit">Сменить пароль</string>
     <string name="settings_change_pw_err_wrong">Текущий пароль неверен.</string>
 
+    <!-- Диалог смены пароля аккаунта (issue #32) -->
+    <string name="settings_security_account_password">Пароль аккаунта</string>
+    <string name="settings_security_account_password_desc">Общий для всех синхронизированных устройств.</string>
+    <string name="settings_change_account_pw_title">Смена пароля аккаунта</string>
+    <string name="settings_change_account_pw_note">Пароль изменится на всех синхронизированных устройствах. На остальных потребуется войти заново с новым паролём.</string>
+    <string name="settings_change_account_pw_submit">Сменить пароль</string>
+    <string name="settings_change_account_pw_err_rewrap">Пароль аккаунта изменён, но это устройство нужно переподключить с новым паролём.</string>
+
     <!-- Раздел Keyboard -->
     <string name="settings_keyboard_title">Клавиатура</string>
     <string name="settings_keyboard_subtitle">Горячие клавиши подстраиваются под вашу платформу. Терминальные привязки работают, когда сессия в фокусе.</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -157,6 +157,14 @@
     <string name="settings_change_pw_submit">更改密码</string>
     <string name="settings_change_pw_err_wrong">当前密码不正确。</string>
 
+    <!-- 更改账户密码对话框 (issue #32) -->
+    <string name="settings_security_account_password">账户密码</string>
+    <string name="settings_security_account_password_desc">由所有已同步设备共享。</string>
+    <string name="settings_change_account_pw_title">更改账户密码</string>
+    <string name="settings_change_account_pw_note">这将更改所有已同步设备上的密码。其他设备需使用新密码重新登录。</string>
+    <string name="settings_change_account_pw_submit">更改密码</string>
+    <string name="settings_change_account_pw_err_rewrap">账户密码已更改，但此设备需使用新密码重新连接。</string>
+
     <!-- 键盘部分 -->
     <string name="settings_keyboard_title">键盘</string>
     <string name="settings_keyboard_subtitle">快捷键适配你的平台。终端快捷键在会话聚焦时生效。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -157,6 +157,14 @@
     <string name="settings_change_pw_submit">Change password</string>
     <string name="settings_change_pw_err_wrong">Current password is incorrect.</string>
 
+    <!-- Change account password dialog (issue #32) -->
+    <string name="settings_security_account_password">Account password</string>
+    <string name="settings_security_account_password_desc">Shared by all your synced devices.</string>
+    <string name="settings_change_account_pw_title">Change account password</string>
+    <string name="settings_change_account_pw_note">This changes the password on every synced device. Your other devices will need to sign in again with the new password.</string>
+    <string name="settings_change_account_pw_submit">Change password</string>
+    <string name="settings_change_account_pw_err_rewrap">The account password was changed, but this device must reconnect with the new password.</string>
+
     <!-- Keyboard section -->
     <string name="settings_keyboard_title">Keyboard</string>
     <string name="settings_keyboard_subtitle">Shortcuts adapt to your platform. Terminal bindings apply while a session is focused.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -99,6 +99,8 @@ import app.skerry.ui.generated.resources.settings_security_2fa
 import app.skerry.ui.generated.resources.settings_security_2fa_desc
 import app.skerry.ui.generated.resources.settings_security_auto_lock
 import app.skerry.ui.generated.resources.settings_security_auto_lock_desc
+import app.skerry.ui.generated.resources.settings_security_account_password
+import app.skerry.ui.generated.resources.settings_security_account_password_desc
 import app.skerry.ui.generated.resources.settings_security_master_password
 import app.skerry.ui.generated.resources.settings_security_no_events
 import app.skerry.ui.generated.resources.settings_security_subtitle
@@ -116,6 +118,7 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.Badge
+import app.skerry.ui.settings.ChangeAccountPasswordDialog
 import app.skerry.ui.settings.ChangeMasterPasswordDialog
 import app.skerry.ui.design.D
 import app.skerry.ui.generated.resources.term_player_open
@@ -290,8 +293,15 @@ fun MobileSecurityScreen(state: MobileDesignState) {
     val controller = remember(vault, biometrics, log) {
         vault?.let { VaultGateController(it, biometrics, securityLog = log) }
     }
+    val sync = LocalSync.current
+    // Sync configured → the password is the account password (issue #32): the account-aware rotation
+    // replaces the local-only master-password change (which would diverge this device, issue #28).
+    // Derived from the status flow (reactive, no per-recomposition disk read).
+    val syncStatus = sync?.status?.collectAsState()?.value
+    val syncConfigured = syncStatus != null && syncStatus !is app.skerry.ui.sync.SyncStatus.Disabled
     var reload by remember { mutableStateOf(0) }
     var changePwOpen by remember { mutableStateOf(false) }
+    var changeAccountPwOpen by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     Box(Modifier.fillMaxSize().background(D.bg)) {
@@ -307,8 +317,17 @@ fun MobileSecurityScreen(state: MobileDesignState) {
                 }
                 Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     Column(Modifier.weight(1f)) {
-                        Txt(stringResource(Res.string.settings_security_master_password), color = D.text, size = 14.5.sp)
-                        Txt(masterPasswordSubtitle(lastChange), color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+                        Txt(
+                            stringResource(if (syncConfigured) Res.string.settings_security_account_password else Res.string.settings_security_master_password),
+                            color = D.text,
+                            size = 14.5.sp,
+                        )
+                        Txt(
+                            if (syncConfigured) stringResource(Res.string.settings_security_account_password_desc) else masterPasswordSubtitle(lastChange),
+                            color = D.dim,
+                            size = 11.5.sp,
+                            modifier = Modifier.padding(top = 3.dp),
+                        )
                     }
                     // Changing the password requires a live vault; without one it's dimmed/inert.
                     Txt(
@@ -316,7 +335,11 @@ fun MobileSecurityScreen(state: MobileDesignState) {
                         color = if (controller != null) D.cyanBright else D.faint,
                         size = 13.sp,
                         weight = FontWeight.Medium,
-                        modifier = if (controller != null) Modifier.clickable { changePwOpen = true } else Modifier,
+                        modifier = if (controller != null) {
+                            Modifier.clickable { if (syncConfigured) changeAccountPwOpen = true else changePwOpen = true }
+                        } else {
+                            Modifier
+                        },
                     )
                 }
                 MobileSecurityDivider()
@@ -421,6 +444,15 @@ fun MobileSecurityScreen(state: MobileDesignState) {
             ChangeMasterPasswordDialog(
                 controller = controller,
                 onClose = { changePwOpen = false },
+                onChanged = { reload++ },
+            )
+        }
+        // Change-account-password dialog (issue #32) — same modal treatment, shown when sync is configured.
+        if (changeAccountPwOpen && sync != null) {
+            PlatformBackHandler(enabled = true) { changeAccountPwOpen = false }
+            ChangeAccountPasswordDialog(
+                sync = sync,
+                onClose = { changeAccountPwOpen = false },
                 onChanged = { reload++ },
             )
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
@@ -95,7 +95,18 @@ import app.skerry.ui.generated.resources.settings_time_today
 import app.skerry.ui.generated.resources.settings_time_yesterday
 import app.skerry.ui.generated.resources.vtail_error_password_mismatch
 import app.skerry.ui.generated.resources.vtail_error_password_too_short
+import app.skerry.ui.generated.resources.settings_change_account_pw_err_rewrap
+import app.skerry.ui.generated.resources.settings_change_account_pw_note
+import app.skerry.ui.generated.resources.settings_change_account_pw_submit
+import app.skerry.ui.generated.resources.settings_change_account_pw_title
+import app.skerry.ui.generated.resources.settings_security_account_password
+import app.skerry.ui.generated.resources.settings_security_account_password_desc
+import app.skerry.ui.sync.AccountPasswordChange
+import app.skerry.ui.sync.SyncCoordinator
+import app.skerry.ui.sync.SyncFailureReason
 import app.skerry.ui.sync.SyncField
+import app.skerry.ui.sync.SyncStatus
+import app.skerry.ui.sync.syncFailureText
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.ui.vault.MIN_MASTER_PASSWORD_LENGTH
 import app.skerry.ui.vault.VaultGateController
@@ -118,7 +129,12 @@ internal fun SecuritySection(
     state: DesktopDesignState,
     controller: VaultGateController?,
     reload: Int,
+    // When sync is configured the password IS the account password (one password model, issue #28):
+    // the local-only "Change master password" would diverge this device from the account, so we swap
+    // it for the account-aware "Change account password" (issue #32) instead of showing both.
+    syncConfigured: Boolean,
     onChangeMasterPassword: () -> Unit,
+    onChangeAccountPassword: () -> Unit,
     onBiometricToggled: () -> Unit,
 ) {
     SectionTitle(stringResource(Res.string.settings_security_title), stringResource(Res.string.settings_security_subtitle))
@@ -130,12 +146,25 @@ internal fun SecuritySection(
     }
     Row(Modifier.fillMaxWidth().padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
         Column(Modifier.weight(1f)) {
-            Txt(stringResource(Res.string.settings_security_master_password), color = D.text, size = 13.sp, weight = FontWeight.Medium)
-            Txt(masterPasswordSubtitle(lastChange), color = D.dim, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+            Txt(
+                stringResource(if (syncConfigured) Res.string.settings_security_account_password else Res.string.settings_security_master_password),
+                color = D.text,
+                size = 13.sp,
+                weight = FontWeight.Medium,
+            )
+            Txt(
+                if (syncConfigured) stringResource(Res.string.settings_security_account_password_desc) else masterPasswordSubtitle(lastChange),
+                color = D.dim,
+                size = 11.5.sp,
+                modifier = Modifier.padding(top = 3.dp),
+            )
         }
         // Change is only available with a live vault; in mock/preview the button is inert.
-        if (controller != null) GhostButton(stringResource(Res.string.settings_change), onClick = onChangeMasterPassword)
-        else GhostButton(stringResource(Res.string.settings_change), onClick = {}, fg = D.faint, border = D.line)
+        if (controller != null) {
+            GhostButton(stringResource(Res.string.settings_change), onClick = if (syncConfigured) onChangeAccountPassword else onChangeMasterPassword)
+        } else {
+            GhostButton(stringResource(Res.string.settings_change), onClick = {}, fg = D.faint, border = D.line)
+        }
     }
     HLine()
 
@@ -376,6 +405,104 @@ internal fun ChangeMasterPasswordDialog(
                 }
                 PrimaryButton(
                     stringResource(Res.string.settings_change_pw_submit),
+                    onClick = submit,
+                    enabled = canSubmit,
+                    bg = if (canSubmit) D.cyan else D.cyan10,
+                    fg = if (canSubmit) D.ink else D.faint,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Change ACCOUNT password dialog (issue #32), shown instead of [ChangeMasterPasswordDialog] when sync
+ * is configured. Same three fields, but the submit rotates the account password over the network
+ * ([SyncCoordinator.changeAccountPassword]): the server swaps the SRP verifier + wrapped dataKey and
+ * revokes the other devices, and the local vault is re-wrapped under the new password. The note warns
+ * that this affects every synced device. [LocalRewrapFailed] gets its own message — the account did
+ * rotate, only this device must reconnect.
+ */
+@Composable
+internal fun ChangeAccountPasswordDialog(
+    sync: SyncCoordinator,
+    onClose: () -> Unit,
+    onChanged: () -> Unit,
+) {
+    var current by remember { mutableStateOf("") }
+    var fresh by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+    // Last coordinator result (kept as the typed value so the localized error text is resolved in
+    // composition via the @Composable syncFailureText); cleared on the next edit.
+    var result by remember { mutableStateOf<AccountPasswordChange?>(null) }
+    var busy by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    val tooShort = fresh.isNotEmpty() && fresh.length < MIN_MASTER_PASSWORD_LENGTH
+    val mismatch = confirm.isNotEmpty() && fresh != confirm
+    val canSubmit = current.isNotEmpty() && fresh.length >= MIN_MASTER_PASSWORD_LENGTH && fresh == confirm && !busy
+
+    val submit = {
+        if (canSubmit) {
+            result = null
+            busy = true
+            val old = current.toCharArray()
+            val next = fresh.toCharArray()
+            scope.launch {
+                val r = withContext(Dispatchers.Default) { sync.changeAccountPassword(old, next) }
+                busy = false
+                if (r is AccountPasswordChange.Success) { onChanged(); onClose() } else result = r
+            }
+            Unit
+        }
+    }
+
+    val error: String? = when (val r = result) {
+        is AccountPasswordChange.WrongCurrentPassword -> stringResource(Res.string.settings_change_pw_err_wrong)
+        is AccountPasswordChange.LocalRewrapFailed -> stringResource(Res.string.settings_change_account_pw_err_rewrap)
+        is AccountPasswordChange.Failed -> syncFailureText(SyncStatus.Failed(r.reason, r.detail))
+        is AccountPasswordChange.NotConfigured -> syncFailureText(SyncStatus.Failed(SyncFailureReason.ConnectFailed))
+        // Success never renders (the coroutine closed the dialog); null is the untouched state — both
+        // fall through to input validation. Exhaustive over the sealed type so a new variant won't
+        // silently land in a validation message.
+        is AccountPasswordChange.Success, null -> when {
+            tooShort -> stringResource(Res.string.vtail_error_password_too_short, MIN_MASTER_PASSWORD_LENGTH)
+            mismatch -> stringResource(Res.string.vtail_error_password_mismatch)
+            else -> null
+        }
+    }
+
+    ModalScrim(onDismiss = onClose) {
+        Column(
+            Modifier
+                .width(360.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(D.surfaceDeep)
+                .border(1.dp, D.cyan14, RoundedCornerShape(12.dp))
+                .consumeClicks()
+                .padding(26.dp),
+        ) {
+            Txt(stringResource(Res.string.settings_change_account_pw_title), color = D.text, size = 16.sp, weight = FontWeight.SemiBold)
+            Box(Modifier.height(8.dp))
+            Txt(stringResource(Res.string.settings_change_account_pw_note), color = D.dim, size = 11.5.sp)
+            Box(Modifier.height(14.dp))
+            FieldLabel(stringResource(Res.string.settings_change_pw_current), top = 0.dp)
+            SyncField(placeholder = "••••••••", value = current, icon = "lock", keyboardType = KeyboardType.Password, imeAction = ImeAction.Next, secret = true) { current = it; result = null }
+            FieldLabel(stringResource(Res.string.settings_change_pw_new))
+            SyncField(placeholder = "••••••••", value = fresh, icon = "lock_reset", keyboardType = KeyboardType.Password, imeAction = ImeAction.Next, secret = true) { fresh = it; result = null }
+            FieldLabel(stringResource(Res.string.settings_change_pw_confirm))
+            SyncField(placeholder = "••••••••", value = confirm, icon = "lock_reset", keyboardType = KeyboardType.Password, imeAction = ImeAction.Done, secret = true, onSubmit = submit) { confirm = it; result = null }
+            if (error != null) Txt(error, color = D.storm, size = 11.5.sp, modifier = Modifier.padding(top = 10.dp))
+            Row(
+                Modifier.fillMaxWidth().padding(top = 18.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(Modifier.clip(RoundedCornerShape(7.dp)).clickable(onClick = onClose).padding(horizontal = 16.dp, vertical = 9.dp)) {
+                    Txt(stringResource(Res.string.settings_cancel), color = D.dim, size = 12.5.sp)
+                }
+                PrimaryButton(
+                    stringResource(Res.string.settings_change_account_pw_submit),
                     onClick = submit,
                     enabled = canSubmit,
                     bg = if (canSubmit) D.cyan else D.cyan10,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SettingsPanel.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +33,7 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalFeatures
 import app.skerry.ui.app.LocalSecurityLog
+import app.skerry.ui.app.LocalSync
 import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
 import app.skerry.ui.app.SettingsTab
@@ -41,6 +43,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.sync.SyncStatus
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.settings_nav_header
 import app.skerry.ui.generated.resources.shtail_nav_about
@@ -61,8 +64,15 @@ fun SettingsPanel(state: DesktopDesignState) {
     // log/label after actions. changePwOpen is lifted to overlay level: the dialog is drawn over
     // the whole settings card.
     val securityController = rememberSecurityController()
+    val sync = LocalSync.current
+    // Sync configured → the password is the account password (issue #32): show/host the account
+    // rotation dialog instead of the local-only master-password one. Derived from the status flow
+    // (reactive, no per-recomposition disk read): a saved link means status is never Disabled.
+    val syncStatus = sync?.status?.collectAsState()?.value
+    val syncConfigured = syncStatus != null && syncStatus !is SyncStatus.Disabled
     var securityReload by remember { mutableStateOf(0) }
     var changePwOpen by remember { mutableStateOf(false) }
+    var changeAccountPwOpen by remember { mutableStateOf(false) }
     ModalScrim(onDismiss = state::closeSettings, scrimColor = Color(0xA6060E16)) {
         Box(
             Modifier
@@ -97,7 +107,9 @@ fun SettingsPanel(state: DesktopDesignState) {
                         state = state,
                         controller = securityController,
                         reload = securityReload,
+                        syncConfigured = syncConfigured,
                         onChangeMasterPassword = { changePwOpen = true },
+                        onChangeAccountPassword = { changeAccountPwOpen = true },
                         onBiometricToggled = { securityReload++ },
                     )
                     SettingsTab.Keyboard -> KeyboardSection()
@@ -121,6 +133,14 @@ fun SettingsPanel(state: DesktopDesignState) {
             ChangeMasterPasswordDialog(
                 controller = securityController,
                 onClose = { changePwOpen = false },
+                onChanged = { securityReload++ },
+            )
+        }
+        // Change account (sync) password dialog — shown when sync is configured (issue #32).
+        if (changeAccountPwOpen && sync != null) {
+            ChangeAccountPasswordDialog(
+                sync = sync,
+                onClose = { changeAccountPwOpen = false },
                 onChanged = { securityReload++ },
             )
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -99,6 +99,31 @@ sealed interface SyncStatus {
     data class Failed(val reason: SyncFailureReason, val detail: String? = null) : SyncStatus
 }
 
+/**
+ * Outcome of [SyncCoordinator.changeAccountPassword] (issue #32). A discrete action result, not a
+ * [SyncStatus] transition: the caller (a dialog) shows the message inline; the localized text lives
+ * in the UI layer.
+ */
+sealed interface AccountPasswordChange {
+    data object Success : AccountPasswordChange
+
+    /** The typed current password doesn't unlock this vault (caught locally, no round-trip). */
+    data object WrongCurrentPassword : AccountPasswordChange
+
+    /** Sync isn't configured on this device — there's no account password to rotate. */
+    data object NotConfigured : AccountPasswordChange
+
+    /**
+     * The server rotated the password, but re-wrapping the local vault under it failed. The account
+     * is now on the new password; this device must reconnect with it (the #28 path heals the local
+     * wrap). Distinct from [Failed] so the UI can tell the user exactly this.
+     */
+    data object LocalRewrapFailed : AccountPasswordChange
+
+    /** The rotation failed before anything changed ([reason] is localized in the UI; [detail] optional). */
+    data class Failed(val reason: SyncFailureReason, val detail: String? = null) : AccountPasswordChange
+}
+
 /** [SyncStatus.Failed] causes — one value per user-facing situation (en+ru strings in the UI). */
 enum class SyncFailureReason {
     VaultLocked,
@@ -606,6 +631,127 @@ class SyncCoordinator(
         pendingReplace = null
         pending.password.fill(' ')
         _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) } ?: SyncStatus.Disabled
+    }
+
+    /**
+     * Change the account (sync) password — the single source of truth shared by all devices (issue
+     * #32). Atomically on the server: the SRP verifier and the wrapped account dataKey are swapped to
+     * the new password's, and every other device is revoked (they re-authenticate with the new
+     * password). Locally the vault is re-wrapped under the new password so this device keeps
+     * unlocking; the dataKey is unchanged (only its wrap), so biometrics — which wraps the dataKey —
+     * stays valid and needs no reset.
+     *
+     * Server-first ordering is the atomic commit point: if this device dies after the server rotates
+     * but before the local re-wrap ([AccountPasswordChange.LocalRewrapFailed]), the account is on the
+     * new password and this device heals on its next reconnect via the confirmed-replace path (#28).
+     *
+     * Requires sync configured ([isConfigured]) and an unlocked vault. Owns copies of [current]/[next]
+     * and wipes them (and all derived key material) before returning.
+     */
+    suspend fun changeAccountPassword(current: CharArray, next: CharArray): AccountPasswordChange {
+        val cfg = savedConfig
+        if (cfg == null) {
+            current.fill(' '); next.fill(' ')
+            return AccountPasswordChange.NotConfigured
+        }
+        // Under opMutex like connect: activating the fresh session must not race with a disconnect or
+        // a concurrent connect.
+        return try {
+            opMutex.withLock { doChangeAccountPassword(cfg, current, next) }
+        } finally {
+            // If cancelled while waiting for opMutex (dialog dismissed mid-submit), doChangeAccountPassword
+            // never ran and never wiped these — wipe here too. Idempotent on the normal path (it already
+            // filled them with spaces).
+            current.fill(' '); next.fill(' ')
+        }
+    }
+
+    // Under [opMutex] (see changeAccountPassword).
+    private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange {
+        // Local current-password check first: catch a typo without a round-trip (and the vault must be
+        // unlocked to export the dataKey for the new wrap anyway).
+        if (!vault.verifyPassword(current.copyOf())) {
+            current.fill(' '); next.fill(' ')
+            return AccountPasswordChange.WrongCurrentPassword
+        }
+        val dataKey = vault.exportDataKey()
+        if (dataKey == null) {
+            current.fill(' '); next.fill(' ')
+            return AccountPasswordChange.Failed(SyncFailureReason.VaultLocked)
+        }
+        var curMasterKey: MasterKey? = null
+        var newMasterKey: MasterKey? = null
+        var curAuthKey: ByteArray? = null
+        var newAuthKey: ByteArray? = null
+        // A client we opened but haven't handed to [activateSession] yet — close it on any early exit
+        // so its Ktor pool/sockets don't leak.
+        var openedClient: SyncClient? = null
+        try {
+            val syncSalt = crypto.deriveSyncSalt(cfg.accountId)
+            val cmk = crypto.deriveMasterKey(current, syncSalt).also { curMasterKey = it }
+            val cak = crypto.deriveAuthKey(cmk).also { curAuthKey = it }
+            val nmk = crypto.deriveMasterKey(next, syncSalt).also { newMasterKey = it }
+            val nak = crypto.deriveAuthKey(nmk).also { newAuthKey = it }
+            val newWrapped = crypto.wrapDataKey(nmk, dataKey)
+            val device = DeviceInfo(cfg.deviceId, deviceName, platformName)
+            val syncClient = clientFactory(cfg.serverUrl).also { openedClient = it }
+
+            // keep-connected: drop the auto-restore token for the rotation window. If this device dies
+            // after the server commits but before the local re-wrap, [restoreSession] must NOT silently
+            // bring it back Online under the OLD password on the next launch (the account moved to the
+            // new one — issue #32 divergence, and the leaked old password would keep unlocking it). The
+            // new token is re-sealed on success; the old one is restored only on errors that provably
+            // precede the server commit.
+            val hadAutoRestore = cfg.keepConnected && cfg.sealedRefreshToken != null
+            if (hadAutoRestore) configStore.save(cfg.copy(sealedRefreshToken = null))
+
+            val newSession = try {
+                syncClient.changePassword(cfg.accountId, cak, nak, newWrapped, device)
+            } catch (e: SyncException) {
+                // UNAUTHORIZED/NOT_FOUND come from the SRP verify gate, before any DB write — nothing
+                // rotated, so it's safe to restore the auto-restore token (a wrong-password typo mustn't
+                // cost the user their "keep connected"). NETWORK/PROTOCOL are ambiguous (the server may
+                // have committed): leave it cleared and let the user reconnect with the new password.
+                if (hadAutoRestore && (e.kind == SyncException.Kind.UNAUTHORIZED || e.kind == SyncException.Kind.NOT_FOUND)) {
+                    configStore.save(cfg)
+                }
+                return when (e.kind) {
+                    // A wrong current password (the server's SRP proof failed) or missing account.
+                    SyncException.Kind.UNAUTHORIZED, SyncException.Kind.NOT_FOUND ->
+                        AccountPasswordChange.Failed(SyncFailureReason.Unauthorized)
+                    SyncException.Kind.NETWORK -> AccountPasswordChange.Failed(SyncFailureReason.Network, e.message)
+                    SyncException.Kind.PROTOCOL -> AccountPasswordChange.Failed(SyncFailureReason.Protocol, e.message)
+                    else -> AccountPasswordChange.Failed(SyncFailureReason.ConnectFailed, e.message)
+                }
+            }
+
+            // Server rotated. Re-wrap the LOCAL vault under the new password so this device keeps
+            // unlocking with it. The dataKey is unchanged, so this doesn't touch biometrics.
+            if (!vault.changePassword(current.copyOf(), next.copyOf())) {
+                // The account is on the new password but the local re-wrap failed (disk error). Don't
+                // report success: this device must reconnect with the new password, and the #28
+                // confirmed-replace path re-wraps the local vault then.
+                return AccountPasswordChange.LocalRewrapFailed
+            }
+
+            // keep-connected: re-seal the fresh refresh token under the (unchanged) dataKey.
+            val sealed = if (cfg.keepConnected) {
+                vault.exportDataKey()?.let { dk -> try { tokens.seal(dk, newSession.refreshToken) } finally { dk.zeroize() } }
+            } else null
+            openedClient = null // ownership passes to activateSession (it closes any superseded client)
+            activateSession(syncClient, newSession, cfg.copy(sealedRefreshToken = sealed), resetCursor = false)
+            return AccountPasswordChange.Success
+        } catch (e: CancellationException) {
+            throw e // don't swallow cancellation — it would break structured concurrency
+        } catch (e: Exception) {
+            return AccountPasswordChange.Failed(SyncFailureReason.ConnectFailed, e.message)
+        } finally {
+            current.fill(' '); next.fill(' ')
+            curMasterKey?.zeroize(); newMasterKey?.zeroize()
+            curAuthKey?.fill(0); newAuthKey?.fill(0)
+            dataKey.zeroize()
+            runCatching { openedClient?.close() } // opened but not activated (error/rewrap-failed path)
+        }
     }
 
     /**

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
@@ -177,6 +177,7 @@ private class FakePingClient(@Volatile var reachable: Boolean) : SyncClient {
     override suspend fun close() {}
     override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
     override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+    override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
     override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
     override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
@@ -76,6 +76,7 @@ class SyncCoordinatorLockPauseTest {
         override suspend fun ping(): Boolean = true
         override suspend fun close() {}
         override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
         override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -25,6 +25,7 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -63,8 +64,9 @@ class SyncCoordinatorPasswordReplaceTest {
         /** Serve a wrap that can't be unwrapped, modelling a corrupted/mismatched server record. */
         private val corruptWrap: Boolean = false,
     ) : SyncClient {
-        private val expectedAuthKey: ByteArray?
-        private val wrappedAccountKey: ByteArray?
+        // var: a password rotation ([changePassword]) swaps both to the new password's material.
+        private var expectedAuthKey: ByteArray?
+        private var wrappedAccountKey: ByteArray?
 
         init {
             if (existingAccountPassword == null) {
@@ -101,6 +103,26 @@ class SyncCoordinatorPasswordReplaceTest {
             return wrap
         }
 
+        /**
+         * Models the server rotation (issue #32): the SRP proof is only accepted for the CURRENT
+         * authKey, then the verifier (authKey) and the wrapped dataKey are swapped to the new ones.
+         * Other-device revocation isn't observable through this stub, so it's not modelled.
+         */
+        override suspend fun changePassword(
+            accountId: String,
+            currentAuthKey: ByteArray,
+            newAuthKey: ByteArray,
+            newWrappedDataKey: ByteArray,
+            device: DeviceInfo,
+        ): SyncSession {
+            if (expectedAuthKey == null || !currentAuthKey.contentEquals(expectedAuthKey)) {
+                throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong current password")
+            }
+            expectedAuthKey = newAuthKey.copyOf()
+            wrappedAccountKey = newWrappedDataKey.copyOf()
+            return SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
+        }
+
         override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
         override suspend fun ping(): Boolean = true
         override suspend fun close() {}
@@ -122,12 +144,31 @@ class SyncCoordinatorPasswordReplaceTest {
             .also { it.create(vaultPassword.toCharArray()) }
     }
 
-    private fun coordinator(vault: Vault, client: SyncClient): SyncCoordinator = SyncCoordinator(
+    private fun coordinator(
+        vault: Vault,
+        client: SyncClient,
+        configStore: SyncConfigStore = InMemorySyncConfigStore(),
+    ): SyncCoordinator = SyncCoordinator(
         clientFactory = { client },
         crypto = crypto,
         vault = vault,
+        configStore = configStore,
+        deviceIdProvider = { "dev-local" },
         engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
     )
+
+    /** Sync already configured for [account] on [serverUrl] (so [SyncCoordinator.changeAccountPassword] runs). */
+    private fun configuredStore(): SyncConfigStore = InMemorySyncConfigStore().apply {
+        save(SyncConfig(serverUrl, account, deviceId = "dev-local"))
+    }
+
+    /** A vault whose local re-wrap fails — models the client dying between the server rotate and the local re-wrap. */
+    private class RewrapFailingVault(private val delegate: Vault) : Vault by delegate {
+        override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean {
+            oldPassword.fill(' '); newPassword.fill(' ')
+            return false
+        }
+    }
 
     @Test
     fun `joining an existing account under a different password pauses without changing the vault password`() = runBlocking {
@@ -286,6 +327,144 @@ class SyncCoordinatorPasswordReplaceTest {
             }
             assertFalse(client.registered, "must not register a divergent account under a non-vault password")
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "vault password is untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    // --- issue #32: change account password ---
+
+    private val rotated = "rotated-E"
+
+    @Test
+    fun `changing the account password rotates it and re-keys the local vault`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault() // on a synced device the vault password IS the account password
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val sut = coordinator(vault, client, configuredStore())
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertTrue(result is AccountPasswordChange.Success, "rotation succeeds, was $result")
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            assertTrue(vault.verifyPassword(rotated.toCharArray()), "the vault now unlocks with the new password")
+            assertFalse(vault.verifyPassword(vaultPassword.toCharArray()), "the old password no longer unlocks")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `changing the account password with a wrong current password changes nothing`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val sut = coordinator(vault, client, configuredStore())
+        try {
+            val result = sut.changeAccountPassword("not-the-password".toCharArray(), rotated.toCharArray())
+            assertTrue(result is AccountPasswordChange.WrongCurrentPassword, "wrong current password is refused, was $result")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is untouched")
+            assertFalse(vault.verifyPassword(rotated.toCharArray()), "the new password does not unlock")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `changing the account password without sync configured is a no-op`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword)
+        val sut = coordinator(vault, client) // no configStore → not configured
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertTrue(result is AccountPasswordChange.NotConfigured, "nothing to rotate, was $result")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The failure the issue calls out: the client dies between the server rotate (step 3) and the local
+     * re-wrap (step 4). The account must end up on the new password (the server committed atomically),
+     * and the device must heal on its next reconnect via the confirmed-replace path (#28) — never a
+     * half-applied state that locks the user out.
+     */
+    @Test
+    fun `an interrupted rotation leaves the account on the new password and heals on reconnect`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val store = configuredStore()
+
+        // The server rotates, but the local re-wrap fails (client "dies" between step 3 and 4).
+        val sut = coordinator(RewrapFailingVault(vault), client, store)
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertTrue(result is AccountPasswordChange.LocalRewrapFailed, "the interruption is reported, not a silent success, was $result")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the local vault is still on the old password")
+        } finally {
+            sut.close()
+        }
+
+        // Reconnecting with the NEW password heals the local wrap (the account already expects it).
+        val heal = coordinator(vault, client, store)
+        try {
+            heal.connect(serverUrl, account, rotated.toCharArray())
+            withTimeout(30_000) { heal.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            heal.confirmPasswordReplace()
+            withTimeout(30_000) { heal.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(heal.status.value is SyncStatus.Online, "reconnect with the new password heals the device, was ${heal.status.value}")
+            assertTrue(vault.verifyPassword(rotated.toCharArray()), "the local vault now unlocks with the new password")
+        } finally {
+            heal.close()
+        }
+    }
+
+    /**
+     * On a keep-connected device an interrupted rotation must drop the saved refresh token, or
+     * [SyncCoordinator.restoreSession] would silently bring the device back Online under the OLD
+     * password on the next launch — the account moved to the new one, and the leaked old password
+     * would keep unlocking this device (issue #32 divergence).
+     */
+    @Test
+    fun `an interrupted rotation on a keep-connected device clears the auto-restore token`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val store = InMemorySyncConfigStore().apply {
+            save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
+        }
+        val sut = coordinator(RewrapFailingVault(vault), client, store)
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertTrue(result is AccountPasswordChange.LocalRewrapFailed, "was $result")
+            assertEquals(null, store.load()?.sealedRefreshToken, "the auto-restore token must be cleared after an interrupted rotation")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The current password passes the local check but the SERVER rejects the SRP proof (e.g. another
+     * device already rotated the account): the coordinator surfaces it as a failure, unchanged locally.
+     */
+    @Test
+    fun `a server-rejected current password surfaces as a failure without changing the vault`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        // Account exists under a DIFFERENT password than this vault's: local verifyPassword passes,
+        // but the server's SRP proof of the current password fails.
+        val client = FakeAccountClient(existingAccountPassword = accountPassword)
+        val sut = coordinator(vault, client, configuredStore())
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertTrue(
+                result is AccountPasswordChange.Failed && result.reason == SyncFailureReason.Unauthorized,
+                "server rejection maps to Failed(Unauthorized), was $result",
+            )
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is untouched")
+            assertFalse(vault.verifyPassword(rotated.toCharArray()), "the new password does not unlock")
         } finally {
             sut.close()
         }

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -55,6 +55,7 @@ object RateLimits {
     val SRP_VERIFY = RateLimitName("srp-verify")
     val PAIRING_CLAIM = RateLimitName("pairing-claim")
     val REFRESH = RateLimitName("auth-refresh")
+    val CHANGE_PASSWORD = RateLimitName("auth-change-password")
     val ADMIN = RateLimitName("admin")
 }
 
@@ -126,6 +127,9 @@ fun Application.configureServer(services: Services) {
         // Refresh needs no password; rate-limited as defense-in-depth even though the signature
         // check is cheap, since it's a public POST with no prior authentication.
         perIp(RateLimits.REFRESH, limit = 30)
+        // Password rotation proves the current password via SRP; rate-limited like the SRP endpoints
+        // as defense-in-depth (it's a public POST that swaps the verifier).
+        perIp(RateLimits.CHANGE_PASSWORD, limit = 10)
         // The admin console uses a constant-time static token compare, which doesn't stop brute
         // forcing the token itself, hence a rate limit on /admin/*.
         perIp(RateLimits.ADMIN, limit = 30)

--- a/server/src/main/kotlin/app/skerry/server/db/AccountRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/AccountRepository.kt
@@ -1,11 +1,14 @@
 package app.skerry.server.db
 
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
 
 /** Accounts: registration (SRP verifier + wrapped dataKey) and lookup. */
 class AccountRepository(private val db: Database) {
@@ -35,6 +38,38 @@ class AccountRepository(private val db: Database) {
             throw IllegalStateException("account already exists", e)
         }
         AccountRow(accountId, srpSalt, srpVerifier, wrappedDataKey, 0)
+    }
+
+    /**
+     * Atomically rotates the account password (issue #32): swaps the SRP verifier (salt + verifier)
+     * and the wrapped dataKey to the new password's, and revokes every device except [keepDeviceId] —
+     * all in one transaction, so an interrupted rotation can't leave the verifier and the wrap out of
+     * step. The dataKey itself is unchanged; only its wrap is.
+     *
+     * Revoking the other devices forces them to re-authenticate with the new password: their
+     * stateless refresh tokens would otherwise survive the change (see [app.skerry.server.auth.TokenService]),
+     * and a device re-logging in with the new password clears its own revocation.
+     *
+     * Returns the account's current `syncSeq` (for a live-pull nudge over the changes stream), or
+     * `null` if the account doesn't exist.
+     */
+    suspend fun rotatePassword(
+        accountId: String,
+        newSrpSalt: String,
+        newSrpVerifier: String,
+        newWrappedDataKey: ByteArray,
+        keepDeviceId: String,
+    ): Long? = dbTransaction(db) {
+        val updated = Accounts.update({ Accounts.id eq accountId }) {
+            it[srpSalt] = newSrpSalt
+            it[srpVerifier] = newSrpVerifier
+            it[wrappedDataKey] = ExposedBlob(newWrappedDataKey)
+        }
+        if (updated == 0) return@dbTransaction null
+        Devices.update({ (Devices.accountId eq accountId) and (Devices.id neq keepDeviceId) }) {
+            it[revoked] = true
+        }
+        Accounts.selectAll().where { Accounts.id eq accountId }.single()[Accounts.syncSeq]
     }
 
     /** Total number of registered accounts (for the optional per-instance registration cap). */

--- a/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
@@ -4,6 +4,8 @@ import app.skerry.server.RateLimits
 import app.skerry.server.Services
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
+import app.skerry.sync.wire.ChangePasswordRequest
+import app.skerry.sync.wire.ChangePasswordResponse
 import app.skerry.server.model.ErrorResponse
 import app.skerry.sync.wire.RefreshRequest
 import app.skerry.sync.wire.RegisterRequest
@@ -124,6 +126,54 @@ fun Route.authRoutes(services: Services) {
                 refreshToken = services.tokens.issueRefresh(verified.accountId, req.deviceId),
             ),
         )
+        }
+    }
+
+    rateLimit(RateLimits.CHANGE_PASSWORD) {
+        post("/auth/change-password") {
+            val req = call.receive<ChangePasswordRequest>()
+            if (tooLong(req.deviceId, req.challengeId)) {
+                call.respond(HttpStatusCode.BadRequest, ErrorResponse("identifier too long"))
+                return@post
+            }
+            // Prove the CURRENT password before touching anything: the SRP proof (M1) is checked
+            // against the account's current verifier, so a stolen access token alone can't rotate.
+            // The proof also establishes the accountId (from the one-shot challenge).
+            val verified = services.srp.verify(req.challengeId, req.a, req.m1)
+            if (verified == null) {
+                call.respond(HttpStatusCode.Unauthorized, ErrorResponse("authentication failed"))
+                return@post
+            }
+            // base64-decode before writing to the DB: invalid payload -> 400, not 500.
+            val newWrapped = req.newWrappedDataKey.unb64()
+            // Ensure the acting device exists and is not revoked (rotatePassword keeps it while
+            // revoking the others), so its fresh tokens below authenticate.
+            services.devices.register(verified.accountId, req.deviceId, req.deviceName, req.platform)
+            val syncSeq = services.accounts.rotatePassword(
+                accountId = verified.accountId,
+                newSrpSalt = req.newSrpSalt,
+                newSrpVerifier = req.newSrpVerifier,
+                newWrappedDataKey = newWrapped,
+                keepDeviceId = req.deviceId,
+            )
+            if (syncSeq == null) {
+                // Should not happen (the SRP proof implies the account exists), but stay defensive.
+                call.respond(HttpStatusCode.Unauthorized, ErrorResponse("authentication failed"))
+                return@post
+            }
+            services.activity.record(verified.accountId, "auth.password_changed", "account password rotated", deviceId = req.deviceId)
+            // Nudge currently-connected devices: the revoked ones' sockets close on the next
+            // emission (per-signal isRevoked check), dropping them to "reconnect" promptly instead
+            // of only on their next server call. The acting device's cursor already equals syncSeq,
+            // so it ignores the signal.
+            services.notifier.publish(verified.accountId, syncSeq)
+            call.respond(
+                ChangePasswordResponse(
+                    m2 = verified.m2,
+                    accessToken = services.tokens.issueAccess(verified.accountId, req.deviceId),
+                    refreshToken = services.tokens.issueRefresh(verified.accountId, req.deviceId),
+                ),
+            )
         }
     }
 

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
@@ -236,6 +236,57 @@ class RoutesTest {
     }
 
     @Test
+    fun `change password swaps verifier and wrap and revokes other devices`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val oldWrap = byteArrayOf(1, 1, 1)
+        val newWrap = byteArrayOf(2, 2, 2)
+        val newPassword = "new-auth-key-hex-xyz789"
+
+        // devA registers; devB logs in via SRP so there is a second device to revoke.
+        client.registerAccount(accountId, password, wrappedDataKey = oldWrap, deviceId = "devA")
+        val devB = client.srpLogin(accountId, password, deviceId = "devB", deviceName = "Phone B")
+        assertEquals(HttpStatusCode.OK, client.get("/vault/keys") { bearerAuth(devB.accessToken) }.status)
+
+        // devA rotates the password.
+        val rotated = client.changePassword(accountId, password, newPassword, newWrap, deviceId = "devA")
+        assertEquals(HttpStatusCode.OK, rotated.status)
+        val body: app.skerry.sync.wire.ChangePasswordResponse = rotated.body()
+        // The acting device's fresh tokens work, and the wrapped dataKey is now the new one.
+        val keys: KeysResponse = client.get("/vault/keys") { bearerAuth(body.accessToken) }.body()
+        assertEquals(newWrap.b64(), keys.wrappedDataKey)
+
+        // The old password no longer logs in; the new one does.
+        assertEquals(HttpStatusCode.Unauthorized, client.srpLoginResponse(accountId, password, "devC", "C").status)
+        assertEquals(HttpStatusCode.OK, client.srpLoginResponse(accountId, newPassword, "devC", "C").status)
+
+        // devB was revoked by the rotation: its old token is dead until it re-authenticates.
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/vault/keys") { bearerAuth(devB.accessToken) }.status)
+    }
+
+    @Test
+    fun `change password with wrong current password is rejected and changes nothing`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val oldWrap = byteArrayOf(1, 1, 1)
+        val newWrap = byteArrayOf(2, 2, 2)
+        client.registerAccount(accountId, password, wrappedDataKey = oldWrap, deviceId = "devA")
+
+        // A rotate proven with the WRONG current password must be refused.
+        val rotated = client.changePassword(accountId, "wrong-password", "new-password", newWrap, deviceId = "devA")
+        assertEquals(HttpStatusCode.Unauthorized, rotated.status)
+
+        // Nothing changed: the original password still logs in and the wrap is untouched.
+        val ok = client.srpLogin(accountId, password, deviceId = "devA", deviceName = "Laptop A")
+        val keys: KeysResponse = client.get("/vault/keys") { bearerAuth(ok.accessToken) }.body()
+        assertEquals(oldWrap.b64(), keys.wrappedDataKey)
+    }
+
+    @Test
     fun `pairing transfers encrypted data key to a new device`() = testApplication {
         val services = testServices()
         application { configureServer(services) }

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
@@ -3,10 +3,15 @@ package app.skerry.server.routes
 import app.skerry.server.Services
 import app.skerry.server.config.ServerConfig
 import app.skerry.server.db.Db
+import app.skerry.sync.wire.ChallengeRequest
+import app.skerry.sync.wire.ChallengeResponse
+import app.skerry.sync.wire.ChangePasswordRequest
 import app.skerry.sync.wire.PushRequest
 import app.skerry.sync.wire.RecordDto
 import app.skerry.sync.wire.RegisterRequest
 import app.skerry.sync.wire.TokenResponse
+import app.skerry.sync.wire.VerifyRequest
+import app.skerry.sync.wire.VerifyResponse
 import app.skerry.server.model.b64
 import com.nimbusds.srp6.SRP6ClientSession
 import com.nimbusds.srp6.SRP6CryptoParams
@@ -76,6 +81,73 @@ suspend fun HttpClient.registerAccount(
     platform: String? = null,
 ): TokenResponse =
     registerAccountResponse(accountId, password, wrappedDataKey, deviceId, deviceName, platform).body()
+
+/** Full SRP login (challenge -> proof) as the client does; returns the raw response. */
+suspend fun HttpClient.srpLoginResponse(
+    accountId: String,
+    password: String,
+    deviceId: String,
+    deviceName: String,
+    platform: String? = null,
+): HttpResponse {
+    val sc = srpClient(accountId, password)
+    val challenge: ChallengeResponse = post("/auth/srp/challenge") {
+        contentType(ContentType.Application.Json)
+        setBody(ChallengeRequest(accountId))
+    }.body()
+    val creds = sc.step2(SRP_PARAMS, BigInteger(challenge.salt, 16), BigInteger(challenge.b, 16))
+    return post("/auth/srp/verify") {
+        contentType(ContentType.Application.Json)
+        setBody(VerifyRequest(challenge.challengeId, creds.A.toString(16), creds.M1.toString(16), deviceId, deviceName, platform))
+    }
+}
+
+/** SRP login returning the token pair (asserts nothing; use [srpLoginResponse] for status checks). */
+suspend fun HttpClient.srpLogin(
+    accountId: String,
+    password: String,
+    deviceId: String,
+    deviceName: String,
+    platform: String? = null,
+): VerifyResponse = srpLoginResponse(accountId, password, deviceId, deviceName, platform).body()
+
+/**
+ * Rotates the account password as the client does (issue #32): SRP-proves the current password,
+ * then submits the new salt/verifier and the re-wrapped dataKey. Returns the raw response.
+ */
+suspend fun HttpClient.changePassword(
+    accountId: String,
+    currentPassword: String,
+    newPassword: String,
+    newWrappedDataKey: ByteArray,
+    deviceId: String = "devA",
+    deviceName: String = "Laptop A",
+    platform: String? = null,
+): HttpResponse {
+    val sc = srpClient(accountId, currentPassword)
+    val challenge: ChallengeResponse = post("/auth/srp/challenge") {
+        contentType(ContentType.Application.Json)
+        setBody(ChallengeRequest(accountId))
+    }.body()
+    val creds = sc.step2(SRP_PARAMS, BigInteger(challenge.salt, 16), BigInteger(challenge.b, 16))
+    val reg = srpRegister(accountId, newPassword) // new salt+verifier, as the client derives from the new password
+    return post("/auth/change-password") {
+        contentType(ContentType.Application.Json)
+        setBody(
+            ChangePasswordRequest(
+                challengeId = challenge.challengeId,
+                a = creds.A.toString(16),
+                m1 = creds.M1.toString(16),
+                deviceId = deviceId,
+                deviceName = deviceName,
+                platform = platform,
+                newSrpSalt = reg.salt,
+                newSrpVerifier = reg.verifier,
+                newWrappedDataKey = newWrappedDataKey.b64(),
+            ),
+        )
+    }
+}
 
 /** PUT /vault/records with a single record, under a bearer token. */
 suspend fun HttpClient.pushRecord(token: String, record: RecordDto): HttpResponse =

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
@@ -73,6 +73,22 @@ interface SyncClient {
     /** Logs in via SRP (password never transmitted): challenge -> proof -> tokens. */
     suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession
 
+    /**
+     * Rotates the account password (issue #32). Proves the CURRENT password with an SRP handshake
+     * ([currentAuthKey]), then atomically swaps the server-side SRP verifier and wrapped dataKey to
+     * the new password's ([newAuthKey] → verifier, [newWrappedDataKey] → wrap) and revokes every
+     * device except [device], forcing them to re-authenticate with the new password. The dataKey
+     * itself is unchanged — only its wrap. Returns a fresh session for [device]. Wrong current
+     * password → [SyncException.Kind.UNAUTHORIZED].
+     */
+    suspend fun changePassword(
+        accountId: String,
+        currentAuthKey: ByteArray,
+        newAuthKey: ByteArray,
+        newWrappedDataKey: ByteArray,
+        device: DeviceInfo,
+    ): SyncSession
+
     /** Wrapped dataKey to decrypt on this device (pairing variant A). */
     suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
@@ -29,6 +29,7 @@ class TeamScopedSyncClient(
 
     override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()
     override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()
+    override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = unsupported()
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = unsupported()
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = unsupported()

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/FakeSyncClient.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/FakeSyncClient.kt
@@ -17,6 +17,7 @@ internal class FakeSyncClient(var serverRecords: List<RemoteRecord> = emptyList(
     }
     override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = error("unused")
     override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = error("unused")
+    override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = error("unused")
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = error("unused")
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = error("unused")
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = error("unused")

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -2,6 +2,8 @@ package app.skerry.shared.sync
 
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
+import app.skerry.sync.wire.ChangePasswordRequest
+import app.skerry.sync.wire.ChangePasswordResponse
 import app.skerry.sync.wire.DevicesResponse
 import app.skerry.sync.wire.KeysResponse
 import app.skerry.sync.wire.PairingClaimRequest
@@ -140,6 +142,54 @@ class KtorSyncClient(
             throw SyncException(SyncException.Kind.PROTOCOL, "server SRP proof (M2) invalid", e)
         }
         return SyncSession(accountId, verify.accessToken, verify.refreshToken)
+    }
+
+    override suspend fun changePassword(
+        accountId: String,
+        currentAuthKey: ByteArray,
+        newAuthKey: ByteArray,
+        newWrappedDataKey: ByteArray,
+        device: DeviceInfo,
+    ): SyncSession {
+        // Prove the current password: same challenge as a login, but instead of /auth/srp/verify the
+        // proof (M1) goes to /auth/change-password together with the new material.
+        val srp = SRP6ClientSession()
+        srp.step1(accountId, currentAuthKey.toHex())
+        val challenge: ChallengeResponse = post("/auth/srp/challenge") {
+            contentType(ContentType.Application.Json)
+            setBody(ChallengeRequest(accountId))
+        }.bodyChecked()
+        val creds = srp.step2(params, BigInteger(challenge.salt, 16), BigInteger(challenge.b, 16))
+
+        // New SRP salt/verifier derived from the new password's authKey — the server never sees it.
+        val newSalt = BigInteger(256, random)
+        val newVerifier = SRP6VerifierGenerator(params).generateVerifier(newSalt, accountId, newAuthKey.toHex())
+
+        val resp: ChangePasswordResponse = post("/auth/change-password") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                ChangePasswordRequest(
+                    challengeId = challenge.challengeId,
+                    a = creds.A.toString(16),
+                    m1 = creds.M1.toString(16),
+                    deviceId = device.id,
+                    deviceName = device.name,
+                    platform = device.platform,
+                    newSrpSalt = newSalt.toString(16),
+                    newSrpVerifier = newVerifier.toString(16),
+                    newWrappedDataKey = newWrappedDataKey.b64(),
+                ),
+            )
+        }.bodyChecked()
+
+        // Verify the server's counter-proof M2 (as in login): guards against a spoofed server that
+        // couldn't actually check the current password before it returned success.
+        try {
+            srp.step3(BigInteger(resp.m2, 16))
+        } catch (e: SRP6Exception) {
+            throw SyncException(SyncException.Kind.PROTOCOL, "server SRP proof (M2) invalid", e)
+        }
+        return SyncSession(accountId, resp.accessToken, resp.refreshToken)
     }
 
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/SyncWireDto.kt
@@ -48,6 +48,32 @@ data class RefreshRequest(val refreshToken: String)
 @Serializable
 data class TokenResponse(val accessToken: String, val refreshToken: String)
 
+/**
+ * Rotate the account password (issue #32). [challengeId]/[a]/[m1] are a fresh SRP proof of the
+ * CURRENT password (obtained via the same `/auth/srp/challenge`) — the server verifies them before
+ * touching anything, so a stolen access token alone can't rotate. [newSrpSalt]/[newSrpVerifier] are
+ * derived from the NEW password, [newWrappedDataKey] is the account dataKey re-wrapped under the new
+ * master key (base64) — the dataKey itself is unchanged. The server swaps the verifier and the wrap
+ * in one transaction and revokes every device except [deviceId], forcing them to re-authenticate
+ * with the new password.
+ */
+@Serializable
+data class ChangePasswordRequest(
+    val challengeId: String,
+    val a: String,
+    val m1: String,
+    val deviceId: String,
+    val deviceName: String,
+    val platform: String? = null,
+    val newSrpSalt: String,
+    val newSrpVerifier: String,
+    val newWrappedDataKey: String,
+)
+
+/** [m2] is the server's SRP counter-proof (client verifies it, as in login); tokens are fresh for the acting device. */
+@Serializable
+data class ChangePasswordResponse(val m2: String, val accessToken: String, val refreshToken: String)
+
 // --- vault ---
 
 @Serializable


### PR DESCRIPTION
Adds a "Change account password" action that rotates the sync master password — the single source of truth shared by every device — which was previously immutable.

## Server (`server/`, `sync-wire/`)
- New `POST /auth/change-password`. It proves the **current** password with a fresh SRP handshake (reusing `/auth/srp/challenge` + the existing verify), then in **one transaction** swaps the SRP verifier (salt + verifier) and the wrapped account dataKey and revokes every device except the acting one. The verifier and the wrap can never be observed out of step.
- The dataKey is unchanged — only its wrap — so records are not re-encrypted.
- Revoked devices must re-authenticate with the new password (their stateless refresh tokens are rejected by the per-request revocation check); connected devices are nudged over the existing `/sync` changes stream. Own rate-limit bucket. No schema migration (columns already exist).

## Client (`shared/`, `composeApp/`)
- `SyncClient.changePassword` performs the SRP proof and submits the new verifier + re-wrapped dataKey; the password/authKey/dataKey never leave the device.
- `SyncCoordinator.changeAccountPassword` commits on the server first, then re-wraps the local vault under the new password. If the device dies between the two steps, the account is on the new password and the device heals on its next reconnect via the existing confirmed-replace flow. On a keep-connected device the saved refresh token is dropped for the rotation window so it cannot silently come back online under the old password.
- Biometrics is not reset: it wraps the dataKey, which does not change.

## UI (desktop + Android)
- Settings → Security shows **Change account password** instead of the local-only **Change master password** when sync is configured, with a note that other devices must sign in again. Strings in en/ru/zh.

## Tests
- Server: rotation swaps verifier + wrap and revokes other devices; a wrong current password is rejected and changes nothing.
- Coordinator: happy path, wrong current password, not-configured, a server-rejected current password, and an interrupted rotation (client killed between the server rotate and the local re-wrap) that heals on reconnect and clears the auto-restore token.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)