### PR TITLE
fix(release): unstick version metadata from 0.1.0

### DIFF
--- a/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
+++ b/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
@@ -78,9 +78,55 @@
   <content_rating type="oars-1.1" />
 
   <releases>
-    <release version="0.1.0" date="2026-07-11">
+    <release version="0.1.4" date="2026-07-23">
       <description>
-        <p>Pre first release.</p>
+        <p>Feature release:</p>
+        <ul>
+          <li>VNC remote desktop: built-in RFB client with clipboard, quality presets and resize-to-window</li>
+          <li>Themes: light theme (Daybreak), theme catalog, live System mode</li>
+          <li>Session recording and playback (asciinema v2), broadcast mode, command palette</li>
+          <li>Snippet categories and run-time variables; host monitor and service discovery</li>
+          <li>SFTP file viewer and editor; rename vault secrets; change account password</li>
+          <li>Simplified Chinese localization and a new UI font (IBM Plex Sans)</li>
+          <li>Sync hardening: single account/vault password, token refresh, self-healing retries</li>
+          <li>Local AI moved into an isolated process — no more native crashes during inference</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.3" date="2026-07-14">
+      <description>
+        <p>Security-focused release:</p>
+        <ul>
+          <li>Vault records fully authenticated: the AEAD tag now binds all record metadata</li>
+          <li>Host-key checks fail closed while the vault is locked</li>
+          <li>OSC 52 clipboard writes are opt-in; copied passwords clear after 30 seconds</li>
+          <li>Team key rotates on member removal; sync transport hardened</li>
+          <li>Android terminal settings on par with desktop (scrollback depth, cursor style)</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.2" date="2026-07-12">
+      <description>
+        <ul>
+          <li>Mosh support: native client, sessions survive network drops and roaming</li>
+          <li>SSH jump hosts (ProxyJump) with host-key verification per hop</li>
+          <li>Per-host keep-alive with auto-reconnect; passive update notifications</li>
+          <li>Custom window chrome on desktop; clickable URLs in the terminal</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.1" date="2026-07-11">
+      <description>
+        <ul>
+          <li>Linux AppImage and Flatpak packaging; fixed Windows MSI build</li>
+          <li>Type-to-jump path bar in SFTP and Files; smoother terminal rendering</li>
+          <li>Weak master passwords blocked at vault creation; modal dismissal fixes</li>
+        </ul>
+      </description>
+    </release>
+    <release version="0.1.0" date="2026-07-10">
+      <description>
+        <p>First release.</p>
       </description>
     </release>
   </releases>

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -53,8 +53,19 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
+// Stamp the project version into version.properties so the runtime never drifts from this file.
+// Captured into a task-local val: referencing `version` (or a script-level val) inside
+// filesMatching would drag the script object into the closure and break the configuration cache.
+tasks.processResources {
+    val projectVersion = project.version.toString()
+    inputs.property("version", projectVersion)
+    filesMatching("version.properties") { expand("version" to projectVersion) }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
+    // Lets tests assert that the reported server version matches this build file's version.
+    systemProperty("skerry.projectVersion", version)
 }
 
 // Kover coverage — applied via pluginManager (classpath comes from the root buildscript) so the

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -59,8 +59,13 @@ object RateLimits {
     val ADMIN = RateLimitName("admin")
 }
 
-/** Server version for /healthz and the admin console. */
-const val SERVER_VERSION = "0.1.0"
+/**
+ * Server version for /admin/health and the admin console. Stamped into version.properties by
+ * Gradle (processResources) from the version in build.gradle.kts — the single bump point.
+ */
+val SERVER_VERSION: String = RateLimits::class.java.getResource("/version.properties")
+    ?.readText()?.substringAfter("version=")?.trim()
+    ?: error("version.properties missing from server resources")
 
 val JWTPrincipal.accountId: String get() = payload.subject
 val JWTPrincipal.deviceId: String get() = payload.getClaim(TokenService.CLAIM_DEVICE).asString()

--- a/server/src/main/resources/version.properties
+++ b/server/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${version}

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
@@ -6,6 +6,7 @@ import app.skerry.server.model.AdminActivityResponse
 import app.skerry.server.model.AdminDevicesResponse
 import app.skerry.server.model.AdminPurgeResponse
 import app.skerry.server.model.AdminRecordsResponse
+import app.skerry.server.model.HealthResponse
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
 import app.skerry.sync.wire.DevicesResponse
@@ -494,6 +495,18 @@ class RoutesTest {
             HttpStatusCode.NotFound,
             client.delete("/admin/accounts/$accountId") { header("X-Admin-Token", "s3cret") }.status,
         )
+    }
+
+    @Test
+    fun `health reports the build version`() = testApplication {
+        val services = testServices(adminToken = "s3cret")
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        // Gradle passes its project version via skerry.projectVersion; the endpoint must match it
+        // so the reported version can never drift from the release bump in build.gradle.kts.
+        val health: HealthResponse = client.get("/admin/health").body()
+        assertEquals(System.getProperty("skerry.projectVersion"), health.version)
     }
 
     @Test


### PR DESCRIPTION
Fixes two places where the app still reported version 0.1.0 after the 0.1.4 release.

## Flatpak metainfo
- `composeApp/flatpak/app.skerry.Skerry.metainfo.xml` had a single `<release>` entry (0.1.0, "Pre first release"), which is what software stores display. Added entries for 0.1.1–0.1.4 with dates and notes from the published GitHub releases; the 0.1.0 entry now says "First release" with the tag date.
- Validated with `appstreamcli validate`. The store card updates with the next flatpak build.

## Sync server version
- The admin console and `/admin/health` served a hardcoded `SERVER_VERSION = "0.1.0"` that was not part of the release bump. The version is now stamped from `server/build.gradle.kts` into `version.properties` by `processResources` and read at runtime — one bump point, no drift.
- New route test `health reports the build version` asserts the endpoint matches the Gradle project version, so a stale version fails the build. The live sync page picks this up with the next `server-v*` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)