### PR TITLE
fix(ai): local AI dies in packaged builds with "Unrecognized option: --llm-host"

### DIFF
--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -21,7 +21,12 @@ kotlin {
 
     jvm("desktop") {
         // kotlin("test") picks its backend from the Test task configuration: this enables JUnit 5
-        testRuns["test"].executionTask.configure { useJUnitPlatform() }
+        testRuns["test"].executionTask.configure {
+            useJUnitPlatform()
+            // A packaged app's JVM carries this jpackage restart marker; the tests prove it never
+            // leaks into a spawned inference host (see LlmHostCommandLine.scrubEnvironment).
+            environment("_JPACKAGE_LAUNCHER", "1")
+        }
     }
 
     androidLibrary {

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostCommandLine.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/LlmHostCommandLine.kt
@@ -48,6 +48,19 @@ object LlmHostCommandLine {
         ) + tail
     }
 
+    /**
+     * The jpackage launcher counts its libjli re-execs in this variable. A child launcher that
+     * inherits a non-zero count skips the cfg file and hands its argv to the JVM verbatim, so
+     * [HOST_FLAG] becomes an unknown JVM option and the host dies with "Could not create the
+     * Java Virtual Machine". Seen on Linux under Flatpak, where libjli always re-execs.
+     */
+    private const val JPACKAGE_RESTART_MARKER = "_JPACKAGE_LAUNCHER"
+
+    /** Must be applied to the child's environment whenever the packaged launcher is re-launched. */
+    fun scrubEnvironment(environment: MutableMap<String, String>) {
+        environment.remove(JPACKAGE_RESTART_MARKER)
+    }
+
     private fun fail(reason: String): Nothing =
         throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host: $reason")
 }

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
@@ -16,6 +16,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.deleteIfExists
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Starts the desktop inference host: a second process running [LlmHostMain] — a plain JVM on this
@@ -66,11 +67,12 @@ class ProcessLlmHostLauncher(
     )
         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
         .redirectError(ProcessBuilder.Redirect.INHERIT)
+        .also { LlmHostCommandLine.scrubEnvironment(it.environment()) }
         .start()
 
     /** Waits for the child to connect back; gives up early if it died instead. */
     private suspend fun accept(server: ServerSocketChannel, process: Process): SocketChannel? = coroutineScope {
-        withTimeoutOrNull(START_TIMEOUT_MILLIS) {
+        withTimeoutOrNull(START_TIMEOUT_MILLIS.milliseconds) {
             val watchdog = launch {
                 runInterruptible(Dispatchers.IO) { process.waitFor() }
                 runCatching { server.close() } // unblocks accept()

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostCommandLineTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlmHostCommandLineTest.kt
@@ -72,6 +72,18 @@ class LlmHostCommandLineTest {
     }
 
     @Test
+    fun `the jpackage restart marker never reaches the child launcher`() {
+        val environment = mutableMapOf(
+            "_JPACKAGE_LAUNCHER" to "1",
+            "PATH" to "/usr/bin",
+        )
+
+        LlmHostCommandLine.scrubEnvironment(environment)
+
+        assertEquals(mapOf("PATH" to "/usr/bin"), environment)
+    }
+
+    @Test
     fun `the host flag tells a host run from an app run`() {
         assertTrue(LlmHostCommandLine.isHostRun(arrayOf("--llm-host", "/tmp/s", "4096")))
         assertFalse(LlmHostCommandLine.isHostRun(emptyArray()))

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
@@ -8,9 +8,11 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import okio.Path.Companion.toPath
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -35,6 +37,37 @@ class ProcessLlmHostLauncherTest {
 
         assertEquals(AiException.Kind.INVALID_REQUEST, error.kind)
         runtime.close()
+    }
+
+    @Test
+    fun `the jpackage restart marker does not leak into the child`() = runBlocking {
+        if (System.getProperty("os.name").startsWith("Windows")) return@runBlocking
+        // Planted by the Gradle test task to mimic a packaged app's JVM. A child launcher that
+        // inherits it feeds our --llm-host flag to the JVM and dies before reaching main.
+        assertEquals("1", System.getenv("_JPACKAGE_LAUNCHER"), "the test task must plant the marker")
+
+        val recorded = Files.createTempFile("skerry-llm-env", ".txt")
+        val launcher = Files.createTempFile("skerry-fake-launcher", ".sh")
+        try {
+            Files.writeString(launcher, "#!/bin/sh\nprintenv > '$recorded'\n")
+            launcher.toFile().setExecutable(true)
+            val runtime = IsolatedLlmRuntime(
+                ProcessLlmHostLauncher(contextLength = 512, selfCommand = launcher.toString()),
+            )
+
+            // The fake launcher exits without connecting back, so generation fails; only the
+            // environment it saw matters here.
+            assertFailsWith<AiException> { runtime.generate("/m.gguf".toPath(), request).toList() }
+
+            val environment = Files.readString(recorded)
+            assertFalse(
+                environment.lineSequence().any { it.startsWith("_JPACKAGE_LAUNCHER=") },
+                "the child saw the marker:\n$environment",
+            )
+        } finally {
+            Files.deleteIfExists(recorded)
+            Files.deleteIfExists(launcher)
+        }
     }
 
     @Test


### PR DESCRIPTION
Fixes the local AI inference host failing to start in packaged desktop builds: the spawned child died with `Unrecognized option: --llm-host / Error: Could not create the Java Virtual Machine` (reliably under Flatpak), while development runs worked.

## What

A packaged build starts the inference host by re-launching its own jpackage launcher with `--llm-host <socket> <context>`. The jpackage launcher tracks libjli re-execs in the `_JPACKAGE_LAUNCHER` environment variable; a launcher started with a non-zero value skips its `.cfg` file and passes argv to the JVM verbatim. The app's JVM carries that marker (under Flatpak libjli always re-execs to adjust `LD_LIBRARY_PATH`), so the child launcher inherited it and fed `--llm-host` to the JVM as a JVM option.

`LlmHostCommandLine.scrubEnvironment` now removes the marker from the child's environment before the spawn. The development path (`java` on the app classpath) is unaffected — the variable is absent there and the scrub is a no-op.

## Behavior

- Packaged builds (Flatpak, deb/rpm/AppImage, MSI, dmg): the inference host starts and answers; local AI works again at parity with development runs.
- No user-visible changes outside local AI.

## What else

- The desktop test task plants `_JPACKAGE_LAUNCHER=1` into the test JVM, so the new integration test (fake launcher script records its environment) proves the marker never reaches a spawned host; a unit test covers the scrub itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)