### PR TITLE
Duplicate host action + server CORS and Docker uid fixes (#70)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -4,6 +4,7 @@
     <string name="conn_subtitle_new">Добавьте хост. Учётные данные шифруются мастер-паролем.</string>
     <string name="conn_subtitle_edit">Измените хост. Учётные данные шифруются мастер-паролем.</string>
     <string name="conn_subtitle_mobile">Шифруется мастер-паролем. Остаётся на этом устройстве.</string>
+    <string name="conn_duplicate_name">%1$s — копия</string>
 
     <string name="conn_field_name">Имя</string>
     <string name="conn_field_protocol">Протокол</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -74,6 +74,7 @@
     <string name="shell_quick_snippets">Сниппеты</string>
     <string name="shell_details">Детали</string>
     <string name="shell_edit_host">Изменить хост</string>
+    <string name="shell_duplicate_host">Дублировать хост</string>
     <string name="shell_delete_host">Удалить хост</string>
 
     <!-- Mobile hosts list (MobileHostsView.kt) -->

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -6,6 +6,7 @@
     <string name="term_search_hosts_placeholder">Поиск хостов, тегов, IP…</string>
     <string name="term_menu_run_snippet">Запустить сниппет…</string>
     <string name="term_menu_edit">Изменить</string>
+    <string name="term_menu_duplicate">Дублировать</string>
     <string name="term_menu_delete">Удалить</string>
     <string name="term_no_active_session">Нет активной сессии</string>
     <string name="term_run_snippet_placeholder">Запустить сниппет…</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -4,6 +4,7 @@
     <string name="conn_subtitle_new">添加主机。凭据使用主密码加密。</string>
     <string name="conn_subtitle_edit">编辑此主机。凭据使用主密码加密。</string>
     <string name="conn_subtitle_mobile">使用主密码加密，仅保存在此设备。</string>
+    <string name="conn_duplicate_name">%1$s 副本</string>
 
     <string name="conn_field_name">名称</string>
     <string name="conn_field_protocol">协议</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -74,6 +74,7 @@
     <string name="shell_quick_snippets">片段</string>
     <string name="shell_details">详情</string>
     <string name="shell_edit_host">编辑主机</string>
+    <string name="shell_duplicate_host">创建主机副本</string>
     <string name="shell_delete_host">删除主机</string>
 
     <!-- 移动端主机列表 (MobileHostsView.kt) -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -6,6 +6,7 @@
     <string name="term_search_hosts_placeholder">搜索主机、标签、IP…</string>
     <string name="term_menu_run_snippet">运行片段…</string>
     <string name="term_menu_edit">编辑</string>
+    <string name="term_menu_duplicate">创建副本</string>
     <string name="term_menu_delete">删除</string>
     <string name="term_no_active_session">无活动会话</string>
     <string name="term_run_snippet_placeholder">运行片段…</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -4,6 +4,7 @@
     <string name="conn_subtitle_new">Add a host. Credentials are encrypted with your master password.</string>
     <string name="conn_subtitle_edit">Edit this host. Credentials are encrypted with your master password.</string>
     <string name="conn_subtitle_mobile">Encrypted with your master password. Stays on this device.</string>
+    <string name="conn_duplicate_name">%1$s Copy</string>
 
     <string name="conn_field_name">Name</string>
     <string name="conn_field_protocol">Protocol</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -74,6 +74,7 @@
     <string name="shell_quick_snippets">Snippets</string>
     <string name="shell_details">Details</string>
     <string name="shell_edit_host">Edit host</string>
+    <string name="shell_duplicate_host">Duplicate host</string>
     <string name="shell_delete_host">Delete host</string>
 
     <!-- Mobile hosts list (MobileHostsView.kt) -->

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -6,6 +6,7 @@
     <string name="term_search_hosts_placeholder">Search hosts, tags, IPs…</string>
     <string name="term_menu_run_snippet">Run snippet…</string>
     <string name="term_menu_edit">Edit</string>
+    <string name="term_menu_duplicate">Duplicate</string>
     <string name="term_menu_delete">Delete</string>
     <string name="term_no_active_session">No active session</string>
     <string name="term_run_snippet_placeholder">Run a snippet…</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -339,6 +339,9 @@ class DesktopDesignState(
     /** Host open in the modal for editing (null means the modal is in "New connection" mode). */
     var editingHost: Host? by mutableStateOf(null); private set
 
+    /** Host the modal is prefilled from as a copy ("Duplicate"); saving creates a new profile. */
+    var duplicatingHost: Host? by mutableStateOf(null); private set
+
     /** Host for which the delete-confirmation dialog is shown (null means no dialog). */
     var pendingDeleteHost: Host? by mutableStateOf(null); private set
 
@@ -402,9 +405,10 @@ class DesktopDesignState(
 
     fun lock() { locked = true; hostSearchQuery = "" }
     fun unlock() { locked = false }
-    fun openModal() { editingHost = null; modalOpen = true }
-    fun openEditModal(host: Host) { editingHost = host; modalOpen = true }
-    fun closeModal() { modalOpen = false; editingHost = null }
+    fun openModal() { editingHost = null; duplicatingHost = null; modalOpen = true }
+    fun openEditModal(host: Host) { editingHost = host; duplicatingHost = null; modalOpen = true }
+    fun openDuplicateModal(host: Host) { editingHost = null; duplicatingHost = host; modalOpen = true }
+    fun closeModal() { modalOpen = false; editingHost = null; duplicatingHost = null }
     fun requestDeleteHost(host: Host) { pendingDeleteHost = host }
     fun dismissDeleteHost() { pendingDeleteHost = null }
     fun requestCloseSession(id: String) { pendingClose = PendingClose.Session(id) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -138,6 +138,12 @@ class MobileDesignState(
      */
     var editingHost: Host? by mutableStateOf(null); private set
 
+    /**
+     * Host the New connection sheet is prefilled from as a copy ("Duplicate" from the detail
+     * screen); saving creates a new profile (parity with the desktop modal's `duplicateOf`).
+     */
+    var duplicatingHost: Host? by mutableStateOf(null); private set
+
     /** Id of the host open on [MobileRoute.HostDetail] — the screen reads it from the store by id. */
     var selectedHostId: String? by mutableStateOf(null); private set
 
@@ -255,12 +261,15 @@ class MobileDesignState(
     }
 
     /** Open the sheet in create-new-host mode (empty form). */
-    fun openNewConn() { editingHost = null; sheetNewConn = true }
+    fun openNewConn() { editingHost = null; duplicatingHost = null; sheetNewConn = true }
 
     /** Open the sheet in edit mode for [host] (form prefilled, save keeps its id). */
-    fun openEditConn(host: Host) { editingHost = host; sheetNewConn = true }
+    fun openEditConn(host: Host) { editingHost = host; duplicatingHost = null; sheetNewConn = true }
 
-    fun closeSheet() { sheetNewConn = false; editingHost = null }
+    /** Open the sheet prefilled as a copy of [host] (save creates a new profile). */
+    fun openDuplicateConn(host: Host) { editingHost = null; duplicatingHost = host; sheetNewConn = true }
+
+    fun closeSheet() { sheetNewConn = false; editingHost = null; duplicatingHost = null }
 
     /** Selected terminal font (More -> Appearance -> Font). Threaded to the terminal via [app.skerry.ui.terminal.LocalTerminalAppearance]. */
     var terminalFont: TerminalFont by mutableStateOf(initialTerminalFont); private set

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -734,7 +734,7 @@ private fun DesktopChrome(
                     onDismiss = state::closeCommandPalette,
                 )
             }
-            if (state.modalOpen) NewConnectionModal(state, editHost = state.editingHost)
+            if (state.modalOpen) NewConnectionModal(state, editHost = state.editingHost, duplicateOf = state.duplicatingHost)
             if (state.settingsOpen) SettingsPanel(state)
             // Sync onboarding modal over settings: appears via "Set up sync", closes itself on a
             // successful connect. Only when the coordinator is supplied (the mock path with no backend has none).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -235,5 +235,13 @@ class NewConnectionFormState {
                 existingCredentialId = host.credentialId
             }
         }
+
+        /**
+         * Prefill for "Duplicate host": the same profile under the given copy [name], sharing the
+         * original's keychain secret (EXISTING binding, nothing re-saved). Unlike edit mode the
+         * caller saves with `toDraft(id = null)`, creating a new record.
+         */
+        fun duplicateOf(host: Host, name: String): NewConnectionFormState =
+            fromHost(host).apply { this.name = name }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -85,6 +85,7 @@ import app.skerry.ui.generated.resources.conn_auth_private_key
 import app.skerry.ui.generated.resources.conn_auth_select_credential
 import app.skerry.ui.generated.resources.conn_cancel
 import app.skerry.ui.generated.resources.conn_create
+import app.skerry.ui.generated.resources.conn_duplicate_name
 import app.skerry.ui.generated.resources.conn_field_ai_policy
 import app.skerry.ui.generated.resources.conn_field_authentication
 import app.skerry.ui.generated.resources.conn_field_baud
@@ -153,21 +154,33 @@ import app.skerry.ui.theme.Skerry
  * it (mock/preview), Save just closes the modal. In edit mode the form is prefilled from
  * [editHost] ([NewConnectionFormState.fromHost]), and saving keeps its [Host.id]. Tags are editable
  * (pills plus inline input, wired to [NewConnectionFormState]).
+ *
+ * [duplicateOf] opens the modal in "New connection" mode prefilled as a copy of that host
+ * ([NewConnectionFormState.duplicateOf]): same profile and shared secret under a "… Copy" name;
+ * saving creates a new record (id = null).
  */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
+fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplicateOf: Host? = null) {
     val hosts = LocalHosts.current
     // Already-created hosts, the suggestion source for the Group/Tags pickers (empty in mock/preview).
     val allHosts = hosts?.hosts ?: emptyList()
     val credentials = LocalCredentials.current
-    // Keyed by editHost: opening the modal for editing (or switching target) rebuilds the form from the profile.
-    val form = remember(editHost) { editHost?.let { NewConnectionFormState.fromHost(it) } ?: NewConnectionFormState() }
+    val copyName = duplicateOf?.let { stringResource(Res.string.conn_duplicate_name, it.label) }
+    // Keyed by editHost/duplicateOf: opening the modal for editing or duplicating (or switching target)
+    // rebuilds the form from the profile.
+    val form = remember(editHost, duplicateOf) {
+        when {
+            editHost != null -> NewConnectionFormState.fromHost(editHost)
+            duplicateOf != null -> NewConnectionFormState.duplicateOf(duplicateOf, copyName.orEmpty())
+            else -> NewConnectionFormState()
+        }
+    }
     // Guards repeated Save (Enter/double click) until the modal closes, otherwise a duplicate secret+host in the vault.
     // Keyed by editHost along with form: switching target resets the guard instead of sticking to the old one.
-    var submitting by remember(editHost) { mutableStateOf(false) }
+    var submitting by remember(editHost, duplicateOf) { mutableStateOf(false) }
     // Uncommitted tag input (pill not created yet). Hoisted here so Save can commit it.
-    var tagDraft by remember(editHost) { mutableStateOf("") }
+    var tagDraft by remember(editHost, duplicateOf) { mutableStateOf("") }
     // "Test connection": a one-off connect without opening a session. Only with a live transport
     // (behind the vault gate); in mock/preview tester == null and the button is disabled.
     val transport = LocalTestTransport.current
@@ -288,7 +301,7 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null) {
                 Spacer14()
                 Field(stringResource(Res.string.conn_field_tags)) {
                     // Suggestions = other hosts' tags not yet added here, narrowed by the typed draft.
-                    var tagFocused by remember(editHost) { mutableStateOf(false) }
+                    var tagFocused by remember(editHost, duplicateOf) { mutableStateOf(false) }
                     val tagFocus = remember { FocusRequester() }
                     val tagSugs = remember(allHosts, form.tags, tagDraft) { tagSuggestions(allHosts, form.tags, tagDraft) }
                     AnchoredDropdown(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -45,6 +45,7 @@ import app.skerry.ui.generated.resources.shell_quick_tunnels
 import app.skerry.ui.generated.resources.shell_quick_snippets
 import app.skerry.ui.generated.resources.shell_details
 import app.skerry.ui.generated.resources.shell_edit_host
+import app.skerry.ui.generated.resources.shell_duplicate_host
 import app.skerry.ui.generated.resources.shell_delete_host
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.LocalConnectHost
@@ -196,7 +197,8 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
         }
 
         // Edit host: opens the New connection sheet in edit mode for this profile (unavailable
-        // outside the gate, nothing to save to). Delete: removes the profile from the live catalog and pops back.
+        // outside the gate, nothing to save to). Duplicate: the same sheet prefilled as a copy.
+        // Delete: removes the profile from the live catalog and pops back.
         Column(
             Modifier.padding(start = 22.dp, end = 22.dp, top = 20.dp, bottom = 30.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
@@ -216,6 +218,21 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
                     contentAlignment = Alignment.Center,
                 ) {
                     Txt(stringResource(Res.string.shell_edit_host), color = Skerry.colors.cyanBright, size = 14.sp, weight = FontWeight.Medium)
+                }
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(13.dp))
+                        .border(1.dp, Skerry.colors.cyan.copy(alpha = 0.4f), RoundedCornerShape(13.dp))
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { state.openDuplicateConn(host) },
+                        )
+                        .padding(13.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Txt(stringResource(Res.string.shell_duplicate_host), color = Skerry.colors.cyanBright, size = 14.sp, weight = FontWeight.Medium)
                 }
             }
             val onDelete = controller?.let { ctrl -> { ctrl.delete(host.id); state.pop() } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -95,6 +95,7 @@ import app.skerry.ui.generated.resources.conn_save_changes
 import app.skerry.ui.generated.resources.conn_save_connection
 import app.skerry.ui.generated.resources.conn_subtitle_mobile
 import app.skerry.ui.generated.resources.conn_tag_add_placeholder
+import app.skerry.ui.generated.resources.conn_duplicate_name
 import app.skerry.ui.generated.resources.conn_title_edit
 import app.skerry.ui.generated.resources.conn_title_new
 import org.jetbrains.compose.resources.stringResource
@@ -143,17 +144,27 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
     val credentials = LocalCredentials.current
     // Edit mode: the sheet is prefilled from the profile and keeps its id (parity with desktop NewConnectionModal).
     val editHost = state.editingHost
-    // Keyed on editHost: opening the sheet to edit (or switching target) rebuilds the form from the profile.
-    val form = remember(editHost) { editHost?.let { NewConnectionFormState.fromHost(it) } ?: NewConnectionFormState() }
+    // Duplicate mode: prefilled as a copy of the profile, saved as a new record (parity with desktop).
+    val duplicateOf = state.duplicatingHost
+    val copyName = duplicateOf?.let { stringResource(Res.string.conn_duplicate_name, it.label) }
+    // Keyed on editHost/duplicateOf: opening the sheet to edit or duplicate (or switching target)
+    // rebuilds the form from the profile.
+    val form = remember(editHost, duplicateOf) {
+        when {
+            editHost != null -> NewConnectionFormState.fromHost(editHost)
+            duplicateOf != null -> NewConnectionFormState.duplicateOf(duplicateOf, copyName.orEmpty())
+            else -> NewConnectionFormState()
+        }
+    }
     val canSave = hosts == null || form.canSave
     // Guards a repeated Save (double tap) before the sheet closes — otherwise a duplicate secret+host in
     // the vault (same as desktop). Keyed on editHost together with form: switching target resets the guard.
-    var submitting by remember(editHost) { mutableStateOf(false) }
+    var submitting by remember(editHost, duplicateOf) { mutableStateOf(false) }
     // Uncommitted tag input (pill not yet created); Save flushes it so it isn't lost.
-    var tagDraft by remember(editHost) { mutableStateOf("") }
+    var tagDraft by remember(editHost, duplicateOf) { mutableStateOf("") }
     // Whether the "New group" dialog is open — kept at the sheet level so the overlay renders at
     // the root (not inside the form's scroll) and rises correctly above the keyboard.
-    var createGroupOpen by remember(editHost) { mutableStateOf(false) }
+    var createGroupOpen by remember(editHost, duplicateOf) { mutableStateOf(false) }
     val onSave = {
         if (submitting) {
             // Repeated tap before close — ignored.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -87,6 +87,7 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_hosts_section
 import app.skerry.ui.generated.resources.term_menu_delete
+import app.skerry.ui.generated.resources.term_menu_duplicate
 import app.skerry.ui.generated.resources.term_menu_edit
 import app.skerry.ui.generated.resources.term_menu_run_snippet
 import app.skerry.ui.generated.resources.term_new_connection
@@ -695,6 +696,7 @@ private fun HostRow(
     val onClick = remember(host, connect) { { connect(host) } }
     val onSelect = remember(host) { { onSelectHost(host.id) } }
     val onEdit = remember(host, state) { { state.openEditModal(host) } }
+    val onDuplicate = remember(host, state) { { state.openDuplicateModal(host) } }
     val onDelete = remember(host, state) { { state.requestDeleteHost(host) } }
     // Forgets the row's geometry once the host leaves the list (deleted/filtered out).
     DisposableEffect(host.id) { onDispose { dragState.clearHostBounds(host.id) } }
@@ -719,8 +721,9 @@ private fun HostRow(
             icon = host.connectionType.icon,
             // Host object, for the "Run snippet..." menu item (runs a snippet on this host).
             host = host,
-            // Edit/delete the profile via the context menu (right-click/long-press).
+            // Edit/duplicate/delete the profile via the context menu (right-click/long-press).
             onEdit = onEdit,
+            onDuplicate = onDuplicate,
             onDelete = onDelete,
         )
     }
@@ -757,10 +760,10 @@ private fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily)
  * optional badge. [icon] is the profile's [app.skerry.ui.host.icon] and stays [Skerry.colors.faint] — the two
  * markers read as separate axes, colour for session status and shape for protocol. Clicking the row
  * connects ([onClick]). When
- * [onEdit]/[onDelete] are provided (live catalog) or a snippet can be run on the host ([host] !=
- * null and [LocalSnippets] is present), a trailing "⋮" button opens a menu (Run snippet.../Edit/
- * Delete); its click is intercepted before [onClick], so opening the menu doesn't trigger a
- * connection. "Run snippet..." opens the snippet picker and runs it on [host] via
+ * [onEdit]/[onDuplicate]/[onDelete] are provided (live catalog) or a snippet can be run on the host
+ * ([host] != null and [LocalSnippets] is present), a trailing "⋮" button opens a menu (Run
+ * snippet.../Edit/Duplicate/Delete); its click is intercepted before [onClick], so opening the menu
+ * doesn't trigger a connection. "Run snippet..." opens the snippet picker and runs it on [host] via
  * [LocalRunSnippetOnHost].
  */
 @Composable
@@ -775,12 +778,13 @@ internal fun HostEntryRow(
     host: Host? = null,
     onSelect: (() -> Unit)? = null,
     onEdit: (() -> Unit)? = null,
+    onDuplicate: (() -> Unit)? = null,
     onDelete: (() -> Unit)? = null,
 ) {
     val snippets = LocalSnippets.current
     val runSnippetOnHost = LocalRunSnippetOnHost.current
     val canRunSnippet = host != null && snippets != null
-    val hasMenu = onEdit != null || onDelete != null || canRunSnippet
+    val hasMenu = onEdit != null || onDuplicate != null || onDelete != null || canRunSnippet
     var menuOpen by remember { mutableStateOf(false) }
     var snippetPickerOpen by remember { mutableStateOf(false) }
     Row(
@@ -833,6 +837,9 @@ internal fun HostEntryRow(
                             }
                             onEdit?.let { edit ->
                                 HostMenuItem(stringResource(Res.string.term_menu_edit), Skerry.colors.text) { menuOpen = false; edit() }
+                            }
+                            onDuplicate?.let { duplicate ->
+                                HostMenuItem(stringResource(Res.string.term_menu_duplicate), Skerry.colors.text) { menuOpen = false; duplicate() }
                             }
                             onDelete?.let { delete ->
                                 HostMenuItem(stringResource(Res.string.term_menu_delete), Skerry.colors.sunset) { menuOpen = false; delete() }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -301,6 +301,44 @@ class NewConnectionFormStateTest {
         assertNull(f.resolveCredentialId { error("ask must not save a credential") })
     }
 
+    // Duplicating a host: same profile under a new name, saved as a new record
+
+    @Test
+    fun duplicateOf_prefills_a_copy_that_saves_as_a_new_host() {
+        val host = Host(
+            id = "h1", label = "prod-web-01", address = "10.0.0.5", port = 2222,
+            username = "root", group = "Production", credentialId = "cred-9",
+            tags = listOf("prod"), jumpHostId = "bastion-1", keepAliveSeconds = 120,
+        )
+        val f = NewConnectionFormState.duplicateOf(host, name = "prod-web-01 Copy")
+        assertEquals("prod-web-01 Copy", f.name)
+        assertEquals(host.connectionType, f.connectionType)
+        assertEquals(host.aiPolicy, f.aiPolicy)
+        assertTrue(f.canSave)
+        // The copy shares the original's secret — nothing is re-saved to the vault.
+        val credentialId = f.resolveCredentialId { error("duplicate must not create a new credential") }
+        val draft = f.toDraft(id = null, credentialId = credentialId)
+        assertNull(draft.id) // a new profile, not an in-place edit of the source
+        assertEquals("cred-9", draft.credentialId)
+        assertEquals("10.0.0.5", draft.address)
+        assertEquals(2222, draft.port)
+        assertEquals("root", draft.username)
+        assertEquals("Production", draft.group)
+        assertEquals(listOf("prod"), draft.tags)
+        assertEquals("bastion-1", draft.jumpHostId)
+        assertEquals(120, draft.keepAliveSeconds)
+    }
+
+    @Test
+    fun duplicateOf_credential_less_host_stays_in_ask_mode() {
+        val host = Host(id = "h2", label = "box", address = "a", port = 22, username = "u")
+        val f = NewConnectionFormState.duplicateOf(host, name = "box Copy")
+        assertEquals(AuthMode.ASK, f.authMode)
+        val draft = f.toDraft(id = null, credentialId = f.resolveCredentialId { error("ask must not save a credential") })
+        assertNull(draft.id)
+        assertNull(draft.credentialId)
+    }
+
     // Tags (single-tag canonicalization is in app.skerry.shared.host.HostTagsTest)
 
     @Test

--- a/server/.env.example
+++ b/server/.env.example
@@ -50,5 +50,7 @@ SKERRY_ADMIN_TOKEN=
 SKERRY_DEV=
 
 # Allowed CORS origins, comma-separated, e.g. https://app.example.com.
+# A scheme prefix narrows the origin to that scheme; a bare host allows http and https.
+# "*" allows any origin (disables the allow-list) — avoid it in production.
 # Empty disables CORS (native clients aren't subject to same-origin anyway).
 SKERRY_CORS_HOSTS=

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -12,7 +12,10 @@ COPY --from=build /src/server/build/install/server/ /app/
 
 # Unprivileged user (least privilege): RCE in the process must not grant root in the container.
 # The /data volume belongs to it so the SQLite file is created without root.
-RUN groupadd --system skerry && useradd --system --gid skerry --home /app skerry \
+# uid/gid are pinned (999): without --uid the allocation follows the base image's user table, so a
+# base bump could shift it and lock the process out of an existing /data volume (SQLITE_READONLY).
+# 1000 is taken by the base image's "ubuntu" user. Bind-mount owners: chown to 999:999.
+RUN groupadd --system --gid 999 skerry && useradd --system --uid 999 --gid skerry --home /app skerry \
     && mkdir -p /data && chown -R skerry:skerry /app /data
 USER skerry
 

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -163,7 +163,7 @@ fun Application.configureServer(services: Services) {
     // SKERRY_CORS_HOSTS.
     if (services.config.corsHosts.isNotEmpty()) {
         install(CORS) {
-            services.config.corsHosts.forEach { allowHost(it, schemes = listOf("http", "https")) }
+            services.config.corsHosts.forEach { allowHost(it.host, schemes = it.schemes) }
             allowHeader(io.ktor.http.HttpHeaders.Authorization)
             allowHeader(io.ktor.http.HttpHeaders.ContentType)
             allowMethod(io.ktor.http.HttpMethod.Put)

--- a/server/src/main/kotlin/app/skerry/server/config/ServerConfig.kt
+++ b/server/src/main/kotlin/app/skerry/server/config/ServerConfig.kt
@@ -1,6 +1,13 @@
 package app.skerry.server.config
 
 /**
+ * One allowed CORS origin: [host] without a scheme (Ktor's `allowHost` rejects `://`), plus the
+ * [schemes] to allow. A scheme-prefixed entry ("https://cdn.example.com") narrows to that scheme;
+ * a bare host allows both http and https.
+ */
+data class CorsHost(val host: String, val schemes: List<String>)
+
+/**
  * Server config from environment variables (single-.env model). All values have sane defaults for local runs; production only requires a stable [jwtSecret]
  * — otherwise a restart invalidates every issued token.
  *
@@ -24,7 +31,7 @@ data class ServerConfig(
     /** How long to retain tombstone records before physical cleanup. */
     val tombstoneRetentionDays: Long,
     /** Allowed CORS origins. Empty disables CORS (native clients aren't subject to it). */
-    val corsHosts: List<String>,
+    val corsHosts: List<CorsHost>,
     /** Upper bound on request body size in bytes (OOM/abuse guard). Enforced via Content-Length -> 413. */
     val maxRequestBodyBytes: Long,
     /**
@@ -67,7 +74,8 @@ data class ServerConfig(
                 pairingTtlSeconds = long("SKERRY_PAIRING_TTL", 300),            // 5 minutes (design §3)
                 tombstoneRetentionDays = long("SKERRY_TOMBSTONE_DAYS", 90),     // design §2
                 corsHosts = str("SKERRY_CORS_HOSTS", "")
-                    .split(",").map { it.trim() }.filter { it.isNotEmpty() },
+                    .split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                    .mapNotNull(::parseCorsHost),
                 maxRequestBodyBytes = long("SKERRY_MAX_BODY_BYTES", 4L * 1024 * 1024), // 4 MiB
                 trustedProxies = str("SKERRY_TRUSTED_PROXIES", "")
                     .split(",").map { it.trim() }.filter { it.isNotEmpty() },
@@ -75,6 +83,23 @@ data class ServerConfig(
                 registrationOpen = str("SKERRY_REGISTRATION", "open").equals("open", ignoreCase = true),
                 maxAccounts = int("SKERRY_MAX_ACCOUNTS", 0).coerceAtLeast(0),
             )
+        }
+
+        /**
+         * Parse one SKERRY_CORS_HOSTS entry. Users paste full origins ("https://cdn.example.com/")
+         * even though Ktor's `allowHost` wants a bare host — passing "://" through would crash the
+         * server at startup. A scheme prefix narrows the allowed schemes to it; anything after the
+         * first "/" (path, trailing slash) is dropped. Returns `null` for an entry with no host
+         * left after stripping.
+         */
+        private fun parseCorsHost(raw: String): CorsHost? {
+            val (schemes, rest) = when {
+                raw.startsWith("https://", ignoreCase = true) -> listOf("https") to raw.drop("https://".length)
+                raw.startsWith("http://", ignoreCase = true) -> listOf("http") to raw.drop("http://".length)
+                else -> listOf("http", "https") to raw
+            }
+            val host = rest.substringBefore('/').trim()
+            return if (host.isEmpty()) null else CorsHost(host, schemes)
         }
     }
 }

--- a/server/src/test/kotlin/app/skerry/server/config/ServerConfigTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/config/ServerConfigTest.kt
@@ -1,0 +1,78 @@
+package app.skerry.server.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ServerConfigTest {
+
+    private fun corsHosts(value: String): List<CorsHost> =
+        ServerConfig.fromEnv(mapOf("SKERRY_CORS_HOSTS" to value)).corsHosts
+
+    @Test
+    fun `plain host allows both schemes`() {
+        assertEquals(
+            listOf(CorsHost("cdn.example.com", listOf("http", "https"))),
+            corsHosts("cdn.example.com"),
+        )
+    }
+
+    @Test
+    fun `https prefix is stripped and narrows to https only`() {
+        // Users naturally paste full origins; Ktor's allowHost throws on "://" in the host.
+        assertEquals(
+            listOf(CorsHost("cdn.example.com", listOf("https"))),
+            corsHosts("https://cdn.example.com"),
+        )
+    }
+
+    @Test
+    fun `http prefix narrows to http only`() {
+        assertEquals(
+            listOf(CorsHost("localhost:5173", listOf("http"))),
+            corsHosts("http://localhost:5173"),
+        )
+    }
+
+    @Test
+    fun `scheme prefix is case-insensitive`() {
+        assertEquals(
+            listOf(CorsHost("cdn.example.com", listOf("https"))),
+            corsHosts("HTTPS://cdn.example.com"),
+        )
+    }
+
+    @Test
+    fun `trailing slash and path are dropped`() {
+        assertEquals(
+            listOf(CorsHost("cdn.example.com", listOf("https"))),
+            corsHosts("https://cdn.example.com/some/path/"),
+        )
+    }
+
+    @Test
+    fun `list splits on commas and trims whitespace`() {
+        assertEquals(
+            listOf(
+                CorsHost("a.example.com", listOf("https")),
+                CorsHost("b.example.com", listOf("http", "https")),
+            ),
+            corsHosts(" https://a.example.com , b.example.com "),
+        )
+    }
+
+    @Test
+    fun `blank and scheme-only entries are dropped`() {
+        assertEquals(emptyList(), corsHosts(" , https:// ,, http://"))
+    }
+
+    @Test
+    fun `empty variable disables CORS`() {
+        assertEquals(emptyList(), corsHosts(""))
+    }
+
+    // Ktor's allowHost special-cases "*" into anyHost(), so the literal must survive parsing.
+    @Test
+    fun `wildcard passes through`() {
+        assertEquals(listOf(CorsHost("*", listOf("http", "https"))), corsHosts("*"))
+    }
+}


### PR DESCRIPTION
Adds a "Duplicate" action for host profiles and fixes two server issues reported in #70.

**Duplicate host** (issue #70, item 1)
- Desktop: "Duplicate" in the host row's "⋮" context menu (between Edit and Delete).
- Android: "Duplicate host" button on the host detail screen (next to Edit).
- Both open the connection form prefilled as a copy named "<name> Copy" (localized en/ru/zh); the copy references the same keychain secret — nothing is re-saved to the vault. Saving creates a new profile; the original is untouched.

**Server: scheme-prefixed CORS origins** (item 3)
- `SKERRY_CORS_HOSTS=https://cdn.example.com` used to crash the server at startup (Ktor's `allowHost` rejects `://` in the host). Entries are now parsed: a scheme prefix is stripped and narrows the allowed schemes to that scheme, a bare host still allows http+https, paths/trailing slashes are dropped, empty leftovers ignored.

**Server: pinned container uid/gid** (item 2)
- `useradd --system` without `--uid` follows the base image's user table, so a base-image bump could shift the uid and lock the process out of an existing `/data` volume (`SQLITE_READONLY`). Pinned to 999 (1000 is taken by the base image's `ubuntu` user). Bind-mount owners: chown to 999:999.

**Tests**
- `NewConnectionFormStateTest`: duplicate prefill round-trip (new record, shared credential, credential-less case).
- New `ServerConfigTest`: 9 cases for CORS entry parsing.

Closes #70 (items 1–3; items 4 and 5 are declined with reasons in the issue discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
