### PR TITLE
Name throttled and broken servers; fix palette focus and host menu width

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -140,6 +140,8 @@
     <string name="lib_teams_err_key_missing">Ключ команды недоступен на этом устройстве</string>
     <string name="lib_teams_err_network">Сетевая ошибка — проверьте соединение с sync-сервером</string>
     <string name="lib_teams_err_protocol">Неожиданный ответ сервера</string>
+    <string name="lib_teams_err_too_many_requests">Сервер ограничивает частоту запросов — подождите и попробуйте снова</string>
+    <string name="lib_teams_err_server_error">Сервер отвечает с ошибкой — попробуйте позже</string>
     <string name="lib_teams_err_forbidden">Недоступно для вашей роли в команде</string>
     <string name="lib_teams_err_vault_unreadable">Локальный файл командного хранилища нечитаем — он сохранён, не удалён</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -112,6 +112,8 @@
     <string name="sync_fail_save_settings">Не удалось сохранить настройки синхронизации</string>
     <string name="sync_fail_sync">Ошибка синхронизации</string>
     <string name="sync_fail_revoke">Не удалось отозвать устройство</string>
+    <string name="sync_fail_too_many_requests">Сервер ограничивает частоту запросов — подождите и попробуйте снова</string>
+    <string name="sync_fail_server_error">Сервер отвечает с ошибкой — попробуйте позже</string>
 
     <!-- issue #28: подключение к существующему аккаунту с другим паролём меняет пароль этого устройства -->
     <string name="sync_password_replace_title">Использовать пароль аккаунта?</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -140,6 +140,8 @@
     <string name="lib_teams_err_key_missing">团队密钥在此设备上不可用</string>
     <string name="lib_teams_err_network">网络错误 — 请检查到同步服务器的连接</string>
     <string name="lib_teams_err_protocol">意外的服务器响应</string>
+    <string name="lib_teams_err_too_many_requests">服务器正在限制请求频率，请稍候重试</string>
+    <string name="lib_teams_err_server_error">服务器响应异常，请稍后重试</string>
     <string name="lib_teams_err_forbidden">你的角色不允许此操作</string>
     <string name="lib_teams_err_vault_unreadable">本地团队保险库文件不可读 — 已保留，未删除</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -112,6 +112,8 @@
     <string name="sync_fail_save_settings">无法保存同步设置</string>
     <string name="sync_fail_sync">同步失败</string>
     <string name="sync_fail_revoke">无法撤销设备</string>
+    <string name="sync_fail_too_many_requests">服务器正在限制请求频率，请稍候重试</string>
+    <string name="sync_fail_server_error">服务器响应异常，请稍后重试</string>
 
     <!-- issue #28: 连接到使用其他密码的现有账户会将本设备改用该密码 -->
     <string name="sync_password_replace_title">使用账户密码？</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -140,6 +140,8 @@
     <string name="lib_teams_err_key_missing">Team key is unavailable on this device</string>
     <string name="lib_teams_err_network">Network error — check the connection to the sync server</string>
     <string name="lib_teams_err_protocol">Unexpected server response</string>
+    <string name="lib_teams_err_too_many_requests">The server is throttling requests — wait a moment and try again</string>
+    <string name="lib_teams_err_server_error">The server isn't responding correctly — try again later</string>
     <string name="lib_teams_err_forbidden">Not allowed for your role in this team</string>
     <string name="lib_teams_err_vault_unreadable">The local team vault file is unreadable — it was kept, not deleted</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -112,6 +112,8 @@
     <string name="sync_fail_save_settings">Couldn't save sync settings</string>
     <string name="sync_fail_sync">Sync failed</string>
     <string name="sync_fail_revoke">Couldn't revoke the device</string>
+    <string name="sync_fail_too_many_requests">The server is throttling requests — wait a moment and try again</string>
+    <string name="sync_fail_server_error">The server isn't responding correctly — try again later</string>
 
     <!-- issue #28: joining an existing account whose password differs re-keys this device to it -->
     <string name="sync_password_replace_title">Use your account password?</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ModalScrim.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ModalScrim.kt
