### PR TITLE
fix(desktop): double-click on the titlebar maximizes the window in place

### DIFF
--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
@@ -1,0 +1,62 @@
+package app.skerry.ui.desktop
+
+import java.awt.Point
+
+/**
+ * Where a titlebar drag should put the window, for the in-app drag used on platforms the window
+ * manager can't do it for (see [NativeWindowMove]). Fed absolute pointer positions, it answers with
+ * the window origin to apply, or `null` while the window has to stay put.
+ *
+ * Two cases deliberately stay put: a press that hasn't left [deadZone] yet, so a plain click and the
+ * double-click-to-maximize gesture never nudge the window, and a window that stopped floating
+ * mid-gesture — the double-click maximizes it while the button is still down, and following the
+ * pointer from the pre-maximize origin would then park a screen-sized window at the old top-left,
+ * pushing its right/bottom edges off-screen.
+ */
+class WindowDragGesture(private val deadZone: Int) {
+
+    private var pressedAt: Point? = null
+
+    /** Window origin minus pointer, captured once the drag leaves the dead zone; `null` until then. */
+    private var grab: Point? = null
+
+    /** Button pressed at absolute [pointer]; arms the gesture. */
+    fun press(pointer: Point) {
+        pressedAt = Point(pointer)
+        grab = null
+    }
+
+    /**
+     * Pointer moved to absolute [pointer] with the button still down. [windowOrigin] is the window's
+     * current top-left, [floating] whether it is still in the floating placement. Returns the origin
+     * to move the window to, or `null` to leave it alone.
+     */
+    fun drag(pointer: Point, windowOrigin: Point, floating: Boolean): Point? {
+        // Maximized mid-gesture: this drag is over, and a later restore must not resume it either
+        // (the grab it captured belongs to the floating window that no longer exists).
+        if (!floating) {
+            release()
+            return null
+        }
+        val pressedAt = this.pressedAt ?: return null
+        val grab = this.grab
+        if (grab == null) {
+            if (!leftDeadZone(pressedAt, pointer)) return null
+            this.grab = Point(windowOrigin.x - pointer.x, windowOrigin.y - pointer.y)
+            return null
+        }
+        return Point(pointer.x + grab.x, pointer.y + grab.y)
+    }
+
+    /** Button released: [drag] does nothing until the next [press]. */
+    fun release() {
+        pressedAt = null
+        grab = null
+    }
+
+    private fun leftDeadZone(from: Point, to: Point): Boolean {
+        val dx = to.x - from.x
+        val dy = to.y - from.y
+        return dx * dx + dy * dy >= deadZone * deadZone
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.window.WindowDraggableArea
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -27,10 +26,10 @@ import java.awt.Cursor
 import java.awt.MouseInfo
 
 /**
- * Custom chrome for the undecorated main window: dragging via [WindowDraggableArea] (with
- * double-click on empty titlebar space toggling maximize), minimize/maximize through
- * [WindowState], close via [exit]. A maximized window is not draggable (only double-click
- * restores it) — moving a maximized AWT window would desync placement from the real bounds.
+ * Custom chrome for the undecorated main window: dragging the empty titlebar space (with
+ * double-click on it toggling maximize), minimize/maximize through [WindowState], close via [exit].
+ * A maximized window is not draggable (only double-click restores it) — moving a maximized AWT
+ * window would desync placement from the real bounds.
  */
 @Composable
 fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit): WindowChrome {
@@ -41,8 +40,9 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
                 if (state.placement == WindowPlacement.Maximized) WindowPlacement.Floating
                 else WindowPlacement.Maximized
         }
+        val isFloating = { state.placement == WindowPlacement.Floating }
         // On X11 the WM moves the window itself (smooth, compositor-driven — see NativeWindowMove);
-        // elsewhere fall back to Compose's frame-by-frame WindowDraggableArea.
+        // elsewhere fall back to moving it frame by frame from the app thread.
         val useNativeMove = NativeWindowMove.isAvailable()
         WindowChrome(
             isMaximized = { state.placement == WindowPlacement.Maximized },
@@ -54,12 +54,42 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
                 when {
                     state.placement == WindowPlacement.Maximized -> Box(doubleClick) { content() }
                     useNativeMove -> Box(doubleClick.then(Modifier.nativeWindowDrag(awtWindow))) { content() }
-                    else -> WindowDraggableArea(doubleClick) { content() }
+                    else -> Box(doubleClick.then(Modifier.inAppWindowDrag(awtWindow, isFloating))) { content() }
                 }
             },
         )
     }
 }
