### PR TITLE
UI bugfix round: desktop host list and tabs, mobile More and Sync polish

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -44,7 +44,7 @@
     <string name="rail_snippets">Сниппеты</string>
     <string name="rail_vault">Хранилище</string>
     <string name="rail_hosts">Хосты</string>
-    <string name="rail_team">Команда</string>
+    <string name="rail_team">Команды</string>
 
     <!-- Нативные файловые диалоги SFTP (desktop). -->
     <string name="sftp_dialog_save_as">Сохранить как</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_more.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_more.xml
@@ -2,10 +2,10 @@
     <string name="more_title">Ещё</string>
     <string name="more_port_forwarding">Проброс портов</string>
     <string name="more_known_hosts">Известные хосты</string>
-    <string name="more_team">Команда</string>
+    <string name="more_team">Команды</string>
     <string name="more_ai_privacy">ИИ-ассистент</string>
     <string name="more_ai_subtitle_byok">OpenAI · BYOK</string>
-    <string name="more_ai_subtitle_local">Локально</string>
+    <string name="more_ai_subtitle_local">Локальный</string>
     <string name="more_ai_subtitle_off">Выключен</string>
     <string name="more_sync">Синхронизация</string>
     <string name="more_lock">Заблокировать Skerry</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ptail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ptail.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="ptail_dynamic_proxy">динамический прокси</string>
-    <string name="ptail_ports_active">активно: %1$d</string>
-    <string name="ptail_all_verified">Все проверены</string>
+    <string name="ptail_ports_active">Активных: %1$d</string>
+    <string name="ptail_all_verified">Ключи подтверждены</string>
     <string name="ptail_changed">изменено: %1$d</string>
     <string name="ptail_type_local">LOCAL</string>
     <string name="ptail_type_remote">REMOTE</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -81,7 +81,7 @@
     <string name="shell_search_hosts">Поиск хостов, тегов…</string>
 
     <!-- Mobile route placeholder (MobileDesignApp.kt) -->
-    <string name="shell_route_team">Команда</string>
+    <string name="shell_route_team">Команды</string>
 
     <!-- Desktop chrome: confirm dialogs, title bar, status bar (DesktopDesignApp.kt) -->
     <string name="shell_this_session">эта сессия</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -80,8 +80,6 @@
     <string name="sync_load_devices_failed">Не удалось загрузить устройства. Нажмите «Синхронизировать».</string>
     <string name="sync_only_this_device">Пока только это устройство.</string>
     <string name="sync_this_device_badge">● это устройство</string>
-    <string name="sync_device_linked_current">привязано · это устройство</string>
-    <string name="sync_device_linked">привязанное устройство</string>
     <string name="sync_confirm">Подтвердить</string>
     <string name="sync_cancel">Отмена</string>
     <string name="sync_revoke">Отозвать</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -80,8 +80,6 @@
     <string name="sync_load_devices_failed">无法加载设备。请尝试\"立即同步\"。</string>
     <string name="sync_only_this_device">目前只有此设备。</string>
     <string name="sync_this_device_badge">● 此设备</string>
-    <string name="sync_device_linked_current">已关联 · 此设备</string>
-    <string name="sync_device_linked">已关联设备</string>
     <string name="sync_confirm">确认</string>
     <string name="sync_cancel">取消</string>
     <string name="sync_revoke">撤销</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -80,8 +80,6 @@
     <string name="sync_load_devices_failed">Couldn't load devices. Try Sync now.</string>
     <string name="sync_only_this_device">Only this device so far.</string>
     <string name="sync_this_device_badge">● this device</string>
-    <string name="sync_device_linked_current">linked · this device</string>
-    <string name="sync_device_linked">linked device</string>
     <string name="sync_confirm">Confirm</string>
     <string name="sync_cancel">Cancel</string>
     <string name="sync_revoke">Revoke</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isTertiaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
@@ -1123,7 +1125,7 @@ private fun SessionDot.tint(): Color = when (this) {
 }
 
 @Composable
-private fun SessionTabChip(
+internal fun SessionTabChip(
     name: String,
     dot: Color,
     active: Boolean,
@@ -1141,6 +1143,9 @@ private fun SessionTabChip(
     val interaction = remember { MutableInteractionSource() }
     val hovered by interaction.collectIsHoveredAsState()
     val showClose = active || hovered
+    // pointerInput(Unit) below outlives recompositions; read the fresh onClose through state so a
+    // reordered tab list doesn't close via a stale lambda.
+    val close = rememberUpdatedState(onClose)
     // Accent tints: the same 10%/20% steps the cyan tokens use, so a non-default accent keeps the
     // chip's weight instead of turning into a solid block.
     val accentBg = accent.copy(alpha = 0.10f)
@@ -1169,6 +1174,17 @@ private fun SessionTabChip(
                 },
             )
             .clickable(interactionSource = interaction, indication = null, onClick = onClick)
+            // Middle-click closes the tab (browser-tab convention), active or not. Raw PRESS
+            // observation like HostsSidebar's double-click: clickable only reacts to the primary
+            // button, so the tertiary press is never consumed by it or by the ✕ IconBtn below.
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val e = awaitPointerEvent()
+                        if (e.type == PointerEventType.Press && e.buttons.isTertiaryPressed) close.value()
+                    }
+                }
+            }
             .padding(start = 11.dp, end = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -1057,7 +1057,7 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                         split = s.splitOpen,
                         active = s.id == sessions.activeId,
                         onClick = { sessions.activate(s.id) },
-                        onClose = { tabDrag.clearBounds(s.id); sessions.close(s.id) },
+                        onClose = { tabDrag.tabClosed(s.id); sessions.close(s.id) },
                         dragging = tabDrag.draggingTabId == s.id,
                         modifier = Modifier
                             .tabBoundsAnchor(tabDrag, s.id)
@@ -1174,14 +1174,25 @@ internal fun SessionTabChip(
                 },
             )
             .clickable(interactionSource = interaction, indication = null, onClick = onClick)
