### PR TITLE
Release 0.1.4 version bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.1.3
-skerry.versionCode=5
+skerry.versionName=0.1.4
+skerry.versionCode=6

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.3"
+version = "0.1.4"
 
 application {
     mainClass.set("app.skerry.server.ApplicationKt")

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.3"
+version = "0.1.4"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Bumps skerry.versionName to 0.1.4 (versionCode 6) and the server / sync-wire module versions to 0.1.4 ahead of tagging v0.1.4 and server-v0.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)