+
+/**
+ * Moves the window frame by frame from the app thread, for platforms without [NativeWindowMove].
+ * Gated by [WindowDragGesture] (dead zone, floating only), and driven by absolute pointer positions
+ * ([MouseInfo]) because local ones shift together with the window and would feed back. [isFloating]
+ * is read per event, so a double-click that maximizes the window mid-gesture stops the drag instead
+ * of dragging the now screen-sized window back to the floating origin (issue #76). Only unconsumed
+ * presses arm it, so buttons/tabs that consume their own press are excluded.
+ */
+private fun Modifier.inAppWindowDrag(window: java.awt.Window, isFloating: () -> Boolean): Modifier =
+    pointerInput(window) {
+        val gesture = WindowDragGesture(viewConfiguration.touchSlop.toInt())
+        awaitEachGesture {
+            awaitFirstDown(requireUnconsumed = true)
+            gesture.press(MouseInfo.getPointerInfo()?.location ?: return@awaitEachGesture)
+            try {
+                while (true) {
+                    val event = awaitPointerEvent()
+                    val change = event.changes.firstOrNull() ?: break
+                    if (!change.pressed) break
+                    val pointer = MouseInfo.getPointerInfo()?.location ?: continue
+                    val target = gesture.drag(pointer, window.location, isFloating()) ?: continue
+                    change.consume()
+                    window.setLocation(target.x, target.y)
+                }
+            } finally {
+                gesture.release()
+            }
+        }
+    }
 
 /**
  * Starts a native WM drag ([NativeWindowMove]) once the pointer moves past touch-slop from the

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
@@ -1,0 +1,76 @@
+package app.skerry.ui.desktop
+
+import java.awt.Point
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WindowDragGestureTest {
+
+    private val deadZone = 18
+    private val origin = Point(100, 200)
+
+    private fun gesture(pressAt: Point = Point(500, 20)) =
+        WindowDragGesture(deadZone).apply { press(pressAt) }
+
+    @Test
+    fun pointerInsideDeadZoneDoesNotMoveTheWindow() {
+        val gesture = gesture(Point(500, 20))
+        assertNull(gesture.drag(Point(502, 21), origin, floating = true))
+        assertNull(gesture.drag(Point(500, 20), origin, floating = true))
+    }
+
+    @Test
+    fun dragPastDeadZoneFollowsThePointer() {
+        val gesture = gesture(Point(500, 20))
+        // The crossing event itself only arms the drag (the window stays where it is)...
+        assertNull(gesture.drag(Point(530, 20), origin, floating = true))
+        // ...and from there the origin follows the pointer delta measured from the crossing point.
+        assertEquals(Point(140, 215), gesture.drag(Point(570, 35), origin, floating = true))
+    }
+
+    /** Issue #76: the double-click maximizes the window while the button is still down. */
+    @Test
+    fun windowMaximizedMidGestureIsNeverMoved() {
+        val gesture = gesture(Point(500, 20))
+        // The maximized window sits at (0,0); moves keep arriving until the button goes up, and not
+        // one of them may reposition it (the second one is what a leaked drag would answer).
+        assertNull(gesture.drag(Point(560, 40), Point(0, 0), floating = false))
+        assertNull(gesture.drag(Point(600, 80), Point(0, 0), floating = false))
+        assertNull(gesture.drag(Point(900, 400), Point(0, 0), floating = false))
+    }
+
+    @Test
+    fun maximizingMidGestureEndsTheGestureForGood() {
+        val gesture = gesture(Point(500, 20))
+        gesture.drag(Point(505, 25), origin, floating = false)
+        // Placement flips back to floating (restore) without releasing the button: still no move,
+        // otherwise the window would jump to a stale origin captured before the maximize.
+        assertNull(gesture.drag(Point(600, 120), origin, floating = true))
+        assertNull(gesture.drag(Point(700, 220), origin, floating = true))
+    }
+
+    @Test
+    fun dragAfterAnAbortedGestureWorksAgain() {
+        val gesture = gesture(Point(500, 20))
+        gesture.drag(Point(505, 25), origin, floating = false)
+        gesture.release()
+        gesture.press(Point(400, 30))
+        assertNull(gesture.drag(Point(440, 30), origin, floating = true))
+        assertEquals(Point(110, 200), gesture.drag(Point(450, 30), origin, floating = true))
+    }
+
+    @Test
+    fun dragWithoutPressIsIgnored() {
+        val gesture = WindowDragGesture(deadZone)
+        assertNull(gesture.drag(Point(900, 400), origin, floating = true))
+    }
+
+    @Test
+    fun releasedGestureStopsFollowingThePointer() {
+        val gesture = gesture(Point(500, 20))
+        gesture.drag(Point(530, 20), origin, floating = true)
+        gesture.release()
+        assertNull(gesture.drag(Point(560, 20), origin, floating = true))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
@@ -43,10 +43,14 @@ class WindowDragGestureTest {
     @Test
     fun maximizingMidGestureEndsTheGestureForGood() {
         val gesture = gesture(Point(500, 20))
-        gesture.drag(Point(505, 25), origin, floating = false)
+        // A drag is already under way — past the dead zone, window following the pointer...
+        assertNull(gesture.drag(Point(530, 20), origin, floating = true))
+        assertEquals(Point(140, 215), gesture.drag(Point(570, 35), origin, floating = true))
+        // ...when the window stops floating (double-click, or the WM's own drag-to-top maximize).
+        assertNull(gesture.drag(Point(600, 80), origin, floating = false))
         // Placement flips back to floating (restore) without releasing the button: still no move,
-        // otherwise the window would jump to a stale origin captured before the maximize.
-        assertNull(gesture.drag(Point(600, 120), origin, floating = true))
+        // otherwise the window would jump to the stale grab captured before the maximize.
+        assertNull(gesture.drag(Point(650, 130), origin, floating = true))
         assertNull(gesture.drag(Point(700, 220), origin, floating = true))
     }
 


### PR DESCRIPTION
Double-clicking the empty titlebar space now maximizes the window properly instead of leaving it at its floating position with the maximized size, its right and bottom edges pushed off-screen (Windows, macOS).

The in-app titlebar drag — the fallback used where the window manager can't take the move over (everything but Linux/X11) — no longer goes through `WindowDraggableArea`. That one repositioned the window on every AWT `mouseDragged` event from the origin recorded at press time, so the maximize triggered by the second click was immediately undone: the drag put the now screen-sized window back at the floating top-left. On X11 the same path instead nudged the window and dropped the maximize altogether, because Mutter un-maximizes a window moved programmatically.

The drag is now driven by `WindowDragGesture` (`composeApp/src/desktopMain/.../WindowDrag.kt`):

- a dead zone (the window's own touch slop) — a click, and the double-click-to-maximize gesture, never nudge the window;
- a floating-only check read per pointer event — a window that stops floating mid-gesture is never repositioned, and a restore within the same gesture doesn't resume the drag either.

Titlebar dragging, the maximize/restore button and the X11 path (`NativeWindowMove`) are unchanged.

Part of #76 (the notes/remarks field from the issue body is not in this PR).

Verified: `WindowDragGestureTest` (7 cases, including a negative run with the guard removed); the old behaviour reproduced locally on the forced fallback path. Live confirmation of the fallback drag on Windows is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)