-            // Middle-click closes the tab (browser-tab convention), active or not. Raw PRESS
+            // Middle-click closes the tab (browser-tab convention), active or not: armed on the
+            // tertiary press, committed on its release while still over the chip — moving off
+            // before releasing aborts an accidental wheel-button bump, like browsers do. Raw event
             // observation like HostsSidebar's double-click: clickable only reacts to the primary
             // button, so the tertiary press is never consumed by it or by the ✕ IconBtn below.
             .pointerInput(Unit) {
                 awaitPointerEventScope {
+                    var armed = false
                     while (true) {
                         val e = awaitPointerEvent()
-                        if (e.type == PointerEventType.Press && e.buttons.isTertiaryPressed) close.value()
+                        when {
+                            e.type == PointerEventType.Press && e.buttons.isTertiaryPressed -> armed = true
+                            e.type == PointerEventType.Release && armed && !e.buttons.isTertiaryPressed -> {
+                                armed = false
+                                val p = e.changes.first().position
+                                val inside = p.x >= 0f && p.y >= 0f && p.x < size.width && p.y < size.height
+                                if (inside) close.value()
+                            }
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSidebarDnd.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSidebarDnd.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.host
 
-import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
@@ -10,7 +11,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerInputScope
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CancellationException
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import app.skerry.ui.host.FolderBounds
@@ -142,10 +149,76 @@ fun Modifier.folderHeaderAnchor(state: HostDragState, name: String): Modifier =
     onGloballyPositioned { state.setFolderHeader(name, it.boundsInWindow()) }
 
 /**
+ * Minimum pointer travel before a mouse press turns into a row/folder drag. Compose's built-in
+ * drag slop for a MOUSE pointer is ~0.125dp — sub-pixel — so the 1–2px of jitter inside a normal
+ * click would start a "drag" that consumes the move and cancels the row's tap/double-tap, making
+ * clicks connect only intermittently (how often depended on how still the hand/mouse was).
+ */
+private val MOUSE_DRAG_DEAD_ZONE = 6.dp
+
+/**
+ * Like detectDragGestures, but the drag claims the pointer only after [MOUSE_DRAG_DEAD_ZONE]
+ * (mouse) or the standard touch slop. Nothing is consumed before that, so click jitter reaches the
+ * row's click handlers untouched; a genuine drag replays the accumulated offset on start, so the
+ * dragged row doesn't jump. [onEnd]/[onCancel] fire only if the drag actually started.
+ */
+private suspend fun PointerInputScope.detectDeadZoneDragGestures(
+    onStart: (Offset) -> Unit,
+    onMove: (PointerInputChange, Offset) -> Unit,
+    onEnd: () -> Unit,
+    onCancel: () -> Unit,
+) = awaitEachGesture {
+    val down = awaitFirstDown(requireUnconsumed = false)
+    val threshold =
+        if (down.type == PointerType.Mouse) MOUSE_DRAG_DEAD_ZONE.toPx() else viewConfiguration.touchSlop
+    var dragging = false
+    var accumulated = Offset.Zero
+    try {
+        while (true) {
+            val event = awaitPointerEvent()
+            val change = event.changes.firstOrNull { it.id == down.id }
+            if (change == null || (change.isConsumed && !change.changedToUpIgnoreConsumed())) {
+                // Pointer stream broken, or a deeper handler claimed a non-up change.
+                if (dragging) onCancel()
+                break
+            }
+            if (change.changedToUpIgnoreConsumed()) {
+                if (dragging) onEnd()
+                break
+            }
+            val delta = change.positionChange()
+            if (dragging) {
+                // Only genuine movement is consumed (and surfaced), like foundation's drag():
+                // a wheel Scroll change mid-drag has a zero positionChange, and consuming it
+                // would block the sidebar's verticalScroll while a drag is active.
+                if (delta != Offset.Zero) {
+                    change.consume()
+                    onMove(change, delta)
+                }
+            } else {
+                accumulated += delta
+                if (accumulated.getDistance() >= threshold) {
+                    dragging = true
+                    change.consume()
+                    onStart(down.position)
+                    onMove(change, accumulated)
+                }
+            }
+        }
+    } catch (e: CancellationException) {
+        // The row can leave composition mid-drag (host deleted/filtered out by a sync apply);
+        // without this the drop highlight would stay stuck until an unrelated drag resets it.
+        if (dragging) onCancel()
+        throw e
+    }
+}
+
+/**
  * Makes a host row draggable. [folders] is read lazily (a fresh list at gesture time), [onDrop]
  * receives the target folder and index and moves the host via the controller. [longPress] selects
- * the gesture start: on desktop, immediately on drag (mouse); on touch (mobile), after a long
- * press, otherwise drag would hijack the list's vertical scroll.
+ * the gesture start: on desktop, on drag past a small dead zone (mouse, see
+ * [detectDeadZoneDragGestures]); on touch (mobile), after a long press, otherwise drag would
+ * hijack the list's vertical scroll.
  */
 fun Modifier.draggableHostRow(
     state: HostDragState,
@@ -175,7 +248,7 @@ fun Modifier.draggableHostRow(
     if (longPress) {
         detectDragGesturesAfterLongPress(onDragStart = onStart, onDrag = onMove, onDragEnd = onEnd, onDragCancel = onCancel)
     } else {
-        detectDragGestures(onDragStart = onStart, onDrag = onMove, onDragEnd = onEnd, onDragCancel = onCancel)
+        detectDeadZoneDragGestures(onStart, onMove, onEnd, onCancel)
     }
 }
 
@@ -211,6 +284,6 @@ fun Modifier.draggableFolderHeader(
     if (longPress) {
         detectDragGesturesAfterLongPress(onDragStart = onStart, onDrag = onMove, onDragEnd = onEnd, onDragCancel = onCancel)
     } else {
-        detectDragGestures(onDragStart = onStart, onDrag = onMove, onDragEnd = onEnd, onDragCancel = onCancel)
+        detectDeadZoneDragGestures(onStart, onMove, onEnd, onCancel)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -124,7 +124,9 @@ fun MobileHostsScreen(state: MobileDesignState) {
             if (query.isBlank() && chip == ALL_HOSTS_CHIP) {
                 MobileTeamHostsSections(hosts)
             }
-            Spacer(Modifier.height(96.dp)) // room for the tab bar and FAB
+            // Room for the tab bar AND the FAB above it (bottom 104dp + 56dp size): anything less
+            // leaves the last rows permanently stuck under the "+" button at full scroll.
+            Spacer(Modifier.height(176.dp))
         }
         MobileFabButton(
             onClick = state::openNewConn,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -59,7 +59,6 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSync
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.teams.AutoPullTeamsOnOnline
-import app.skerry.ui.app.MobileTab
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.host.folderHeaderAnchor
@@ -81,7 +80,7 @@ internal val MOBILE_PREVIEW_HOSTS = listOf(
 )
 
 /**
- * Root screen of the Hosts tab: header with title and avatar (→ More), search field, tag
+ * Root screen of the Hosts tab: header with title and sync indicator, search field, tag
  * filter-chip row, host sections, and "new connection" FAB. Catalog is the live [LocalHosts]
  * (behind the vault gate) or [MOBILE_PREVIEW_HOSTS] on the preview path. Tapping a host opens
  * [MobileRoute.HostDetail].
@@ -105,7 +104,7 @@ fun MobileHostsScreen(state: MobileDesignState) {
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
-            HostsHeader(onAvatar = { state.select(MobileTab.More) })
+            HostsHeader()
             HostsSearch(query, onChange = { query = it })
             HostsChips(list.chips, active = chip, onSelect = { chip = it })
             Spacer(Modifier.height(2.dp))
@@ -236,33 +235,25 @@ private fun MobileDropLine(horizontal: Dp = 18.dp) {
     )
 }
 
-/** Header: "Hosts" (28sp) + round account avatar on the right (opens the More tab). */
+/** Header: "Hosts" (28sp) + sync indicator on the right. */
 @Composable
-private fun HostsHeader(onAvatar: () -> Unit) {
+private fun HostsHeader() {
     Row(
         Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
         MobileScreenTitle(stringResource(Res.string.shell_hosts))
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            // Sync indicator driven by session status (see syncIndicator), not just server
-            // reachability: shows "paused/error" without a working session instead of a false green online.
-            val syncC = LocalSync.current
-            val ind = syncC?.let { syncIndicatorLocalized(it.status.collectAsState().value, it.serverReachable.collectAsState().value) }
-            if (ind != null) {
-                Sym(ind.icon, size = 19.sp, color = when (ind.level) {
-                    SyncIndicatorLevel.OK -> Skerry.colors.moss
-                    SyncIndicatorLevel.WARN -> Skerry.colors.amber
-                    SyncIndicatorLevel.ERROR -> Skerry.colors.sunset
-                })
-            }
-            Box(
-                Modifier.size(34.dp).clip(CircleShape).background(Skerry.colors.cyan).clickable(onClick = onAvatar),
-                contentAlignment = Alignment.Center,
-            ) {
-                Sym("person", size = 19.sp, color = Skerry.colors.ink)
-            }
+        // Sync indicator driven by session status (see syncIndicator), not just server
+        // reachability: shows "paused/error" without a working session instead of a false green online.
+        val syncC = LocalSync.current
+        val ind = syncC?.let { syncIndicatorLocalized(it.status.collectAsState().value, it.serverReachable.collectAsState().value) }
+        if (ind != null) {
+            Sym(ind.icon, size = 19.sp, color = when (ind.level) {
+                SyncIndicatorLevel.OK -> Skerry.colors.moss
+                SyncIndicatorLevel.WARN -> Skerry.colors.amber
+                SyncIndicatorLevel.ERROR -> Skerry.colors.sunset
+            })
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -124,7 +124,7 @@ fun MobileHostsScreen(state: MobileDesignState) {
             if (query.isBlank() && chip == ALL_HOSTS_CHIP) {
                 MobileTeamHostsSections(hosts)
             }
-            // Room for the tab bar AND the FAB above it (bottom 104dp + 56dp size): anything less
+            // Room for the tab bar AND the FAB above it (bottom 104dp + 56dp size + 16dp margin): anything less
             // leaves the last rows permanently stuck under the "+" button at full scroll.
             Spacer(Modifier.height(176.dp))
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -210,6 +210,13 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             // "Security" section: master password, biometrics, auto-lock, event log. Live path is
             // behind the gate (vault present); in preview the row is inert (nothing to configure without a vault).
             MoreRow("shield_lock", Skerry.colors.cyanBright, stringResource(Res.string.settings_security_title), null, Skerry.colors.dim, onClick = if (preview) null else { -> state.push(MobileRoute.Security) })
+            // Recording player: opens a .cast picker. Lives here because watching a recording needs no
+            // session — the terminal menu would hide it behind a live connection.
+            val playerScope = rememberCoroutineScope()
+            MoreRow(
+                "play_circle", Skerry.colors.cyanBright, stringResource(Res.string.term_player_open), null, Skerry.colors.dim,
+                onClick = { playerScope.launch { state.showCast(openCastFile()) } },
+            )
             // About: subtitle is the current version, or an amber "Update x.y.z" when a newer
             // release is known (the passive mobile counterpart of the desktop status-bar notice).
             val updateVersion = LocalUpdates.current?.available?.versionLabel
@@ -218,13 +225,6 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
                 updateVersion?.let { stringResource(Res.string.settings_update_status, it) } ?: AppVersion.VERSION,
                 if (updateVersion != null) Skerry.colors.amber else Skerry.colors.dim,
                 onClick = { state.push(MobileRoute.About) },
-            )
-            // Recording player: opens a .cast picker. Lives here because watching a recording needs no
-            // session — the terminal menu would hide it behind a live connection.
-            val playerScope = rememberCoroutineScope()
-            MoreRow(
-                "play_circle", Skerry.colors.cyanBright, stringResource(Res.string.term_player_open), null, Skerry.colors.dim,
-                onClick = { playerScope.launch { state.showCast(openCastFile()) } },
             )
             MoreRow("lock", Skerry.colors.sunset, stringResource(Res.string.more_lock), null, Skerry.colors.dim, labelColor = Skerry.colors.sunset, divider = false, onClick = onLock)
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -146,7 +146,9 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
                     onRenameCategory = { tag -> renamingTag = tag },
                 )
             }
-            Spacer(Modifier.height(96.dp))
+            // Clears the tab bar and the FAB above it (bottom 104dp + 56dp size), so the last
+            // snippet card can scroll out from under the "+" button.
+            Spacer(Modifier.height(176.dp))
         }
 
         // Add FAB (bottom-right, above the tab bar). Hidden while any sheet (edit/rename) is open.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -146,7 +146,7 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
                     onRenameCategory = { tag -> renamingTag = tag },
                 )
             }
-            // Clears the tab bar and the FAB above it (bottom 104dp + 56dp size), so the last
+            // Clears the tab bar and the FAB above it (bottom 104dp + 56dp size + 16dp margin), so the last
             // snippet card can scroll out from under the "+" button.
             Spacer(Modifier.height(176.dp))
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSyncView.kt
@@ -70,8 +70,6 @@ import app.skerry.ui.generated.resources.sync_loading_devices
 import app.skerry.ui.generated.resources.sync_load_devices_failed
 import app.skerry.ui.generated.resources.sync_only_this_device
 import app.skerry.ui.generated.resources.sync_this_device_badge
-import app.skerry.ui.generated.resources.sync_device_linked_current
-import app.skerry.ui.generated.resources.sync_device_linked
 import app.skerry.ui.generated.resources.sync_confirm
 import app.skerry.ui.generated.resources.sync_cancel
 import app.skerry.ui.generated.resources.sync_revoke
@@ -80,6 +78,7 @@ import app.skerry.ui.generated.resources.stail_reenroll_prompt_cancel
 import app.skerry.ui.generated.resources.stail_reenroll_prompt_subtitle
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.HLine
 import app.skerry.ui.app.LocalSync
 import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
@@ -203,13 +202,9 @@ private fun SyncBody(sync: SyncCoordinator) {
             // Account+Sync into one screen, so this block lives here (desktop has a separate Account tab).
             AccountIdentityBlock(s.accountId, Modifier.padding(top = 12.dp))
             // Same style as desktop (ghost, not filled primary) for platform parity.
-            // Mobile merges the desktop Account+Sync tabs into one screen, so Sync now and
-            // Disconnect sit next to each other (separated by tabs on desktop).
-            Row(Modifier.padding(top = 16.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                GhostButton(stringResource(Res.string.sync_sync_now), onClick = { sync.syncNow() })
-                GhostButton(stringResource(Res.string.sync_disconnect), onClick = { sync.disconnect() }, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.4f))
-            }
-            MobileLinkDeviceSection(sync)
+            // Mobile merges the desktop Account+Sync tabs into one screen, so Sync now,
+            // Disconnect and Link a device sit together (separated by tabs on desktop).
+            MobileAccountActions(sync)
             MobileWhatSyncs(sync)
             MobileLinkedDevices(sync)
         }
@@ -250,7 +245,9 @@ private fun SyncBody(sync: SyncCoordinator) {
 private fun MobileWhatSyncs(sync: SyncCoordinator) {
     val settings = sync.syncSettings.collectAsState().value
     LaunchedEffect(Unit) { sync.refreshSyncSettings() }
-    Txt(stringResource(Res.string.sync_what_syncs), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(top = 26.dp, bottom = 4.dp))
+    // Section framed by lines above the header and below the toggles, matching desktop WhatSyncsHeader.
+    HLine(modifier = Modifier.padding(top = 20.dp))
+    Txt(stringResource(Res.string.sync_what_syncs), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(top = 18.dp, bottom = 4.dp))
     // onToggle reads the current value from the flow, not a composition snapshot (stale-closure write-write).
     MobileSyncToggleRow(stringResource(Res.string.sync_what_hosts), null, on = settings.syncHosts) {
         val current = sync.syncSettings.value
@@ -260,17 +257,24 @@ private fun MobileWhatSyncs(sync: SyncCoordinator) {
         val current = sync.syncSettings.value
         sync.setSyncSettings(current.copy(syncSnippets = !current.syncSnippets))
     }
+    HLine()
 }
 
 /**
- * Mobile "Link a device" section: the button expands an inline card with the pairing QR/code (shared
- * [PairingOfferContent]). Inline rather than a dialog — the mobile idiom of the Sync screen.
+ * Connected-account actions stretched to the full screen width so the edges line up: Sync now and
+ * Disconnect split the first row in half, Link a device takes the whole second row (content-hugging
+ * buttons left the block ragged). "Link a device" expands an inline card with the pairing QR/code
+ * (shared [PairingOfferContent]) — inline rather than a dialog, the mobile idiom of the Sync screen.
  */
 @Composable
-private fun MobileLinkDeviceSection(sync: SyncCoordinator) {
+private fun MobileAccountActions(sync: SyncCoordinator) {
     var show by remember { mutableStateOf(false) }
+    Row(Modifier.fillMaxWidth().padding(top = 16.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        GhostButton(stringResource(Res.string.sync_sync_now), onClick = { sync.syncNow() }, modifier = Modifier.weight(1f))
+        GhostButton(stringResource(Res.string.sync_disconnect), onClick = { sync.disconnect() }, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.4f), modifier = Modifier.weight(1f))
+    }
     if (!show) {
-        GhostButton(stringResource(Res.string.sync_link_device), onClick = { show = true }, icon = "qr_code", modifier = Modifier.padding(top = 12.dp))
+        GhostButton(stringResource(Res.string.sync_link_device), onClick = { show = true }, icon = "qr_code", modifier = Modifier.fillMaxWidth().padding(top = 10.dp))
         return
     }
     Spacer(Modifier.height(16.dp))
@@ -345,17 +349,14 @@ private fun MobileDeviceRow(device: RemoteDevice, onRevoke: (() -> Unit)?) {
     // Revoke is irreversible from the UI (the device reconnects with the master password) — confirm on a second click.
     var confirming by remember { mutableStateOf(false) }
     Row(
-        Modifier.fillMaxWidth().padding(vertical = 9.dp),
+        Modifier.fillMaxWidth().padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Sym("devices", size = 20.sp, color = Skerry.colors.dim)
-        Column(Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                Txt(device.name, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
-                if (device.current) Txt(stringResource(Res.string.sync_this_device_badge), color = Skerry.colors.moss, size = 10.sp)
-            }
-            Txt(if (device.current) stringResource(Res.string.sync_device_linked_current) else stringResource(Res.string.sync_device_linked), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
+        Row(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            Txt(device.name, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
+            if (device.current) Txt(stringResource(Res.string.sync_this_device_badge), color = Skerry.colors.moss, size = 10.sp)
         }
         if (onRevoke != null) {
             if (confirming) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionTabDnd.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionTabDnd.kt
@@ -53,6 +53,17 @@ class TabDragState {
     /** Forget geometry for a closed tab, so bounds don't accumulate for stale ids. */
     fun clearBounds(id: String) { bounds.remove(id) }
 
+    /**
+     * Forget a closed tab entirely. Besides dropping its bounds, aborts the drag if the closed tab
+     * is the one being dragged — possible via middle-click, which is independent of the primary
+     * button holding the drag. The chip's removal cancels the drag coroutine without onDragEnd/
+     * onDragCancel, so without this the insert line would linger at a stale index.
+     */
+    fun tabClosed(id: String) {
+        clearBounds(id)
+        if (draggingTabId == id) end()
+    }
+
     fun start(id: String, localOffsetX: Float) {
         draggingTabId = id
         pointerX = (bounds[id]?.left ?: 0f) + localOffsetX

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/AccountIdentity.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/AccountIdentity.kt
@@ -62,18 +62,28 @@ fun AccountIdentityBlock(accountId: String, modifier: Modifier = Modifier) {
     ) {
         IdentityRow(stringResource(Res.string.sync_account_id_label), accountId, mono, copied == accountId) { copied = accountId }
         if (fingerprint != null) {
-            IdentityRow(stringResource(Res.string.sync_sharing_fingerprint_label), fingerprint, mono, copied == fingerprint) { copied = fingerprint }
+            IdentityRow(stringResource(Res.string.sync_sharing_fingerprint_label), fingerprint, mono, copied == fingerprint, display = elideFingerprint(fingerprint)) { copied = fingerprint }
         }
         Txt(stringResource(Res.string.sync_identity_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
     }
 }
 
+/**
+ * All 8 dash-separated groups don't fit a phone-width row; show head and tail only. The copy
+ * button still copies the full value, and invite dialogs keep showing it whole for verification.
+ */
+internal fun elideFingerprint(value: String): String {
+    val groups = value.split('-')
+    if (groups.size < 5) return value
+    return groups.take(2).joinToString("-") + "-…-" + groups.takeLast(2).joinToString("-")
+}
+
 @Composable
-private fun IdentityRow(label: String, value: String, mono: FontFamily, copied: Boolean, onCopied: () -> Unit) {
+private fun IdentityRow(label: String, value: String, mono: FontFamily, copied: Boolean, display: String = value, onCopied: () -> Unit) {
     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
         Column(Modifier.weight(1f)) {
             Txt(label.uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
-            Txt(value, color = Skerry.colors.cyanBright, size = 13.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
+            Txt(display, color = Skerry.colors.cyanBright, size = 13.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
         }
         if (copied) {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.LocalIndication
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
@@ -46,6 +45,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -123,12 +123,23 @@ import app.skerry.ui.theme.Skerry
 // preview), a RECENT section, and the "New connection" button.
 
 /**
+ * Double-click window for host rows, between two PRESS events (like [app.skerry.ui.sftp]'s file
+ * rows). Compose's own onDoubleClick rides the desktop ViewConfiguration's 300ms up→down window —
+ * tighter than OS double-click conventions (GNOME 400ms, Windows 500ms press-to-press) — so
+ * relaxed double clicks missed it and the row connected "every other time".
+ */
+private const val HOST_DOUBLE_CLICK_MS = 400L
+
+/** [HOST_DOUBLE_CLICK_MS] press-tracking reset: far enough in the past that no press pairs with it. */
+private const val NO_PRESS = Long.MIN_VALUE / 2
+
+/**
  * Host-row connect click behavior from Settings → Terminal → Behavior: single click connects
  * directly, double click requires a second click. Desktop-only (mobile always connects on tap).
  *
  * Double-click mode keeps two affordances:
  * - A single mouse click still *does* something: [onSingleClick] runs when provided (live catalog
- *   rows use it for selection highlight); otherwise combinedClickable's press feedback shows the
+ *   rows use it for selection highlight); otherwise clickable's press feedback shows the
  *   row isn't inert.
  * - Keyboard activation (Enter/Space) connects directly — the double-click requirement applies to
  *   the mouse only, so keyboard-only users can always connect.
@@ -141,25 +152,22 @@ private fun Modifier.hostConnectClick(
     when (LocalHostClickConnectMode.current) {
         HostClickConnectMode.SingleClick -> clickable(onClick = onClick)
         HostClickConnectMode.DoubleClick -> {
-            // Selection fires on the press *Release*, not on combinedClickable's onClick: when
-            // onDoubleClick is set, onClick is held back by the double-tap timeout (~300 ms) to
-            // disambiguate a single tap from a double one, so routing selection through onClick makes
-            // the highlight lag noticeably. Release fires on pointer-up of a genuine click, well
-            // before that timeout — so the highlight still feels immediate, but a press that turns
-            // into a drag-reorder or a drag-scroll emits Cancel (not Release) and no longer
-            // spuriously selects the row under the pointer.
+            // Selection fires on the press *Release*, not on clickable's onClick, keeping the
+            // highlight immediate while a press that turns into a drag-reorder or a drag-scroll
+            // emits Cancel (not Release) and doesn't spuriously select the row under the pointer.
             val interaction = remember { MutableInteractionSource() }
             val select = rememberUpdatedState(onSingleClick)
             LaunchedEffect(interaction) {
                 interaction.interactions.collect { if (it is PressInteraction.Release) select.value?.invoke() }
             }
+            val connect = rememberUpdatedState(onClick)
             // Chain onto `this` (not a fresh Modifier): the receiver already carries the row's
             // fillMaxWidth/padding/clip, and starting over would drop them — the row would lose its
             // left indent and stop filling the width, so it shifts when the mode changes.
-            // onPreviewKeyEvent must sit *outer* to combinedClickable: key events travel
-            // root→focused on the preview pass, and combinedClickable consumes Enter/Space itself,
-            // so a descendant onKeyEvent never fires. The preview handler intercepts first, making
-            // Enter/Space connect while the mouse still requires a double click (same pattern as
+            // onPreviewKeyEvent must sit *outer* to clickable: key events travel root→focused on
+            // the preview pass, and clickable consumes Enter/Space itself, so a descendant
+            // onKeyEvent never fires. The preview handler intercepts first, making Enter/Space
+            // connect while the mouse still requires a double click (same pattern as
             // TerminalScreen/CommandPalette).
             this
                 .onPreviewKeyEvent { event ->
@@ -172,12 +180,36 @@ private fun Modifier.hostConnectClick(
                         false
                     }
                 }
-                .combinedClickable(
+                .clickable(
                     interactionSource = interaction,
                     indication = LocalIndication.current,
                     onClick = {},
-                    onDoubleClick = onClick,
                 )
+                // The double click itself: raw PRESS counting in one loop, like SftpView's
+                // LiveFileRow — immune to Compose's 300ms up→down window (see HOST_DOUBLE_CLICK_MS)
+                // and to other gestures consuming the tap. Time comes from the event itself
+                // (uptimeMillis) — deterministic. Sits after clickable in the chain so it observes
+                // the Main pass before it; a press that arrives already consumed belongs to a
+                // descendant (the row's "⋮" menu button) and must not count toward a row
+                // double-click. RMB is skipped (the row has no right-click action).
+                .pointerInput(Unit) {
+                    var lastDownMs = NO_PRESS
+                    awaitPointerEventScope {
+                        while (true) {
+                            val e = awaitPointerEvent()
+                            if (e.type != PointerEventType.Press || e.buttons.isSecondaryPressed) continue
+                            val change = e.changes.first()
+                            if (change.isConsumed) continue
+                            val t = change.uptimeMillis
+                            if (t - lastDownMs <= HOST_DOUBLE_CLICK_MS) {
+                                connect.value()
+                                lastDownMs = NO_PRESS // a triple click doesn't connect twice
+                            } else {
+                                lastDownMs = t
+                            }
+                        }
+                    }
+                }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -45,7 +45,9 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isPrimaryPressed
 import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.isTertiaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -191,13 +193,17 @@ private fun Modifier.hostConnectClick(
                 // (uptimeMillis) — deterministic. Sits after clickable in the chain so it observes
                 // the Main pass before it; a press that arrives already consumed belongs to a
                 // descendant (the row's "⋮" menu button) and must not count toward a row
-                // double-click. RMB is skipped (the row has no right-click action).
+                // double-click. Only primary-button presses count: middle/right have no row action
+                // (and middle is its own gesture on session tabs), so a left+middle chord or two
+                // middle clicks must not connect.
                 .pointerInput(Unit) {
                     var lastDownMs = NO_PRESS
                     awaitPointerEventScope {
                         while (true) {
                             val e = awaitPointerEvent()
-                            if (e.type != PointerEventType.Press || e.buttons.isSecondaryPressed) continue
+                            if (e.type != PointerEventType.Press || !e.buttons.isPrimaryPressed ||
+                                e.buttons.isSecondaryPressed || e.buttons.isTertiaryPressed
+                            ) continue
                             val change = e.changes.first()
                             if (change.isConsumed) continue
                             val t = change.uptimeMillis

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
@@ -725,7 +726,7 @@ private fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily)
  * [LocalRunSnippetOnHost].
  */
 @Composable
-private fun HostEntryRow(
+internal fun HostEntryRow(
     label: String,
     selected: Boolean,
     dot: Color,
@@ -776,7 +777,14 @@ private fun HostEntryRow(
         }
         if (hasMenu) {
             Box {
-                IconBtn("more_vert", onClick = { menuOpen = !menuOpen }, box = 22, icon = 16.sp, tint = Skerry.colors.faint)
+                // Mouse-only: keeping the menu out of Tab traversal makes one Tab = one host row
+                // (otherwise every row costs two presses); keyboard users get Enter/Space to connect.
+                IconBtn(
+                    "more_vert",
+                    onClick = { menuOpen = !menuOpen },
+                    modifier = Modifier.focusProperties { canFocus = false },
+                    box = 22, icon = 16.sp, tint = Skerry.colors.faint,
+                )
                 if (menuOpen) {
                     Popup(alignment = Alignment.TopEnd, onDismissRequest = { menuOpen = false }) {
                         Column(

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/FingerprintElisionTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/FingerprintElisionTest.kt
@@ -1,0 +1,22 @@
+package app.skerry.ui.sync
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FingerprintElisionTest {
+
+    @Test
+    fun `full 8-group fingerprint keeps head and tail pairs`() {
+        assertEquals(
+            "a117-d7d7-…-8eda-d598",
+            elideFingerprint("a117-d7d7-0d5d-bd7c-901c-c8cf-8eda-d598"),
+        )
+    }
+
+    @Test
+    fun `short values stay untouched`() {
+        assertEquals("a117-d7d7-0d5d-bd7c", elideFingerprint("a117-d7d7-0d5d-bd7c"))
+        assertEquals("a117", elideFingerprint("a117"))
+        assertEquals("", elideFingerprint(""))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
@@ -1,0 +1,98 @@
+package app.skerry.ui.desktop
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Middle-click (mouse wheel button) on a session tab must close it, like a browser tab. The close
+ * must fire regardless of the chip being active or hovered (the ✕ button is hidden on resting
+ * tabs), and a middle click must not also activate the tab.
+ */
+@OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
+class SessionTabMiddleClickTest {
+
+    private fun runChipScene(
+        active: Boolean,
+        onClick: () -> Unit,
+        onClose: () -> Unit,
+        body: ImageComposeScene.() -> Unit,
+    ) {
+        ImageComposeScene(width = 300, height = 60, density = Density(1f)).use { scene ->
+            scene.setContent { ChipUnderTest(active, onClick, onClose) }
+            scene.render(16_666_667L)
+            scene.body()
+            scene.render(33_333_334L)
+        }
+    }
+
+    @Composable
+    private fun ChipUnderTest(active: Boolean, onClick: () -> Unit, onClose: () -> Unit) {
+        SkerryTheme {
+            CompositionLocalProvider(
+                LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+            ) {
+                SessionTabChip(name = "Orchestrator", dot = Color.Green, active = active, onClick = onClick, onClose = onClose)
+            }
+        }
+    }
+
+    /** One middle-button click at [at]: press with the tertiary button held, then release. */
+    private fun ImageComposeScene.middleClick(at: Offset) {
+        sendPointerEvent(
+            PointerEventType.Press, at, timeMillis = 16,
+            buttons = PointerButtons(isTertiaryPressed = true), button = PointerButton.Tertiary,
+        )
+        sendPointerEvent(
+            PointerEventType.Release, at, timeMillis = 32,
+            buttons = PointerButtons(), button = PointerButton.Tertiary,
+        )
+    }
+
+    @Test
+    fun middleClickClosesInactiveTab() {
+        var clicks = 0
+        var closes = 0
+        runChipScene(active = false, onClick = { clicks++ }, onClose = { closes++ }) {
+            middleClick(Offset(40f, 14f))
+        }
+        assertEquals(1, closes, "middle click on a resting tab must close it")
+        assertEquals(0, clicks, "middle click must not also activate the tab")
+    }
+
+    @Test
+    fun middleClickClosesActiveTab() {
+        var closes = 0
+        runChipScene(active = true, onClick = {}, onClose = { closes++ }) {
+            middleClick(Offset(40f, 14f))
+        }
+        assertEquals(1, closes, "middle click on the active tab must close it")
+    }
+
+    @Test
+    fun primaryClickStillActivatesAndDoesNotClose() {
+        var clicks = 0
+        var closes = 0
+        runChipScene(active = false, onClick = { clicks++ }, onClose = { closes++ }) {
+            sendPointerEvent(PointerEventType.Press, Offset(40f, 14f), timeMillis = 16)
+            sendPointerEvent(PointerEventType.Release, Offset(40f, 14f), timeMillis = 32)
+        }
+        assertEquals(1, clicks, "a left click must still activate the tab")
+        assertEquals(0, closes, "a left click must not close the tab")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
@@ -158,10 +158,14 @@ class SessionTabMiddleClickTest {
                 PointerEventType.Release, Offset(90f, 14f), timeMillis = 48,
                 buttons = PointerButtons(isPrimaryPressed = true), button = PointerButton.Tertiary,
             )
-            sendPointerEvent(PointerEventType.Release, Offset(90f, 14f), timeMillis = 56)
+            // Assert while the scene is still live and the primary button still held: in
+            // production the close removes the chip and cancels the drag coroutine without
+            // onDragEnd, so only tabClosed can reset the state at this point. After the scene
+            // closes (or on a trailing primary release) the gesture's own end() would fire and
+            // mask a missing abort.
+            assertNull(drag.draggingTabId, "closing the dragged tab must abort the drag")
+            assertNull(drag.insertLineIndex, "the insert line must not linger after the dragged tab closes")
         }
         assertEquals(1, closes, "a middle click during a drag of the same tab must still close it")
-        assertNull(drag.draggingTabId, "closing the dragged tab must abort the drag")
-        assertNull(drag.insertLineIndex, "the insert line must not linger after the dragged tab closes")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/SessionTabMiddleClickTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerButton
@@ -15,14 +16,20 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
 import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.session.TabDragState
+import app.skerry.ui.session.draggableTab
+import app.skerry.ui.session.tabBoundsAnchor
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 /**
- * Middle-click (mouse wheel button) on a session tab must close it, like a browser tab. The close
- * must fire regardless of the chip being active or hovered (the ✕ button is hidden on resting
- * tabs), and a middle click must not also activate the tab.
+ * Middle-click (mouse wheel button) on a session tab must close it, like a browser tab: armed on
+ * the tertiary press, committed on its release while still over the chip (moving off first aborts
+ * an accidental wheel-button bump). The close must fire regardless of the chip being active or
+ * hovered (the ✕ button is hidden on resting tabs), and a middle click must not also activate the
+ * tab.
  */
 @OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
 class SessionTabMiddleClickTest {
@@ -31,10 +38,11 @@ class SessionTabMiddleClickTest {
         active: Boolean,
         onClick: () -> Unit,
         onClose: () -> Unit,
+        modifier: Modifier = Modifier,
         body: ImageComposeScene.() -> Unit,
     ) {
         ImageComposeScene(width = 300, height = 60, density = Density(1f)).use { scene ->
-            scene.setContent { ChipUnderTest(active, onClick, onClose) }
+            scene.setContent { ChipUnderTest(active, onClick, onClose, modifier) }
             scene.render(16_666_667L)
             scene.body()
             scene.render(33_333_334L)
@@ -42,12 +50,15 @@ class SessionTabMiddleClickTest {
     }
 
     @Composable
-    private fun ChipUnderTest(active: Boolean, onClick: () -> Unit, onClose: () -> Unit) {
+    private fun ChipUnderTest(active: Boolean, onClick: () -> Unit, onClose: () -> Unit, modifier: Modifier) {
         SkerryTheme {
             CompositionLocalProvider(
                 LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
             ) {
-                SessionTabChip(name = "Orchestrator", dot = Color.Green, active = active, onClick = onClick, onClose = onClose)
+                SessionTabChip(
+                    name = "Orchestrator", dot = Color.Green, active = active,
+                    onClick = onClick, onClose = onClose, modifier = modifier,
+                )
             }
         }
     }
@@ -94,5 +105,63 @@ class SessionTabMiddleClickTest {
         }
         assertEquals(1, clicks, "a left click must still activate the tab")
         assertEquals(0, closes, "a left click must not close the tab")
+    }
+
+    @Test
+    fun middlePressReleasedOffTabDoesNotClose() {
+        // The browser escape hatch: press the wheel button on the tab, drag the pointer off it,
+        // release — the close must be aborted (the chip is 28px tall; y=50 is well below it).
+        var closes = 0
+        runChipScene(active = false, onClick = {}, onClose = { closes++ }) {
+            sendPointerEvent(
+                PointerEventType.Press, Offset(40f, 14f), timeMillis = 16,
+                buttons = PointerButtons(isTertiaryPressed = true), button = PointerButton.Tertiary,
+            )
+            sendPointerEvent(
+                PointerEventType.Move, Offset(40f, 50f), timeMillis = 24,
+                buttons = PointerButtons(isTertiaryPressed = true),
+            )
+            sendPointerEvent(
+                PointerEventType.Release, Offset(40f, 50f), timeMillis = 32,
+                buttons = PointerButtons(), button = PointerButton.Tertiary,
+            )
+        }
+        assertEquals(0, closes, "releasing the wheel button off the tab must abort the close")
+    }
+
+    @Test
+    fun middleClickMidDragClosesAndResetsDragState() {
+        // Production modifier chain: the chip also carries tabBoundsAnchor + draggableTab. Middle-
+        // click is independent of the primary button holding a drag, so closing the dragged tab
+        // must also abort the drag (TabDragState.tabClosed) — otherwise the insert line lingers.
+        val drag = TabDragState()
+        var closes = 0
+        val chain = Modifier
+            .tabBoundsAnchor(drag, "t1")
+            .draggableTab(drag, "t1", ids = { listOf("t1") }) { _, _ -> }
+        runChipScene(
+            active = true, onClick = {},
+            onClose = { drag.tabClosed("t1"); closes++ },
+            modifier = chain,
+        ) {
+            // Primary drag well past slop…
+            sendPointerEvent(PointerEventType.Press, Offset(40f, 14f), timeMillis = 16)
+            sendPointerEvent(PointerEventType.Move, Offset(70f, 14f), timeMillis = 24)
+            sendPointerEvent(PointerEventType.Move, Offset(90f, 14f), timeMillis = 32)
+            // …then a middle click on the same chip while the primary button is still down.
+            sendPointerEvent(
+                PointerEventType.Press, Offset(90f, 14f), timeMillis = 40,
+                buttons = PointerButtons(isPrimaryPressed = true, isTertiaryPressed = true),
+                button = PointerButton.Tertiary,
+            )
+            sendPointerEvent(
+                PointerEventType.Release, Offset(90f, 14f), timeMillis = 48,
+                buttons = PointerButtons(isPrimaryPressed = true), button = PointerButton.Tertiary,
+            )
+            sendPointerEvent(PointerEventType.Release, Offset(90f, 14f), timeMillis = 56)
+        }
+        assertEquals(1, closes, "a middle click during a drag of the same tab must still close it")
+        assertNull(drag.draggingTabId, "closing the dragged tab must abort the drag")
+        assertNull(drag.insertLineIndex, "the insert line must not linger after the dragged tab closes")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
@@ -1,0 +1,134 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.ui.app.HostClickConnectMode
+import app.skerry.ui.app.LocalHostClickConnectMode
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.host.HostDragState
+import app.skerry.ui.host.HostDrop
+import app.skerry.ui.host.HostFolder
+import app.skerry.ui.host.draggableHostRow
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Regression test for "host row double-click connects only every other time": a catalog row carries
+ * both a click handler (connect) and a drag-reorder gesture. Compose's drag start slop for a MOUSE
+ * pointer is ~0.125dp — sub-pixel — so the 1–2px of jitter inside a normal click starts a "drag"
+ * that consumes the move and cancels the row's tap/double-tap. Whether a click lands then depends
+ * on how still the hand/mouse is, which is why it varied between sessions. The drag gesture must
+ * tolerate a small dead zone before it claims the pointer.
+ */
+@OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
+class HostRowClickJitterTest {
+
+    /** One mouse click at [at] whose pointer drifts by [jitterPx] between press and release. */
+    private fun ImageComposeScene.jitteryClick(at: Offset, jitterPx: Float, timeMillis: Long) {
+        sendPointerEvent(PointerEventType.Press, at, timeMillis = timeMillis)
+        val drifted = at + Offset(jitterPx, 0f)
+        sendPointerEvent(PointerEventType.Move, drifted, timeMillis = timeMillis + 8)
+        sendPointerEvent(PointerEventType.Release, drifted, timeMillis = timeMillis + 16)
+    }
+
+    private fun runRowScene(
+        mode: HostClickConnectMode,
+        onConnect: () -> Unit,
+        onDrop: (HostDrop) -> Unit = {},
+        body: ImageComposeScene.(HostDragState) -> Unit,
+    ) {
+        val dragState = HostDragState()
+        // The whole scene is one drop-capable folder, so a genuine drag has a target to land on.
+        val folders = listOf(HostFolder("srv", emptyList()))
+        dragState.setFolderRange("srv", Rect(0f, 0f, 400f, 300f))
+        ImageComposeScene(width = 400, height = 300, density = Density(1f)).use { scene ->
+            scene.setContent {
+                RowUnderTest(mode, dragState, folders, onConnect, onDrop)
+            }
+            Snapshot.sendApplyNotifications()
+            scene.render(16_666_667L)
+            scene.body(dragState)
+            Snapshot.sendApplyNotifications()
+            scene.render(33_333_334L)
+        }
+    }
+
+    @Composable
+    private fun RowUnderTest(
+        mode: HostClickConnectMode,
+        dragState: HostDragState,
+        folders: List<HostFolder>,
+        onConnect: () -> Unit,
+        onDrop: (HostDrop) -> Unit,
+    ) {
+        SkerryTheme {
+            CompositionLocalProvider(
+                LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                LocalHostClickConnectMode provides mode,
+            ) {
+                // Same layering as HostRow: the drag gesture wraps the clickable row.
+                Box(Modifier.draggableHostRow(dragState, "h1", { folders }, onDrop = onDrop)) {
+                    HostEntryRow(
+                        label = "alpha", selected = false, dot = Color.Green, badge = null,
+                        onClick = onConnect, mono = FontFamily.Monospace, icon = "dns",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun doubleClickWithMouseJitterConnects() {
+        var connects = 0
+        runRowScene(HostClickConnectMode.DoubleClick, onConnect = { connects++ }) {
+            // Two clicks, each drifting 2px while the button is down; 64ms apart (over the 40ms
+            // double-tap minimum, under the timeout).
+            jitteryClick(Offset(50f, 13f), jitterPx = 2f, timeMillis = 0)
+            jitteryClick(Offset(52f, 13f), jitterPx = 2f, timeMillis = 80)
+        }
+        assertEquals(1, connects, "a double click with 2px of mouse jitter must still connect")
+    }
+
+    @Test
+    fun singleClickWithMouseJitterConnects() {
+        var connects = 0
+        runRowScene(HostClickConnectMode.SingleClick, onConnect = { connects++ }) {
+            jitteryClick(Offset(50f, 13f), jitterPx = 2f, timeMillis = 0)
+        }
+        assertEquals(1, connects, "a single click with 2px of mouse jitter must still connect")
+    }
+
+    @Test
+    fun genuineDragStillReordersAndDoesNotConnect() {
+        var connects = 0
+        var drop: HostDrop? = null
+        runRowScene(HostClickConnectMode.SingleClick, onConnect = { connects++ }, onDrop = { drop = it }) {
+            sendPointerEvent(PointerEventType.Press, Offset(50f, 13f), timeMillis = 0)
+            // Well past any reasonable dead zone, in several steps like a real drag.
+            var y = 13f
+            repeat(5) { step ->
+                y += 20f
+                sendPointerEvent(PointerEventType.Move, Offset(50f, y), timeMillis = 8L + step * 8)
+            }
+            sendPointerEvent(PointerEventType.Release, Offset(50f, y), timeMillis = 56)
+        }
+        assertNotNull(drop, "a genuine 100px drag must still commit a drop")
+        assertEquals(0, connects, "a drag must not also connect")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
@@ -82,11 +82,13 @@ class HostRowClickJitterTest {
                 LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
                 LocalHostClickConnectMode provides mode,
             ) {
-                // Same layering as HostRow: the drag gesture wraps the clickable row.
+                // Same layering as HostRow: the drag gesture wraps the clickable row. onEdit gives
+                // the row its trailing "⋮" menu button, like the live catalog.
                 Box(Modifier.draggableHostRow(dragState, "h1", { folders }, onDrop = onDrop)) {
                     HostEntryRow(
                         label = "alpha", selected = false, dot = Color.Green, badge = null,
                         onClick = onConnect, mono = FontFamily.Monospace, icon = "dns",
+                        onEdit = {},
                     )
                 }
             }
@@ -112,6 +114,39 @@ class HostRowClickJitterTest {
             jitteryClick(Offset(50f, 13f), jitterPx = 2f, timeMillis = 0)
         }
         assertEquals(1, connects, "a single click with 2px of mouse jitter must still connect")
+    }
+
+    @Test
+    fun relaxedDoubleClickWithinSystemConventionConnects() {
+        // Desktop Compose's built-in double-tap window is 300ms from first UP to second DOWN
+        // (EmptyViewConfiguration) — tighter than OS double-click conventions (GNOME 400ms,
+        // Windows 500ms press-to-press). A relaxed double click within those conventions must
+        // still connect. Real sleep: the built-in window is a real-time withTimeout.
+        var connects = 0
+        runRowScene(HostClickConnectMode.DoubleClick, onConnect = { connects++ }) {
+            sendPointerEvent(PointerEventType.Press, Offset(50f, 13f), timeMillis = 16)
+            sendPointerEvent(PointerEventType.Release, Offset(50f, 13f), timeMillis = 32)
+            Thread.sleep(380)
+            sendPointerEvent(PointerEventType.Press, Offset(50f, 13f), timeMillis = 396)
+            sendPointerEvent(PointerEventType.Release, Offset(50f, 13f), timeMillis = 412)
+        }
+        assertEquals(1, connects, "a 380ms press-to-press double click must still connect")
+    }
+
+    @Test
+    fun menuButtonClickThenRowClickDoesNotConnect() {
+        // The "⋮" menu button is a descendant of the row: a click on it followed by a quick click
+        // on the row body must not read as a row double-click. The button's press is consumed by
+        // its own clickable and must be ignored by the row's double-click detection.
+        var connects = 0
+        runRowScene(HostClickConnectMode.DoubleClick, onConnect = { connects++ }) {
+            // IconBtn: box 22px at the row's right edge (padding end = 2) → center ≈ x 387.
+            sendPointerEvent(PointerEventType.Press, Offset(387f, 13f), timeMillis = 16)
+            sendPointerEvent(PointerEventType.Release, Offset(387f, 13f), timeMillis = 32)
+            sendPointerEvent(PointerEventType.Press, Offset(50f, 13f), timeMillis = 80)
+            sendPointerEvent(PointerEventType.Release, Offset(50f, 13f), timeMillis = 96)
+        }
+        assertEquals(0, connects, "⋮ click + row click must not count as a row double-click")
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowClickJitterTest.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerButton
+import androidx.compose.ui.input.pointer.PointerButtons
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
@@ -147,6 +149,36 @@ class HostRowClickJitterTest {
             sendPointerEvent(PointerEventType.Release, Offset(50f, 13f), timeMillis = 96)
         }
         assertEquals(0, connects, "⋮ click + row click must not count as a row double-click")
+    }
+
+    @Test
+    fun middleClickDoesNotCountTowardDoubleClick() {
+        // The press counter must only count the primary button: a left click chased by a middle
+        // click (X11 paste reflex), or two middle clicks, must not read as a row double-click —
+        // middle-click is its own gesture elsewhere (tab close), never a stand-in for primary.
+        var connects = 0
+        runRowScene(HostClickConnectMode.DoubleClick, onConnect = { connects++ }) {
+            sendPointerEvent(PointerEventType.Press, Offset(50f, 13f), timeMillis = 16)
+            sendPointerEvent(PointerEventType.Release, Offset(50f, 13f), timeMillis = 32)
+            middleClick(Offset(50f, 13f), timeMillis = 80)
+        }
+        assertEquals(0, connects, "left click + middle click must not count as a double-click")
+        runRowScene(HostClickConnectMode.DoubleClick, onConnect = { connects++ }) {
+            middleClick(Offset(50f, 13f), timeMillis = 16)
+            middleClick(Offset(50f, 13f), timeMillis = 80)
+        }
+        assertEquals(0, connects, "two middle clicks must not count as a double-click")
+    }
+
+    private fun ImageComposeScene.middleClick(at: Offset, timeMillis: Long) {
+        sendPointerEvent(
+            PointerEventType.Press, at, timeMillis = timeMillis,
+            buttons = PointerButtons(isTertiaryPressed = true), button = PointerButton.Tertiary,
+        )
+        sendPointerEvent(
+            PointerEventType.Release, at, timeMillis = timeMillis + 16,
+            buttons = PointerButtons(), button = PointerButton.Tertiary,
+        )
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowFocusTraversalTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowFocusTraversalTest.kt
@@ -1,0 +1,89 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Regression test for "Tab needs two presses to reach the next host": every catalog host row
+ * carries a trailing "⋮" menu button, and if that button participates in focus traversal the Tab
+ * order becomes row -> its "⋮" -> next row. RECENT rows have no menu button, which is why they
+ * moved in one press — host rows must match: one Tab per row, the menu stays mouse-only.
+ */
+@OptIn(ExperimentalComposeUiApi::class, InternalComposeUiApi::class)
+class HostRowFocusTraversalTest {
+
+    @Test
+    fun tabMovesFocusToNextHostRowInOnePress() {
+        var firstHasFocus = false
+        var secondHasFocus = false
+        ImageComposeScene(width = 400, height = 300, density = Density(1f)).use { scene ->
+            scene.setContent {
+                SkerryTheme {
+                    CompositionLocalProvider(
+                        LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                    ) {
+                        Column {
+                            FocusTrackedRow(label = "alpha") { firstHasFocus = it }
+                            FocusTrackedRow(label = "beta") { secondHasFocus = it }
+                        }
+                    }
+                }
+            }
+            var timeNanos = 0L
+            fun frame() {
+                Snapshot.sendApplyNotifications()
+                timeNanos += 16_666_667L
+                scene.render(timeNanos)
+            }
+            frame()
+            fun tab() {
+                scene.sendKeyEvent(KeyEvent(Key.Tab, KeyEventType.KeyDown))
+                scene.sendKeyEvent(KeyEvent(Key.Tab, KeyEventType.KeyUp))
+                frame()
+            }
+
+            tab()
+            assertTrue(firstHasFocus, "first Tab should focus the first host row")
+            assertFalse(secondHasFocus, "second row must not be focused yet")
+
+            tab()
+            assertTrue(
+                secondHasFocus,
+                "one Tab from a host row must land on the NEXT row — not on the row's ⋮ menu button",
+            )
+            assertFalse(firstHasFocus, "focus must have left the first row entirely")
+        }
+    }
+
+    @Composable
+    private fun FocusTrackedRow(label: String, onFocus: (Boolean) -> Unit) {
+        Box(Modifier.onFocusChanged { onFocus(it.hasFocus) }) {
+            HostEntryRow(
+                label = label, selected = false, dot = Color.Green, badge = null,
+                onClick = {}, mono = FontFamily.Monospace, icon = "dns",
+                onEdit = {}, onDelete = {},
+            )
+        }
+    }
+}


### PR DESCRIPTION
A batch of small UI fixes across the desktop host list, session tabs, and the mobile More/Sync screens.

## Desktop

- **Host list keyboard focus**: the sidebar exposes one Tab stop per host row instead of a stop for every inner control.
- **Host row clicks**: single clicks are no longer swallowed by sub-pixel mouse drag slop (6dp dead zone before a drag starts), and double-click detection follows OS click tempo (400ms, counted manually on press events) instead of Compose's 300ms window.
- **Session tabs**: middle-click closes a tab, browser-style — armed on press, committed on release inside the tab; drag state is aborted when the tab closes.

## Mobile

- **Hosts header**: removed the avatar button (dead control on mobile).
- **More list**: About moved below the recording player; lists scroll clear of the FAB; Russian copy polished in More and subtitles.
- **Sync screen**: share-key fingerprint is elided to head/tail groups so it fits a phone-width row (copy still yields the full value); Sync now / Disconnect split a full-width row and Link a device spans one; the What syncs section is framed with lines like on desktop; device rows are single-line and more compact.

## Tests

New unit tests for host row click jitter/tempo, focus traversal, tab middle-click, and fingerprint elision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)