### PR TITLE
fix(sync): refresh keychain list when sync pulls credentials

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -469,6 +469,9 @@ class MainActivity : FragmentActivity() {
             onSynced = {
                 lifecycleScope.launch(Dispatchers.Main) {
                     hosts.reload(); snippets.reload(); tunnels.reload(); knownHosts.refresh()
+                    // Keychain secrets are CREDENTIAL records too: without this a key pulled by live
+                    // sync shows up only after the next lock/unlock cycle re-enters MobileChrome.
+                    credentials.reload()
                 }
                 teamsForSync?.onAccountSynced()
             },
@@ -547,6 +550,9 @@ class MainActivity : FragmentActivity() {
             hosts.reload()
             snippets.reload()
             tunnels.reload()
+            // The vault is locked after reset, so this clears the in-memory secret list (all() is
+            // empty on a locked vault) — desktop parity; rereads on the next vault create + unlock.
+            credentials.reload()
         }
         // Local AI: GGUF models in the private filesDir/models (allowBackup=false so gigabyte-sized
         // weights don't break cloud backup); inference via Llamatik/llama.cpp arm64 in the ":llm"

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -302,6 +302,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         snippets.reload()
         tunnels.reload()
         knownHosts.refresh()
+        // Keychain secrets are CREDENTIAL records too: a key/password pulled by live sync must show
+        // up without a restart. Safe on a locked vault (all() degrades to an empty list).
+        credentials.reload()
         // AI BYOK settings (key/model) are also a SETTINGS vault record, so they're reread here too:
         // an edit that arrives via live sync from another device (onSynced calls reloadManagers)
         // reflects in the UI immediately instead of only after a re-login.
@@ -317,10 +320,6 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         // restore the session (the open vault means a dataKey to unseal the refresh token with).
         sync.resumeAfterUnlock()
     }
-    // External cleanup on an irreversible vault reset (forgotten password / corrupted file). The
-    // vault file is already erased by the controller (Vault.reset) and now locked, so
-    // credentials.reload() is NOT called here (it requires an open vault); the secret list rereads
-    // when a new vault is created.
     // Vault reset (forgotten password / corrupted file). Hosts/snippets/tunnels are vault records,
     // so Vault.reset() already erased them along with the secrets (zero-knowledge: they can't be
     // recovered without the master password — "keep profiles, wipe only secrets" is technically
@@ -362,6 +361,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         hosts.reload()
         snippets.reload()
         tunnels.reload()
+        // The vault is locked after reset, so this clears the in-memory secret list (all() is empty
+        // on a locked vault); the list rereads when a new vault is created and unlocked.
+        credentials.reload()
     }
     val deps = AppDependencies(transport = transport, hosts = hosts, vault = vault, credentials = credentials, knownHosts = knownHosts, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, snippets = snippets, sync = sync, teams = teams, localAi = localAi)
     return DesktopGraph(

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
@@ -5,16 +5,21 @@ package app.skerry.shared.vault
  * record whose payload is a JSON serialization of [Credential] (label and secret inside the
  * encrypted blob). Pure common logic over the [Vault] contract — no platform part.
  *
- * Requires an unlocked vault: CRUD on a locked one throws from [Vault] itself. Records whose
- * payload fails to decrypt or parse (corruption/incompatible migration) are silently skipped —
- * one broken record must not break the whole list.
+ * Requires an unlocked vault for mutations: CRUD on a locked one throws from [Vault] itself.
+ * Reading [all] on a locked vault safely returns an empty list (like [app.skerry.shared.host.VaultHostStore]):
+ * sync-driven reloads may race a lock and must degrade, not crash. Records whose payload fails to
+ * decrypt or parse (corruption/incompatible migration) are silently skipped — one broken record
+ * must not break the whole list.
  */
 class CredentialStore(private val vault: Vault) {
 
     private val codec = VaultRecordCodec(vault, RecordType.CREDENTIAL, Credential.serializer())
 
-    /** All live secrets (tombstones and other record types excluded). */
-    fun all(): List<Credential> = codec.list()
+    /** All live secrets (tombstones and other record types excluded); empty on a locked vault. */
+    fun all(): List<Credential> {
+        if (!vault.isUnlocked) return emptyList()
+        return codec.list()
+    }
 
     /** Secret by [id], or `null` if missing, deleted, or unreadable. */
     fun get(id: String): Credential? = codec.get(id)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
@@ -64,6 +64,19 @@ class CredentialStoreTest {
     }
 
     @Test
+    fun `all on a locked vault safely returns an empty list`() {
+        val vault = FakeVault()
+        val store = CredentialStore(vault)
+        store.put(Credential("a", "A", CredentialSecret.Password("x")))
+
+        vault.locked = true
+
+        // Sync-driven reloads (onSynced -> reloadManagers) may race a lock; reading must degrade to
+        // an empty list like the sibling vault stores, not throw from Vault.records().
+        assertEquals(emptyList(), store.all())
+    }
+
+    @Test
     fun `rename changes the label and keeps the id and secret`() {
         val store = CredentialStore(FakeVault())
         val secret = CredentialSecret.PrivateKey(privateKeyPem = "pem", passphrase = "pp")


### PR DESCRIPTION
Makes keychain secrets synced from another device appear immediately, without an app restart.

## What

Sync writes pulled records straight into the vault, but the keychain list was never reloaded afterwards: a key or password synced from another device showed up on desktop only after a restart. On mobile the gap was masked by the frequent lock/unlock cycle, which re-reads the list on every unlock.

## Behavior

- `CredentialStore.all()` returns an empty list on a locked vault (same contract as the host/snippet/tunnel stores) instead of throwing, so sync-driven reloads can race a lock safely. Mutations still require an unlocked vault.
- Desktop: the keychain list reloads on every sync pull (`reloadManagers`) and clears on vault reset.
- Android: the keychain list reloads in the `onSynced` main-thread block and clears on vault reset (desktop parity).

## Tests

- New unit test pinning the locked-vault contract of `CredentialStore.all()` (verified failing before the fix).
- Full `:shared:desktopTest` and `:composeApp:desktopTest` suites green; desktop and Android compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)