### PR TITLE
feat(vault): rename keychain secrets

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -36,6 +36,7 @@
     <string name="vault_copy_password">Скопировать пароль</string>
     <string name="vault_export">Экспорт</string>
     <string name="vault_delete">Удалить</string>
+    <string name="vault_rename">Переименовать</string>
     <string name="vault_cancel">Отмена</string>
     <string name="vault_used_by_one">Используется · 1 хостом</string>
     <string name="vault_used_by">Используется · %1$d хостами</string>
@@ -82,6 +83,9 @@
     <string name="vault_placeholder_master_password">мастер-пароль</string>
     <string name="vault_password_mismatch_retry">Пароль не подошёл — попробуйте ещё раз.</string>
     <string name="vault_copy">Скопировать</string>
+
+    <!-- Диалог переименования секрета. -->
+    <string name="vault_rename_title">Переименовать «%1$s»</string>
 
     <!-- Диалог удаления секрета. -->
     <string name="vault_delete_title">Удалить «%1$s»?</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -36,6 +36,7 @@
     <string name="vault_copy_password">复制密码</string>
     <string name="vault_export">导出</string>
     <string name="vault_delete">删除</string>
+    <string name="vault_rename">重命名</string>
     <string name="vault_cancel">取消</string>
     <string name="vault_used_by_one">被 1 台主机使用</string>
     <string name="vault_used_by">被 %1$d 台主机使用</string>
@@ -82,6 +83,9 @@
     <string name="vault_placeholder_master_password">主密码</string>
     <string name="vault_password_mismatch_retry">密码不匹配——请重试。</string>
     <string name="vault_copy">复制</string>
+
+    <!-- 重命名密钥对话框 -->
+    <string name="vault_rename_title">重命名「%1$s」</string>
 
     <!-- 删除密钥对话框 -->
     <string name="vault_delete_title">删除「%1$s」？</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -36,6 +36,7 @@
     <string name="vault_copy_password">Copy password</string>
     <string name="vault_export">Export</string>
     <string name="vault_delete">Delete</string>
+    <string name="vault_rename">Rename</string>
     <string name="vault_cancel">Cancel</string>
     <string name="vault_used_by_one">Used by · 1 host</string>
     <string name="vault_used_by">Used by · %1$d hosts</string>
@@ -82,6 +83,9 @@
     <string name="vault_placeholder_master_password">master password</string>
     <string name="vault_password_mismatch_retry">That password didn't match — try again.</string>
     <string name="vault_copy">Copy</string>
+
+    <!-- Rename secret dialog. -->
+    <string name="vault_rename_title">Rename \"%1$s\"</string>
 
     <!-- Delete secret dialog. -->
     <string name="vault_delete_title">Delete \"%1$s\"?</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -65,6 +65,16 @@ class CredentialManagerController(
         return id
     }
 
+    /**
+     * Renames a secret in place — keeps its id and secret material, changing only the label — and
+     * reloads the list. A no-op if [id] is missing/deleted. The rename propagates to sync on its own
+     * (it's a re-put of the same record; see [CredentialStore.rename]).
+     */
+    fun rename(id: String, label: String) {
+        store.rename(id, label)
+        credentials = store.all()
+    }
+
     fun delete(id: String) {
         store.remove(id)
         credentials = store.all()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -60,6 +60,7 @@ import app.skerry.ui.generated.resources.vault_label_public_key
 import app.skerry.ui.generated.resources.vault_meta_any_principal
 import app.skerry.ui.generated.resources.vault_meta_certificate
 import app.skerry.ui.generated.resources.vault_meta_password
+import app.skerry.ui.generated.resources.vault_rename
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
 import app.skerry.ui.generated.resources.vault_subtitle_password
@@ -100,6 +101,7 @@ import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.vault.PasswordConfirmDialog
+import app.skerry.ui.vault.RenameSecretDialog
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.vault.SecretIcon
 import app.skerry.ui.design.Sym
@@ -146,6 +148,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     var showGenerate by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
     var showImportCert by remember { mutableStateOf(false) }
+    var pendingRename by remember { mutableStateOf<Credential?>(null) }
     var pendingDelete by remember { mutableStateOf<Credential?>(null) }
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
@@ -155,7 +158,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     // over the centered dialog and covers the bottom input fields above the keyboard. LaunchedEffect
     // writes the flag only on value change (not every list recomposition); DisposableEffect clears it
     // on leaving the tab so the tab bar isn't left hidden.
-    val modalOpen = showGenerate || showAddPassword || showImportCert || pendingDelete != null ||
+    val modalOpen = showGenerate || showAddPassword || showImportCert || pendingRename != null || pendingDelete != null ||
         selectedCred != null || copyAuth.passwordPromptVisible
     LaunchedEffect(modalOpen) { state.modalOverlay(modalOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
@@ -244,6 +247,20 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 },
             )
         }
