### PR TITLE
feat(terminal): local shell

### DIFF
--- a/composeApp/flatpak/flatpak-sources.json
+++ b/composeApp/flatpak/flatpak-sources.json
@@ -2773,6 +2773,20 @@
   },
   {
     "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.14.0/jna-platform-5.14.0.jar",
+    "sha512": "6d6e5292b50c53c6b42bcf293cd28ccf32f8580e6818329604af4277e916d375e436b4f3858586f5e07a93405a930e04d88d6384bc9f1ac2d58de4bb7180faeb",
+    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.14.0",
+    "dest-filename": "jna-platform-5.14.0.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.14.0/jna-platform-5.14.0.pom",
+    "sha512": "ea83c9446d027d7b04bdb0f1786a6facb0109830fd882c21cddd333016622f072aae4b4b07016b87661d345d8770034c24c8e47873307003ef6134ffa908744c",
+    "dest": "offline-repository/net/java/dev/jna/jna-platform/5.14.0",
+    "dest-filename": "jna-platform-5.14.0.pom"
+  },
+  {
+    "type": "file",
     "url": "https://repo.maven.apache.org/maven2/net/java/dev/jna/jna-platform/5.19.1/jna-platform-5.19.1.jar",
     "sha512": "a8cdc1a080f0a11905014c125697d54815d5102f50a42380bc6b1230f229d84e44d1a0a501f12b49da90e191437259b4fa7b7e2a43bfc3b5485e8cb253c0c490",
     "dest": "offline-repository/net/java/dev/jna/jna-platform/5.19.1",
@@ -3596,6 +3610,20 @@
     "sha512": "ae58d75b40e44cb0d8e3bb701c7afefa8cbf96066ae52fc3d57c69b7a7e819fd9b3b01971376da6ea94ee010b9ee59ba05a331b93a65e94c047b095131efd6c0",
     "dest": "offline-repository/org/jetbrains/annotations/23.0.0",
     "dest-filename": "annotations-23.0.0.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/24.0.1/annotations-24.0.1.jar",
+    "sha512": "ac5879c0170b80106962881ed2d9a3d5f4b4ef0f6908806ab19c8418fab3b59e2dd7b5f03eb434544119c92c559bcab52a50dcac036b01ff4436c34411f80682",
+    "dest": "offline-repository/org/jetbrains/annotations/24.0.1",
+    "dest-filename": "annotations-24.0.1.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/annotations/24.0.1/annotations-24.0.1.pom",
+    "sha512": "1bdef3b7d9575590cbd176311b770f0f138199dc4b62b67c6bdd0d5bad7ecc3d71386255edea945d5a3b68e2446452b6104804ae88ed39a91af8573ed5491f66",
+    "dest": "offline-repository/org/jetbrains/annotations/24.0.1",
+    "dest-filename": "annotations-24.0.1.pom"
   },
   {
     "type": "file",
@@ -6571,6 +6599,27 @@
     "sha512": "d9198a2a9196d38e200ae8dabbcf3fb5dfe1be15a7da3dee2a62a528906d92fa16874f4bc17eaef983c9c50db6a6adb3814f4081b68e090948799fa41c70f0a4",
     "dest": "offline-repository/org/jetbrains/kotlinx/kotlinx-serialization-protobuf/1.7.3",
     "dest-filename": "kotlinx-serialization-protobuf-1.7.3.pom"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/pty4j/pty4j/0.13.12/pty4j-0.13.12.jar",
+    "sha512": "eac4224ed0e941d308f23653402355cc1022247d0b2ad2edf3b0a3c5f5f9bcdd4009aa5a0b90068cf4b94686fb9b876aa53d860d0324b46c3a6e71c9c685f18f",
+    "dest": "offline-repository/org/jetbrains/pty4j/pty4j/0.13.12",
+    "dest-filename": "pty4j-0.13.12.jar"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/pty4j/pty4j/0.13.12/pty4j-0.13.12.module",
+    "sha512": "70f4b3d81a29adb9daf0d23437e47f0c8dbf970dabb4caa190f6f6cd0c4105ab10138f75d94bce35e33551931df36e57cd85c40802ebe60b95402257fbb4871a",
+    "dest": "offline-repository/org/jetbrains/pty4j/pty4j/0.13.12",
+    "dest-filename": "pty4j-0.13.12.module"
+  },
+  {
+    "type": "file",
+    "url": "https://repo.maven.apache.org/maven2/org/jetbrains/pty4j/pty4j/0.13.12/pty4j-0.13.12.pom",
+    "sha512": "0e00580d5f8ceff2d42d9fc4b9ddf712a7474819dd2a43b31579200e244814f24d6fd14277706ed5402d9d766a5b9d871630184a15b677eab494cbc9a1d5d9df",
+    "dest": "offline-repository/org/jetbrains/pty4j/pty4j/0.13.12",
+    "dest-filename": "pty4j-0.13.12.pom"
   },
   {
     "type": "file",

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -10,6 +10,7 @@
     <string name="conn_field_protocol">Протокол</string>
     <string name="conn_field_host_address">Адрес хоста</string>
     <string name="conn_field_device">Устройство</string>
+    <string name="conn_field_shell_placeholder">/bin/bash — пусто для системной оболочки</string>
     <string name="conn_field_port">Порт</string>
     <string name="conn_field_baud">Скорость</string>
     <string name="conn_field_username">Пользователь</string>
@@ -39,6 +40,7 @@
     <string name="conn_protocol_telnet">Telnet</string>
     <string name="conn_protocol_serial">Serial</string>
     <string name="conn_protocol_vnc">VNC</string>
+    <string name="conn_protocol_local">Локальный</string>
     <string name="conn_telnet_plaintext_warning">Telnet не шифруется — учётные данные и содержимое сессии идут открытым текстом. Используйте SSH вне доверенной сети.</string>
     <string name="conn_vnc_plaintext_warning">VNC (RFB) не шифруется — экран и ввод идут открытым текстом. Используйте доверенную сеть или SSH-туннель.</string>
 
@@ -105,6 +107,7 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">Serial</string>
     <string name="conn_type_vnc">VNC</string>
+    <string name="conn_type_local">Локальная оболочка</string>
 
     <string name="conn_import_action">Импорт из ssh_config</string>
     <string name="conn_import_title">Импорт из ssh_config</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -206,4 +206,6 @@
     <string name="settings_about_update_available">Доступна версия %1$s</string>
     <string name="settings_about_update_open">Открыть страницу релиза</string>
     <string name="settings_update_status">Обновление %1$s</string>
+    <string name="settings_terminal_section_local_shell">Локальная оболочка</string>
+    <string name="settings_local_shell_desc">Оболочка для сессий локального терминала. Пусто — системная оболочка по умолчанию.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -115,4 +115,6 @@
     <string name="term_broadcast_none">Нет подключённых сессий</string>
     <string name="term_broadcast_selected">Выбрано %1$s из %2$s</string>
     <string name="term_broadcast_sent">Отправлено: %1$s</string>
+    <string name="local_shell_name">Локальная оболочка</string>
+    <string name="term_launch_local_shell">Запустить локальную оболочку</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -10,6 +10,7 @@
     <string name="conn_field_protocol">协议</string>
     <string name="conn_field_host_address">主机地址</string>
     <string name="conn_field_device">设备</string>
+    <string name="conn_field_shell_placeholder">/bin/bash — 留空使用默认 Shell</string>
     <string name="conn_field_port">端口</string>
     <string name="conn_field_baud">波特率</string>
     <string name="conn_field_username">用户名</string>
@@ -39,6 +40,7 @@
     <string name="conn_protocol_telnet">Telnet</string>
     <string name="conn_protocol_serial">串口</string>
     <string name="conn_protocol_vnc">VNC</string>
+    <string name="conn_protocol_local">本地</string>
     <string name="conn_telnet_plaintext_warning">Telnet 未加密 — 凭据和会话数据以明文传输。非可信网络请使用 SSH。</string>
     <string name="conn_vnc_plaintext_warning">VNC (RFB) 未加密 — 屏幕和输入以明文传输。请使用可信网络或 SSH 隧道。</string>
 
@@ -105,6 +107,7 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">串口</string>
     <string name="conn_type_vnc">VNC</string>
+    <string name="conn_type_local">本地 Shell</string>
 
     <string name="conn_import_action">从 ssh_config 导入</string>
     <string name="conn_import_title">从 ssh_config 导入</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -206,4 +206,6 @@
     <string name="settings_about_update_available">版本 %1$s 可用</string>
     <string name="settings_about_update_open">打开发布页面</string>
     <string name="settings_update_status">更新 %1$s</string>
+    <string name="settings_terminal_section_local_shell">本地 Shell</string>
+    <string name="settings_local_shell_desc">运行本地终端会话所用的 Shell。留空则使用默认 Shell。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -115,4 +115,6 @@
     <string name="term_broadcast_none">没有已连接的会话</string>
     <string name="term_broadcast_selected">已选 %1$s / %2$s</string>
     <string name="term_broadcast_sent">已发送到 %1$s</string>
+    <string name="local_shell_name">本地 Shell</string>
+    <string name="term_launch_local_shell">启动本地 Shell</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -10,6 +10,7 @@
     <string name="conn_field_protocol">Protocol</string>
     <string name="conn_field_host_address">Host address</string>
     <string name="conn_field_device">Device</string>
+    <string name="conn_field_shell_placeholder">/bin/bash — blank for the default shell</string>
     <string name="conn_field_port">Port</string>
     <string name="conn_field_baud">Baud</string>
     <string name="conn_field_username">Username</string>
@@ -39,6 +40,7 @@
     <string name="conn_protocol_telnet">Telnet</string>
     <string name="conn_protocol_serial">Serial</string>
     <string name="conn_protocol_vnc">VNC</string>
+    <string name="conn_protocol_local">Local</string>
     <string name="conn_telnet_plaintext_warning">Telnet is unencrypted — credentials and session data travel in the clear. Use SSH unless the network is trusted.</string>
     <string name="conn_vnc_plaintext_warning">VNC (RFB) is unencrypted — screen and input travel in the clear. Use a trusted network or tunnel through SSH.</string>
 
@@ -105,6 +107,7 @@
     <string name="conn_type_telnet">Telnet</string>
     <string name="conn_type_serial">Serial</string>
     <string name="conn_type_vnc">VNC</string>
+    <string name="conn_type_local">Local shell</string>
 
     <string name="conn_import_action">Import from ssh_config</string>
     <string name="conn_import_title">Import from ssh_config</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -206,4 +206,6 @@
     <string name="settings_about_update_available">Version %1$s is available</string>
     <string name="settings_about_update_open">Open release page</string>
     <string name="settings_update_status">Update %1$s</string>
+    <string name="settings_terminal_section_local_shell">Local shell</string>
+    <string name="settings_local_shell_desc">Shell run for local terminal sessions. Leave blank to use your default shell.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -115,4 +115,6 @@
     <string name="term_broadcast_none">No connected sessions</string>
     <string name="term_broadcast_selected">%1$s of %2$s selected</string>
     <string name="term_broadcast_sent">Sent to %1$s</string>
+    <string name="local_shell_name">Local shell</string>
+    <string name="term_launch_local_shell">Launch local shell</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -182,6 +182,11 @@ class DesktopDesignState(
     // App theme (Settings → Appearance). Default (night-sea dark, no-op) preserves the prior look.
     initialThemeMode: ThemeMode = ThemeMode.DEFAULT,
     private val onThemeModeChange: (ThemeMode) -> Unit = {},
+    // Shell binary for the pinned local terminal (blank = the system default shell). Device-local
+    // (a local shell is machine-specific, not synced); read from persistence, written back via the
+    // callback. Default (blank) is correct for mock/preview/tests.
+    initialLocalShellPath: String = "",
+    private val onLocalShellPathChange: (String) -> Unit = {},
     // Idle auto-lock threshold (Settings → Security). Read from persistence, written back via the
     // callback; threaded into [app.skerry.ui.vault.VaultGate] as the timer's idleMs.
     initialAutoLock: AutoLockDuration = AutoLockDuration.DEFAULT,
@@ -330,6 +335,16 @@ class DesktopDesignState(
     /** Open group management dialog (create/edit), or `null`. */
     var groupDialog: GroupDialog? by mutableStateOf(null); private set
     var selectedHost: String by mutableStateOf("prod-web-01"); private set
+
+    /** Shell binary for the local shell (blank = system default). Edited in Settings → Terminal → Local shell. */
+    var localShellPath: String by mutableStateOf(initialLocalShellPath); private set
+
+    fun chooseLocalShellPath(path: String) {
+        val normalized = path.trim()
+        if (normalized == localShellPath) return
+        localShellPath = normalized
+        onLocalShellPathChange(normalized)
+    }
 
     /** Host sidebar search text (by name/address/user/group/tags). Empty means no filter. */
     var hostSearchQuery: String by mutableStateOf(""); private set

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.connection
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshJump
 import app.skerry.shared.ssh.SshTarget
@@ -26,8 +27,13 @@ fun Host.toTarget(jump: SshJump? = null): SshTarget =
         jump = jump, keepAliveSeconds = keepAliveSeconds,
     )
 
-/** `user@addr:port` string — the session's tab/title label. */
-fun Host.connectionSubtitle(): String = "$username@$address:$port"
+/**
+ * Session tab/title subtitle. `user@addr:port` for networked profiles; a local shell has no
+ * host/user, so it shows the shell/command (blank → "local shell").
+ */
+fun Host.connectionSubtitle(): String =
+    if (connectionType == ConnectionType.LOCAL) address.ifBlank { "local shell" }
+    else "$username@$address:$port"
 
 /**
  * Keychain secret from the vault → SSH auth method. Password/key/certificate map one-to-one;

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/SectionChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/SectionChrome.kt
@@ -76,6 +76,7 @@ fun EmptyState(
     modifier: Modifier = Modifier,
     subtitle: String? = null,
     tint: Color = Skerry.colors.faint,
+    action: (@Composable () -> Unit)? = null,
 ) {
     Column(
         modifier.fillMaxSize().padding(horizontal = 32.dp),
@@ -97,6 +98,11 @@ fun EmptyState(
                 lineHeight = 19.sp,
                 align = TextAlign.Center,
             )
+        }
+        // Optional call-to-action (e.g. "Launch local shell" on the empty terminal), below the copy.
+        if (action != null) {
+            Spacer(Modifier.height(18.dp))
+            action()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -290,6 +290,8 @@ fun DesktopDesignApp(
     // App theme (Settings → Appearance) — persisted externally (desktop main).
     initialThemeMode: ThemeMode = ThemeMode.DEFAULT,
     onThemeModeChange: (ThemeMode) -> Unit = {},
+    initialLocalShellPath: String = "",
+    onLocalShellPathChange: (String) -> Unit = {},
     // Idle auto-lock threshold (Settings → Security) — persisted externally (desktop main).
     initialAutoLock: AutoLockDuration = AutoLockDuration.DEFAULT,
     onAutoLockChange: (AutoLockDuration) -> Unit = {},
@@ -313,6 +315,7 @@ fun DesktopDesignApp(
             initialTerminalTheme, onTerminalThemeChange,
             initialCustomTerminalTheme, onCustomTerminalThemeChange,
             initialThemeMode, onThemeModeChange,
+            initialLocalShellPath, onLocalShellPathChange,
             initialAutoLock, onAutoLockChange,
             initialShowRecent, onShowRecentChange,
             initialRecentLimit, onRecentLimitChange,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionTypeIcon.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionTypeIcon.kt
@@ -14,4 +14,5 @@ val ConnectionType.icon: String
         ConnectionType.TELNET -> "terminal"
         ConnectionType.SERIAL -> "cable"
         ConnectionType.VNC -> "desktop_windows"
+        ConnectionType.LOCAL -> "keyboard_command_key"
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostGrouping.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostGrouping.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_type_local
 import app.skerry.ui.generated.resources.conn_type_mosh
 import app.skerry.ui.generated.resources.conn_type_serial
 import app.skerry.ui.generated.resources.conn_type_ssh
@@ -61,5 +62,6 @@ fun connectionTypeLabel(type: ConnectionType): String = stringResource(
         ConnectionType.TELNET -> Res.string.conn_type_telnet
         ConnectionType.SERIAL -> Res.string.conn_type_serial
         ConnectionType.VNC -> Res.string.conn_type_vnc
+        ConnectionType.LOCAL -> Res.string.conn_type_local
     },
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/LocalTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/LocalTerminal.kt
@@ -1,0 +1,28 @@
+package app.skerry.ui.host
+
+import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
+
+/**
+ * Stable id of the local-terminal session. It isn't a stored profile: the host is synthesized on
+ * demand from the device-local shell path (configured in Settings → Terminal → Local shell) and
+ * launched from the empty-tab placeholder, so it can't be created, duplicated or deleted like a
+ * normal host.
+ */
+const val LOCAL_TERMINAL_HOST_ID = "__local_terminal__"
+
+/**
+ * Synthetic [Host] for the local shell, built from the device-local [shellPath] (blank → the system
+ * default shell) and a localized [label] used as the session/tab title. Not persisted in the host
+ * store; it only carries what the connect path needs ([Host.address] = the shell binary path,
+ * [ConnectionType.LOCAL]). Auth resolves to an empty password (LOCAL has no SSH auth), so opening it
+ * prompts for nothing.
+ */
+fun localTerminalHost(shellPath: String, label: String): Host = Host(
+    id = LOCAL_TERMINAL_HOST_ID,
+    label = label,
+    address = shellPath.trim(),
+    username = "",
+    connectionType = ConnectionType.LOCAL,
+    keepAliveSeconds = 0,
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -154,6 +154,8 @@ class NewConnectionFormState {
                 // VNC authenticates with an optional password (no username): base + a valid auth
                 // choice (Ask / a stored password), same secret resolution as SSH minus the username.
                 ConnectionType.VNC -> base && authValid
+                // Local shell: no address (blank = default shell), no port, no auth — only a name.
+                ConnectionType.LOCAL -> name.isNotBlank()
             }
         }
 
@@ -210,6 +212,7 @@ class NewConnectionFormState {
             ConnectionType.TELNET -> 23
             ConnectionType.SERIAL -> 9600
             ConnectionType.VNC -> 5900
+            ConnectionType.LOCAL -> 0 // no port — a local shell isn't networked
         }
 
         /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -104,6 +104,7 @@ import app.skerry.ui.generated.resources.conn_group_new
 import app.skerry.ui.generated.resources.conn_group_new_title
 import app.skerry.ui.generated.resources.conn_group_none
 import app.skerry.ui.generated.resources.conn_jump_none
+import app.skerry.ui.generated.resources.conn_protocol_local
 import app.skerry.ui.generated.resources.conn_protocol_serial
 import app.skerry.ui.generated.resources.conn_protocol_mosh
 import app.skerry.ui.generated.resources.conn_protocol_ssh
@@ -539,7 +540,9 @@ private fun ProtocolPicker(form: NewConnectionFormState) {
     ) {
         // Driven off ConnectionType.entries: a new protocol gets its segment for free, and the
         // exhaustive `when`s behind labelRes/icon fail the build until it's given a label and an icon.
-        ConnectionType.entries.forEach { type ->
+        // LOCAL is excluded: the local shell isn't a user-created profile — it's launched from the
+        // empty-tab placeholder and configured in Settings → Terminal → Local shell, not here.
+        ConnectionType.entries.filter { it != ConnectionType.LOCAL }.forEach { type ->
             ProtocolSegment(stringResource(type.labelRes), type.icon, form.connectionType == type, Modifier.weight(1f)) {
                 form.chooseConnectionType(type)
             }
@@ -555,6 +558,7 @@ private val ConnectionType.labelRes: StringResource
         ConnectionType.TELNET -> Res.string.conn_protocol_telnet
         ConnectionType.SERIAL -> Res.string.conn_protocol_serial
         ConnectionType.VNC -> Res.string.conn_protocol_vnc
+        ConnectionType.LOCAL -> Res.string.conn_protocol_local
     }
 
 /** One pill of the segmented protocol picker: the active one sits on a cyan backing. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -363,6 +363,8 @@ private fun MobileProtocolPicker(form: NewConnectionFormState) {
         MobileProtocolSegment(stringResource(Res.string.conn_protocol_telnet), form.connectionType == ConnectionType.TELNET, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.TELNET) }
         MobileProtocolSegment(stringResource(Res.string.conn_protocol_serial), form.connectionType == ConnectionType.SERIAL, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.SERIAL) }
         MobileProtocolSegment(stringResource(Res.string.conn_protocol_vnc), form.connectionType == ConnectionType.VNC, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.VNC) }
+        // LOCAL is intentionally absent — the local shell isn't a user-created profile; it's launched
+        // from the empty-tab placeholder and configured in Settings, not created here.
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -12,10 +12,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -27,8 +31,12 @@ import app.skerry.ui.design.DropdownField
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.NumberStepper
+import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_field_shell_placeholder
+import app.skerry.ui.generated.resources.settings_local_shell_desc
+import app.skerry.ui.generated.resources.settings_terminal_section_local_shell
 import app.skerry.ui.generated.resources.appearance_badge_active
 import app.skerry.ui.generated.resources.appearance_font
 import app.skerry.ui.generated.resources.appearance_font_size
@@ -171,6 +179,47 @@ internal fun TerminalSection(state: DesktopDesignState) {
         stringResource(Res.string.settings_terminal_clipboard_write_desc),
         on = state.allowServerClipboardWrite,
         onToggle = state::toggleAllowServerClipboardWrite,
+    )
+    HLine(modifier = Modifier.padding(top = 12.dp))
+    // Local shell: the shell binary run for local-terminal sessions (launched from the empty-tab
+    // placeholder). Blank uses the system default shell. Device-local, not synced with hosts.
+    SectionLabel(stringResource(Res.string.settings_terminal_section_local_shell))
+    Txt(
+        stringResource(Res.string.settings_local_shell_desc),
+        color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp,
+        modifier = Modifier.padding(bottom = 8.dp),
+    )
+    LocalShellField(state.localShellPath, onChange = state::chooseLocalShellPath)
+}
+
+/** Single-line path field for the local shell binary (Terminal → Local shell). Blank = default shell. */
+@Composable
+private fun LocalShellField(value: String, onChange: (String) -> Unit) {
+    val fonts = LocalFonts.current
+    val textColor = Skerry.colors.text
+    val textStyle = remember(fonts.ui, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = fonts.ui) }
+    val placeholder = stringResource(Res.string.conn_field_shell_placeholder)
+    BasicTextField(
+        value = value,
+        onValueChange = onChange,
+        singleLine = true,
+        textStyle = textStyle,
+        cursorBrush = SolidColor(Skerry.colors.cyan),
+        modifier = Modifier.fillMaxWidth(),
+        decorationBox = { inner ->
+            Row(
+                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg)
+                    .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Sym("terminal", size = 16.sp, color = Skerry.colors.faint)
+                Box(Modifier.weight(1f)) {
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp)
+                    inner()
+                }
+            }
+        },
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -59,6 +60,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.shared.host.Host
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.shared.ssh.ConnectionType
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.HostClickConnectMode

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -49,6 +49,9 @@ import androidx.compose.ui.window.Popup
 import app.skerry.shared.ai.AiPolicyDecision
 import app.skerry.ui.app.AiPolicy
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalConnectHost
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.host.localTerminalHost
 import app.skerry.ui.app.DesktopView
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalConnectSplit
@@ -72,6 +75,8 @@ import app.skerry.ui.generated.resources.term_connecting
 import app.skerry.ui.generated.resources.term_connection_failed
 import app.skerry.ui.generated.resources.term_connection_lost
 import app.skerry.ui.generated.resources.term_no_active_session
+import app.skerry.ui.generated.resources.term_launch_local_shell
+import app.skerry.ui.generated.resources.local_shell_name
 import app.skerry.ui.generated.resources.term_player_title
 import app.skerry.ui.generated.resources.term_no_host_selected
 import app.skerry.ui.generated.resources.term_no_hosts_in_catalog
@@ -304,22 +309,34 @@ private fun SessionToolbar(state: DesktopDesignState) {
 @Composable
 private fun TerminalPane(state: DesktopDesignState, modifier: Modifier = Modifier) {
     val sessions = LocalSessions.current
-    if (sessions != null) LiveTerminalPane(sessions, modifier) else MockTerminalPane(state, modifier)
+    if (sessions != null) LiveTerminalPane(sessions, state, modifier) else MockTerminalPane(state, modifier)
 }
 
 /** Live terminal of the active tab: renders based on its [ConnectionUiState]. */
 @Composable
-private fun LiveTerminalPane(sessions: SessionsController, modifier: Modifier = Modifier) {
+private fun LiveTerminalPane(sessions: SessionsController, state: DesktopDesignState, modifier: Modifier = Modifier) {
     val active = sessions.active
     val st = active?.controller?.uiState
     // A live or frozen screen sits on the terminal's own background; every notice (no session /
     // connecting / error) sits on the app background, so the empty terminal matches other sections.
     val onScreen = st is ConnectionUiState.Connected || st is ConnectionUiState.Disconnected
+    // "Launch local shell": on an empty terminal, open a local-shell session on this machine (its
+    // shell path comes from Settings → Terminal → Local shell). LOCAL needs no auth, so the connect
+    // reuses the current blank tab in place (SessionsController.connect).
+    val connect = LocalConnectHost.current
+    val localName = stringResource(Res.string.local_shell_name)
+    val launchLocalShell: (@Composable () -> Unit) = {
+        GhostButton(
+            stringResource(Res.string.term_launch_local_shell),
+            onClick = { connect(localTerminalHost(state.localShellPath, localName)) },
+            icon = "terminal",
+        )
+    }
     Box(modifier.fillMaxHeight().fillMaxWidth().background(if (onScreen) Skerry.colors.terminalBg else Skerry.colors.bg)) {
         when (st) {
-            null -> TerminalNotice("terminal", stringResource(Res.string.term_no_active_session), stringResource(Res.string.term_notice_pick_host_to_connect))
+            null -> TerminalNotice("terminal", stringResource(Res.string.term_no_active_session), stringResource(Res.string.term_notice_pick_host_to_connect), action = launchLocalShell)
             // Form state on the active tab means an empty ("+") tab: connection not yet started.
-            ConnectionUiState.Form -> TerminalNotice("terminal", stringResource(Res.string.term_notice_not_connected), stringResource(Res.string.term_notice_pick_or_new))
+            ConnectionUiState.Form -> TerminalNotice("terminal", stringResource(Res.string.term_notice_not_connected), stringResource(Res.string.term_notice_pick_or_new), action = launchLocalShell)
             ConnectionUiState.Connecting -> TerminalNotice("sync", stringResource(Res.string.term_connecting), active.subtitle)
             is ConnectionUiState.Connected -> TerminalScreen(st.terminal, Modifier.fillMaxSize())
             is ConnectionUiState.Error -> TerminalNotice("error", stringResource(Res.string.term_connection_failed), connectionErrorText(st), color = Skerry.colors.sunset)
@@ -364,8 +381,8 @@ private fun DisconnectedBanner(state: ConnectionUiState.Disconnected, modifier: 
  * the glyph (red for errors).
  */
 @Composable
-private fun TerminalNotice(icon: String, title: String, subtitle: String, color: Color = Skerry.colors.dim) {
-    EmptyState(icon = icon, title = title, subtitle = subtitle, tint = color)
+private fun TerminalNotice(icon: String, title: String, subtitle: String, color: Color = Skerry.colors.dim, action: (@Composable () -> Unit)? = null) {
+    EmptyState(icon = icon, title = title, subtitle = subtitle, tint = color, action = action)
 }
 
 // Split pane.

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -460,6 +460,8 @@ fun main(args: Array<String>) {
                     onCustomTerminalThemeChange = { prefs.set("custom_terminal_theme", it) },
                     initialThemeMode = currentThemeMode.value,
                     onThemeModeChange = { prefs.set("app_theme", it.id); currentThemeMode.value = it },
+                    initialLocalShellPath = prefs.id("local_shell_path", "") { it },
+                    onLocalShellPathChange = { prefs.set("local_shell_path", it) },
                     initialUiLanguage = currentUiLanguage.value,
                     onUiLanguageChange = { currentUiLanguage.value = it; prefs.set("ui_language", it.id) },
                     initialTerminalScrollback = readTerminalScrollback(prefs),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,10 @@ jserialcomm = "2.11.4"
 # usb-serial-for-android: access to USB-serial adapters (CDC/FTDI/CP210x/CH34x) via the USB Host API.
 # androidMain only — desktop uses jSerialComm.
 usbSerial = "3.11.0"
+# pty4j: real pseudo-terminal for the local-shell transport (LocalShell desktop actual). Bundles
+# native helpers for Linux/macOS/Windows and depends on JNA (compatible with jna 5.19.1 above).
+# desktopMain only — Android uses a native PTY helper.
+pty4j = "0.13.12"
 # full BouncyCastle: an sshj transitive (as implementation, not visible on the compile classpath),
 # added explicitly — on Android the system "BC" is stripped down and SshjTransport.ensureCryptoProvider replaces it
 bouncycastle = "1.85"
@@ -123,6 +127,7 @@ slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 sshj = { module = "com.hierynomus:sshj", version.ref = "sshj" }
 jserialcomm = { module = "com.fazecast:jSerialComm", version.ref = "jserialcomm" }
 usbserial = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "usbSerial" }
+pty4j = { module = "org.jetbrains.pty4j:pty4j", version.ref = "pty4j" }
 bouncycastle-prov = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bouncycastle" }
 sshd-core = { module = "org.apache.sshd:sshd-core", version.ref = "sshd" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -108,6 +108,10 @@ kotlin {
                 // Native access to serial ports (SerialSystem actual). Desktop only —
                 // on Android, serial will go over USB-OTG as a separate implementation.
                 implementation(libs.jserialcomm)
+                // Real PTY for the local-shell transport (LocalShell actual): job control, window
+                // size, raw mode on Linux/macOS/Windows. Bundles its own natives + JNA (compatible
+                // with the JNA already on the classpath). Desktop only — Android uses a native helper.
+                implementation(libs.pty4j)
             }
         }
         androidMain.dependencies {

--- a/shared/src/androidMain/kotlin/app/skerry/shared/local/LocalShell.android.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/local/LocalShell.android.kt
@@ -1,0 +1,12 @@
+package app.skerry.shared.local
+
+/**
+ * Android local shell. A real controlling PTY needs a native helper (`forkpty`+`setsid`+
+ * `TIOCSCTTY`+`execvp` done entirely in native code — `fork()` in a JVM is unsafe to follow with a
+ * Kotlin `exec`), which is delivered separately. Until then, starting a local terminal on Android
+ * reports unavailable; the surrounding transport turns this into a clear connect error.
+ */
+actual object LocalShell {
+    actual fun start(config: LocalShellConfig): LocalShellHandle =
+        throw LocalShellUnavailableException("Local terminal is not yet supported on Android")
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
@@ -11,7 +11,10 @@ import kotlinx.serialization.Serializable
  * profile `address` holds the device name and `port` holds the baud rate. [VNC] — remote desktop
  * over the RFB protocol (framebuffer + input, not a byte stream): `address`/`port` name the RFB
  * server (default 5900), `credentialId` holds the optional VNC password (no username); it does not
- * flow through the shell/terminal stack (see [app.skerry.shared.vnc.VncTransport]).
+ * flow through the shell/terminal stack (see [app.skerry.shared.vnc.VncTransport]). [LOCAL] — a
+ * local shell over a pseudo-terminal on this machine (no network): `address` optionally holds the
+ * path to the shell binary to run (blank → the system default shell), `port`/`username`/`credentialId`/jump/
+ * keep-alive are unused and there is no authentication (see [app.skerry.shared.local.LocalShellTransport]).
  *
  * Lives in package `ssh` as a transport tag: [SshTarget.connectionType] feeds it to the transport
  * router ([RoutingTransport]), [app.skerry.shared.host.Host.connectionType] to the profile.
@@ -19,7 +22,7 @@ import kotlinx.serialization.Serializable
  * compatibility; a missing field in old files defaults to [SSH].
  */
 @Serializable
-enum class ConnectionType { SSH, MOSH, TELNET, SERIAL, VNC }
+enum class ConnectionType { SSH, MOSH, TELNET, SERIAL, VNC, LOCAL }
 
 /**
  * Whether the profile authenticates over SSH: username/credentials/jump host apply. True for

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/local/LocalShell.desktop.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/local/LocalShell.desktop.kt
@@ -1,0 +1,74 @@
+package app.skerry.shared.local
+
+import app.skerry.shared.ai.local.LlmHostCommandLine
+import com.pty4j.PtyProcess
+import com.pty4j.PtyProcessBuilder
+import com.pty4j.WinSize
+import java.util.concurrent.TimeUnit
+
+/**
+ * Desktop local shell via pty4j (real PTY with job control and window size on Linux/macOS/Windows).
+ * The child inherits the user's environment minus the jpackage relaunch marker (see
+ * [LlmHostCommandLine.scrubEnvironment]) so packaging internals don't leak into their shell, with
+ * `TERM` defaulted for programs that key off it.
+ */
+actual object LocalShell {
+    actual fun start(config: LocalShellConfig): LocalShellHandle {
+        val command = config.command.ifEmpty { listOf(defaultShell()) }
+        val environment = HashMap(System.getenv())
+        LlmHostCommandLine.scrubEnvironment(environment)
+        environment.putIfAbsent("TERM", "xterm-256color")
+        environment.putAll(config.env)
+        val process = try {
+            PtyProcessBuilder(command.toTypedArray())
+                .setEnvironment(environment)
+                .setDirectory(config.workingDir ?: System.getProperty("user.home"))
+                .setInitialColumns(config.cols)
+                .setInitialRows(config.rows)
+                .setConsole(false)
+                .start()
+        } catch (e: Exception) {
+            throw LocalShellUnavailableException(
+                "Failed to start local shell (${command.firstOrNull() ?: "?"})",
+                e,
+            )
+        }
+        return Pty4jHandle(process)
+    }
+
+    private fun defaultShell(): String {
+        val windows = System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+        return if (windows) System.getenv("COMSPEC") ?: "cmd.exe"
+        else System.getenv("SHELL") ?: "/bin/sh"
+    }
+}
+
+private class Pty4jHandle(private val process: PtyProcess) : LocalShellHandle {
+    private val input = process.inputStream
+    private val output = process.outputStream
+
+    override val isOpen: Boolean get() = process.isAlive
+
+    override fun read(buffer: ByteArray): Int = input.read(buffer)
+
+    override fun write(data: ByteArray) {
+        output.write(data)
+        output.flush()
+    }
+
+    override fun resize(cols: Int, rows: Int) {
+        process.winSize = WinSize(cols, rows)
+    }
+
+    override fun close() {
+        // Terminate and reap: destroy() (SIGHUP-equivalent) then a bounded wait; if the child
+        // ignores it, escalate to a forcible kill so repeated open/close cycles can't leak
+        // orphaned processes. All wrapped so close() itself never hangs or throws.
+        runCatching { process.destroy() }
+        runCatching {
+            if (!process.waitFor(1, TimeUnit.SECONDS)) process.destroyForcibly()
+        }
+        runCatching { input.close() }
+        runCatching { output.close() }
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/local/LocalShellTransportTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/local/LocalShellTransportTest.kt
@@ -1,0 +1,133 @@
+package app.skerry.shared.local
+
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshConnectionException
+import app.skerry.shared.ssh.SshTarget
+import java.io.ByteArrayOutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+
+private const val TIMEOUT_MS = 15_000L
+
+/**
+ * Local-shell transport tests. The transport logic (byte forwarding, resize propagation, clean-EOF
+ * on process exit, unavailability) runs against a stand-in [LocalShellHandle] backed by in-memory
+ * pipes — no real process. A separate integration test drives a real `/bin/sh` through pty4j.
+ */
+class LocalShellTransportTest {
+
+    /**
+     * Fake shell: [deviceToApp] is the "process stdout" (test writes into it), reads drain it;
+     * writes accumulate; [resizedTo] records the last window size. Closing the writer (via
+     * [endClean]) yields `read == -1` — the clean-exit path; [close] tears both ends down.
+     */
+    private class FakeHandle : LocalShellHandle {
+        val deviceToApp = PipedOutputStream()
+        private val appReads = PipedInputStream(deviceToApp)
+        val written = ByteArrayOutputStream()
+        var resizedTo: Pair<Int, Int>? = null
+            private set
+        private var open = true
+        override val isOpen: Boolean get() = open
+        override fun read(buffer: ByteArray): Int = appReads.read(buffer)
+        override fun write(data: ByteArray) { written.write(data); written.flush() }
+        override fun resize(cols: Int, rows: Int) { resizedTo = cols to rows }
+        /** Simulate the shell process exiting cleanly: EOF on the read side. */
+        fun endClean() { runCatching { deviceToApp.close() } }
+        override fun close() {
+            open = false
+            runCatching { deviceToApp.close() }
+            runCatching { appReads.close() }
+        }
+    }
+
+    private fun transport(handle: LocalShellHandle) = LocalShellTransport(start = { handle })
+
+    @Test
+    fun `bytes written to the channel reach the shell`() = runBlocking {
+        val handle = FakeHandle()
+        val conn = transport(handle).connect(localTarget(), SshAuth.Password(""))
+        val shell = conn.openShell(PtySize())
+        withTimeout(TIMEOUT_MS) { shell.write("ls\n".encodeToByteArray()) }
+        assertEquals("ls\n", handle.written.toByteArray().decodeToString())
+        conn.disconnect()
+    }
+
+    @Test
+    fun `bytes from the shell reach the terminal output`() = runBlocking {
+        val handle = FakeHandle()
+        val conn = transport(handle).connect(localTarget(), SshAuth.Password(""))
+        val shell = conn.openShell(PtySize())
+        withTimeout(TIMEOUT_MS) {
+            handle.deviceToApp.write("hello\n".encodeToByteArray())
+            handle.deviceToApp.flush()
+            val received = StringBuilder()
+            shell.output.first { chunk ->
+                received.append(chunk.decodeToString())
+                received.contains("hello\n")
+            }
+        }
+        conn.disconnect()
+    }
+
+    @Test
+    fun `resize propagates the window size to the shell`() = runBlocking {
+        val handle = FakeHandle()
+        val conn = transport(handle).connect(localTarget(), SshAuth.Password(""))
+        val shell = conn.openShell(PtySize(cols = 80, rows = 24))
+        withTimeout(TIMEOUT_MS) { shell.resize(PtySize(cols = 120, rows = 40)) }
+        assertEquals(120 to 40, handle.resizedTo)
+        conn.disconnect()
+    }
+
+    @Test
+    fun `shell process exit is reported as a clean EOF`() = runBlocking {
+        val handle = FakeHandle()
+        val conn = transport(handle).connect(localTarget(), SshAuth.Password(""))
+        val shell = conn.openShell(PtySize())
+        withTimeout(TIMEOUT_MS) {
+            handle.endClean()
+            shell.output.collect { }
+        }
+        assertTrue(shell.endedWithEof, "process exit (read == -1) must mark endedWithEof")
+        conn.disconnect()
+    }
+
+    @Test
+    fun `unavailable platform surfaces as a connection exception`() = runBlocking<Unit> {
+        val transport = LocalShellTransport(start = {
+            throw LocalShellUnavailableException("Local terminal is not yet supported on Android")
+        })
+        val conn = transport.connect(localTarget(), SshAuth.Password(""))
+        assertFailsWith<SshConnectionException> { conn.openShell(PtySize()) }
+    }
+
+    @Test
+    fun `real shell over pty4j echoes output and ends on exit`() {
+        val shell = java.io.File("/bin/sh")
+        if (!shell.exists()) return // integration test is Unix-only
+        runBlocking {
+            val conn = LocalShellTransport().connect(SshTarget(host = shell.path, username = ""), SshAuth.Password(""))
+            val channel = conn.openShell(PtySize(cols = 80, rows = 24))
+            withTimeout(TIMEOUT_MS) {
+                channel.write("printf abc123\n".encodeToByteArray())
+                val received = StringBuilder()
+                channel.output.first { chunk ->
+                    received.append(chunk.decodeToString())
+                    received.contains("abc123")
+                }
+            }
+            conn.disconnect()
+        }
+    }
+
+    private fun localTarget() = SshTarget(host = "", username = "")
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/local/LocalShell.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/local/LocalShell.kt
@@ -1,0 +1,47 @@
+package app.skerry.shared.local
+
+/**
+ * Parameters for starting a local shell over a pseudo-terminal. [command] is the argv to exec; an
+ * empty list means "the platform default shell" (resolved by the actual: `$SHELL`/`/bin/sh` on
+ * Unix, `%COMSPEC%` on Windows). [cols]/[rows] are the initial PTY window size. [workingDir] is the
+ * child's working directory (`null` → the user's home). [env] are extra environment overrides
+ * layered on top of the (scrubbed) inherited environment.
+ */
+data class LocalShellConfig(
+    val command: List<String> = emptyList(),
+    val cols: Int = 80,
+    val rows: Int = 24,
+    val workingDir: String? = null,
+    val env: Map<String, String> = emptyMap(),
+)
+
+/**
+ * An open local shell on a pseudo-terminal — blocking byte-IO plus window resize. Implemented per
+ * platform ([LocalShell]): desktop via pty4j, Android via a native PTY helper. [read] blocks until
+ * output arrives, returning the byte count or `-1` when the shell process has exited (clean EOF).
+ * [resize] applies the terminal window size (`TIOCSWINSZ`) so full-screen programs (vi/top) redraw.
+ */
+interface LocalShellHandle {
+    val isOpen: Boolean
+    fun read(buffer: ByteArray): Int
+    fun write(data: ByteArray)
+    fun resize(cols: Int, rows: Int)
+    fun close()
+}
+
+/**
+ * Platform launcher for a local shell on a PTY. Lives in the JVM node (desktop + Android); the
+ * desktop actual uses pty4j, Android uses a native helper. [LocalShellUnavailableException] signals
+ * the platform can't provide a local terminal (e.g. not yet implemented).
+ */
+expect object LocalShell {
+    /**
+     * Start a shell described by [config].
+     * @throws LocalShellUnavailableException the platform has no local terminal support
+     */
+    fun start(config: LocalShellConfig): LocalShellHandle
+}
+
+/** The platform can't start a local shell (no PTY support / not implemented on this target). */
+class LocalShellUnavailableException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/local/LocalShellTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/local/LocalShellTransport.kt
@@ -1,0 +1,114 @@
+package app.skerry.shared.local
+
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.ssh.ShellChannel
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshConnectionException
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.ssh.StreamOnlyConnection
+import app.skerry.shared.ssh.StreamShellChannel
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * Local shell transport implementing the same [SshTransport] contract as SSH/Telnet/Serial, so the
+ * terminal/session stack is reused unchanged. There is no network and no authentication —
+ * [SshAuth] is ignored. SSH-only capabilities (SFTP, forwarding, exec) are absent and throw
+ * [UnsupportedOperationException].
+ *
+ * Configuration comes via [SshTarget]: [SshTarget.host] carries the path to the shell binary to run
+ * (a single executable, not a command line — blank → the platform default shell);
+ * [SshTarget.port]/[SshTarget.username] are unused. Starting is
+ * delegated to the platform [LocalShell]; [start] is injectable for tests (defaults to a real PTY).
+ */
+class LocalShellTransport(
+    private val start: (LocalShellConfig) -> LocalShellHandle = { LocalShell.start(it) },
+) : SshTransport {
+
+    override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection =
+        withContext(Dispatchers.IO) {
+            val command = target.host.trim().takeIf { it.isNotEmpty() }?.let { listOf(it) } ?: emptyList()
+            LocalShellConnection(start, command)
+        }
+}
+
+/**
+ * Connection over a single local shell: one interactive stream. The PTY isn't started until
+ * [openShell] (which carries the initial window size). SSH capabilities a local shell lacks (exec,
+ * SFTP, forwarding) are thrown by the base [StreamOnlyConnection].
+ */
+private class LocalShellConnection(
+    private val start: (LocalShellConfig) -> LocalShellHandle,
+    private val command: List<String>,
+) : StreamOnlyConnection("Local shell") {
+
+    private val shellOpened = AtomicBoolean(false)
+
+    @Volatile private var handle: LocalShellHandle? = null
+
+    // The PTY is spawned lazily in openShell (it needs the initial window size), so before that the
+    // connection reports connected (true) with no process yet — mirror this if adding health checks.
+    override val isConnected: Boolean get() = handle?.isOpen ?: true
+
+    override suspend fun openShell(size: PtySize, term: String): ShellChannel {
+        check(shellOpened.compareAndSet(false, true)) { "Local shell already started its stream" }
+        val started = withContext(Dispatchers.IO) {
+            try {
+                start(LocalShellConfig(command = command, cols = size.cols, rows = size.rows))
+            } catch (e: LocalShellUnavailableException) {
+                throw SshConnectionException(e.message ?: "Local terminal is not available", e)
+            }
+        }
+        handle = started
+        return LocalShellChannel(started)
+    }
+
+    override suspend fun disconnect() {
+        withContext(Dispatchers.IO) { runCatching { handle?.close() } }
+    }
+}
+
+/**
+ * Interactive local shell stream. The read-loop/close scaffolding lives in [StreamShellChannel]:
+ * pty4j's blocking read ignores Thread.interrupt (unblockReadOnCancel = true — cancelling the
+ * collector closes the shell), and `read < 0` means the shell process exited, which is a clean EOF
+ * like an SSH `exit` (eofOnStreamEnd = true, the default). Writes are serialized via [writeLock].
+ * Unlike serial, a local PTY has a window size — [resize] applies it.
+ */
+private class LocalShellChannel(private val handle: LocalShellHandle) :
+    StreamShellChannel(unblockReadOnCancel = true) {
+
+    private val writeLock = Mutex()
+
+    override val isOpen: Boolean get() = handle.isOpen
+
+    override fun readBlocking(buffer: ByteArray): Int = handle.read(buffer)
+
+    override fun closeSource() {
+        runCatching { handle.close() } // unblocks read in output
+    }
+
+    override suspend fun write(data: ByteArray) = withContext(Dispatchers.IO) {
+        writeLock.withLock {
+            try {
+                handle.write(data)
+                countBytesUp(data.size)
+            } catch (e: IOException) {
+                throw SshConnectionException("Failed to write to the local shell", e)
+            }
+        }
+    }
+
+    override suspend fun resize(size: PtySize) = withContext(Dispatchers.IO) {
+        // A local shell that has already exited can't be resized — swallow the native error rather
+        // than surfacing it as a connection failure (the terminal is already closing).
+        runCatching { handle.resize(size.cols, size.rows) }
+        Unit
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/RoutingTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/RoutingTransport.kt
@@ -1,24 +1,26 @@
 package app.skerry.shared.ssh
 
+import app.skerry.shared.local.LocalShellTransport
 import app.skerry.shared.mosh.MoshTransport
 import app.skerry.shared.serial.SerialTransport
 import app.skerry.shared.telnet.TelnetTransport
 
 /**
  * Transport router: delegates connection setup to the right implementation — SSH (sshj), Mosh,
- * Telnet or Serial — based on [SshTarget.connectionType]. Keeps the session/terminal/reconnect
- * stack (`ConnectionController` in the UI layer) working over any of them through a single call
- * site.
+ * Telnet, Serial or a local shell — based on [SshTarget.connectionType]. Keeps the
+ * session/terminal/reconnect stack (`ConnectionController` in the UI layer) working over any of them
+ * through a single call site.
  *
  * [ssh] is injected from outside (carries its own [HostKeyVerifier]/known-hosts); Mosh bootstraps
- * over that same SSH transport, so host-key trust and ProxyJump behave identically. Telnet/Serial
- * are stateless and default-constructed, but can be swapped in tests too.
+ * over that same SSH transport, so host-key trust and ProxyJump behave identically. Telnet/Serial/
+ * Local are stateless and default-constructed, but can be swapped in tests too.
  */
 class RoutingTransport(
     private val ssh: SshTransport,
     private val telnet: SshTransport = TelnetTransport(),
     private val serial: SshTransport = SerialTransport(),
     private val mosh: SshTransport = MoshTransport(ssh),
+    private val local: SshTransport = LocalShellTransport(),
 ) : SshTransport {
 
     override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection =
@@ -27,6 +29,7 @@ class RoutingTransport(
             ConnectionType.MOSH -> mosh.connect(target, auth)
             ConnectionType.TELNET -> telnet.connect(target, auth)
             ConnectionType.SERIAL -> serial.connect(target, auth)
+            ConnectionType.LOCAL -> local.connect(target, auth)
             // VNC is a framebuffer protocol, not a shell/terminal one — it has its own transport
             // (app.skerry.shared.vnc.VncTransport) and never reaches this SSH-shaped router.
             ConnectionType.VNC ->


### PR DESCRIPTION
Adds a local shell over a PTY on the machine running Skerry.

**Launch** — from the empty-tab placeholder ("Launch local shell"), not the New connection form. A local shell is not a saved host: it opens ephemerally into the current blank tab and needs no auth.

**Configure** — Settings → Terminal → Local shell: the shell binary path (blank = system default shell), persisted device-local.

**Transport** — `ConnectionType.LOCAL` reuses the SSH-shaped session/terminal stack through `LocalShellTransport`, routed by `RoutingTransport`. Desktop runs a real PTY via pty4j (job control, window resize, env scrubbed of the jpackage relaunch marker). Android reports unavailable for now (native `forkpty` helper pending).

**Naming** — "Local shell" across the UI (en/ru/zh).

Also in this PR:
- `EmptyState` gains an optional `action` slot for the placeholder CTA.
- `LocalShellTransportTest` covers the transport wiring.
- `flatpak-sources.json` regenerated to vendor pty4j (+ jna-platform, jetbrains annotations) for the hermetic offline Flatpak build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)