### PR TITLE
Optional notes on a connection profile

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -17,6 +17,8 @@
     <string name="conn_field_authentication">Аутентификация</string>
     <string name="conn_field_group">Группа</string>
     <string name="conn_field_tags">Теги</string>
+    <string name="conn_field_notes">Заметки</string>
+    <string name="conn_notes_placeholder">Окно обслуживания, владелец — всё, что стоит помнить</string>
     <string name="conn_field_jump_host">Прыжковый хост</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
     <string name="conn_field_ai_policy">Политика AI для этого подключения</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shtail.xml
@@ -16,6 +16,7 @@
     <string name="shtail_host_ask_on_connect">Спрашивать при подключении</string>
     <string name="shtail_host_group">Группа</string>
     <string name="shtail_host_jump">Прыжковый хост</string>
+    <string name="shtail_host_notes">Заметки</string>
 
     <!-- Host grouping: synthetic bucket for hosts without a group (display only) -->
     <string name="shtail_ungrouped">Без группы</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -17,6 +17,8 @@
     <string name="conn_field_authentication">认证方式</string>
     <string name="conn_field_group">分组</string>
     <string name="conn_field_tags">标签</string>
+    <string name="conn_field_notes">备注</string>
+    <string name="conn_notes_placeholder">维护窗口、负责人，以及任何值得记住的信息</string>
     <string name="conn_field_jump_host">跳板主机</string>
     <string name="conn_field_keep_alive">保活</string>
     <string name="conn_field_ai_policy">此连接的 AI 策略</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shtail.xml
@@ -16,6 +16,7 @@
     <string name="shtail_host_ask_on_connect">连接时询问</string>
     <string name="shtail_host_group">分组</string>
     <string name="shtail_host_jump">跳板主机</string>
+    <string name="shtail_host_notes">备注</string>
 
     <!-- 主机分组：无分组主机的合成桶（仅显示） -->
     <string name="shtail_ungrouped">未分组</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -17,6 +17,8 @@
     <string name="conn_field_authentication">Authentication</string>
     <string name="conn_field_group">Group</string>
     <string name="conn_field_tags">Tags</string>
+    <string name="conn_field_notes">Notes</string>
+    <string name="conn_notes_placeholder">Maintenance window, owner, anything worth remembering</string>
     <string name="conn_field_jump_host">Jump host</string>
     <string name="conn_field_keep_alive">Keep-alive</string>
     <string name="conn_field_ai_policy">AI policy for this connection</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shtail.xml
@@ -16,6 +16,7 @@
     <string name="shtail_host_ask_on_connect">Ask on connect</string>
     <string name="shtail_host_group">Group</string>
     <string name="shtail_host_jump">Jump host</string>
+    <string name="shtail_host_notes">Notes</string>
 
     <!-- Host grouping: synthetic bucket for hosts without a group (display only) -->
     <string name="shtail_ungrouped">Ungrouped</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -271,13 +272,18 @@ fun IconBtn(
         contentAlignment = Alignment.Center,
     ) {
         Sym(name, size = icon, color = if (hovered && hoverTint != null) hoverTint else tint)
-        if (tooltip != null && hovered) IconTooltip(tooltip)
+        if (tooltip != null && hovered) HoverTooltip(tooltip)
     }
 }
 
-/** Hover tooltip shown centered just below its icon button (toolbar icons carry no visible label). */
+/**
+ * Hover tooltip shown centered just below its anchor (toolbar icons carry no visible label; host
+ * rows in the sidebar show their note this way). The caller decides when it's visible — render it
+ * inside the hovered element's [Box]. Long text wraps at [maxWidth] and is cut off after
+ * [maxLines]: a tooltip is a peek, not a reader.
+ */
 @Composable