+        pendingRename?.let { target ->
+            // Rename edits only the label; the id (hosts reference it) and the secret stay put, and the
+            // change propagates to sync on its own (see CredentialManagerController.rename).
+            RenameSecretDialog(
+                currentLabel = target.label,
+                onDismiss = { pendingRename = null },
+                onConfirm = { newLabel ->
+                    // Abort on a lock race: idle auto-lock can fire while the dialog is open, and vault
+                    // CRUD throws once locked. Mirrors the delete guard.
+                    if (vault?.isUnlocked == true) credentials.rename(target.id, newLabel)
+                    pendingRename = null
+                },
+            )
+        }
         pendingDelete?.let { victim ->
             val bound = VaultPresentation.hostsUsing(victim.id, hosts)
             DeleteSecretDialog(
@@ -271,8 +288,12 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onCopy = { copyTextToClipboard(it) },
                 onCopyPassword = { pwd -> copyAuth.authorize { copyPasswordToClipboard(pwd) } },
                 onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
-                // Close the detail sheet before showing the confirm dialog: otherwise the sheet (drawn
-                // on top) would cover the centered DeleteSecretDialog, leaving only its edge visible.
+                // Close the detail sheet before showing a centered dialog (rename/delete): otherwise the
+                // sheet, drawn on top, would cover it and leave only its edge visible.
+                onRename = {
+                    selectedId = null
+                    pendingRename = credential
+                },
                 onDelete = {
                     selectedId = null
                     pendingDelete = credential
@@ -443,6 +464,7 @@ private fun MobileSecretDetailSheet(
     onCopy: (String) -> Unit,
     onCopyPassword: (String) -> Unit,
     onExport: (name: String, content: String) -> Unit,
+    onRename: () -> Unit,
     onDelete: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -485,29 +507,31 @@ private fun MobileSecretDetailSheet(
                 }
                 UsedByHosts(hosts, mono)
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                    // Copy is type-specific (what's copyable differs); rename is universal and edits only
+                    // the label; export/delete are type-specific again.
                     when (secret) {
-                        is CredentialSecret.Certificate -> {
+                        is CredentialSecret.Certificate ->
                             MobileSheetButton(stringResource(Res.string.vault_copy_certificate), onClick = { onCopy(secret.certificate) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                                MobileSheetButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, filled = false, modifier = Modifier.weight(1f))
-                                MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
-                            }
-                        }
-                        is CredentialSecret.PrivateKey -> {
+                        is CredentialSecret.PrivateKey ->
                             MobileSheetButton(stringResource(Res.string.vault_copy_public_key), onClick = { keyInfo?.let { onCopy(it.publicKeyOpenSsh) } }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                                MobileSheetButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, filled = false, modifier = Modifier.weight(1f))
-                                MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
-                            }
-                        }
-                        is CredentialSecret.Password -> {
-                            // The password is sensitive: copying requires re-authentication
-                            // (biometrics/master password, see onCopyPassword) and goes through the
-                            // platform path (Android: sensitive clip + auto-clear), not the normal
-                            // clipboard like cert/public key.
+                        // The password is sensitive: copying requires re-authentication (biometrics/master
+                        // password, see onCopyPassword) and goes through the platform path (Android:
+                        // sensitive clip + auto-clear), not the normal clipboard like cert/public key.
+                        is CredentialSecret.Password ->
                             MobileSheetButton(stringResource(Res.string.vault_copy_password), onClick = { onCopyPassword(secret.password) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.fillMaxWidth())
+                    }
+                    MobileSheetButton(stringResource(Res.string.vault_rename), onClick = onRename, filled = false, modifier = Modifier.fillMaxWidth())
+                    when (secret) {
+                        is CredentialSecret.Certificate -> Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            MobileSheetButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, filled = false, modifier = Modifier.weight(1f))
+                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
                         }
+                        is CredentialSecret.PrivateKey -> Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            MobileSheetButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, filled = false, modifier = Modifier.weight(1f))
+                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
+                        }
+                        is CredentialSecret.Password ->
+                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.fillMaxWidth())
                     }
                 }
                 Spacer(Modifier.height(8.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.relocation.BringIntoViewRequester
 import androidx.compose.foundation.relocation.bringIntoViewRequester
 import androidx.compose.foundation.layout.Arrangement
@@ -124,6 +125,8 @@ import app.skerry.ui.generated.resources.vault_placeholder_name_key
 import app.skerry.ui.generated.resources.vault_placeholder_name_password
 import app.skerry.ui.generated.resources.vault_placeholder_optional
 import app.skerry.ui.generated.resources.vault_placeholder_password
+import app.skerry.ui.generated.resources.vault_rename
+import app.skerry.ui.generated.resources.vault_rename_title
 import app.skerry.ui.generated.resources.vault_sidebar_header
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
@@ -210,6 +213,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     var showGenerate by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
     var showImportCert by remember { mutableStateOf(false) }
+    var pendingRenameCred by remember { mutableStateOf<Credential?>(null) }
     var pendingDeleteCred by remember { mutableStateOf<Credential?>(null) }
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
@@ -260,6 +264,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                             onCopy = { copyTextToClipboard(it) },
                             onCopyPassword = { pwd -> copyAuth.authorize { copyPasswordToClipboard(pwd) } },
                             onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
+                            onRename = { pendingRenameCred = credential },
                             onDelete = { pendingDeleteCred = credential },
                         )
                     }
