### PR TITLE
fix(ui): restore label visibility on disabled lock-screen buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
@@ -199,8 +199,7 @@ fun DesktopResetScreen(onConfirm: (ResetScope) -> Unit, onCancel: () -> Unit) {
             stringResource(Res.string.shell_reset_permanently),
             onClick = { if (canConfirm) onConfirm(scope) },
             modifier = Modifier.fillMaxWidth(),
-            bg = if (canConfirm) Skerry.colors.storm else Skerry.colors.whiteFaint,
-            fg = if (canConfirm) Skerry.colors.ink else Skerry.colors.faint,
+            bg = Skerry.colors.storm,
             enabled = canConfirm,
         )
         Txt(
@@ -290,8 +289,6 @@ fun DesktopCreateScreen(
             stringResource(Res.string.shell_create_vault),
             onClick = submit,
             modifier = Modifier.fillMaxWidth(),
-            bg = if (canCreate) Skerry.colors.cyan else Skerry.colors.whiteFaint,
-            fg = if (canCreate) Skerry.colors.ink else Skerry.colors.faint,
             enabled = canCreate,
         )
         if (sync != null && onPairingComplete != null) {


### PR DESCRIPTION
Fixes the blank gray primary button on the master-password creation and reset screens.

## What
- The disabled "Create vault" and "Reset permanently" buttons rendered as an unlabeled gray plate: both call sites passed pre-dimmed colors (`whiteFaint`/`faint`) to `PrimaryButton` on top of `enabled = false`, and the primitive's own disabled dimming (background alpha replaced with 0.35) brightened the plate while erasing the label's contrast.

## Behavior
- Both buttons now rely solely on `enabled` — the primitive owns the disabled look, consistent with every other `PrimaryButton` call site. Enabled colors are unchanged (cyan for create, storm for reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)