### PR TITLE
Import hosts from ~/.ssh/config

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/host/LocalOsUser.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/host/LocalOsUser.android.kt
@@ -1,0 +1,4 @@
+package app.skerry.ui.host
+
+// Android has no SSH-relevant local account name; imported hosts keep an empty username instead.
+actual fun localOsUserName(): String? = null

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ImportFile.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ImportFile.android.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.withContext
  * `content://` provider can report anything (or nothing), so the limit is enforced while reading and
  * an oversized file yields `null` instead of an out-of-memory crash.
  */
-actual suspend fun importTextFile(maxBytes: Int): ImportedFile? {
+actual suspend fun importTextFile(title: String, maxBytes: Int): ImportedFile? {
+    // title is unused: the Storage Access Framework picker has no custom-title hook.
     val ctx = SafBridge.context() ?: return null
     val uri = SafBridge.openDocument() ?: return null
     return withContext(Dispatchers.IO) {

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -105,4 +105,12 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">Serial</string>
     <string name="conn_type_vnc">VNC</string>
+
+    <string name="conn_import_action">Импорт из ssh_config</string>
+    <string name="conn_import_title">Импорт из ssh_config</string>
+    <string name="conn_import_subtitle">Выберите хосты для добавления. Ключи не импортируются — аутентификацию укажете при подключении.</string>
+    <string name="conn_import_select_all">Выбрать все</string>
+    <string name="conn_import_empty">В этом файле не найдено хостов.</string>
+    <string name="conn_import_button">Импортировать (%1$d)</string>
+    <string name="conn_import_skipped">Некоторые строки были пропущены при импорте.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -105,4 +105,12 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">串口</string>
     <string name="conn_type_vnc">VNC</string>
+
+    <string name="conn_import_action">从 ssh_config 导入</string>
+    <string name="conn_import_title">从 ssh_config 导入</string>
+    <string name="conn_import_subtitle">选择要添加的主机。不会导入密钥——连接时再设置身份验证。</string>
+    <string name="conn_import_select_all">全选</string>
+    <string name="conn_import_empty">此文件中未找到主机。</string>
+    <string name="conn_import_button">导入 (%1$d)</string>
+    <string name="conn_import_skipped">导入时跳过了部分行。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -105,4 +105,12 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">Serial</string>
     <string name="conn_type_vnc">VNC</string>
+
+    <string name="conn_import_action">Import from ssh_config</string>
+    <string name="conn_import_title">Import from ssh_config</string>
+    <string name="conn_import_subtitle">Pick the hosts to add. Keys aren\'t imported — you set authentication when you connect.</string>
+    <string name="conn_import_select_all">Select all</string>
+    <string name="conn_import_empty">No hosts found in this file.</string>
+    <string name="conn_import_button">Import (%1$d)</string>
+    <string name="conn_import_skipped">Some lines were skipped during import.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -342,6 +342,15 @@ class DesktopDesignState(
     /** Host the modal is prefilled from as a copy ("Duplicate"); saving creates a new profile. */
     var duplicatingHost: Host? by mutableStateOf(null); private set
 
+    /**
+     * ssh_config import: hosts parsed from a picked file, awaiting the user's selection in the import
+     * modal; `null` means the modal is closed. Held on the state (not local Compose state) so the
+     * sidebar coroutine that picks and parses the file can hand the result to the modal rendered at
+     * the app root.
+     */
+    var sshImport: app.skerry.shared.ssh.SshConfigParseResult? by mutableStateOf(null); private set
+    val sshImportOpen: Boolean get() = sshImport != null
+
     /** Host for which the delete-confirmation dialog is shown (null means no dialog). */
     var pendingDeleteHost: Host? by mutableStateOf(null); private set
 
@@ -409,6 +418,8 @@ class DesktopDesignState(
     fun openEditModal(host: Host) { editingHost = host; duplicatingHost = null; modalOpen = true }
     fun openDuplicateModal(host: Host) { editingHost = null; duplicatingHost = host; modalOpen = true }
     fun closeModal() { modalOpen = false; editingHost = null; duplicatingHost = null }
+    fun beginSshImport(result: app.skerry.shared.ssh.SshConfigParseResult) { sshImport = result }
+    fun closeSshImport() { sshImport = null }
     fun requestDeleteHost(host: Host) { pendingDeleteHost = host }
     fun dismissDeleteHost() { pendingDeleteHost = null }
     fun requestCloseSession(id: String) { pendingClose = PendingClose.Session(id) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -148,6 +148,13 @@ class MobileDesignState(
     var selectedHostId: String? by mutableStateOf(null); private set
 
     /**
+     * ssh_config import: hosts parsed from a picked file, awaiting the user's selection in the import
+     * sheet; `null` means it's closed. Parity with the desktop [DesktopDesignState.sshImport] flow —
+     * the More-tab row picks/parses the file, then hands the result here for the sheet to render.
+     */
+    var sshImport: app.skerry.shared.ssh.SshConfigParseResult? by mutableStateOf(null); private set
+
+    /**
      * Whether a tab's modal overlay is open (e.g. a vault Generate/Import dialog) — hides the tab
      * bar, otherwise it floats over the dialog and covers input fields above the keyboard. Mutated
      * only via [modalOverlay] (encapsulation, like the other fields).
@@ -270,6 +277,9 @@ class MobileDesignState(
     fun openDuplicateConn(host: Host) { editingHost = null; duplicatingHost = host; sheetNewConn = true }
 
     fun closeSheet() { sheetNewConn = false; editingHost = null; duplicatingHost = null }
+
+    fun beginSshImport(result: app.skerry.shared.ssh.SshConfigParseResult) { sshImport = result }
+    fun closeSshImport() { sshImport = null }
 
     /** Selected terminal font (More -> Appearance -> Font). Threaded to the terminal via [app.skerry.ui.terminal.LocalTerminalAppearance]. */
     var terminalFont: TerminalFont by mutableStateOf(initialTerminalFont); private set

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -197,6 +197,7 @@ import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
 import app.skerry.ui.vault.LockScreen
 import app.skerry.ui.host.NewConnectionModal
+import app.skerry.ui.host.SshConfigImportModal
 import app.skerry.ui.sync.PairingShowDialog
 import app.skerry.ui.app.PendingClose
 import app.skerry.ui.settings.SettingsPanel
@@ -692,6 +693,7 @@ private fun DesktopChrome(
                 if (event.type != KeyEventType.KeyDown) false
                 else if (
                     state.appOverlay != null || state.modalOpen || state.settingsOpen ||
+                    state.sshImportOpen ||
                     state.commandPaletteOpen || state.broadcastOpen || state.castRecording != null ||
                     // The snippet-variable confirmation dialog is modal too: a hotkey firing over it
                     // would type into the terminal under the dialog or race the pending run.
@@ -757,6 +759,7 @@ private fun DesktopChrome(
                 )
             }
             if (state.modalOpen) NewConnectionModal(state, editHost = state.editingHost, duplicateOf = state.duplicatingHost)
+            state.sshImport?.let { SshConfigImportModal(state, it) }
             if (state.settingsOpen) SettingsPanel(state)
             // Sync onboarding modal over settings: appears via "Set up sync", closes itself on a
             // successful connect. Only when the coordinator is supplied (the mock path with no backend has none).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -8,6 +8,8 @@ import app.skerry.shared.ai.AiPolicy
 import app.skerry.shared.host.Host
 import app.skerry.shared.host.HostStore
 import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.SshConfigHost
+import app.skerry.shared.ssh.SshConfigImport
 
 /**
  * Editable profile fields without [Host.id]: the create/edit form operates on a draft, and
@@ -83,6 +85,27 @@ class HostManagerController(
         )
         hosts = store.all()
         return id
+    }
+
+    /**
+     * Persist a batch of already-built profiles (e.g. from an `ssh_config` import) and reread once.
+     * Ids are pre-assigned by the caller so intra-batch references (ProxyJump → [Host.jumpHostId])
+     * are already resolved; existing hosts are left untouched.
+     */
+    fun importHosts(imported: List<Host>) {
+        for (host in imported) store.put(host)
+        hosts = store.all()
+    }
+
+    /**
+     * Import hosts parsed from an `ssh_config` file: plans the [selected] aliases into profiles
+     * (resolving ProxyJump within the batch, filling [defaultUser] where the config omits `User`)
+     * using this controller's id generator, persists them, and returns how many were created.
+     */
+    fun importSshConfig(parsed: List<SshConfigHost>, selected: Set<String>, defaultUser: String?): Int {
+        val planned = SshConfigImport.plan(parsed, selected, defaultUser, newId)
+        importHosts(planned)
+        return planned.size
     }
 
     /** Persist the VNC "Resize to window" toggle changed from a live session (unknown id: no-op). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/LocalOsUser.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/LocalOsUser.kt
@@ -1,0 +1,8 @@
+package app.skerry.ui.host
+
+/**
+ * Local OS account name, used as the default SSH username when an imported `ssh_config` entry omits
+ * `User` (OpenSSH itself falls back to the local user in that case). `null` when unavailable —
+ * Android has no meaningful equivalent, so imported hosts there simply keep an empty username.
+ */
+expect fun localOsUserName(): String?

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportFlow.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportFlow.kt
@@ -1,0 +1,21 @@
+package app.skerry.ui.host
+
+import app.skerry.shared.ssh.SshConfigParseResult
+import app.skerry.shared.ssh.SshConfigParser
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_import_title
+import app.skerry.ui.vault.importTextFile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.getString
+
+/**
+ * Opens the native file picker for an `ssh_config` file and parses it off the main thread. Returns
+ * `null` when the user cancels or the file can't be read (nothing to show); a picked file always
+ * returns a result — an empty [SshConfigParseResult.hosts] is a valid outcome the modal reports as
+ * "no hosts found" rather than silently doing nothing.
+ */
+suspend fun pickAndParseSshConfig(): SshConfigParseResult? {
+    val file = importTextFile(getString(Res.string.conn_import_title)) ?: return null
+    return withContext(Dispatchers.Default) { SshConfigParser.parse(file.text) }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
@@ -1,0 +1,157 @@
+package app.skerry.ui.host
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.SshConfigParseResult
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.ModalScrim
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_cancel
+import app.skerry.ui.generated.resources.conn_import_button
+import app.skerry.ui.generated.resources.conn_import_empty
+import app.skerry.ui.generated.resources.conn_import_select_all
+import app.skerry.ui.generated.resources.conn_import_skipped
+import app.skerry.ui.generated.resources.conn_import_subtitle
+import app.skerry.ui.generated.resources.conn_import_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Preview-and-select modal for importing hosts parsed from an `ssh_config` file. Shows every parsed
+ * host with a checkbox (all selected by default), a select-all toggle, and any parser warnings, then
+ * creates the chosen profiles via [HostManagerController.importSshConfig]. Rendered at the desktop
+ * app root while [DesktopDesignState.sshImport] is non-null; the picking/parsing happens beforehand
+ * (see [pickAndParseSshConfig]) so this modal only handles selection.
+ */
+@Composable
+fun SshConfigImportModal(state: DesktopDesignState, result: SshConfigParseResult) {
+    val hosts = LocalHosts.current
+    val defaultUser = remember { localOsUserName() }
+    var selected by remember(result) { mutableStateOf(result.hosts.map { it.alias }.toSet()) }
+    val allSelected = result.hosts.isNotEmpty() && selected.size == result.hosts.size
+
+    ModalScrim(onDismiss = state::closeSshImport) {
+        Column(
+            Modifier
+                .widthIn(max = 520.dp)
+                .fillMaxWidth()
+                .padding(20.dp)
+                .heightIn(max = 680.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Skerry.colors.surfaceDeep)
+                .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(12.dp))
+                .consumeClicks(),
+        ) {
+            Box(Modifier.fillMaxWidth().padding(start = 26.dp, end = 26.dp, top = 22.dp, bottom = 14.dp)) {
+                Column {
+                    Txt(stringResource(Res.string.conn_import_title), color = Skerry.colors.text, size = 18.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+                    Txt(stringResource(Res.string.conn_import_subtitle), color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp, modifier = Modifier.padding(top = 6.dp))
+                }
+                IconBtn("close", onClick = state::closeSshImport, modifier = Modifier.align(Alignment.TopEnd))
+            }
+            HLine()
+
+            if (result.hosts.isEmpty()) {
+                Box(Modifier.fillMaxWidth().padding(horizontal = 26.dp, vertical = 40.dp), contentAlignment = Alignment.Center) {
+                    Txt(stringResource(Res.string.conn_import_empty), color = Skerry.colors.dim, size = 13.sp)
+                }
+            } else {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { selected = if (allSelected) emptySet() else result.hosts.map { it.alias }.toSet() }
+                        .padding(horizontal = 26.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    SshImportCheck(allSelected)
+                    Txt(stringResource(Res.string.conn_import_select_all), color = Skerry.colors.dim, size = 12.sp, weight = FontWeight.Medium)
+                }
+                HLine()
+                Column(Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState())) {
+                    result.hosts.forEach { host ->
+                        val isSelected = host.alias in selected
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { selected = if (isSelected) selected - host.alias else selected + host.alias }
+                                .background(if (isSelected) Skerry.colors.cyan10 else androidx.compose.ui.graphics.Color.Transparent)
+                                .padding(horizontal = 26.dp, vertical = 9.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            SshImportCheck(isSelected)
+                            Column(Modifier.weight(1f)) {
+                                Txt(host.alias, color = Skerry.colors.text, size = 13.sp, weight = FontWeight.Medium)
+                                Txt(sshImportHostSummary(host), color = Skerry.colors.faint, size = 11.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            }
+                        }
+                    }
+                }
+                if (result.warnings.isNotEmpty()) {
+                    HLine()
+                    Row(
+                        Modifier.fillMaxWidth().padding(horizontal = 26.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Sym("info", size = 14.sp, color = Skerry.colors.faint)
+                        Txt(stringResource(Res.string.conn_import_skipped), color = Skerry.colors.faint, size = 11.5.sp)
+                    }
+                }
+            }
+
+            HLine()
+            Row(
+                Modifier.fillMaxWidth().background(Skerry.colors.shade15).padding(horizontal = 26.dp, vertical = 14.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Spacer(Modifier.weight(1f))
+                CancelButton(stringResource(Res.string.conn_cancel), onClick = state::closeSshImport)
+                PrimaryButton(
+                    stringResource(Res.string.conn_import_button, selected.size),
+                    onClick = {
+                        hosts?.importSshConfig(result.hosts, selected, defaultUser)
+                        state.closeSshImport()
+                    },
+                    icon = "download",
+                    enabled = selected.isNotEmpty(),
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshImportShared.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshImportShared.kt
@@ -1,0 +1,30 @@
+package app.skerry.ui.host
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.SshConfigHost
+import app.skerry.ui.design.Sym
+import app.skerry.ui.theme.Skerry
+
+/**
+ * Checkbox glyph for an ssh_config import row, shared by the desktop modal and the mobile sheet so
+ * the two stay visually in step. Uses the app icon set rather than a Material checkbox for
+ * consistency with the rest of the chrome.
+ */
+@Composable
+internal fun SshImportCheck(selected: Boolean, size: TextUnit = 18.sp) {
+    Sym(
+        if (selected) "check_box" else "check_box_outline_blank",
+        size = size,
+        color = if (selected) Skerry.colors.cyanBright else Skerry.colors.faint,
+    )
+}
+
+/** Secondary line under an alias in the import preview: `user@host[:port]`, port shown only when
+ *  non-default. Shared by the desktop and mobile import UIs. */
+internal fun sshImportHostSummary(host: SshConfigHost): String = buildString {
+    host.user?.let { append(it); append('@') }
+    append(host.hostName)
+    if (host.port != 22) { append(':'); append(host.port) }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -431,7 +431,7 @@ private fun MobileChrome(
         // → intercept first per the dispatcher's LIFO), so while an overlay is open the navigation
         // intercept is kept disabled to avoid firing afterward. Registered before the content, making
         // it the lowest-priority handler in the back stack.
-        val overlayOpen = pending != null || state.sheetNewConn || state.renamingGroup != null || state.modalOpen
+        val overlayOpen = pending != null || state.sheetNewConn || state.renamingGroup != null || state.modalOpen || state.sshImport != null
         val backAction = if (overlayOpen) null else mobileBackAction(state.route, state.tab)
         PlatformBackHandler(enabled = backAction != null) {
             when (backAction) {
@@ -465,6 +465,7 @@ private fun MobileChrome(
             if (state.sheetNewConn) {
                 MobileNewConnectionSheet(state)
             }
+            state.sshImport?.let { MobileSshImportSheet(state, it) }
             // Confirmation for a snippet with ${{…}} variables — every launch path (terminal
             // palette, Snippets tab) parks such a run in SnippetManager.pendingRun. Desktop parity.
             LocalSnippets.current?.let { SnippetRunDialog(it) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -135,6 +135,9 @@ import app.skerry.ui.design.Badge
 import app.skerry.ui.settings.ChangeAccountPasswordDialog
 import app.skerry.ui.settings.ChangeMasterPasswordDialog
 import app.skerry.ui.generated.resources.term_player_open
+import app.skerry.ui.generated.resources.conn_import_action
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.host.pickAndParseSshConfig
 import app.skerry.ui.terminal.openCastFile
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlinx.coroutines.launch
@@ -216,6 +219,17 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             MoreRow(
                 "play_circle", Skerry.colors.cyanBright, stringResource(Res.string.term_player_open), null, Skerry.colors.dim,
                 onClick = { playerScope.launch { state.showCast(openCastFile()) } },
+            )
+            // Import hosts from an OpenSSH ssh_config file (desktop parity). Live path only: importing
+            // needs a host store to write to. Picks + parses the file, then hands off to the sheet.
+            val hostsForImport = LocalHosts.current
+            MoreRow(
+                "download", Skerry.colors.cyanBright, stringResource(Res.string.conn_import_action), null, Skerry.colors.dim,
+                onClick = if (hostsForImport != null) {
+                    { playerScope.launch { pickAndParseSshConfig()?.let(state::beginSshImport) } }
+                } else {
+                    null
+                },
             )
             // About: subtitle is the current version, or an amber "Update x.y.z" when a newer
             // release is known (the passive mobile counterpart of the desktop status-bar notice).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
@@ -1,0 +1,141 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.SshConfigParseResult
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.host.SshImportCheck
+import app.skerry.ui.host.localOsUserName
+import app.skerry.ui.host.sshImportHostSummary
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_import_button
+import app.skerry.ui.generated.resources.conn_import_empty
+import app.skerry.ui.generated.resources.conn_import_select_all
+import app.skerry.ui.generated.resources.conn_import_skipped
+import app.skerry.ui.generated.resources.conn_import_subtitle
+import app.skerry.ui.generated.resources.conn_import_title
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Mobile counterpart of the desktop [app.skerry.ui.host.SshConfigImportModal]: a bottom sheet that
+ * previews the hosts parsed from a picked `ssh_config`, lets the user pick which to add, and creates
+ * them via [app.skerry.ui.host.HostManagerController.importSshConfig]. Shown while
+ * [MobileDesignState.sshImport] is non-null (opened from the More tab).
+ */
+@Composable
+fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult) {
+    val hosts = LocalHosts.current
+    val defaultUser = remember { localOsUserName() }
+    var selected by remember(result) { mutableStateOf(result.hosts.map { it.alias }.toSet()) }
+    val allSelected = result.hosts.isNotEmpty() && selected.size == result.hosts.size
+
+    MobileBottomSheet(
+        onDismiss = state::closeSshImport,
+        panelModifier = Modifier.fillMaxHeight(0.85f).padding(start = 22.dp, end = 22.dp, bottom = 30.dp),
+    ) {
+        Txt(stringResource(Res.string.conn_import_title), color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
+        Txt(stringResource(Res.string.conn_import_subtitle), color = Skerry.colors.dim, size = 13.sp, lineHeight = 18.sp, modifier = Modifier.padding(top = 6.dp))
+        Spacer(Modifier.height(14.dp))
+
+        if (result.hosts.isEmpty()) {
+            Box(Modifier.fillMaxWidth().weight(1f), contentAlignment = Alignment.Center) {
+                Txt(stringResource(Res.string.conn_import_empty), color = Skerry.colors.dim, size = 14.sp)
+            }
+        } else {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                        selected = if (allSelected) emptySet() else result.hosts.map { it.alias }.toSet()
+                    }
+                    .padding(vertical = 10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                SshImportCheck(allSelected, size = 20.sp)
+                Txt(stringResource(Res.string.conn_import_select_all), color = Skerry.colors.dim, size = 13.sp, weight = FontWeight.Medium)
+            }
+            Column(Modifier.fillMaxWidth().weight(1f).verticalScroll(rememberScrollState())) {
+                result.hosts.forEach { host ->
+                    val isSelected = host.alias in selected
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(10.dp))
+                            .background(if (isSelected) Skerry.colors.cyan10 else Color.Transparent)
+                            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                                selected = if (isSelected) selected - host.alias else selected + host.alias
+                            }
+                            .padding(horizontal = 4.dp, vertical = 11.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        SshImportCheck(isSelected, size = 20.sp)
+                        Column(Modifier.weight(1f)) {
+                            Txt(host.alias, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.Medium)
+                            Txt(sshImportHostSummary(host), color = Skerry.colors.faint, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
+                    }
+                }
+            }
+            if (result.warnings.isNotEmpty()) {
+                Row(
+                    Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Sym("info", size = 15.sp, color = Skerry.colors.faint)
+                    Txt(stringResource(Res.string.conn_import_skipped), color = Skerry.colors.faint, size = 12.sp)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+        val enabled = selected.isNotEmpty()
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(14.dp))
+                .background(if (enabled) Skerry.colors.cyan else Skerry.colors.cyan.copy(alpha = 0.4f))
+                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, enabled = enabled) {
+                    hosts?.importSshConfig(result.hosts, selected, defaultUser)
+                    state.closeSshImport()
+                }
+                .padding(15.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Txt(stringResource(Res.string.conn_import_button, selected.size), color = Skerry.colors.ink, size = 16.sp, weight = FontWeight.Bold)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastOpen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastOpen.kt
@@ -2,9 +2,12 @@ package app.skerry.ui.terminal
 
 import app.skerry.shared.terminal.Asciicast
 import app.skerry.shared.terminal.parseAsciicast
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_player_open
 import app.skerry.ui.vault.importTextFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.getString
 
 /** What came back from "Play a recording": a recording, nothing (cancelled), or an unusable file. */
 sealed interface CastOpenResult {
@@ -22,7 +25,7 @@ sealed interface CastOpenResult {
  * recording is megabytes of JSON lines, and the picker returns on the UI dispatcher.
  */
 suspend fun openCastFile(): CastOpenResult {
-    val file = importTextFile() ?: return CastOpenResult.Cancelled
+    val file = importTextFile(getString(Res.string.term_player_open)) ?: return CastOpenResult.Cancelled
     val cast = withContext(Dispatchers.Default) { parseAsciicast(file.text) } ?: return CastOpenResult.Invalid
     return CastOpenResult.Loaded(cast, file.name)
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -77,6 +77,8 @@ import app.skerry.ui.design.Chip
 import app.skerry.ui.design.Dot
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
+import app.skerry.ui.host.pickAndParseSshConfig
+import app.skerry.ui.generated.resources.conn_import_action
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SIDEBAR_WIDTH
@@ -374,8 +376,21 @@ internal fun HostsSidebar(state: DesktopDesignState) {
         }
         HLine()
         // Fixed to the AI bar's idle height so both bottom strips share one top line.
+        val importScope = rememberCoroutineScope()
         Box(Modifier.height(BOTTOM_BAR_HEIGHT).padding(horizontal = 12.dp), contentAlignment = Alignment.Center) {
-            PrimaryButton(stringResource(Res.string.term_new_connection), onClick = state::openModal, icon = "add_link", modifier = Modifier.fillMaxWidth())
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                PrimaryButton(stringResource(Res.string.term_new_connection), onClick = state::openModal, icon = "add_link", modifier = Modifier.weight(1f))
+                // Import hosts from an OpenSSH ~/.ssh/config: pick + parse off the main thread, then the
+                // preview modal (rendered at the app root) handles selection and persistence. Shown only
+                // on the live path — importing needs a host store to write to (mock/preview has none).
+                if (liveHosts != null) {
+                    IconBtn(
+                        "download",
+                        onClick = { importScope.launch { pickAndParseSshConfig()?.let(state::beginSshImport) } },
+                        tooltip = stringResource(Res.string.conn_import_action),
+                    )
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ImportFile.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ImportFile.kt
@@ -13,5 +13,9 @@ data class ImportedFile(val name: String, val text: String)
 /**
  * Reads a text file chosen by the user in the native picker, as UTF-8. Returns `null` on cancel, on
  * a read failure, or when the file is larger than [maxBytes] — nothing is imported silently.
+ *
+ * [title] labels the picker window so each caller (play a recording, import ssh_config, …) reads
+ * correctly. Desktop's [java.awt.FileDialog] shows it; Android's Storage Access Framework has no
+ * custom-title hook, so it's ignored there.
  */
-expect suspend fun importTextFile(maxBytes: Int = MAX_IMPORT_BYTES): ImportedFile?
+expect suspend fun importTextFile(title: String, maxBytes: Int = MAX_IMPORT_BYTES): ImportedFile?

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
 import app.skerry.shared.host.HostStore
+import app.skerry.shared.ssh.SshConfigHost
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -113,6 +114,45 @@ class HostManagerControllerTest {
         )
 
         assertEquals(listOf("prod", "db"), controller.hosts.single().tags)
+    }
+
+    @Test
+    fun `importHosts persists a batch and keeps existing hosts`() {
+        val store = FakeHostStore(Host("1", "a", "a.local", 22, "u"))
+        val controller = HostManagerController(store) { error("ids are pre-assigned") }
+
+        controller.importHosts(
+            listOf(
+                Host("i1", "web", "10.0.0.1", 22, "deploy"),
+                Host("i2", "db", "10.0.0.2", 22, "deploy", jumpHostId = "i1"),
+            ),
+        )
+
+        assertEquals(listOf("1", "i1", "i2"), controller.hosts.map { it.id })
+        assertEquals("i1", controller.find("i2")?.jumpHostId)
+        assertEquals(controller.hosts, store.all())
+    }
+
+    @Test
+    fun `importSshConfig plans and persists selected hosts with resolved jump`() {
+        val store = FakeHostStore()
+        var n = 0
+        val controller = HostManagerController(store) { "gen-${++n}" }
+        val parsed = listOf(
+            SshConfigHost("web", "10.0.0.1", 22, user = null, proxyJump = "bastion", identityFile = null),
+            SshConfigHost("bastion", "10.0.0.2", 22, user = "root", proxyJump = null, identityFile = null),
+            SshConfigHost("skip", "10.0.0.3", 22, user = null, proxyJump = null, identityFile = null),
+        )
+
+        val count = controller.importSshConfig(parsed, selected = setOf("web", "bastion"), defaultUser = "me")
+
+        assertEquals(2, count)
+        assertEquals(setOf("web", "bastion"), controller.hosts.map { it.label }.toSet())
+        val web = controller.hosts.single { it.label == "web" }
+        val bastion = controller.hosts.single { it.label == "bastion" }
+        assertEquals("me", web.username) // default user filled where config omitted User
+        assertEquals("root", bastion.username)
+        assertEquals(bastion.id, web.jumpHostId)
     }
 
     @Test

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/host/LocalOsUser.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/host/LocalOsUser.desktop.kt
@@ -1,0 +1,3 @@
+package app.skerry.ui.host
+
+actual fun localOsUserName(): String? = System.getProperty("user.name")?.takeIf { it.isNotBlank() }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ImportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ImportFile.desktop.kt
@@ -1,22 +1,18 @@
 package app.skerry.ui.vault
 
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.term_player_open
 import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
-import org.jetbrains.compose.resources.getString
 
 /**
  * Desktop import via the native AWT [FileDialog] in LOAD mode — the mirror of [exportTextFile].
  * The modal dialog runs a nested EDT event loop, so it is shown on [Dispatchers.Swing] and the read
  * happens on IO. A file over [maxBytes] is rejected before it is read.
  */
-actual suspend fun importTextFile(maxBytes: Int): ImportedFile? {
-    val title = getString(Res.string.term_player_open)
+actual suspend fun importTextFile(title: String, maxBytes: Int): ImportedFile? {
     val path = withContext(Dispatchers.Swing) {
         val dialog = FileDialog(null as Frame?, title, FileDialog.LOAD).apply { isVisible = true }
         val dir = dialog.directory ?: return@withContext null

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigImport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigImport.kt
@@ -1,0 +1,47 @@
+package app.skerry.shared.ssh
+
+import app.skerry.shared.host.Host
+
+/**
+ * Turns entries parsed from `ssh_config` into ready-to-save [Host] profiles. Pure and
+ * platform-independent so the mapping (including ProxyJump resolution and the username fallback) is
+ * covered by commonTest, leaving the UI/controller layer to only pick a file and persist the result.
+ *
+ * v1 scope, matching the parser: SSH-only, no secrets. `IdentityFile` is not read into the vault, so
+ * every profile gets [Host.credentialId] `null` (the key/password is entered at connect time).
+ */
+object SshConfigImport {
+
+    /**
+     * Builds a [Host] for each [selected] alias in [hosts] (order preserved), assigning ids from
+     * [newId]. [defaultUser] is the local OS user, used when the config omits `User`. ProxyJump is
+     * resolved against the ids of the hosts being imported in this same batch — a jump target that
+     * isn't selected leaves [Host.jumpHostId] `null` rather than a dangling reference.
+     */
+    fun plan(
+        hosts: List<SshConfigHost>,
+        selected: Set<String>,
+        defaultUser: String?,
+        newId: () -> String,
+    ): List<Host> {
+        val chosen = hosts.filter { it.alias in selected }
+        // Assign every id up front so ProxyJump can reference a host that appears later in the list.
+        val idByAlias = LinkedHashMap<String, String>()
+        for (entry in chosen) idByAlias[entry.alias] = newId()
+        return chosen.map { entry ->
+            Host(
+                id = idByAlias.getValue(entry.alias),
+                label = entry.alias,
+                address = entry.hostName,
+                port = entry.port,
+                username = entry.user ?: defaultUser ?: "",
+                credentialId = null,
+                connectionType = ConnectionType.SSH,
+                // Resolve ProxyJump within the batch; drop a self-reference (an alias jumping through
+                // itself) so we never persist an obviously-broken jump. Mutual cycles that survive are
+                // caught at connect time by resolveJumpChain.
+                jumpHostId = entry.proxyJump?.takeIf { it != entry.alias }?.let { idByAlias[it] },
+            )
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
@@ -43,20 +43,37 @@ object SshConfigParser {
 
     /**
      * Upper bound on parsed `Host`/`Match` blocks. Far above any real `~/.ssh/config` (hundreds of
-     * hosts at most), it caps the cost of resolving each alias against every block — an untrusted
-     * file can't force an O(blocks × aliases) blow-up on the import thread.
+     * hosts at most).
      */
     private const val MAX_BLOCKS = 4000
+
+    /**
+     * Upper bound on total `Host` patterns across the whole file. [MAX_BLOCKS] caps the number of
+     * `Host` *lines*, but a single line (`Host a b c … zN`) can carry any number of aliases, so the
+     * block count alone does not bound resolution cost. Since every alias is resolved against every
+     * block, this cap is what keeps an untrusted file from forcing an O(aliases × patterns) blow-up.
+     */
+    private const val MAX_PATTERNS = 8000
+
+    /** A real host alias/pattern is short; anything longer is dropped so it can't inflate the
+     *  glob matcher's per-call cost (the two-pointer matcher is O(pattern × value) worst-case). */
+    private const val MAX_PATTERN_LEN = 256
+
+    /** Hard ceiling on pattern comparisons during resolution — a deterministic backstop so no crafted
+     *  combination of blocks and aliases can peg the import thread regardless of the caps above. */
+    private const val MAX_RESOLVE_STEPS = 10_000_000L
 
     private class Block(val patterns: List<String>) {
         // First value wins per keyword (OpenSSH semantics); keys are lowercased.
         val options = LinkedHashMap<String, String>()
 
-        fun matches(alias: String): Boolean {
-            val positive = patterns.filter { !it.startsWith("!") }
-            val negative = patterns.filter { it.startsWith("!") }.map { it.substring(1) }
-            return positive.any { globMatches(it, alias) } && negative.none { globMatches(it, alias) }
-        }
+        // Precomputed once per block: re-filtering these on every matches() call was both O(patterns)
+        // per call and a large temporary allocation (an OOM risk on a crafted many-pattern line).
+        private val positive = patterns.filter { !it.startsWith("!") }
+        private val negative = patterns.filter { it.startsWith("!") }.map { it.substring(1) }
+
+        fun matches(alias: String): Boolean =
+            positive.any { globMatches(it, alias) } && negative.none { globMatches(it, alias) }
     }
 
     fun parse(text: String): SshConfigParseResult {
@@ -64,9 +81,10 @@ object SshConfigParser {
         val warnings = LinkedHashSet<String>()
         var current: Block? = null
         var ignoringMatch = false
+        var totalPatterns = 0
 
         for (rawLine in text.lineSequence()) {
-            if (blocks.size >= MAX_BLOCKS) {
+            if (blocks.size >= MAX_BLOCKS || totalPatterns >= MAX_PATTERNS) {
                 warnings.add("Too many entries — not all lines were parsed")
                 break
             }
@@ -76,11 +94,16 @@ object SshConfigParser {
             when (keyword.lowercase()) {
                 "host" -> {
                     ignoringMatch = false
-                    val patterns = tokenize(args)
-                    if (patterns.isEmpty()) {
+                    val tokens = tokenize(args)
+                    val patterns = tokens.filter { it.length <= MAX_PATTERN_LEN }
+                    if (patterns.size < tokens.size) warnings.add("Some host patterns were too long and skipped")
+                    val capped = patterns.take(MAX_PATTERNS - totalPatterns)
+                    if (capped.size < patterns.size) warnings.add("Too many entries — not all lines were parsed")
+                    if (capped.isEmpty()) {
                         current = null
                     } else {
-                        current = Block(patterns).also { blocks.add(it) }
+                        totalPatterns += capped.size
+                        current = Block(capped).also { blocks.add(it) }
                     }
                 }
                 "match" -> {
@@ -93,7 +116,7 @@ object SshConfigParser {
                     if (ignoringMatch) continue
                     val value = tokenize(args).firstOrNull() ?: continue
                     // Options before the first Host apply globally (OpenSSH) — model as a `*` block.
-                    val block = current ?: Block(listOf("*")).also { blocks.add(it); current = it }
+                    val block = current ?: Block(listOf("*")).also { blocks.add(it); current = it; totalPatterns++ }
                     block.options.putIfAbsent(keyword.lowercase(), value)
                 }
             }
@@ -108,20 +131,29 @@ object SshConfigParser {
             }
         }
 
-        val hosts = aliases.map { alias ->
+        var steps = 0L
+        val hosts = mutableListOf<SshConfigHost>()
+        for (alias in aliases) {
+            if (steps > MAX_RESOLVE_STEPS) {
+                warnings.add("Too many entries — not all hosts were imported")
+                break
+            }
             fun resolve(key: String): String? {
                 for (block in blocks) {
+                    steps += block.patterns.size
                     if (block.matches(alias)) block.options[key]?.let { return it }
                 }
                 return null
             }
-            SshConfigHost(
-                alias = alias,
-                hostName = resolve("hostname") ?: alias,
-                port = resolve("port")?.toIntOrNull()?.takeIf { it in 1..65535 } ?: 22,
-                user = resolve("user"),
-                proxyJump = resolve("proxyjump")?.let { firstJumpHop(it) },
-                identityFile = resolve("identityfile"),
+            hosts.add(
+                SshConfigHost(
+                    alias = alias,
+                    hostName = resolve("hostname") ?: alias,
+                    port = resolve("port")?.toIntOrNull()?.takeIf { it in 1..65535 } ?: 22,
+                    user = resolve("user"),
+                    proxyJump = resolve("proxyjump")?.let { firstJumpHop(it) },
+                    identityFile = resolve("identityfile"),
+                )
             )
         }
 
@@ -185,10 +217,12 @@ object SshConfigParser {
 
     /**
      * OpenSSH glob: `*` matches any run (including empty), `?` matches exactly one character;
-     * everything else is literal. Deliberately a linear two-pointer matcher rather than a translated
-     * regex: patterns come from an untrusted file, and a regex built from many `*` (`.*.*.*…`) is the
-     * classic catastrophic-backtracking (ReDoS) shape on the JVM engine. This algorithm backtracks
-     * only the last `*`, so a pattern packed with wildcards can't blow up.
+     * everything else is literal. Deliberately a two-pointer matcher rather than a translated regex:
+     * patterns come from an untrusted file, and a regex built from many `*` (`.*.*.*…`) is the classic
+     * catastrophic-backtracking (ReDoS) shape on the JVM engine. This algorithm backtracks only the
+     * last `*`, so many wildcards can't blow up; its remaining worst case (a `*` followed by a long
+     * literal that keeps failing) is O(pattern × value), which is why callers cap the pattern length
+     * (MAX_PATTERN_LEN) and the total resolution steps (MAX_RESOLVE_STEPS).
      */
     private fun globMatches(pattern: String, value: String): Boolean {
         var p = 0

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
@@ -1,0 +1,209 @@
+package app.skerry.shared.ssh
+
+/**
+ * One importable entry parsed from an OpenSSH `ssh_config` file. [alias] is the `Host` name (the
+ * label the user typed to connect); [hostName] is the resolved dial target (`HostName`, or the alias
+ * itself when absent, matching OpenSSH). [user]/[proxyJump]/[identityFile] are `null` when the file
+ * doesn't specify them. [proxyJump] holds only the first-hop host token (user/port stripped) — the
+ * importer resolves it against the other imported aliases.
+ */
+data class SshConfigHost(
+    val alias: String,
+    val hostName: String,
+    val port: Int,
+    val user: String?,
+    val proxyJump: String?,
+    val identityFile: String?,
+)
+
+/**
+ * Outcome of parsing an `ssh_config` file: the importable [hosts] and human-readable [warnings] for
+ * directives Skerry can't honour (e.g. `Include`, `Match`), so the UI can tell the user what was
+ * skipped rather than pretending it imported everything.
+ */
+data class SshConfigParseResult(
+    val hosts: List<SshConfigHost>,
+    val warnings: List<String>,
+)
+
+/**
+ * Parser for OpenSSH client config (`~/.ssh/config`). Pure and platform-independent — the caller
+ * supplies the file text (read via the platform file picker) so it stays testable in commonTest.
+ *
+ * Scope is deliberately a pragmatic subset (v1): `Host` blocks with `HostName`, `Port`, `User`,
+ * `ProxyJump`, `IdentityFile`. Wildcard patterns (`*`, `?`) and negations (`!`) are honoured for
+ * option matching but never become hosts themselves. `Match` blocks and `Include` are skipped with a
+ * warning — evaluating them needs a live host/connection context the importer doesn't have.
+ *
+ * Option resolution follows OpenSSH's "first obtained value wins" rule: for a given alias each
+ * keyword takes the value from the first (file-order) block whose pattern list matches it, so a
+ * trailing `Host *` acts as a fallback and a specific block earlier in the file overrides it.
+ */
+object SshConfigParser {
+
+    /**
+     * Upper bound on parsed `Host`/`Match` blocks. Far above any real `~/.ssh/config` (hundreds of
+     * hosts at most), it caps the cost of resolving each alias against every block — an untrusted
+     * file can't force an O(blocks × aliases) blow-up on the import thread.
+     */
+    private const val MAX_BLOCKS = 4000
+
+    private class Block(val patterns: List<String>) {
+        // First value wins per keyword (OpenSSH semantics); keys are lowercased.
+        val options = LinkedHashMap<String, String>()
+
+        fun matches(alias: String): Boolean {
+            val positive = patterns.filter { !it.startsWith("!") }
+            val negative = patterns.filter { it.startsWith("!") }.map { it.substring(1) }
+            return positive.any { globMatches(it, alias) } && negative.none { globMatches(it, alias) }
+        }
+    }
+
+    fun parse(text: String): SshConfigParseResult {
+        val blocks = mutableListOf<Block>()
+        val warnings = LinkedHashSet<String>()
+        var current: Block? = null
+        var ignoringMatch = false
+
+        for (rawLine in text.lineSequence()) {
+            if (blocks.size >= MAX_BLOCKS) {
+                warnings.add("Too many entries — not all lines were parsed")
+                break
+            }
+            val trimmed = rawLine.trim()
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) continue
+            val (keyword, args) = splitKeyword(trimmed) ?: continue
+            when (keyword.lowercase()) {
+                "host" -> {
+                    ignoringMatch = false
+                    val patterns = tokenize(args)
+                    if (patterns.isEmpty()) {
+                        current = null
+                    } else {
+                        current = Block(patterns).also { blocks.add(it) }
+                    }
+                }
+                "match" -> {
+                    ignoringMatch = true
+                    current = null
+                    warnings.add("Match blocks are ignored")
+                }
+                "include" -> warnings.add("Include is not supported")
+                else -> {
+                    if (ignoringMatch) continue
+                    val value = tokenize(args).firstOrNull() ?: continue
+                    // Options before the first Host apply globally (OpenSSH) — model as a `*` block.
+                    val block = current ?: Block(listOf("*")).also { blocks.add(it); current = it }
+                    block.options.putIfAbsent(keyword.lowercase(), value)
+                }
+            }
+        }
+
+        val aliases = LinkedHashSet<String>()
+        for (block in blocks) {
+            for (pattern in block.patterns) {
+                if (!pattern.startsWith("!") && !pattern.contains('*') && !pattern.contains('?')) {
+                    aliases.add(pattern)
+                }
+            }
+        }
+
+        val hosts = aliases.map { alias ->
+            fun resolve(key: String): String? {
+                for (block in blocks) {
+                    if (block.matches(alias)) block.options[key]?.let { return it }
+                }
+                return null
+            }
+            SshConfigHost(
+                alias = alias,
+                hostName = resolve("hostname") ?: alias,
+                port = resolve("port")?.toIntOrNull()?.takeIf { it in 1..65535 } ?: 22,
+                user = resolve("user"),
+                proxyJump = resolve("proxyjump")?.let { firstJumpHop(it) },
+                identityFile = resolve("identityfile"),
+            )
+        }
+
+        return SshConfigParseResult(hosts, warnings.toList())
+    }
+
+    /** Splits a config line into keyword and the remaining argument text, honouring `key value` and
+     *  `key=value` (with optional spaces around `=`). Returns null for a keyword-only garbage line. */
+    private fun splitKeyword(line: String): Pair<String, String>? {
+        var i = 0
+        while (i < line.length && !line[i].isWhitespace() && line[i] != '=') i++
+        if (i == 0) return null
+        val keyword = line.substring(0, i)
+        var j = i
+        while (j < line.length && line[j].isWhitespace()) j++
+        if (j < line.length && line[j] == '=') {
+            j++
+            while (j < line.length && line[j].isWhitespace()) j++
+        }
+        return keyword to line.substring(j).trim()
+    }
+
+    /**
+     * Whitespace-splits arguments, treating a double-quoted run as one token (for names with spaces).
+     * An unquoted `#` at a token boundary starts an inline comment and ends the line — so
+     * `Host web  # prod` yields just `web`, not the phantom aliases `web`, `#`, `prod`. A `#` inside a
+     * token (e.g. `id_rsa#1`) stays literal.
+     */
+    private fun tokenize(s: String): List<String> {
+        val tokens = mutableListOf<String>()
+        val token = StringBuilder()
+        var inQuotes = false
+        var started = false
+        for (c in s) {
+            when {
+                c == '"' -> { inQuotes = !inQuotes; started = true }
+                c == '#' && !inQuotes && !started -> break
+                c.isWhitespace() && !inQuotes -> {
+                    if (started) { tokens.add(token.toString()); token.clear(); started = false }
+                }
+                else -> { token.append(c); started = true }
+            }
+        }
+        if (started) tokens.add(token.toString())
+        return tokens
+    }
+
+    /** `ProxyJump` can be `none`, a comma-separated chain, and each hop may carry `user@` / `:port`.
+     *  Returns the bare host of the first hop, or null for `none`. */
+    private fun firstJumpHop(value: String): String? {
+        if (value.equals("none", ignoreCase = true)) return null
+        val hop = value.substringBefore(",").trim()
+        val afterUser = hop.substringAfterLast("@")
+        val host = if (afterUser.startsWith("[")) {
+            afterUser.substringAfter("[").substringBefore("]")
+        } else {
+            afterUser.substringBefore(":")
+        }
+        return host.ifBlank { null }
+    }
+
+    /**
+     * OpenSSH glob: `*` matches any run (including empty), `?` matches exactly one character;
+     * everything else is literal. Deliberately a linear two-pointer matcher rather than a translated
+     * regex: patterns come from an untrusted file, and a regex built from many `*` (`.*.*.*…`) is the
+     * classic catastrophic-backtracking (ReDoS) shape on the JVM engine. This algorithm backtracks
+     * only the last `*`, so a pattern packed with wildcards can't blow up.
+     */
+    private fun globMatches(pattern: String, value: String): Boolean {
+        var p = 0
+        var v = 0
+        var star = -1
+        var afterStar = 0
+        while (v < value.length) {
+            when {
+                p < pattern.length && (pattern[p] == '?' || pattern[p] == value[v]) -> { p++; v++ }
+                p < pattern.length && pattern[p] == '*' -> { star = p; afterStar = v; p++ }
+                star != -1 -> { p = star + 1; afterStar++; v = afterStar }
+                else -> return false
+            }
+        }
+        while (p < pattern.length && pattern[p] == '*') p++
+        return p == pattern.length
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
@@ -1,0 +1,143 @@
+package app.skerry.shared.ssh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SshConfigImportTest {
+
+    private fun ids(): () -> String {
+        var n = 0
+        return { "id-${++n}" }
+    }
+
+    private fun host(
+        alias: String,
+        hostName: String = alias,
+        port: Int = 22,
+        user: String? = null,
+        proxyJump: String? = null,
+    ) = SshConfigHost(alias, hostName, port, user, proxyJump, identityFile = null)
+
+    @Test
+    fun `maps parsed fields onto a host profile`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", hostName = "10.0.0.1", port = 2222, user = "deploy")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        val h = plan.single()
+        assertEquals("web", h.label)
+        assertEquals("10.0.0.1", h.address)
+        assertEquals(2222, h.port)
+        assertEquals("deploy", h.username)
+        assertEquals(ConnectionType.SSH, h.connectionType)
+        assertNull(h.credentialId)
+        assertNull(h.jumpHostId)
+        assertEquals("id-1", h.id)
+    }
+
+    @Test
+    fun `default user fills in when the config omits User`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web")),
+            selected = setOf("web"),
+            defaultUser = "localuser",
+            newId = ids(),
+        )
+        assertEquals("localuser", plan.single().username)
+    }
+
+    @Test
+    fun `config User wins over the default user`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", user = "configured")),
+            selected = setOf("web"),
+            defaultUser = "localuser",
+            newId = ids(),
+        )
+        assertEquals("configured", plan.single().username)
+    }
+
+    @Test
+    fun `username is empty when neither config nor default supplies one`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertEquals("", plan.single().username)
+    }
+
+    @Test
+    fun `only selected aliases are imported`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("a"), host("b"), host("c")),
+            selected = setOf("a", "c"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertEquals(listOf("a", "c"), plan.map { it.label })
+    }
+
+    @Test
+    fun `proxyJump resolves to the jump host id within the batch`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", proxyJump = "bastion"), host("bastion")),
+            selected = setOf("web", "bastion"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        val web = plan.single { it.label == "web" }
+        val bastion = plan.single { it.label == "bastion" }
+        assertEquals(bastion.id, web.jumpHostId)
+    }
+
+    @Test
+    fun `proxyJump to a host that was not selected leaves no jump`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", proxyJump = "bastion"), host("bastion")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertNull(plan.single().jumpHostId)
+    }
+
+    @Test
+    fun `every imported host gets a distinct id`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("a"), host("b"), host("c")),
+            selected = setOf("a", "b", "c"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertEquals(3, plan.map { it.id }.toSet().size)
+        assertTrue(plan.all { it.id.isNotBlank() })
+    }
+
+    @Test
+    fun `proxyJump referencing its own alias does not create a self jump`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", proxyJump = "web")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertNull(plan.single().jumpHostId)
+    }
+
+    @Test
+    fun `empty selection imports nothing`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("a")),
+            selected = emptySet(),
+            defaultUser = null,
+            newId = ids(),
+        )
+        assertTrue(plan.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
@@ -1,0 +1,266 @@
+package app.skerry.shared.ssh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SshConfigParserTest {
+
+    private fun parse(text: String) = SshConfigParser.parse(text)
+
+    @Test
+    fun `single host block maps every field`() {
+        val result = parse(
+            """
+            Host web
+                HostName 10.0.0.1
+                User deploy
+                Port 2222
+            """.trimIndent(),
+        )
+        assertEquals(1, result.hosts.size)
+        val host = result.hosts.single()
+        assertEquals("web", host.alias)
+        assertEquals("10.0.0.1", host.hostName)
+        assertEquals("deploy", host.user)
+        assertEquals(2222, host.port)
+        assertEquals(null, host.proxyJump)
+        assertEquals(null, host.identityFile)
+    }
+
+    @Test
+    fun `missing HostName falls back to the alias`() {
+        val result = parse("Host myserver\n    User root")
+        val host = result.hosts.single()
+        assertEquals("myserver", host.alias)
+        assertEquals("myserver", host.hostName)
+    }
+
+    @Test
+    fun `port defaults to 22 and user is null when absent`() {
+        val result = parse("Host bare\n    HostName example.com")
+        val host = result.hosts.single()
+        assertEquals(22, host.port)
+        assertEquals(null, host.user)
+    }
+
+    @Test
+    fun `keywords are case-insensitive`() {
+        val result = parse("HOST web\n    hostname 10.0.0.9\n    USER admin\n    PORT 42")
+        val host = result.hosts.single()
+        assertEquals("10.0.0.9", host.hostName)
+        assertEquals("admin", host.user)
+        assertEquals(42, host.port)
+    }
+
+    @Test
+    fun `equals separator is accepted`() {
+        val result = parse("Host web\n    HostName=1.2.3.4\n    Port = 2200\n    User=bob")
+        val host = result.hosts.single()
+        assertEquals("1.2.3.4", host.hostName)
+        assertEquals(2200, host.port)
+        assertEquals("bob", host.user)
+    }
+
+    @Test
+    fun `comments and blank lines are ignored`() {
+        val result = parse(
+            """
+            # a comment
+            Host web
+
+              # indented comment
+              HostName 10.0.0.2
+            """.trimIndent(),
+        )
+        val host = result.hosts.single()
+        assertEquals("10.0.0.2", host.hostName)
+    }
+
+    @Test
+    fun `multiple patterns on one Host line produce a host each`() {
+        val result = parse("Host web1 web2\n    User deploy")
+        assertEquals(listOf("web1", "web2"), result.hosts.map { it.alias })
+        assertTrue(result.hosts.all { it.user == "deploy" })
+    }
+
+    @Test
+    fun `wildcard defaults apply to concrete hosts but do not create a host`() {
+        val result = parse(
+            """
+            Host *
+                User defaultuser
+                Port 2022
+
+            Host web
+                HostName 10.0.0.5
+            """.trimIndent(),
+        )
+        assertEquals(listOf("web"), result.hosts.map { it.alias })
+        val host = result.hosts.single()
+        assertEquals("defaultuser", host.user)
+        assertEquals(2022, host.port)
+    }
+
+    @Test
+    fun `first match wins - per-host value overrides later wildcard default`() {
+        // OpenSSH semantics: the first obtained value is used, regardless of file position.
+        val result = parse(
+            """
+            Host web
+                User specific
+
+            Host *
+                User fallback
+            """.trimIndent(),
+        )
+        assertEquals("specific", result.hosts.single().user)
+    }
+
+    @Test
+    fun `question mark wildcard matches a single character`() {
+        val result = parse(
+            """
+            Host db?
+                User dba
+
+            Host db1
+                HostName 10.0.0.7
+            """.trimIndent(),
+        )
+        val host = result.hosts.single { it.alias == "db1" }
+        assertEquals("dba", host.user)
+    }
+
+    @Test
+    fun `proxyJump keeps only the first hop host token`() {
+        val result = parse("Host web\n    ProxyJump jump1,jump2")
+        assertEquals("jump1", result.hosts.single().proxyJump)
+    }
+
+    @Test
+    fun `proxyJump strips user and port`() {
+        val result = parse("Host web\n    ProxyJump admin@bastion:2222")
+        assertEquals("bastion", result.hosts.single().proxyJump)
+    }
+
+    @Test
+    fun `proxyJump none means no jump`() {
+        val result = parse("Host web\n    ProxyJump none")
+        assertEquals(null, result.hosts.single().proxyJump)
+    }
+
+    @Test
+    fun `identityFile is captured verbatim`() {
+        val result = parse("Host web\n    IdentityFile ~/.ssh/id_ed25519")
+        assertEquals("~/.ssh/id_ed25519", result.hosts.single().identityFile)
+    }
+
+    @Test
+    fun `quoted values are unquoted`() {
+        val result = parse("Host \"web server\"\n    HostName \"10.0.0.8\"")
+        val host = result.hosts.single()
+        assertEquals("web server", host.alias)
+        assertEquals("10.0.0.8", host.hostName)
+    }
+
+    @Test
+    fun `negated pattern excludes an alias from a wildcard block`() {
+        val result = parse(
+            """
+            Host * !secret
+                User common
+
+            Host secret
+                HostName 10.0.0.10
+
+            Host public
+                HostName 10.0.0.11
+            """.trimIndent(),
+        )
+        assertEquals(null, result.hosts.single { it.alias == "secret" }.user)
+        assertEquals("common", result.hosts.single { it.alias == "public" }.user)
+    }
+
+    @Test
+    fun `duplicate alias across blocks yields one host`() {
+        val result = parse(
+            """
+            Host web
+                HostName 10.0.0.1
+
+            Host web
+                User late
+            """.trimIndent(),
+        )
+        assertEquals(1, result.hosts.size)
+        val host = result.hosts.single()
+        assertEquals("10.0.0.1", host.hostName)
+        assertEquals("late", host.user)
+    }
+
+    @Test
+    fun `Include directive is skipped with a warning`() {
+        val result = parse("Include ~/.ssh/other_config\nHost web\n    HostName 10.0.0.1")
+        assertEquals(listOf("web"), result.hosts.map { it.alias })
+        assertTrue(result.warnings.any { it.contains("Include", ignoreCase = true) })
+    }
+
+    @Test
+    fun `Match block is ignored with a warning`() {
+        val result = parse(
+            """
+            Host web
+                HostName 10.0.0.1
+
+            Match host web
+                User matched
+            """.trimIndent(),
+        )
+        // Options under Match must not leak into the host.
+        assertEquals(null, result.hosts.single().user)
+        assertTrue(result.warnings.any { it.contains("Match", ignoreCase = true) })
+    }
+
+    @Test
+    fun `empty input yields no hosts`() {
+        assertEquals(0, parse("").hosts.size)
+        assertEquals(0, parse("   \n# only a comment\n").hosts.size)
+    }
+
+    @Test
+    fun `invalid port is ignored and falls back to default`() {
+        val result = parse("Host web\n    Port notanumber")
+        assertEquals(22, result.hosts.single().port)
+    }
+
+    @Test
+    fun `inline comment on a Host line does not create phantom aliases`() {
+        val result = parse("Host web  # production box\n    HostName 10.0.0.1")
+        assertEquals(listOf("web"), result.hosts.map { it.alias })
+        assertEquals("10.0.0.1", result.hosts.single().hostName)
+    }
+
+    @Test
+    fun `inline comment after a value is stripped`() {
+        val result = parse("Host web\n    HostName 10.0.0.1 # main")
+        assertEquals("10.0.0.1", result.hosts.single().hostName)
+    }
+
+    @Test
+    fun `hash inside a token stays literal`() {
+        val result = parse("Host web\n    IdentityFile ~/.ssh/id#1")
+        assertEquals("~/.ssh/id#1", result.hosts.single().identityFile)
+    }
+
+    @Test
+    fun `pathological wildcard pattern resolves without catastrophic backtracking`() {
+        // A block whose pattern is packed with `*` matched against a long non-matching alias is the
+        // classic ReDoS shape; the linear matcher must return promptly (this test would hang on a
+        // backtracking regex). We only assert the parse completes and yields the concrete host.
+        val stars = "a*".repeat(60)
+        val alias = "b".repeat(120)
+        val result = parse("Host $stars\n    User u\n\nHost $alias\n    HostName 10.0.0.1")
+        assertEquals("10.0.0.1", result.hosts.single { it.alias == alias }.hostName)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
@@ -263,4 +263,25 @@ class SshConfigParserTest {
         val result = parse("Host $stars\n    User u\n\nHost $alias\n    HostName 10.0.0.1")
         assertEquals("10.0.0.1", result.hosts.single { it.alias == alias }.hostName)
     }
+
+    @Test
+    fun `a single Host line with a huge alias list stays bounded`() {
+        // MAX_BLOCKS caps the number of `Host` *lines*, not the patterns on one line. A single line
+        // packing tens of thousands of aliases would otherwise drive an O(aliases^2) resolution on
+        // the import thread. The parser must cap the total pattern count and return promptly.
+        val aliases = (0 until 50_000).joinToString(" ") { "h$it" }
+        val result = parse("Host $aliases\n    User u")
+        assertTrue(result.hosts.size <= 8_000, "host count must be capped, was ${result.hosts.size}")
+        assertTrue(result.warnings.any { it.contains("too many", ignoreCase = true) })
+    }
+
+    @Test
+    fun `an absurdly long host pattern is skipped`() {
+        // A multi-kilobyte "hostname" is not a real host; skipping it bounds the glob matcher's input
+        // length (the two-pointer matcher is O(pattern x value) in its worst case).
+        val huge = "a".repeat(5_000)
+        val result = parse("Host real $huge\n    HostName 10.0.0.2")
+        assertEquals(listOf("real"), result.hosts.map { it.alias })
+        assertEquals("10.0.0.2", result.hosts.single().hostName)
+    }
 }


### PR DESCRIPTION
Import host profiles from an OpenSSH `~/.ssh/config` file.

**Where / how**
- Desktop: download icon in the hosts sidebar → file picker → preview modal.
- Android: row in the More tab → file picker → preview sheet.
- Config text is parsed off the main thread; the preview lists every resolved host before anything is written to the vault.

**Behavior**
- Parser (shared core): first-match-wins directive semantics, wildcard/`?` and negated (`!`) `Host` patterns, `key=value`, quoting, and inline `#` comments.
- Mapper: resolves `ProxyJump` aliases within the imported batch and assigns ids; multi-hop `a,b,c` keeps the first hop.
- Only host profiles are imported — private keys (`IdentityFile`) are never read from disk; auth is provided on connect. Invalid `Port` falls back to 22; a missing username defaults to the local OS user on desktop.

**Also in this PR**
- `expect/actual localOsUserName` for the default username.
- Tests: 26 parser + 10 mapper + host-controller import cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)