### PR TITLE
Explain terminal output from the AI bar

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -77,6 +77,8 @@
     <string name="term_status_no_session">нет сессии</string>
     <string name="term_ai_ask_short">Спросите Skerry…</string>
     <string name="term_ai_confirm">Подтвердить</string>
+    <string name="term_ai_explain">Объяснить вывод</string>
+    <string name="term_ai_explain_reading">Читаю вывод…</string>
     <string name="term_password_label">ПАРОЛЬ</string>
     <string name="term_connect">Подключиться</string>
     <string name="term_disconnect">Отключиться</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -77,6 +77,8 @@
     <string name="term_status_no_session">无会话</string>
     <string name="term_ai_ask_short">向 Skerry 提问…</string>
     <string name="term_ai_confirm">确认</string>
+    <string name="term_ai_explain">解释输出</string>
+    <string name="term_ai_explain_reading">正在读取输出…</string>
     <string name="term_password_label">密码</string>
     <string name="term_connect">连接</string>
     <string name="term_disconnect">断开连接</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -77,6 +77,8 @@
     <string name="term_status_no_session">no session</string>
     <string name="term_ai_ask_short">Ask Skerry…</string>
     <string name="term_ai_confirm">Confirm</string>
+    <string name="term_ai_explain">Explain output</string>
+    <string name="term_ai_explain_reading">Reading output…</string>
     <string name="term_password_label">PASSWORD</string>
     <string name="term_connect">Connect</string>
     <string name="term_disconnect">Disconnect</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