-private fun IconTooltip(text: String) {
+fun HoverTooltip(text: String, maxWidth: Dp = 260.dp, maxLines: Int = 8) {
     val gap = with(LocalDensity.current) { 6.dp.roundToPx() }
     val position = remember(gap) {
         object : PopupPositionProvider {
@@ -295,12 +301,17 @@ private fun IconTooltip(text: String) {
     Popup(popupPositionProvider = position, properties = PopupProperties(focusable = false)) {
         Box(
             Modifier
+                .widthIn(max = maxWidth)
                 .clip(RoundedCornerShape(6.dp))
                 .background(Skerry.colors.railBg)
                 .border(1.dp, Skerry.colors.cyan.copy(alpha = 0.18f), RoundedCornerShape(6.dp))
                 .padding(horizontal = 10.dp, vertical = 5.dp),
         ) {
-            Txt(text, color = Skerry.colors.textBright, size = 11.sp, weight = FontWeight.Medium)
+            Txt(
+                text,
+                color = Skerry.colors.textBright, size = 11.sp, weight = FontWeight.Medium, lineHeight = 15.sp,
+                maxLines = maxLines, overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
@@ -39,7 +39,7 @@ fun hostTagChipLabel(tag: String): String = "#$tag"
 
 /**
  * Narrow [hosts] by the active chip ([activeChip] = tag, `All` = no filter) and [query] (AND).
- * Case-insensitive search across name/address/username/group/tags.
+ * Case-insensitive search across name/address/username/group/tags/notes.
  */
 fun filterHosts(hosts: List<Host>, activeChip: String = ALL_HOSTS_CHIP, query: String = ""): List<Host> {
     val needle = query.trim().lowercase()
@@ -56,4 +56,5 @@ private fun Host.matchesQuery(needle: String): Boolean =
         address.lowercase().contains(needle) ||
         username.lowercase().contains(needle) ||
         group?.lowercase()?.contains(needle) == true ||
+        notes?.lowercase()?.contains(needle) == true ||
         tags.any { it.contains(needle) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -29,6 +29,7 @@ data class HostDraft(
     val connectionType: ConnectionType = ConnectionType.SSH,
     val jumpHostId: String? = null,
     val keepAliveSeconds: Int = 30,
+    val notes: String? = null,
 )
 
 /**
@@ -79,6 +80,7 @@ class HostManagerController(
                 connectionType = draft.connectionType,
                 jumpHostId = draft.jumpHostId,
                 keepAliveSeconds = draft.keepAliveSeconds,
+                notes = draft.notes,
                 // Not a form field — toggled from the live VNC session; a form save must not reset it.
                 vncResizeToWindow = find(id)?.vncResizeToWindow ?: false,
             ),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.ai.AiPolicy
 import app.skerry.shared.host.Host
+import app.skerry.shared.host.normalizeNotes
 import app.skerry.shared.tag.MAX_TAGS_PER_RECORD
 import app.skerry.shared.tag.normalizeTag
 import app.skerry.shared.ssh.ConnectionType
@@ -45,6 +46,12 @@ class NewConnectionFormState {
     var port: String by mutableStateOf("22")
     var username: String by mutableStateOf("")
     var group: String by mutableStateOf("")
+
+    /**
+     * Free-form remark about the profile, raw as typed; normalized on the way into the draft
+     * ([app.skerry.shared.host.normalizeNotes]) so the cap and trimming apply once, at the store's edge.
+     */
+    var notes: String by mutableStateOf("")
 
     /**
      * Profile transport. Changing it via [chooseConnectionType] substitutes the default port/speed
@@ -203,6 +210,7 @@ class NewConnectionFormState {
         connectionType = connectionType,
         jumpHostId = jumpHostId,
         keepAliveSeconds = keepAliveSeconds,
+        notes = normalizeNotes(notes),
     )
 
     companion object {
@@ -229,6 +237,7 @@ class NewConnectionFormState {
             port = host.port.toString()
             username = host.username
             group = host.group ?: ""
+            notes = host.notes ?: ""
             tags = host.tags
             aiPolicy = host.aiPolicy
             jumpHostId = host.jumpHostId

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -53,7 +53,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.shared.host.Host
-import app.skerry.shared.host.MAX_NOTES_LENGTH
+import app.skerry.shared.host.capNotes
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
@@ -346,7 +346,7 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                 Field(stringResource(Res.string.conn_field_notes)) {
                     ModalTextField(
                         form.notes,
-                        { form.notes = it.take(MAX_NOTES_LENGTH) },
+                        { form.notes = capNotes(it) },
                         stringResource(Res.string.conn_notes_placeholder),
                         singleLine = false,
                         minHeightDp = 64,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.shared.host.Host
+import app.skerry.shared.host.MAX_NOTES_LENGTH
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
@@ -95,6 +96,7 @@ import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_jump_host
 import app.skerry.ui.generated.resources.conn_field_keep_alive
 import app.skerry.ui.generated.resources.conn_field_name
+import app.skerry.ui.generated.resources.conn_field_notes
 import app.skerry.ui.generated.resources.conn_field_port
 import app.skerry.ui.generated.resources.conn_field_protocol
 import app.skerry.ui.generated.resources.conn_field_tags
@@ -104,6 +106,7 @@ import app.skerry.ui.generated.resources.conn_group_new
 import app.skerry.ui.generated.resources.conn_group_new_title
 import app.skerry.ui.generated.resources.conn_group_none
 import app.skerry.ui.generated.resources.conn_jump_none
+import app.skerry.ui.generated.resources.conn_notes_placeholder
 import app.skerry.ui.generated.resources.conn_protocol_local
 import app.skerry.ui.generated.resources.conn_protocol_serial
 import app.skerry.ui.generated.resources.conn_protocol_mosh
@@ -336,6 +339,17 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                                 tagSugs.forEach { tag -> key(tag) { SuggestionRow("#$tag") { form.addTag(tag); tagDraft = "" } } }
                             }
                         },
+                    )
+                }
+                Spacer14()
+                // Free-form remark about the profile; shown as a hover tooltip on the sidebar row.
+                Field(stringResource(Res.string.conn_field_notes)) {
+                    ModalTextField(
+                        form.notes,
+                        { form.notes = it.take(MAX_NOTES_LENGTH) },
+                        stringResource(Res.string.conn_notes_placeholder),
+                        singleLine = false,
+                        minHeightDp = 64,
                     )
                 }
                 // AI policy selection is visible when AI is actually available (live controller or feature flag).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
@@ -33,6 +34,7 @@ import app.skerry.ui.generated.resources.shtail_host_ask_on_connect
 import app.skerry.ui.generated.resources.shtail_host_auth
 import app.skerry.ui.generated.resources.shtail_host_group
 import app.skerry.ui.generated.resources.shtail_host_jump
+import app.skerry.ui.generated.resources.shtail_host_notes
 import app.skerry.ui.generated.resources.shtail_host_port
 import app.skerry.ui.generated.resources.shtail_host_saved_credential
 import app.skerry.ui.connection.jumpRouteLabel
@@ -66,9 +68,10 @@ data class HostDetailRow(val label: String, val value: String, val mono: Boolean
 
 /**
  * Reduces a [Host] profile to Details card rows: Address, Port, Auth, jump route (only when the
- * profile has one — [jumpRouteLabel] over [findHost]), Group. Auth reflects whether a keychain
- * secret is bound (`Saved credential` / `Ask on connect`); Group falls back to "Ungrouped". AI
- * policy and online status are not in the model.
+ * profile has one — [jumpRouteLabel] over [findHost]), Group, Notes (only when the profile carries
+ * one — the desktop shows the same text as a sidebar hover tooltip, which a phone has no equivalent
+ * of). Auth reflects whether a keychain secret is bound (`Saved credential` / `Ask on connect`);
+ * Group falls back to "Ungrouped". AI policy and online status are not in the model.
  */
 @Composable
 fun mobileHostDetailRows(host: Host, findHost: (String) -> Host? = { null }): List<HostDetailRow> = listOfNotNull(
@@ -81,6 +84,7 @@ fun mobileHostDetailRows(host: Host, findHost: (String) -> Host? = { null }): Li
     ),
     jumpRouteLabel(host, findHost)?.let { HostDetailRow(stringResource(Res.string.shtail_host_jump), it, mono = false) },
     HostDetailRow(stringResource(Res.string.shtail_host_group), host.group?.takeIf { it.isNotBlank() } ?: ungroupedLabel(), mono = false),
+    host.notes?.takeIf { it.isNotBlank() }?.let { HostDetailRow(stringResource(Res.string.shtail_host_notes), it, mono = false) },
 )
 
 /**
@@ -179,7 +183,7 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
             rows.forEachIndexed { i, row ->
                 Row(
                     Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Txt(row.label, color = Skerry.colors.dim, size = 13.sp)
@@ -187,7 +191,12 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
                         row.value,
                         color = Skerry.colors.text,
                         size = 13.sp,
+                        lineHeight = 18.sp,
                         font = if (row.mono) LocalFonts.current.mono else null,
+                        // A note runs long: let the value wrap and stay right-aligned instead of
+                        // squeezing the label off the row.
+                        align = TextAlign.End,
+                        modifier = Modifier.weight(1f),
                     )
                 }
                 if (i < rows.lastIndex) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
-import app.skerry.shared.host.MAX_NOTES_LENGTH
+import app.skerry.shared.host.capNotes
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isVnc
@@ -298,7 +298,7 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
             MobileFormField(stringResource(Res.string.conn_field_notes)) {
                 MobileFormInput(
                     form.notes,
-                    { form.notes = it.take(MAX_NOTES_LENGTH) },
+                    { form.notes = capNotes(it) },
                     stringResource(Res.string.conn_notes_placeholder),
                     singleLine = false,
                     minHeightDp = 80,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
+import app.skerry.shared.host.MAX_NOTES_LENGTH
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isVnc
@@ -77,7 +78,9 @@ import app.skerry.ui.generated.resources.conn_field_host_address
 import app.skerry.ui.generated.resources.conn_field_name
 import app.skerry.ui.generated.resources.conn_field_port
 import app.skerry.ui.generated.resources.conn_field_protocol
+import app.skerry.ui.generated.resources.conn_field_notes
 import app.skerry.ui.generated.resources.conn_field_tags
+import app.skerry.ui.generated.resources.conn_notes_placeholder
 import app.skerry.ui.generated.resources.conn_field_username
 import app.skerry.ui.generated.resources.conn_group_delete
 import app.skerry.ui.generated.resources.conn_group_new
@@ -286,6 +289,19 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                     placeholder = stringResource(Res.string.conn_tag_add_placeholder),
                     onPick = { tag -> form.addTag(tag); tagDraft = "" },
                     menuBackground = Skerry.colors.surface2,
+                )
+            }
+
+            Spacer(Modifier.height(14.dp))
+            // Free-form remark about the profile; surfaced in the host details screen (parity with
+            // the desktop sidebar's hover tooltip, which a phone has no equivalent of).
+            MobileFormField(stringResource(Res.string.conn_field_notes)) {
+                MobileFormInput(
+                    form.notes,
+                    { form.notes = it.take(MAX_NOTES_LENGTH) },
+                    stringResource(Res.string.conn_notes_placeholder),
+                    singleLine = false,
+                    minHeightDp = 80,
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
@@ -78,6 +80,7 @@ import app.skerry.ui.design.Badge
 import app.skerry.ui.design.Chip
 import app.skerry.ui.design.Dot
 import app.skerry.ui.design.HLine
+import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.host.pickAndParseSshConfig
 import app.skerry.ui.generated.resources.conn_import_action
@@ -122,6 +125,7 @@ import app.skerry.ui.host.hostTagChips
 import app.skerry.ui.host.icon
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.session.sessionDotColor
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
@@ -772,6 +776,9 @@ private fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily)
     )
 }
 
+/** How long the pointer must rest on a host row before its note pops up. */
+private const val NOTE_TOOLTIP_DELAY_MS = 450L
+
 /**
  * Shared host row for the sidebar (mock and live catalog): status dot + protocol icon + name +
  * optional badge. [icon] is the profile's [app.skerry.ui.host.icon] and stays [Skerry.colors.faint] — the two
@@ -781,7 +788,7 @@ private fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily)
  * ([host] != null and [LocalSnippets] is present), a trailing "⋮" button opens a menu (Run
  * snippet.../Edit/Duplicate/Delete); its click is intercepted before [onClick], so opening the menu
  * doesn't trigger a connection. "Run snippet..." opens the snippet picker and runs it on [host] via
- * [LocalRunSnippetOnHost].
+ * [LocalRunSnippetOnHost]. A profile carrying [Host.notes] shows them as a hover tooltip.
  */
 @Composable
 internal fun HostEntryRow(
@@ -804,79 +811,100 @@ internal fun HostEntryRow(
     val hasMenu = onEdit != null || onDuplicate != null || onDelete != null || canRunSnippet
     var menuOpen by remember { mutableStateOf(false) }
     var snippetPickerOpen by remember { mutableStateOf(false) }
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(5.dp))
-            .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-            .hostConnectClick(
-                onClick = {
-                    // Connecting also marks the row selected (single-click mode too — it reads as
-                    // "the host you just opened"), then opens the session.
-                    onSelect?.invoke()
-                    onClick()
-                },
-                onSingleClick = onSelect,
-            )
-            .padding(start = 8.dp, end = 2.dp, top = 5.dp, bottom = 5.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Dot(dot)
-        Sym(icon, size = 13.sp, color = Skerry.colors.faint)
-        Txt(
-            label,
-            color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim, size = 11.5.sp, font = mono,
-            maxLines = 1, overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        if (badge != null) {
-            val strict = badge == "STRICT"
-            Badge(badge, bg = if (strict) Skerry.colors.strictBg else Skerry.colors.devBg, fg = if (strict) Skerry.colors.strictFg else Skerry.colors.moss)
+    // The profile's note is shown on hover — mouse-only by nature; on Android the same code simply
+    // never reports a hover (the note lives in the host detail screen there).
+    val hoverInteraction = remember { MutableInteractionSource() }
+    val hovered by hoverInteraction.collectIsHoveredAsState()
+    // Dwell before the note pops up, so sweeping the pointer down the list doesn't flash a tooltip
+    // over every row on the way.
+    var noteVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(hovered) {
+        noteVisible = false
+        if (hovered) {
+            delay(NOTE_TOOLTIP_DELAY_MS)
+            noteVisible = true
         }
-        if (hasMenu) {
-            Box {
-                // Mouse-only: keeping the menu out of Tab traversal makes one Tab = one host row
-                // (otherwise every row costs two presses); keyboard users get Enter/Space to connect.
-                IconBtn(
-                    "more_vert",
-                    onClick = { menuOpen = !menuOpen },
-                    modifier = Modifier.focusProperties { canFocus = false },
-                    box = 22, icon = 16.sp, tint = Skerry.colors.faint,
+    }
+    // The tooltip is a sibling of the row, not a child: inside the row its (zero-sized) popup node
+    // would still collect the row's 8dp item spacing and shift the label sideways on hover.
+    Box(Modifier.fillMaxWidth()) {
+        val note = host?.notes
+        if (noteVisible && !note.isNullOrBlank() && !menuOpen) HoverTooltip(note)
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(5.dp))
+                .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
+                .hoverable(hoverInteraction)
+                .hostConnectClick(
+                    onClick = {
+                        // Connecting also marks the row selected (single-click mode too — it reads as
+                        // "the host you just opened"), then opens the session.
+                        onSelect?.invoke()
+                        onClick()
+                    },
+                    onSingleClick = onSelect,
                 )
-                if (menuOpen) {
-                    Popup(alignment = Alignment.TopEnd, onDismissRequest = { menuOpen = false }) {
-                        Column(
-                            Modifier.clip(RoundedCornerShape(7.dp)).background(Skerry.colors.surface2).border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(7.dp)).padding(4.dp),
-                        ) {
-                            if (canRunSnippet) {
-                                HostMenuItem(stringResource(Res.string.term_menu_run_snippet), Skerry.colors.text) { menuOpen = false; snippetPickerOpen = true }
-                            }
-                            onEdit?.let { edit ->
-                                HostMenuItem(stringResource(Res.string.term_menu_edit), Skerry.colors.text) { menuOpen = false; edit() }
-                            }
-                            onDuplicate?.let { duplicate ->
-                                HostMenuItem(stringResource(Res.string.term_menu_duplicate), Skerry.colors.text) { menuOpen = false; duplicate() }
-                            }
-                            onDelete?.let { delete ->
-                                HostMenuItem(stringResource(Res.string.term_menu_delete), Skerry.colors.sunset) { menuOpen = false; delete() }
+                .padding(start = 8.dp, end = 2.dp, top = 5.dp, bottom = 5.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Dot(dot)
+            Sym(icon, size = 13.sp, color = Skerry.colors.faint)
+            Txt(
+                label,
+                color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim, size = 11.5.sp, font = mono,
+                maxLines = 1, overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            if (badge != null) {
+                val strict = badge == "STRICT"
+                Badge(badge, bg = if (strict) Skerry.colors.strictBg else Skerry.colors.devBg, fg = if (strict) Skerry.colors.strictFg else Skerry.colors.moss)
+            }
+            if (hasMenu) {
+                Box {
+                    // Mouse-only: keeping the menu out of Tab traversal makes one Tab = one host row
+                    // (otherwise every row costs two presses); keyboard users get Enter/Space to connect.
+                    IconBtn(
+                        "more_vert",
+                        onClick = { menuOpen = !menuOpen },
+                        modifier = Modifier.focusProperties { canFocus = false },
+                        box = 22, icon = 16.sp, tint = Skerry.colors.faint,
+                    )
+                    if (menuOpen) {
+                        Popup(alignment = Alignment.TopEnd, onDismissRequest = { menuOpen = false }) {
+                            Column(
+                                Modifier.clip(RoundedCornerShape(7.dp)).background(Skerry.colors.surface2).border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(7.dp)).padding(4.dp),
+                            ) {
+                                if (canRunSnippet) {
+                                    HostMenuItem(stringResource(Res.string.term_menu_run_snippet), Skerry.colors.text) { menuOpen = false; snippetPickerOpen = true }
+                                }
+                                onEdit?.let { edit ->
+                                    HostMenuItem(stringResource(Res.string.term_menu_edit), Skerry.colors.text) { menuOpen = false; edit() }
+                                }
+                                onDuplicate?.let { duplicate ->
+                                    HostMenuItem(stringResource(Res.string.term_menu_duplicate), Skerry.colors.text) { menuOpen = false; duplicate() }
+                                }
+                                onDelete?.let { delete ->
+                                    HostMenuItem(stringResource(Res.string.term_menu_delete), Skerry.colors.sunset) { menuOpen = false; delete() }
+                                }
                             }
                         }
                     }
-                }
-                // Snippet picker: runs on this host (opens/reuses a session and runs the command after
-                // connecting). An empty library shows "No snippets yet".
-                if (snippetPickerOpen && host != null && snippets != null) {
-                    Popup(
-                        alignment = Alignment.TopEnd,
-                        onDismissRequest = { snippetPickerOpen = false },
-                        properties = PopupProperties(focusable = true),
-                    ) {
-                        SnippetPalette(snippets) { entry ->
-                            // Through the manager: a snippet with ${{…}} variables opens the confirm
-                            // dialog first; the resolved line (newline included) lands here after.
-                            snippets.run(entry.id) { line -> runSnippetOnHost(host, line) }
-                            snippetPickerOpen = false
+                    // Snippet picker: runs on this host (opens/reuses a session and runs the command after
+                    // connecting). An empty library shows "No snippets yet".
+                    if (snippetPickerOpen && host != null && snippets != null) {
+                        Popup(
+                            alignment = Alignment.TopEnd,
+                            onDismissRequest = { snippetPickerOpen = false },
+                            properties = PopupProperties(focusable = true),
+                        ) {
+                            SnippetPalette(snippets) { entry ->
+                                // Through the manager: a snippet with ${{…}} variables opens the confirm
+                                // dialog first; the resolved line (newline included) lands here after.
+                                snippets.run(entry.id) { line -> runSnippetOnHost(host, line) }
+                                snippetPickerOpen = false
+                            }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -829,7 +829,8 @@ internal fun HostEntryRow(
     // would still collect the row's 8dp item spacing and shift the label sideways on hover.
     Box(Modifier.fillMaxWidth()) {
         val note = host?.notes
-        if (noteVisible && !note.isNullOrBlank() && !menuOpen) HoverTooltip(note)
+        // Suppressed while the row's own popups are up, so the note doesn't land on top of them.
+        if (noteVisible && !note.isNullOrBlank() && !menuOpen && !snippetPickerOpen) HoverTooltip(note)
         Row(
             Modifier
                 .fillMaxWidth()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
@@ -17,7 +17,8 @@ class HostChipsTest {
         username: String = "root",
         group: String? = null,
         tags: List<String> = emptyList(),
-    ) = Host(id = id, label = label, address = address, username = username, group = group, tags = tags)
+        notes: String? = null,
+    ) = Host(id = id, label = label, address = address, username = username, group = group, tags = tags, notes = notes)
 
     @Test
     fun chips_are_all_plus_distinct_tags_in_first_appearance_order() {
@@ -65,6 +66,17 @@ class HostChipsTest {
         assertEquals(listOf("db-master"), filterHosts(hosts, query = "1.50").map { it.label })
         assertEquals(listOf("prod-web-01"), filterHosts(hosts, query = "EDGE").map { it.label }) // matched by tag
         assertEquals(listOf("db-master"), filterHosts(hosts, query = "postgres").map { it.label })
+    }
+
+    @Test
+    fun query_matches_notes() {
+        val hosts = listOf(
+            host("1", label = "prod-web-01", notes = "Reboot window: Sunday 03:00 MSK"),
+            host("2", label = "db-master"),
+        )
+        assertEquals(listOf("prod-web-01"), filterHosts(hosts, query = "sunday").map { it.label })
+        // A host without notes must not match a notes-only needle.
+        assertEquals(emptyList(), filterHosts(hosts, query = "msk").map { it.label } - "prod-web-01")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
@@ -129,6 +129,22 @@ class HostManagerControllerTest {
     }
 
     @Test
+    fun `duplicating a host carries its note onto the new record`() {
+        // Duplicate goes form -> draft -> controller with a fresh id; the note must ride along.
+        val original = Host("1", "prod-web", "10.0.0.5", 22, "deploy", notes = "ask ops before reboot")
+        val store = FakeHostStore(original)
+        val controller = HostManagerController(store) { "gen-id" }
+
+        val copyId = controller.save(
+            NewConnectionFormState.duplicateOf(original, "prod-web (copy)").toDraft(id = null),
+        )
+
+        assertEquals("gen-id", copyId)
+        assertEquals("ask ops before reboot", controller.find("gen-id")?.notes)
+        assertEquals("ask ops before reboot", controller.find("1")?.notes) // original untouched
+    }
+
+    @Test
     fun `save carries tags through to the stored host`() {
         val store = FakeHostStore()
         val controller = HostManagerController(store) { "gen-id" }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
@@ -105,6 +105,30 @@ class HostManagerControllerTest {
     }
 
     @Test
+    fun `save carries notes through to the stored host`() {
+        val store = FakeHostStore()
+        val controller = HostManagerController(store) { "gen-id" }
+
+        controller.save(
+            HostDraft(label = "prod", address = "10.0.0.5", port = 22, username = "deploy", notes = "ask ops before reboot"),
+        )
+
+        assertEquals("ask ops before reboot", controller.hosts.single().notes)
+        assertEquals("ask ops before reboot", store.all().single().notes)
+    }
+
+    @Test
+    fun `save without notes clears them on the stored host`() {
+        // Emptying the field in the edit form must actually drop the note, not keep the old one.
+        val store = FakeHostStore(Host("1", "a", "a.local", 22, "u", notes = "stale"))
+        val controller = HostManagerController(store) { error("must not be called") }
+
+        controller.save(HostDraft(id = "1", label = "a", address = "a.local", port = 22, username = "u"))
+
+        assertNull(controller.find("1")?.notes)
+    }
+
+    @Test
     fun `save carries tags through to the stored host`() {
         val store = FakeHostStore()
         val controller = HostManagerController(store) { "gen-id" }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.host.MAX_NOTES_LENGTH
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
 import kotlin.test.Test
@@ -88,6 +89,23 @@ class NewConnectionFormStateTest {
 
         val host = Host(id = "h1", label = "Web", address = "web", username = "root", keepAliveSeconds = 120)
         assertEquals(120, NewConnectionFormState.fromHost(host).keepAliveSeconds)
+    }
+
+    @Test
+    fun notes_travel_the_draft_normalized_and_prefill_from_host() {
+        val f = NewConnectionFormState().apply { name = "h"; address = "a"; username = "u" }
+        assertEquals("", f.notes)
+        assertNull(f.toDraft().notes) // blank notes are stored as absent, like an empty group
+
+        f.notes = "  reboot window: Sun 03:00  "
+        assertEquals("reboot window: Sun 03:00", f.toDraft().notes)
+
+        f.notes = "x".repeat(MAX_NOTES_LENGTH + 40)
+        assertEquals(MAX_NOTES_LENGTH, f.toDraft().notes?.length)
+
+        val host = Host(id = "h1", label = "Web", address = "web", username = "root", notes = "ask ops before reboot")
+        assertEquals("ask ops before reboot", NewConnectionFormState.fromHost(host).notes)
+        assertEquals("", NewConnectionFormState.fromHost(host.copy(notes = null)).notes)
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
@@ -45,6 +45,13 @@ import kotlinx.serialization.Serializable
  *
  * [vncResizeToWindow] remembers the VNC session's "Resize to window" toggle across restarts.
  * VNC-only; toggled from the live session's graphics menu, not the edit form (which preserves it).
+ *
+ * [notes] is an optional free-form remark about the profile (maintenance window, who owns the box),
+ * shown as a hover tooltip in the desktop sidebar and in the mobile host details. Stored normalized
+ * ([normalizeNotes]): trimmed, ≤ [MAX_NOTES_LENGTH], blank collapsed to `null`. Note: a client
+ * predating this field silently drops it when it re-saves the profile (unknown keys are ignored on
+ * read, the record is rebuilt without them and LWW propagates that), same as an unknown
+ * `connectionType`.
  */
 @Serializable
 data class Host(
@@ -61,4 +68,5 @@ data class Host(
     val jumpHostId: String? = null,
     val keepAliveSeconds: Int = 30,
     val vncResizeToWindow: Boolean = false,
+    val notes: String? = null,
 )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/HostNotes.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/HostNotes.kt
@@ -14,4 +14,17 @@ const val MAX_NOTES_LENGTH = 500
  * is free-form text, not a label. Lives in `shared` because notes are *stored* in this form —
  * every write path must go through the same normalization.
  */
-fun normalizeNotes(raw: String): String? = raw.trim().take(MAX_NOTES_LENGTH).ifBlank { null }
+fun normalizeNotes(raw: String): String? = capNotes(raw.trim()).ifBlank { null }
+
+/**
+ * Cut [raw] down to [MAX_NOTES_LENGTH] without splitting a surrogate pair: a plain `take` counts
+ * UTF-16 code units, so an emoji straddling the limit would leave a lone high surrogate behind,
+ * which the UTF-8 encoder on the way into the vault blob turns into a replacement character —
+ * silent corruption rather than an honest truncation. The dangling half is dropped instead.
+ * Used by the input fields (per keystroke) and by [normalizeNotes] (on the way to the store).
+ */
+fun capNotes(raw: String): String {
+    if (raw.length <= MAX_NOTES_LENGTH) return raw
+    val cut = if (raw[MAX_NOTES_LENGTH - 1].isHighSurrogate()) MAX_NOTES_LENGTH - 1 else MAX_NOTES_LENGTH
+    return raw.substring(0, cut)
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/HostNotes.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/HostNotes.kt
@@ -1,0 +1,17 @@
+package app.skerry.shared.host
+
+/**
+ * Max length of a host note. Not a security boundary (notes only flow into Compose text / JSON —
+ * no injection), but a guard against pathological input: a pasted log file would bloat the stored
+ * profile (and the synced record) and slow the hover tooltip's layout.
+ */
+const val MAX_NOTES_LENGTH = 500
+
+/**
+ * Canonicalize a host note: trim the edges and cap the length ([MAX_NOTES_LENGTH]); blank becomes
+ * `null` (no note stored, so [Host.notes] tells "has a note" apart from "has an empty note" — the
+ * hover tooltip and the mobile Details row both key off `null`). Inner line breaks are kept: a note
+ * is free-form text, not a label. Lives in `shared` because notes are *stored* in this form —
+ * every write path must go through the same normalization.
+ */
+fun normalizeNotes(raw: String): String? = raw.trim().take(MAX_NOTES_LENGTH).ifBlank { null }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamShare.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamShare.kt
@@ -11,6 +11,9 @@ private val json = Json { ignoreUnknownKeys = true }
  * Host payload fields that lose meaning in team scope: `group` is a personal folder structure;
  * `credentialId` references a record in the owner's PERSONAL vault (secrets aren't shared —
  * members' references would dangle; each member connects with their own secret).
+ *
+ * `notes` is deliberately NOT stripped: a host note describes the box (maintenance window, owner),
+ * which is exactly what a team sharing the profile needs.
  */
 val HOST_SHARE_STRIP: Set<String> = setOf("group", "credentialId")
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/HostNotesTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/HostNotesTest.kt
@@ -1,0 +1,37 @@
+package app.skerry.shared.host
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class HostNotesTest {
+
+    @Test
+    fun trims_and_maps_blank_to_null() {
+        assertEquals("root password is in 1Password", normalizeNotes("  root password is in 1Password  "))
+        assertNull(normalizeNotes(""))
+        assertNull(normalizeNotes("   \n\t "))
+    }
+
+    @Test
+    fun truncates_to_max_length() {
+        val long = "a".repeat(MAX_NOTES_LENGTH + 25)
+        assertEquals("a".repeat(MAX_NOTES_LENGTH), normalizeNotes(long))
+    }
+
+    @Test
+    fun trims_before_truncating_so_padding_does_not_eat_the_budget() {
+        val padded = "   " + "b".repeat(MAX_NOTES_LENGTH) + "   "
+        assertEquals("b".repeat(MAX_NOTES_LENGTH), normalizeNotes(padded))
+    }
+
+    @Test
+    fun keeps_inner_line_breaks() {
+        assertEquals("reboot window: Sun 03:00\nask ops first", normalizeNotes("reboot window: Sun 03:00\nask ops first\n"))
+    }
+
+    @Test
+    fun host_notes_default_to_null_for_profiles_saved_before_the_field_existed() {
+        assertNull(Host(id = "1", label = "web", address = "10.0.0.1", username = "root").notes)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/HostNotesTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/HostNotesTest.kt
@@ -26,6 +26,21 @@ class HostNotesTest {
     }
 
     @Test
+    fun truncation_does_not_split_a_surrogate_pair() {
+        // An emoji straddling the limit: cutting between its halves would leave a lone surrogate,
+        // which the UTF-8 encoder later replaces with U+FFFD — corruption, not truncation.
+        val emoji = "🚀" // rocket, one code point / two UTF-16 units
+        val straddling = "a".repeat(MAX_NOTES_LENGTH - 1) + emoji
+        val capped = normalizeNotes(straddling)
+        assertEquals("a".repeat(MAX_NOTES_LENGTH - 1), capped)
+        assertEquals(false, capped?.lastOrNull()?.isHighSurrogate())
+
+        // A pair that ends exactly on the limit is kept whole.
+        val fitting = "a".repeat(MAX_NOTES_LENGTH - 2) + emoji
+        assertEquals(fitting, normalizeNotes(fitting))
+    }
+
+    @Test
     fun keeps_inner_line_breaks() {
         assertEquals("reboot window: Sun 03:00\nask ops first", normalizeNotes("reboot window: Sun 03:00\nask ops first\n"))
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/HostSyncRoundTripTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/HostSyncRoundTripTest.kt
@@ -1,0 +1,74 @@
+package app.skerry.shared.host
+
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.VaultCrypto
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A profile edited on one device must arrive intact on another: sync ships the record's sealed blob
+ * verbatim (zero-knowledge — the server never sees fields), so anything the JSON payload doesn't
+ * carry is lost fleet-wide. Exercised end to end over the real vault: two devices sharing a data
+ * key, one seals the profile, the other merges the record and reads it back through its own store.
+ */
+class HostSyncRoundTripTest {
+
+    private val crypto: VaultCrypto = IonspinVaultCrypto()
+    private val fs = FakeFileSystem()
+
+    private fun vault(name: String, deviceId: String) =
+        FileVault("/$name.json".toPath(), crypto, deviceId = deviceId, fileSystem = fs, now = { TS })
+
+    /** libsodium needs async init before first use; init is idempotent. */
+    private fun vaultTest(block: suspend () -> Unit): TestResult = runTest {
+        initializeVaultCrypto()
+        block()
+    }
+
+    @Test
+    fun `notes reach another device through a record merge`() = vaultTest {
+        val a = vault("vault-a", "device-1").apply { create("master".toCharArray()) }
+        val b = vault("vault-b", "device-2").apply { createWithDataKey(a.exportDataKey()!!) }
+
+        val note = "reboot window: Sun 03:00 MSK\nask ops before touching it"
+        VaultHostStore(a).put(
+            Host(id = "h1", label = "prod-web-01", address = "10.0.0.5", username = "root", notes = note),
+        )
+
+        val merged = b.mergeRemote(a.records())
+
+        assertTrue(merged.rejected.isEmpty())
+        val synced = VaultHostStore(b).all().single { it.id == "h1" }
+        assertEquals(note, synced.notes)
+        assertEquals("prod-web-01", synced.label) // the rest of the profile came along unchanged
+    }
+
+    @Test
+    fun `clearing a note propagates instead of leaving the old one on the other device`() = vaultTest {
+        val a = vault("vault-c", "device-1").apply { create("master".toCharArray()) }
+        val b = vault("vault-d", "device-2").apply { createWithDataKey(a.exportDataKey()!!) }
+        val storeA = VaultHostStore(a)
+        val host = Host(id = "h1", label = "web", address = "10.0.0.5", username = "root", notes = "stale note")
+        storeA.put(host)
+        b.mergeRemote(a.records())
+
+        // Emptying the field on device A must overwrite (not merely omit) the note on device B.
+        storeA.put(host.copy(notes = null))
+        val merged = b.mergeRemote(a.records())
+
+        assertTrue(merged.rejected.isEmpty())
+        assertNull(VaultHostStore(b).all().single { it.id == "h1" }.notes)
+    }
+
+    private companion object {
+        const val TS = "2026-06-12T00:00:00Z"
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
@@ -111,6 +111,16 @@ class VaultHostStoreTest {
     }
 
     @Test
+    fun `notes survive persist and reload with a null default`() {
+        val vault = FakeVault()
+        VaultHostStore(vault).put(host("web").copy(notes = "reboot window: Sun 03:00\nask ops first"))
+        assertEquals("reboot window: Sun 03:00\nask ops first", VaultHostStore(vault).all().single().notes)
+        // Absent in records written before the field existed -> null (backward compatible default).
+        VaultHostStore(vault).put(host("plain"))
+        assertNull(VaultHostStore(vault).all().first { it.id == "plain" }.notes)
+    }
+
+    @Test
     fun `all on a locked vault is empty rather than throwing`() {
         val store = VaultHostStore(LockedVault)
         assertTrue(store.all().isEmpty())

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
@@ -36,6 +36,9 @@ class SshConfigImportTest {
         assertEquals(ConnectionType.SSH, h.connectionType)
         assertNull(h.credentialId)
         assertNull(h.jumpHostId)
+        // An ssh_config carries no free-form remark for us to import — the note starts out empty
+        // rather than picking up an alias/comment.
+        assertNull(h.notes)
         assertEquals("id-1", h.id)
     }
 


### PR DESCRIPTION
Adds a free-form notes field to a saved host profile — a place for the maintenance window, the box's owner, or anything else worth remembering next to the connection.

**Where**
- Desktop: `New connection` / `Edit host` modal — a multi-line `Notes` field under Tags.
- Android: the same field in the new-connection sheet, and a `Notes` row in the host Details card.
- Desktop sidebar: hovering a host row for ~450 ms pops up its note; no note, no tooltip.

**Behaviour**
- Host search (sidebar and mobile list) matches notes along with name/address/user/group/tags.
- Notes are normalized on save: trimmed, capped at 500 characters, blank stored as absent.
- The field rides the existing HOST record, so sync carries it with no wire change; profiles saved before this field read back as "no note".

**Also in this PR**
- `IconTooltip` in `DesignPrimitives.kt` becomes the reusable `HoverTooltip` (width-capped, wraps, cut off after 8 lines).
- Mobile Details rows let a long value wrap right-aligned instead of squeezing the label off the row.

Closes part 2 of #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)