### PR TITLE
Search the terminal scrollback

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -57,6 +57,19 @@
     <!-- Transient "copied to clipboard" banner shown after copying a terminal selection. -->
     <string name="terminal_copied">Скопировано</string>
 
+    <!-- Панель поиска по выводу терминала (scrollback). -->
+    <string name="terminal_search_placeholder">Поиск по выводу</string>
+    <string name="terminal_search_counter">%1$d/%2$d</string>
+    <string name="terminal_search_counter_capped">%1$d/%2$d+</string>
+    <string name="terminal_search_no_matches">Нет совпадений</string>
+    <string name="terminal_search_invalid_pattern">Неверный шаблон</string>
+    <string name="terminal_search_too_complex">Слишком сложный шаблон</string>
+    <string name="terminal_search_match_case">Учитывать регистр</string>
+    <string name="terminal_search_regex">Регулярное выражение</string>
+    <string name="terminal_search_next">Следующее совпадение</string>
+    <string name="terminal_search_prev">Предыдущее совпадение</string>
+    <string name="terminal_search_close">Закрыть поиск</string>
+
     <!-- Экран сканирования QR (mobile, связывание устройств). -->
     <string name="qr_scan_hint">Наведите камеру на QR-код, показанный на другом устройстве.</string>
     <string name="qr_permission_needed">Для сканирования кода связывания нужен доступ к камере.</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -182,6 +182,7 @@
     <string name="settings_kb_accept_autocomplete">Принять подсказку автодополнения</string>
     <string name="settings_kb_cycle_suggestions">Перебрать подсказки</string>
     <string name="settings_kb_search_history">Поиск по истории команд</string>
+    <string name="settings_kb_search_output">Поиск по выводу</string>
     <string name="settings_kb_copy_selection">Копировать выделение</string>
     <string name="settings_kb_paste">Вставить</string>
     <string name="settings_kb_global">ОБЩИЕ</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -57,6 +57,19 @@
     <!-- 复制到剪贴板提示 -->
     <string name="terminal_copied">已复制</string>
 
+    <!-- 终端输出搜索面板 -->
+    <string name="terminal_search_placeholder">在输出中查找</string>
+    <string name="terminal_search_counter">%1$d/%2$d</string>
+    <string name="terminal_search_counter_capped">%1$d/%2$d+</string>
+    <string name="terminal_search_no_matches">无匹配</string>
+    <string name="terminal_search_invalid_pattern">表达式无效</string>
+    <string name="terminal_search_too_complex">表达式过于复杂</string>
+    <string name="terminal_search_match_case">区分大小写</string>
+    <string name="terminal_search_regex">正则表达式</string>
+    <string name="terminal_search_next">下一个匹配</string>
+    <string name="terminal_search_prev">上一个匹配</string>
+    <string name="terminal_search_close">关闭搜索</string>
+
     <!-- 扫码配对（移动端） -->
     <string name="qr_scan_hint">将摄像头对准另一设备上显示的二维码。</string>
     <string name="qr_permission_needed">需要相机权限才能扫描配对码。</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -182,6 +182,7 @@
     <string name="settings_kb_accept_autocomplete">接受自动补全建议</string>
     <string name="settings_kb_cycle_suggestions">循环切换建议</string>
     <string name="settings_kb_search_history">搜索命令历史</string>
+    <string name="settings_kb_search_output">在输出中查找</string>
     <string name="settings_kb_copy_selection">复制选中内容</string>
     <string name="settings_kb_paste">粘贴</string>
     <string name="settings_kb_global">全局</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -58,6 +58,19 @@
     <!-- Transient "copied to clipboard" banner shown after copying a terminal selection. -->
     <string name="terminal_copied">Copied</string>
 
+    <!-- Панель поиска по выводу терминала (scrollback). -->
+    <string name="terminal_search_placeholder">Find in output</string>
+    <string name="terminal_search_counter">%1$d/%2$d</string>
+    <string name="terminal_search_counter_capped">%1$d/%2$d+</string>
+    <string name="terminal_search_no_matches">No matches</string>
+    <string name="terminal_search_invalid_pattern">Invalid pattern</string>
+    <string name="terminal_search_too_complex">Pattern too complex</string>
+    <string name="terminal_search_match_case">Match case</string>
+    <string name="terminal_search_regex">Regular expression</string>
+    <string name="terminal_search_next">Next match</string>
+    <string name="terminal_search_prev">Previous match</string>
+    <string name="terminal_search_close">Close search</string>
+
     <!-- Экран сканирования QR (mobile, связывание устройств). -->
     <string name="qr_scan_hint">Point the camera at the QR code shown on your other device.</string>
     <string name="qr_permission_needed">Camera permission is needed to scan the pairing code.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -182,6 +182,7 @@
     <string name="settings_kb_accept_autocomplete">Accept autocomplete suggestion</string>
     <string name="settings_kb_cycle_suggestions">Cycle suggestions</string>
     <string name="settings_kb_search_history">Search command history</string>
+    <string name="settings_kb_search_output">Find in output</string>
     <string name="settings_kb_copy_selection">Copy selection</string>
     <string name="settings_kb_paste">Paste</string>
     <string name="settings_kb_global">GLOBAL</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -121,6 +121,7 @@ import app.skerry.ui.terminal.LocalTerminalAppearance
 import app.skerry.ui.terminal.LocalTerminalTheme
 import app.skerry.ui.terminal.TerminalAppearance
 import app.skerry.ui.terminal.TerminalCursorStyle
+import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.terminal.TerminalTheme
 import app.skerry.ui.theme.ThemeMode
 import app.skerry.ui.theme.systemInDarkTheme
@@ -932,6 +933,19 @@ private fun runDesktopShortcut(
         } else {
             state.showView(DesktopView.Sftp)
         }
+        // Search over the buffer of the pane the user is looking at (the split, when it holds focus).
+        // With no terminal on screen there is nothing to search: fall through instead of no-oping,
+        // so the chord can still reach a snippet binding.
+        DesktopShortcut.FindInTerminal -> {
+            val session = sessions?.active ?: return false
+            val pane = if (session.focusedSplit) session.splitSession else session
+            val terminal = paneTerminal(pane?.controller?.uiState) ?: return false
+            // The panel lives inside the terminal view, so bring that view up first — pressed over
+            // SFTP or a recording, the chord would otherwise open a panel on a screen nobody sees.
+            state.clearOverlay()
+            sessions.setActiveView(SessionView.Terminal)
+            terminal.openSearch()
+        }
         DesktopShortcut.Lock -> onLock()
         DesktopShortcut.Broadcast -> state.openBroadcast()
         // These three live in toolbar buttons that own their state; the shortcut nudges them.
@@ -947,6 +961,17 @@ private fun runDesktopShortcut(
         DesktopShortcut.FocusAiBar -> state.requestAiBarFocus()
     }
     return true
+}
+
+/**
+ * The terminal of a pane's connection state, or `null` if it has none. A dropped session keeps its
+ * frozen screen ([ConnectionUiState.Disconnected]), and searching that output is exactly when it is
+ * wanted — "what did that command print before the link died".
+ */
+private fun paneTerminal(state: ConnectionUiState?): TerminalScreenState? = when (state) {
+    is ConnectionUiState.Connected -> state.terminal
+    is ConnectionUiState.Disconnected -> state.terminal
+    else -> null
 }
 
 /** Select a tab by 0-based index; `false` if no such tab exists (the key falls through). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt
@@ -15,8 +15,11 @@ sealed interface DesktopShortcut {
     /** Split/collapse the active tab's terminal pane (⌘D / Ctrl+Shift+D). */
     data object SplitTerminal : DesktopShortcut
 
-    /** Open the active tab's SFTP (⌘F / Ctrl+Shift+F). */
+    /** Open the active tab's SFTP (⌘E / Ctrl+Shift+E). */
     data object OpenSftp : DesktopShortcut
+
+    /** Open search over the focused terminal's output (⌘F / Ctrl+Shift+F). */
+    data object FindInTerminal : DesktopShortcut
 
     /** Focus the AI bar's input field (⌘/ / Ctrl+Shift+/). */
     data object FocusAiBar : DesktopShortcut
@@ -79,7 +82,8 @@ fun matchDesktopShortcut(ctrl: Boolean, shift: Boolean, alt: Boolean, meta: Bool
     return when (key) {
         Key.N -> DesktopShortcut.NewConnection
         Key.D -> DesktopShortcut.SplitTerminal
-        Key.F -> DesktopShortcut.OpenSftp
+        Key.F -> DesktopShortcut.FindInTerminal
+        Key.E -> DesktopShortcut.OpenSftp
         Key.L -> DesktopShortcut.Lock
         Key.K -> DesktopShortcut.CommandPalette
         Key.B -> DesktopShortcut.Broadcast

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -717,6 +717,9 @@ private fun MobileKeybar(
         }
         // Reverse history search (Ctrl-R): open the search overlay (query typed on the soft keyboard).
         KeyCapIcon("search") { terminal.openReverseSearch() }
+        // Find in output (desktop ⌘F parity): opens the search panel over the terminal, which takes
+        // the soft keyboard for its query field.
+        KeyCapIcon("find_in_page") { terminal.openSearch() }
         // ctrl — special panel key (always cyan); arming fills it solid cyan.
         KeyCap("ctrl", accent = true, active = ctrlArmed) { onCtrlArmedChange(!ctrlArmed) }
         KeyCap("/") { char("/") }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -55,6 +55,7 @@ import app.skerry.ui.generated.resources.settings_kb_paste
 import app.skerry.ui.generated.resources.settings_kb_play_recording
 import app.skerry.ui.generated.resources.settings_kb_record_session
 import app.skerry.ui.generated.resources.settings_kb_search_history
+import app.skerry.ui.generated.resources.settings_kb_search_output
 import app.skerry.ui.generated.resources.settings_kb_select_tab_number
 import app.skerry.ui.generated.resources.settings_kb_snippet_palette
 import app.skerry.ui.generated.resources.settings_kb_split_terminal
@@ -88,7 +89,7 @@ internal fun KeyboardSection() {
         KeyboardBinding(stringResource(Res.string.settings_kb_next_prev_tab), "${ctrl("Tab")} / ${ctrlShift("Tab")}", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_select_tab_number), if (mac) "⌥1–9" else "Alt+1–9", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_focus_ai), mod("/"), live = true),
-        KeyboardBinding(stringResource(Res.string.settings_kb_open_sftp), mod("F"), live = true),
+        KeyboardBinding(stringResource(Res.string.settings_kb_open_sftp), mod("E"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_lock), mod("L"), live = true),
     )
     // Terminal-internal hotkeys (handled by TerminalScreen): fish-style autocomplete, history
@@ -97,6 +98,9 @@ internal fun KeyboardSection() {
         KeyboardBinding(stringResource(Res.string.settings_kb_accept_autocomplete), "Tab", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_cycle_suggestions), shift("Tab"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_search_history), ctrl("R"), live = true),
