### PR TITLE
fix(desktop): recent host highlight on click + connect mode picker width

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -181,7 +181,7 @@ internal fun TerminalSection(state: DesktopDesignState) {
         Column(Modifier.weight(1f)) { Txt(stringResource(Res.string.settings_terminal_host_connect), color = D.text, size = 13.sp, weight = FontWeight.Medium) }
         // No fixed-width Box: DropdownField sizes itself to the longest option, matching the
         // neighbouring CursorStylePicker.
-        HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode)
+        Box(Modifier.width(200.dp)) { HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode) }
     }
     HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -281,7 +281,7 @@ internal fun HostsSidebar(state: DesktopDesignState) {
                 }
                 if (state.showRecent && recent.isNotEmpty()) {
                     RecentSectionHeader()
-                    recent.forEach { host -> key(host.id) { RecentHostRow(host, mono) } }
+                    recent.forEach { host -> key(host.id) { RecentHostRow(host, mono, selectedHostId == host.id) { selectedHostId = host.id } } }
                 }
             } else {
                 RecentSectionHeader()
@@ -435,7 +435,7 @@ private fun TeamHostsSection(hostsSnapshot: List<Host>, state: DesktopDesignStat
 }
 
 /** Collapse-key prefix for teams in the shared [DesktopDesignState.collapsedGroups], see [TeamHostsSection]. */
-private const val TEAM_COLLAPSE_PREFIX = " team "
+private const val TEAM_COLLAPSE_PREFIX = "team"
 
 /**
  * Team header in the sidebar, modeled on [FolderHeader] (collapse chevron + icon + name + count) to
@@ -491,7 +491,7 @@ private fun TeamHostRow(host: Host, mono: FontFamily) {
  * instead. Click reconnects via [LocalConnectHost], same path as clicking a catalog row.
  */
 @Composable
-private fun RecentHostRow(host: Host, mono: FontFamily) {
+private fun RecentHostRow(host: Host, mono: FontFamily, selected: Boolean = false, onSelect: (() -> Unit)? = null) {
     val connect = LocalConnectHost.current
     // Stabilizes the lambda on (host, connect), like catalog rows: without remember it would be
     // recreated on every row recomposition.
@@ -501,7 +501,14 @@ private fun RecentHostRow(host: Host, mono: FontFamily) {
             .fillMaxWidth()
             .padding(start = 16.dp)
             .clip(RoundedCornerShape(5.dp))
-            .hostConnectClick(onClick)
+            .background(if (selected) D.cyan10 else Color.Transparent)
+            .hostConnectClick(
+                onClick = {
+                    onSelect?.invoke()
+                    onClick()
+                },
+                onSingleClick = onSelect,
+            )
             .padding(horizontal = 8.dp, vertical = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -510,7 +517,7 @@ private fun RecentHostRow(host: Host, mono: FontFamily) {
         Column(Modifier.weight(1f)) {
             Txt(
                 host.label,
-                color = D.dim, size = 12.sp,
+                color = if (selected) D.cyanBright else D.dim, size = 12.sp,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
             )
             Txt(


### PR DESCRIPTION
Two small desktop UI fixes from our testing:

### 1. Recent connections: single-click highlight

The recent connections list in the sidebar didn't visually highlight a host on single click — only double-click would connect. This adds `selected`/`onSelect` parameters to `RecentHostRow` so single-click highlights the host (cyan10 background + cyanBright text), matching the main host list behavior. Double-click still connects as before.

**File:** `HostsSidebar.kt`

### 2. Connect mode picker width (Chinese locale)

In Chinese locale, the `HostConnectModePicker` in Terminal settings had no fixed width — the dropdown text lengths vary between options ("单击连接" vs "双击连接"), causing the picker to resize and the surrounding layout to shift. Wrapped it in a fixed `Box(Modifier.width(200.dp))` to keep the layout stable across all languages.

**File:** `TerminalSection.kt`

---

**Question for you:** The 8 quick-action icons in the terminal top-right (split, SFTP, tunnels, snippets, record, playback, info, disconnect) currently have no hover tooltips. We've added `PlainTooltipBox`-based tooltips in our fork. Do you have plans to add tooltips for these icons upstream? If so we'll skip duplicating the effort; if not, we're happy to submit a follow-up PR.