### PR TITLE
Recover sync status automatically after a network failure

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/ServerHealthMonitor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/ServerHealthMonitor.kt
@@ -4,13 +4,14 @@ import app.skerry.shared.sync.SyncClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Poll period for the server health ping used by the reachability indicator: frequent enough for
@@ -39,6 +40,11 @@ internal class ServerHealthMonitor(
     private val pollMs: Long = HEALTH_POLL_MS,
 ) {
     private val target = MutableStateFlow(initialTarget)
+
+    // A [pingNow] nudge: the ping loop waits out the poll interval on it, so a send short-circuits
+    // the wait. CONFLATED keeps a nudge that arrives during an in-flight ping for the next wait
+    // instead of dropping it (that ping started before the nudge, so its result may be stale).
+    private val kick = Channel<Unit>(Channel.CONFLATED)
 
     private val _reachable = MutableStateFlow(ServerReachable.UNKNOWN)
     val reachable: StateFlow<ServerReachable> = _reachable.asStateFlow()
@@ -69,7 +75,7 @@ internal class ServerHealthMonitor(
                         }
                         _reachable.value =
                             if (ok) ServerReachable.REACHABLE else ServerReachable.UNREACHABLE
-                        delay(pollMs)
+                        withTimeoutOrNull(pollMs) { kick.receive() } // next tick early on a pingNow nudge
                     }
                 }
             } finally {
@@ -82,6 +88,14 @@ internal class ServerHealthMonitor(
     /** Changes the ping target (coordinator connect/disconnect); null stops the poller at UNKNOWN. */
     fun setTarget(serverUrl: String?) {
         target.value = serverUrl
+    }
+
+    /**
+     * Ping right now instead of waiting out the rest of the poll interval — the indicator may hold a
+     * value from before the device slept (app resume/unlock). No-op while no target is set.
+     */
+    fun pingNow() {
+        kick.trySend(Unit)
     }
 
     // suspend isn't superfluous: [SyncClient.close] is suspend, and closing the old client on URL

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -215,6 +215,8 @@ class SyncCoordinator(
      * [SyncRunner]). `null` (prod) — the real [SyncEngine] over vault/cursor/settings.
      */
     engineFactory: ((SyncClient) -> SyncRunner)? = null,
+    /** Health-ping poll period — test injection point (prod keeps [HEALTH_POLL_MS]). */
+    healthPollMs: Long = HEALTH_POLL_MS,
 ) {
     private val _status = MutableStateFlow<SyncStatus>(SyncStatus.Disabled)
     val status: StateFlow<SyncStatus> = _status.asStateFlow()
@@ -303,7 +305,7 @@ class SyncCoordinator(
 
     // Server availability via health ping — a dedicated poller with its own client (see
     // [ServerHealthMonitor]); lives for the coordinator's lifetime, holds UNKNOWN while target is null.
-    private val health = ServerHealthMonitor(clientFactory, scope, initialTarget = configStore.load()?.serverUrl)
+    private val health = ServerHealthMonitor(clientFactory, scope, initialTarget = configStore.load()?.serverUrl, pollMs = healthPollMs)
 
     /**
      * Server availability via health ping (see [ServerReachable]). Updated by the [health] poller
@@ -324,6 +326,12 @@ class SyncCoordinator(
     // reconnect — also strictly under [opMutex].
     @Volatile
     private var pushJob: Job? = null
+
+    // Backoff retry after a sync that failed with NETWORK (see [scheduleNetworkRetry]). Not cancelled
+    // by pause/disconnect: every tick rechecks lockPaused/session/status and the loop exits by itself
+    // when the failure is gone or nothing is left to sync. Scheduled only under [syncMutex].
+    @Volatile
+    private var retryJob: Job? = null
 
     // Set by [pauseForLock], cleared by [resumeAfterUnlock]: which of the two the coordinator should end
     // up obeying when they queue up behind a long operation holding [opMutex], regardless of the order
@@ -355,6 +363,26 @@ class SyncCoordinator(
         // server/account as Configured — the UI offers "reconnect" with one password, no retyping.
         // Disconnect erases the config → back to Disabled.
         configStore.load()?.let { _status.value = SyncStatus.Configured(it.serverUrl, it.accountId) }
+        // Self-heal on the server coming back into reach. The first sync after a display unlock often
+        // races the radio waking up from Doze and fails with NETWORK; nothing else retries it (WS
+        // signals need a remote change, push needs a local edit), so the status would park on Failed
+        // ("Sync error") indefinitely. When the health ping transitions to REACHABLE: a live session
+        // with a network-failed status re-syncs; no session retries the silent keep-connected restore
+        // (its own network failure parks on Configured the same way — restoreSession no-ops unless it
+        // actually applies). Skipped while the vault lock has live sync paused.
+        scope.launch {
+            var previous = health.reachable.value
+            health.reachable.collect { now ->
+                val cameUp = now == ServerReachable.REACHABLE && previous != ServerReachable.REACHABLE
+                previous = now
+                if (!cameUp || lockPaused) return@collect
+                if (session != null) {
+                    if ((_status.value as? SyncStatus.Failed)?.reason == SyncFailureReason.Network) runSync()
+                } else {
+                    restoreSession()
+                }
+            }
+        }
     }
 
     val isConfigured: Boolean get() = configStore.load() != null
@@ -1100,6 +1128,33 @@ class SyncCoordinator(
             // SupervisorJob and the status stuck on Busy (eternal spinner). syncNow/restoreSession call this.
             _status.value = SyncStatus.Failed(SyncFailureReason.SyncFailed, e.message)
         }
+        // A network failure is transient by nature — retry with backoff instead of leaving the status
+        // parked on "Sync error" until a manual sync. One central hook: every sync cycle ends here.
+        if ((_status.value as? SyncStatus.Failed)?.reason == SyncFailureReason.Network) scheduleNetworkRetry()
+    }
+
+    /**
+     * Retry loop for a sync that failed with [SyncFailureReason.Network]: re-run with exponential
+     * backoff ([SYNC_RETRY_MIN_MS]…[SYNC_RETRY_MAX_MS]) until the status stops being that failure.
+     * Complements the reachability trigger (init): that one fires only on an UNREACHABLE→REACHABLE
+     * transition of the health ping, which never comes for a blip the ping didn't see (transient DNS
+     * failure, one dropped connection). Self-terminating — every tick rechecks the pause flag, the
+     * session, and the status, so lock/disconnect/success all end it without an explicit cancel; a
+     * successful retry sets Online inside [runSync] itself. Scheduled under [syncMutex] (the caller
+     * holds it), so the single-instance check doesn't race.
+     */
+    private fun scheduleNetworkRetry() {
+        if (retryJob?.isActive == true) return
+        retryJob = scope.launch {
+            var backoff = SYNC_RETRY_MIN_MS
+            while (true) {
+                delay(backoff)
+                backoff = (backoff * 2).coerceAtMost(SYNC_RETRY_MAX_MS)
+                if (lockPaused || session == null || client == null) return@launch
+                if ((_status.value as? SyncStatus.Failed)?.reason != SyncFailureReason.Network) return@launch
+                runSync()
+            }
+        }
     }
 
     // One sync attempt + the Online bookkeeping; exceptions propagate to runSyncLocked.
@@ -1385,6 +1440,9 @@ class SyncCoordinator(
      */
     fun resumeAfterUnlock() {
         lockPaused = false
+        // The reachability indicator may hold a value from before the device slept (on Android the
+        // process freezes with the screen off); don't leave it visibly stale for up to a poll period.
+        health.pingNow()
         if (session == null) {
             restoreSession()
             return
@@ -1492,6 +1550,14 @@ private const val PUSH_DEBOUNCE_MS = 1500L
  */
 private const val WATCH_RETRY_MIN_MS = 1_000L
 private const val WATCH_RETRY_MAX_MS = 60_000L
+
+/**
+ * Backoff for retrying a sync that failed with a network error ([SyncCoordinator.scheduleNetworkRetry]):
+ * the minimum is small enough that the post-unlock radio race on mobile heals within seconds, the
+ * ceiling caps the retry rate during a long outage (the reachability trigger usually recovers first).
+ */
+private const val SYNC_RETRY_MIN_MS = 5_000L
+private const val SYNC_RETRY_MAX_MS = 60_000L
 
 /**
  * Cryptographically random 128-bit deviceId as hex. 16 bytes from the libsodium CSPRNG via

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -327,9 +327,11 @@ class SyncCoordinator(
     @Volatile
     private var pushJob: Job? = null
 
-    // Backoff retry after a sync that failed with NETWORK (see [scheduleNetworkRetry]). Not cancelled
-    // by pause/disconnect: every tick rechecks lockPaused/session/status and the loop exits by itself
-    // when the failure is gone or nothing is left to sync. Scheduled only under [syncMutex].
+    // Backoff retry after a sync that failed with NETWORK (see [scheduleNetworkRetry]). Every tick
+    // rechecks lockPaused/session/status, so the loop also exits by itself when the failure is gone
+    // or nothing is left to sync; session turnover (activateSession/stopSubscriptions/dead refresh)
+    // additionally cancels it (no join needed) so a sleeping loop with an escalated backoff can't
+    // outlive its session and slow-roll the first retry of the next one. Scheduled only under [syncMutex].
     @Volatile
     private var retryJob: Job? = null
 
@@ -606,6 +608,9 @@ class SyncCoordinator(
             superseded = client?.takeIf { it !== syncClient }
             client = syncClient
             session = newSession
+            // A retry loop armed for the previous session must not carry its escalated backoff into
+            // this one — the fresh session's first network failure re-arms from the minimum.
+            retryJob?.cancel()
         }
         // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the first
         // sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
@@ -1075,6 +1080,14 @@ class SyncCoordinator(
 
     // Body of one sync cycle; called only with [syncMutex] already held (runSync/syncNow).
     private suspend fun runSyncLocked(c: SyncClient, s: SyncSession) {
+        // The vault may have locked while this cycle waited for [syncMutex]: the retry loop and the
+        // reachability trigger aren't part of [pauseForLock]'s cancel+join ordering (watch/push are),
+        // so their runSync can win the mutex after the pause parked Configured. Don't run a cycle
+        // that's guaranteed to throw inside the locked vault.
+        if (lockPaused) {
+            parkOnConfigured()
+            return
+        }
         try {
             runSyncAttempt(c, s)
         } catch (e: CancellationException) {
@@ -1128,9 +1141,24 @@ class SyncCoordinator(
             // SupervisorJob and the status stuck on Busy (eternal spinner). syncNow/restoreSession call this.
             _status.value = SyncStatus.Failed(SyncFailureReason.SyncFailed, e.message)
         }
+        // The vault locked while this cycle was in flight (pauseForLock joins only watch/push, so an
+        // untracked cycle — retry tick, syncNow, reachability trigger — can still be running when it
+        // parks Configured): whatever this cycle just wrote is stale. Restore Configured instead of
+        // leaving a Failed that nothing behind the lock screen would ever correct. Mirrors the
+        // lockPaused branch of the 401 recovery above, which covers only the UNAUTHORIZED path.
+        if (lockPaused) {
+            parkOnConfigured()
+            return
+        }
         // A network failure is transient by nature — retry with backoff instead of leaving the status
         // parked on "Sync error" until a manual sync. One central hook: every sync cycle ends here.
         if ((_status.value as? SyncStatus.Failed)?.reason == SyncFailureReason.Network) scheduleNetworkRetry()
+    }
+
+    /** Park the status on Configured (the vault-locked resting state); Disabled without a link. */
+    private fun parkOnConfigured() {
+        _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) }
+            ?: SyncStatus.Disabled
     }
 
     /**
@@ -1142,6 +1170,12 @@ class SyncCoordinator(
      * session, and the status, so lock/disconnect/success all end it without an explicit cancel; a
      * successful retry sets Online inside [runSync] itself. Scheduled under [syncMutex] (the caller
      * holds it), so the single-instance check doesn't race.
+     *
+     * Single instance is deliberate: a failure that lands while a loop is already sleeping inherits
+     * its current backoff rather than resetting to the minimum — it's the same server, and the
+     * reachability trigger reacts to a real recovery instantly regardless of where the backoff is.
+     * Session turnover does reset it: activateSession/stopSubscriptions cancel the loop, so a fresh
+     * session's first failure re-arms at [SYNC_RETRY_MIN_MS].
      */
     private fun scheduleNetworkRetry() {
         if (retryJob?.isActive == true) return
@@ -1213,6 +1247,7 @@ class SyncCoordinator(
                 session = null
                 watchJob?.cancel() // cancel only — join/replace stay under opMutex (activateSession/disconnect)
                 pushJob?.cancel()
+                retryJob?.cancel() // the session is dead — nothing left for the retry loop to heal
                 runCatching { c.close() }
                 client = null
                 val cfg = configStore.load()
@@ -1467,10 +1502,14 @@ class SyncCoordinator(
     private suspend fun stopSubscriptions() {
         watchJob?.cancel()
         pushJob?.cancel()
+        // Cancel-only, no join: the retry loop takes only syncMutex and self-checks every tick — the
+        // cancel just frees the slot so the next failure arms a fresh loop at the minimum backoff.
+        retryJob?.cancel()
         watchJob?.join()
         pushJob?.join()
         watchJob = null
         pushJob = null
+        retryJob = null
     }
 
     /**
@@ -1481,13 +1520,18 @@ class SyncCoordinator(
      * erased, user reconnects by password). Already connected → no-op.
      */
     fun restoreSession() {
-        val cfg = configStore.load() ?: return
-        if (!cfg.keepConnected || cfg.sealedRefreshToken == null || session != null) return
+        // Cheap pre-check only — the authoritative copy is re-loaded under the lock below.
+        val quick = configStore.load() ?: return
+        if (!quick.keepConnected || quick.sealedRefreshToken == null || session != null) return
         scope.launch {
             opMutex.withLock {
-                // Recheck under the lock: a parallel connect/claim may have activated the session while
-                // we waited for opMutex — then there's nothing to restore.
-                if (session != null) return@withLock
+                // Re-load and re-check under the lock: while this coroutine waited for opMutex, a
+                // parallel connect/claim may have activated a session (nothing to restore), or a
+                // disconnect may have erased the link — restoring from the stale pre-check copy would
+                // silently re-link a device the user just disconnected (the refresh token is still
+                // valid server-side; disconnect doesn't revoke it).
+                val cfg = configStore.load() ?: return@withLock
+                if (!cfg.keepConnected || cfg.sealedRefreshToken == null || session != null) return@withLock
                 val dataKey = vault.exportDataKey() ?: return@withLock
                 _status.value = SyncStatus.Busy
                 try {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
@@ -51,7 +51,7 @@ class SyncCoordinatorHealthTest {
     }
 
     @Test
-    fun configured_but_down_server_reports_unreachable() = runBlocking {
+    fun configured_but_down_server_reports_unreachable() = runBlocking<Unit> {
         val client = FakePingClient(reachable = false)
         val sut = SyncCoordinator({ client }, StubCrypto(), StubVault(), configStore = configuredStore())
         withTimeout(3_000) { sut.serverReachable.first { it == ServerReachable.UNREACHABLE } }
@@ -67,12 +67,32 @@ class SyncCoordinatorHealthTest {
     }
 
     @Test
-    fun disconnect_returns_indicator_to_unknown() = runBlocking {
+    fun disconnect_returns_indicator_to_unknown() = runBlocking<Unit> {
         val client = FakePingClient(reachable = true)
         val sut = SyncCoordinator({ client }, StubCrypto(), StubVault(), configStore = configuredStore())
         withTimeout(3_000) { sut.serverReachable.first { it == ServerReachable.REACHABLE } }
         sut.disconnect()
         withTimeout(3_000) { sut.serverReachable.first { it == ServerReachable.UNKNOWN } }
+    }
+
+    @Test
+    fun resume_after_unlock_pings_immediately_instead_of_waiting_out_the_poll_interval() = runBlocking {
+        val client = FakePingClient(reachable = true)
+        // Poll interval far beyond the test: any second ping can only come from the resume nudge.
+        val sut = SyncCoordinator(
+            { client }, StubCrypto(), StubVault(),
+            configStore = configuredStore(), healthPollMs = 60_000,
+        )
+        try {
+            withTimeout(3_000) { sut.serverReachable.first { it == ServerReachable.REACHABLE } }
+            assertEquals(1, client.pings)
+            // After a display unlock the indicator may hold a value from before the device slept;
+            // waiting out the rest of a poll interval leaves it visibly stale.
+            sut.resumeAfterUnlock()
+            withTimeout(3_000) { while (client.pings < 2) delay(10) }
+        } finally {
+            sut.close()
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
@@ -1,0 +1,201 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.concurrent.Volatile
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Self-healing after a network-failed sync. On mobile the first sync after a display unlock often
+ * races the radio waking up from Doze and fails with NETWORK; without a retry the status parks on
+ * Failed ("Sync error", red crossed cloud) until the user syncs manually or a remote change happens
+ * to arrive — indefinitely long. The coordinator must bring itself back Online once the network is
+ * up: via the server-reachability transition of the health ping and via its own retry backoff.
+ *
+ * Real vault and crypto (the connect path derives keys with Argon2id); only the network is faked.
+ */
+class SyncCoordinatorNetworkRecoveryTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    /** Client with a switchable server: [up] = false makes ping fail and refresh throw NETWORK. */
+    private class SwitchableServerClient : SyncClient {
+        @Volatile var up = true
+
+        override suspend fun ping(): Boolean = up
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+
+        override suspend fun refresh(session: SyncSession): SyncSession {
+            if (!up) throw SyncException(SyncException.Kind.NETWORK, "server down")
+            return SyncSession(session.accountId, accessToken = "access-2", refreshToken = "refresh-2")
+        }
+
+        override fun changes(session: SyncSession): Flow<SyncSignal> = flow { awaitCancellation() }
+
+        override suspend fun close() {}
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
+        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()
+        private fun nope(): Nothing = throw NotImplementedError("recovery flow should not call this")
+    }
+
+    private fun localVault(): Vault {
+        val file = Files.createTempFile("skerry-net-recovery", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "dev-local", fileSystem = FileSystem.SYSTEM, now = { "2026-07-23T00:00:00Z" })
+            .also { it.create(password.toCharArray()) }
+    }
+
+    /** Engine that mirrors the fake server: sync fails with NETWORK while [client.up] is false. */
+    private fun coordinator(
+        vault: Vault,
+        client: SwitchableServerClient,
+        configStore: SyncConfigStore = InMemorySyncConfigStore(),
+    ): SyncCoordinator = SyncCoordinator(
+        clientFactory = { client },
+        crypto = crypto,
+        vault = vault,
+        configStore = configStore,
+        engineFactory = { _ ->
+            SyncRunner { _ ->
+                if (!client.up) throw SyncException(SyncException.Kind.NETWORK, "server down")
+                SyncOutcome(pulled = 0, pushed = 0, cursor = 0L)
+            }
+        },
+        healthPollMs = 200,
+    )
+
+    @Test
+    fun `network-failed sync heals itself when the server becomes reachable again`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = SwitchableServerClient()
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            withTimeout(5_000) { sut.serverReachable.first { it == ServerReachable.REACHABLE } }
+
+            // The network drops: a sync cycle fails with NETWORK and the status parks on Failed.
+            client.up = false
+            sut.syncNow()
+            withTimeout(5_000) {
+                sut.status.first { (it as? SyncStatus.Failed)?.reason == SyncFailureReason.Network }
+            }
+            withTimeout(5_000) { sut.serverReachable.first { it == ServerReachable.UNREACHABLE } }
+
+            // The network returns. No manual sync, no remote change — the status must recover on its
+            // own once the health ping sees the server again. The 3s bound is below the retry-backoff
+            // minimum, so only the reachability-transition path can pass it.
+            client.up = true
+            withTimeout(3_000) { sut.status.first { it is SyncStatus.Online } }
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `network-failed sync retries with backoff even if the server never looked down`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = SwitchableServerClient()
+        val engineBroken = java.util.concurrent.atomic.AtomicBoolean(false)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            engineFactory = { _ ->
+                SyncRunner { _ ->
+                    if (engineBroken.get()) throw SyncException(SyncException.Kind.NETWORK, "connection reset")
+                    SyncOutcome(pulled = 0, pushed = 0, cursor = 0L)
+                }
+            },
+            healthPollMs = 200,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+
+            // A transient blip: the sync path fails with NETWORK while the health ping stays green, so
+            // no reachability transition will ever fire — only the coordinator's own retry can heal it.
+            engineBroken.set(true)
+            sut.syncNow()
+            withTimeout(5_000) {
+                sut.status.first { (it as? SyncStatus.Failed)?.reason == SyncFailureReason.Network }
+            }
+            engineBroken.set(false)
+            withTimeout(15_000) { sut.status.first { it is SyncStatus.Online } }
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `keep-connected restore retries when the server becomes reachable`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = SwitchableServerClient()
+        val configStore = InMemorySyncConfigStore()
+
+        // First launch: connect with keep-connected so the sealed refresh token lands in the config.
+        val first = coordinator(vault, client, configStore)
+        try {
+            first.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            withTimeout(30_000) { first.status.first { it is SyncStatus.Online } }
+            assertTrue(configStore.load()?.sealedRefreshToken != null, "keep-connected must seal the refresh token")
+        } finally {
+            first.close()
+        }
+
+        // Cold start with the network down: the silent restore fails and falls back to Configured.
+        client.up = false
+        val second = coordinator(vault, client, configStore)
+        try {
+            withTimeout(5_000) { second.status.first { it is SyncStatus.Configured } }
+            second.resumeAfterUnlock() // the vault is already unlocked; restore hits the dead network
+            delay(500)
+            assertTrue(second.status.value is SyncStatus.Configured, "restore over a dead network must fall back to Configured")
+
+            // The network returns: the restore must be retried without user action.
+            client.up = true
+            withTimeout(10_000) { second.status.first { it is SyncStatus.Online } }
+        } finally {
+            second.close()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -45,14 +46,22 @@ class SyncCoordinatorNetworkRecoveryTest {
     private val account = "maya"
     private val password = "vault-A"
 
-    /** Client with a switchable server: [up] = false makes ping fail and refresh throw NETWORK. */
-    private class SwitchableServerClient : SyncClient {
+    /**
+     * Client with a switchable server: [up] = false makes ping fail and refresh throw NETWORK.
+     * [registerGate], when given, holds `register` open so a connect can be parked on [opMutex]
+     * mid-flight ([registering] completes once it is there).
+     */
+    private class SwitchableServerClient(private val registerGate: CompletableDeferred<Unit>? = null) : SyncClient {
         @Volatile var up = true
+        val registering = CompletableDeferred<Unit>()
 
         override suspend fun ping(): Boolean = up
 
-        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
+            registering.complete(Unit)
+            registerGate?.await()
+            return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+        }
 
         override suspend fun refresh(session: SyncSession): SyncSession {
             if (!up) throw SyncException(SyncException.Kind.NETWORK, "server down")
@@ -160,6 +169,100 @@ class SyncCoordinatorNetworkRecoveryTest {
             }
             engineBroken.set(false)
             withTimeout(15_000) { sut.status.first { it is SyncStatus.Online } }
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `a sync finishing after a vault lock must not overwrite the parked Configured status`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = SwitchableServerClient()
+        val engineBlocked = java.util.concurrent.atomic.AtomicBoolean(false)
+        val engineGate = CompletableDeferred<Unit>()
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            engineFactory = { _ ->
+                SyncRunner { _ ->
+                    if (engineBlocked.get()) {
+                        engineGate.await()
+                        // What a cycle inside a locked vault really does: throws from decrypt/merge.
+                        throw IllegalStateException("vault is locked")
+                    }
+                    SyncOutcome(pulled = 0, pushed = 0, cursor = 0L)
+                }
+            },
+            healthPollMs = 200,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+
+            // A sync is in flight (parked inside the engine) when the vault locks: pauseForLock joins
+            // only watch/push, so it parks Configured while this cycle is still running.
+            engineBlocked.set(true)
+            sut.syncNow()
+            withTimeout(5_000) { sut.status.first { it == SyncStatus.Busy } }
+            vault.lock()
+            sut.pauseForLock()
+            withTimeout(5_000) { sut.status.first { it is SyncStatus.Configured } }
+
+            // The in-flight cycle now fails inside the locked vault. Its failure must not overwrite
+            // the Configured the pause just parked — that would show "Sync error" behind a lock screen
+            // with nothing left to correct it until the next unlock.
+            engineGate.complete(Unit)
+            delay(500)
+            assertTrue(
+                sut.status.value is SyncStatus.Configured,
+                "expected Configured after the lock, got ${sut.status.value}",
+            )
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `a queued restore must not resurrect a link the user disconnected`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val configStore = InMemorySyncConfigStore()
+        // Seed a keep-connected link (token sealed under the live vault dataKey) so restoreSession applies.
+        val dk = vault.exportDataKey()!!
+        try {
+            configStore.save(
+                SyncConfig(
+                    serverUrl, account, deviceId = "dev-1", keepConnected = true,
+                    sealedRefreshToken = SealedTokenCodec(crypto).seal(dk, "refresh"),
+                ),
+            )
+        } finally {
+            dk.zeroize()
+        }
+        val gate = CompletableDeferred<Unit>()
+        val client = SwitchableServerClient(registerGate = gate)
+        val sut = coordinator(vault, client, configStore)
+        try {
+            // A connect parks on opMutex inside the gated register; disconnect and restore queue behind
+            // it in FIFO order (kotlinx Mutex is fair). The restore passes its pre-checks NOW — config
+            // present, no session yet — but by the time it gets the mutex the disconnect has erased the
+            // link. Restoring from the stale copy would silently re-link the device.
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { client.registering.await() }
+            sut.disconnect()
+            delay(100) // keep the queue order deterministic: disconnect enters the mutex queue first
+            sut.restoreSession()
+            gate.complete(Unit)
+
+            withTimeout(10_000) { sut.status.first { it == SyncStatus.Disabled } }
+            delay(700) // give the stale restore its chance to (wrongly) bring the link back
+            assertTrue(
+                sut.status.value == SyncStatus.Disabled,
+                "expected Disabled to stick after disconnect, got ${sut.status.value}",
+            )
+            assertTrue(configStore.load() == null, "disconnect erased the link; restore must not re-save it")
         } finally {
             sut.close()
         }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -43,7 +43,9 @@ import app.skerry.sync.wire.TeamsResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.timeout
 import io.ktor.client.plugins.websocket.WebSockets
 import io.ktor.client.plugins.websocket.webSocket
 import io.ktor.client.request.bearerAuth
@@ -385,7 +387,11 @@ class KtorSyncClient(
     override suspend fun ping(): Boolean = try {
         // Open liveness endpoint (see server Plugins.kt `/healthz`). No bearer token — the ping
         // must succeed even without a session (vault locked). Any failure means unreachable (don't throw).
-        http.get("$serverUrl/healthz").status.isSuccess()
+        // Tight per-request timeout: after a device sleep the pooled connection is often dead (NAT
+        // mappings dropped), and waiting out CIO's default 15s on it keeps the indicator stale.
+        http.get("$serverUrl/healthz") {
+            timeout { requestTimeoutMillis = PING_TIMEOUT_MS }
+        }.status.isSuccess()
     } catch (e: CancellationException) {
         throw e // coroutine cancellation isn't "server unreachable" — the signal must reach the caller
     } catch (e: Exception) {
@@ -479,8 +485,14 @@ class KtorSyncClient(
          */
         const val WS_PING_INTERVAL_MS = 30_000L
 
+        /** Health-ping timeout (see [ping]) — /healthz answers in milliseconds, 5s is generous. */
+        const val PING_TIMEOUT_MS = 5_000L
+
         fun defaultHttpClient(): HttpClient = HttpClient(CIO) {
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+            // No global values — only the per-request ping timeout applies; the sync/auth calls keep
+            // the engine defaults, and WebSockets stay exempt (see WS_PING_INTERVAL_MS above).
+            install(HttpTimeout)
             install(WebSockets) { pingIntervalMillis = WS_PING_INTERVAL_MS }
         }
     }


### PR DESCRIPTION
Fixes the sync indicator staying on "Sync error" (red crossed cloud) for a very long time after a display unlock on mobile.

## What

The first sync after an unlock races the radio waking up from Doze and fails with a network error; nothing retried it, so the status parked on Failed until a manual sync or an incoming remote change. The coordinator now heals itself:

- A NETWORK-failed sync retries with exponential backoff (5s → 60s). The loop self-terminates on success, vault lock, or disconnect.
- When the health ping sees the server come back into reach, a network-failed live session re-syncs immediately, and with no session the silent keep-connected restore is retried (covers a cold start while offline).
- `resumeAfterUnlock()` pings the server immediately instead of waiting out the rest of the 15s poll interval, and the ping gets a 5s per-request timeout so a pooled connection that died during the device sleep can't hold the indicator stale.

## Behavior

- After unlock the indicator reflects reality within ~1–2 seconds; a sync that failed while the radio was still down recovers as soon as the server is reachable again.
- Server outages behave as before: the indicator shows offline while down and recovers on the next successful ping.

## What else

- Revives two silently dead tests in `SyncCoordinatorHealthTest`: their expression bodies made the `@Test` methods return non-void, and JUnit 5 skips such methods without a word. New tests pin the return type with `runBlocking<Unit>`.
- New `SyncCoordinatorNetworkRecoveryTest` covers all three recovery paths (verified to fail with the fix reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)