### PR TITLE
fix(sync): refresh expired access tokens mid-session instead of logging out

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -568,9 +568,17 @@ class SyncCoordinator(
         resetCursor: Boolean,
         clearLocalRecords: Boolean = false,
     ) {
-        val superseded = client?.takeIf { it !== syncClient }
-        client = syncClient
-        session = newSession
+        // Publish under [syncMutex]: the 401 recovery ([refreshSessionLocked]) rotates/nulls the
+        // session and rewrites the config while holding syncMutex only — without sharing the lock, a
+        // refresh in flight (a suspended network call) would resolve after this activation and clobber
+        // the just-published session and config (including the pendingReconcile marker saved below).
+        // Lock order holds: we're under opMutex, syncMutex nests inside it.
+        val superseded: SyncClient?
+        syncMutex.withLock {
+            superseded = client?.takeIf { it !== syncClient }
+            client = syncClient
+            session = newSession
+        }
         // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the first
         // sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
         // push can't resurrect a record the server purged while this device was revoked.
@@ -1040,21 +1048,150 @@ class SyncCoordinator(
     // Body of one sync cycle; called only with [syncMutex] already held (runSync/syncNow).
     private suspend fun runSyncLocked(c: SyncClient, s: SyncSession) {
         try {
-            val outcome = engineFactory(c).sync(s)
-            _status.value = SyncStatus.Online(s.accountId, outcome.pushed, outcome.pulled)
-            // Pulled records from the server → refresh list managers, else synced data isn't visible until reopen.
-            if (outcome.pulled > 0) {
-                refreshSyncSettings() // another device may have changed "what to sync"
-                runCatching { onSynced() }
-            }
+            runSyncAttempt(c, s)
         } catch (e: CancellationException) {
             throw e // don't swallow cancellation — it would break structured concurrency
         } catch (e: SyncException) {
-            _status.value = syncFailure(e)
+            // 401 mid-session = the short-TTL access token expired (15 min by default) while the
+            // session stayed alive — the norm on mobile, where the process survives in background far
+            // past the TTL. The refresh token in [session] is still valid: rotate and retry once
+            // instead of surfacing Failed(Unauthorized), which the UI renders as "logged out".
+            if (e.kind == SyncException.Kind.UNAUTHORIZED) {
+                // The vault locked while this sync was in flight (pauseForLock doesn't track a manual
+                // syncNow, only the subscriptions): don't recover into a state the pause just parked —
+                // the retry would throw inside the locked vault and overwrite Configured with a failure.
+                if (lockPaused) {
+                    configStore.load()?.let { _status.value = SyncStatus.Configured(it.serverUrl, it.accountId) }
+                    return
+                }
+                when (val r = refreshSessionLocked(c, s)) {
+                    RefreshResult.Refreshed -> {
+                        val fresh = session ?: return
+                        try {
+                            runSyncAttempt(c, fresh)
+                        } catch (e2: CancellationException) {
+                            throw e2
+                        } catch (e2: SyncException) {
+                            _status.value = syncFailure(e2)
+                        } catch (e2: Exception) {
+                            _status.value = SyncStatus.Failed(SyncFailureReason.SyncFailed, e2.message)
+                        }
+                    }
+                    // Refresh itself was rejected: refreshSessionLocked already tore the dead session
+                    // down and parked the status on Configured (password reauth).
+                    RefreshResult.Dead -> {}
+                    // Session vanished or was replaced (disconnect/connect raced): its owner drives the
+                    // status, and retrying the NEW session over the OLD client would send its bearer
+                    // token to a possibly different server.
+                    RefreshResult.StandDown -> {}
+                    // The refresh attempt failed for a non-auth reason: report THAT cause, not the
+                    // original 401 — "Unauthorized" for a network blip during refresh would be exactly
+                    // the bogus "logged out" rendering this recovery exists to remove. The session
+                    // stays; the next sync retries the whole recovery.
+                    is RefreshResult.Failed ->
+                        _status.value = (r.cause as? SyncException)?.let { syncFailure(it) }
+                            ?: SyncStatus.Failed(SyncFailureReason.SyncFailed, r.cause.message)
+                }
+            } else {
+                _status.value = syncFailure(e)
+            }
         } catch (e: Exception) {
             // Unexpected (serialization, OOM, engine bug) — otherwise it would go silently to the
             // SupervisorJob and the status stuck on Busy (eternal spinner). syncNow/restoreSession call this.
             _status.value = SyncStatus.Failed(SyncFailureReason.SyncFailed, e.message)
+        }
+    }
+
+    // One sync attempt + the Online bookkeeping; exceptions propagate to runSyncLocked.
+    private suspend fun runSyncAttempt(c: SyncClient, s: SyncSession) {
+        val outcome = engineFactory(c).sync(s)
+        _status.value = SyncStatus.Online(s.accountId, outcome.pushed, outcome.pulled)
+        // Pulled records from the server → refresh list managers, else synced data isn't visible until reopen.
+        if (outcome.pulled > 0) {
+            refreshSyncSettings() // another device may have changed "what to sync"
+            runCatching { onSynced() }
+        }
+    }
+
+    /** What [refreshSessionLocked] did with the expired session. */
+    private sealed interface RefreshResult {
+        /** Tokens rotated (or already rotated by the other recovery path): retry the failed call. */
+        data object Refreshed : RefreshResult
+
+        /** Refresh token rejected: session torn down, status parked on Configured (password reauth). */
+        data object Dead : RefreshResult
+
+        /** Session vanished or was replaced while we ran: its new owner drives status — do nothing. */
+        data object StandDown : RefreshResult
+
+        /** The refresh attempt itself failed (network/protocol); session kept for a later retry. */
+        data class Failed(val cause: Exception) : RefreshResult
+    }
+
+    /**
+     * Rotate the tokens of the live session via its refresh token ([SyncClient.refresh]) after a 401.
+     * Call with [syncMutex] held — every [session]/config writer shares it: [disconnect]'s null and
+     * [activateSession]'s publish take syncMutex too, so a suspended refresh can't clobber a session
+     * or config another path just wrote. [stale] is the session the caller failed with; if [session]
+     * moved on since (a parallel connect, or the other of the two 401-recovery paths — sync and
+     * watch — won the race), nothing is rotated ([RefreshResult.StandDown]). The identity is
+     * re-checked after the suspending refresh as defense-in-depth for any future writer that
+     * bypasses the mutex.
+     *
+     * A refresh rejected as UNAUTHORIZED/NOT_FOUND means the refresh token itself is dead (device
+     * revoked, 30-day expiry, account gone): tear the session down — cancel the live subscriptions
+     * (no join: the watch loop may be this very caller and exits on the nulled session by itself),
+     * close the client (disconnect's "no live client" hygiene), drop the known-dead sealed token so
+     * cold starts stop burning a refresh round trip on it — and park on [SyncStatus.Configured]: the
+     * link survives and the user reconnects with the password, mirroring [restoreSession]'s fallback.
+     */
+    private suspend fun refreshSessionLocked(c: SyncClient, stale: SyncSession): RefreshResult {
+        val current = session ?: return RefreshResult.StandDown
+        if (current !== stale) return RefreshResult.Refreshed
+        val fresh = try {
+            c.refresh(stale)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: SyncException) {
+            if (e.kind == SyncException.Kind.UNAUTHORIZED || e.kind == SyncException.Kind.NOT_FOUND) {
+                if (session !== stale) return RefreshResult.StandDown
+                session = null
+                watchJob?.cancel() // cancel only — join/replace stay under opMutex (activateSession/disconnect)
+                pushJob?.cancel()
+                runCatching { c.close() }
+                client = null
+                val cfg = configStore.load()
+                if (cfg?.sealedRefreshToken != null) {
+                    runCatching { configStore.save(cfg.copy(sealedRefreshToken = null)) }
+                }
+                _status.value = cfg?.let { SyncStatus.Configured(it.serverUrl, it.accountId) }
+                    ?: SyncStatus.Disabled
+                return RefreshResult.Dead
+            }
+            return RefreshResult.Failed(e)
+        } catch (e: Exception) {
+            return RefreshResult.Failed(e)
+        }
+        if (session !== stale) return RefreshResult.StandDown
+        session = fresh
+        resealRefreshToken(fresh)
+        return RefreshResult.Refreshed
+    }
+
+    /**
+     * keep-connected: re-seal the rotated refresh token into the config, or the next cold-start
+     * [restoreSession] would run on a stale (eventually 30-day-expired) one. Best-effort: a locked
+     * vault or a config write failure must not fail the recovery — the old sealed token stays valid
+     * until its own expiry (the server's refresh tokens are stateless, not single-use).
+     */
+    private fun resealRefreshToken(fresh: SyncSession) {
+        val cfg = configStore.load() ?: return
+        if (!cfg.keepConnected) return
+        val dk = vault.exportDataKey() ?: return
+        try {
+            runCatching { configStore.save(cfg.copy(sealedRefreshToken = tokens.seal(dk, fresh.refreshToken))) }
+        } finally {
+            dk.zeroize()
         }
     }
 
@@ -1080,7 +1217,7 @@ class SyncCoordinator(
      */
     private suspend fun startWatch() {
         val c = client ?: return
-        val s = session ?: return
+        if (session == null) return
         // cancel + join the old subscription before starting a new one (reconnect without disconnect):
         // otherwise the old collect could run runSync with the new session under the old cursor.
         watchJob?.cancel()
@@ -1088,6 +1225,12 @@ class SyncCoordinator(
         watchJob = scope.launch {
             var backoff = WATCH_RETRY_MIN_MS
             while (true) {
+                // Re-read the live session on every attempt: a mid-session token rotation (the 401
+                // recovery in runSyncLocked, or the refresh below) must reach the next WS handshake —
+                // a captured copy would reconnect with the dead access token forever, live-pull
+                // silently gone while the status stays Online. A nulled session (dead refresh token,
+                // disconnect is a cancel and never reaches here) ends the loop.
+                val s = session ?: break
                 try {
                     c.changes(s).collect { signal ->
                         backoff = WATCH_RETRY_MIN_MS // a live signal — reset the delay to the minimum
@@ -1106,7 +1249,13 @@ class SyncCoordinator(
                 } catch (e: CancellationException) {
                     throw e // don't swallow cancellation (disconnect/reconnect)
                 } catch (e: Exception) {
-                    // WS dropped (network/server/expired token) — don't give up, wait backoff and reconnect.
+                    // WS dropped. A handshake 401 (access token expired while the socket was down)
+                    // surfaces as an untyped Ktor error, indistinguishable from a network blip — so
+                    // rotate the tokens best-effort before retrying. Cheap: rate-limited by the
+                    // backoff, a no-op when another path already rotated, and a healthy-token rotate
+                    // is harmless (server refresh tokens are stateless, the old one stays valid). A
+                    // dead refresh token nulls the session — the re-read above ends the loop.
+                    syncMutex.withLock { refreshSessionLocked(c, s) }
                 }
                 delay(backoff)
                 backoff = (backoff * 2).coerceAtMost(WATCH_RETRY_MAX_MS)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
@@ -1,0 +1,253 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Mid-session token refresh: the server's access token has a short TTL (15 min by default), so a
+ * session older than that gets 401 on its next sync. The coordinator holds a perfectly valid refresh
+ * token (30 days) in [SyncSession] — it must rotate the tokens and retry instead of surfacing
+ * Failed(Unauthorized), which the mobile UI renders as "logged out, re-enter password".
+ *
+ * Real [FileVault] + real crypto (the sealed-token re-seal is part of the contract); the network and
+ * the sync cycle are stubbed ([SyncClient] fake + `engineFactory`).
+ */
+class SyncCoordinatorTokenRefreshTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    /**
+     * Existing account under this vault's own key (register collides, login adopts nothing). Tokens
+     * are numbered: login issues `access-1`/`refresh-1`, each [refresh] rotates to the next pair.
+     * [expiredTokens] simulates server-side access-token expiry; [changesFails] makes the WS stream
+     * drop immediately on each subscription (recording the token it was opened with).
+     */
+    private inner class RotatingClient(
+        private val ownWrappedKey: ByteArray,
+        private val changesFails: Boolean = false,
+    ) : SyncClient {
+        val expiredTokens = CopyOnWriteArrayList<String>()
+        val refreshCalls = AtomicInteger(0)
+        val watchTokens = CopyOnWriteArrayList<String>()
+        val closeCalls = AtomicInteger(0)
+        @Volatile
+        var refreshUnauthorized = false
+        @Volatile
+        var refreshNetworkError = false
+        private val issued = AtomicInteger(1)
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            throw SyncException(SyncException.Kind.CONFLICT, "account exists")
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
+            SyncSession(accountId, accessToken = "access-1", refreshToken = "refresh-1")
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
+        override suspend fun refresh(session: SyncSession): SyncSession {
+            refreshCalls.incrementAndGet()
+            if (refreshUnauthorized) throw SyncException(SyncException.Kind.UNAUTHORIZED, "invalid refresh token")
+            if (refreshNetworkError) throw SyncException(SyncException.Kind.NETWORK, "refresh unreachable")
+            val n = issued.incrementAndGet()
+            return SyncSession(session.accountId, accessToken = "access-$n", refreshToken = "refresh-$n")
+        }
+        override fun changes(session: SyncSession): Flow<SyncSignal> = flow {
+            watchTokens += session.accessToken
+            if (changesFails) throw SyncException(SyncException.Kind.NETWORK, "ws drop")
+            awaitCancellation()
+        }
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = RecordPage(emptyList(), 1)
+        override suspend fun push(session: SyncSession, records: List<app.skerry.shared.sync.RemoteRecord>): RecordPage = RecordPage(emptyList(), 1)
+        override suspend fun ping(): Boolean = true
+        override suspend fun close() { closeCalls.incrementAndGet() }
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
+        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = throw NotImplementedError()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
+    }
+
+    private fun freshVault(): Vault {
+        val file = Files.createTempFile("skerry-token-refresh", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-23T00:00:00Z" })
+            .also { it.create(password.toCharArray()) }
+    }
+
+    /** This vault's own dataKey wrapped under the account (= vault) password, so the connect adopts nothing. */
+    private fun ownWrap(vault: Vault): ByteArray {
+        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
+        val dk = vault.exportDataKey()!!
+        val wrapped = crypto.wrapDataKey(mk, dk)
+        mk.zeroize(); dk.zeroize()
+        return wrapped
+    }
+
+    /** Coordinator whose sync cycle fails with 401 whenever the session's access token is expired. */
+    private fun coordinator(client: RotatingClient, vault: Vault, config: InMemorySyncConfigStore) =
+        SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            engineFactory = { _ ->
+                SyncRunner { s ->
+                    if (s.accessToken in client.expiredTokens) throw SyncException(SyncException.Kind.UNAUTHORIZED, "token expired")
+                    SyncOutcome(pulled = 0, pushed = 0, cursor = 1)
+                }
+            },
+        )
+
+    @Test
+    fun `expired access token is rotated via the refresh token and the sync retried`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        val client = RotatingClient(ownWrap(vault))
+        val config = InMemorySyncConfigStore()
+        val sut = coordinator(client, vault, config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online, "connect should come Online, got ${sut.status.value}")
+            val sealedAtConnect = config.load()?.sealedRefreshToken
+            assertNotNull(sealedAtConnect, "keep-connected must seal the refresh token at connect")
+
+            // The 15-minute TTL passes: the server now rejects the session's access token.
+            client.expiredTokens += "access-1"
+            sut.syncNow()
+            val terminal = withTimeout(30_000) {
+                sut.status.first { (it is SyncStatus.Online && client.refreshCalls.get() > 0) || it is SyncStatus.Failed || it is SyncStatus.Configured }
+            }
+            assertTrue(terminal is SyncStatus.Online, "an expired access token must refresh+retry, not surface as $terminal")
+            assertEquals(1, client.refreshCalls.get(), "exactly one refresh for one expired sync")
+
+            // The rotated refresh token must be re-sealed, or the next cold-start restore would use a stale one.
+            val sealedAfter = config.load()?.sealedRefreshToken
+            assertNotNull(sealedAfter)
+            assertNotEquals(sealedAtConnect, sealedAfter, "rotated refresh token must be re-sealed into the config")
+            val dk = vault.exportDataKey()!!
+            try {
+                assertEquals("refresh-2", SealedTokenCodec(crypto).open(dk, sealedAfter), "re-sealed token must be the rotated one")
+            } finally {
+                dk.zeroize()
+            }
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `dead refresh token falls back to Configured (password reauth), not a raw error`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        val client = RotatingClient(ownWrap(vault))
+        val config = InMemorySyncConfigStore()
+        val sut = coordinator(client, vault, config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online)
+
+            // Both tokens are dead (device revoked / 30-day refresh expiry): the link survives, the
+            // session doesn't — the user reconnects with the password, like restoreSession's fallback.
+            client.expiredTokens += "access-1"
+            client.refreshUnauthorized = true
+            sut.syncNow()
+            val terminal = withTimeout(30_000) {
+                sut.status.first { it is SyncStatus.Configured || it is SyncStatus.Failed }
+            }
+            assertTrue(terminal is SyncStatus.Configured, "a dead refresh token must ask for the password (Configured), got $terminal")
+            assertEquals(null, sut.currentSession(), "the dead session must be dropped")
+            assertTrue(client.closeCalls.get() > 0, "the dead session's client must be closed")
+            assertEquals(null, config.load()?.sealedRefreshToken, "the known-dead sealed token must be dropped from the config")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `network failure during refresh surfaces as Network and keeps the session for a later retry`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        val client = RotatingClient(ownWrap(vault))
+        val config = InMemorySyncConfigStore()
+        val sut = coordinator(client, vault, config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online)
+
+            // Access token expired AND the refresh round trip hits a network blip: the truthful status
+            // is Network — Failed(Unauthorized) here would be the very "logged out" rendering the
+            // recovery exists to remove. The session must survive for the next attempt.
+            client.expiredTokens += "access-1"
+            client.refreshNetworkError = true
+            sut.syncNow()
+            val failed = withTimeout(30_000) { sut.status.first { it is SyncStatus.Failed || it is SyncStatus.Configured } }
+            assertTrue(failed is SyncStatus.Failed && failed.reason == SyncFailureReason.Network, "a refresh network blip must surface as Network, got $failed")
+            assertTrue(sut.currentSession() != null, "the session must survive a transient refresh failure")
+
+            // The blip passes: the next sync recovers through the normal refresh+retry path.
+            client.refreshNetworkError = false
+            sut.syncNow()
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            assertEquals(2, client.refreshCalls.get(), "one failed and one successful refresh")
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `watch reconnect picks up the rotated access token`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        val client = RotatingClient(ownWrap(vault), changesFails = true)
+        val config = InMemorySyncConfigStore()
+        val sut = coordinator(client, vault, config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            assertTrue(sut.status.value is SyncStatus.Online)
+
+            // Every WS drop rotates the session (best-effort refresh) — the NEXT handshake must use
+            // the fresh token, not the one captured when the watch started (a dead captured token
+            // would otherwise loop 401 forever while the status stays Online).
+            withTimeout(30_000) {
+                while (client.watchTokens.size < 2) delay(50)
+            }
+            assertEquals("access-1", client.watchTokens[0])
+            assertEquals("access-2", client.watchTokens[1], "watch reconnect must use the refreshed session")
+        } finally {
+            sut.close()
+        }
+    }
+}


### PR DESCRIPTION
Keeps a connected sync session alive past the server's 15-minute access-token TTL: on a 401 the client now rotates the tokens via its refresh token and retries, instead of dropping to a "logged out, re-enter password" error. This was routine on mobile, where the app process outlives the TTL in background — reopening the app looked like a forced logout even though the 30-day refresh token was still valid.

**Behavior**
- A sync that hits 401 rotates the tokens and retries once; the rotated refresh token is re-sealed into the config (keep-connected), so cold-start auto-restore keeps working.
- A rejected refresh token (revoked device, 30-day expiry) tears the session down cleanly and shows the "reconnect with password" state instead of a raw error.
- A network failure during the refresh round trip reports Network — the session survives and the next sync retries.
- The WS live-pull loop picks up rotated tokens on every reconnect and refreshes best-effort on a drop; previously it reconnected forever with the dead token while the status stayed Online.

**Also in this PR**
- All session/config writes are serialized under one mutex, so an in-flight refresh can't clobber a freshly activated session or the pendingReconcile reconcile marker.
- 4 new coordinator tests (`SyncCoordinatorTokenRefreshTest`) covering refresh+retry, dead-token fallback, refresh network failure, and watch-loop token pickup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)