@@ -311,6 +316,20 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                     )
                     category = VaultCategoryKind.CERTIFICATES
                     showImportCert = false
+                },
+            )
+        }
+        pendingRenameCred?.let { target ->
+            // Rename edits only the label; the id (which hosts reference) and the secret stay put, and
+            // the change propagates to sync on its own (see CredentialManagerController.rename).
+            RenameSecretDialog(
+                currentLabel = target.label,
+                onDismiss = { pendingRenameCred = null },
+                onConfirm = { newLabel ->
+                    // Abort on a lock race: idle auto-lock can fire while the dialog is open, and vault
+                    // CRUD throws once locked. Mirrors the delete guard just below.
+                    if (vault?.isUnlocked == true) credentials.rename(target.id, newLabel)
+                    pendingRenameCred = null
                 },
             )
         }
@@ -547,6 +566,7 @@ private fun LiveSecretDetail(
     onCopy: (String) -> Unit,
     onCopyPassword: (String) -> Unit,
     onExport: (name: String, content: String) -> Unit,
+    onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val secret = credential.secret
@@ -580,28 +600,31 @@ private fun LiveSecretDetail(
         }
         UsedByHosts(hosts, mono)
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Copy is type-specific (what's copyable differs); rename is universal and edits only the
+            // label (see onRename); delete/export are type-specific again.
             when (secret) {
-                is CredentialSecret.Certificate -> {
+                is CredentialSecret.Certificate ->
                     PrimaryButton(stringResource(Res.string.vault_copy_certificate), onClick = { onCopy(secret.certificate) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        GhostButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, modifier = Modifier.weight(1f))
-                        GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
-                    }
-                }
-                is CredentialSecret.PrivateKey -> {
+                is CredentialSecret.PrivateKey ->
                     PrimaryButton(stringResource(Res.string.vault_copy_public_key), onClick = { keyInfo?.let { onCopy(it.publicKeyOpenSsh) } }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        GhostButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, modifier = Modifier.weight(1f))
-                        GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
-                    }
-                }
-                is CredentialSecret.Password -> {
-                    // Password is sensitive: copying requires re-authentication (biometrics/master password,
-                    // see onCopyPassword) and goes through a platform-specific path (Android: sensitive clip +
-                    // auto-clear) rather than the plain clipboard used for cert/public key.
+                // Password is sensitive: copying requires re-authentication (biometrics/master password,
+                // see onCopyPassword) and goes through a platform-specific path (Android: sensitive clip +
+                // auto-clear) rather than the plain clipboard used for cert/public key.
+                is CredentialSecret.Password ->
                     PrimaryButton(stringResource(Res.string.vault_copy_password), onClick = { onCopyPassword(secret.password) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
-                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.fillMaxWidth())
+            }
+            GhostButton(stringResource(Res.string.vault_rename), onClick = onRename, modifier = Modifier.fillMaxWidth())
+            when (secret) {
+                is CredentialSecret.Certificate -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    GhostButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, modifier = Modifier.weight(1f))
+                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
                 }
+                is CredentialSecret.PrivateKey -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    GhostButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, modifier = Modifier.weight(1f))
+                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
+                }
+                is CredentialSecret.Password ->
+                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = D.sunset, border = D.sunset.copy(alpha = 0.3f), modifier = Modifier.fillMaxWidth())
             }
         }
     }