+        // Find in the session's output: the panel's own keys (Enter / Shift+Enter / Esc) are listed
+        // with it, since they only exist while it is open.
+        KeyboardBinding(stringResource(Res.string.settings_kb_search_output), "${mod("F")} · Enter / ${shift("Enter")} · Esc", live = true),
         // Both conventions are live, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
         // Both conventions work, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
         KeyboardBinding(stringResource(Res.string.settings_kb_copy_selection), "${ctrlShift("C")} / ${ctrl("Insert")}", live = true),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGeometry.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGeometry.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.geometry.Rect
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.TerminalSelection
+import kotlin.math.roundToInt
 
 /**
  * Monospace terminal cell size in pixels. Measured once on the UI side (mono-char advance +
@@ -91,6 +92,33 @@ class TerminalAutoScroll(initialInputVersion: Int, private val slackPx: Int) {
         previousMax = max
         return typed || previous == null || shouldStickToBottom(value, previous, slackPx)
     }
+}
+
+/**
+ * Buffer rows that intersect the viewport, with one row of slack on each side (a row at the scroll
+ * boundary is partly visible and still drawn; clipping cuts the spill). Both the draw pass and the
+ * search highlight take their row range from here — computed apart, they drifted by the slack row
+ * and a match on it went unpainted. Empty when there is nothing in the buffer.
+ */
+fun visibleRowWindow(scrollPx: Float, viewportPx: Float, cellHeight: Float, rowCount: Int): IntRange {
+    if (rowCount <= 0 || cellHeight <= 0f) return IntRange.EMPTY
+    val first = ((scrollPx / cellHeight).toInt() - 1).coerceAtLeast(0)
+    val last = (((scrollPx + viewportPx) / cellHeight).toInt() + 1).coerceAtMost(rowCount - 1)
+    return first..last
+}
+
+/**
+ * Scroll offset that brings buffer row [row] into view, or `null` if the whole row is already
+ * visible (search navigation must not jog the viewport for a hit the user can already see).
+ * [viewportPx] is the content height (padding excluded), [currentScroll]/[maxScroll] the live
+ * scroll state. An off-screen row is centered vertically and clamped to the scroll range.
+ */
+fun scrollToRow(row: Int, currentScroll: Int, viewportPx: Float, maxScroll: Int, cellHeight: Float): Int? {
+    val top = row * cellHeight
+    val bottom = top + cellHeight
+    if (top >= currentScroll && bottom <= currentScroll + viewportPx) return null
+    val centered = top - (viewportPx - cellHeight) / 2f
+    return centered.roundToInt().coerceIn(0, maxScroll.coerceAtLeast(0))
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -106,6 +107,7 @@ import app.skerry.shared.terminal.TermStyle
 import app.skerry.shared.terminal.UnderlineStyle
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.TerminalSelection
+import app.skerry.shared.terminal.searchTerminal
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.design.ModalPresence
 import kotlin.math.roundToInt
@@ -303,8 +305,13 @@ fun TerminalScreen(
     // Also re-keyed on the open-modal count: a modal scrim takes keyboard focus for Esc handling and
     // its disposal clears focus to no one, so the terminal re-claims it once every modal is closed —
     // otherwise typing goes dead until the user clicks the terminal.
+    // Also re-keyed on the search panel: while it is open its field owns the keyboard, and the
+    // terminal takes focus back when it closes (otherwise typing would go dead until a click).
     val modalsOpen = ModalPresence.openCount
-    LaunchedEffect(state, modalsOpen) { if (!closed && !imeInput && modalsOpen == 0) focusRequester.requestFocus() }
+    val searchOpen = state.searchQuery != null
+    LaunchedEffect(state, modalsOpen, searchOpen) {
+        if (!closed && !imeInput && modalsOpen == 0 && !searchOpen) focusRequester.requestFocus()
+    }
 
     // Autoscroll to bottom on new output — but only when the user was already at the bottom
     // (sticky bottom, like a real terminal): scrolling up to read history must survive streaming
@@ -320,7 +327,36 @@ fun TerminalScreen(
         val autoScroll = TerminalAutoScroll(state.inputVersion, slackPx = (2 * metrics.cellHeight).roundToInt())
         snapshotFlow { Triple(state.snapshotVersion, state.inputVersion, scroll.maxValue) }
             .collect { (_, input, max) ->
-                if (autoScroll.shouldSnap(scroll.value, max, input)) scroll.scrollTo(max)
+                val snap = autoScroll.shouldSnap(scroll.value, max, input)
+                // While a search hit is selected, the viewport belongs to the search: output
+                // streaming in must not yank the user away from the line they are reading.
+                // shouldSnap is still consulted (it tracks input/max) — only the scroll is skipped.
+                if (snap && state.currentMatch == null) scroll.scrollTo(max)
+            }
+    }
+
+    // Bring the selected search hit into view (only when it is off-screen — see scrollToRow), so
+    // stepping through matches moves the viewport the way a browser's find bar does. Keyed on the
+    // user's own navigation (searchNavVersion) plus the selected index, never on the match's row:
+    // while scrollback evicts rows under streaming output, that row shifts on its own, and
+    // following it would drag the viewport away from what the user is reading.
+    LaunchedEffect(state, metrics, paddingPx) {
+        var lastSelection: Pair<Int, Int>? = null
+        snapshotFlow { Triple(state.searchNavVersion, state.searchIndex, viewportSize.height) }
+            .collect { (navVersion, index, height) ->
+                val match = state.currentMatch
+                if (match == null || height == 0) return@collect
+                val selection = navVersion to index
+                if (selection == lastSelection) return@collect
+                lastSelection = selection
+                val target = scrollToRow(
+                    row = match.row,
+                    currentScroll = scroll.value,
+                    viewportPx = (height - 2 * paddingPx).coerceAtLeast(metrics.cellHeight),
+                    maxScroll = scroll.maxValue,
+                    cellHeight = metrics.cellHeight,
+                )
+                if (target != null) scroll.scrollTo(target)
             }
     }
 
@@ -573,6 +609,39 @@ fun TerminalScreen(
       if (sized && screen.isNotEmpty()) {
           val sel = state.selection
           val palette = state.palette // OSC 4/104 index overrides; empty — theme defaults
+          // Search hits are found for the visible rows only, not taken from the state's match list:
+          // that list is rebuilt on a throttle (a pass over a 50 000-row scrollback is expensive),
+          // so during streaming output it can lag by a snapshot — and a highlight painted from
+          // stale rows would sit on the wrong lines. Rescanning ~50 rows per change is cheap.
+          val currentHit = state.currentMatch
+          // The same window the draw loop below walks, so a hit on the partly visible slack row is
+          // highlighted too. derivedStateOf, not a plain read of scroll.value: this sits in
+          // composition, and the raw value changes every pixel of a drag — the window changes per row.
+          val searchWindow by remember(metrics, viewportSize, screen) {
+              derivedStateOf {
+                  visibleRowWindow(scroll.value.toFloat(), viewportSize.height.toFloat(), metrics.cellHeight, screen.size)
+              }
+          }
+          // The viewport bottom is what an incremental search re-selects around, and only the render
+          // layer knows the scroll position — so it keeps the state's anchor current.
+          LaunchedEffect(state, searchWindow) { state.setSearchAnchorRow(searchWindow.last) }
+          val hitsByRow = remember(
+              screen, state.searchQuery, state.searchCaseSensitive, state.searchRegex, searchWindow,
+          ) {
+              val query = state.searchQuery
+              if (query.isNullOrEmpty()) {
+                  emptyMap()
+              } else {
+                  searchTerminal(
+                      screen = screen,
+                      query = query,
+                      caseSensitive = state.searchCaseSensitive,
+                      regex = state.searchRegex,
+                      fromRow = searchWindow.first,
+                      toRow = searchWindow.last + 1,
+                  ).matches.groupBy { it.row }
+              }
+          }
           // clipToBounds after padding: the scrollback row at the scroll boundary is drawn at top=-chh and
           // would otherwise spill into the top padding zone (desktop has no default clip, unlike Android)
           // — after `clear` the command row would peek there. The clip cuts it at the content edge.
@@ -582,10 +651,9 @@ fun TerminalScreen(
               val chh = metrics.cellHeight
               // Only the rows intersecting the viewport (±1 row of slack; clipToBounds cuts the
               // spill): walking all of scrollback per repaint is O(history) of wasted work
-              // whenever output streams while the user sits scrolled up in history.
-              val firstRow = ((scrollPx / chh).toInt() - 1).coerceAtLeast(0)
-              val lastRow = (((scrollPx + size.height) / chh).toInt() + 1).coerceAtMost(screen.lastIndex)
-              for (r in firstRow..lastRow) {
+              // whenever output streams while the user sits scrolled up in history. The search
+              // highlight above derives its window from the same helper.
+              for (r in visibleRowWindow(scrollPx, size.height, chh, screen.size)) {
                   val top = r * chh - scrollPx
                   val row = screen[r]
                   // 1) Cell backgrounds — collapse same-color runs; stretch the trailing run to the viewport edge.
@@ -608,6 +676,16 @@ fun TerminalScreen(
                           while (k < row.size && sel.contains(r, k)) k++
                           drawRect(selectionBg, topLeft = Offset(s * cw, top), size = Size((k - s) * cw, chh))
                       }
+                  }
+                  // 2b) Search hits — over the background like the selection, under the glyphs. The
+                  // selected hit is washed stronger so it is findable among the others.
+                  hitsByRow[r]?.forEach { hit ->
+                      val left = hit.startCol * cw
+                      drawRect(
+                          if (hit == currentHit) termTheme.searchCurrentMatch else termTheme.searchMatch,
+                          topLeft = Offset(left, top),
+                          size = Size((hit.endCol - hit.startCol) * cw, chh),
+                      )
                   }
                   // 3) Glyphs — segment the row into runs (see glyphRuns): consecutive same-style ASCII
                   // cells are drawn with one drawText (the fast monospace case), while each non-ASCII glyph
@@ -1102,7 +1180,9 @@ fun TerminalScreen(
 
       // Touch input: an invisible field captures soft-keyboard characters. Diff against the anchor
       // ([imeDeltaToPty]) and reset immediately — the field is just a "funnel" into the PTY, holds no text.
-      if (imeInput && !closed) {
+      // Stood down while the search panel is open: two fields fighting over the soft keyboard would
+      // send the query into the PTY.
+      if (imeInput && !closed && !searchOpen) {
           BasicTextField(
               value = imeValue,
               onValueChange = { nv ->
@@ -1136,6 +1216,17 @@ fun TerminalScreen(
                   imeAction = ImeAction.None,
               ),
           )
+      }
+
+      // Find-in-output panel (⌘F / Ctrl+Shift+F, or the mobile keybar's magnifier). Pinned to the
+      // pane's top edge over the terminal: on a phone it spans the width (its controls would not
+      // fit otherwise), on desktop it hugs the right corner like a browser's find bar.
+      if (searchOpen && !closed) {
+          if (imeInput) {
+              TerminalSearchBar(state, expand = true, modifier = Modifier.align(Alignment.TopCenter).fillMaxWidth().padding(6.dp))
+          } else {
+              TerminalSearchBar(state, modifier = Modifier.align(Alignment.TopEnd).padding(8.dp))
+          }
       }
 
       // Transient "Copied" confirmation over the top of the terminal (right-click / Ctrl+Shift+C /

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.AutocompleteEngine
 import app.skerry.shared.terminal.CommandHistory
@@ -17,19 +18,25 @@ import app.skerry.shared.terminal.MouseTracking
 import app.skerry.shared.terminal.TermCell
 import app.skerry.shared.terminal.TermColor
 import app.skerry.shared.terminal.TerminalEmulator
+import app.skerry.shared.terminal.TerminalMatch
 import app.skerry.shared.terminal.TerminalPos
+import app.skerry.shared.terminal.TerminalSearchError
 import app.skerry.shared.terminal.TerminalSelection
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.shared.terminal.bracketedPasteWrap
 import app.skerry.shared.terminal.encodeMouseReport
 import app.skerry.shared.terminal.lineSelectionAt
+import app.skerry.shared.terminal.matchNearestTo
+import app.skerry.shared.terminal.searchTerminal
 import app.skerry.shared.terminal.wordSelectionAt
 import kotlin.concurrent.Volatile
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -63,6 +70,9 @@ class TerminalScreenState(
     // an untrusted host must not silently overwrite the system clipboard until the user opts in.
     // Snapshotted at connect; also pushed live into an open session via [applyClipboardWriteEnabled].
     clipboardWriteEnabled: Boolean = false,
+    // Monotonic milliseconds, injectable for tests. Only the search refresh throttle reads it, and
+    // it must not step backwards (a wall clock would), or a refresh could be skipped for minutes.
+    private val nowMillis: () -> Long = { STARTED_AT.elapsedNow().inWholeMilliseconds },
 ) {
     // OSC 52 requests to write to the system clipboard. extraBufferCapacity keeps tryEmit from the
     // owner coroutine from dropping when there's no subscriber yet; DROP_OLDEST on burst keeps the
@@ -375,6 +385,10 @@ class TerminalScreenState(
         if (altScreen && suggestionTail != null) suggestionTail = null
         title = emulator.title
         palette = emulator.paletteSnapshot()
+        // The buffer changed under an open search panel: rebuild the match list (throttled — see
+        // refreshSearch) so the counter and navigation follow the output, keeping the user on the
+        // hit they were reading.
+        if (searchQuery != null) refreshSearch(keep = currentMatch, force = false)
         snapshotVersion++
     }
 
@@ -554,6 +568,9 @@ class TerminalScreenState(
     /** Open reverse search (empty query). No-op in alt-screen (no line history there). */
     fun openReverseSearch() {
         if (altScreen) return
+        // Only one overlay can own the keyboard: the find bar's field would keep focus and leave
+        // this overlay visible but deaf to its own keys.
+        closeSearch()
         reverseSearchQuery = ""
         reverseSearchIndex = 0
     }
@@ -626,6 +643,232 @@ class TerminalScreenState(
 
     private fun refreshSuggestion() {
         suggestionTail = if (altScreen) null else autocomplete.suggestionTail()
+    }
+
+    // --- Output search (find in scrollback): the panel's whole state lives here so desktop keys and
+    // the mobile panel drive it uniformly and the render overlay reads a single source. It searches
+    // whatever [screen] holds — in alt-screen (vim/less/htop) that is the application's own frame,
+    // which has no scrollback, so the search follows what is on screen. ---
+
+    /** Current search query, or `null` if the panel is closed. */
+    var searchQuery: String? by mutableStateOf(null)
+        private set
+
+    /** Whether the search respects letter case (panel's `Aa` toggle). */
+    var searchCaseSensitive: Boolean by mutableStateOf(false)
+        private set
+
+    /** Whether the query is a regular expression rather than a literal (panel's `.*` toggle). */
+    var searchRegex: Boolean by mutableStateOf(false)
+        private set
+
+    /** Matches in the current buffer, top to bottom. Empty while the panel is closed. */
+    var searchMatches: List<TerminalMatch> by mutableStateOf(emptyList())
+        private set
+
+    /** Index of the selected match in [searchMatches], or `-1` when there is nothing selected. */
+    var searchIndex: Int by mutableStateOf(-1)
+        private set
+
+    /** Why the query yielded nothing usable (bad or too costly regex), or `null`. */
+    var searchError: TerminalSearchError? by mutableStateOf(null)
+        private set
+
+    /** Whether the match list hit its cap and more matches exist in the buffer. */
+    var searchTruncated: Boolean by mutableStateOf(false)
+        private set
+
+    /** The selected match (render scrolls to it and paints it as the current hit), or `null`. */
+    val currentMatch: TerminalMatch?
+        get() = searchMatches.getOrNull(searchIndex)
+
+    // Query of the last search, kept across closing so reopening the panel resumes it (as editors do).
+    private var lastSearchQuery: String = ""
+
+    // Buffer row the selection is measured from when the query changes: the bottom of what the user
+    // was looking at, so an incremental search lands on the nearest hit above rather than at the top
+    // of a long scrollback.
+    private var searchAnchorRow: Int = 0
+
+    // When the match list was last rebuilt, for the snapshot-driven throttle in [refreshSearch].
+    private var lastSearchRefreshAt: Long = Long.MIN_VALUE / 2
+
+    // The running search. A newer one cancels it: only the latest query's result may be published,
+    // and an abandoned pass stops scanning instead of burning a core to completion.
+    private var searchJob: Job? = null
+
+    // Steps requested by next/previous that no published list has applied yet. The pass runs off
+    // this coroutine, so a press is banked here and applied when its result lands — two quick
+    // presses move two matches, not one.
+    private var pendingSearchStep: Int = 0
+
+    /**
+     * Bumped by every user action that deliberately moves the selection (open, new query, toggle,
+     * next/previous). The viewport follows *this*, not the selected match itself: while scrollback
+     * evicts rows under streaming output, a match's row index shifts without the user asking for
+     * anything, and scrolling to it would yank them off the line they are reading.
+     */
+    var searchNavVersion: Int by mutableStateOf(0)
+        private set
+
+    /**
+     * Open the search panel, restoring the previous query. [anchorRow] is the buffer row at the
+     * viewport bottom (kept current by [TerminalScreen] through [setSearchAnchorRow]); the first
+     * selected match is the last one at or above it.
+     */
+    fun openSearch(anchorRow: Int = searchAnchorRow) {
+        // See [openReverseSearch]: the two overlays cannot both hold the keyboard.
+        closeReverseSearch()
+        searchAnchorRow = anchorRow
+        searchQuery = lastSearchQuery
+        searchNavVersion++
+        refreshSearch(keep = null)
+    }
+
+    /**
+     * Report the buffer row currently at the bottom of the viewport. The render layer owns the
+     * scroll position, so it feeds the anchor that an incremental search re-selects around.
+     */
+    fun setSearchAnchorRow(row: Int) {
+        searchAnchorRow = row
+    }
+
+    /** Close the search panel and drop its matches (the highlight goes with them). */
+    fun closeSearch() {
+        searchJob?.cancel()
+        searchJob = null
+        pendingSearchStep = 0
+        searchQuery = null
+        searchMatches = emptyList()
+        searchIndex = -1
+        searchError = null
+        searchTruncated = false
+    }
+
+    /** Replace the query and re-run the search (incremental: selection re-anchors to the viewport). */
+    fun updateSearchQuery(text: String) {
+        if (searchQuery == null) return
+        // A pasted novel is not a search term; the cap keeps pattern compilation bounded too.
+        val query = if (text.length <= MAX_SEARCH_QUERY_LENGTH) text else text.take(MAX_SEARCH_QUERY_LENGTH)
+        lastSearchQuery = query
+        searchQuery = query
+        pendingSearchStep = 0
+        searchNavVersion++
+        refreshSearch(keep = null)
+    }
+
+    /** Toggle case sensitivity, keeping the selected match if it survives. */
+    fun applySearchCase(enabled: Boolean) {
+        if (searchCaseSensitive == enabled) return
+        searchCaseSensitive = enabled
+        searchNavVersion++
+        refreshSearch(keep = currentMatch)
+    }
+
+    /** Switch between literal and regex matching, keeping the selected match if it survives. */
+    fun applySearchRegex(enabled: Boolean) {
+        if (searchRegex == enabled) return
+        searchRegex = enabled
+        searchNavVersion++
+        refreshSearch(keep = currentMatch)
+    }
+
+    /** Select the next (lower) match, wrapping around. No-op without matches. */
+    fun searchNext() {
+        stepSearch(+1)
+    }
+
+    /** Select the previous (higher) match, wrapping around. No-op without matches. */
+    fun searchPrev() {
+        stepSearch(-1)
+    }
+
+    /**
+     * Move the selection by [delta] matches. The step is banked ([pendingSearchStep]) and applied
+     * to the freshly published list rather than to the current one: navigation must walk the buffer
+     * as it is now, not as it was when the list was last rebuilt (up to
+     * [SEARCH_REFRESH_INTERVAL_MS] ago under streaming output).
+     */
+    private fun stepSearch(delta: Int) {
+        if (searchQuery.isNullOrEmpty()) return
+        pendingSearchStep += delta
+        searchNavVersion++
+        refreshSearch(keep = currentMatch)
+    }
+
+    /**
+     * Re-run the search over the current buffer. [keep] is the match to stay on if it is still
+     * there (output arriving, a toggle flipped); otherwise the selection re-anchors to the viewport
+     * ([searchAnchorRow]).
+     *
+     * The pass runs in its own coroutine and only the latest one publishes: a full buffer walk
+     * takes tens of milliseconds, and doing it inline would either block the UI thread (a keystroke
+     * in the field) or the coroutine that feeds the emulator (a published snapshot), which the user
+     * sees as a terminal that stopped updating.
+     *
+     * Snapshot-driven refreshes are additionally throttled to [SEARCH_REFRESH_INTERVAL_MS] ([force]
+     * `false`). Nothing visible lags behind — the highlight is computed per frame over the visible
+     * rows by [TerminalScreen] — only the counter and the navigation list.
+     */
+    private fun refreshSearch(keep: TerminalMatch?, force: Boolean = true) {
+        val query = searchQuery
+        if (query.isNullOrEmpty()) {
+            searchJob?.cancel()
+            searchJob = null
+            searchMatches = emptyList()
+            searchIndex = -1
+            searchError = null
+            searchTruncated = false
+            return
+        }
+        val now = nowMillis()
+        if (!force && now - lastSearchRefreshAt < SEARCH_REFRESH_INTERVAL_MS) return
+        lastSearchRefreshAt = now
+        // Everything the pass depends on is captured up front: it runs off this coroutine, while
+        // the fields it reads keep changing.
+        val buffer = screen
+        val caseSensitive = searchCaseSensitive
+        val useRegex = searchRegex
+        val anchorRow = keep?.row ?: searchAnchorRow
+        searchJob?.cancel()
+        searchJob = scope.launch {
+            val result = searchTerminal(
+                screen = buffer,
+                query = query,
+                caseSensitive = caseSensitive,
+                regex = useRegex,
+                cancelled = { !isActive },
+            )
+            if (!isActive) return@launch
+            // One atomic publish: readers must never see a new match list against an old counter
+            // or a selection index from another query.
+            Snapshot.withMutableSnapshot {
+                // A newer search took over while this one ran — its result is the one that counts.
+                if (searchQuery != query || searchCaseSensitive != caseSensitive || searchRegex != useRegex) {
+                    return@withMutableSnapshot
+                }
+                searchMatches = result.matches
+                searchError = result.error
+                searchTruncated = result.truncated
+                searchIndex = selectMatch(result.matches, keep, anchorRow)
+            }
+        }
+    }
+
+    /**
+     * Index to select in a freshly built [matches] list: the same hit if it is still there, else the
+     * nearest one to [anchorRow] — then any banked next/previous steps ([pendingSearchStep]).
+     */
+    private fun selectMatch(matches: List<TerminalMatch>, keep: TerminalMatch?, anchorRow: Int): Int {
+        if (matches.isEmpty()) {
+            pendingSearchStep = 0
+            return -1
+        }
+        val kept = keep?.let { matches.indexOf(it) } ?: -1
+        val base = if (kept >= 0) kept else matchNearestTo(matches, anchorRow)
+        val stepped = if (pendingSearchStep == 0) base else (base + pendingSearchStep).mod(matches.size)
+        pendingSearchStep = 0
+        return stepped
     }
 
     /** Send typed text to the PTY (fire-and-forget via the [outbound] queue, FIFO order). */
@@ -727,6 +970,19 @@ class TerminalScreenState(
         commands.trySend(TerminalCommand.SetClipboardWriteEnabled(enabled))
     }
 }
+
+/**
+ * How often a published snapshot may rebuild the search match list. Long enough that streaming
+ * output cannot stall the emulator's coroutine with full-buffer passes, short enough that the
+ * counter never looks frozen. The on-screen highlight does not wait for this (see [TerminalScreen]).
+ */
+const val SEARCH_REFRESH_INTERVAL_MS = 300L
+
+/** Longest accepted search query: past this it is not a search term but a paste accident. */
+const val MAX_SEARCH_QUERY_LENGTH = 512
+
+/** Process start mark: the default monotonic clock behind [TerminalScreenState]'s refresh throttle. */
+private val STARTED_AT = TimeSource.Monotonic.markNow()
 
 /** Command to the sole emulator owner; the queue preserves feed/resize ordering. */
 private sealed interface TerminalCommand {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalSearchBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalSearchBar.kt
@@ -1,0 +1,212 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.foundation.hoverable
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.terminal.TerminalSearchError
+import app.skerry.ui.design.HoverTooltip
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.terminal_search_close
+import app.skerry.ui.generated.resources.terminal_search_counter
+import app.skerry.ui.generated.resources.terminal_search_counter_capped
+import app.skerry.ui.generated.resources.terminal_search_invalid_pattern
+import app.skerry.ui.generated.resources.terminal_search_match_case
+import app.skerry.ui.generated.resources.terminal_search_next
+import app.skerry.ui.generated.resources.terminal_search_no_matches
+import app.skerry.ui.generated.resources.terminal_search_placeholder
+import app.skerry.ui.generated.resources.terminal_search_prev
+import app.skerry.ui.generated.resources.terminal_search_regex
+import app.skerry.ui.generated.resources.terminal_search_too_complex
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Width of the query field on desktop; on a phone it takes the row's free space instead. */
+internal val SEARCH_FIELD_WIDTH = 200.dp
+
+/**
+ * Search panel over the terminal's output ([TerminalScreenState.searchQuery] and friends): query
+ * field, hit counter, case/regex toggles, and previous/next/close controls. Sits at the pane's top
+ * edge the way a browser's find bar sits over the page; the highlight itself is painted onto the
+ * cell grid by [TerminalScreen].
+ *
+ * The field owns keyboard focus while the panel is open, so its keys never reach the PTY: Enter /
+ * Shift+Enter step through hits, Esc closes. The same panel serves desktop and mobile — on touch it
+ * takes the soft keyboard from the terminal's hidden IME field, which [TerminalScreen] stands down
+ * while the panel is up.
+ */
+@Composable
+internal fun TerminalSearchBar(state: TerminalScreenState, modifier: Modifier = Modifier, expand: Boolean = false) {
+    val mono = LocalFonts.current.mono
+    val query = state.searchQuery ?: return
+    val focusRequester = remember { FocusRequester() }
+    // The field's own buffer: the terminal state holds the query, this adds the caret. On open it is
+    // seeded from the restored query with everything selected, so typing replaces it (as find bars
+    // do). Keyed on the session: switching tabs swaps `state` while reusing this composable, and an
+    // unkeyed buffer would keep showing the previous tab's query next to the new tab's matches.
+    var value by remember(state) { mutableStateOf(TextFieldValue(query, TextRange(0, query.length))) }
+    LaunchedEffect(state) { focusRequester.requestFocus() }
+    Row(
+        modifier
+            .clip(RoundedCornerShape(7.dp))
+            .background(Skerry.colors.surface2)
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp))
+            .padding(start = 8.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Sym("search", size = 15.sp, color = Skerry.colors.faint)
+        // Fixed width (or the whole free row on a phone) with the field filling it: sized by its own
+        // text instead, an empty field is a few pixels wide and the rest of the input area is dead —
+        // a click there falls through to the terminal behind the panel and takes the focus with it.
+        Box(
+            if (expand) Modifier.weight(1f) else Modifier.width(SEARCH_FIELD_WIDTH),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            if (value.text.isEmpty()) {
+                Txt(stringResource(Res.string.terminal_search_placeholder), color = Skerry.colors.faint, size = 12.sp, font = mono)
+            }
+            BasicTextField(
+                value = value,
+                onValueChange = {
+                    value = it
+                    state.updateSearchQuery(it.text)
+                },
+                singleLine = true,
+                textStyle = TextStyle(color = Skerry.colors.text, fontSize = 12.sp, fontFamily = mono),
+                cursorBrush = SolidColor(Skerry.colors.cyan),
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.None,
+                    autoCorrectEnabled = false,
+                    keyboardType = KeyboardType.Ascii,
+                    imeAction = ImeAction.Search,
+                ),
+                // The soft keyboard's search key steps to the next hit — the touch equivalent of
+                // Enter, which arrives as a key event only on desktop.
+                keyboardActions = KeyboardActions(onSearch = { state.searchNext() }),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onPreviewKeyEvent { event ->
+                        if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+                        when (event.key) {
+                            Key.Escape -> { state.closeSearch(); true }
+                            // Enter walks the hits (Shift reverses), like every find bar. Consumed
+                            // either way: a newline must not slip into the query or the PTY.
+                            Key.Enter, Key.NumPadEnter -> {
+                                if (event.isShiftPressed) state.searchPrev() else state.searchNext()
+                                true
+                            }
+                            else -> false
+                        }
+                    },
+            )
+        }
+        SearchStatus(state, mono)
+        // Toggles re-run the current query, so a search can be narrowed without retyping it.
+        SearchToggle("Aa", state.searchCaseSensitive, stringResource(Res.string.terminal_search_match_case), mono) {
+            state.applySearchCase(!state.searchCaseSensitive)
+        }
+        SearchToggle(".*", state.searchRegex, stringResource(Res.string.terminal_search_regex), mono) {
+            state.applySearchRegex(!state.searchRegex)
+        }
+        IconBtn("keyboard_arrow_up", onClick = state::searchPrev, box = 24, icon = 16.sp, tooltip = stringResource(Res.string.terminal_search_prev))
+        IconBtn("keyboard_arrow_down", onClick = state::searchNext, box = 24, icon = 16.sp, tooltip = stringResource(Res.string.terminal_search_next))
+        IconBtn("close", onClick = state::closeSearch, box = 24, icon = 16.sp, tooltip = stringResource(Res.string.terminal_search_close))
+    }
+}
+
+/** Hit counter ("3/17"), or why the query yielded nothing. */
+@Composable
+private fun SearchStatus(state: TerminalScreenState, mono: FontFamily) {
+    val error = state.searchError
+    val total = state.searchMatches.size
+    when {
+        error != null -> Txt(
+            when (error) {
+                TerminalSearchError.InvalidPattern -> stringResource(Res.string.terminal_search_invalid_pattern)
+                TerminalSearchError.PatternTooComplex -> stringResource(Res.string.terminal_search_too_complex)
+            },
+            color = Skerry.colors.sunset, size = 11.sp, font = mono,
+        )
+        state.searchQuery.isNullOrEmpty() -> Unit // nothing typed yet — no verdict to show
+        total == 0 -> Txt(stringResource(Res.string.terminal_search_no_matches), color = Skerry.colors.faint, size = 11.sp, font = mono)
+        // A capped list ("3/5000+") must not read as the true total.
+        else -> Txt(
+            stringResource(
+                if (state.searchTruncated) Res.string.terminal_search_counter_capped else Res.string.terminal_search_counter,
+                state.searchIndex + 1,
+                total,
+            ),
+            color = Skerry.colors.dim, size = 11.sp, font = mono,
+        )
+    }
+}
+
+/** Case / regex toggle chip: cyan-filled while on, like the mobile keybar's sticky `ctrl` key. */
+@Composable
+private fun SearchToggle(label: String, active: Boolean, tooltip: String, mono: FontFamily, onClick: () -> Unit) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(5.dp))
+            .background(if (active) Skerry.colors.cyan else Skerry.colors.overlayMed)
+            .hoverable(interaction)
+            .clickable(interactionSource = interaction, indication = null, onClick = onClick)
+            .padding(horizontal = 6.dp, vertical = 3.dp),
+    ) {
+        Txt(
+            label,
+            color = if (active) Skerry.colors.ink else Skerry.colors.dim,
+            size = 11.sp,
+            weight = FontWeight.Medium,
+            font = mono,
+        )
+        if (hovered) HoverTooltip(tooltip)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalTheme.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalTheme.kt
@@ -33,6 +33,16 @@ data class TerminalTheme(
 
     /** Glyph color under a block cursor (contrast against [cursor]). */
     val cursorText: Color get() = background
+
+    /**
+     * Wash over every search hit, drawn below glyphs like [selection]. Built from the theme's own
+     * yellow (ANSI 3) rather than a fixed color, so hits read as highlighter marks on dark and
+     * light themes alike and never collide with the cyan selection.
+     */
+    val searchMatch: Color get() = ansi[3].copy(alpha = 0.28f)
+
+    /** Wash over the selected hit — the same hue, strong enough to pick it out among the others. */
+    val searchCurrentMatch: Color get() = ansi[11].copy(alpha = 0.55f)
 }
 
 // The TerminalThemes catalog (NightSea, TokyoNight, … plus all/DEFAULT/fromId) is generated from

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -71,10 +71,19 @@ class DesktopShortcutsTest {
     }
 
     @Test
+    fun `find in terminal output is on the app modifier plus F`() {
+        // The chord every terminal binds to "find" (GNOME Terminal, Windows Terminal); SFTP moved to E.
+        assertEquals(DesktopShortcut.FindInTerminal, match(meta = true, key = Key.F))
+        assertEquals(DesktopShortcut.FindInTerminal, match(ctrl = true, shift = true, key = Key.F))
+        // Plain Ctrl+F is readline's forward-char and belongs to the shell.
+        assertNull(match(ctrl = true, key = Key.F))
+    }
+
+    @Test
     fun `app modifier on macOS is Cmd alone`() {
         assertEquals(DesktopShortcut.NewConnection, match(meta = true, key = Key.N))
         assertEquals(DesktopShortcut.SplitTerminal, match(meta = true, key = Key.D))
-        assertEquals(DesktopShortcut.OpenSftp, match(meta = true, key = Key.F))
+        assertEquals(DesktopShortcut.OpenSftp, match(meta = true, key = Key.E))
         assertEquals(DesktopShortcut.Lock, match(meta = true, key = Key.L))
         assertEquals(DesktopShortcut.FocusAiBar, match(meta = true, key = Key.Slash))
     }
@@ -83,7 +92,7 @@ class DesktopShortcutsTest {
     fun `app modifier off macOS is Ctrl plus Shift`() {
         assertEquals(DesktopShortcut.NewConnection, match(ctrl = true, shift = true, key = Key.N))
         assertEquals(DesktopShortcut.SplitTerminal, match(ctrl = true, shift = true, key = Key.D))
-        assertEquals(DesktopShortcut.OpenSftp, match(ctrl = true, shift = true, key = Key.F))
+        assertEquals(DesktopShortcut.OpenSftp, match(ctrl = true, shift = true, key = Key.E))
         assertEquals(DesktopShortcut.Lock, match(ctrl = true, shift = true, key = Key.L))
         assertEquals(DesktopShortcut.FocusAiBar, match(ctrl = true, shift = true, key = Key.Slash))
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGeometryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGeometryTest.kt
@@ -15,6 +15,52 @@ class TerminalGeometryTest {
     // space (after verticalScroll and padding in the modifier chain), so mapping is a plain division.
     private val metrics = TerminalMetrics(cellWidth = 8f, cellHeight = 18f)
 
+    // --- visibleRowWindow: which rows the draw pass (and the search highlight) covers ---
+
+    @Test
+    fun `the visible window keeps a row of slack on each side`() {
+        // Rows 10..19 sit in a 180px viewport scrolled to 180px; the window has to include the
+        // partially visible rows above and below, which the draw pass also paints.
+        assertEquals(9..21, visibleRowWindow(scrollPx = 180f, viewportPx = 180f, cellHeight = 18f, rowCount = 100))
+    }
+
+    @Test
+    fun `the visible window is clamped to the buffer`() {
+        assertEquals(0..11, visibleRowWindow(scrollPx = 0f, viewportPx = 180f, cellHeight = 18f, rowCount = 100))
+        assertEquals(0..4, visibleRowWindow(scrollPx = 0f, viewportPx = 180f, cellHeight = 18f, rowCount = 5))
+        assertTrue(visibleRowWindow(scrollPx = 0f, viewportPx = 180f, cellHeight = 18f, rowCount = 0).isEmpty())
+    }
+
+    // --- scrollToRow: bringing a search hit into view ---
+
+    @Test
+    fun `a row already in view needs no scrolling`() {
+        // Viewport 180px = 10 rows starting at row 5 (scroll 90): row 8 is on screen.
+        assertNull(scrollToRow(row = 8, currentScroll = 90, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+    }
+
+    @Test
+    fun `a row above the viewport is centered`() {
+        // Row 2 (top 36px) with a 180px viewport: centered means 36 - (180-18)/2 = -45 → clamped to 0.
+        assertEquals(0, scrollToRow(row = 2, currentScroll = 400, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+        // Row 30 (top 540px): 540 - 81 = 459.
+        assertEquals(459, scrollToRow(row = 30, currentScroll = 900, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+    }
+
+    @Test
+    fun `a row below the viewport is centered and clamped to the scroll range`() {
+        assertEquals(459, scrollToRow(row = 30, currentScroll = 0, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+        // Deep at the bottom of the buffer: never past maxScroll.
+        assertEquals(1000, scrollToRow(row = 200, currentScroll = 0, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+    }
+
+    @Test
+    fun `a partially visible row at the bottom edge is scrolled into full view`() {
+        // Viewport [0,180): row 9 spans 162..180 exactly — visible; row 10 (180..198) is not.
+        assertNull(scrollToRow(row = 9, currentScroll = 0, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+        assertEquals(99, scrollToRow(row = 10, currentScroll = 0, viewportPx = 180f, maxScroll = 1000, cellHeight = 18f))
+    }
+
     @Test
     fun `fit scale grows the font when the pane is wider than the recording`() {
         // 80 cols x 24 rows at 8x18 px = 640x432; a 1280x864 pane (no padding) fits it twice over.

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -6,6 +6,7 @@ import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
 import app.skerry.shared.terminal.TerminalPos
+import app.skerry.shared.terminal.TerminalSearchError
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import kotlinx.coroutines.CancellationException
@@ -237,6 +238,323 @@ class TerminalScreenStateTest {
         state.reverseSearchDeleteSelected()
         assertEquals(emptyList(), state.reverseSearchResults) // "gti" is no longer found
         assertEquals(listOf("git status"), snapshots.last()) // persisted without the typo
+        scope.cancel()
+    }
+
+    // --- Scrollback search (find in output) ---
+
+    @Test
+    fun `search finds matches in the buffer and selects one`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("alpha\r\nbeta\r\nalpha again\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("alpha")
+
+        assertEquals(2, state.searchMatches.size)
+        assertEquals(true, state.currentMatch != null)
+        scope.cancel()
+    }
+
+    @Test
+    fun `search selects the last match at or above the anchor row`() = runTest {
+        // Opening search mid-history should land on the newest match the user can see, not on the
+        // oldest one at the top of the scrollback.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\nfiller\r\nhit\r\nfiller\r\nhit\r\n".encodeToByteArray())
+        state.openSearch(anchorRow = 2) // viewport bottom sits on the second "hit"
+        state.updateSearchQuery("hit")
+
+        assertEquals(1, state.searchIndex)
+        assertEquals(2, state.currentMatch?.row)
+        scope.cancel()
+    }
+
+    @Test
+    fun `next and previous cycle through matches`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\nhit\r\nhit\r\n".encodeToByteArray())
+        state.openSearch(anchorRow = 0)
+        state.updateSearchQuery("hit")
+
+        assertEquals(0, state.searchIndex)
+        state.searchNext()
+        assertEquals(1, state.searchIndex)
+        state.searchPrev()
+        assertEquals(0, state.searchIndex)
+        state.searchPrev() // wraps to the last match
+        assertEquals(2, state.searchIndex)
+        state.searchNext() // wraps back to the first
+        assertEquals(0, state.searchIndex)
+        scope.cancel()
+    }
+
+    @Test
+    fun `case sensitivity and regex toggles re-run the search`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("Error 404\r\nerror 500\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("error")
+        assertEquals(2, state.searchMatches.size)
+
+        state.applySearchCase(true)
+        assertEquals(1, state.searchMatches.size)
+
+        state.applySearchCase(false)
+        state.updateSearchQuery("\\d{3}")
+        assertEquals(0, state.searchMatches.size) // still a literal search
+        state.applySearchRegex(true)
+        assertEquals(2, state.searchMatches.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `an invalid regex is reported without matches`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("anything\r\n".encodeToByteArray())
+        state.openSearch()
+        state.applySearchRegex(true)
+        state.updateSearchQuery("a(")
+
+        assertEquals(TerminalSearchError.InvalidPattern, state.searchError)
+        assertEquals(emptyList(), state.searchMatches)
+        assertEquals(null, state.currentMatch)
+        scope.cancel()
+    }
+
+    @Test
+    fun `new output refreshes matches while search is open`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        var now = 0L
+        val state = TerminalScreenState(session, scope, nowMillis = { now })
+
+        session.emit("hit one\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        assertEquals(1, state.searchMatches.size)
+
+        now += SEARCH_REFRESH_INTERVAL_MS + 1 // past the refresh throttle window
+        session.emit("hit two\r\n".encodeToByteArray())
+        assertEquals(2, state.searchMatches.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the selected match survives new output arriving`() = runTest {
+        // Output streaming in while the user is reading a hit must not silently jump the selection
+        // to another match (the viewport follows the selection).
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        var now = 0L
+        val state = TerminalScreenState(session, scope, nowMillis = { now })
+
+        session.emit("hit one\r\nhit two\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        state.searchPrev() // select the first (older) hit
+        val selected = state.currentMatch
+
+        now += SEARCH_REFRESH_INTERVAL_MS + 1
+        session.emit("hit three\r\n".encodeToByteArray())
+
+        assertEquals(selected, state.currentMatch)
+        assertEquals(3, state.searchMatches.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the match list refresh is throttled while output streams`() = runTest {
+        // A full pass over a deep scrollback costs tens of milliseconds and runs on the coroutine
+        // that feeds the emulator: rebuilding the list on every published snapshot would stall the
+        // terminal under streaming output. The visible highlight is computed by the render layer
+        // per frame, so a slightly stale list only shows up in the counter.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        var now = 0L
+        val state = TerminalScreenState(session, scope, nowMillis = { now })
+
+        session.emit("hit one\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        assertEquals(1, state.searchMatches.size)
+
+        session.emit("hit two\r\n".encodeToByteArray()) // same instant — throttled away
+        assertEquals(1, state.searchMatches.size)
+
+        now += SEARCH_REFRESH_INTERVAL_MS + 1
+        session.emit("hit three\r\n".encodeToByteArray())
+        assertEquals(3, state.searchMatches.size) // catches up on the next snapshot after the window
+        scope.cancel()
+    }
+
+    @Test
+    fun `stepping through matches refreshes the list first`() = runTest {
+        // Navigation must not walk a stale list: the user asked for the next hit, so the pass is
+        // worth running even mid-stream.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope, nowMillis = { 0L }) // clock frozen: always throttled
+
+        session.emit("hit one\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        session.emit("hit two\r\n".encodeToByteArray())
+        assertEquals(1, state.searchMatches.size)
+
+        state.searchNext()
+
+        assertEquals(2, state.searchMatches.size)
+        assertEquals(1, state.searchIndex) // moved onto the newly found hit
+        scope.cancel()
+    }
+
+    @Test
+    fun `the two search overlays never stay open together`() = runTest {
+        // Both are driven by keys, but only one owns the keyboard: the find bar's field takes focus,
+        // which strands the reverse-search overlay's key handling on the (now unfocused) terminal
+        // node — a visible panel that no longer reacts to anything.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope, initialHistory = listOf("uptime"))
+
+        session.emit("hit\r\n".encodeToByteArray())
+        state.openReverseSearch()
+        state.openSearch()
+        assertEquals(null, state.reverseSearchQuery)
+
+        state.openReverseSearch()
+        assertEquals(null, state.searchQuery)
+        scope.cancel()
+    }
+
+    @Test
+    fun `an oversized query is capped`() = runTest {
+        // A stray paste (a whole log line, a file) is not a search term; an unbounded pattern also
+        // hands the regex compiler unbounded work.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val state = TerminalScreenState(FakeTerminalSession(), scope)
+
+        state.openSearch()
+        state.updateSearchQuery("x".repeat(MAX_SEARCH_QUERY_LENGTH + 500))
+
+        assertEquals(MAX_SEARCH_QUERY_LENGTH, state.searchQuery?.length)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the viewport anchor comes from the render layer`() = runTest {
+        // The scroll position lives in the composable, so it reports the row at the viewport bottom;
+        // an incremental search re-selects around that, not around the live cursor.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\nfiller\r\nhit\r\nfiller\r\nhit\r\n".encodeToByteArray())
+        state.setSearchAnchorRow(2) // user scrolled up: second "hit" is the last visible row
+        state.openSearch()
+        state.updateSearchQuery("hit")
+
+        assertEquals(2, state.currentMatch?.row)
+        scope.cancel()
+    }
+
+    @Test
+    fun `closing search drops the query and matches`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        state.closeSearch()
+
+        assertEquals(null, state.searchQuery)
+        assertEquals(emptyList(), state.searchMatches)
+        assertEquals(null, state.currentMatch)
+        scope.cancel()
+    }
+
+    @Test
+    fun `output is not searched while the panel is closed`() = runTest {
+        // The buffer is walked on every published snapshot, so a closed panel must cost nothing.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        state.closeSearch()
+        session.emit("hit\r\n".encodeToByteArray())
+
+        assertEquals(emptyList(), state.searchMatches)
+        scope.cancel()
+    }
+
+    @Test
+    fun `reopening search keeps the previous query`() = runTest {
+        // Reopening with the last query is how editors behave; the match list is rebuilt for the
+        // buffer as it is now.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        state.closeSearch()
+        state.openSearch()
+
+        assertEquals("hit", state.searchQuery)
+        assertEquals(1, state.searchMatches.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `an empty query clears matches without erroring`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.emit("hit\r\n".encodeToByteArray())
+        state.openSearch()
+        state.updateSearchQuery("hit")
+        state.updateSearchQuery("")
+
+        assertEquals(emptyList(), state.searchMatches)
+        assertEquals(null, state.searchError)
+        assertEquals(-1, state.searchIndex)
+        scope.cancel()
+    }
+
+    @Test
+    fun `next and previous are no-ops without matches`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        state.openSearch()
+        state.updateSearchQuery("nothing here")
+        state.searchNext()
+        state.searchPrev()
+
+        assertEquals(-1, state.searchIndex)
+        assertEquals(null, state.currentMatch)
         scope.cancel()
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
@@ -1,0 +1,151 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.math.abs
+import kotlin.math.roundToInt
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Renders a live [TerminalScreen] offscreen and checks that a scrollback search actually paints:
+ * every hit gets the theme's match wash and the selected one a stronger wash, so "3 of 17" is
+ * visible on the grid rather than only in the panel's counter. The state-level behavior is covered
+ * by TerminalScreenStateTest; this is the draw path (the highlight layer between cell backgrounds
+ * and glyphs).
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class TerminalSearchRenderTest {
+
+    /** Fake PTY session: output only, input/resize are no-ops. */
+    private class FakeSession : TerminalSession {
+        private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+        override val state: StateFlow<TerminalState> = _state.asStateFlow()
+        private val _output = MutableSharedFlow<ByteArray>(extraBufferCapacity = 64)
+        override val output: Flow<ByteArray> = _output.asSharedFlow()
+        override suspend fun send(data: ByteArray) {}
+        override suspend fun resize(size: PtySize) {}
+        override suspend fun close() {}
+        fun emit(text: String) {
+            check(_output.tryEmit(text.encodeToByteArray())) { "output buffer overflow" }
+        }
+    }
+
+    @Test
+    fun searchPaintsEveryHitAndMarksTheSelectedOne() {
+        // Unconfined: feed/resize run synchronously at the emit point, making frames deterministic.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        val theme = TerminalThemes.NightSea
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    // The search panel draws design primitives (icons/labels), so the scene needs
+                    // the app's theme and font set; system families stand in for the bundled fonts.
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+
+                // Let layout settle (resize -> sized=true) before emitting, so the rows stay on screen.
+                repeat(3) { frame() }
+                // Blank lines first: the panel is pinned to the pane's top-right corner and would
+                // otherwise cover the very rows whose highlight this test looks for.
+                session.emit("\r\n\r\n\r\n\r\nalpha one\r\nalpha two")
+
+                val match = theme.searchMatch.over(theme.background)
+                val current = theme.searchCurrentMatch.over(theme.background)
+                var pixels = frame()
+                repeat(3) { pixels = frame() }
+                assertFalse(pixels.hasColorNear(match), "nothing is highlighted before a search runs")
+
+                state.openSearch()
+                state.updateSearchQuery("alpha")
+                assertTrue(state.searchMatches.size == 2, "expected both rows to match, got ${state.searchMatches}")
+
+                pixels = frame()
+                var attempts = 0
+                while (!(pixels.hasColorNear(match) && pixels.hasColorNear(current)) && attempts < 30) {
+                    pixels = frame()
+                    attempts++
+                }
+                assertTrue(pixels.hasColorNear(match), "an unselected hit should carry the match wash")
+                assertTrue(pixels.hasColorNear(current), "the selected hit should carry the stronger wash")
+
+                // Closing the panel drops the highlight with it.
+                state.closeSearch()
+                pixels = frame()
+                repeat(2) { pixels = frame() }
+                assertFalse(pixels.hasColorNear(match), "highlight should disappear once search is closed")
+                assertFalse(pixels.hasColorNear(current), "selected-hit highlight should disappear too")
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** This translucent color composited over opaque [background] (source-over), as Skia draws it. */
+    private fun Color.over(background: Color): Int {
+        fun mix(src: Float, dst: Float) = ((src * alpha + dst * (1 - alpha)) * 255f).roundToInt()
+        return Color(mix(red, background.red), mix(green, background.green), mix(blue, background.blue)).toArgb()
+    }
+
+    /** Whether any pixel is within [tolerance] per channel of [argb] (rounding differs by a unit). */
+    private fun PixelMap.hasColorNear(argb: Int, tolerance: Int = 2): Boolean {
+        fun close(a: Int, b: Int) = abs(a - b) <= tolerance
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val p = this[x, y].toArgb()
+                if (close(p shr 16 and 0xFF, argb shr 16 and 0xFF) &&
+                    close(p shr 8 and 0xFF, argb shr 8 and 0xFF) &&
+                    close(p and 0xFF, argb and 0xFF) &&
+                    (p ushr 24) == 0xFF
+                ) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSearch.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSearch.kt
@@ -1,0 +1,365 @@
+package app.skerry.shared.terminal
+
+/** Default cap on reported matches: a highlight pass walks them per repaint, so it stays bounded. */
+const val DEFAULT_SEARCH_MATCH_LIMIT = 5000
+
+/**
+ * Character-access budget for one regex search over the whole buffer, bounding wall-clock time
+ * rather than pattern shape: roughly 4 ms per million reads on a desktop JVM, so ~80 ms worst case.
+ * A user pattern is not hostile input, but an everyday one — `(.*)*error`, `(.+)+@` — backtracks
+ * quadratically over a long unwrapped row (a URL, a JWT, minified JSON), and without a ceiling that
+ * is seconds of compute. Sized above a full linear scan of a deep scrollback, so ordinary searches
+ * never reach it.
+ *
+ * Note on the guard's reach: it counts characters the regex engine reads, which works because
+ * `java.util.regex` walks its input through `CharSequence.get` (verified on OpenJDK 21; Android's
+ * libcore regex is derived from the same code but this has not been measured on a device).
+ */
+const val DEFAULT_REGEX_STEP_BUDGET = 20_000_000
+
+/**
+ * Per-row slice of [DEFAULT_REGEX_STEP_BUDGET]: 64 reads per character plus a floor, i.e. quadratic
+ * backtracking over a normal-width row still completes, while a pathological row is abandoned. One
+ * such row must not take the whole search down with it — the rest of the buffer still searches, and
+ * the result is flagged [TerminalSearchError.PatternTooComplex].
+ */
+private fun rowStepBudget(length: Int): Int = 4096 + length * 64
+
+/** Why a search produced nothing usable (only for regex mode; a substring search cannot fail). */
+enum class TerminalSearchError {
+    /** The pattern does not compile. */
+    InvalidPattern,
+
+    /**
+     * The pattern blew its backtracking budget ([DEFAULT_REGEX_STEP_BUDGET]) on at least one row.
+     * Matches found elsewhere are still reported — the buffer is only partly searched.
+     */
+    PatternTooComplex,
+}
+
+/**
+ * One hit in the terminal buffer: [row] in the snapshot grid and the half-open column range
+ * `[startCol, endCol)`. Columns are grid cells, not string offsets, so a wide (CJK) glyph covers its
+ * continuation cell too and the highlight lines up with the text.
+ */
+data class TerminalMatch(val row: Int, val startCol: Int, val endCol: Int) {
+    /** Whether cell [col] of this row is inside the match (for the highlight pass). */
+    fun contains(col: Int): Boolean = col >= startCol && col < endCol
+}
+
+/**
+ * Search outcome: [matches] top to bottom, [truncated] when the limit cut the list short, and
+ * [error] when the pattern could not be used at all (then [matches] is empty).
+ */
+data class TerminalSearchResult(
+    val matches: List<TerminalMatch> = emptyList(),
+    val truncated: Boolean = false,
+    val error: TerminalSearchError? = null,
+)
+
+/**
+ * Finds [query] in the terminal buffer [screen] (scrollback + screen rows, as published by
+ * [TerminalEmulator.lines]).
+ *
+ * Each row is searched on its own: rows are physical, so a hit spanning a soft wrap is not found —
+ * the render snapshot carries no `wrapped` flag (see [TermRow]) and joining rows would need it.
+ * Trailing blank cells are ignored, as when copying a selection: grid rows are padded to the
+ * terminal width, and searching the padding would match spaces on every row.
+ *
+ * [fromRow]/[toRow] narrow the scan to a row window (reported rows stay absolute buffer indices):
+ * the render highlights only what is on screen, and walking a 50 000-row scrollback per frame is
+ * not affordable. Out-of-range bounds are clamped.
+ *
+ * [regex] switches from a literal substring to a regular expression; [caseSensitive] is off by
+ * default. Matches never overlap: scanning resumes after the previous hit, and a zero-width regex
+ * match (`x*`) is skipped rather than reported (and cannot loop the scan). [stepBudget] bounds the
+ * regex engine's work (see [DEFAULT_REGEX_STEP_BUDGET]); [cancelled] lets a caller abandon a search
+ * that has been superseded — it is polled per row, and the partial result is then discarded.
+ */
+fun searchTerminal(
+    screen: List<List<TermCell>>,
+    query: String,
+    caseSensitive: Boolean = false,
+    regex: Boolean = false,
+    limit: Int = DEFAULT_SEARCH_MATCH_LIMIT,
+    stepBudget: Int = DEFAULT_REGEX_STEP_BUDGET,
+    fromRow: Int = 0,
+    toRow: Int = screen.size,
+    cancelled: () -> Boolean = { false },
+): TerminalSearchResult {
+    if (query.isEmpty() || limit <= 0) return TerminalSearchResult()
+    val first = fromRow.coerceIn(0, screen.size)
+    val lastExclusive = toRow.coerceIn(first, screen.size)
+    val pattern = if (!regex) null else {
+        val options = if (caseSensitive) emptySet() else setOf(RegexOption.IGNORE_CASE)
+        try {
+            Regex(query, options)
+        } catch (_: IllegalArgumentException) {
+            return TerminalSearchResult(error = TerminalSearchError.InvalidPattern)
+        }
+    }
+    val budget = StepBudget(stepBudget)
+    val matches = ArrayList<TerminalMatch>()
+    var truncated = false
+    var tooComplex = false
+    for (rowIndex in first until lastExclusive) {
+        // Cancellation is checked per row, not per match: a superseded search (the user typed
+        // another character) should stop burning CPU rather than run to completion unheard.
+        if (rowIndex and CANCEL_CHECK_MASK == 0 && cancelled()) break
+        val row = screen[rowIndex]
+        // Literal search first tries the allocation-free cell scan; it handles the plain
+        // single-width rows that make up nearly all of a buffer, and the search re-runs on every
+        // published snapshot, so building a string per row would cost real frames under output.
+        if (pattern == null) {
+            val fast = findSubstringInCells(row, rowIndex, query, caseSensitive, limit - matches.size)
+            if (fast != null) {
+                matches += fast
+                if (matches.size >= limit) {
+                    truncated = true
+                    break
+                }
+                continue
+            }
+        }
+        val text = rowText(row) ?: continue
+        val found = if (pattern == null) {
+            findSubstring(text, rowIndex, query, caseSensitive, limit - matches.size)
+        } else {
+            budget.startRow(rowStepBudget(text.text.length))
+            try {
+                findRegex(text, rowIndex, pattern, budget, limit - matches.size)
+            } catch (_: RowBudgetExceeded) {
+                // One row is pathological for this pattern; the rest of the buffer is still worth
+                // searching, so skip it and flag the result.
+                tooComplex = true
+                emptyList()
+            } catch (_: SearchBudgetExceeded) {
+                // The whole search hit its ceiling: stop here, keep what was found, and say so.
+                return TerminalSearchResult(matches, truncated, TerminalSearchError.PatternTooComplex)
+            }
+        }
+        matches += found
+        if (matches.size >= limit) {
+            truncated = true
+            break
+        }
+    }
+    return TerminalSearchResult(
+        matches = matches,
+        truncated = truncated,
+        error = if (tooComplex) TerminalSearchError.PatternTooComplex else null,
+    )
+}
+
+/** How often [searchTerminal] asks whether it has been superseded (every 64th row). */
+private const val CANCEL_CHECK_MASK = 63
+
+/**
+ * Index of the match to select for anchor row [row]: the last match at or above it (what the user
+ * sees at the viewport bottom), else the first match below. `-1` when there is nothing to select.
+ * [matches] must be ordered top to bottom, as [searchTerminal] returns them.
+ */
+fun matchNearestTo(matches: List<TerminalMatch>, row: Int): Int {
+    if (matches.isEmpty()) return -1
+    val above = matches.indexOfLast { it.row <= row }
+    return if (above >= 0) above else 0
+}
+
+/**
+ * Non-overlapping literal occurrences scanned straight over the cells, with no per-row string or
+ * column table built. Returns `null` when the row holds anything but plain one-character
+ * single-width cells (wide glyphs, combining sequences) — the caller then takes the general path.
+ * Trailing blank cells are excluded exactly as in [rowText].
+ */
+private fun findSubstringInCells(
+    row: List<TermCell>,
+    rowIndex: Int,
+    query: String,
+    caseSensitive: Boolean,
+    remaining: Int,
+): List<TerminalMatch>? {
+    var last = row.lastIndex
+    while (last >= 0 && row[last].text.isBlank()) last--
+    if (last < 0) return emptyList()
+    for (col in 0..last) {
+        val cell = row[col]
+        if (cell.width != CellWidth.Single || cell.text.length != 1) return null
+    }
+    val width = last + 1
+    if (query.length > width) return emptyList()
+    var out: MutableList<TerminalMatch>? = null
+    var col = 0
+    while (col <= width - query.length) {
+        var i = 0
+        while (i < query.length && row[col + i].text[0].equals(query[i], ignoreCase = !caseSensitive)) i++
+        if (i < query.length) {
+            col++
+            continue
+        }
+        val hits = out ?: ArrayList<TerminalMatch>(4).also { out = it }
+        hits += TerminalMatch(rowIndex, col, col + query.length)
+        if (hits.size >= remaining) break
+        col += query.length // non-overlapping, like the string path
+    }
+    return out ?: emptyList()
+}
+
+/** Non-overlapping literal occurrences of [query] in one row. */
+private fun findSubstring(
+    text: RowText,
+    rowIndex: Int,
+    query: String,
+    caseSensitive: Boolean,
+    remaining: Int,
+): List<TerminalMatch> {
+    val out = ArrayList<TerminalMatch>()
+    var from = 0
+    while (out.size < remaining) {
+        val at = text.text.indexOf(query, from, ignoreCase = !caseSensitive)
+        if (at < 0) break
+        val end = at + query.length
+        out += text.match(rowIndex, at, end)
+        from = end
+    }
+    return out
+}
+
+/** Non-overlapping regex matches in one row; zero-width matches are stepped over, not reported. */
+private fun findRegex(
+    text: RowText,
+    rowIndex: Int,
+    pattern: Regex,
+    budget: StepBudget,
+    remaining: Int,
+): List<TerminalMatch> {
+    val out = ArrayList<TerminalMatch>()
+    val guarded = BudgetedCharSequence(text.text, budget)
+    var from = 0
+    while (out.size < remaining && from <= text.text.length) {
+        val match = pattern.find(guarded, from) ?: break
+        val range = match.range
+        if (range.isEmpty()) {
+            from = match.range.first + 1 // zero-width: nothing to highlight, move on
+            continue
+        }
+        out += text.match(rowIndex, range.first, range.last + 1)
+        from = range.last + 1
+    }
+    return out
+}
+
+/**
+ * A row's searchable text plus the grid column each character came from. Cells can hold more than
+ * one character (astral glyphs, combining sequences) and a wide glyph owns two columns, so string
+ * offsets and columns are not interchangeable — except on a plain single-width ASCII/BMP row, where
+ * the mapping is the identity and the tables are left out ([startCol] == null). That fast path is
+ * the common case, and the search re-runs on every published snapshot while the panel is open, so
+ * skipping two per-row int tables there is what keeps a full-scrollback pass affordable.
+ */
+private class RowText(
+    val text: CharSequence,
+    private val startCol: IntArray?,
+    private val endCol: IntArray?,
+) {
+    /** Converts a `[from, to)` string range into a match over grid columns. */
+    fun match(row: Int, from: Int, to: Int): TerminalMatch =
+        if (startCol == null || endCol == null) {
+            TerminalMatch(row, from, to)
+        } else {
+            TerminalMatch(row, startCol[from], endCol[to - 1])
+        }
+}
+
+/** Builds [RowText] for a row, ignoring its trailing blank padding. `null` for a blank row. */
+private fun rowText(row: List<TermCell>): RowText? {
+    var last = row.lastIndex
+    while (last >= 0 && row[last].text.isBlank()) last--
+    if (last < 0) return null
+    val text = StringBuilder(last + 1)
+    // One char per cell and no wide glyph so far: while that holds, column == character index.
+    var simple = true
+    var startCol: IntArray? = null
+    var endCol: IntArray? = null
+    for (col in 0..last) {
+        val cell = row[col]
+        val chars = cell.text.length
+        val span = if (cell.width == CellWidth.Wide) 2 else 1
+        if (simple && (chars != 1 || span != 1)) {
+            // First irregular cell (wide glyph, its empty continuation, or a multi-char cell):
+            // materialize the tables over the identity-mapped prefix, then keep filling them below.
+            simple = false
+            val size = maxOf(row.size + chars, 16)
+            startCol = IntArray(size) { it }
+            endCol = IntArray(size) { it + 1 }
+        }
+        if (chars == 0) continue // continuation cell of a wide glyph — carries no text
+        if (!simple) {
+            val from = text.length
+            startCol = startCol.grownTo(from + chars)
+            endCol = endCol.grownTo(from + chars)
+            for (i in 0 until chars) {
+                startCol!![from + i] = col
+                endCol!![from + i] = col + span
+            }
+        }
+        text.append(cell.text)
+    }
+    if (text.isEmpty()) return null
+    return if (simple) RowText(text, null, null) else RowText(text, startCol, endCol)
+}
+
+/** Grows an index table to hold at least [size] entries (doubling), keeping what is already in it. */
+private fun IntArray?.grownTo(size: Int): IntArray {
+    val current = this ?: IntArray(size.coerceAtLeast(16))
+    if (current.size >= size) return current
+    return current.copyOf(maxOf(size, current.size * 2))
+}
+
+/**
+ * Remaining character reads a regex search may perform: [left] for the whole buffer, [rowLeft] for
+ * the row being scanned (never more than what is left overall). Running out of the row's share only
+ * costs that row; running out overall ends the search.
+ */
+private class StepBudget(var left: Int) {
+    var rowLeft: Int = 0
+        private set
+
+    fun startRow(limit: Int) {
+        rowLeft = minOf(limit, left)
+    }
+
+    /** Charges one character read, throwing when either budget is spent. */
+    fun spend() {
+        if (--left < 0) throw SearchBudgetExceeded()
+        if (--rowLeft < 0) throw RowBudgetExceeded()
+    }
+}
+
+/** Thrown when the whole-buffer budget runs out mid-match; caught in [searchTerminal]. */
+private class SearchBudgetExceeded : Exception()
+
+/** Thrown when one row's share of the budget runs out; that row is skipped. */
+private class RowBudgetExceeded : Exception()
+
+/**
+ * Row text that charges every character read to a shared [StepBudget]. The regex engine walks its
+ * input through `get`, so a heavily backtracking pattern burns the budget instead of the caller's
+ * thread. [subSequence] is deliberately not charged — it is only reached when a match's text is
+ * materialized, which this file never does (only `MatchResult.range` is read). Keep it that way:
+ * reading `match.value`/`groupValues` would go through the uncharged delegate and slip past the
+ * budget accounting.
+ */
+private class BudgetedCharSequence(
+    private val delegate: CharSequence,
+    private val budget: StepBudget,
+) : CharSequence {
+    override val length: Int get() = delegate.length
+
+    override fun get(index: Int): Char {
+        budget.spend()
+        return delegate[index]
+    }
+
+    override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
+        delegate.subSequence(startIndex, endIndex)
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalSearchTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalSearchTest.kt
@@ -1,0 +1,250 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TerminalSearchTest {
+
+    /** Grid from string rows: each character is a default-style cell. */
+    private fun grid(vararg rows: String): List<List<TermCell>> =
+        rows.map { row -> row.map { TermCell(it) } }
+
+    @Test
+    fun `finds a plain substring and reports its cell range`() {
+        val result = searchTerminal(grid("error: disk full"), "disk")
+
+        assertEquals(listOf(TerminalMatch(row = 0, startCol = 7, endCol = 11)), result.matches)
+        assertEquals(null, result.error)
+    }
+
+    @Test
+    fun `search is case insensitive by default and exact when asked`() {
+        val screen = grid("Error", "error")
+
+        assertEquals(listOf(0, 1), searchTerminal(screen, "error").matches.map { it.row })
+        assertEquals(listOf(1), searchTerminal(screen, "error", caseSensitive = true).matches.map { it.row })
+    }
+
+    @Test
+    fun `all occurrences on a row are reported in column order`() {
+        val result = searchTerminal(grid("ab ab ab"), "ab")
+
+        assertEquals(listOf(0, 3, 6), result.matches.map { it.startCol })
+    }
+
+    @Test
+    fun `overlapping candidates advance past the previous match`() {
+        // "aaaa" contains "aa" at 0,1,2 — non-overlapping scanning reports 0 and 2, never a loop.
+        val result = searchTerminal(grid("aaaa"), "aa")
+
+        assertEquals(listOf(0, 2), result.matches.map { it.startCol })
+    }
+
+    @Test
+    fun `an empty query finds nothing`() {
+        assertEquals(emptyList(), searchTerminal(grid("anything"), "").matches)
+    }
+
+    @Test
+    fun `matches carry the row they were found on`() {
+        val result = searchTerminal(grid("nothing here", "the needle", "nothing"), "needle")
+
+        assertEquals(1, result.matches.single().row)
+        assertEquals(4, result.matches.single().startCol)
+    }
+
+    @Test
+    fun `trailing blank cells are not searchable`() {
+        // Grid rows are padded to the terminal width; a query of spaces must not match that padding,
+        // or every row would "contain" the query (the same trim copy/selection does).
+        val result = searchTerminal(grid("ok        "), "  ")
+
+        assertEquals(emptyList(), result.matches)
+    }
+
+    @Test
+    fun `a wide cell spans two columns in the reported range`() {
+        // CJK glyph occupies two columns: the match must cover the continuation cell too, or the
+        // highlight would leave half the glyph unpainted.
+        val row = listOf(
+            TermCell("a"),
+            TermCell("漢", width = CellWidth.Wide),
+            TermCell("", width = CellWidth.Continuation),
+            TermCell("b"),
+        )
+        val result = searchTerminal(listOf(row), "漢")
+
+        assertEquals(TerminalMatch(row = 0, startCol = 1, endCol = 3), result.matches.single())
+    }
+
+    @Test
+    fun `a match after a wide cell keeps grid columns, not string offsets`() {
+        val row = listOf(
+            TermCell("漢", width = CellWidth.Wide),
+            TermCell("", width = CellWidth.Continuation),
+            TermCell("o"),
+            TermCell("k"),
+        )
+        val result = searchTerminal(listOf(row), "ok")
+
+        assertEquals(TerminalMatch(row = 0, startCol = 2, endCol = 4), result.matches.single())
+    }
+
+    @Test
+    fun `regex mode matches a pattern`() {
+        val result = searchTerminal(grid("code 404 here", "code 200 here"), "4\\d\\d", regex = true)
+
+        assertEquals(listOf(TerminalMatch(row = 0, startCol = 5, endCol = 8)), result.matches)
+    }
+
+    @Test
+    fun `regex metacharacters are literal in substring mode`() {
+        val result = searchTerminal(grid("a.c", "abc"), "a.c")
+
+        assertEquals(listOf(0), result.matches.map { it.row })
+    }
+
+    @Test
+    fun `an invalid regex reports an error instead of matches`() {
+        val result = searchTerminal(grid("anything"), "a(", regex = true)
+
+        assertEquals(TerminalSearchError.InvalidPattern, result.error)
+        assertEquals(emptyList(), result.matches)
+    }
+
+    @Test
+    fun `a regex that can match empty never loops and yields no zero-width matches`() {
+        // "x*" matches empty at every position; a naive scan would either hang or report the whole row.
+        val result = searchTerminal(grid("axxb"), "x*", regex = true)
+
+        assertEquals(listOf(TerminalMatch(row = 0, startCol = 1, endCol = 3)), result.matches)
+    }
+
+    @Test
+    fun `a regex that outruns the step budget is abandoned instead of hanging the UI`() {
+        // A backtracking pattern must not block the caller indefinitely. The budget is asserted
+        // directly (a tiny one here) rather than through a known-exponential pattern: how much
+        // backtracking a given regex engine actually does is a JVM/ART implementation detail.
+        val result = searchTerminal(grid("a".repeat(40) + "!"), "(a+)+b", regex = true, stepBudget = 8)
+
+        assertEquals(TerminalSearchError.PatternTooComplex, result.error)
+        assertEquals(emptyList(), result.matches)
+    }
+
+    @Test
+    fun `one pathological row does not take the rest of the buffer down with it`() {
+        // A single very long row (a URL, a JWT, minified JSON) can backtrack far past its share of
+        // the budget. Skipping it is right; refusing to search the other 9 999 rows is not.
+        val nasty = "x".repeat(6000) // no "error" in it: the pattern backtracks over the whole row
+        val screen = grid(nasty, "boom: error here")
+
+        val result = searchTerminal(screen, "(.*)*error", regex = true)
+
+        assertEquals(listOf(1), result.matches.map { it.row })
+        assertEquals(TerminalSearchError.PatternTooComplex, result.error) // partial, and says so
+    }
+
+    @Test
+    fun `an ordinary regex over a wide row stays inside its per-row budget`() {
+        // The per-row share must not turn normal searching into "too complex" on wide terminals.
+        val screen = grid("2026-07-25 12:00:00 " + "payload=abc123 ".repeat(30) + "done in 42ms")
+
+        val result = searchTerminal(screen, "in \\d+ms", regex = true)
+
+        assertEquals(null, result.error)
+        assertEquals(1, result.matches.size)
+    }
+
+    @Test
+    fun `a cancelled search stops early`() {
+        // The caller supersedes a search (another character typed): it must stop scanning rather
+        // than run the whole buffer to completion.
+        val screen = grid(*Array(5000) { "hit" })
+        var rowsSeen = 0
+
+        val result = searchTerminal(screen, "hit", cancelled = { rowsSeen++ > 0 })
+
+        assertTrue(result.matches.size < screen.size, "expected an early stop, got ${result.matches.size} matches")
+    }
+
+    @Test
+    fun `an ordinary regex over a deep scrollback stays within the default budget`() {
+        // The guard must not fire on normal use: a full scrollback of typical rows.
+        val rows = Array(10_000) { "2026-07-25 12:00:00 service[$it]: request handled in 12ms" }
+
+        val result = searchTerminal(grid(*rows), "in \\d+ms", regex = true)
+
+        assertEquals(null, result.error)
+        assertEquals(5000, result.matches.size) // the default match limit, not a budget failure
+        assertTrue(result.truncated)
+    }
+
+    @Test
+    fun `the match list is capped and reports truncation`() {
+        val rows = Array(50) { "hit hit hit hit" }
+        val result = searchTerminal(grid(*rows), "hit", limit = 10)
+
+        assertEquals(10, result.matches.size)
+        assertTrue(result.truncated)
+    }
+
+    @Test
+    fun `an untruncated result reports no truncation`() {
+        assertEquals(false, searchTerminal(grid("hit"), "hit").truncated)
+    }
+
+    @Test
+    fun `matches are ordered top to bottom`() {
+        val result = searchTerminal(grid("hit", "miss", "hit"), "hit")
+
+        assertEquals(listOf(0, 2), result.matches.map { it.row })
+    }
+
+    @Test
+    fun `a row window limits the scan and still reports absolute rows`() {
+        // The render highlights only the visible rows; their indices must stay buffer indices, or
+        // the wash would land on the wrong lines.
+        val screen = grid("hit", "hit", "hit", "hit")
+
+        val result = searchTerminal(screen, "hit", fromRow = 1, toRow = 3)
+
+        assertEquals(listOf(1, 2), result.matches.map { it.row })
+    }
+
+    @Test
+    fun `a row window past the buffer is clamped`() {
+        val screen = grid("hit", "hit")
+
+        assertEquals(listOf(1), searchTerminal(screen, "hit", fromRow = 1, toRow = 99).matches.map { it.row })
+        assertEquals(emptyList(), searchTerminal(screen, "hit", fromRow = 5, toRow = 99).matches)
+        assertEquals(emptyList(), searchTerminal(screen, "hit", fromRow = -3, toRow = -1).matches)
+    }
+
+    // --- currentMatchFor: which match to select when the query changes ---
+
+    @Test
+    fun `the first selected match is the last one at or above the viewport bottom`() {
+        // Opening search on a live terminal should land on the newest match the user can see, the
+        // way less/vim land near the cursor rather than at the top of a long scrollback.
+        val matches = listOf(
+            TerminalMatch(2, 0, 3),
+            TerminalMatch(40, 0, 3),
+            TerminalMatch(90, 0, 3),
+        )
+
+        assertEquals(1, matchNearestTo(matches, row = 50))
+    }
+
+    @Test
+    fun `with every match below the anchor the first one is selected`() {
+        val matches = listOf(TerminalMatch(70, 0, 3), TerminalMatch(90, 0, 3))
+
+        assertEquals(0, matchNearestTo(matches, row = 10))
+    }
+
+    @Test
+    fun `an empty match list has no selection`() {
+        assertEquals(-1, matchNearestTo(emptyList(), row = 10))
+    }
+}


### PR DESCRIPTION
Find in output: search the session's scrollback for a substring or a regular expression, with every hit highlighted on the grid and navigation between them.

## Where / keys

- `⌘F` / `Ctrl+Shift+F` opens the panel over the focused pane (the split, when it holds focus). SFTP moves to `⌘E` / `Ctrl+Shift+E`.
- In the panel: `Enter` / `Shift+Enter` step through hits, `Esc` closes, `Aa` toggles case, `.*` switches to regex.
- Android: the `find_in_page` key in the key bar opens the same panel.
- Settings → Keyboard lists the new binding and the moved SFTP one.

## Behaviour

- Every match carries a highlight wash; the selected one is accented, and stepping to it scrolls the viewport only when it is off-screen.
- The counter shows `3/17`, `3/5000+` when the match cap is reached, or why a pattern yielded nothing (invalid / too complex).
- Opening the panel restores the previous query and selects the last hit at or above the row the viewport shows.
- A search runs against whatever the buffer holds: in alt-screen (vim/less) that is the application's own frame.
- Matches within a soft-wrapped line are not found — the render snapshot carries no `wrapped` flag.

## Also in this PR

- `TerminalSearch.kt` in shared: columns are grid cells (a wide glyph covers its continuation cell), trailing row padding is not searchable, matches never overlap, and a zero-width regex match is stepped over.
- Regex work is bounded per row and per pass, so a pathological pattern costs one row instead of the whole search, and a search can be cancelled when a newer one supersedes it.
- The match list is rebuilt in its own coroutine (single-flight, throttled, published atomically); the on-screen highlight is computed per frame over the visible rows, so streaming output never stalls the emulator.
- Tests: engine unit tests, search state tests, viewport geometry tests, and an offscreen render test asserting both highlight levels actually paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)