@@ -85,6 +85,13 @@ class TerminalAiController(
     var busy by mutableStateOf(false); private set
 
     /**
+     * Free-prose explanation of terminal output (from [explain]); the partial reply while streaming,
+     * the final text on completion, and `null` when not explaining. Distinct from [pending], which is
+     * a command — an explanation is only ever displayed, never offered for execution.
+     */
+    var explanation by mutableStateOf<String?>(null); private set
+
+    /**
      * The non-command outcome shown in the bar, at most one at a time; cleared by [dismiss] and by
      * the next [ask]. A sealed type instead of parallel flags, so a new kind of notice cannot be
      * left showing alongside another.
@@ -105,6 +112,7 @@ class TerminalAiController(
         pending = null
         pendingRisk = null
         pendingInfo = null
+        explanation = null
         val current = settings()
         val device = LocalModelCatalog.resolve(current.localModelId)
         val route = AiRouter.route(decision, current, device, localInstalled(device))
@@ -131,6 +139,71 @@ class TerminalAiController(
                 }
             },
         )
+    }
+
+    /**
+     * Ask the model to explain a chunk of terminal [output] — the current selection, or the visible
+     * screen. No-op if busy, empty, or AI is disabled.
+     *
+     * Routing is identical to [ask], so the per-host policy is honoured: under [AiPolicy.Strict] the
+     * output stays on the on-device model and is never sent to the cloud — terminal output can carry
+     * secrets, so this must not be weaker than command generation. Balanced still redacts secrets
+     * ([SecretRedactor]) before sending. Unlike [ask], the reply is free prose surfaced in
+     * [explanation]; it is never parsed as a command or offered for execution.
+     */
+    fun explain(output: String) {
+        val context = clampContext(output)
+        if (busy || context.isEmpty() || !decision.aiEnabled) return
+        notice = null
+        pending = null
+        pendingRisk = null
+        pendingInfo = null
+        explanation = null
+        val current = settings()
+        val device = LocalModelCatalog.resolve(current.localModelId)
+        val route = AiRouter.route(decision, current, device, localInstalled(device))
+        if (route !is AiRoute.Use) {
+            notice = AiNotice.Blocked((route as AiRoute.Blocked).reason)
+            return
+        }
+        val outbound = if (decision.sanitizeSecrets) SecretRedactor.redact(context) else context
+        busy = true
+        // Non-null (empty) marks the explain surface active so the bar shows it immediately, before
+        // the first delta, instead of the generic "Thinking…" line.
+        explanation = ""
+        val gen = ++generation
+        val messages = listOf(AiMessage(AiRole.SYSTEM, explainPrompt(responseLanguage())), AiMessage(AiRole.USER, outbound))
+        job = runner.launch(
+            temperature = EXPLAIN_TEMPERATURE,
+            endpoint = route.endpoint,
+            messages = messages,
+            onDelta = { explanation = it },
+            onComplete = { reply ->
+                val trimmed = reply.trim()
+                // A model that returns nothing usable falls back to the same fixed notice as a command
+                // reply with no content, rather than leaving an empty panel open.
+                if (trimmed.isEmpty()) {
+                    explanation = null
+                    notice = AiNotice.Rejected
+                } else {
+                    explanation = trimmed
+                }
+            },
+            onError = {
+                explanation = null
+                notice = AiNotice.Error(it)
+            },
+            onFinally = {
+                if (gen == generation) busy = false
+            },
+        )
+    }
+
+    /** Keep the tail of long output within [EXPLAIN_CONTEXT_LIMIT]; the most recent lines matter most. */
+    private fun clampContext(output: String): String {
+        val trimmed = output.trim()
+        if (trimmed.length <= EXPLAIN_CONTEXT_LIMIT) return trimmed
+        return "…" + trimmed.substring(trimmed.length - EXPLAIN_CONTEXT_LIMIT)
     }
 
     /**
@@ -168,11 +241,13 @@ class TerminalAiController(
         pendingInfo = info
     }
 
-    /** Dismiss the proposal and clear messages. */
+    /** Dismiss the proposal, explanation, or notice; cancels an in-flight explanation. */
     fun dismiss() {
+        if (busy) cancel()
         pending = null
         pendingRisk = null
         pendingInfo = null
+        explanation = null
         notice = null
     }
 
@@ -182,11 +257,40 @@ class TerminalAiController(
         job?.cancel()
         busy = false
         streaming = null
+        explanation = null
     }
 
     companion object {
         /** Command-generation temperature: near-deterministic; small local models are unreliable at higher values. */
         const val COMMAND_TEMPERATURE = 0.2
+
+        /** Explanation temperature: a touch higher than commands for readable prose, still low for small local models. */
+        const val EXPLAIN_TEMPERATURE = 0.3
+
+        /**
+         * Max characters of terminal output sent for an explanation. The tail is kept (recent output
+         * is what the user is asking about), bounding request size for both cloud and small local models.
+         */
+        const val EXPLAIN_CONTEXT_LIMIT = 6000
+
+        /**
+         * Prompt that turns a chunk of terminal output into a plain-language explanation. [language]
+         * is the English name of the UI language the explanation must be written in (see [ask]). Plain
+         * prose only — the AI bar renders text, not markdown — and grounded strictly in the given output.
+         */
+        fun explainPrompt(language: String): String =
+            // The language mandate is front-loaded AND repeated at the end: the command output is
+            // usually English, and a single trailing instruction was ignored — the model mirrored the
+            // output's language instead of the UI's.
+            "Write your entire reply in " + language + ". This is mandatory: even though the command " +
+                "output below is in another language, the explanation must be in " + language + ".\n" +
+                "You explain terminal output for a user connected to a remote server over SSH. " +
+                "The user's message is raw output from a command that ran on that server. Explain " +
+                "concisely what it means: what happened, what any errors or warnings indicate, and — if " +
+                "something failed — the likely cause and a safe next step. Base the explanation only on " +
+                "the given output; never invent files, hosts, or values that are not shown.\n" +
+                "Write plain prose (short paragraphs or a short bullet list), no markdown headings and no " +
+                "code fences. Remember: the entire explanation must be written in " + language + "."
 
         /**
          * Prompt that turns a request into a command. [language] is the English name of the UI

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -85,6 +87,7 @@ import app.skerry.ui.generated.resources.term_ai_run
 import app.skerry.ui.generated.resources.term_ai_run_anyway
 import app.skerry.ui.generated.resources.term_ai_confirm
 import app.skerry.ui.generated.resources.term_ai_dismiss
+import app.skerry.ui.generated.resources.term_ai_explain_reading
 import app.skerry.ui.generated.resources.term_ai_not_a_command
 import app.skerry.ui.generated.resources.term_password_label
 import app.skerry.ui.generated.resources.term_connect
@@ -414,6 +417,7 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
         if (text.isNotEmpty()) { controller.ask(text); prompt = "" }
     }
     val pending = controller.pending
+    val explanation = controller.explanation
     val risk = controller.pendingRisk?.risk ?: CommandRisk.None
     val danger = risk == CommandRisk.Danger
     // Red for any destructive command (delete/overwrite), even Warn.
@@ -427,7 +431,11 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Sym(
-                if (pending != null) (if (severe) "block" else "terminal") else "auto_awesome",
+                when {
+                    pending != null -> if (severe) "block" else "terminal"
+                    explanation != null -> "summarize"
+                    else -> "auto_awesome"
+                },
                 size = 16.sp, color = if (pending != null) accent else Skerry.colors.amber,
             )
             Box(Modifier.weight(1f)) {
@@ -445,6 +453,14 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                             if (info != null) Txt(info, color = infoColor, size = 10.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f).alignByBaseline())
                         }
                     }
+                    explanation != null ->
+                        if (explanation.isEmpty()) {
+                            Txt(stringResource(Res.string.term_ai_explain_reading), color = Skerry.colors.dim, size = 13.sp)
+                        } else {
+                            Column(Modifier.heightIn(max = 160.dp).verticalScroll(rememberScrollState())) {
+                                Txt(explanation, color = Skerry.colors.text, size = 12.sp, lineHeight = 17.sp)
+                            }
+                        }
                     controller.busy -> Txt(stringResource(Res.string.term_ai_thinking), color = Skerry.colors.dim, size = 13.sp)
                     controller.notice != null -> when (val notice = controller.notice!!) {
                         is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
@@ -475,9 +491,24 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                     }
                     MobileAiChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint) { controller.dismiss() }
                 }
+                explanation != null ->
+                    MobileAiChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint) { controller.dismiss() }
                 controller.notice != null ->
                     MobileAiChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint) { controller.dismiss() }
                 else -> {
+                    // Explain the current selection, or the visible screen when nothing is selected.
+                    Box(
+                        Modifier.size(30.dp).clip(RoundedCornerShape(7.dp))
+                            .background(Skerry.colors.overlaySoft)
+                            .border(1.dp, Skerry.colors.line, RoundedCornerShape(7.dp))
+                            .clickable(enabled = !controller.busy) {
+                                // Selection wins; else the last command's output; else the whole screen.
+                                controller.explain(terminal.selectedText() ?: terminal.lastOutput() ?: terminal.output)
+                            },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Sym("summarize", size = 16.sp, color = Skerry.colors.amber)
+                    }
                     Txt(labelUppercase(controller.policy.shortLabel()), color = Skerry.colors.faint, size = 10.sp, font = mono)
                     Box(
                         Modifier.size(30.dp).clip(RoundedCornerShape(7.dp)).background(Skerry.colors.cyan)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -53,6 +55,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_ai_ask_placeholder
 import app.skerry.ui.generated.resources.term_ai_confirm_run
 import app.skerry.ui.generated.resources.term_ai_dismiss
+import app.skerry.ui.generated.resources.term_ai_explain_reading
 import app.skerry.ui.generated.resources.term_ai_not_a_command
 import app.skerry.ui.generated.resources.term_ai_run
 import app.skerry.ui.generated.resources.term_ai_run_anyway
@@ -119,6 +122,7 @@ internal fun AiBarInput(
         }
     }
     val pending = controller.pending
+    val explanation = controller.explanation
     val risk = controller.pendingRisk?.risk ?: CommandRisk.None
     val danger = risk == CommandRisk.Danger
     // Any destructive command (delete/overwrite) is colored red, even at Warn level.
@@ -136,8 +140,12 @@ internal fun AiBarInput(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             val leadColor = if (pending != null) accent else Skerry.colors.amber
-            // A destructive command shows a block icon instead of the terminal icon.
-            val leadIcon = if (pending != null) (if (severe) "block" else "terminal") else "auto_awesome"
+            // A destructive command shows a block icon; an explanation shows a summarize icon.
+            val leadIcon = when {
+                pending != null -> if (severe) "block" else "terminal"
+                explanation != null -> "summarize"
+                else -> "auto_awesome"
+            }
             Box(Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).background(leadColor.copy(alpha = 0.12f)), contentAlignment = Alignment.Center) {
                 Sym(leadIcon, size = 16.sp, color = leadColor)
             }
@@ -159,6 +167,16 @@ internal fun AiBarInput(
                             if (info != null) Txt(info, color = infoColor, size = 11.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f).alignByBaseline())
                         }
                     }
+                    explanation != null ->
+                        // Free prose (may be several lines): scrolls within a bounded height rather than
+                        // growing the bar without limit. Empty while the request is starting.
+                        if (explanation.isEmpty()) {
+                            Txt(stringResource(Res.string.term_ai_explain_reading), color = Skerry.colors.dim, size = 13.sp)
+                        } else {
+                            Column(Modifier.heightIn(max = 160.dp).verticalScroll(rememberScrollState())) {
+                                Txt(explanation, color = Skerry.colors.text, size = 12.5.sp, lineHeight = 18.sp)
+                            }
+                        }
                     controller.busy -> Txt(stringResource(Res.string.term_ai_thinking), color = Skerry.colors.dim, size = 13.sp)
                     controller.notice != null -> when (val notice = controller.notice!!) {
                         is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = Skerry.colors.amber, size = 12.5.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
@@ -194,9 +212,26 @@ internal fun AiBarInput(
                     )
                     AiActionChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint, onClick = { controller.dismiss() })
                 }
+                explanation != null ->
+                    AiActionChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint, onClick = { controller.dismiss() })
                 controller.notice != null ->
                     AiActionChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint, onClick = { controller.dismiss() })
                 else -> {
+                    // Explain the current selection, or the visible screen when nothing is selected.
+                    if (terminal != null) {
+                        Box(
+                            Modifier.size(28.dp).clip(RoundedCornerShape(6.dp))
+                                .background(Skerry.colors.overlaySoft)
+                                .border(1.dp, Skerry.colors.line, RoundedCornerShape(6.dp))
+                                .clickable(enabled = !controller.busy) {
+                                    // Selection wins; else the last command's output; else the whole screen.
+                                    controller.explain(terminal.selectedText() ?: terminal.lastOutput() ?: terminal.output)
+                                },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Sym("summarize", size = 16.sp, color = Skerry.colors.amber)
+                        }
+                    }
                     AiBarTag("verified_user", labelUppercase(controller.policy.shortLabel()), mono)
                     Box(
                         Modifier.size(28.dp).clip(RoundedCornerShape(6.dp)).background(Skerry.colors.cyan)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -429,6 +429,14 @@ class TerminalScreenState(
         ?.takeIf { it.isNotEmpty() }
 
     /**
+     * Best-effort text of the last command and its output — for "explain this output" when nothing is
+     * selected, so the AI sees the recent result rather than the whole screen (a long login banner
+     * would otherwise drown it out). `null` when the command boundary can't be found; the caller then
+     * falls back to the whole visible screen. See [lastCommandBlock] for the heuristic.
+     */
+    fun lastOutput(): String? = lastCommandBlock(output)
+
+    /**
      * In-app PRIMARY buffer: text of the last mouse selection. Used for middle-click paste where
      * the system PRIMARY selection is unavailable (Wayland: AWT `getSystemSelection()`==null) —
      * paste then falls back to this instead of CLIPBOARD.
@@ -756,3 +764,28 @@ private sealed interface TerminalCommand {
 private val PASSWORD_PROMPT_HINTS = listOf(
     "password", "passphrase", "passcode", "verification code", "pin",
 )
+
+/**
+ * Extract the last command and its output from flat screen [text] (rows joined by '\n', trailing
+ * blanks trimmed — see [TerminalScreenState.output]). The bottom line is the current shell prompt;
+ * the nearest line above it that starts with that same prompt string is where the last command was
+ * entered, so everything from there down to (but not including) the current prompt is that command
+ * plus its output. Returns `null` when no such boundary exists.
+ *
+ * Heuristic only — no shell cooperation (OSC 133) is assumed, and prompts vary. A very short prompt
+ * (e.g. a bare "$") is rejected, since it would match unrelated lines and mis-slice the screen.
+ */
+internal fun lastCommandBlock(text: String): String? {
+    val lines = text.split("\n")
+    if (lines.size < 2) return null
+    val prompt = lines.last()
+    if (prompt.length < 3) return null
+    for (i in lines.size - 2 downTo 0) {
+        val line = lines[i]
+        // A command line repeats the prompt and has something typed after it.
+        if (line.length > prompt.length && line.startsWith(prompt)) {
+            return lines.subList(i, lines.size - 1).joinToString("\n").trim().ifBlank { null }
+        }
+    }
+    return null
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
@@ -24,11 +24,13 @@ private class CapturingProvider(
     private val failWith: AiException? = null,
 ) : AiProvider {
     var lastUserContent: String? = null
+    var lastSystemContent: String? = null
     var lastTemperature: Double? = null
     var built = false
     override fun chat(request: AiChatRequest): Flow<AiDelta> = flow {
         built = true
         lastUserContent = request.messages.last().content
+        lastSystemContent = request.messages.first().content
         lastTemperature = request.temperature
         failWith?.let { throw it }
         deltas.forEach { emit(AiDelta(it)) }
@@ -380,5 +382,123 @@ class TerminalAiControllerTest {
         assertEquals(AiFailure.UNAUTHORIZED, assertIs<AiNotice.Error>(c.notice).failure)
         assertNull(c.pending)
         assertFalse(c.busy)
+    }
+
+    // --- Explain output ---
+
+    @Test
+    fun `explain surfaces the reply as prose, never a runnable command`() = runTest {
+        val p = CapturingProvider(deltas = listOf("This lists ", "files; nothing failed."))
+        val c = controller(AiPolicy.Balanced, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.explain("$ ls -la\ntotal 4\ndrwxr-xr-x 2 root root")
+        advanceUntilIdle()
+
+        assertEquals("This lists files; nothing failed.", c.explanation)
+        assertNull(c.pending, "an explanation is prose, never offered for execution")
+        assertNull(c.notice)
+        assertFalse(c.busy)
+        // The output being explained is sent as the user message; the system prompt asks for an explanation.
+        assertTrue(p.lastSystemContent!!.contains("explain", ignoreCase = true))
+        assertTrue(p.lastUserContent!!.contains("total 4"))
+    }
+
+    @Test
+    fun `explain mandates the UI language up front and repeats it`() = runTest {
+        // Regression: with a single trailing "reply in X" the model mirrored the (English) output's
+        // language instead of the UI's. The mandate must lead the prompt and be repeated.
+        val p = CapturingProvider(deltas = listOf("Команда uptime показывает аптайм."))
+        val c = TerminalAiController(
+            AiPolicy.Balanced, settings = { AiSettings(apiKey = "sk-x") },
+            providerFactory = { p }, scope = this, responseLanguage = { "Russian" },
+        )
+
+        c.explain("12:21:14 up 129 days, load average: 0.36, 0.20, 0.10")
+        advanceUntilIdle()
+
+        val system = p.lastSystemContent!!
+        assertTrue(system.take(60).contains("Russian"), "the language mandate must lead the prompt")
+        assertTrue("Russian".toRegex().findAll(system).count() >= 2, "language must be repeated for emphasis")
+    }
+
+    @Test
+    fun `explain is a no-op on blank output`() = runTest {
+        val p = CapturingProvider(deltas = listOf("anything"))
+        val c = controller(AiPolicy.Balanced, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.explain("   \n  ")
+        advanceUntilIdle()
+
+        assertFalse(p.built)
+        assertNull(c.explanation)
+        assertFalse(c.busy)
+    }
+
+    @Test
+    fun `explain respects strict policy and never sends output to the cloud`() = runTest {
+        val p = CapturingProvider(deltas = listOf("some prose"))
+        val c = controller(AiPolicy.Strict, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.explain("secret log output")
+        advanceUntilIdle()
+
+        assertEquals(AiNotice.Blocked(app.skerry.shared.ai.AiRoute.Reason.STRICT_NEEDS_DEVICE), c.notice)
+        assertFalse(p.built, "Strict must not build a cloud provider for output that may be sensitive")
+        assertNull(c.explanation)
+    }
+
+    @Test
+    fun `explain sanitizes secrets in the output for balanced policy`() = runTest {
+        val p = CapturingProvider(deltas = listOf("ok"))
+        val c = controller(AiPolicy.Balanced, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.explain("db connect password=hunter2 established")
+        advanceUntilIdle()
+
+        assertNotNull(p.lastUserContent)
+        assertFalse(p.lastUserContent!!.contains("hunter2"), "secrets in the output must be scrubbed for Balanced")
+    }
+
+    @Test
+    fun `explain clamps long output to a bounded tail`() = runTest {
+        val p = CapturingProvider(deltas = listOf("ok"))
+        val c = controller(AiPolicy.Permissive, AiSettings(apiKey = "sk-x"), p, this)
+
+        val long = "z".repeat(TerminalAiController.EXPLAIN_CONTEXT_LIMIT + 500)
+        c.explain(long)
+        advanceUntilIdle()
+
+        val sent = p.lastUserContent!!
+        assertEquals(TerminalAiController.EXPLAIN_CONTEXT_LIMIT + 1, sent.length, "kept tail plus one ellipsis marker")
+        assertTrue(sent.startsWith("…"), "the truncated head is marked with an ellipsis")
+    }
+
+    @Test
+    fun `starting an explanation clears a previous command suggestion`() = runTest {
+        val p = CapturingProvider(deltas = listOf("uptime"))
+        val c = controller(AiPolicy.Balanced, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.ask("show uptime")
+        advanceUntilIdle()
+        assertEquals("uptime", c.pending)
+
+        c.explain("$ uptime\n load average: 0.0")
+        advanceUntilIdle()
+
+        assertEquals("uptime", c.explanation, "the explain surface replaces the pending command")
+        assertNull(c.pending)
+    }
+
+    @Test
+    fun `dismiss clears an explanation`() = runTest {
+        val p = CapturingProvider(deltas = listOf("some prose"))
+        val c = controller(AiPolicy.Balanced, AiSettings(apiKey = "sk-x"), p, this)
+
+        c.explain("$ ls")
+        advanceUntilIdle()
+        assertEquals("some prose", c.explanation)
+
+        c.dismiss()
+        assertNull(c.explanation)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -103,6 +103,71 @@ class TerminalScreenStateTest {
         scope.cancel()
     }
 
+    // --- lastOutput / lastCommandBlock (for "explain this output") ---
+
+    @Test
+    fun `lastCommandBlock returns the last command and its output, not the login banner`() {
+        // Regression: with nothing selected, explaining sent the whole screen, so a long MOTD banner
+        // drowned out the actual last command (uptime). The block must be just that command + output.
+        val screen = listOf(
+            "Welcome to Ubuntu 22.04.5 LTS",
+            "",
+            " * Documentation:  https://help.ubuntu.com",
+            "This system has been minimized by removing packages.",
+            "Last login: Fri Jul 24 11:51:03 2026 from 178.205.96.77",
+            "root@140722:~# uptime",
+            " 12:21:14 up 129 days, 18:42,  1 user,  load average: 0.48, 0.14, 0.05",
+            "root@140722:~#",
+        ).joinToString("\n")
+
+        val block = lastCommandBlock(screen)
+
+        assertEquals(
+            "root@140722:~# uptime\n 12:21:14 up 129 days, 18:42,  1 user,  load average: 0.48, 0.14, 0.05",
+            block,
+        )
+        // The banner and unrelated history are excluded.
+        assertEquals(false, block!!.contains("Documentation"))
+        assertEquals(false, block.contains("Last login"))
+    }
+
+    @Test
+    fun `lastCommandBlock returns null when the prompt does not repeat`() {
+        // Only one prompt on screen: no earlier command line to bound the block, so fall back to the
+        // whole screen at the call site rather than mis-slicing.
+        assertEquals(null, lastCommandBlock("some free-form output\nwith no repeated prompt\nroot@140722:~#"))
+    }
+
+    @Test
+    fun `lastCommandBlock ignores a too-short prompt that would match everything`() {
+        // A bare "$" prompt would start-with-match unrelated lines; reject it.
+        assertEquals(null, lastCommandBlock("total output here\n$ ls\n$"))
+    }
+
+    @Test
+    fun `lastCommandBlock keeps a command that produced no output`() {
+        assertEquals("root@140722:~# cd /var/log", lastCommandBlock("root@140722:~# cd /var/log\nroot@140722:~#"))
+    }
+
+    @Test
+    fun `lastOutput reads the last command block from the live screen`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit(
+            ("Last login: Fri Jul 24 11:51:03 2026 from 178.205.96.77\r\n" +
+                "root@140722:~# uptime\r\n" +
+                " 12:21:14 up 129 days, 18:42,  1 user,  load average: 0.48, 0.14, 0.05\r\n" +
+                "root@140722:~#").encodeToByteArray(),
+        )
+
+        val last = state.lastOutput()
+        assertEquals(true, last != null && last.contains("uptime") && last.contains("load average"))
+        assertEquals(false, last!!.contains("Last login"))
+        scope.cancel()
+    }
+
     @Test
     fun `preloaded history feeds autosuggestion`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))


### PR DESCRIPTION
Explains terminal output with AI, directly from the terminal AI bar.

**Where:** a summarize button in the AI bar (desktop and mobile). It sends the current selection — or, with nothing selected, the last command's output, falling back to the whole visible screen — to the model.

**Behaviour:**
- The reply is plain-language prose shown inline in the bar (scrollable, Dismiss to close). It is never parsed as a command or offered for execution.
- Routing matches command generation, so the per-host policy is honoured: Strict keeps output on the on-device model, Balanced redacts secrets before sending.
- `lastCommandBlock()` derives the last command + output from the visible screen via a prompt-line heuristic, so a long login banner no longer drowns out the recent result.
- The explanation is written in the UI language.

**Also in this PR:** en/ru/zh strings (`term_ai_explain`, `term_ai_explain_reading`); unit tests for the controller (`explain`) and the output heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)