@@ -44,12 +44,7 @@ fun ModalScrim(
     content: @Composable BoxScope.() -> Unit,
 ) {
     val noop = remember { MutableInteractionSource() }
-    var token by remember { mutableStateOf(-1) }
-    DisposableEffect(Unit) {
-        val t = ModalPresence.opened()
-        token = t
-        onDispose { ModalPresence.closed(t) }
-    }
+    val token = rememberModalPresence()
     // Esc handling: the scrim listens on key bubble-up (onKeyEvent), so a focused field or a
     // nested modal handles the event first. The scrim claims focus only while nothing inside the
     // modal holds it — otherwise it would steal focus from an auto-focused field.
@@ -85,6 +80,23 @@ fun ModalScrim(
         withFrameNanos {} // let an auto-focused field inside claim focus first
         if (!subtreeFocused) runCatching { escFocus.requestFocus() }
     }
+}
+
+/**
+ * Registers the calling composable with [ModalPresence] for as long as it stays in composition, and
+ * returns its token (for [ModalPresence.isTop]; -1 until the effect runs). Needed by every modal
+ * that takes the keyboard, not just [ModalScrim] ones: a focusable Popup owns focus while it is up
+ * and leaves it with no one when it goes, so without this the terminal never reclaims it.
+ */
+@Composable
+fun rememberModalPresence(): Int {
+    var token by remember { mutableStateOf(-1) }
+    DisposableEffect(Unit) {
+        val t = ModalPresence.opened()
+        token = t
+        onDispose { ModalPresence.closed(t) }
+    }
+    return token
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -153,6 +153,8 @@ enum class SyncFailureReason {
     SaveSettingsFailed,    // sync settings didn't save (detail: cause)
     SyncFailed,            // sync cycle failure (detail: cause)
     RevokeFailed,          // device revoke failed (detail: cause)
+    TooManyRequests,       // the server's rate limiter turned the request away — retrying later works
+    ServerError,           // the server (or the proxy in front of it) is broken or restarting
 }
 
 /**
@@ -801,11 +803,16 @@ class SyncCoordinator(
             val newSession = try {
                 syncClient.changePassword(cfg.accountId, cak, nak, newWrapped, device)
             } catch (e: SyncException) {
-                // UNAUTHORIZED/NOT_FOUND come from the SRP verify gate, before any DB write — nothing
-                // rotated, so it's safe to restore the auto-restore token (a wrong-password typo mustn't
-                // cost the user their "keep connected"). NETWORK/PROTOCOL are ambiguous (the server may
-                // have committed): leave it cleared and let the user reconnect with the new password.
-                if (hadAutoRestore && (e.kind == SyncException.Kind.UNAUTHORIZED || e.kind == SyncException.Kind.NOT_FOUND)) {
+                // UNAUTHORIZED/NOT_FOUND come from the SRP verify gate, and TOO_MANY_REQUESTS from the
+                // rate limiter ahead of the route — all three land before any DB write, so nothing
+                // rotated and it's safe to restore the auto-restore token (a wrong-password typo or a
+                // throttled retry mustn't cost the user their "keep connected"). NETWORK/PROTOCOL/5xx
+                // are ambiguous (the server may have committed): leave it cleared and let the user
+                // reconnect with the new password.
+                val rejectedBeforeAnyWrite = e.kind == SyncException.Kind.UNAUTHORIZED ||
+                    e.kind == SyncException.Kind.NOT_FOUND ||
+                    e.kind == SyncException.Kind.TOO_MANY_REQUESTS
+                if (hadAutoRestore && rejectedBeforeAnyWrite) {
                     configStore.save(cfg)
                 }
                 return when (e.kind) {
@@ -814,6 +821,8 @@ class SyncCoordinator(
                         AccountPasswordChange.Failed(SyncFailureReason.Unauthorized)
                     SyncException.Kind.NETWORK -> AccountPasswordChange.Failed(SyncFailureReason.Network, e.message)
                     SyncException.Kind.PROTOCOL -> AccountPasswordChange.Failed(SyncFailureReason.Protocol, e.message)
+                    SyncException.Kind.TOO_MANY_REQUESTS -> AccountPasswordChange.Failed(SyncFailureReason.TooManyRequests)
+                    SyncException.Kind.SERVER_ERROR -> AccountPasswordChange.Failed(SyncFailureReason.ServerError, e.message)
                     else -> AccountPasswordChange.Failed(SyncFailureReason.ConnectFailed, e.message)
                 }
             }
@@ -1576,6 +1585,8 @@ class SyncCoordinator(
         SyncException.Kind.GONE -> SyncStatus.Failed(SyncFailureReason.PairingCodeExpired)
         SyncException.Kind.NETWORK -> SyncStatus.Failed(SyncFailureReason.Network, e.message)
         SyncException.Kind.PROTOCOL -> SyncStatus.Failed(SyncFailureReason.Protocol, e.message)
+        SyncException.Kind.TOO_MANY_REQUESTS -> SyncStatus.Failed(SyncFailureReason.TooManyRequests)
+        SyncException.Kind.SERVER_ERROR -> SyncStatus.Failed(SyncFailureReason.ServerError, e.message)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
@@ -17,10 +17,13 @@ import app.skerry.ui.generated.resources.stail_sync_fail_key_adopt
 import app.skerry.ui.generated.resources.stail_sync_fail_rekey
 import app.skerry.ui.generated.resources.sync_fail_revoke
 import app.skerry.ui.generated.resources.sync_fail_save_settings
+import app.skerry.ui.generated.resources.sync_fail_server_error
 import app.skerry.ui.generated.resources.sync_fail_sync
+import app.skerry.ui.generated.resources.sync_fail_too_many_requests
 import app.skerry.ui.generated.resources.sync_fail_unauthorized
 import app.skerry.ui.generated.resources.sync_fail_vault_locked
 import app.skerry.ui.generated.resources.sync_fail_wrong_device_password
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 /**
@@ -30,28 +33,32 @@ import org.jetbrains.compose.resources.stringResource
  */
 @Composable
 fun syncFailureText(failed: SyncStatus.Failed): String {
-    val base = stringResource(
-        when (failed.reason) {
-            SyncFailureReason.VaultLocked -> Res.string.sync_fail_vault_locked
-            SyncFailureReason.Unauthorized -> Res.string.sync_fail_unauthorized
-            SyncFailureReason.AccountNotFound -> Res.string.sync_fail_account_not_found
-            SyncFailureReason.AccountExists -> Res.string.sync_fail_account_exists
-            SyncFailureReason.PairingCodeExpired -> Res.string.sync_fail_pairing_expired
-            SyncFailureReason.Network -> Res.string.sync_fail_network
-            SyncFailureReason.Protocol -> Res.string.sync_fail_protocol
-            SyncFailureReason.ConnectFailed -> Res.string.sync_fail_connect
-            SyncFailureReason.PairingCodeMalformed -> Res.string.sync_fail_code_malformed
-            SyncFailureReason.PairingCodeInvalid -> Res.string.sync_fail_code_invalid
-            SyncFailureReason.WrongDevicePassword -> Res.string.sync_fail_wrong_device_password
-            SyncFailureReason.LocalVaultCorrupted -> Res.string.sync_fail_local_vault_corrupted
-            SyncFailureReason.PairingFailed -> Res.string.sync_fail_pairing
-            SyncFailureReason.VaultRekeyFailed -> Res.string.stail_sync_fail_rekey
-            SyncFailureReason.AccountKeyNotAdopted -> Res.string.stail_sync_fail_key_adopt
-            SyncFailureReason.SaveSettingsFailed -> Res.string.sync_fail_save_settings
-            SyncFailureReason.SyncFailed -> Res.string.sync_fail_sync
-            SyncFailureReason.RevokeFailed -> Res.string.sync_fail_revoke
-        },
-    )
+    val base = stringResource(syncFailureResource(failed.reason))
     val detail = failed.detail?.takeIf { it.isNotBlank() } ?: return base
     return stringResource(Res.string.stail_sync_fail_detail, base, detail)
 }
+
+/** Reason → its text. Split out of the composable so the wiring itself is unit-testable. */
+internal fun syncFailureResource(reason: SyncFailureReason): StringResource =
+    when (reason) {
+        SyncFailureReason.VaultLocked -> Res.string.sync_fail_vault_locked
+        SyncFailureReason.Unauthorized -> Res.string.sync_fail_unauthorized
+        SyncFailureReason.AccountNotFound -> Res.string.sync_fail_account_not_found
+        SyncFailureReason.AccountExists -> Res.string.sync_fail_account_exists
+        SyncFailureReason.PairingCodeExpired -> Res.string.sync_fail_pairing_expired
+        SyncFailureReason.Network -> Res.string.sync_fail_network
+        SyncFailureReason.Protocol -> Res.string.sync_fail_protocol
+        SyncFailureReason.ConnectFailed -> Res.string.sync_fail_connect
+        SyncFailureReason.PairingCodeMalformed -> Res.string.sync_fail_code_malformed
+        SyncFailureReason.PairingCodeInvalid -> Res.string.sync_fail_code_invalid
+        SyncFailureReason.WrongDevicePassword -> Res.string.sync_fail_wrong_device_password
+        SyncFailureReason.LocalVaultCorrupted -> Res.string.sync_fail_local_vault_corrupted
+        SyncFailureReason.PairingFailed -> Res.string.sync_fail_pairing
+        SyncFailureReason.VaultRekeyFailed -> Res.string.stail_sync_fail_rekey
+        SyncFailureReason.AccountKeyNotAdopted -> Res.string.stail_sync_fail_key_adopt
+        SyncFailureReason.SaveSettingsFailed -> Res.string.sync_fail_save_settings
+        SyncFailureReason.SyncFailed -> Res.string.sync_fail_sync
+        SyncFailureReason.RevokeFailed -> Res.string.sync_fail_revoke
+        SyncFailureReason.TooManyRequests -> Res.string.sync_fail_too_many_requests
+        SyncFailureReason.ServerError -> Res.string.sync_fail_server_error
+    }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -40,6 +40,23 @@ import app.skerry.shared.team.stripShareFields
 enum class TeamsFailure {
     NotConnected, VaultLocked, NoRecipientKey, AlreadyInvited, NoSuchAccount,
     KeyMissing, Network, Protocol, Forbidden, VaultUnreadable,
+    TooManyRequests, ServerError,
+}
+
+/**
+ * Sync-client error → team-level failure. Same server as sync, so its rate limiter and its 5xx are
+ * named here too instead of landing in the generic protocol bucket. A null kind (any non-sync
+ * exception) is a protocol failure.
+ */
+internal fun SyncException.Kind?.toTeamsFailure(): TeamsFailure = when (this) {
+    SyncException.Kind.NETWORK -> TeamsFailure.Network
+    SyncException.Kind.UNAUTHORIZED -> TeamsFailure.Forbidden
+    SyncException.Kind.NOT_FOUND -> TeamsFailure.NoSuchAccount
+    SyncException.Kind.CONFLICT -> TeamsFailure.AlreadyInvited
+    SyncException.Kind.TOO_MANY_REQUESTS -> TeamsFailure.TooManyRequests
+    SyncException.Kind.SERVER_ERROR -> TeamsFailure.ServerError
+    // GONE is a pairing-code state with no team-level meaning; PROTOCOL and null stay generic.
+    SyncException.Kind.GONE, SyncException.Kind.PROTOCOL, null -> TeamsFailure.Protocol
 }
 
 /** A team as the UI sees it: server metadata + local key (the name lives in its vault / envelope). */
@@ -649,13 +666,7 @@ class TeamsCoordinator(
         _lastError.value = reason
     }
 
-    private fun Exception.toFailure(): TeamsFailure = when ((this as? SyncException)?.kind) {
-        SyncException.Kind.NETWORK -> TeamsFailure.Network
-        SyncException.Kind.UNAUTHORIZED -> TeamsFailure.Forbidden
-        SyncException.Kind.NOT_FOUND -> TeamsFailure.NoSuchAccount
-        SyncException.Kind.CONFLICT -> TeamsFailure.AlreadyInvited
-        else -> TeamsFailure.Protocol
-    }
+    private fun Exception.toFailure(): TeamsFailure = (this as? SyncException)?.kind.toTeamsFailure()
 
     private companion object {
         /** Bounded retries when a rotation loses the epoch race to a concurrent rotation. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -72,6 +72,8 @@ import app.skerry.ui.generated.resources.lib_teams_err_no_recipient_key
 import app.skerry.ui.generated.resources.lib_teams_err_no_such_account
 import app.skerry.ui.generated.resources.lib_teams_err_not_connected
 import app.skerry.ui.generated.resources.lib_teams_err_protocol
+import app.skerry.ui.generated.resources.lib_teams_err_server_error
+import app.skerry.ui.generated.resources.lib_teams_err_too_many_requests
 import app.skerry.ui.generated.resources.lib_teams_err_vault_locked
 import app.skerry.ui.generated.resources.lib_teams_err_vault_unreadable
 import app.skerry.ui.generated.resources.lib_teams_history
@@ -500,6 +502,8 @@ internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
     TeamsFailure.Protocol -> stringResource(Res.string.lib_teams_err_protocol)
     TeamsFailure.Forbidden -> stringResource(Res.string.lib_teams_err_forbidden)
     TeamsFailure.VaultUnreadable -> stringResource(Res.string.lib_teams_err_vault_unreadable)
+    TeamsFailure.TooManyRequests -> stringResource(Res.string.lib_teams_err_too_many_requests)
+    TeamsFailure.ServerError -> stringResource(Res.string.lib_teams_err_server_error)
 }
 
 /** launch from click handlers: a param-less suspend block, shorter than a lambda with CoroutineScope. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -914,11 +915,15 @@ internal fun HostEntryRow(
     }
 }
 
-/** Context menu item for a host row. */
+/**
+ * Context menu item for a host row. The width floor keeps the card from collapsing onto its longest
+ * label — short verbs in some locales leave a sliver of a click target, and the same menu would
+ * change width from row to row depending on which actions that row offers.
+ */
 @Composable
 private fun HostMenuItem(label: String, color: Color, onClick: () -> Unit) {
     Box(
-        Modifier.clip(RoundedCornerShape(5.dp)).clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 7.dp),
+        Modifier.widthIn(min = 140.dp).clip(RoundedCornerShape(5.dp)).clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 7.dp),
     ) {
         Txt(label, color = color, size = 12.sp)
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.rememberModalPresence
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
@@ -92,6 +93,9 @@ internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? 
 
 @Composable
 internal fun SnippetPalette(manager: SnippetManager, onPick: (SnippetEntry) -> Unit) {
+    // Registered here rather than at each call site: the palette is only ever shown inside a
+    // focusable Popup (toolbar button, host row menu), and both must hand the keyboard back.
+    rememberModalPresence()
     val mono = LocalFonts.current.mono
     var query by remember { mutableStateOf("") }
     val all = manager.snippets

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncFailureResourceTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncFailureResourceTest.kt
@@ -1,0 +1,37 @@
+package app.skerry.ui.sync
+
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sync_fail_network
+import app.skerry.ui.generated.resources.sync_fail_protocol
+import app.skerry.ui.generated.resources.sync_fail_server_error
+import app.skerry.ui.generated.resources.sync_fail_too_many_requests
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Reason → string resource. The `when` is exhaustive, so a missing branch can't compile, but nothing
+ * stops two reasons from being wired to each other's text: "wait a moment and try again" for a dead
+ * server sends the user off to retry forever, and "the server is broken" for a rate limit sends them
+ * to check a server that is fine.
+ */
+class SyncFailureResourceTest {
+
+    @Test
+    fun `throttling and server failure each get their own text`() {
+        assertEquals(Res.string.sync_fail_too_many_requests, syncFailureResource(SyncFailureReason.TooManyRequests))
+        assertEquals(Res.string.sync_fail_server_error, syncFailureResource(SyncFailureReason.ServerError))
+    }
+
+    @Test
+    fun `the reasons they are easiest to confuse with keep their own text`() {
+        assertEquals(Res.string.sync_fail_network, syncFailureResource(SyncFailureReason.Network))
+        assertEquals(Res.string.sync_fail_protocol, syncFailureResource(SyncFailureReason.Protocol))
+    }
+
+    @Test
+    fun `every reason resolves to a distinct text`() {
+        val byResource = SyncFailureReason.entries.groupBy { syncFailureResource(it) }
+        val shared = byResource.filterValues { it.size > 1 }
+        assertEquals(emptyMap(), shared, "reasons sharing one text can't be told apart by the user")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsFailureMappingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsFailureMappingTest.kt
@@ -1,0 +1,35 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.SyncException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Team operations talk to the same server as sync and hit the same two states — its rate limiter and
+ * its 5xx — so they must be named the same way here. Folding them into "protocol error" tells a user
+ * whose invite was simply throttled that something is wrong with the client.
+ */
+class TeamsFailureMappingTest {
+
+    @Test
+    fun `throttling and server failures are named, not folded into protocol`() {
+        assertEquals(TeamsFailure.TooManyRequests, SyncException.Kind.TOO_MANY_REQUESTS.toTeamsFailure())
+        assertEquals(TeamsFailure.ServerError, SyncException.Kind.SERVER_ERROR.toTeamsFailure())
+    }
+
+    @Test
+    fun `the existing mappings are unchanged`() {
+        assertEquals(TeamsFailure.Network, SyncException.Kind.NETWORK.toTeamsFailure())
+        assertEquals(TeamsFailure.Forbidden, SyncException.Kind.UNAUTHORIZED.toTeamsFailure())
+        assertEquals(TeamsFailure.NoSuchAccount, SyncException.Kind.NOT_FOUND.toTeamsFailure())
+        assertEquals(TeamsFailure.AlreadyInvited, SyncException.Kind.CONFLICT.toTeamsFailure())
+        // GONE has no team-level meaning (it's a pairing-code state) and stays generic.
+        assertEquals(TeamsFailure.Protocol, SyncException.Kind.GONE.toTeamsFailure())
+        assertEquals(TeamsFailure.Protocol, SyncException.Kind.PROTOCOL.toTeamsFailure())
+    }
+
+    @Test
+    fun `a non-sync exception is still a protocol failure`() {
+        assertEquals(TeamsFailure.Protocol, (null as SyncException.Kind?).toTeamsFailure())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -445,6 +445,75 @@ class SyncCoordinatorPasswordReplaceTest {
         }
     }
 
+    /** Delegates everything but the rotation, which the server turns away with [kind]. */
+    private class RotationRejectingClient(
+        inner: SyncClient,
+        private val kind: SyncException.Kind,
+    ) : SyncClient by inner {
+        override suspend fun changePassword(
+            accountId: String,
+            currentAuthKey: ByteArray,
+            newAuthKey: ByteArray,
+            newWrappedDataKey: ByteArray,
+            device: DeviceInfo,
+        ): SyncSession = throw SyncException(kind, "rejected")
+    }
+
+    /**
+     * The rate limiter turns the rotation away before the route runs, so nothing rotated: the
+     * keep-connected token must survive. Clearing it (the treatment ambiguous failures get) would
+     * cost the user their auto-restore for a failure that changed nothing on the server — and 429
+     * is the one a user hits by simply retrying a mistyped password a few times.
+     */
+    @Test
+    fun `a throttled rotation keeps the auto-restore token and is named as throttling`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val store = InMemorySyncConfigStore().apply {
+            save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
+        }
+        val sut = coordinator(vault, RotationRejectingClient(client, SyncException.Kind.TOO_MANY_REQUESTS), store)
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertEquals(
+                SyncFailureReason.TooManyRequests,
+                (result as? AccountPasswordChange.Failed)?.reason,
+                "a throttled rotation must be named as throttling, was $result",
+            )
+            assertEquals("sealed-old", store.load()?.sealedRefreshToken, "nothing rotated — the auto-restore token stays")
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the local vault is untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A 5xx is ambiguous — the server may have committed the rotation before dying — so it keeps the
+     * conservative treatment (token cleared), but it must still be named as a server failure.
+     */
+    @Test
+    fun `a rotation against a broken server is named as a server failure`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val store = InMemorySyncConfigStore().apply {
+            save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
+        }
+        val sut = coordinator(vault, RotationRejectingClient(client, SyncException.Kind.SERVER_ERROR), store)
+        try {
+            val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
+            assertEquals(
+                SyncFailureReason.ServerError,
+                (result as? AccountPasswordChange.Failed)?.reason,
+                "was $result",
+            )
+            assertEquals(null, store.load()?.sealedRefreshToken, "an ambiguous failure still clears the auto-restore token")
+        } finally {
+            sut.close()
+        }
+    }
+
     /**
      * The current password passes the local check but the SERVER rejects the SRP proof (e.g. another
      * device already rotated the account): the coordinator surfaces it as a failure, unchanged locally.

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
@@ -1,0 +1,102 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A throttled or broken server must be named as such. Both are reachable states of a self-hosted
+ * instance — the rate limiter guards register/SRP/pairing, and a restart behind a reverse proxy
+ * answers 5xx — but both used to collapse into PROTOCOL, i.e. "protocol error", which reads like a
+ * client bug and tells the user nothing about waiting or checking the server.
+ */
+class SyncCoordinatorServerFailureTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    /** Server that rejects registration with [kind] — the first call any connect makes. */
+    private class RejectingClient(private val kind: SyncException.Kind) : SyncClient {
+        override suspend fun ping(): Boolean = true
+
+        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            throw SyncException(kind, "rejected")
+
+        override fun changes(session: SyncSession): Flow<SyncSignal> = flow { awaitCancellation() }
+        override suspend fun close() {}
+        override suspend fun refresh(session: SyncSession): SyncSession = nope()
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
+        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
+        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
+        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
+        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()
+        private fun nope(): Nothing = throw NotImplementedError("connect fails before this is reached")
+    }
+
+    private fun localVault(): Vault {
+        val file = Files.createTempFile("skerry-server-failure", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "dev-local", fileSystem = FileSystem.SYSTEM, now = { "2026-07-25T00:00:00Z" })
+            .also { it.create(password.toCharArray()) }
+    }
+
+    private fun reasonForRejectedConnect(kind: SyncException.Kind): SyncFailureReason = runBlocking {
+        initializeVaultCrypto()
+        val sut = SyncCoordinator(
+            clientFactory = { RejectingClient(kind) },
+            crypto = crypto,
+            vault = localVault(),
+            engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            withTimeout(30_000) { (sut.status.first { it is SyncStatus.Failed } as SyncStatus.Failed).reason }
+        } finally {
+            sut.close()
+        }
+    }
+
+    @Test
+    fun `a throttled server is reported as rate limiting, not as a protocol error`() {
+        assertEquals(SyncFailureReason.TooManyRequests, reasonForRejectedConnect(SyncException.Kind.TOO_MANY_REQUESTS))
+    }
+
+    @Test
+    fun `a broken server is reported as a server failure, not as a protocol error`() {
+        assertEquals(SyncFailureReason.ServerError, reasonForRejectedConnect(SyncException.Kind.SERVER_ERROR))
+    }
+
+    @Test
+    fun `an actual protocol error still reports as one`() {
+        assertEquals(SyncFailureReason.Protocol, reasonForRejectedConnect(SyncException.Kind.PROTOCOL))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostMenuWidthTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostMenuWidthTest.kt
@@ -1,0 +1,105 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The host row's "⋮" menu sizes itself to its longest label, so in a language with short verbs the
+ * card collapses to a sliver of text with barely any click target, and the same menu changes width
+ * per row (Edit/Duplicate/Delete vs Edit only). It must never render narrower than the floor,
+ * whatever the labels say.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class HostMenuWidthTest {
+
+    /**
+     * Item floor (140dp) plus the card's 4dp padding on both sides, less the 1dp border that paints
+     * over the fill on each edge — the run of background pixels the scan below can actually see, at
+     * density 1. Without a floor the same card measures ~92px (its two labels).
+     */
+    private val minimumCardWidthPx = 146
+
+    private val sceneWidth = 400f
+
+    /** The trailing "⋮" IconBtn's box size in HostEntryRow, at density 1. */
+    private val MENU_BUTTON_BOX = 22f
+
+    // Captured from the live theme rather than hardcoded, so a change of default theme doesn't turn
+    // this into a colour-literal test. Only the menu card paints surface2 in this scene: the row
+    // itself is unselected (transparent), and Color equality includes alpha.
+    private var cardColor = Color.Unspecified
+
+    @Composable
+    private fun RowUnderTest() {
+        SkerryTheme {
+            cardColor = Skerry.colors.surface2
+            CompositionLocalProvider(
+                LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+            ) {
+                Box(Modifier.fillMaxWidth()) {
+                    HostEntryRow(
+                        label = "alpha", selected = false, dot = Color.Green, badge = null,
+                        onClick = {}, mono = FontFamily.Monospace, icon = "dns",
+                        onEdit = {}, onDelete = {},
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the row menu never renders narrower than its floor`() {
+        ImageComposeScene(width = sceneWidth.toInt(), height = 300, density = Density(1f)).use { scene ->
+            scene.setContent { RowUnderTest() }
+            Snapshot.sendApplyNotifications()
+            scene.render(16_666_667L)
+
+            // Open the menu from the trailing "⋮" button. It is pinned to the row's right edge, so
+            // aim half a button-box in from there rather than at a fixed coordinate — this survives
+            // padding changes in HostEntryRow. If the row's trailing layout ever changes so much
+            // that the click misses, the "menu didn't open" assertion below says so outright.
+            val menuButton = Offset(sceneWidth - MENU_BUTTON_BOX / 2f, 13f)
+            scene.sendPointerEvent(PointerEventType.Press, menuButton, timeMillis = 0)
+            scene.sendPointerEvent(PointerEventType.Release, menuButton, timeMillis = 16)
+            Snapshot.sendApplyNotifications()
+            scene.render(33_333_334L)
+            Snapshot.sendApplyNotifications()
+            val pixels = scene.render(50_000_000L).toComposeImageBitmap().toPixelMap()
+
+            // The menu card is the widest run of its background colour in the frame.
+            var widest = 0
+            for (y in 0 until pixels.height) {
+                var run = 0
+                for (x in 0 until pixels.width) {
+                    if (pixels[x, y] == cardColor) run++ else { widest = maxOf(widest, run); run = 0 }
+                }
+                widest = maxOf(widest, run)
+            }
+            assertTrue(widest > 0, "the menu didn't open — the click missed the row's \"⋮\" button")
+            assertTrue(
+                widest >= minimumCardWidthPx,
+                "the menu card must be at least ${minimumCardWidthPx}px wide, was ${widest}px",
+            )
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SnippetPaletteModalPresenceTest.kt
@@ -1,0 +1,75 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.ModalPresence
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.snippet.SnippetStore
+import app.skerry.ui.snippet.SnippetManager
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The palette always lives in a focusable Popup (the terminal toolbar and the host row's menu both
+ * open it that way), so while it is up the popup owns the keyboard. Closing it disposes that focus
+ * and Compose clears focus to no one: unless the palette counts as an open modal, the terminal never
+ * learns it should take the keyboard back, and typing stays dead until the user clicks the terminal.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class SnippetPaletteModalPresenceTest {
+
+    private class FakeStore : SnippetStore {
+        private val entries = mutableListOf<Snippet>()
+        override fun all(): List<Snippet> = entries.toList()
+        override fun put(snippet: Snippet) {
+            val i = entries.indexOfFirst { it.id == snippet.id }
+            if (i >= 0) entries[i] = snippet else entries += snippet
+        }
+        override fun remove(id: String) {
+            entries.removeAll { it.id == id }
+        }
+    }
+
+    @Composable
+    private fun PaletteUnderTest(manager: SnippetManager) {
+        SkerryTheme {
+            CompositionLocalProvider(
+                LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+            ) {
+                SnippetPalette(manager) {}
+            }
+        }
+    }
+
+    @Test
+    fun `an open palette counts as a modal and stops counting once it is gone`() {
+        var n = 0
+        val manager = SnippetManager(FakeStore()) { "id-${n++}" }
+        val shown = mutableStateOf(true)
+        val base = ModalPresence.openCount
+        ImageComposeScene(width = 420, height = 400, density = Density(1f)).use { scene ->
+            scene.setContent {
+                if (shown.value) PaletteUnderTest(manager)
+            }
+            Snapshot.sendApplyNotifications()
+            scene.render(16_666_667L)
+            assertEquals(base + 1, ModalPresence.openCount, "an open palette must register as a modal")
+
+            // Picking a snippet (or Esc, or a click outside) drops the palette from composition.
+            shown.value = false
+            Snapshot.sendApplyNotifications()
+            scene.render(33_333_334L)
+            assertEquals(base, ModalPresence.openCount, "closing the palette must release the modal slot")
+        }
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
@@ -131,6 +131,11 @@ fun Route.authRoutes(services: Services) {
         }
     }
 
+    // The limiter gates the route, so a 429 is always emitted before rotatePassword below ever runs.
+    // The client relies on that: SyncCoordinator.changeAccountPassword treats 429 as "rejected before
+    // any write" and keeps the device's auto-restore token. Don't move this check past receive()/
+    // verify()/rotatePassword() — a 429 after a committed rotation would leave that device holding a
+    // live token for a password the account no longer uses.
     rateLimit(RateLimits.CHANGE_PASSWORD) {
         post("/auth/change-password") {
             val req = call.receive<ChangePasswordRequest>()

--- a/server/src/test/kotlin/app/skerry/server/routes/ChangePasswordRateLimitTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/ChangePasswordRateLimitTest.kt
@@ -1,0 +1,76 @@
+package app.skerry.server.routes
+
+import app.skerry.server.configureServer
+import app.skerry.sync.wire.ChangePasswordRequest
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The rate limiter gates the route, so a throttled rotation is rejected before it can reach
+ * rotatePassword. The client leans on that: SyncCoordinator.changeAccountPassword treats a 429 as
+ * "nothing was written" and keeps the device's auto-restore token. If this ever inverts — a limiter
+ * that counts inside the handler, a check moved after verify() — the device would hold a live token
+ * for a password the account no longer uses, and only this test would notice.
+ */
+class ChangePasswordRateLimitTest {
+
+    private val account = "alice@example.com"
+    private val oldPassword = "pw-hex-old"
+    private val newPassword = "pw-hex-new"
+
+    /** Well-formed request that can't rotate anything (unknown challenge) — burns one bucket slot. */
+    private fun spentAttempt(n: Int) = ChangePasswordRequest(
+        challengeId = "no-such-challenge-$n",
+        a = "1",
+        m1 = "1",
+        deviceId = "devA",
+        deviceName = "Laptop A",
+        platform = null,
+        newSrpSalt = "aa",
+        newSrpVerifier = "bb",
+        newWrappedDataKey = "AA==",
+    )
+
+    @Test
+    fun `a rotation rejected by the rate limiter leaves the account password untouched`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        client.registerAccount(account, oldPassword)
+
+        // Exhaust the per-IP bucket (10/min) without touching the SRP challenge endpoint, which has
+        // its own bucket the valid attempt below still needs.
+        repeat(10) { n ->
+            val resp = client.post("/auth/change-password") {
+                contentType(ContentType.Application.Json)
+                setBody(spentAttempt(n))
+            }
+            assertEquals(HttpStatusCode.Unauthorized, resp.status, "attempt $n should fail on SRP, not on the limiter")
+        }
+
+        // A fully valid rotation — correct current password, fresh challenge, real new verifier.
+        // It must be turned away by the limiter, not served.
+        val throttled = client.changePassword(account, oldPassword, newPassword, byteArrayOf(1))
+        assertEquals(HttpStatusCode.TooManyRequests, throttled.status)
+
+        // The verifier never moved: the old password still logs in, the new one doesn't exist.
+        assertEquals(
+            HttpStatusCode.OK,
+            client.srpLoginResponse(account, oldPassword, "devA", "Laptop A").status,
+            "a throttled rotation must not have changed the password",
+        )
+        assertEquals(
+            HttpStatusCode.Unauthorized,
+            client.srpLoginResponse(account, newPassword, "devA", "Laptop A").status,
+            "the new password must not work — the rotation never happened",
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
@@ -153,5 +153,16 @@ sealed interface SyncSignal {
 
 /** Sync client error: network, protocol, or expected (no account / wrong password). */
 class SyncException(val kind: Kind, message: String, cause: Throwable? = null) : Exception(message, cause) {
-    enum class Kind { NETWORK, UNAUTHORIZED, CONFLICT, NOT_FOUND, GONE, PROTOCOL }
+    enum class Kind {
+        NETWORK,
+        UNAUTHORIZED,
+        CONFLICT,
+        NOT_FOUND,
+        GONE,
+        PROTOCOL,
+        /** The server's own rate limiter (429) — register, SRP login and pairing claim are throttled. */
+        TOO_MANY_REQUESTS,
+        /** Any 5xx: the server is down, restarting, or a reverse proxy in front of it has nothing to talk to. */
+        SERVER_ERROR,
+    }
 }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncClientStatusMappingTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncClientStatusMappingTest.kt
@@ -1,0 +1,62 @@
+package app.skerry.shared.sync
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Status → [SyncException.Kind] mapping. Everything the client can't name lands in PROTOCOL, which
+ * the UI renders as "protocol error" — useless for the two failures a self-hosted user actually
+ * hits: the server's own rate limiter (429 on register/SRP/pairing) and a restart behind a reverse
+ * proxy (502/503). Both must be told apart so the message can say "wait" or "server is down".
+ */
+class SyncClientStatusMappingTest {
+
+    private fun clientRespondingWith(status: HttpStatusCode): KtorSyncClient =
+        KtorSyncClient(
+            serverUrl = "https://sync.example.com",
+            http = HttpClient(MockEngine { respond(content = "", status = status) }),
+        )
+
+    private val session = SyncSession(accountId = "a@example.com", accessToken = "t", refreshToken = "r")
+
+    /** Any request goes through the same status mapping; pull is the simplest one. */
+    private suspend fun kindFor(status: HttpStatusCode): SyncException.Kind =
+        assertFailsWith<SyncException> { clientRespondingWith(status).pull(session, since = 0) }.kind
+
+    @Test
+    fun `rate limiting is its own kind`() = runTest {
+        assertEquals(SyncException.Kind.TOO_MANY_REQUESTS, kindFor(HttpStatusCode.TooManyRequests))
+    }
+
+    @Test
+    fun `the whole 5xx range is one kind`() = runTest {
+        // 500 — the server itself; 502/503/504 — a reverse proxy in front of a restarting or absent
+        // server. The range is taken whole: a proxy can answer with codes the server never emits
+        // (507, 508), and for the user they all mean the same thing — not your fault, retry later.
+        assertEquals(SyncException.Kind.SERVER_ERROR, kindFor(HttpStatusCode.InternalServerError))
+        assertEquals(SyncException.Kind.SERVER_ERROR, kindFor(HttpStatusCode.BadGateway))
+        assertEquals(SyncException.Kind.SERVER_ERROR, kindFor(HttpStatusCode.ServiceUnavailable))
+        assertEquals(SyncException.Kind.SERVER_ERROR, kindFor(HttpStatusCode.GatewayTimeout))
+        assertEquals(SyncException.Kind.SERVER_ERROR, kindFor(HttpStatusCode.InsufficientStorage))
+    }
+
+    @Test
+    fun `named statuses keep their existing kinds`() = runTest {
+        assertEquals(SyncException.Kind.UNAUTHORIZED, kindFor(HttpStatusCode.Unauthorized))
+        assertEquals(SyncException.Kind.NOT_FOUND, kindFor(HttpStatusCode.NotFound))
+        assertEquals(SyncException.Kind.CONFLICT, kindFor(HttpStatusCode.Conflict))
+        assertEquals(SyncException.Kind.GONE, kindFor(HttpStatusCode.Gone))
+    }
+
+    @Test
+    fun `anything else stays protocol`() = runTest {
+        assertEquals(SyncException.Kind.PROTOCOL, kindFor(HttpStatusCode.BadRequest))
+        assertEquals(SyncException.Kind.PROTOCOL, kindFor(HttpStatusCode.MethodNotAllowed))
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -455,7 +455,10 @@ class KtorSyncClient(
             HttpStatusCode.NotFound -> SyncException.Kind.NOT_FOUND
             HttpStatusCode.Conflict -> SyncException.Kind.CONFLICT
             HttpStatusCode.Gone -> SyncException.Kind.GONE
-            else -> SyncException.Kind.PROTOCOL
+            HttpStatusCode.TooManyRequests -> SyncException.Kind.TOO_MANY_REQUESTS
+            // Whole range, not just 500/502/503: a proxy can answer with codes the server never
+            // emits, and they all mean the same to the user — not your fault, retry later.
+            else -> if (status.value in 500..599) SyncException.Kind.SERVER_ERROR else SyncException.Kind.PROTOCOL
         }
         return SyncException(kind, "server responded ${status.value}")
     }


### PR DESCRIPTION
Sync now tells a rate-limited server apart from a broken one instead of calling both a protocol error, the terminal takes the keyboard back when the snippet palette closes, and the host row menu no longer collapses onto its labels.

## Sync error mapping

- `SyncException.Kind` gains `TOO_MANY_REQUESTS` (429) and `SERVER_ERROR` (the whole 5xx range — a reverse proxy answers with codes the server never emits, and they all mean the same to the user).
- `SyncFailureReason` and `TeamsFailure` gain matching values, with texts in en/ru/zh. Team operations talk to the same server, so they name the same two states.
- Password rotation: a 429 keeps the device's auto-restore token. The limiter gates the route, so a 429 always precedes any write; 5xx stays ambiguous and keeps clearing the token. `AuthRoutes` carries a note on that ordering, and a server test asserts a throttled rotation leaves the verifier untouched.

## Snippet palette focus

The palette lives in a focusable popup, so closing it left focus with no one and typing went dead until the user clicked the terminal. It registers with `ModalPresence` — already what the terminal watches — via a `rememberModalPresence()` helper split out of `ModalScrim`. This covers both places the palette opens: the toolbar button and the host row menu.

## Host row menu width

Menu items get a 140dp floor, so the card no longer sizes itself to its longest label.

## Also in this PR

Tests for each: HTTP status mapping via `MockEngine`, coordinator reason mapping, reason-to-string wiring, the team mapping, a pixel test for the menu width, and a modal-registration test for the palette.