@@ -745,6 +768,23 @@ internal fun PasswordConfirmDialog(error: Boolean, busy: Boolean, onDismiss: () 
     }
 }
 
+/**
+ * Renames a keychain secret: a single prefilled NAME field. The secret material and id are untouched
+ * (only the label changes). Confirm is enabled only for a non-blank label that actually differs — a
+ * rename to the same name is a pointless sync push. Shared by desktop and mobile. [onConfirm] gets the
+ * trimmed label.
+ */
+@Composable
+internal fun RenameSecretDialog(currentLabel: String, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+    var name by remember { mutableStateOf(currentLabel) }
+    val trimmed = name.trim()
+    val valid = trimmed.isNotEmpty() && trimmed != currentLabel
+    VaultDialogScaffold(stringResource(Res.string.vault_rename_title, currentLabel), null, onDismiss) {
+        DialogField(stringResource(Res.string.vault_field_name), name, { name = it }, placeholder = currentLabel)
+        DialogButtons(confirmLabel = stringResource(Res.string.vault_rename), confirmEnabled = valid, onDismiss = onDismiss, onConfirm = { onConfirm(trimmed) })
+    }
+}
+
 @Composable
 internal fun DeleteSecretDialog(label: String, boundHostCount: Int, onDismiss: () -> Unit, onConfirm: () -> Unit) {
     VaultDialogScaffold(stringResource(Res.string.vault_delete_title, label), null, onDismiss) {
@@ -769,7 +809,7 @@ private fun VaultDialogScaffold(title: String, subtitle: String?, onDismiss: () 
     Box(
         // The dialog centers in the visible area; it ends up above the keyboard on its own — on mobile the
         // root `safeDrawing` shrinks the area above the IME, and `Center` centers within what's left (no-op on desktop).
-        Modifier.fillMaxSize().background(Color(0xB3060E16)).clickable(onClick = onDismiss),
+        Modifier.fillMaxSize().background(Color(0xB3060E16)).clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onDismiss),
         contentAlignment = Alignment.Center,
     ) {
         Column(
@@ -781,7 +821,8 @@ private fun VaultDialogScaffold(title: String, subtitle: String?, onDismiss: () 
                 .background(D.surfaceDeep)
                 .border(1.dp, D.cyan14, RoundedCornerShape(12.dp))
                 // Absorbs the click on the card so it doesn't close the dialog (same as DesktopPasswordDialog).
-                .clickable(onClick = {})
+                // indication = null: the card is a static surface, not a button — no hover/press highlight.
+                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = {})
                 // Scrolls the content: a tall dialog (certificate import — 4 fields) doesn't fit under the
                 // on-screen keyboard; scrolling keeps the fields and buttons reachable. No-op on desktop.
                 .verticalScroll(rememberScrollState())

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
@@ -81,6 +81,28 @@ class CredentialManagerControllerTest {
     }
 
     @Test
+    fun `rename changes the label in the reactive list and keeps id and secret`() {
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+        controller.save(CredentialDraft(label = "old", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem", passphrase = "pp"))
+
+        controller.rename("gen", "new")
+
+        val c = controller.credentials.single()
+        assertEquals("gen", c.id)
+        assertEquals("new", c.label)
+        assertEquals(CredentialSecret.PrivateKey("pem", passphrase = "pp"), c.secret)
+    }
+
+    @Test
+    fun `rename of a missing id is a no-op`() {
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+
+        controller.rename("missing", "x")
+
+        assertEquals(emptyList(), controller.credentials)
+    }
+
+    @Test
     fun `delete removes the credential`() {
         val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
         controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
@@ -24,6 +24,22 @@ class CredentialStore(private val vault: Vault) {
         codec.put(credential.id, credential)
     }
 
+    /**
+     * Renames a secret in place: keeps its [Credential.id] (hosts reference secrets by id, not label)
+     * and its secret material, replacing only the [Credential.label]. The re-[put] bumps the record
+     * version, so the change propagates to other devices via sync like any other edit. No-op if [id]
+     * is missing or deleted — a tombstone must not be resurrected under a new name.
+     *
+     * The read-check-write runs in one [Vault.transaction] (like [app.skerry.shared.host.VaultHostStore]):
+     * otherwise a concurrent [Vault.mergeRemote] from background sync could land a tombstone between the
+     * [get] and the [put], and the [put] would resurrect the deleted record under the new label and push
+     * that un-delete to every device.
+     */
+    fun rename(id: String, label: String) = vault.transaction {
+        val existing = get(id) ?: return@transaction
+        put(existing.copy(label = label))
+    }
+
     /** Soft-delete a secret (tombstone). Hosts referencing it are reconciled in the UI layer. */
     fun remove(id: String) {
         codec.remove(id)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
@@ -2,7 +2,9 @@ package app.skerry.shared.vault
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class CredentialStoreTest {
 
@@ -59,6 +61,65 @@ class CredentialStoreTest {
         store.remove("a")
 
         assertEquals(listOf("b"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `rename changes the label and keeps the id and secret`() {
+        val store = CredentialStore(FakeVault())
+        val secret = CredentialSecret.PrivateKey(privateKeyPem = "pem", passphrase = "pp")
+        store.put(Credential("c-1", "old name", secret))
+
+        store.rename("c-1", "new name")
+
+        assertEquals(Credential("c-1", "new name", secret), store.get("c-1"))
+    }
+
+    @Test
+    fun `rename bumps the record version so the change propagates to sync`() {
+        val vault = FakeVault()
+        val store = CredentialStore(vault)
+        store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
+
+        store.rename("c-1", "new")
+
+        // A rename is a re-put of the same id: the version must advance so LWW/live-sync push it.
+        assertEquals(2L, vault.records().single { it.id == "c-1" }.version)
+    }
+
+    @Test
+    fun `rename of a missing id is a no-op`() {
+        val store = CredentialStore(FakeVault())
+
+        store.rename("ghost", "whatever")
+
+        assertNull(store.get("ghost"))
+        assertEquals(emptyList(), store.all())
+    }
+
+    @Test
+    fun `rename runs its read-modify-write inside a single transaction`() {
+        val vault = FakeVault()
+        val store = CredentialStore(vault)
+        store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
+        // A plain put is a single call and holds no transaction — the control for the assertion below.
+        assertFalse(vault.lastPutInTransaction)
+
+        store.rename("c-1", "new")
+
+        // rename's put must run under a held transaction so a concurrent mergeRemote can't slip a
+        // tombstone between the get and the put (TOCTOU resurrection across all synced devices).
+        assertTrue(vault.lastPutInTransaction)
+    }
+
+    @Test
+    fun `rename does not resurrect a deleted credential`() {
+        val store = CredentialStore(FakeVault())
+        store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
+        store.remove("c-1")
+
+        store.rename("c-1", "back from the dead")
+
+        assertNull(store.get("c-1"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -16,6 +16,22 @@ internal class FakeVault : Vault {
     /** Flip to exercise the locked-vault path of a store; unlocked by default. */
     var locked: Boolean = false
 
+    /** Nesting depth of [transaction] (0 = no transaction held) — lets tests assert atomic sequences. */
+    private var transactionDepth = 0
+
+    /** Whether the most recent [put] happened while a [transaction] was held. */
+    var lastPutInTransaction: Boolean = false
+        private set
+
+    override fun <T> transaction(block: () -> T): T {
+        transactionDepth++
+        try {
+            return block()
+        } finally {
+            transactionDepth--
+        }
+    }
+
     override fun exists(): Boolean = true
     override val isUnlocked: Boolean get() = !locked
     override fun create(password: CharArray) = Unit
@@ -32,6 +48,7 @@ internal class FakeVault : Vault {
         entries[id]?.takeIf { !it.record.deleted }?.payload
 
     override fun put(id: String, type: RecordType, payload: ByteArray) {
+        lastPutInTransaction = transactionDepth > 0
         val version = (entries[id]?.record?.version ?: 0L) + 1
         entries[id] = Entry(
             VaultRecord(id, type, version, "2026-06-12T00:00:00Z", "test-device", deleted = false, blob = SEALED),


### PR DESCRIPTION
Rename SSH keys, passwords and certificates in the vault, keeping their host bindings and secret material — only the label changes.

- **Storage**: `CredentialStore.rename(id, label)` re-puts the same record under one `vault.transaction`, so the id (hosts reference it via `Host.credentialId`) and secret survive and the change syncs like any other edit. The transaction makes the read-modify-write atomic against a concurrent `mergeRemote` that could otherwise land a tombstone between the read and the write.
- **UI**: a Rename action in the secret detail panel (between Copy and Export/Delete) opens a prefilled name dialog, shared across desktop and Android. Confirm is enabled only for a non-blank, changed name; a lock race while the dialog is open aborts instead of throwing.
- **i18n**: strings in en/ru/zh.
- Also drops the hover highlight from vault dialog cards and scrim — they are static surfaces, not buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)