### PR TITLE
Portable Windows zip build in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,25 +157,31 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
-      - name: Package msi
+      - name: Package msi + portable zip
+        # packagePortableZip reuses the app-image createDistributable already builds for the
+        # msi, so the extra artifact costs only the zipping.
         shell: bash
         run: >
-          ./gradlew :composeApp:packageMsi --stacktrace
+          ./gradlew :composeApp:packageMsi :composeApp:packagePortableZip --stacktrace
           ${{ needs.version.outputs.name && format('-Pskerry.versionName={0}', needs.version.outputs.name) || '' }}
 
-      - name: Suffix msi with the architecture
+      - name: Suffix msi and portable zip with the architecture
         # jpackage emits Skerry-<version>.msi with no arch marker; every other desktop
         # asset carries one, and a Windows ARM build would otherwise collide.
         shell: bash
         run: |
           cd composeApp/build/compose/binaries/main/msi
           for f in *.msi; do mv "$f" "${f%.msi}-x64.msi"; done
+          cd ../portable
+          for f in *.zip; do mv "$f" "${f%.zip}-x64.zip"; done
 
-      - name: Upload Windows distributable
+      - name: Upload Windows distributables
         uses: actions/upload-artifact@v7
         with:
           name: skerry-windows-x64
-          path: composeApp/build/compose/binaries/main/msi/*.msi
+          path: |
+            composeApp/build/compose/binaries/main/msi/*.msi
+            composeApp/build/compose/binaries/main/portable/*.zip
           if-no-files-found: error
 
   macos-desktop:

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -297,6 +297,22 @@ tasks.register<Exec>("packageAppImage") {
     environment("VERSION", providers.gradleProperty("skerry.versionName").orNull ?: "0.1.0")
 }
 
+// Portable build: zip the jpackage app-image (createDistributable) as-is — no installer, the
+// user extracts and runs Skerry.exe. Used by the release workflow for the Windows portable
+// asset (the arch suffix is appended there, like for the msi). The bundled README warns about
+// paths with spaces — libsodium's loader (goterl) fails to initialize from them.
+tasks.register<Zip>("packagePortableZip") {
+    group = "compose desktop"
+    description = "Build a portable .zip from the jpackage app-image"
+    dependsOn("createDistributable")
+
+    val appVersion = providers.gradleProperty("skerry.versionName").orNull ?: "0.1.0"
+    archiveFileName.set("Skerry-$appVersion-portable.zip")
+    destinationDirectory.set(layout.buildDirectory.dir("compose/binaries/main/portable"))
+    from(layout.buildDirectory.dir("compose/binaries/main/app"))
+    from(project.file("portable/README.txt"))
+}
+
 // Build a single-file Skerry.flatpak via flatpak-builder. Unlike the other packaging tasks this
 // does NOT depend on createDistributable: flatpak-builder compiles the app hermetically inside the
 // sandbox from the committed offline sources (composeApp/flatpak/flatpak-sources.json). The task

--- a/composeApp/portable/README.txt
+++ b/composeApp/portable/README.txt
@@ -1,0 +1,9 @@
+Skerry — portable Windows build
+
+Extract this archive anywhere and run Skerry\Skerry.exe.
+Nothing is installed; settings are stored in your user profile as usual.
+
+IMPORTANT: pick a folder whose full path contains NO spaces
+(e.g. C:\Tools\Skerry — not C:\Program Files\Skerry). The bundled
+libsodium loader fails to initialize from a path with spaces, and the
+app will not start.


### PR DESCRIPTION
Adds a portable Windows build: a zip of the app that runs without installation.

## What

- New Gradle task `:composeApp:packagePortableZip` — zips the jpackage app-image (`createDistributable`) into `Skerry-<version>-portable.zip` with the app under a top-level `Skerry/` folder; extract and run `Skerry\Skerry.exe`.
- A `README.txt` in the zip root warns to extract into a path without spaces — the bundled libsodium loader fails to initialize from such paths (same constraint that makes the MSI per-user).

## CI

- The `windows-desktop` job builds the zip in the same Gradle invocation as the MSI, so the app-image is built once and the extra artifact costs only the zipping.
- The zip gets the architecture suffix (`Skerry-<version>-portable-x64.zip`) and ships in the `skerry-windows-x64` artifact — on tag pushes it lands in the draft release and `SHA256SUMS.txt` automatically, no changes to the publish job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)