### PR TITLE
Production guard for hosts tagged prod

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -163,6 +163,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalFontSizeChange = { writeTerminalFontSize(dir, it) },
                     initialAllowServerClipboardWrite = readClipboardWrite(dir),
                     onAllowServerClipboardWriteChange = { writeClipboardWrite(dir, it) },
+                    initialConfirmProductionWarnings = readProdWarnings(dir),
+                    onConfirmProductionWarningsChange = { writeProdWarnings(dir, it) },
                     initialUiLanguage = currentUiLanguage.value,
                     onUiLanguageChange = { currentUiLanguage.value = it; writeUiLanguage(dir, it) },
                     initialAutoLock = readAutoLock(dir),
@@ -264,6 +266,17 @@ class MainActivity : FragmentActivity() {
     private fun writeClipboardWrite(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_clipboard_write").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Production guard threshold: `terminal_prod_warnings`, default off (Danger only). */
+    private fun readProdWarnings(dir: File): Boolean = runCatching {
+        File(dir, "terminal_prod_warnings").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeProdWarnings(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_prod_warnings").writeText(enabled.toString()) }
         }
     }
 
@@ -552,6 +565,7 @@ class MainActivity : FragmentActivity() {
                 writeTerminalTheme(dir, TerminalThemes.DEFAULT)
                 writeThemeMode(dir, ThemeMode.DEFAULT)
                 writeClipboardWrite(dir, false)
+                writeProdWarnings(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)
             }

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_guard.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_guard.xml
@@ -1,0 +1,13 @@
+<resources>
+    <string name="guard_prod_connect_title">Подключиться к продуктовой среде?</string>
+    <string name="guard_prod_connect_message">У хоста %1$s стоит тег #prod. В этой сессии рискованные команды будут спрашивать подтверждение.</string>
+    <string name="guard_prod_connect_confirm">Подключиться</string>
+    <string name="guard_prod_command_title">Выполнить это на продуктовой среде?</string>
+    <string name="guard_prod_command_host">У хоста %1$s стоит тег #prod.</string>
+    <string name="guard_prod_command_confirm">Выполнить</string>
+    <string name="guard_prod_broadcast_title">Разослать на продуктовую среду?</string>
+    <string name="guard_prod_broadcast_message">Среди выбранных сессий %1$d приходится на хосты продуктовой среды. Команда уйдёт во все сессии сразу.</string>
+    <string name="guard_prod_broadcast_confirm">Отправить</string>
+    <string name="guard_prod_snippet_title">Запустить сниппет на продуктовой среде?</string>
+    <string name="guard_prod_snippet_message">У хоста %1$s стоит тег #prod. Сниппет выполнится сразу после подключения.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_risk.xml
@@ -1,0 +1,22 @@
+<resources>
+    <string name="risk_fork_bomb">Форк-бомба — исчерпает ресурсы системы.</string>
+    <string name="risk_recursive_force_delete">Рекурсивное принудительное удаление — данные не восстановить.</string>
+    <string name="risk_recursive_broad_delete">Рекурсивное удаление по широкому пути — данные не восстановить.</string>
+    <string name="risk_disk_device_write">Пишет прямо на дисковое устройство — может уничтожить файловую систему.</string>
+    <string name="risk_download_to_shell">Передаёт скачанный скрипт прямо в шелл — выполняет непроверенный код.</string>
+    <string name="risk_pipe_to_interpreter">Передаёт вывод в интерпретатор — выполняет собранный или удалённый код.</string>
+    <string name="risk_mirror_delete">Зеркальное удаление — сотрёт в приёмнике файлы, которых нет в источнике.</string>
+    <string name="risk_power_off">Выключает или перезагружает машину.</string>
+    <string name="risk_recursive_permissions">Рекурсивно меняет права или владельца системного пути.</string>
+    <string name="risk_security_file_overwrite">Перезаписывает файл, критичный для безопасности.</string>
+    <string name="risk_firewall_flush">Сбрасывает правила фаервола — можно потерять удалённый доступ.</string>
+    <string name="risk_deletes_files">Удаляет файлы.</string>
+    <string name="risk_kills_processes">Завершает запущенные процессы.</string>
+    <string name="risk_uninstalls_packages">Удаляет пакеты.</string>
+    <string name="risk_git_destructive">Отбрасывает локальные изменения или переписывает историю.</string>
+    <string name="risk_world_writable">Даёт права на запись всем.</string>
+    <string name="risk_stops_service">Останавливает или отключает сервис.</string>
+    <string name="risk_bulk_delete">Массово удаляет найденные файлы.</string>
+    <string name="risk_truncates_content">Обнуляет содержимое файлов.</string>
+    <string name="risk_elevated">Выполняется с повышенными правами.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -225,4 +225,6 @@
     <string name="settings_trash_kind_snippet">Сниппет</string>
     <string name="settings_trash_kind_tunnel">Туннель</string>
     <string name="settings_trash_locked">Разблокируйте хранилище, чтобы увидеть корзину</string>
+    <string name="settings_terminal_prod_warnings">Подтверждать предупреждения на проде</string>
+    <string name="settings_terminal_prod_warnings_desc">На хостах с тегом #prod спрашивать не только на опасных командах, но и на предупреждениях (sudo, kill, остановка сервиса). В сессиях под root разрушительные команды подтверждаются всегда.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -226,5 +226,5 @@
     <string name="settings_trash_kind_tunnel">Туннель</string>
     <string name="settings_trash_locked">Разблокируйте хранилище, чтобы увидеть корзину</string>
     <string name="settings_terminal_prod_warnings">Подтверждать предупреждения на проде</string>
-    <string name="settings_terminal_prod_warnings_desc">На хостах с тегом #prod спрашивать не только на опасных командах, но и на предупреждениях (sudo, kill, остановка сервиса). В сессиях под root разрушительные команды подтверждаются всегда.</string>
+    <string name="settings_terminal_prod_warnings_desc">На хостах с тегом #prod спрашивать не только на опасных командах, но и на предупреждениях (kill, остановка сервиса, удаление пакета). В сессии под root правило про sudo не действует — там оно ничего не значит, — а разрушительные предупреждения подтверждаются в любом случае.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_guard.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_guard.xml
@@ -1,0 +1,13 @@
+<resources>
+    <string name="guard_prod_connect_title">连接到生产环境？</string>
+    <string name="guard_prod_connect_message">主机 %1$s 带有 #prod 标签。在该会话中，高风险命令执行前会要求确认。</string>
+    <string name="guard_prod_connect_confirm">连接</string>
+    <string name="guard_prod_command_title">在生产环境执行该命令？</string>
+    <string name="guard_prod_command_host">主机 %1$s 带有 #prod 标签。</string>
+    <string name="guard_prod_command_confirm">执行</string>
+    <string name="guard_prod_broadcast_title">向生产环境群发？</string>
+    <string name="guard_prod_broadcast_message">所选会话中有 %1$d 个位于生产环境主机。命令将同时发送到全部会话。</string>
+    <string name="guard_prod_broadcast_confirm">发送</string>
+    <string name="guard_prod_snippet_title">在生产环境运行该片段？</string>
+    <string name="guard_prod_snippet_message">主机 %1$s 带有 #prod 标签。片段会在连接建立后立即执行。</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_risk.xml
@@ -1,0 +1,22 @@
+<resources>
+    <string name="risk_fork_bomb">Fork 炸弹 —— 会耗尽系统资源。</string>
+    <string name="risk_recursive_force_delete">递归强制删除 —— 数据无法恢复。</string>
+    <string name="risk_recursive_broad_delete">对宽泛路径递归删除 —— 数据无法恢复。</string>
+    <string name="risk_disk_device_write">直接写入磁盘设备 —— 可能损毁文件系统。</string>
+    <string name="risk_download_to_shell">将下载的脚本直接管道给 shell —— 执行未经校验的远程代码。</string>
+    <string name="risk_pipe_to_interpreter">将输出管道给解释器 —— 执行拼接或远程的代码。</string>
+    <string name="risk_mirror_delete">镜像删除 —— 会清除目标端源端没有的文件。</string>
+    <string name="risk_power_off">关闭或重启机器。</string>
+    <string name="risk_recursive_permissions">递归修改系统路径的权限或属主。</string>
+    <string name="risk_security_file_overwrite">覆盖安全关键文件。</string>
+    <string name="risk_firewall_flush">清空防火墙规则 —— 可能切断远程访问。</string>
+    <string name="risk_deletes_files">删除文件。</string>
+    <string name="risk_kills_processes">终止正在运行的进程。</string>
+    <string name="risk_uninstalls_packages">卸载软件包。</string>
+    <string name="risk_git_destructive">丢弃本地修改或重写历史。</string>
+    <string name="risk_world_writable">授予所有用户写权限。</string>
+    <string name="risk_stops_service">停止或禁用服务。</string>
+    <string name="risk_bulk_delete">批量删除匹配到的文件。</string>
+    <string name="risk_truncates_content">清空文件内容。</string>
+    <string name="risk_elevated">以提升的权限运行。</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -226,5 +226,5 @@
     <string name="settings_trash_kind_tunnel">隧道</string>
     <string name="settings_trash_locked">解锁保险库以查看回收站</string>
     <string name="settings_terminal_prod_warnings">在生产环境确认警告级命令</string>
-    <string name="settings_terminal_prod_warnings_desc">在带 #prod 标签的主机上，除危险命令外也确认警告级命令（sudo、kill、停止服务）。root 会话始终确认破坏性命令。</string>
+    <string name="settings_terminal_prod_warnings_desc">在带 #prod 标签的主机上，除危险命令外也确认警告级命令（kill、停止服务、卸载软件包）。root 会话不适用 sudo 规则（在那里没有意义），但无论如何都会确认破坏性警告。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -225,4 +225,6 @@
     <string name="settings_trash_kind_snippet">代码片段</string>
     <string name="settings_trash_kind_tunnel">隧道</string>
     <string name="settings_trash_locked">解锁保险库以查看回收站</string>
+    <string name="settings_terminal_prod_warnings">在生产环境确认警告级命令</string>
+    <string name="settings_terminal_prod_warnings_desc">在带 #prod 标签的主机上，除危险命令外也确认警告级命令（sudo、kill、停止服务）。root 会话始终确认破坏性命令。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_guard.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_guard.xml
@@ -1,0 +1,13 @@
+<resources>
+    <string name="guard_prod_connect_title">Connect to production?</string>
+    <string name="guard_prod_connect_message">%1$s is tagged #prod. In this session risky commands ask for confirmation before they run.</string>
+    <string name="guard_prod_connect_confirm">Connect</string>
+    <string name="guard_prod_command_title">Run this on production?</string>
+    <string name="guard_prod_command_host">%1$s is tagged #prod.</string>
+    <string name="guard_prod_command_confirm">Run</string>
+    <string name="guard_prod_broadcast_title">Broadcast to production?</string>
+    <string name="guard_prod_broadcast_message">%1$d of the selected sessions run on production hosts. The command goes to every session at once.</string>
+    <string name="guard_prod_broadcast_confirm">Send</string>
+    <string name="guard_prod_snippet_title">Run the snippet on production?</string>
+    <string name="guard_prod_snippet_message">%1$s is tagged #prod. The snippet runs as soon as the session opens.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_risk.xml
@@ -1,0 +1,22 @@
+<resources>
+    <string name="risk_fork_bomb">Fork bomb — will exhaust system resources.</string>
+    <string name="risk_recursive_force_delete">Recursive force delete — irreversible data loss.</string>
+    <string name="risk_recursive_broad_delete">Recursive delete of a broad path — irreversible data loss.</string>
+    <string name="risk_disk_device_write">Writes directly to a disk device — can destroy the filesystem.</string>
+    <string name="risk_download_to_shell">Pipes a downloaded script straight into a shell — runs unverified remote code.</string>
+    <string name="risk_pipe_to_interpreter">Pipes output into an interpreter — runs constructed or remote code.</string>
+    <string name="risk_mirror_delete">Mirror delete — wipes files in the destination that are absent from the source.</string>
+    <string name="risk_power_off">Powers off or reboots the machine.</string>
+    <string name="risk_recursive_permissions">Recursive permission/ownership change on a system path.</string>
+    <string name="risk_security_file_overwrite">Overwrites a security-critical file.</string>
+    <string name="risk_firewall_flush">Flushes firewall rules — may cut off remote access.</string>
+    <string name="risk_deletes_files">Deletes files.</string>
+    <string name="risk_kills_processes">Terminates running processes.</string>
+    <string name="risk_uninstalls_packages">Uninstalls packages.</string>
+    <string name="risk_git_destructive">Discards local changes or rewrites history.</string>
+    <string name="risk_world_writable">Grants world-writable permissions.</string>
+    <string name="risk_stops_service">Stops or disables a service.</string>
+    <string name="risk_bulk_delete">Bulk-deletes matched files.</string>
+    <string name="risk_truncates_content">Discards file contents.</string>
+    <string name="risk_elevated">Runs with elevated privileges.</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -225,4 +225,6 @@
     <string name="settings_trash_kind_snippet">Snippet</string>
     <string name="settings_trash_kind_tunnel">Tunnel</string>
     <string name="settings_trash_locked">Unlock the vault to see the trash</string>
+    <string name="settings_terminal_prod_warnings">Confirm warnings on production</string>
+    <string name="settings_terminal_prod_warnings_desc">On hosts tagged #prod also confirm warnings (sudo, kill, stopping a service), not only dangerous commands. Root sessions always confirm destructive ones.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -226,5 +226,5 @@
     <string name="settings_trash_kind_tunnel">Tunnel</string>
     <string name="settings_trash_locked">Unlock the vault to see the trash</string>
     <string name="settings_terminal_prod_warnings">Confirm warnings on production</string>
-    <string name="settings_terminal_prod_warnings_desc">On hosts tagged #prod also confirm warnings (sudo, kill, stopping a service), not only dangerous commands. Root sessions always confirm destructive ones.</string>
+    <string name="settings_terminal_prod_warnings_desc">On hosts tagged #prod also confirm warnings (kill, stopping a service, uninstalling a package), not only dangerous commands. A root session drops the sudo rule — it says nothing there — and confirms destructive warnings either way.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/CommandRiskText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/CommandRiskText.kt
@@ -1,0 +1,57 @@
+package app.skerry.ui.ai
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.ai.CommandRiskReason
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.risk_bulk_delete
+import app.skerry.ui.generated.resources.risk_deletes_files
+import app.skerry.ui.generated.resources.risk_disk_device_write
+import app.skerry.ui.generated.resources.risk_download_to_shell
+import app.skerry.ui.generated.resources.risk_elevated
+import app.skerry.ui.generated.resources.risk_firewall_flush
+import app.skerry.ui.generated.resources.risk_fork_bomb
+import app.skerry.ui.generated.resources.risk_git_destructive
+import app.skerry.ui.generated.resources.risk_kills_processes
+import app.skerry.ui.generated.resources.risk_mirror_delete
+import app.skerry.ui.generated.resources.risk_pipe_to_interpreter
+import app.skerry.ui.generated.resources.risk_power_off
+import app.skerry.ui.generated.resources.risk_recursive_broad_delete
+import app.skerry.ui.generated.resources.risk_recursive_force_delete
+import app.skerry.ui.generated.resources.risk_recursive_permissions
+import app.skerry.ui.generated.resources.risk_security_file_overwrite
+import app.skerry.ui.generated.resources.risk_stops_service
+import app.skerry.ui.generated.resources.risk_truncates_content
+import app.skerry.ui.generated.resources.risk_uninstalls_packages
+import app.skerry.ui.generated.resources.risk_world_writable
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Localized text for a [CommandRiskReason]. The classifier lives in `shared` and only names the
+ * reason; the sentence the user reads is a resource, so it follows the app language in the AI bar
+ * and in the production-guard confirmation alike.
+ */
+@Composable
+fun commandRiskReasonText(reason: CommandRiskReason): String = stringResource(
+    when (reason) {
+        CommandRiskReason.ForkBomb -> Res.string.risk_fork_bomb
+        CommandRiskReason.RecursiveForceDelete -> Res.string.risk_recursive_force_delete
+        CommandRiskReason.RecursiveBroadDelete -> Res.string.risk_recursive_broad_delete
+        CommandRiskReason.DiskDeviceWrite -> Res.string.risk_disk_device_write
+        CommandRiskReason.DownloadToShell -> Res.string.risk_download_to_shell
+        CommandRiskReason.PipeToInterpreter -> Res.string.risk_pipe_to_interpreter
+        CommandRiskReason.MirrorDelete -> Res.string.risk_mirror_delete
+        CommandRiskReason.PowerOff -> Res.string.risk_power_off
+        CommandRiskReason.RecursivePermissions -> Res.string.risk_recursive_permissions
+        CommandRiskReason.SecurityFileOverwrite -> Res.string.risk_security_file_overwrite
+        CommandRiskReason.FirewallFlush -> Res.string.risk_firewall_flush
+        CommandRiskReason.DeletesFiles -> Res.string.risk_deletes_files
+        CommandRiskReason.KillsProcesses -> Res.string.risk_kills_processes
+        CommandRiskReason.UninstallsPackages -> Res.string.risk_uninstalls_packages
+        CommandRiskReason.GitDestructive -> Res.string.risk_git_destructive
+        CommandRiskReason.WorldWritable -> Res.string.risk_world_writable
+        CommandRiskReason.StopsService -> Res.string.risk_stops_service
+        CommandRiskReason.BulkDelete -> Res.string.risk_bulk_delete
+        CommandRiskReason.TruncatesContent -> Res.string.risk_truncates_content
+        CommandRiskReason.Elevated -> Res.string.risk_elevated
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -169,6 +169,9 @@ class DesktopDesignState(
     // [app.skerry.ui.terminal.TerminalSessionPrefs] and pushed live into open ones.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
+    initialConfirmProductionWarnings: Boolean = false,
+    private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
     // Terminal color theme (Appearance → theme cards). Read from persistence at startup, written back
     // via the callback. Threaded into the terminal via [app.skerry.ui.terminal.LocalTerminalTheme] and
     // applied to open sessions live. Default (Night Sea, no-op) preserves the prior look for
@@ -331,6 +334,14 @@ class DesktopDesignState(
      * write). Off by default; snapshotted into new sessions and pushed live into open ones.
      */
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
+
+    /**
+     * Whether the production guard also confirms [app.skerry.shared.ai.CommandRisk.Warn] commands
+     * (Terminal → Confirm warnings on production). Off by default: `sudo` is a warning and makes up
+     * half of what is typed on a production box, so asking every time turns the dialog into a
+     * reflex. Dangerous commands are confirmed regardless.
+     */
+    var confirmProductionWarnings: Boolean by mutableStateOf(initialConfirmProductionWarnings); private set
 
     /** Open group management dialog (create/edit), or `null`. */
     var groupDialog: GroupDialog? by mutableStateOf(null); private set
@@ -685,6 +696,12 @@ class DesktopDesignState(
         if (mode == hostClickConnectMode) return
         hostClickConnectMode = mode
         onHostClickConnectModeChange(mode)
+    }
+
+    /** Toggle confirming Warn-level commands on production hosts and report outward (for persistence). */
+    fun toggleConfirmProductionWarnings() {
+        confirmProductionWarnings = !confirmProductionWarnings
+        onConfirmProductionWarningsChange(confirmProductionWarnings)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -109,6 +109,9 @@ class MobileDesignState(
     // and pushed live into open ones. Persisted on Android; no-op default for previews/tests.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
+    initialConfirmProductionWarnings: Boolean = false,
+    private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
     // UI language (More -> Appearance -> Language). Initial value is read from persistence at
     // startup, the callback writes it back — the choice survives restart. Defaults (System, no-op)
     // auto-detect from the OS locale for previews/tests.
@@ -308,6 +311,12 @@ class MobileDesignState(
      */
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
 
+    /**
+     * Whether the production guard also confirms Warn-level commands (More → Terminal). Off by
+     * default — desktop parity, see [app.skerry.ui.app.DesktopDesignState.confirmProductionWarnings].
+     */
+    var confirmProductionWarnings: Boolean by mutableStateOf(initialConfirmProductionWarnings); private set
+
     /** UI language (More -> Appearance -> Language). Threaded to the root via [app.skerry.ui.i18n.AppLocaleProvider]. */
     var uiLanguage: UiLanguage by mutableStateOf(initialUiLanguage); private set
 
@@ -352,6 +361,12 @@ class MobileDesignState(
         if (mode == themeMode) return
         themeMode = mode
         onThemeModeChange(mode)
+    }
+
+    /** Toggle confirming Warn-level commands on production hosts and report outward (for persistence). */
+    fun toggleConfirmProductionWarnings() {
+        confirmProductionWarnings = !confirmProductionWarnings
+        onConfirmProductionWarningsChange(confirmProductionWarnings)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -225,6 +225,7 @@ import app.skerry.ui.host.ProdConnectDialog
 import app.skerry.ui.host.ProdConnectRequest
 import app.skerry.ui.host.prodConnectGate
 import app.skerry.ui.host.ProdCommandGate
+import app.skerry.ui.host.prodGuardDialogOpen
 import app.skerry.ui.host.ProdGuardSync
 import app.skerry.ui.host.rememberProductionLookup
 
@@ -664,8 +665,9 @@ private fun DesktopChrome(
     // SnippetManager.run parks them in the dialog and only then hands the line over.
     val runSnippetOnHost = remember(sessions, credentials, hostManager, state) {
         { host: Host, line: String ->
-            // snippet = true: the confirmation says the command runs the moment the session opens.
-            prodConnect = prodConnectGate(host, snippet = true) { connectOrAsk(PendingAuth.Snippet(host, line)) }
+            // The line goes into the confirmation: it runs the moment the session opens, before the
+            // session's own guard is bound to it, so this dialog is where it has to be read.
+            prodConnect = prodConnectGate(host, snippetLine = line) { connectOrAsk(PendingAuth.Snippet(host, line)) }
         }
     }
 
@@ -727,7 +729,11 @@ private fun DesktopChrome(
                     state.commandPaletteOpen || state.broadcastOpen || state.castRecording != null ||
                     // The snippet-variable confirmation dialog is modal too: a hotkey firing over it
                     // would type into the terminal under the dialog or race the pending run.
-                    snippets?.pendingRun != null
+                    snippets?.pendingRun != null ||
+                    // Same for both production-guard dialogs. This handler runs on the root's
+                    // preview pass, above the focus their scrim takes, so a snippet chord would
+                    // otherwise reach the production shell while the user is reading the question.
+                    prodConnect != null || prodGuardDialogOpen(sessions?.active)
                 ) false
                 else {
                     val shortcut = matchDesktopShortcut(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -289,6 +289,9 @@ fun DesktopDesignApp(
     // OSC 52 server clipboard-write gate (Settings → Terminal) — persisted externally (desktop main).
     initialAllowServerClipboardWrite: Boolean = false,
     onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Production guard: confirm Warn-level commands too (Settings → Terminal) — persisted externally.
+    initialConfirmProductionWarnings: Boolean = false,
+    onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
     // Terminal color theme (Appearance → theme cards) — persisted externally (desktop main).
     initialTerminalTheme: TerminalTheme = TerminalThemes.DEFAULT,
     onTerminalThemeChange: (TerminalTheme) -> Unit = {},
@@ -320,6 +323,7 @@ fun DesktopDesignApp(
             initialShowTerminalTitleOnTabs, onShowTerminalTitleOnTabsChange,
             initialHostClickConnectMode, onHostClickConnectModeChange,
             initialAllowServerClipboardWrite, onAllowServerClipboardWriteChange,
+            initialConfirmProductionWarnings, onConfirmProductionWarningsChange,
             initialTerminalTheme, onTerminalThemeChange,
             initialCustomTerminalTheme, onCustomTerminalThemeChange,
             initialThemeMode, onThemeModeChange,
@@ -829,7 +833,7 @@ private fun DesktopChrome(
             }
             // …and, once inside, keep every open session armed and confirm the risky commands it
             // holds. At the root, so the confirmation is never covered by the terminal's own chrome.
-            ProdGuardSync(sessions)
+            ProdGuardSync(sessions, state.confirmProductionWarnings)
             ProdCommandGate(sessions?.active)
             // Broken ProxyJump chain for the clicked host: explain instead of connecting (never
             // silently direct). Set by openResolved for all three connect paths.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -220,6 +220,13 @@ import app.skerry.ui.session.tabBoundsAnchor
 import app.skerry.ui.app.asDesktopView
 import app.skerry.ui.session.draggableTab
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.host.isProdHostId
+import app.skerry.ui.host.ProdConnectDialog
+import app.skerry.ui.host.ProdConnectRequest
+import app.skerry.ui.host.prodConnectGate
+import app.skerry.ui.host.ProdCommandGate
+import app.skerry.ui.host.ProdGuardSync
+import app.skerry.ui.host.rememberProductionLookup
 
 /**
  * Root of the desktop app. Supplies fonts
@@ -585,6 +592,11 @@ private fun DesktopChrome(
     // VNC "ask every time": a host with no stored password prompts before opening the framebuffer tab.
     var pendingVncHost by remember { mutableStateOf<Host?>(null) }
 
+    // Production guard: a connection to a #prod host is held here until confirmed. It wraps ALL
+    // connect paths (new tab / split / VNC / snippet), so the confirmation can't be walked around by
+    // taking another route to the same host.
+    var prodConnect by remember { mutableStateOf<ProdConnectRequest?>(null) }
+
     // ProxyJump chain resolution failed for the clicked host — connecting would either dial
     // forever or silently go direct, so a notice is shown instead ([JumpErrorDialog]).
     var jumpProblem by remember { mutableStateOf<JumpChainProblem?>(null) }
@@ -621,22 +633,24 @@ private fun DesktopChrome(
     // flowing into a staticCompositionLocalOf, would invalidate all consumers of [LocalConnectHost] etc.
     val connectHost = remember(sessions, credentials, hostManager, state) {
         { host: Host ->
-            if (host.connectionType.isVnc) {
-                // VNC opens a framebuffer tab (not a terminal). A stored password is used directly;
-                // "ask every time" (no bound secret) prompts for one first. No ProxyJump/host-key path.
-                val cred = credentials?.find(host.credentialId)
-                if (cred != null) {
-                    sessions?.openVnc(
-                        host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
-                        remoteResize = host.vncResizeToWindow,
-                        onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
-                    )
+            prodConnect = prodConnectGate(host) {
+                if (host.connectionType.isVnc) {
+                    // VNC opens a framebuffer tab (not a terminal). A stored password is used directly;
+                    // "ask every time" (no bound secret) prompts for one first. No ProxyJump/host-key path.
+                    val cred = credentials?.find(host.credentialId)
+                    if (cred != null) {
+                        sessions?.openVnc(
+                            host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
+                            remoteResize = host.vncResizeToWindow,
+                            onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
+                        )
+                    } else {
+                        pendingVncHost = host
+                    }
+                    Unit
                 } else {
-                    pendingVncHost = host
+                    connectOrAsk(PendingAuth.NewTab(host))
                 }
-                Unit
-            } else {
-                connectOrAsk(PendingAuth.NewTab(host))
             }
         }
     }
@@ -645,12 +659,17 @@ private fun DesktopChrome(
     // line (newline included) once connected. Dynamic variables were confirmed before this point —
     // SnippetManager.run parks them in the dialog and only then hands the line over.
     val runSnippetOnHost = remember(sessions, credentials, hostManager, state) {
-        { host: Host, line: String -> connectOrAsk(PendingAuth.Snippet(host, line)) }
+        { host: Host, line: String ->
+            // snippet = true: the confirmation says the command runs the moment the session opens.
+            prodConnect = prodConnectGate(host, snippet = true) { connectOrAsk(PendingAuth.Snippet(host, line)) }
+        }
     }
 
     // Same resolution, but into the active tab's split pane (a new independent secondary session).
     val connectSplitHost = remember(sessions, credentials, hostManager, state) {
-        { host: Host -> connectOrAsk(PendingAuth.Split(host, sessions?.activeId)) }
+        { host: Host ->
+            prodConnect = prodConnectGate(host) { connectOrAsk(PendingAuth.Split(host, sessions?.activeId)) }
+        }
     }
 
     // Pending password-prompt dialogs are dismissed on lock (don't leave password entry sitting under
@@ -663,6 +682,9 @@ private fun DesktopChrome(
     val onLockWithTunnels: (() -> Unit)? = if (onLock == null) null else remember(onLock, state) {
         {
             pendingAuth = null
+            // Same for a held-back production connect: after unlock it must be re-initiated, not
+            // waiting behind the lock screen with its "Connect" button armed.
+            prodConnect = null
             // Also dismiss any pending disconnect/close confirmation — after unlock an action needs a
             // fresh user intent (like pendingAuth), not to "resurface" on its own.
             state.dismissClose()
@@ -746,7 +768,7 @@ private fun DesktopChrome(
             if (state.broadcastOpen) {
                 BroadcastPanel(
                     controller = state.broadcast,
-                    targets = broadcastTargets(sessions),
+                    targets = broadcastTargets(sessions, rememberProductionLookup()),
                     onDismiss = state::closeBroadcast,
                 )
             }
@@ -800,6 +822,15 @@ private fun DesktopChrome(
                     },
                 )
             }
+            // Production guard: confirm before a #prod session opens. Sits in front of the password
+            // prompt — the question is whether to touch production at all, not which secret to use.
+            prodConnect?.let { request ->
+                ProdConnectDialog(request, onDismiss = { prodConnect = null })
+            }
+            // …and, once inside, keep every open session armed and confirm the risky commands it
+            // holds. At the root, so the confirmation is never covered by the terminal's own chrome.
+            ProdGuardSync(sessions)
+            ProdCommandGate(sessions?.active)
             // Broken ProxyJump chain for the clicked host: explain instead of connecting (never
             // silently direct). Set by openResolved for all three connect paths.
             jumpProblem?.let { problem ->
@@ -906,7 +937,7 @@ private fun runSnippetHotkey(event: KeyEvent, manager: SnippetManager?, sessions
     ) ?: return false
     val entry = manager.forShortcut(combo) ?: return false
     val terminal = (sessions?.active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal ?: return false
-    manager.run(entry.id, recording = terminal.recording) { terminal.sendUserInput(it) }
+    manager.run(entry.id, recording = terminal.recording) { terminal.sendUserInputGuarded(it) }
     return true
 }
 
@@ -1101,12 +1132,15 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                     // On a split, the chip shows the focused pane: the name changes when focus
                     // switches between the main and split panes.
                     val focused = if (s.splitOpen && s.focusedSplit) s.splitSession ?: s else s
+                    // A production session paints its chip sunset (strip/border/tint) — the tab row
+                    // is where a wrong-window mistake starts, so the marker sits there too.
+                    val prodTab = isProdHostId(focused.hostId)
                     SessionTabChip(
                         name = focused.tabTitle(state.showTerminalTitleOnTabs),
                         // A recording tab has no connection: its dot and accent are sunset, so it
                         // never reads as a live (or dead) session.
                         dot = if (s.isPlayer) Skerry.colors.sunset else sessionDotColor(focused.controller.uiState),
-                        accent = if (s.isPlayer) Skerry.colors.sunset else Skerry.colors.cyan,
+                        accent = if (s.isPlayer || prodTab) Skerry.colors.sunset else Skerry.colors.cyan,
                         split = s.splitOpen,
                         active = s.id == sessions.activeId,
                         onClick = { sessions.activate(s.id) },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionFormSuggestions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionFormSuggestions.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.tag.PROD_TAG
 import app.skerry.shared.tag.normalizeTag
 
 /**
@@ -22,15 +23,23 @@ fun groupSuggestions(hosts: List<Host>, query: String = ""): List<String> {
 }
 
 /**
- * Tag suggestions for the Tags inline input: unique tags from all [hosts] (canonical form, see
- * [normalizeTag]), excluding already-[selected] tags, narrowed by [query] (also canonicalized,
- * substring match). First-seen order. Pure function.
+ * Tag suggestions for the Tags inline input: [PROD_TAG] first, then unique tags from all [hosts]
+ * (canonical form, see [normalizeTag]), excluding already-[selected] tags, narrowed by [query]
+ * (also canonicalized, substring match). First-seen order for the rest. Pure function.
+ *
+ * `prod` is offered even when no host carries it yet — it is the tag that arms the production guard
+ * ([app.skerry.shared.guard.ProductionGuard]), so it must be one tap away on the very first host,
+ * not something to be typed from memory. It is filtered by [query] like any other tag.
  */
 fun tagSuggestions(hosts: List<Host>, selected: List<String>, query: String = ""): List<String> {
     val taken = selected.toHashSet()
     val needle = normalizeTag(query)
     val seen = LinkedHashSet<String>()
     return buildList {
+        if (PROD_TAG !in taken && (needle == null || PROD_TAG.contains(needle))) {
+            seen.add(PROD_TAG)
+            add(PROD_TAG)
+        }
         for (host in hosts) for (tag in host.tags) {
             if (tag in taken || tag in seen) continue
             if (needle != null && !tag.contains(needle)) continue

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostChips.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.host
 
 import androidx.compose.runtime.Composable
 import app.skerry.shared.host.Host
+import app.skerry.shared.tag.PROD_TAG
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shtail_chip_all
 import org.jetbrains.compose.resources.stringResource
@@ -18,14 +19,19 @@ const val ALL_HOSTS_CHIP = "All"
 fun allHostsChipLabel(): String = stringResource(Res.string.shtail_chip_all)
 
 /**
- * Filter chips: `All` plus unique host tags in order of first appearance (canonical form, no `#`).
- * List folders are built separately by [Host.group] ([app.skerry.ui.host.groupHostsByFolder]) —
- * group is the folder section, tag is the filter chip, two independent axes. Pure function, shared
- * by desktop and mobile lists.
+ * Filter chips: `All`, then [PROD_TAG], then the remaining unique host tags in order of first
+ * appearance (canonical form, no `#`). List folders are built separately by [Host.group]
+ * ([app.skerry.ui.host.groupHostsByFolder]) — group is the folder section, tag is the filter chip,
+ * two independent axes. Pure function, shared by desktop and mobile lists.
+ *
+ * `prod` is always present, even with no production host yet: it is the one tag that carries
+ * behavior ([app.skerry.shared.guard.ProductionGuard]), and a user who never sees it never learns
+ * the guard exists. Picking it on a catalog without production hosts simply shows an empty list.
  */
 fun hostTagChips(hosts: List<Host>): List<String> = buildList {
     add(ALL_HOSTS_CHIP)
-    val seen = LinkedHashSet<String>()
+    add(PROD_TAG)
+    val seen = hashSetOf(PROD_TAG)
     for (host in hosts) for (tag in host.tags) if (seen.add(tag)) add(tag)
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -11,6 +11,7 @@ import app.skerry.shared.host.Host
 import app.skerry.shared.host.normalizeNotes
 import app.skerry.shared.tag.MAX_TAGS_PER_RECORD
 import app.skerry.shared.tag.normalizeTag
+import app.skerry.shared.tag.orderTagsProdFirst
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.ssh.usesSshAuth
@@ -151,7 +152,10 @@ class NewConnectionFormState {
         val additions = raw.split(',').mapNotNull(::normalizeTag)
         if (additions.isEmpty()) return
         // Cap on tag count (guards against pasting thousands of labels): drop beyond [MAX_TAGS_PER_RECORD].
-        tags = LinkedHashSet(tags).apply { addAll(additions) }.take(MAX_TAGS_PER_RECORD)
+        // `prod` is hoisted before the cap — the pill that arms the production guard must never be
+        // the one that falls off the end (same rule as [normalizeTags]).
+        tags = orderTagsProdFirst(LinkedHashSet(tags).apply { addAll(additions) }.toList())
+            .take(MAX_TAGS_PER_RECORD)
     }
 
     /** Remove a tag (value is already canonical, the one rendered on the pill). */
@@ -276,7 +280,7 @@ class NewConnectionFormState {
             username = host.username
             group = host.group ?: ""
             notes = host.notes ?: ""
-            tags = host.tags
+            tags = orderTagsProdFirst(host.tags) // records saved before the rule keep their old order
             aiPolicy = host.aiPolicy
             jumpHostId = host.jumpHostId
             keepAliveSeconds = host.keepAliveSeconds

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdAccent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdAccent.kt
@@ -1,0 +1,58 @@
+package app.skerry.ui.host
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.guard.ProductionGuard
+import app.skerry.shared.host.Host
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.design.Badge
+import app.skerry.ui.theme.Skerry
+import androidx.compose.runtime.remember
+
+/**
+ * Label on the production badge. Not localized on purpose: it names the `prod` tag, which is stored
+ * data shared across clients and locales — a translated badge would read as a different marker.
+ */
+const val PROD_BADGE = "PROD"
+
+/** Whether [host] is production (carries the `prod` tag). */
+fun isProdHost(host: Host?): Boolean = host != null && ProductionGuard.isProduction(host.tags)
+
+/**
+ * Whether the catalog profile [hostId] is production. For call sites that only hold an id (session
+ * tabs, terminal chrome); resolves through [LocalHosts], so it follows a tag edit live. Ad-hoc
+ * sessions with no saved profile (`null`) are never production.
+ */
+@Composable
+fun isProdHostId(hostId: String?): Boolean {
+    val hosts = LocalHosts.current ?: return false
+    return isProdHost(hostId?.let { hosts.find(it) })
+}
+
+/**
+ * Predicate over host ids for non-composable callers (the broadcast target list), bound to the live
+ * catalog: re-created when the catalog changes, so a freshly tagged host is production right away.
+ */
+@Composable
+fun rememberProductionLookup(): (String?) -> Boolean {
+    val hosts = LocalHosts.current
+    return remember(hosts, hosts?.hosts) { { id -> isProdHost(id?.let { hosts?.find(it) }) } }
+}
+
+/** Red `PROD` pill for host rows — the resting-state marker of the production guard. */
+@Composable
+fun ProdBadge(modifier: Modifier = Modifier) {
+    Badge(PROD_BADGE, bg = Skerry.colors.strictBg, fg = Skerry.colors.strictFg, modifier = modifier)
+}
+
+/**
+ * Red outline around a production session's work area: the "which window am I in" cue that has to
+ * land without reading a single label. A no-op when [enabled] is false, so non-production sessions
+ * keep the exact layout they had.
+ */
+@Composable
+fun Modifier.prodOutline(enabled: Boolean, radius: Int = 0): Modifier =
+    if (!enabled) this else border(1.dp, Skerry.colors.sunset, RoundedCornerShape(radius.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
@@ -46,29 +46,45 @@ import androidx.compose.runtime.key
 import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.ai.commandRiskReasonText
+import app.skerry.shared.ai.CommandRiskReason
+import app.skerry.shared.guard.ProductionGuard
 import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.generated.resources.guard_prod_broadcast_confirm
+import app.skerry.ui.generated.resources.guard_prod_broadcast_message
+import app.skerry.ui.generated.resources.guard_prod_broadcast_title
 
 /**
  * A connection to a production host waiting for confirmation: [host] names it in the dialog,
- * [proceed] is the connect that was held back, [snippet] marks the "run a snippet on this host"
- * path (it opens a session AND runs a command, so it says so).
+ * [proceed] is the connect that was held back, [snippetLine] carries the command of the "run a
+ * snippet on this host" path (it opens a session AND runs a command, so the dialog quotes it).
  */
 @Immutable
-class ProdConnectRequest(val host: Host, val snippet: Boolean = false, val proceed: () -> Unit)
+class ProdConnectRequest(val host: Host, val snippetLine: String? = null, val proceed: () -> Unit)
 
 /**
  * Gate in front of every connect path: a production host confirms first, anything else goes
  * straight through. Returns the pending request to show ([ProdConnectDialog]) or `null` when
  * [action] already ran.
  */
-fun prodConnectGate(host: Host, snippet: Boolean = false, action: () -> Unit): ProdConnectRequest? {
+fun prodConnectGate(host: Host, snippetLine: String? = null, action: () -> Unit): ProdConnectRequest? {
     if (!isProdHost(host)) {
         action()
         return null
     }
-    return ProdConnectRequest(host, snippet, action)
+    return ProdConnectRequest(host, snippetLine, action)
 }
+
+/**
+ * Risk of a command that runs outside a session's own guard — a snippet fired at connect time, a
+ * broadcast line fanned out to several hosts. Both are known verbatim and classified for display
+ * only, so the threshold is the widest one: the dialog is already being shown, and the reason is
+ * what makes it worth reading.
+ */
+fun prodDisplayRisk(command: String): GuardedCommand? =
+    ProductionGuard.inspect(command, DISPLAY_POLICY)
+
+private val DISPLAY_POLICY = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
 /**
  * Keeps every open session's terminal guard ([TerminalScreenState.guardProduction]) in step with
@@ -89,21 +105,41 @@ fun ProdGuardSync(sessions: SessionsController?, confirmWarnings: Boolean) {
 @Composable
 private fun BindProdGuard(session: Session, confirmWarnings: Boolean) {
     val host = session.hostId?.let { LocalHosts.current?.find(it) }
-    val policy = ProductionGuardPolicy(
-        production = isProdHost(host),
-        confirmWarnings = confirmWarnings,
-        // The login the profile connects with. `sudo` on a root session says nothing, while a
-        // destructive command has nothing in front of it — see [ProductionGuardPolicy].
-        rootLogin = host?.username?.trim().equals(ROOT_LOGIN, ignoreCase = true),
-    )
+    // Keyed on what the policy is made of: this runs for every open session (splits included) on
+    // every recomposition of the app root, and the tags/username only change when the profile is
+    // edited.
+    val policy = remember(host?.tags, host?.username, confirmWarnings) { prodGuardPolicy(host, confirmWarnings) }
     val terminal = session.liveTerminal
     // SideEffect, not LaunchedEffect: this is a plain state write with nothing to suspend on, and it
     // must be applied on every successful composition, not on a coroutine that may run a frame later.
     SideEffect { terminal?.guardPolicy = policy }
 }
 
+/** The guard policy a session on [host] runs under. Pure — [BindProdGuard] only applies it. */
+fun prodGuardPolicy(host: Host?, confirmWarnings: Boolean): ProductionGuardPolicy =
+    ProductionGuardPolicy(
+        production = isProdHost(host),
+        confirmWarnings = confirmWarnings,
+        // The login the profile connects with. `sudo` on a root session says nothing, while a
+        // destructive command has nothing in front of it — see [ProductionGuardPolicy].
+        rootLogin = isRootLogin(host),
+    )
+
+/** Whether the profile logs in as root. Trimmed and case-insensitive: it is free-typed in the form. */
+fun isRootLogin(host: Host?): Boolean = host?.username?.trim().equals(ROOT_LOGIN, ignoreCase = true)
+
 /** Login that means "no sudo step in front of anything" for the guard. */
 private const val ROOT_LOGIN = "root"
+
+/**
+ * Whether a guard confirmation is on screen for [session] (its split pane included).
+ *
+ * The window-level hotkey handler asks before acting: it sits on the root's preview pass, above the
+ * focus the dialog's scrim takes, so without this a snippet chord or a shell shortcut would fire
+ * over an open confirmation.
+ */
+fun prodGuardDialogOpen(session: Session?): Boolean =
+    session != null && listOfNotNull(session, session.splitSession).any { it.liveTerminal?.pendingGuarded != null }
 
 /**
  * Shows the confirmation for a command held by the guard in [session] (or in its focused split
@@ -114,7 +150,8 @@ private const val ROOT_LOGIN = "root"
 fun ProdCommandGate(session: Session?) {
     if (session == null) return
     // The split pane is checked first: it is the pane that has focus while it is being typed into.
-    val held = listOfNotNull(session.splitSession, session).firstOrNull { it.liveTerminal?.pendingGuarded != null }
+    val held = listOfNotNull(session.splitSession, session)
+        .firstOrNull { it.liveTerminal?.pendingGuarded != null }
     val terminal = held?.liveTerminal ?: return
     val guarded = terminal.pendingGuarded ?: return
     ProdCommandDialog(
@@ -125,14 +162,30 @@ fun ProdCommandGate(session: Session?) {
     )
 }
 
-/** "Connect to production?" confirmation. Cancel/Esc drops the pending connection. */
+/**
+ * "Connect to production?" confirmation. Cancel/Esc drops the pending connection.
+ *
+ * The snippet variant quotes the command: it runs by itself the moment the session opens, before
+ * the session's own guard can hold anything, so this dialog is the only place it can be read.
+ */
 @Composable
 fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
-    val title = if (request.snippet) Res.string.guard_prod_snippet_title else Res.string.guard_prod_connect_title
-    val message = if (request.snippet) Res.string.guard_prod_snippet_message else Res.string.guard_prod_connect_message
-    ConfirmActionDialog(
-        title = stringResource(title),
-        message = stringResource(message, request.host.label),
+    val line = request.snippetLine
+    if (line == null) {
+        ConfirmActionDialog(
+            title = stringResource(Res.string.guard_prod_connect_title),
+            message = stringResource(Res.string.guard_prod_connect_message, request.host.label),
+            confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),
+            onConfirm = { onDismiss(); request.proceed() },
+            onDismiss = onDismiss,
+        )
+        return
+    }
+    ProdCommandSheet(
+        title = stringResource(Res.string.guard_prod_snippet_title),
+        subtitle = stringResource(Res.string.guard_prod_snippet_message, request.host.label),
+        command = line,
+        reason = remember(line) { prodDisplayRisk(line) }?.assessment?.reason,
         confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),
         onConfirm = { onDismiss(); request.proceed() },
         onDismiss = onDismiss,
@@ -140,15 +193,61 @@ fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
 }
 
 /**
- * "Run this on production?" confirmation for a command held back on its way to the shell. Unlike
- * [ConfirmActionDialog] it shows the command verbatim in a monospace block: the whole point is to
- * let the user read what they are about to run — the classifier's [GuardedCommand.assessment]
- * reason alone doesn't say WHICH command tripped it.
+ * "Run this on production?" confirmation for a command held back on its way to the shell.
  */
 @Composable
 fun ProdCommandDialog(
     hostLabel: String,
     guarded: GuardedCommand,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ProdCommandSheet(
+        title = stringResource(Res.string.guard_prod_command_title),
+        subtitle = stringResource(Res.string.guard_prod_command_host, hostLabel),
+        command = guarded.command,
+        reason = guarded.assessment.reason,
+        confirmLabel = stringResource(Res.string.guard_prod_command_confirm),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * "Broadcast to production?" confirmation: one question for the whole fan-out. Quotes the command
+ * for the same reason the single-session dialog does — this is the widest blast radius in the app,
+ * and a count of production sessions says nothing about what is about to run on them.
+ */
+@Composable
+fun ProdBroadcastDialog(
+    command: String,
+    productionCount: Int,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ProdCommandSheet(
+        title = stringResource(Res.string.guard_prod_broadcast_title),
+        subtitle = stringResource(Res.string.guard_prod_broadcast_message, productionCount),
+        command = command,
+        reason = remember(command) { prodDisplayRisk(command) }?.assessment?.reason,
+        confirmLabel = stringResource(Res.string.guard_prod_broadcast_confirm),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * Shared body of the guard confirmations. Unlike [ConfirmActionDialog] it shows the command
+ * verbatim in a monospace block: the whole point is to let the user read what they are about to
+ * run — a reason alone doesn't say WHICH command tripped it.
+ */
+@Composable
+private fun ProdCommandSheet(
+    title: String,
+    subtitle: String,
+    command: String,
+    reason: CommandRiskReason?,
+    confirmLabel: String,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -165,11 +264,11 @@ fun ProdCommandDialog(
                 .padding(26.dp),
         ) {
             Txt(
-                stringResource(Res.string.guard_prod_command_title),
+                title,
                 color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
             )
             Txt(
-                stringResource(Res.string.guard_prod_command_host, hostLabel),
+                subtitle,
                 color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp,
                 modifier = Modifier.padding(top = 10.dp),
             )
@@ -184,11 +283,11 @@ fun ProdCommandDialog(
                     .padding(horizontal = 12.dp, vertical = 10.dp)
                     .horizontalScroll(rememberScrollState()),
             ) {
-                Txt(guarded.command, color = Skerry.colors.text, size = 12.sp, font = LocalFonts.current.mono, maxLines = 1)
+                Txt(command, color = Skerry.colors.text, size = 12.sp, font = LocalFonts.current.mono, maxLines = 1)
             }
-            guarded.assessment.reason?.let { reason ->
+            reason?.let {
                 Txt(
-                    commandRiskReasonText(reason),
+                    commandRiskReasonText(it),
                     color = Skerry.colors.sunset, size = 12.sp, lineHeight = 17.sp,
                     modifier = Modifier.padding(top = 10.dp),
                 )
@@ -200,7 +299,7 @@ fun ProdCommandDialog(
             ) {
                 CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
                 PrimaryButton(
-                    stringResource(Res.string.guard_prod_command_confirm),
+                    confirmLabel,
                     onClick = onConfirm,
                     bg = Skerry.colors.sunset,
                     fg = Skerry.colors.sunsetInk,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
@@ -1,0 +1,199 @@
+package app.skerry.ui.host
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.guard.GuardedCommand
+import app.skerry.shared.host.Host
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.ConfirmActionDialog
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.ModalScrim
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.guard_prod_command_confirm
+import app.skerry.ui.generated.resources.guard_prod_command_host
+import app.skerry.ui.generated.resources.guard_prod_command_title
+import app.skerry.ui.generated.resources.guard_prod_connect_confirm
+import app.skerry.ui.generated.resources.guard_prod_connect_message
+import app.skerry.ui.generated.resources.guard_prod_connect_title
+import app.skerry.ui.generated.resources.guard_prod_snippet_message
+import app.skerry.ui.generated.resources.guard_prod_snippet_title
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.key
+import app.skerry.ui.session.Session
+import app.skerry.ui.session.SessionsController
+import app.skerry.ui.ai.commandRiskReasonText
+
+/**
+ * A connection to a production host waiting for confirmation: [host] names it in the dialog,
+ * [proceed] is the connect that was held back, [snippet] marks the "run a snippet on this host"
+ * path (it opens a session AND runs a command, so it says so).
+ */
+@Immutable
+class ProdConnectRequest(val host: Host, val snippet: Boolean = false, val proceed: () -> Unit)
+
+/**
+ * Gate in front of every connect path: a production host confirms first, anything else goes
+ * straight through. Returns the pending request to show ([ProdConnectDialog]) or `null` when
+ * [action] already ran.
+ */
+fun prodConnectGate(host: Host, snippet: Boolean = false, action: () -> Unit): ProdConnectRequest? {
+    if (!isProdHost(host)) {
+        action()
+        return null
+    }
+    return ProdConnectRequest(host, snippet, action)
+}
+
+/**
+ * Keeps every open session's terminal guard ([TerminalScreenState.guardProduction]) in step with
+ * its host profile, splits included. Driven from the composition rather than set once at connect,
+ * so tagging a host `#prod` arms the sessions that are already open (and untagging disarms them).
+ */
+@Composable
+fun ProdGuardSync(sessions: SessionsController?) {
+    val open = sessions?.sessions ?: return
+    for (session in open) {
+        key(session.id) {
+            BindProdGuard(session)
+            session.splitSession?.let { split -> key(split.id) { BindProdGuard(split) } }
+        }
+    }
+}
+
+@Composable
+private fun BindProdGuard(session: Session) {
+    val prod = isProdHostId(session.hostId)
+    val terminal = session.liveTerminal
+    // SideEffect, not LaunchedEffect: this is a plain state write with nothing to suspend on, and it
+    // must be applied on every successful composition, not on a coroutine that may run a frame later.
+    SideEffect { terminal?.guardProduction = prod }
+}
+
+/**
+ * Shows the confirmation for a command held by the guard in [session] (or in its focused split
+ * pane). Rendered at the app root, not inside the terminal pane, so the scrim covers the window
+ * and the confirmation can't be left behind an overlay.
+ */
+@Composable
+fun ProdCommandGate(session: Session?) {
+    if (session == null) return
+    // The split pane is checked first: it is the pane that has focus while it is being typed into.
+    val held = listOfNotNull(session.splitSession, session).firstOrNull { it.liveTerminal?.pendingGuarded != null }
+    val terminal = held?.liveTerminal ?: return
+    val guarded = terminal.pendingGuarded ?: return
+    ProdCommandDialog(
+        hostLabel = held.title,
+        guarded = guarded,
+        onConfirm = { terminal.confirmGuardedCommand() },
+        onDismiss = { terminal.dismissGuardedCommand() },
+    )
+}
+
+/** "Connect to production?" confirmation. Cancel/Esc drops the pending connection. */
+@Composable
+fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
+    val title = if (request.snippet) Res.string.guard_prod_snippet_title else Res.string.guard_prod_connect_title
+    val message = if (request.snippet) Res.string.guard_prod_snippet_message else Res.string.guard_prod_connect_message
+    ConfirmActionDialog(
+        title = stringResource(title),
+        message = stringResource(message, request.host.label),
+        confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),
+        onConfirm = { onDismiss(); request.proceed() },
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * "Run this on production?" confirmation for a command held back on its way to the shell. Unlike
+ * [ConfirmActionDialog] it shows the command verbatim in a monospace block: the whole point is to
+ * let the user read what they are about to run — the classifier's [GuardedCommand.assessment]
+ * reason alone doesn't say WHICH command tripped it.
+ */
+@Composable
+fun ProdCommandDialog(
+    hostLabel: String,
+    guarded: GuardedCommand,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalScrim(onDismiss = onDismiss) {
+        Column(
+            Modifier
+                .widthIn(max = 460.dp)
+                .fillMaxWidth()
+                .padding(20.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Skerry.colors.surfaceDeep)
+                .border(1.dp, Skerry.colors.sunset, RoundedCornerShape(12.dp))
+                .consumeClicks()
+                .padding(26.dp),
+        ) {
+            Txt(
+                stringResource(Res.string.guard_prod_command_title),
+                color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+            )
+            Txt(
+                stringResource(Res.string.guard_prod_command_host, hostLabel),
+                color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp,
+                modifier = Modifier.padding(top = 10.dp),
+            )
+            // The command scrolls sideways instead of wrapping: a wrapped one-liner reads as several
+            // commands, and this dialog exists to be read exactly.
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Skerry.colors.terminalBg)
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+                    .horizontalScroll(rememberScrollState()),
+            ) {
+                Txt(guarded.command, color = Skerry.colors.text, size = 12.sp, font = LocalFonts.current.mono, maxLines = 1)
+            }
+            guarded.assessment.reason?.let { reason ->
+                Txt(
+                    commandRiskReasonText(reason),
+                    color = Skerry.colors.sunset, size = 12.sp, lineHeight = 17.sp,
+                    modifier = Modifier.padding(top = 10.dp),
+                )
+            }
+            Row(
+                Modifier.fillMaxWidth().padding(top = 18.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+                PrimaryButton(
+                    stringResource(Res.string.guard_prod_command_confirm),
+                    onClick = onConfirm,
+                    bg = Skerry.colors.sunset,
+                    fg = Skerry.colors.sunsetInk,
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
@@ -46,6 +46,8 @@ import androidx.compose.runtime.key
 import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.ai.commandRiskReasonText
+import app.skerry.shared.guard.ProductionGuardPolicy
+import app.skerry.ui.app.LocalHosts
 
 /**
  * A connection to a production host waiting for confirmation: [host] names it in the dialog,
@@ -74,24 +76,34 @@ fun prodConnectGate(host: Host, snippet: Boolean = false, action: () -> Unit): P
  * so tagging a host `#prod` arms the sessions that are already open (and untagging disarms them).
  */
 @Composable
-fun ProdGuardSync(sessions: SessionsController?) {
+fun ProdGuardSync(sessions: SessionsController?, confirmWarnings: Boolean) {
     val open = sessions?.sessions ?: return
     for (session in open) {
         key(session.id) {
-            BindProdGuard(session)
-            session.splitSession?.let { split -> key(split.id) { BindProdGuard(split) } }
+            BindProdGuard(session, confirmWarnings)
+            session.splitSession?.let { split -> key(split.id) { BindProdGuard(split, confirmWarnings) } }
         }
     }
 }
 
 @Composable
-private fun BindProdGuard(session: Session) {
-    val prod = isProdHostId(session.hostId)
+private fun BindProdGuard(session: Session, confirmWarnings: Boolean) {
+    val host = session.hostId?.let { LocalHosts.current?.find(it) }
+    val policy = ProductionGuardPolicy(
+        production = isProdHost(host),
+        confirmWarnings = confirmWarnings,
+        // The login the profile connects with. `sudo` on a root session says nothing, while a
+        // destructive command has nothing in front of it — see [ProductionGuardPolicy].
+        rootLogin = host?.username?.trim().equals(ROOT_LOGIN, ignoreCase = true),
+    )
     val terminal = session.liveTerminal
     // SideEffect, not LaunchedEffect: this is a plain state write with nothing to suspend on, and it
     // must be applied on every successful composition, not on a coroutine that may run a frame later.
-    SideEffect { terminal?.guardProduction = prod }
+    SideEffect { terminal?.guardPolicy = policy }
 }
+
+/** Login that means "no sudo step in front of anything" for the guard. */
+private const val ROOT_LOGIN = "root"
 
 /**
  * Shows the confirmation for a command held by the guard in [session] (or in its focused split

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileBroadcast.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileBroadcast.kt
@@ -41,6 +41,8 @@ import app.skerry.ui.generated.resources.term_broadcast_send
 import app.skerry.ui.generated.resources.term_broadcast_sent
 import app.skerry.ui.generated.resources.term_broadcast_subtitle
 import app.skerry.ui.generated.resources.term_broadcast_title
+import app.skerry.ui.host.ProdBadge
+import app.skerry.ui.host.ProdBroadcastDialog
 import app.skerry.ui.session.BroadcastController
 import app.skerry.ui.session.BroadcastTarget
 import org.jetbrains.compose.resources.stringResource
@@ -61,6 +63,19 @@ internal fun MobileBroadcastSheet(
     var command by remember { mutableStateOf("") }
     var lastSentTo by remember { mutableStateOf<Int?>(null) }
     val selected = controller.selectedCount(targets)
+
+    // Production guard, same as the desktop panel: the fan-out is confirmed once for the whole
+    // group. It has to be asked here — the targets take the command with their own per-session
+    // guard turned off, so nothing downstream would stop it.
+    var confirmProduction by remember { mutableStateOf(false) }
+
+    val deliver = {
+        val delivered = controller.send(command, targets)
+        if (delivered > 0) {
+            lastSentTo = delivered
+            command = ""
+        }
+    }
 
     MobileBottomSheet(onDismiss = onDismiss, maxHeightFraction = 0.8f) {
         Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -106,6 +121,7 @@ internal fun MobileBroadcastSheet(
                                 Sym(if (on) "check_box" else "check_box_outline_blank", size = 18.sp, color = if (on) Skerry.colors.cyanBright else Skerry.colors.faint)
                             }
                             Txt(target.label, color = if (on) Skerry.colors.text else Skerry.colors.dim, size = 13.sp, font = mono)
+                            if (target.production) ProdBadge()
                         }
                     }
                 }
@@ -114,11 +130,7 @@ internal fun MobileBroadcastSheet(
                 MobileSheetButton(
                     label = stringResource(Res.string.term_broadcast_send),
                     onClick = {
-                        val delivered = controller.send(command, targets)
-                        if (delivered > 0) {
-                            lastSentTo = delivered
-                            command = ""
-                        }
+                        if (controller.needsProductionConfirmation(command, targets)) confirmProduction = true else deliver()
                     },
                     modifier = Modifier.fillMaxWidth(),
                     icon = "send",
@@ -127,5 +139,13 @@ internal fun MobileBroadcastSheet(
             }
             Spacer(Modifier.height(6.dp))
         }
+    }
+    if (confirmProduction) {
+        ProdBroadcastDialog(
+            command = command,
+            productionCount = controller.selectedProductionCount(targets),
+            onConfirm = { confirmProduction = false; deliver() },
+            onDismiss = { confirmProduction = false },
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -384,10 +384,14 @@ private fun MobileChrome(
             // session that is already live is NOT gated — the confirmation belongs to opening the
             // connection, and asking on every tab switch would train the user to tap through it.
             val live = sessions?.sessions?.lastOrNull { it.hostId == host.id }
+            // Decided here, before the question is asked, and carried into [open] — re-reading the
+            // session list on OK would connect against a state the user was never shown.
+            val planned = mobileConnectAction(live?.controller?.uiState)
+            val liveId = live?.id
             val confirmProd = mobileProdConfirmNeeded(
                 production = isProdHost(host),
                 isVnc = host.connectionType.isVnc,
-                action = mobileConnectAction(live?.controller?.uiState),
+                action = planned,
             )
             val open = {
                 if (host.connectionType.isVnc) {
@@ -405,8 +409,11 @@ private fun MobileChrome(
                         pendingVnc = host
                     }
                 } else {
-                    val existing = sessions?.sessions?.lastOrNull { it.hostId == host.id }
-                    when (mobileConnectAction(existing?.controller?.uiState)) {
+                    // The session the decision was made about, looked up by the id captured with it.
+                    // Only its survival is re-checked ([mobileResolvedAction]) — a session that died
+                    // behind the confirmation has nothing to resume onto.
+                    val existing = liveId?.let { id -> sessions?.sessions?.firstOrNull { it.id == id } }
+                    when (mobileResolvedAction(planned, stillLive = existing != null)) {
                         MobileConnectAction.Resume -> {
                             existing?.let { sessions.activate(it.id) }
                             navigateAfterConnect(state, dest)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -98,6 +98,12 @@ import app.skerry.ui.theme.Skerry
 import app.skerry.ui.theme.ThemeMode
 import app.skerry.ui.theme.systemInDarkTheme
 import app.skerry.ui.theme.terminalThemeId
+import app.skerry.ui.host.ProdConnectDialog
+import app.skerry.ui.host.ProdConnectRequest
+import app.skerry.ui.host.prodConnectGate
+import app.skerry.ui.host.ProdCommandGate
+import app.skerry.ui.host.ProdGuardSync
+import app.skerry.ui.host.isProdHost
 
 /**
  * Root of the mobile layout. Supplies fonts via [LocalFonts] and live backends via
@@ -358,6 +364,9 @@ private fun MobileChrome(
     var pending by remember { mutableStateOf<PendingConnect?>(null) }
     // VNC "ask every time": a host with no stored password prompts before opening the framebuffer screen.
     var pendingVnc by remember { mutableStateOf<Host?>(null) }
+    // Production guard: a session about to open on a #prod host waits here for confirmation
+    // (desktop parity — the gate wraps every connect path, terminal / files / VNC).
+    var prodConnect by remember { mutableStateOf<ProdConnectRequest?>(null) }
 
     // ProxyJump chain resolution failed for the tapped host — show a notice instead of connecting
     // (never silently direct). Desktop parity ([JumpErrorDialog]).
@@ -371,50 +380,62 @@ private fun MobileChrome(
     // including the password prompt, diverging only in the final navigation [navigateAfterConnect]).
     val connect = remember(sessions, credentials, hostManager, state) {
         { host: Host, dest: MobileConnectDest ->
-            if (host.connectionType.isVnc) {
-                // VNC opens a framebuffer screen (not a terminal). A stored password is used directly;
-                // "ask every time" (no bound secret) prompts for one first.
-                val cred = credentials?.find(host.credentialId)
-                if (cred != null) {
-                    sessions?.openVnc(
-                        host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
-                        remoteResize = host.vncResizeToWindow,
-                        onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
-                    )
-                    if (sessions != null) state.push(MobileRoute.Vnc)
-                } else {
-                    pendingVnc = host
-                }
-            } else {
-                val existing = sessions?.sessions?.lastOrNull { it.hostId == host.id }
-                when (mobileConnectAction(existing?.controller?.uiState)) {
-                    MobileConnectAction.Resume -> {
-                        existing?.let { sessions.activate(it.id) }
-                        navigateAfterConnect(state, dest)
+            // Production guard: opening a session on a #prod host confirms first. Returning to a
+            // session that is already live is NOT gated — the confirmation belongs to opening the
+            // connection, and asking on every tab switch would train the user to tap through it.
+            val live = sessions?.sessions?.lastOrNull { it.hostId == host.id }
+            val confirmProd = mobileProdConfirmNeeded(
+                production = isProdHost(host),
+                isVnc = host.connectionType.isVnc,
+                action = mobileConnectAction(live?.controller?.uiState),
+            )
+            val open = {
+                if (host.connectionType.isVnc) {
+                    // VNC opens a framebuffer screen (not a terminal). A stored password is used directly;
+                    // "ask every time" (no bound secret) prompts for one first.
+                    val cred = credentials?.find(host.credentialId)
+                    if (cred != null) {
+                        sessions?.openVnc(
+                            host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
+                            remoteResize = host.vncResizeToWindow,
+                            onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
+                        )
+                        if (sessions != null) state.push(MobileRoute.Vnc)
+                    } else {
+                        pendingVnc = host
                     }
-                    MobileConnectAction.OpenFresh -> {
-                        existing?.let { sessions.close(it.id) }
-                        // ProxyJump chain first — resolved before the password prompt so a broken
-                        // chain surfaces immediately, not after the user typed a password.
-                        when (val chain = resolveJumpChain(host, { id -> hostManager?.find(id) }, { id -> credentials?.find(id) })) {
-                            is JumpChainResolution.Unavailable -> jumpProblem = chain.problem
-                            is JumpChainResolution.Resolved -> {
-                                // Single-level resolve: host → keychain secret by credentialId → SshAuth; no binding → password.
-                                val credential = credentials?.find(host.credentialId)
-                                when {
-                                    // Telnet/Serial have no auth — connect immediately, no password
-                                    // prompt. SSH and Mosh resolve a credential or ask for a password.
-                                    !host.connectionType.usesSshAuth ->
-                                        openMobileSession(sessions, state, host, SshAuth.Password(""), chain.jump, dest)
-                                    credential != null ->
-                                        openMobileSession(sessions, state, host, credential.toSshAuth(), chain.jump, dest)
-                                    else -> pending = PendingConnect(host, dest, chain.jump)
+                } else {
+                    val existing = sessions?.sessions?.lastOrNull { it.hostId == host.id }
+                    when (mobileConnectAction(existing?.controller?.uiState)) {
+                        MobileConnectAction.Resume -> {
+                            existing?.let { sessions.activate(it.id) }
+                            navigateAfterConnect(state, dest)
+                        }
+                        MobileConnectAction.OpenFresh -> {
+                            existing?.let { sessions.close(it.id) }
+                            // ProxyJump chain first — resolved before the password prompt so a broken
+                            // chain surfaces immediately, not after the user typed a password.
+                            when (val chain = resolveJumpChain(host, { id -> hostManager?.find(id) }, { id -> credentials?.find(id) })) {
+                                is JumpChainResolution.Unavailable -> jumpProblem = chain.problem
+                                is JumpChainResolution.Resolved -> {
+                                    // Single-level resolve: host → keychain secret by credentialId → SshAuth; no binding → password.
+                                    val credential = credentials?.find(host.credentialId)
+                                    when {
+                                        // Telnet/Serial have no auth — connect immediately, no password
+                                        // prompt. SSH and Mosh resolve a credential or ask for a password.
+                                        !host.connectionType.usesSshAuth ->
+                                            openMobileSession(sessions, state, host, SshAuth.Password(""), chain.jump, dest)
+                                        credential != null ->
+                                            openMobileSession(sessions, state, host, credential.toSshAuth(), chain.jump, dest)
+                                        else -> pending = PendingConnect(host, dest, chain.jump)
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
+            if (confirmProd) prodConnect = ProdConnectRequest(host, proceed = open) else open()
         }
     }
     // Derived stable lambdas for the two entry points: Connect (→ terminal) and SFTP (→ Files push screen).
@@ -526,6 +547,14 @@ private fun MobileChrome(
                     },
                 )
             }
+            // Production guard: confirm before a #prod session opens (ahead of the password sheet —
+            // the question is whether to touch production at all).
+            prodConnect?.let { request ->
+                ProdConnectDialog(request, onDismiss = { prodConnect = null })
+            }
+            // Inside a session: keep it armed from the host tags and confirm the commands it holds.
+            ProdGuardSync(sessions)
+            ProdCommandGate(sessions?.active)
             // Broken ProxyJump chain for the tapped host: explain instead of connecting.
             jumpProblem?.let { problem ->
                 JumpErrorDialog(problem, onDismiss = { jumpProblem = null })

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -553,7 +553,7 @@ private fun MobileChrome(
                 ProdConnectDialog(request, onDismiss = { prodConnect = null })
             }
             // Inside a session: keep it armed from the host tags and confirm the commands it holds.
-            ProdGuardSync(sessions)
+            ProdGuardSync(sessions, state.confirmProductionWarnings)
             ProdCommandGate(sessions?.active)
             // Broken ProxyJump chain for the tapped host: explain instead of connecting.
             jumpProblem?.let { problem ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.ui.host.HostFolder
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.ProdBadge
+import app.skerry.ui.host.isProdHost
 import app.skerry.ui.host.UNGROUPED_LABEL
 import app.skerry.ui.host.ungroupedLabel
 import app.skerry.ui.generated.resources.Res
@@ -403,12 +405,13 @@ private fun MobileFolderHeader(
 @Composable
 private fun MobileHostRow(host: Host, onClick: () -> Unit) {
     val dotColor = sessionDotColor(LocalSessions.current?.statusFor(host.id))
+    val prod = isProdHost(host)
     Row(
         Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
             .background(Skerry.colors.card)
-            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(14.dp))
+            .border(1.dp, if (prod) Skerry.colors.sunset else Skerry.colors.cyan08, RoundedCornerShape(14.dp))
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
@@ -425,7 +428,13 @@ private fun MobileHostRow(host: Host, onClick: () -> Unit) {
             Sym(host.connectionType.icon, size = 21.sp, color = Skerry.colors.cyanBright)
         }
         Column(Modifier.weight(1f)) {
-            Txt(host.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold, maxLines = 1)
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Txt(
+                    host.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold,
+                    maxLines = 1, modifier = Modifier.weight(1f, fill = false),
+                )
+                if (prod) ProdBadge()
+            }
             Spacer(Modifier.height(2.dp))
             Txt(
                 "${host.username}@${host.address}",

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -170,6 +170,8 @@ import app.skerry.ui.theme.Skerry
 import app.skerry.ui.theme.palette
 import app.skerry.ui.theme.systemInDarkTheme
 import app.skerry.ui.theme.ThemeMode
+import app.skerry.ui.generated.resources.settings_terminal_prod_warnings
+import app.skerry.ui.generated.resources.settings_terminal_prod_warnings_desc
 
 /**
  * Root More tab: title + profile card + list of section links. Navigation hub to the
@@ -599,6 +601,20 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
                     Txt(stringResource(Res.string.settings_terminal_clipboard_write_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
                 }
                 Toggle(on = state.allowServerClipboardWrite, onToggle = state::toggleAllowServerClipboardWrite)
+            }
+            // Production guard threshold (desktop parity): dangerous commands always confirm, the
+            // warnings on top of them are opt-in.
+            HLine()
+            Row(
+                Modifier.fillMaxWidth().padding(vertical = 11.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Txt(stringResource(Res.string.settings_terminal_prod_warnings), color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
+                    Txt(stringResource(Res.string.settings_terminal_prod_warnings_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
+                }
+                Toggle(on = state.confirmProductionWarnings, onToggle = state::toggleConfirmProductionWarnings)
             }
             Txt(stringResource(Res.string.appearance_section_interface), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 18.dp, bottom = 6.dp))
             FontSettingRow(stringResource(Res.string.appearance_language)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -185,7 +185,7 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
                 onDelete = target?.let { e -> { manager.delete(e.id); adding = false; editing = null } },
                 onRun = run@{
                     val e = target ?: return@run
-                    manager.run(e.id, recording = activeTerminal?.recording == true) { text -> activeTerminal?.send(text) }
+                    manager.run(e.id, recording = activeTerminal?.recording == true) { text -> activeTerminal?.sendUserInputGuarded(text) }
                     adding = false; editing = null
                     sessions?.active?.let { state.push(MobileRoute.Terminal) }
                 },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
@@ -64,6 +64,17 @@ fun mobileConnectAction(existing: ConnectionUiState?): MobileConnectAction =
     }
 
 /**
+ * The action to actually take when the connect runs, given the [planned] one decided when the
+ * production confirmation was put on screen and whether that session is [stillLive] now.
+ *
+ * The decision is made once, when the question is asked, and carried to the answer: re-deciding on
+ * OK would act on a state the user never saw. The one thing that must still be checked is whether
+ * the session survived the wait — resuming one that died in between would land on an empty screen.
+ */
+fun mobileResolvedAction(planned: MobileConnectAction, stillLive: Boolean): MobileConnectAction =
+    if (planned == MobileConnectAction.Resume && !stillLive) MobileConnectAction.OpenFresh else planned
+
+/**
  * Whether tapping Connect on a production host must confirm first ([app.skerry.shared.guard.ProductionGuard]).
  * Returning to a session that is already live is not a new connection, so it doesn't ask — a
  * confirmation on every tab switch would be trained away within a day. A VNC tap always opens a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminal.kt
@@ -63,6 +63,15 @@ fun mobileConnectAction(existing: ConnectionUiState?): MobileConnectAction =
         MobileConnectAction.OpenFresh
     }
 
+/**
+ * Whether tapping Connect on a production host must confirm first ([app.skerry.shared.guard.ProductionGuard]).
+ * Returning to a session that is already live is not a new connection, so it doesn't ask — a
+ * confirmation on every tab switch would be trained away within a day. A VNC tap always opens a
+ * fresh framebuffer screen, so it always asks.
+ */
+fun mobileProdConfirmNeeded(production: Boolean, isVnc: Boolean, action: MobileConnectAction): Boolean =
+    production && (isVnc || action != MobileConnectAction.Resume)
+
 /** Where to go from the host screen after opening/resuming a session: Connect → terminal, SFTP → files. */
 enum class MobileConnectDest { Terminal, Files }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -685,7 +685,11 @@ private fun MobileKeybar(
             terminal.sendUserInput(controlByte(c[0]))
             onCtrlArmedChange(false)
         } else {
-            terminal.sendUserInput(c)
+            // typeInput, not sendUserInput: a character from the panel is typing, and it has to reach
+            // the tracked line like any other. Sending it raw left `/`, `|`, `~` out of the line the
+            // production guard classifies (the panel has no Enter key, so nothing ran unguarded —
+            // but the guard was reading a line that was missing characters).
+            terminal.typeInput(c)
         }
     }
     val arrow = { key: ArrowKey -> plain(arrowSequence(key, terminal.applicationCursorKeys)) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -115,6 +115,10 @@ import app.skerry.shared.terminal.castFileName
 import app.skerry.shared.terminal.recordingStamp
 import app.skerry.ui.vault.exportTextFile
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.host.isProdHostId
+import app.skerry.ui.host.prodOutline
+import app.skerry.ui.host.rememberProductionLookup
+import app.skerry.ui.ai.commandRiskReasonText
 
 /** ESC (0x1B) — prefix of arrow CSI sequences and the esc key itself. */
 private const val ESC = "\u001b"
@@ -210,7 +214,9 @@ fun MobileTerminalScreen(state: MobileDesignState) {
         }
     }
 
-    Box(Modifier.fillMaxSize().background(Skerry.colors.terminalBg)) {
+    // Red frame around a production session (desktop parity): the phone has no tab row to carry the
+    // marker, so the screen edge is the only always-visible place for it.
+    Box(Modifier.fillMaxSize().background(Skerry.colors.terminalBg).prodOutline(isProdHostId(active?.hostId))) {
         // imePadding here, not at the app root: this screen opts out of the root safeDrawing padding
         // to run edge to edge, so lifting the content above the soft keyboard is its own job now.
         Column(Modifier.fillMaxSize().imePadding()) {
@@ -290,7 +296,7 @@ fun MobileTerminalScreen(state: MobileDesignState) {
         if (paletteOpen && snippets != null && activeTerminal != null) {
             MobileSnippetRunSheet(
                 manager = snippets,
-                onRun = { entry -> snippets.run(entry.id, recording = activeTerminal.recording) { text -> activeTerminal.sendUserInput(text) }; paletteOpen = false },
+                onRun = { entry -> snippets.run(entry.id, recording = activeTerminal.recording) { text -> activeTerminal.sendUserInputGuarded(text) }; paletteOpen = false },
                 onDismiss = { paletteOpen = false },
             )
         }
@@ -308,7 +314,7 @@ fun MobileTerminalScreen(state: MobileDesignState) {
         if (broadcastOpen) {
             MobileBroadcastSheet(
                 controller = state.broadcast,
-                targets = broadcastTargets(sessions),
+                targets = broadcastTargets(sessions, rememberProductionLookup()),
                 onDismiss = { broadcastOpen = false },
             )
         }
@@ -444,7 +450,7 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                         val infoColor = if (severe) Skerry.colors.sunset else if (risk == CommandRisk.Warn) Skerry.colors.amber else Skerry.colors.dim
                         val info = when (risk) {
                             CommandRisk.None -> controller.pendingInfo
-                            else -> controller.pendingRisk?.reason
+                            else -> controller.pendingRisk?.reason?.let { commandRiskReasonText(it) }
                         }
                         Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                             // The command wraps (up to 6 lines), not truncated: the user sees in full what
@@ -487,7 +493,7 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                 pending != null -> {
                     MobileAiChip(when { !danger -> stringResource(Res.string.term_ai_run); !armed -> stringResource(Res.string.term_ai_run_anyway); else -> stringResource(Res.string.term_ai_confirm) }, accent) {
                         if (danger && !armed) armed = true
-                        else controller.confirm()?.let { terminal.sendUserInput(it + "\r") }
+                        else controller.confirm()?.let { terminal.sendUserInputGuarded(it + "\r") }
                     }
                     MobileAiChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint) { controller.dismiss() }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.setValue
 data class BroadcastTarget(
     val id: String,
     val label: String,
+    /** Whether this session runs on a production host — the panel confirms before reaching one. */
+    val production: Boolean = false,
     val send: (String) -> Boolean,
 )
 
@@ -46,6 +48,14 @@ class BroadcastController {
 
     /** How many of the still-live [targets] are selected (stale ids don't count). */
     fun selectedCount(targets: List<BroadcastTarget>): Int = targets.count { it.id in selectedIds }
+
+    /**
+     * How many selected targets sit on production hosts. A broadcast is the one path where a single
+     * keystroke reaches several shells at once, so the panel asks once for the whole fan-out
+     * instead of holding the command per session (see [BroadcastTarget.production]).
+     */
+    fun selectedProductionCount(targets: List<BroadcastTarget>): Int =
+        targets.count { it.id in selectedIds && it.production }
 
     /**
      * Send [command] plus a newline to every selected live target; returns how many actually

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastController.kt
@@ -58,6 +58,15 @@ class BroadcastController {
         targets.count { it.id in selectedIds && it.production }
 
     /**
+     * Whether sending [command] now has to be confirmed first. The panels (desktop and mobile) both
+     * ask this rather than deciding for themselves: [BroadcastTarget.send] hands the command to each
+     * session with the per-session guard turned off, so a platform that forgets to ask has no second
+     * line of defence.
+     */
+    fun needsProductionConfirmation(command: String, targets: List<BroadcastTarget>): Boolean =
+        command.isNotBlank() && selectedProductionCount(targets) > 0
+
+    /**
      * Send [command] plus a newline to every selected live target; returns how many actually
      * received it. A blank command is a no-op. One target failing (its channel died between the
      * picker rendering and the send) must not swallow the rest of the broadcast — that would be the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
@@ -61,6 +61,11 @@ import app.skerry.ui.generated.resources.term_broadcast_subtitle
 import app.skerry.ui.generated.resources.term_broadcast_title
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.design.ConfirmActionDialog
+import app.skerry.ui.host.ProdBadge
+import app.skerry.ui.generated.resources.guard_prod_broadcast_confirm
+import app.skerry.ui.generated.resources.guard_prod_broadcast_message
+import app.skerry.ui.generated.resources.guard_prod_broadcast_title
 
 /**
  * Every connected terminal a broadcast can reach: top-level tabs and their split panes, VNC tabs
@@ -68,7 +73,11 @@ import app.skerry.ui.theme.Skerry
  * [app.skerry.ui.terminal.TerminalScreenState.typeInput] rather than a raw send, so a broadcast
  * lands in each host's own command history like anything else the user typed.
  */
-internal fun broadcastTargets(sessions: SessionsController?): List<BroadcastTarget> =
+internal fun broadcastTargets(
+    sessions: SessionsController?,
+    // Whether a session's host is production; the panel confirms once before a fan-out reaches one.
+    isProduction: (String?) -> Boolean = { false },
+): List<BroadcastTarget> =
     sessions?.sessions.orEmpty().flatMap { session ->
         listOfNotNull(session, session.splitSession).mapNotNull { candidate ->
             val terminal = (candidate.controller.uiState as? ConnectionUiState.Connected)?.terminal
@@ -76,12 +85,15 @@ internal fun broadcastTargets(sessions: SessionsController?): List<BroadcastTarg
                 BroadcastTarget(
                     id = candidate.id,
                     label = candidate.displayTitle.ifBlank { candidate.subtitle },
+                    production = isProduction(candidate.hostId),
                     send = { text ->
                         // Delivery is judged on the session's state, not on the write: typeInput
                         // hands bytes to an unbounded queue and never fails, so a host whose
                         // transport dropped a moment ago would still be counted as reached.
                         val live = it.state.value is TerminalState.Open
-                        if (live) it.typeInput(text)
+                        // guarded = false: the panel already confirmed the production targets as a
+                        // group. Holding here instead would park the command in background tabs.
+                        if (live) it.typeInput(text, guarded = false)
                         live
                     },
                 )
@@ -107,13 +119,19 @@ internal fun BroadcastPanel(
     LaunchedEffect(Unit) { inputFocus.requestFocus() }
     val selected = controller.selectedCount(targets)
 
-    val submit = {
+    // Production guard: how many selected sessions are on #prod hosts. Non-zero means the send is
+    // held until the extra confirmation below — one question for the whole fan-out.
+    val productionSelected = controller.selectedProductionCount(targets)
+    var confirmProduction by remember { mutableStateOf(false) }
+
+    val deliver = {
         val delivered = controller.send(command, targets)
         if (delivered > 0) {
             lastSentTo = delivered
             command = ""
         }
     }
+    val submit = { if (productionSelected > 0 && command.isNotBlank()) confirmProduction = true else deliver() }
 
     ModalScrim(onDismiss = onDismiss, contentAlignment = Alignment.TopCenter) {
         Column(
@@ -146,7 +164,7 @@ internal fun BroadcastPanel(
                 Column(Modifier.heightIn(max = 220.dp).verticalScroll(rememberScrollState()), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     targets.forEach { target ->
                         key(target.id) {
-                            TargetRow(target.label, controller.isSelected(target.id), mono) { controller.toggle(target.id) }
+                            TargetRow(target.label, controller.isSelected(target.id), target.production, mono) { controller.toggle(target.id) }
                         }
                     }
                 }
@@ -160,10 +178,19 @@ internal fun BroadcastPanel(
             }
         }
     }
+    if (confirmProduction) {
+        ConfirmActionDialog(
+            title = stringResource(Res.string.guard_prod_broadcast_title),
+            message = stringResource(Res.string.guard_prod_broadcast_message, productionSelected),
+            confirmLabel = stringResource(Res.string.guard_prod_broadcast_confirm),
+            onConfirm = { confirmProduction = false; deliver() },
+            onDismiss = { confirmProduction = false },
+        )
+    }
 }
 
 @Composable
-private fun TargetRow(label: String, selected: Boolean, mono: FontFamily, onToggle: () -> Unit) {
+private fun TargetRow(label: String, selected: Boolean, production: Boolean, mono: FontFamily, onToggle: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()
@@ -178,6 +205,7 @@ private fun TargetRow(label: String, selected: Boolean, mono: FontFamily, onTogg
             Sym(if (selected) "check_box" else "check_box_outline_blank", size = 16.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.faint)
         }
         Txt(label, color = if (selected) Skerry.colors.textBright else Skerry.colors.dim, size = 12.5.sp, font = mono)
+        if (production) ProdBadge()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
@@ -61,11 +61,8 @@ import app.skerry.ui.generated.resources.term_broadcast_subtitle
 import app.skerry.ui.generated.resources.term_broadcast_title
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
-import app.skerry.ui.design.ConfirmActionDialog
 import app.skerry.ui.host.ProdBadge
-import app.skerry.ui.generated.resources.guard_prod_broadcast_confirm
-import app.skerry.ui.generated.resources.guard_prod_broadcast_message
-import app.skerry.ui.generated.resources.guard_prod_broadcast_title
+import app.skerry.ui.host.ProdBroadcastDialog
 
 /**
  * Every connected terminal a broadcast can reach: top-level tabs and their split panes, VNC tabs
@@ -131,7 +128,7 @@ internal fun BroadcastPanel(
             command = ""
         }
     }
-    val submit = { if (productionSelected > 0 && command.isNotBlank()) confirmProduction = true else deliver() }
+    val submit = { if (controller.needsProductionConfirmation(command, targets)) confirmProduction = true else deliver() }
 
     ModalScrim(onDismiss = onDismiss, contentAlignment = Alignment.TopCenter) {
         Column(
@@ -179,10 +176,9 @@ internal fun BroadcastPanel(
         }
     }
     if (confirmProduction) {
-        ConfirmActionDialog(
-            title = stringResource(Res.string.guard_prod_broadcast_title),
-            message = stringResource(Res.string.guard_prod_broadcast_message, productionSelected),
-            confirmLabel = stringResource(Res.string.guard_prod_broadcast_confirm),
+        ProdBroadcastDialog(
+            command = command,
+            productionCount = productionSelected,
             onConfirm = { confirmProduction = false; deliver() },
             onDismiss = { confirmProduction = false },
         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -73,6 +73,8 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.generated.resources.settings_terminal_prod_warnings
+import app.skerry.ui.generated.resources.settings_terminal_prod_warnings_desc
 
 // Terminal section: themes, font/metrics, scrollback, cursor style, live OSC title on tabs.
 
@@ -171,6 +173,15 @@ internal fun TerminalSection(state: DesktopDesignState) {
         // the longest localized option ("Двойной клик (клик выделяет)") on a single line.
         Box(Modifier.width(232.dp)) { HostConnectModePicker(state.hostClickConnectMode, onPick = state::chooseHostClickConnectMode) }
     }
+    HLine()
+    // Production guard threshold: Danger is always confirmed, warnings only if asked for (sudo is a
+    // warning and would otherwise fire on half the commands typed on a production box).
+    SettingToggleRow(
+        stringResource(Res.string.settings_terminal_prod_warnings),
+        stringResource(Res.string.settings_terminal_prod_warnings_desc),
+        on = state.confirmProductionWarnings,
+        onToggle = state::toggleConfirmProductionWarnings,
+    )
     HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from
     // silently overwriting the system clipboard. Applies to new and already-open sessions.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/AiBar.kt
@@ -65,6 +65,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.ai.commandRiskReasonText
 
 // Terminal AI bar: live input under per-host policy, or a decorative mock preview.
 
@@ -156,7 +157,7 @@ internal fun AiBarInput(
                         val infoColor = if (severe) Skerry.colors.sunset else if (risk == CommandRisk.Warn) Skerry.colors.amber else Skerry.colors.dim
                         val info = when (risk) {
                             CommandRisk.None -> controller.pendingInfo
-                            else -> controller.pendingRisk?.reason
+                            else -> controller.pendingRisk?.reason?.let { commandRiskReasonText(it) }
                         }
                         // Command and explanation share a baseline so differing font sizes don't drift.
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -207,7 +208,7 @@ internal fun AiBarInput(
                         enabled = terminal != null,
                         onClick = {
                             if (danger && !armed) armed = true
-                            else controller.confirm()?.let { terminal?.sendUserInput(it + "\r") }
+                            else controller.confirm()?.let { terminal?.sendUserInputGuarded(it + "\r") }
                         },
                     )
                     AiActionChip(stringResource(Res.string.term_ai_dismiss), Skerry.colors.faint, onClick = { controller.dismiss() })

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -109,6 +109,8 @@ import app.skerry.ui.host.HostFolder
 import app.skerry.ui.host.HostGroup
 import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.host.MockHost
+import app.skerry.ui.host.ProdBadge
+import app.skerry.ui.host.isProdHost
 import app.skerry.ui.host.UNGROUPED_LABEL
 import app.skerry.ui.host.color
 import app.skerry.ui.host.draggableFolderHeader
@@ -806,6 +808,9 @@ internal fun HostEntryRow(
     onDuplicate: (() -> Unit)? = null,
     onDelete: (() -> Unit)? = null,
 ) {
+    // Production marker: shown before the row is ever clicked, so "wrong window" is visible in the
+    // list itself and not only once a session is open.
+    val prod = isProdHost(host)
     val snippets = LocalSnippets.current
     val runSnippetOnHost = LocalRunSnippetOnHost.current
     val canRunSnippet = host != null && snippets != null
@@ -859,6 +864,7 @@ internal fun HostEntryRow(
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
             )
+            if (prod) ProdBadge()
             if (badge != null) {
                 val strict = badge == "STRICT"
                 Badge(badge, bg = if (strict) Skerry.colors.strictBg else Skerry.colors.devBg, fg = if (strict) Skerry.colors.strictFg else Skerry.colors.moss)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ProductionGuardHold.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ProductionGuardHold.kt
@@ -1,0 +1,79 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.guard.GuardedCommand
+import app.skerry.shared.guard.ProductionGuard
+import app.skerry.shared.guard.ProductionGuardPolicy
+
+/** Where a held input block came from — it is replayed exactly the way that path would send it. */
+enum class HeldInputSource { Typed, Command, Paste }
+
+/** An input block that was held back, ready to be replayed by the path it came from. */
+data class HeldInput(val text: String, val from: HeldInputSource)
+
+/**
+ * The production guard's hold/confirm/dismiss state for one terminal: what is waiting for the user's
+ * answer, and the input to replay once they give it.
+ *
+ * Split out of [TerminalScreenState] because every input path has to obey the same two rules, and
+ * they are easy to get subtly wrong when spelled out three times:
+ *
+ * 1. **One at a time.** While something is held, NOTHING else runs — not a second risky command, not
+ *    a harmless one. Confirming a dialog that shows command A must never run command B, and the user
+ *    is answering a question about A. What arrives meanwhile is dropped, not queued: a command that
+ *    runs minutes later, after the dialog is gone, is its own kind of surprise.
+ * 2. **Classification is the last step.** The rules above are decided before a candidate is ever
+ *    classified, so a path can't leak an input block just because it happened to look harmless.
+ *
+ * The caller owns everything terminal-specific (what the candidates are, how to replay them); this
+ * only decides whether the input is held.
+ */
+@Stable
+class ProductionGuardHold {
+
+    /** What the guard asks about in this session. [ProductionGuardPolicy.Off] — no guard at all. */
+    var policy: ProductionGuardPolicy by mutableStateOf(ProductionGuardPolicy.Off)
+
+    /** Command awaiting the user's confirmation; `null` when nothing is pending. */
+    var pending: GuardedCommand? by mutableStateOf(null)
+        private set
+
+    private var held: HeldInput? = null
+
+    /**
+     * Whether [text] is held back instead of being sent. [candidates] is evaluated only when it can
+     * matter — it reads the screen and the tracked line, which is wasted work on a session with no
+     * guard.
+     *
+     * `true` means the caller must send nothing: either the input is now waiting for confirmation,
+     * or it was dropped because something else already is.
+     */
+    fun hold(text: String, from: HeldInputSource, candidates: () -> List<String>): Boolean {
+        if (!policy.production) return false
+        if (pending != null) return true
+        val guarded = ProductionGuard.inspect(candidates(), policy) ?: return false
+        pending = guarded
+        held = HeldInput(text, from)
+        return true
+    }
+
+    /**
+     * Take the held input to replay it, clearing the hold in the same step. `null` when nothing is
+     * held — a confirmation that arrives twice (double click, a stray Enter) replays nothing.
+     */
+    fun take(): HeldInput? {
+        val current = held ?: return null
+        pending = null
+        held = null
+        return current
+    }
+
+    /** Drop what is held: the user said no, or the session is being torn down. */
+    fun dismiss() {
+        pending = null
+        held = null
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -83,7 +83,7 @@ internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? 
                 properties = PopupProperties(focusable = true),
             ) {
                 SnippetPalette(manager) { entry ->
-                    manager.run(entry.id, recording = terminal.recording) { text -> terminal.send(text) }
+                    manager.run(entry.id, recording = terminal.recording) { text -> terminal.sendUserInputGuarded(text) }
                     open = false
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import app.skerry.shared.guard.GuardedCommand
 import app.skerry.shared.guard.ProductionGuard
+import app.skerry.shared.guard.ProductionGuardPolicy
 
 /**
  * Terminal screen state over [TerminalSession]. Raw PTY bytes go through [TerminalEmulator]
@@ -520,8 +521,11 @@ class TerminalScreenState(
     // UI from the session's host profile (see [app.skerry.ui.host.isProdHostId]) and kept live, so
     // adding or removing the tag arms/disarms an open session.
 
-    /** Whether this session runs on a production host and holds risky commands for confirmation. */
-    var guardProduction: Boolean by mutableStateOf(false)
+    /**
+     * What the production guard asks about in this session (host tag, root login, the
+     * confirm-warnings setting). [ProductionGuardPolicy.Off] — no guard at all.
+     */
+    var guardPolicy: ProductionGuardPolicy by mutableStateOf(ProductionGuardPolicy.Off)
 
     /** Command held by the guard, awaiting the user's confirmation; `null` when nothing is pending. */
     var pendingGuarded: GuardedCommand? by mutableStateOf(null)
@@ -548,7 +552,7 @@ class TerminalScreenState(
      * command recalled with arrow-up, where nothing was typed at all).
      */
     private fun holdForProductionGuard(text: String): Boolean {
-        if (!guardProduction || altScreen) return false
+        if (!guardPolicy.production || altScreen) return false
         val enter = text.indexOfFirst { it == '\r' || it == '\n' }
         if (enter < 0) return false
         // The first line continues whatever is already on the shell line; the rest of the block
@@ -558,6 +562,7 @@ class TerminalScreenState(
         val typed = listOf(autocomplete.currentLine + lines.first()) + lines.drop(1)
         val guarded = ProductionGuard.inspect(
             ProductionGuard.promptCandidates(screenLineToCursor()) + typed,
+            guardPolicy,
         ) ?: return false
         // One command is held at a time. A second risky one arriving while the dialog is still up
         // is dropped, not sent: confirming a dialog that shows command A must never run command B.
@@ -575,8 +580,8 @@ class TerminalScreenState(
      * session is not production or the command is harmless.
      */
     fun sendUserInputGuarded(text: String) {
-        if (guardProduction) {
-            val guarded = ProductionGuard.inspect(text.split('\n', '\r'))
+        if (guardPolicy.production) {
+            val guarded = ProductionGuard.inspect(text.split('\n', '\r'), guardPolicy)
             if (guarded != null) {
                 // Same one-at-a-time rule as [holdForProductionGuard]: a command arriving while a
                 // confirmation is up is dropped rather than slipped past the open dialog.
@@ -1053,8 +1058,8 @@ class TerminalScreenState(
         // A paste carrying a newline runs the moment it lands — on a production session it goes
         // through the same confirmation as a typed command. A paste without one only fills the
         // shell line, and the Enter that would run it is guarded separately ([typeInput]).
-        if (guardProduction && pendingGuarded == null && text.any { it == '\n' || it == '\r' }) {
-            val guarded = ProductionGuard.inspect(text.split('\n', '\r'))
+        if (guardPolicy.production && pendingGuarded == null && text.any { it == '\n' || it == '\r' }) {
+            val guarded = ProductionGuard.inspect(text.split('\n', '\r'), guardPolicy)
             if (guarded != null) {
                 pendingGuarded = guarded
                 heldInput = text

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -521,27 +521,24 @@ class TerminalScreenState(
     // UI from the session's host profile (see [app.skerry.ui.host.isProdHostId]) and kept live, so
     // adding or removing the tag arms/disarms an open session.
 
+    // The hold/confirm/dismiss rules live in [ProductionGuardHold]; what belongs here is only what
+    // is terminal-specific — which candidates a path offers, and how a held block is replayed.
+    private val guard = ProductionGuardHold()
+
     /**
      * What the production guard asks about in this session (host tag, root login, the
      * confirm-warnings setting). [ProductionGuardPolicy.Off] — no guard at all.
      */
-    var guardPolicy: ProductionGuardPolicy by mutableStateOf(ProductionGuardPolicy.Off)
+    var guardPolicy: ProductionGuardPolicy
+        get() = guard.policy
+        set(value) { guard.policy = value }
 
     /** Command held by the guard, awaiting the user's confirmation; `null` when nothing is pending. */
-    var pendingGuarded: GuardedCommand? by mutableStateOf(null)
-        private set
-
-    /** The exact input block that was held, replayed verbatim on confirmation. */
-    private var heldInput: String? = null
-
-    /** Where the held input came from — it is replayed exactly the way that path would send it. */
-    private enum class HeldInput { Typed, Command, Paste }
-
-    private var heldFrom: HeldInput = HeldInput.Typed
+    val pendingGuarded: GuardedCommand? get() = guard.pending
 
     /**
      * Holds [text] when it would run a risky command on a production session; `true` means nothing
-     * was sent and [pendingGuarded] now carries what to confirm.
+     * was sent (see [ProductionGuardHold.hold] for when a held block is dropped instead).
      *
      * Only an input block containing Enter can run something, so that is the only thing held —
      * typing itself stays live (a half-typed line the user is still editing must keep echoing).
@@ -552,25 +549,16 @@ class TerminalScreenState(
      * command recalled with arrow-up, where nothing was typed at all).
      */
     private fun holdForProductionGuard(text: String): Boolean {
-        if (!guardPolicy.production || altScreen) return false
-        val enter = text.indexOfFirst { it == '\r' || it == '\n' }
-        if (enter < 0) return false
-        // The first line continues whatever is already on the shell line; the rest of the block
-        // stands on its own. A soft-keyboard delta or an IME clipboard insert arrives whole, so a
-        // risky command can sit on any line of it, not just the first.
-        val lines = text.split('\n', '\r')
-        val typed = listOf(autocomplete.currentLine + lines.first()) + lines.drop(1)
-        val guarded = ProductionGuard.inspect(
-            ProductionGuard.promptCandidates(screenLineToCursor()) + typed,
-            guardPolicy,
-        ) ?: return false
-        // One command is held at a time. A second risky one arriving while the dialog is still up
-        // is dropped, not sent: confirming a dialog that shows command A must never run command B.
-        if (pendingGuarded != null) return true
-        pendingGuarded = guarded
-        heldInput = text
-        heldFrom = HeldInput.Typed
-        return true
+        if (altScreen) return false
+        if (text.none { it == '\r' || it == '\n' }) return false
+        return guard.hold(text, HeldInputSource.Typed) {
+            // The first line continues whatever is already on the shell line; the rest of the block
+            // stands on its own. A soft-keyboard delta or an IME clipboard insert arrives whole, so
+            // a risky command can sit on any line of it, not just the first.
+            val lines = ProductionGuard.candidatesOf(text)
+            val typed = listOf(autocomplete.currentLine + lines.first()) + lines.drop(1)
+            ProductionGuard.promptCandidates(screenLineToCursor()) + typed
+        }
     }
 
     /**
@@ -580,31 +568,17 @@ class TerminalScreenState(
      * session is not production or the command is harmless.
      */
     fun sendUserInputGuarded(text: String) {
-        if (guardPolicy.production) {
-            val guarded = ProductionGuard.inspect(text.split('\n', '\r'), guardPolicy)
-            if (guarded != null) {
-                // Same one-at-a-time rule as [holdForProductionGuard]: a command arriving while a
-                // confirmation is up is dropped rather than slipped past the open dialog.
-                if (pendingGuarded != null) return
-                pendingGuarded = guarded
-                heldInput = text
-                heldFrom = HeldInput.Command
-                return
-            }
-        }
+        if (guard.hold(text, HeldInputSource.Command) { ProductionGuard.candidatesOf(text) }) return
         sendUserInput(text)
     }
 
     /** Run the held command: replays the original input exactly as the path it came from would. */
     fun confirmGuardedCommand() {
-        val text = heldInput ?: return
-        val from = heldFrom
-        pendingGuarded = null
-        heldInput = null
-        when (from) {
-            HeldInput.Typed -> deliverTypedInput(text)
-            HeldInput.Command -> sendUserInput(text)
-            HeldInput.Paste -> deliverPaste(text)
+        val held = guard.take() ?: return
+        when (held.from) {
+            HeldInputSource.Typed -> deliverTypedInput(held.text)
+            HeldInputSource.Command -> sendUserInput(held.text)
+            HeldInputSource.Paste -> deliverPaste(held.text)
         }
     }
 
@@ -613,10 +587,7 @@ class TerminalScreenState(
      * as they were typed) ready to be edited; a pasted or ready-made command never reached the
      * host, so dismissing discards it outright.
      */
-    fun dismissGuardedCommand() {
-        pendingGuarded = null
-        heldInput = null
-    }
+    fun dismissGuardedCommand() = guard.dismiss()
 
     /**
      * Visible cursor row up to the cursor column — the shell line as the user sees it, prompt
@@ -1058,14 +1029,14 @@ class TerminalScreenState(
         // A paste carrying a newline runs the moment it lands — on a production session it goes
         // through the same confirmation as a typed command. A paste without one only fills the
         // shell line, and the Enter that would run it is guarded separately ([typeInput]).
-        if (guardPolicy.production && pendingGuarded == null && text.any { it == '\n' || it == '\r' }) {
-            val guarded = ProductionGuard.inspect(text.split('\n', '\r'), guardPolicy)
-            if (guarded != null) {
-                pendingGuarded = guarded
-                heldInput = text
-                heldFrom = HeldInput.Paste
-                return
-            }
+        // The password-prompt exemption is [typeInput]'s, for the same reason: a manager pastes the
+        // secret with a trailing newline, and holding it would print it in the dialog.
+        // A middle-click paste arrives through a raw pointer handler the modal scrim never sees, so
+        // this is the only place that can stop one while a confirmation is open.
+        if (guardPolicy.production && !session.echoSuppressed && !atPasswordPrompt() &&
+            text.any { it == '\n' || it == '\r' }
+        ) {
+            if (guard.hold(text, HeldInputSource.Paste) { ProductionGuard.candidatesOf(text) }) return
         }
         deliverPaste(text)
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -43,6 +43,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import app.skerry.shared.guard.GuardedCommand
+import app.skerry.shared.guard.ProductionGuard
 
 /**
  * Terminal screen state over [TerminalSession]. Raw PTY bytes go through [TerminalEmulator]
@@ -485,23 +487,142 @@ class TerminalScreenState(
      * to the PTY. Separate from [send]/[sendBytes], used for mouse/focus reports, paste, and
      * snippet output, which must not reach the engine or the tracked line would be corrupted.
      */
-    fun typeInput(text: String) {
+    fun typeInput(text: String, guarded: Boolean = true) {
         inputVersion++
         // Server not echoing input (password entry / line-mode signaled by the transport): do not
         // track the line or write it to history, so a secret does not persist and surface as a
         // suggestion. SSH echo status is unavailable (always false), so a password prompt is also
         // detected heuristically from the current screen line ([atPasswordPrompt]).
+        // The production guard is skipped here for the same reason: what is being typed is a secret,
+        // and parking it in a confirmation dialog would put it on screen in clear text.
         if (session.echoSuppressed || atPasswordPrompt()) {
             autocomplete.reset()
             if (suggestionTail != null) suggestionTail = null
             send(text)
             return
         }
+        // guarded=false: the caller already asked (broadcast confirms once for the whole fan-out,
+        // where a per-session hold would strand commands in tabs nobody is looking at).
+        if (guarded && holdForProductionGuard(text)) return
+        deliverTypedInput(text)
+    }
+
+    private fun deliverTypedInput(text: String) {
         val committed = autocomplete.onUserInput(text.encodeToByteArray())
         refreshSuggestion()
         send(text)
         // Command was committed with Enter (and was echoed): persist the history snapshot for this host.
         if (committed != null) onHistoryChanged?.invoke(autocomplete.commandHistory.commands)
+    }
+
+    // --- Production guard ---
+    // On a host tagged #prod a risky command is confirmed before it reaches the PTY. Enabled by the
+    // UI from the session's host profile (see [app.skerry.ui.host.isProdHostId]) and kept live, so
+    // adding or removing the tag arms/disarms an open session.
+
+    /** Whether this session runs on a production host and holds risky commands for confirmation. */
+    var guardProduction: Boolean by mutableStateOf(false)
+
+    /** Command held by the guard, awaiting the user's confirmation; `null` when nothing is pending. */
+    var pendingGuarded: GuardedCommand? by mutableStateOf(null)
+        private set
+
+    /** The exact input block that was held, replayed verbatim on confirmation. */
+    private var heldInput: String? = null
+
+    /** Where the held input came from — it is replayed exactly the way that path would send it. */
+    private enum class HeldInput { Typed, Command, Paste }
+
+    private var heldFrom: HeldInput = HeldInput.Typed
+
+    /**
+     * Holds [text] when it would run a risky command on a production session; `true` means nothing
+     * was sent and [pendingGuarded] now carries what to confirm.
+     *
+     * Only an input block containing Enter can run something, so that is the only thing held —
+     * typing itself stays live (a half-typed line the user is still editing must keep echoing).
+     * Alt-screen is exempt: inside vim/htop there is no shell line, and Enter is not "run this".
+     *
+     * The command is guessed from two sources, because the client never truly knows it: the locally
+     * tracked line (what was typed here) and the screen line up to the cursor (which also covers a
+     * command recalled with arrow-up, where nothing was typed at all).
+     */
+    private fun holdForProductionGuard(text: String): Boolean {
+        if (!guardProduction || altScreen) return false
+        val enter = text.indexOfFirst { it == '\r' || it == '\n' }
+        if (enter < 0) return false
+        // The first line continues whatever is already on the shell line; the rest of the block
+        // stands on its own. A soft-keyboard delta or an IME clipboard insert arrives whole, so a
+        // risky command can sit on any line of it, not just the first.
+        val lines = text.split('\n', '\r')
+        val typed = listOf(autocomplete.currentLine + lines.first()) + lines.drop(1)
+        val guarded = ProductionGuard.inspect(
+            ProductionGuard.promptCandidates(screenLineToCursor()) + typed,
+        ) ?: return false
+        // One command is held at a time. A second risky one arriving while the dialog is still up
+        // is dropped, not sent: confirming a dialog that shows command A must never run command B.
+        if (pendingGuarded != null) return true
+        pendingGuarded = guarded
+        heldInput = text
+        heldFrom = HeldInput.Typed
+        return true
+    }
+
+    /**
+     * Runs a ready-made command (snippet, palette, any caller that already has the full line) with
+     * the guard in front of it. Unlike [typeInput] the command is known verbatim, so it is
+     * classified as-is — nothing is guessed off the screen. Falls back to [sendUserInput] when the
+     * session is not production or the command is harmless.
+     */
+    fun sendUserInputGuarded(text: String) {
+        if (guardProduction) {
+            val guarded = ProductionGuard.inspect(text.split('\n', '\r'))
+            if (guarded != null) {
+                // Same one-at-a-time rule as [holdForProductionGuard]: a command arriving while a
+                // confirmation is up is dropped rather than slipped past the open dialog.
+                if (pendingGuarded != null) return
+                pendingGuarded = guarded
+                heldInput = text
+                heldFrom = HeldInput.Command
+                return
+            }
+        }
+        sendUserInput(text)
+    }
+
+    /** Run the held command: replays the original input exactly as the path it came from would. */
+    fun confirmGuardedCommand() {
+        val text = heldInput ?: return
+        val from = heldFrom
+        pendingGuarded = null
+        heldInput = null
+        when (from) {
+            HeldInput.Typed -> deliverTypedInput(text)
+            HeldInput.Command -> sendUserInput(text)
+            HeldInput.Paste -> deliverPaste(text)
+        }
+    }
+
+    /**
+     * Drop the held command. A typed one leaves its line in the shell (the characters were echoed
+     * as they were typed) ready to be edited; a pasted or ready-made command never reached the
+     * host, so dismissing discards it outright.
+     */
+    fun dismissGuardedCommand() {
+        pendingGuarded = null
+        heldInput = null
+    }
+
+    /**
+     * Visible cursor row up to the cursor column — the shell line as the user sees it, prompt
+     * included ([ProductionGuard.promptCandidates] strips it). Reads the published [screen]
+     * snapshot, like [atPasswordPrompt].
+     */
+    private fun screenLineToCursor(): String {
+        val grid = screen
+        if (grid.isEmpty() || rows <= 0) return ""
+        val line = grid.getOrNull(grid.size - rows + cursorRow) ?: return ""
+        return line.take(cursorCol.coerceIn(0, line.size)).joinToString("") { it.text }
     }
 
     /**
@@ -929,7 +1050,31 @@ class TerminalScreenState(
     /** Paste clipboard text: wraps it in markers when bracketed paste is enabled (DEC 2004). */
     fun paste(text: String) {
         if (text.isEmpty()) return
+        // A paste carrying a newline runs the moment it lands — on a production session it goes
+        // through the same confirmation as a typed command. A paste without one only fills the
+        // shell line, and the Enter that would run it is guarded separately ([typeInput]).
+        if (guardProduction && pendingGuarded == null && text.any { it == '\n' || it == '\r' }) {
+            val guarded = ProductionGuard.inspect(text.split('\n', '\r'))
+            if (guarded != null) {
+                pendingGuarded = guarded
+                heldInput = text
+                heldFrom = HeldInput.Paste
+                return
+            }
+        }
+        deliverPaste(text)
+    }
+
+    private fun deliverPaste(text: String) {
         inputVersion++
+        // A paste is tracked like typing: without this the Enter after a no-newline paste has
+        // nothing to classify (the tracked line is empty and the host's echo may not have arrived
+        // yet), and the guard would miss a pasted command. The engine also records the lines a
+        // multi-line paste commits, same as if they had been typed.
+        if (!session.echoSuppressed && !atPasswordPrompt()) {
+            autocomplete.onUserInput(text.encodeToByteArray())
+            refreshSuggestion()
+        }
         send(bracketedPasteWrap(text, bracketedPaste))
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -93,6 +93,8 @@ import app.skerry.ui.session.SessionsController
 import app.skerry.ui.session.sessionDotColor
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.host.isProdHostId
+import app.skerry.ui.host.prodOutline
 
 /**
  * Session action icons (split / SFTP / tunnels / snippets / info panel / disconnect). Pinned to the
@@ -332,7 +334,14 @@ private fun LiveTerminalPane(sessions: SessionsController, state: DesktopDesignS
             icon = "terminal",
         )
     }
-    Box(modifier.fillMaxHeight().fillMaxWidth().background(if (onScreen) Skerry.colors.terminalBg else Skerry.colors.bg)) {
+    // Production sessions get a red outline around the whole pane — the guard's resting state, so a
+    // command lands in the wrong window only after ignoring a full-height red frame.
+    val prod = isProdHostId(active?.hostId)
+    Box(
+        modifier.fillMaxHeight().fillMaxWidth()
+            .background(if (onScreen) Skerry.colors.terminalBg else Skerry.colors.bg)
+            .prodOutline(prod),
+    ) {
         when (st) {
             null -> TerminalNotice("terminal", stringResource(Res.string.term_no_active_session), stringResource(Res.string.term_notice_pick_host_to_connect), action = launchLocalShell)
             // Form state on the active tab means an empty ("+") tab: connection not yet started.
@@ -407,6 +416,7 @@ private fun LiveSplitPane(
     val split = parent.splitSession
     Column(
         modifier.fillMaxHeight().background(Skerry.colors.terminalBg)
+            .prodOutline(isProdHostId(split?.hostId))
             .focusPaneOnPress(sessions, parent.id, split = true),
     ) {
         Box(Modifier.fillMaxWidth().background(Skerry.colors.surface2)) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
@@ -38,6 +38,21 @@ class DesktopDesignStateTest {
     }
 
     @Test
+    fun toggleConfirmProductionWarnings_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = DesktopDesignState(onConfirmProductionWarningsChange = { seen += it })
+        // Off by default: sudo is a warning and half of what gets typed on a production box.
+        assertFalse(s.confirmProductionWarnings)
+        s.toggleConfirmProductionWarnings()
+        assertTrue(s.confirmProductionWarnings)
+        s.toggleConfirmProductionWarnings()
+        assertFalse(s.confirmProductionWarnings)
+        // Reported outward on every flip, or the setting would not survive a restart.
+        assertEquals(listOf(true, false), seen)
+        assertTrue(DesktopDesignState(initialConfirmProductionWarnings = true).confirmProductionWarnings)
+    }
+
+    @Test
     fun open_settings_resets_to_the_first_nav_tab() {
         val s = DesktopDesignState()
         s.openSettings()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -58,6 +58,21 @@ class MobileDesignStateTest {
     }
 
     @Test
+    fun toggleConfirmProductionWarnings_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onConfirmProductionWarningsChange = { seen += it })
+        // Off by default: sudo is a warning and half of what gets typed on a production box.
+        assertEquals(false, s.confirmProductionWarnings)
+        s.toggleConfirmProductionWarnings()
+        assertEquals(true, s.confirmProductionWarnings)
+        s.toggleConfirmProductionWarnings()
+        assertEquals(false, s.confirmProductionWarnings)
+        // Reported outward on every flip, or the setting would not survive a restart.
+        assertEquals(listOf(true, false), seen)
+        assertTrue(MobileDesignState(initialConfirmProductionWarnings = true).confirmProductionWarnings)
+    }
+
+    @Test
     fun chooseTerminalFont_updates_and_reports_once_skipping_repeat() {
         val seen = mutableListOf<TerminalFont>()
         val s = MobileDesignState(onTerminalFontChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ConnectionFormSuggestionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ConnectionFormSuggestionsTest.kt
@@ -47,6 +47,17 @@ class ConnectionFormSuggestionsTest {
     }
 
     @Test
+    fun prod_is_suggested_first_even_when_no_host_carries_it() {
+        val hosts = listOf(host("1", tags = listOf("web", "db")))
+        assertEquals(listOf("prod", "web", "db"), tagSuggestions(hosts, selected = emptyList()))
+        assertEquals(listOf("prod"), tagSuggestions(emptyList(), selected = emptyList()))
+        // already on this host: not offered again
+        assertEquals(listOf("web", "db"), tagSuggestions(hosts, selected = listOf("prod")))
+        // and it obeys the query like any other tag
+        assertEquals(listOf("web"), tagSuggestions(hosts, selected = emptyList(), query = "we"))
+    }
+
+    @Test
     fun tag_suggestions_filtered_by_canonicalized_query() {
         val hosts = listOf(host("1", tags = listOf("prod", "web", "docker")))
         // input is canonicalized as a tag: "#DOC" -> "doc" -> substring of "docker"

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostChipsTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.tag.PROD_TAG
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -31,8 +32,16 @@ class HostChipsTest {
     }
 
     @Test
-    fun empty_hosts_yield_only_all_chip() {
-        assertEquals(listOf(ALL_HOSTS_CHIP), hostTagChips(emptyList()))
+    fun prod_chip_is_offered_even_with_no_production_hosts() {
+        val hosts = listOf(host("1", tags = listOf("web")))
+        assertEquals(listOf(ALL_HOSTS_CHIP, PROD_TAG, "web"), hostTagChips(hosts))
+        assertEquals(listOf(ALL_HOSTS_CHIP, PROD_TAG), hostTagChips(emptyList()))
+    }
+
+    @Test
+    fun prod_chip_comes_first_whatever_the_tag_order() {
+        val hosts = listOf(host("1", tags = listOf("web", "db")), host("2", tags = listOf("prod")))
+        assertEquals(listOf(ALL_HOSTS_CHIP, PROD_TAG, "web", "db"), hostTagChips(hosts))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -432,6 +432,23 @@ class NewConnectionFormStateTest {
     }
 
     @Test
+    fun addTag_hoists_prod_pill_to_the_front() {
+        val f = NewConnectionFormState()
+        f.addTag("web")
+        f.addTag("db")
+        f.addTag("prod")
+        assertEquals(listOf("prod", "web", "db"), f.tags)
+    }
+
+    @Test
+    fun addTag_keeps_prod_when_the_cap_is_hit() {
+        val f = NewConnectionFormState()
+        f.addTag((1..app.skerry.shared.tag.MAX_TAGS_PER_RECORD + 5).joinToString(",") { "tag$it" })
+        f.addTag("prod")
+        assertEquals("prod", f.tags.first())
+    }
+
+    @Test
     fun addTag_splits_on_commas() {
         val f = NewConnectionFormState()
         f.addTag("prod, #docker ,, db")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ProdGuardTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ProdGuardTest.kt
@@ -1,0 +1,88 @@
+package app.skerry.ui.host
+
+import app.skerry.shared.host.Host
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.mobile.MobileConnectAction
+import app.skerry.ui.mobile.mobileConnectAction
+import app.skerry.ui.mobile.mobileProdConfirmNeeded
+import app.skerry.shared.ssh.ConnectionType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Gate in front of every connect path (desktop and mobile) plus the mobile-only "resume is not a
+ * new connection" rule. The dialogs themselves are composables; what decides whether one appears
+ * is these pure functions.
+ */
+class ProdGuardTest {
+
+    private fun host(vararg tags: String, type: ConnectionType = ConnectionType.SSH) = Host(
+        id = "h1", label = "web-01", address = "10.0.0.1", username = "root",
+        tags = tags.toList(), connectionType = type,
+    )
+
+    @Test
+    fun a_plain_host_connects_without_asking() {
+        var connected = false
+        val request = prodConnectGate(host("web")) { connected = true }
+
+        assertTrue(connected)
+        assertNull(request)
+    }
+
+    @Test
+    fun a_production_host_holds_the_connection_until_confirmed() {
+        var connected = false
+        val request = prodConnectGate(host("web", "prod")) { connected = true }
+
+        assertFalse(connected) // nothing happens until the user confirms
+        assertNotNull(request)
+        assertEquals("web-01", request.host.label)
+        assertFalse(request.snippet)
+
+        request.proceed()
+        assertTrue(connected)
+    }
+
+    @Test
+    fun the_snippet_path_is_marked_so_the_dialog_can_say_the_command_runs_on_connect() {
+        val request = prodConnectGate(host("prod"), snippet = true) {}
+        assertEquals(true, request?.snippet)
+    }
+
+    @Test
+    fun production_is_read_from_the_tags() {
+        assertTrue(isProdHost(host("prod")))
+        assertTrue(isProdHost(host("db", "prod")))
+        assertFalse(isProdHost(host("staging")))
+        assertFalse(isProdHost(null)) // ad-hoc session with no saved profile
+    }
+
+    @Test
+    fun mobile_asks_when_opening_a_production_session() {
+        val fresh = mobileConnectAction(null)
+        assertEquals(MobileConnectAction.OpenFresh, fresh)
+        assertTrue(mobileProdConfirmNeeded(production = true, isVnc = false, action = fresh))
+        assertFalse(mobileProdConfirmNeeded(production = false, isVnc = false, action = fresh))
+    }
+
+    @Test
+    fun mobile_does_not_ask_again_when_returning_to_a_live_session() {
+        val resume = mobileConnectAction(ConnectionUiState.Connecting)
+        assertEquals(MobileConnectAction.Resume, resume)
+        assertFalse(mobileProdConfirmNeeded(production = true, isVnc = false, action = resume))
+        // A dead session is reopened, not resumed — that IS a new connection and asks again.
+        val dead = mobileConnectAction(ConnectionUiState.Form)
+        assertTrue(mobileProdConfirmNeeded(production = true, isVnc = false, action = dead))
+    }
+
+    @Test
+    fun mobile_always_asks_for_a_production_vnc_tap() {
+        // A VNC tap opens a fresh framebuffer screen; the resume path never applies to it.
+        assertTrue(mobileProdConfirmNeeded(production = true, isVnc = true, action = MobileConnectAction.Resume))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ProdGuardTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ProdGuardTest.kt
@@ -5,6 +5,7 @@ import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.mobile.MobileConnectAction
 import app.skerry.ui.mobile.mobileConnectAction
 import app.skerry.ui.mobile.mobileProdConfirmNeeded
+import app.skerry.ui.mobile.mobileResolvedAction
 import app.skerry.shared.ssh.ConnectionType
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -42,16 +43,42 @@ class ProdGuardTest {
         assertFalse(connected) // nothing happens until the user confirms
         assertNotNull(request)
         assertEquals("web-01", request.host.label)
-        assertFalse(request.snippet)
+        assertNull(request.snippetLine)
 
         request.proceed()
         assertTrue(connected)
     }
 
     @Test
-    fun the_snippet_path_is_marked_so_the_dialog_can_say_the_command_runs_on_connect() {
-        val request = prodConnectGate(host("prod"), snippet = true) {}
-        assertEquals(true, request?.snippet)
+    fun the_snippet_path_carries_its_command_into_the_dialog() {
+        // It runs the moment the session opens, before the session's own guard is bound to it, so
+        // the connect confirmation is the only place the command can be read.
+        val request = prodConnectGate(host("prod"), snippetLine = "systemctl stop nginx\n") {}
+        assertEquals("systemctl stop nginx\n", request?.snippetLine)
+        assertNotNull(prodDisplayRisk("systemctl stop nginx\n")?.assessment?.reason)
+        assertNull(prodDisplayRisk("uptime\n"))
+    }
+
+    @Test
+    fun the_root_login_rule_reads_the_profile_username() {
+        assertTrue(isRootLogin(host("prod")))
+        assertTrue(isRootLogin(host("prod").copy(username = " Root ")))
+        assertFalse(isRootLogin(host("prod").copy(username = "deploy")))
+        assertFalse(isRootLogin(null))
+    }
+
+    @Test
+    fun the_policy_of_a_session_follows_its_host_profile() {
+        val prod = prodGuardPolicy(host("prod"), confirmWarnings = true)
+        assertTrue(prod.production)
+        assertTrue(prod.confirmWarnings)
+        assertTrue(prod.rootLogin)
+
+        val staging = prodGuardPolicy(host("staging").copy(username = "deploy"), confirmWarnings = false)
+        assertFalse(staging.production)
+        assertFalse(staging.rootLogin)
+        // An ad-hoc session with no saved profile is never guarded.
+        assertFalse(prodGuardPolicy(null, confirmWarnings = true).production)
     }
 
     @Test
@@ -78,6 +105,26 @@ class ProdGuardTest {
         // A dead session is reopened, not resumed — that IS a new connection and asks again.
         val dead = mobileConnectAction(ConnectionUiState.Form)
         assertTrue(mobileProdConfirmNeeded(production = true, isVnc = false, action = dead))
+    }
+
+    @Test
+    fun mobile_carries_the_decision_from_the_question_to_the_answer() {
+        // Whatever was decided when the dialog opened is what runs on OK — the session list is not
+        // re-read to decide again, or the connect would act on a state the user never saw.
+        assertEquals(
+            MobileConnectAction.OpenFresh,
+            mobileResolvedAction(MobileConnectAction.OpenFresh, stillLive = true),
+        )
+        assertEquals(
+            MobileConnectAction.Resume,
+            mobileResolvedAction(MobileConnectAction.Resume, stillLive = true),
+        )
+        // The single exception: the session died while the confirmation was up, so there is nothing
+        // left to resume onto.
+        assertEquals(
+            MobileConnectAction.OpenFresh,
+            mobileResolvedAction(MobileConnectAction.Resume, stillLive = false),
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileHostListTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileHostListTest.kt
@@ -23,7 +23,8 @@ class MobileHostListTest {
     @Test
     fun empty_hosts_yield_only_all_chip_and_no_sections() {
         val view = buildMobileHostList(emptyList())
-        assertEquals(listOf(ALL_HOSTS_CHIP), view.chips)
+        // `prod` is always offered, even with an empty catalog (it arms the production guard).
+        assertEquals(listOf(ALL_HOSTS_CHIP, "prod"), view.chips)
         assertEquals(emptyList(), view.sections)
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
@@ -42,6 +42,24 @@ class BroadcastControllerTest {
     }
 
     @Test
+    fun a_fan_out_reaching_production_is_confirmed_first() {
+        val c = BroadcastController()
+        val all = listOf(
+            BroadcastTarget("prod", "web-prod", production = true, send = { true }),
+            BroadcastTarget("stage", "web-stage", send = { true }),
+        )
+
+        c.toggle("stage")
+        assertFalse(c.needsProductionConfirmation("uptime", all))
+        c.toggle("prod")
+        assertTrue(c.needsProductionConfirmation("uptime", all))
+        // Nothing to confirm for a command that send() would refuse anyway.
+        assertFalse(c.needsProductionConfirmation("   ", all))
+        // The production session closed since it was picked: the fan-out no longer reaches one.
+        assertFalse(c.needsProductionConfirmation("uptime", all.filter { it.id == "stage" }))
+    }
+
+    @Test
     fun nothing_is_selected_initially() {
         val c = BroadcastController()
         val (all, _) = targets("a", "b")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/BroadcastControllerTest.kt
@@ -23,6 +23,25 @@ class BroadcastControllerTest {
     }
 
     @Test
+    fun production_targets_are_counted_only_while_selected() {
+        val c = BroadcastController()
+        val all = listOf(
+            BroadcastTarget("prod-1", "web-prod", production = true, send = { true }),
+            BroadcastTarget("prod-2", "db-prod", production = true, send = { true }),
+            BroadcastTarget("stage", "web-stage", send = { true }),
+        )
+
+        assertEquals(0, c.selectedProductionCount(all))
+        c.toggle("stage")
+        assertEquals(0, c.selectedProductionCount(all))
+        c.toggle("prod-1")
+        c.toggle("prod-2")
+        assertEquals(2, c.selectedProductionCount(all))
+        // A session closed after being selected drops out of the count with the rest of the list.
+        assertEquals(1, c.selectedProductionCount(all.filter { it.id != "prod-2" }))
+    }
+
+    @Test
     fun nothing_is_selected_initially() {
         val c = BroadcastController()
         val (all, _) = targets("a", "b")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -21,8 +21,10 @@ import app.skerry.shared.vnc.VncQuality
 import app.skerry.shared.vnc.VncSession
 import app.skerry.shared.vnc.VncTransport
 import app.skerry.shared.vnc.VncUpdate
+import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.host.prodGuardDialogOpen
 import app.skerry.ui.vnc.VncSessionController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -254,6 +256,48 @@ class SessionsControllerTest {
         assertEquals(3, targets.size)
         assertEquals(listOf("alpha", "beta"), targets.map { it.label }.filter { it == "alpha" || it == "beta" })
         assertTrue(targets.map { it.id }.contains(sessions.active!!.splitSession!!.id))
+        scope.cancel()
+    }
+
+    @Test
+    fun `broadcastTargets marks production sessions and delivers past their own guard`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val prod = sessions.open(hostId = "host-prod")
+        sessions.open(hostId = "host-stage")
+
+        val targets = broadcastTargets(sessions, isProduction = { it == "host-prod" })
+
+        assertEquals(listOf(true, false), targets.map { it.production })
+        // The per-session guard is deliberately off for a broadcast: the panel confirms once for the
+        // whole fan-out, and holding here would park commands in tabs nobody is looking at. That is
+        // also why the panel MUST ask — nothing downstream will.
+        val terminal = sessions.sessions.first { it.id == prod }.liveTerminal!!
+        terminal.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+        assertTrue(targets.first { it.production }.send("rm -rf /srv\n"))
+        assertNull(terminal.pendingGuarded)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a held confirmation is visible to the window-level hotkey gate from either pane`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+        val a = sessions.open(hostId = "host-a")
+        sessions.toggleSplit()
+        sessions.connectSplit(parentId = a, hostId = "host-b")
+        val session = sessions.active!!
+
+        assertFalse(prodGuardDialogOpen(session))
+        assertFalse(prodGuardDialogOpen(null))
+
+        // Held in the split pane — the one being typed into. The gate has to see it there too, or a
+        // snippet chord would fire over the open dialog.
+        val split = session.splitSession!!.liveTerminal!!
+        split.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+        split.typeInput("shutdown now\r")
+        assertTrue(prodGuardDialogOpen(session))
+
+        split.dismissGuardedCommand()
+        assertFalse(prodGuardDialogOpen(session))
         scope.cancel()
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
@@ -290,7 +290,8 @@ class SnippetManagerTest {
         manager.renameTag("db", "database")
 
         assertEquals(listOf("database"), manager.find(a)!!.snippet.tags)
-        assertEquals(listOf("database", "prod"), manager.find(b)!!.snippet.tags)
+        // `prod` is hoisted to the front by normalizeTags — the rename keeps the rest in place.
+        assertEquals(listOf("prod", "database"), manager.find(b)!!.snippet.tags)
         assertEquals(listOf("prod"), manager.find(c)!!.snippet.tags) // untouched
         // Persisted to the store too.
         assertEquals(listOf("database"), store.all().first { it.id == a }.tags)
@@ -317,8 +318,8 @@ class SnippetManagerTest {
 
         manager.renameTag("db", "db")
 
-        assertEquals(listOf("db", "prod"), manager.find(id)!!.snippet.tags)
-        assertEquals(listOf("db", "prod"), store.all().single().tags)
+        assertEquals(listOf("prod", "db"), manager.find(id)!!.snippet.tags)
+        assertEquals(listOf("prod", "db"), store.all().single().tags)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldTest.kt
@@ -1,0 +1,82 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.guard.ProductionGuardPolicy
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The two rules every input path shares. [TerminalScreenStateTest] covers them through the real
+ * paths (typed, pasted, ready-made); these pin them on the state machine itself.
+ */
+class ProductionGuardHoldTest {
+
+    private fun guarding() = ProductionGuardHold().apply {
+        policy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+    }
+
+    @Test
+    fun a_session_with_no_guard_holds_nothing_and_never_classifies() {
+        val hold = ProductionGuardHold()
+        var asked = false
+        assertFalse(hold.hold("rm -rf /\n", HeldInputSource.Typed) { asked = true; listOf("rm -rf /") })
+        // Reading the screen and the tracked line is wasted work off a production host.
+        assertFalse(asked)
+        assertNull(hold.pending)
+    }
+
+    @Test
+    fun a_risky_block_is_held_with_the_input_to_replay() {
+        val hold = guarding()
+        assertTrue(hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { listOf("rm -rf /srv") })
+        assertEquals("rm -rf /srv", hold.pending?.command)
+        assertEquals(HeldInput("rm -rf /srv\n", HeldInputSource.Paste), hold.take())
+        assertNull(hold.pending)
+    }
+
+    @Test
+    fun nothing_else_runs_while_something_is_held() {
+        val hold = guarding()
+        hold.hold("rm -rf /srv\n", HeldInputSource.Typed) { listOf("rm -rf /srv") }
+
+        var asked = false
+        // Harmless or not, it is held back — and it isn't even classified: the answer is the same.
+        assertTrue(hold.hold("uptime\n", HeldInputSource.Command) { asked = true; listOf("uptime") })
+        assertFalse(asked)
+        // What was dropped stays dropped: the pending command is still the one being asked about.
+        assertEquals("rm -rf /srv", hold.pending?.command)
+        assertEquals("rm -rf /srv\n", hold.take()?.text)
+    }
+
+    @Test
+    fun a_harmless_block_is_not_held() {
+        val hold = guarding()
+        assertFalse(hold.hold("uptime\n", HeldInputSource.Typed) { listOf("uptime") })
+        assertNull(hold.pending)
+        assertNull(hold.take())
+    }
+
+    @Test
+    fun confirming_twice_replays_nothing_the_second_time() {
+        val hold = guarding()
+        hold.hold("shutdown now\n", HeldInputSource.Command) { listOf("shutdown now") }
+
+        assertEquals("shutdown now\n", hold.take()?.text)
+        // A double click on Confirm must not run the command again.
+        assertNull(hold.take())
+    }
+
+    @Test
+    fun dismissing_drops_the_held_input() {
+        val hold = guarding()
+        hold.hold("shutdown now\n", HeldInputSource.Typed) { listOf("shutdown now") }
+
+        hold.dismiss()
+        assertNull(hold.pending)
+        assertNull(hold.take())
+        // The next command is judged on its own again.
+        assertTrue(hold.hold("rm -rf /etc\n", HeldInputSource.Typed) { listOf("rm -rf /etc") })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.terminal
 
+import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.CursorShape
 import app.skerry.shared.terminal.MouseButton
@@ -1049,7 +1050,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /var/lib".forEach { state.typeInput(it.toString()) }
         state.typeInput("\r")
@@ -1065,7 +1066,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
         assertEquals(0, session.sent.size)
@@ -1081,7 +1082,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("shutdown now\r")
         state.dismissGuardedCommand()
@@ -1097,11 +1098,11 @@ class TerminalScreenStateTest {
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
 
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         state.typeInput("ls -la\r")
         assertEquals(null, state.pendingGuarded)
 
-        state.guardProduction = false
+        state.guardPolicy = ProductionGuardPolicy.Off
         state.typeInput("rm -rf /\r")
         assertEquals(null, state.pendingGuarded)
         assertEquals(2, session.sent.size)
@@ -1113,7 +1114,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Nothing was typed locally (arrow-up recall) — the command exists only on the screen.
         session.emit("root@prod:~# rm -rf /srv/data".encodeToByteArray())
@@ -1128,7 +1129,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // The soft keyboard delivers a whole IME delta in one call — a clipboard insert can carry
         // several lines, and the risky one is not necessarily the first.
@@ -1144,7 +1145,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Paste, then Enter before the host echoed anything back: the screen line is still empty,
         // so the guard has to remember what was pasted into the line.
@@ -1160,7 +1161,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("rm -rf /var/lib\n")
         state.sendUserInputGuarded("shutdown now\n") // e.g. a snippet hotkey over the open dialog
@@ -1176,7 +1177,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("systemctl stop nginx\n")
         assertEquals("systemctl stop nginx", state.pendingGuarded?.command)
@@ -1192,7 +1193,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("uptime\n")
 
@@ -1206,7 +1207,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
         val first = state.pendingGuarded
@@ -1226,7 +1227,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Paste carrying a newline runs on arrival — the classic "copied it off a wiki page" case.
         state.paste("systemctl stop postgres\n")
@@ -1243,7 +1244,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Lands on the shell line for the user to read and edit; Enter is still guarded separately.
         state.paste("rm -rf /var/lib")
@@ -1258,7 +1259,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // At a password prompt the typed text is a secret, not a command: it must not be parked in
         // a dialog for everyone to read, whatever it happens to look like.
@@ -1275,7 +1276,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val state = TerminalScreenState(session, scope)
-        state.guardProduction = true
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // vim/htop: there is no shell line to classify, and Enter there is not "run a command".
         val esc = 27.toChar().toString()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -1290,6 +1290,92 @@ class TerminalScreenStateTest {
     }
 
     @Test
+    fun `a paste is dropped while a confirmation is open`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.typeInput("rm -rf /var/lib\r")
+        // Middle-click paste lands on the terminal surface through a raw pointer handler, which the
+        // modal scrim does not consume — it must not slip past the open dialog.
+        state.paste("shutdown now\n")
+
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        assertEquals(emptyList(), session.sent.toList())
+        state.confirmGuardedCommand()
+        assertContentEquals("rm -rf /var/lib\r".encodeToByteArray(), session.sent.single())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a harmless paste is dropped while a confirmation is open too`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.typeInput("rm -rf /var/lib\r")
+        state.paste("uptime\n")
+
+        // Harmless or not, it would run on the production shell under a dialog asking about
+        // something else entirely.
+        assertEquals(emptyList(), session.sent.toList())
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a pasted password is never held or shown by the guard`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // Same rule as typing one: a password manager pastes the secret with a trailing newline, and
+        // a passphrase can look like anything — parking it in the dialog would print it on screen.
+        session.emit("sudo password for root: ".encodeToByteArray())
+        state.paste("sudo rm -rf everything\n")
+
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a harmless typed command is not sent while a confirmation is open`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.typeInput("rm -rf /var/lib\r")
+        state.typeInput("uptime\r")
+
+        // Nothing runs on a production shell while the user is answering a question about a
+        // different command — the dialog is not a queue.
+        assertEquals(emptyList(), session.sent.toList())
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a harmless ready-made command is dropped while a confirmation is open`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.sendUserInputGuarded("rm -rf /var/lib\n")
+        // A snippet hotkey fires from the window root, above the modal scrim's focus.
+        state.sendUserInputGuarded("uptime\n")
+
+        assertEquals(emptyList(), session.sent.toList())
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        scope.cancel()
+    }
+
+    @Test
     fun `empty selection produces no copyable text`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -1042,6 +1042,252 @@ class TerminalScreenStateTest {
         scope.cancel()
     }
 
+    // --- production guard (risky commands on a #prod host) ---
+
+    @Test
+    fun `risky command is held before it reaches the pty on a production session`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        "rm -rf /var/lib".forEach { state.typeInput(it.toString()) }
+        state.typeInput("\r")
+
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        // Everything typed so far went through; only the Enter that would run it is held.
+        assertEquals(false, session.sent.any { it.contentEquals("\r".encodeToByteArray()) })
+        scope.cancel()
+    }
+
+    @Test
+    fun `confirming the held command sends it once`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.typeInput("rm -rf /var/lib\r")
+        assertEquals(0, session.sent.size)
+
+        state.confirmGuardedCommand()
+        assertContentEquals("rm -rf /var/lib\r".encodeToByteArray(), session.sent.single())
+        assertEquals(null, state.pendingGuarded)
+        scope.cancel()
+    }
+
+    @Test
+    fun `dismissing the held command sends nothing`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.typeInput("shutdown now\r")
+        state.dismissGuardedCommand()
+
+        assertEquals(emptyList(), session.sent.toList())
+        assertEquals(null, state.pendingGuarded)
+        scope.cancel()
+    }
+
+    @Test
+    fun `harmless commands and non-production sessions are not held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        state.guardProduction = true
+        state.typeInput("ls -la\r")
+        assertEquals(null, state.pendingGuarded)
+
+        state.guardProduction = false
+        state.typeInput("rm -rf /\r")
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(2, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a command recalled from history is caught off the screen line`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // Nothing was typed locally (arrow-up recall) — the command exists only on the screen.
+        session.emit("root@prod:~# rm -rf /srv/data".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertEquals("rm -rf /srv/data", state.pendingGuarded?.command)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a multi-line input block is judged by every line, not just the first`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // The soft keyboard delivers a whole IME delta in one call — a clipboard insert can carry
+        // several lines, and the risky one is not necessarily the first.
+        state.typeInput("ls\nrm -rf /var/lib\n")
+
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        assertEquals(emptyList(), session.sent.toList())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a command pasted without a newline is still caught on Enter`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // Paste, then Enter before the host echoed anything back: the screen line is still empty,
+        // so the guard has to remember what was pasted into the line.
+        state.paste("rm -rf /var/lib")
+        state.typeInput("\r")
+
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a ready-made command is dropped while another one is pending`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.sendUserInputGuarded("rm -rf /var/lib\n")
+        state.sendUserInputGuarded("shutdown now\n") // e.g. a snippet hotkey over the open dialog
+
+        assertEquals("rm -rf /var/lib", state.pendingGuarded?.command)
+        state.confirmGuardedCommand()
+        assertContentEquals("rm -rf /var/lib\n".encodeToByteArray(), session.sent.single())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a snippet command is held and then sent without touching autocomplete`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.sendUserInputGuarded("systemctl stop nginx\n")
+        assertEquals("systemctl stop nginx", state.pendingGuarded?.command)
+        assertEquals(emptyList(), session.sent.toList())
+
+        state.confirmGuardedCommand()
+        assertContentEquals("systemctl stop nginx\n".encodeToByteArray(), session.sent.single())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a harmless snippet command goes straight through`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.sendUserInputGuarded("uptime\n")
+
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a second risky command while one is pending does not replace it`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        state.typeInput("rm -rf /var/lib\r")
+        val first = state.pendingGuarded
+        // Impatient second Enter while the dialog is still up: the held command must stay the one
+        // the dialog is showing, or the user would confirm a different command than they read.
+        state.typeInput("shutdown now\r")
+
+        assertEquals(first?.command, state.pendingGuarded?.command)
+        state.confirmGuardedCommand()
+        // Only the command the dialog was showing runs; the second one was dropped, not queued.
+        assertContentEquals("rm -rf /var/lib\r".encodeToByteArray(), session.sent.single())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a pasted command that would run is held too`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // Paste carrying a newline runs on arrival — the classic "copied it off a wiki page" case.
+        state.paste("systemctl stop postgres\n")
+        assertEquals("systemctl stop postgres", state.pendingGuarded?.command)
+        assertEquals(emptyList(), session.sent.toList())
+
+        state.confirmGuardedCommand()
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a paste with no newline runs nothing and is not held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // Lands on the shell line for the user to read and edit; Enter is still guarded separately.
+        state.paste("rm -rf /var/lib")
+
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a password is never held or shown by the guard`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // At a password prompt the typed text is a secret, not a command: it must not be parked in
+        // a dialog for everyone to read, whatever it happens to look like.
+        session.emit("sudo password for root: ".encodeToByteArray())
+        state.typeInput("rm -rf /\r")
+
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `full-screen apps are not guarded`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardProduction = true
+
+        // vim/htop: there is no shell line to classify, and Enter there is not "run a command".
+        val esc = 27.toChar().toString()
+        session.emit("$esc[?1049h".encodeToByteArray())
+        session.emit(":%s/a/b/g sudo rm -rf".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertEquals(null, state.pendingGuarded)
+        assertEquals(1, session.sent.size)
+        scope.cancel()
+    }
+
     @Test
     fun `empty selection produces no copyable text`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -365,6 +365,7 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
             prefs.set("terminal_cursor_style", TerminalCursorStyle.DEFAULT.id)
             prefs.set("terminal_show_title", false)
             prefs.set("terminal_clipboard_write", false)
+            prefs.set("terminal_prod_warnings", false)
             prefs.set("auto_lock", AutoLockDuration.DEFAULT.id)
         }
         hosts.reload()
@@ -483,6 +484,8 @@ fun main(args: Array<String>) {
                     onHostClickConnectModeChange = { prefs.set("host_click_connect", it.id) },
                     initialAllowServerClipboardWrite = prefs.bool("terminal_clipboard_write", false),
                     onAllowServerClipboardWriteChange = { prefs.set("terminal_clipboard_write", it) },
+                    initialConfirmProductionWarnings = prefs.bool("terminal_prod_warnings", false),
+                    onConfirmProductionWarningsChange = { prefs.set("terminal_prod_warnings", it) },
                     initialAutoLock = prefs.id("auto_lock", AutoLockDuration.DEFAULT, AutoLockDuration::fromId),
                     onAutoLockChange = { prefs.set("auto_lock", it.id) },
                     initialShowRecent = prefs.bool("recent_show", true),

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/CommandRisk.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/CommandRisk.kt
@@ -4,11 +4,44 @@ package app.skerry.shared.ai
 enum class CommandRisk { None, Warn, Danger }
 
 /**
- * Command assessment: level plus a human-readable reason ([reason] is `null` only for [CommandRisk.None]).
- * [destructive] marks commands that lose/overwrite data (delete, overwrite, format): the UI colors it
- * red even at [CommandRisk.Warn] (non-destructive warns like sudo/kill stay amber).
+ * Why a command was flagged. An enum, not a sentence: the reason is rendered in the terminal AI bar
+ * and in the production-guard confirmation, both of which are localized — a string baked in here
+ * would always come out English. The UI maps each value to a resource
+ * ([app.skerry.ui.ai.commandRiskReasonText]).
  */
-data class CommandAssessment(val risk: CommandRisk, val reason: String?, val destructive: Boolean = false) {
+enum class CommandRiskReason {
+    // Danger
+    ForkBomb,
+    RecursiveForceDelete,
+    RecursiveBroadDelete,
+    DiskDeviceWrite,
+    DownloadToShell,
+    PipeToInterpreter,
+    MirrorDelete,
+    PowerOff,
+    RecursivePermissions,
+    SecurityFileOverwrite,
+    FirewallFlush,
+
+    // Warn
+    DeletesFiles,
+    KillsProcesses,
+    UninstallsPackages,
+    GitDestructive,
+    WorldWritable,
+    StopsService,
+    BulkDelete,
+    TruncatesContent,
+    Elevated,
+}
+
+/**
+ * Command assessment: level plus the reason it was flagged ([reason] is `null` only for
+ * [CommandRisk.None]). [destructive] marks commands that lose/overwrite data (delete, overwrite,
+ * format): the UI colors it red even at [CommandRisk.Warn] (non-destructive warns like sudo/kill
+ * stay amber).
+ */
+data class CommandAssessment(val risk: CommandRisk, val reason: CommandRiskReason?, val destructive: Boolean = false) {
     companion object {
         val SAFE = CommandAssessment(CommandRisk.None, null)
     }
@@ -89,7 +122,7 @@ object CommandRiskClassifier {
             FORK_BOMB_ANON.containsMatchIn(cmd) ||
             FORK_BOMB_NAMED.containsMatchIn(cmd)
         ) {
-            return danger("Fork bomb — will exhaust system resources.")
+            return danger(CommandRiskReason.ForkBomb)
         }
 
         // rm: recursive + force, or recursive on a broad target (/, ~, $HOME, *)
@@ -97,8 +130,8 @@ object CommandRiskClassifier {
             val recursive = RM_RECURSIVE.containsMatchIn(lower)
             val force = RM_FORCE.containsMatchIn(lower)
             val broadTarget = RM_BROAD_TARGET.containsMatchIn(lower)
-            if (recursive && force) return danger("Recursive force delete — irreversible data loss.")
-            if (recursive && broadTarget) return danger("Recursive delete of a broad path — irreversible data loss.")
+            if (recursive && force) return danger(CommandRiskReason.RecursiveForceDelete)
+            if (recursive && broadTarget) return danger(CommandRiskReason.RecursiveBroadDelete)
         }
 
         // Direct write to a disk device / formatting
@@ -106,23 +139,23 @@ object CommandRiskClassifier {
             DISK_TOOLS.containsMatchIn(lower) ||
             REDIRECT_TO_DISK.containsMatchIn(lower)
         ) {
-            return danger("Writes directly to a disk device — can destroy the filesystem.")
+            return danger(CommandRiskReason.DiskDeviceWrite)
         }
 
         // Download and pipe straight into a shell (unverified remote code)
         if (DOWNLOAD_TO_SHELL.containsMatchIn(lower)) {
-            return danger("Pipes a downloaded script straight into a shell — runs unverified remote code.")
+            return danger(CommandRiskReason.DownloadToShell)
         }
 
         // Any pipe into an interpreter (shell or python/perl/ruby/node, e.g. base64 -d | python3) —
         // runs constructed/decoded code. Interpreter list matches curl|... above.
         if (PIPE_TO_INTERPRETER.containsMatchIn(lower)) {
-            return danger("Pipes output into an interpreter — runs constructed or remote code.")
+            return danger(CommandRiskReason.PipeToInterpreter)
         }
 
         // rsync --delete — mirror delete, wipes destination files absent from the source
         if (RSYNC_DELETE.containsMatchIn(lower)) {
-            return danger("Mirror delete — wipes files in the destination that are absent from the source.")
+            return danger(CommandRiskReason.MirrorDelete)
         }
 
         // Power off / reboot
@@ -130,58 +163,58 @@ object CommandRiskClassifier {
             INIT_0_6.containsMatchIn(lower) ||
             SYSTEMCTL_POWER.containsMatchIn(lower)
         ) {
-            return danger("Powers off or reboots the machine.")
+            return danger(CommandRiskReason.PowerOff)
         }
 
         // Recursive permission/ownership change on a system path
         if (CHMOD_CHOWN_RECURSIVE.containsMatchIn(lower) &&
             SYSTEM_PATH.containsMatchIn(lower)
         ) {
-            return danger("Recursive permission/ownership change on a system path.")
+            return danger(CommandRiskReason.RecursivePermissions)
         }
 
         // Overwrite of security-critical files (via > or tee)
         if (REDIRECT_TO_SECURITY_FILE.containsMatchIn(lower) ||
             TEE_TO_SECURITY_FILE.containsMatchIn(lower)
         ) {
-            return danger("Overwrites a security-critical file.")
+            return danger(CommandRiskReason.SecurityFileOverwrite)
         }
 
         // Firewall flush — can cut off own access
         if (FIREWALL_FLUSH.containsMatchIn(lower)) {
-            return danger("Flushes firewall rules — may cut off remote access.")
+            return danger(CommandRiskReason.FirewallFlush)
         }
 
         // ---------- WARN ----------
 
         if (RM_ANY.containsMatchIn(lower)) {
-            return warn("Deletes files.", destructive = true)
+            return warn(CommandRiskReason.DeletesFiles, destructive = true)
         }
         if (KILL_PROCESS.containsMatchIn(lower)) {
-            return warn("Terminates running processes.")
+            return warn(CommandRiskReason.KillsProcesses)
         }
         if (PKG_REMOVE.containsMatchIn(lower) ||
             PACMAN_REMOVE.containsMatchIn(lower)
         ) {
-            return warn("Uninstalls packages.")
+            return warn(CommandRiskReason.UninstallsPackages)
         }
         if (GIT_DESTRUCTIVE.containsMatchIn(lower)) {
-            return warn("Discards local changes or rewrites history.", destructive = true)
+            return warn(CommandRiskReason.GitDestructive, destructive = true)
         }
         if (CHMOD_777.containsMatchIn(lower)) {
-            return warn("Grants world-writable permissions.")
+            return warn(CommandRiskReason.WorldWritable)
         }
         if (SERVICE_STOP.containsMatchIn(lower)) {
-            return warn("Stops or disables a service.")
+            return warn(CommandRiskReason.StopsService)
         }
         if (FIND_DELETE.containsMatchIn(lower)) {
-            return warn("Bulk-deletes matched files.", destructive = true)
+            return warn(CommandRiskReason.BulkDelete, destructive = true)
         }
         if (TRUNCATE_CONTENT.containsMatchIn(lower)) {
-            return warn("Discards file contents.", destructive = true)
+            return warn(CommandRiskReason.TruncatesContent, destructive = true)
         }
         if (ELEVATED.containsMatchIn(lower)) {
-            return warn("Runs with elevated privileges.")
+            return warn(CommandRiskReason.Elevated)
         }
 
         return CommandAssessment.SAFE
@@ -205,6 +238,6 @@ object CommandRiskClassifier {
         return s.replace(WHITESPACE_RUN, " ").trim()
     }
 
-    private fun danger(reason: String) = CommandAssessment(CommandRisk.Danger, reason, destructive = true)
-    private fun warn(reason: String, destructive: Boolean = false) = CommandAssessment(CommandRisk.Warn, reason, destructive)
+    private fun danger(reason: CommandRiskReason) = CommandAssessment(CommandRisk.Danger, reason, destructive = true)
+    private fun warn(reason: CommandRiskReason, destructive: Boolean = false) = CommandAssessment(CommandRisk.Warn, reason, destructive)
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
@@ -3,6 +3,7 @@ package app.skerry.shared.guard
 import app.skerry.shared.ai.CommandAssessment
 import app.skerry.shared.ai.CommandRisk
 import app.skerry.shared.ai.CommandRiskClassifier
+import app.skerry.shared.ai.CommandRiskReason
 import app.skerry.shared.tag.PROD_TAG
 
 /**
@@ -21,6 +22,30 @@ const val MAX_GUARDED_CANDIDATES = 200
 
 /** A command that needs confirmation on a production host, with the reason to show the user. */
 data class GuardedCommand(val command: String, val assessment: CommandAssessment)
+
+/**
+ * What the guard asks about in one session.
+ *
+ * [production] — the host carries [PROD_TAG]; everything else is off without it.
+ * [confirmWarnings] — the user opted into confirming [CommandRisk.Warn] as well (Settings →
+ * Terminal). Off by default: `sudo` is a Warn, and on a production box it is half the commands
+ * typed — a dialog that frequent gets clicked through without reading, which is worse than no
+ * dialog at all.
+ * [rootLogin] — the session logs in as root. That flips two things: `sudo` stops meaning anything
+ * (nobody types it, so the rule is pure noise), while a destructive Warn — `rm`, `git reset
+ * --hard`, `find -delete` — has no sudo step in front of it any more, so it is confirmed even
+ * when [confirmWarnings] is off.
+ */
+data class ProductionGuardPolicy(
+    val production: Boolean = false,
+    val confirmWarnings: Boolean = false,
+    val rootLogin: Boolean = false,
+) {
+    companion object {
+        /** No guard at all — a non-production session. */
+        val Off = ProductionGuardPolicy()
+    }
+}
 
 /**
  * Production guard: on a host tagged [PROD_TAG] a risky command is confirmed before it reaches the
@@ -55,13 +80,14 @@ object ProductionGuard {
      * Ties go to the shortest candidate: the same command shows up with and without its prompt
      * prefix, and the dialog should quote what was run, not `root@host:~# …`.
      */
-    fun inspect(candidates: List<String>): GuardedCommand? {
+    fun inspect(candidates: List<String>, policy: ProductionGuardPolicy): GuardedCommand? {
+        if (!policy.production) return null
         var worst: GuardedCommand? = null
         for (candidate in candidates.take(MAX_GUARDED_CANDIDATES)) {
             val command = candidate.trim().take(MAX_GUARDED_COMMAND_LENGTH)
             if (command.isEmpty()) continue
             val assessment = CommandRiskClassifier.assess(command)
-            if (assessment.risk == CommandRisk.None) continue
+            if (!needsConfirmation(assessment, policy)) continue
             val current = worst
             val better = current == null ||
                 assessment.risk.ordinal > current.assessment.risk.ordinal ||
@@ -72,7 +98,25 @@ object ProductionGuard {
     }
 
     /** Single-candidate form: broadcast lines and snippets are known verbatim. */
-    fun inspect(command: String): GuardedCommand? = inspect(listOf(command))
+    fun inspect(command: String, policy: ProductionGuardPolicy): GuardedCommand? =
+        inspect(listOf(command), policy)
+
+    /**
+     * Whether [assessment] crosses the bar set by [policy]. Danger always does. Warn does when the
+     * user asked for it, or when the session is root and the command destroys data — see
+     * [ProductionGuardPolicy] for why root changes the answer. `sudo` under root is dropped
+     * entirely: it says nothing about a session that is already root.
+     */
+    private fun needsConfirmation(assessment: CommandAssessment, policy: ProductionGuardPolicy): Boolean =
+        when (assessment.risk) {
+            CommandRisk.None -> false
+            CommandRisk.Danger -> true
+            CommandRisk.Warn -> when {
+                policy.rootLogin && assessment.reason == CommandRiskReason.Elevated -> false
+                policy.confirmWarnings -> true
+                else -> policy.rootLogin && assessment.destructive
+            }
+        }
 
     /**
      * Command candidates from a raw screen line: the line itself plus, when it looks like a prompt,

--- a/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
@@ -102,6 +102,17 @@ object ProductionGuard {
         inspect(listOf(command), policy)
 
     /**
+     * Candidates from one input block (a paste, an IME commit, a ready-made command). Both caps are
+     * applied while splitting, not after: a multi-megabyte paste would otherwise materialize a
+     * String per line before [inspect] ever gets to drop them.
+     */
+    fun candidatesOf(text: String): List<String> =
+        text.lineSequence()
+            .take(MAX_GUARDED_CANDIDATES)
+            .map { it.take(MAX_GUARDED_COMMAND_LENGTH) }
+            .toList()
+
+    /**
      * Whether [assessment] crosses the bar set by [policy]. Danger always does. Warn does when the
      * user asked for it, or when the session is root and the command destroys data — see
      * [ProductionGuardPolicy] for why root changes the answer. `sudo` under root is dropped

--- a/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
@@ -1,0 +1,92 @@
+package app.skerry.shared.guard
+
+import app.skerry.shared.ai.CommandAssessment
+import app.skerry.shared.ai.CommandRisk
+import app.skerry.shared.ai.CommandRiskClassifier
+import app.skerry.shared.tag.PROD_TAG
+
+/**
+ * Longest command text the guard inspects. A candidate can come from a screen row, which may hold
+ * program output rather than a command; truncating keeps a pathological line out of the regex
+ * engine. Long enough for any realistic one-liner.
+ */
+const val MAX_GUARDED_COMMAND_LENGTH = 512
+
+/**
+ * How many candidates one inspection classifies. A paste can carry a whole log file, and every line
+ * of it would otherwise run through ~30 regexes on the caller's thread. Anything past this many
+ * lines is not a command someone meant to run — it is a document that landed in a terminal.
+ */
+const val MAX_GUARDED_CANDIDATES = 200
+
+/** A command that needs confirmation on a production host, with the reason to show the user. */
+data class GuardedCommand(val command: String, val assessment: CommandAssessment)
+
+/**
+ * Production guard: on a host tagged [PROD_TAG] a risky command is confirmed before it reaches the
+ * shell, connecting asks first, and the session is marked red.
+ *
+ * Reuses [CommandRiskClassifier] (static rules, no AI). Threshold here is lower than in the AI bar:
+ * anything above [CommandRisk.None] — including Warn (`sudo`, `systemctl stop`, `kill`) — is
+ * confirmed, because on production the cost of a wrong command outweighs the friction of one extra
+ * keypress.
+ *
+ * Not a security boundary: the guard sees what the client sends, so shell aliases, scripts, and
+ * variable indirection pass through. It is a "wrong window" guard — the classic footgun is a
+ * command typed into the production tab that was meant for staging.
+ */
+object ProductionGuard {
+
+    /**
+     * Prompt terminator: the `$`/`#`/`%`/`>` (and the usual powerline/starship arrows) followed by a
+     * space that separates a shell prompt from what was typed after it.
+     */
+    private val PROMPT_TERMINATOR = Regex("""[$#%>❯➜»›]\s""")
+
+    /** Whether [tags] make a host production (carries [PROD_TAG]). */
+    fun isProduction(tags: List<String>): Boolean = PROD_TAG in tags
+
+    /**
+     * The riskiest of [candidates] that needs confirmation, or `null` if none does. Several
+     * candidates exist because the client only guesses at the command: the locally tracked typed
+     * line and the line read off the screen can disagree (history recall, remote line editing), and
+     * missing a dangerous command is worse than confirming a harmless one — so the worst wins.
+     *
+     * Ties go to the shortest candidate: the same command shows up with and without its prompt
+     * prefix, and the dialog should quote what was run, not `root@host:~# …`.
+     */
+    fun inspect(candidates: List<String>): GuardedCommand? {
+        var worst: GuardedCommand? = null
+        for (candidate in candidates.take(MAX_GUARDED_CANDIDATES)) {
+            val command = candidate.trim().take(MAX_GUARDED_COMMAND_LENGTH)
+            if (command.isEmpty()) continue
+            val assessment = CommandRiskClassifier.assess(command)
+            if (assessment.risk == CommandRisk.None) continue
+            val current = worst
+            val better = current == null ||
+                assessment.risk.ordinal > current.assessment.risk.ordinal ||
+                (assessment.risk == current.assessment.risk && command.length < current.command.length)
+            if (better) worst = GuardedCommand(command, assessment)
+        }
+        return worst
+    }
+
+    /** Single-candidate form: broadcast lines and snippets are known verbatim. */
+    fun inspect(command: String): GuardedCommand? = inspect(listOf(command))
+
+    /**
+     * Command candidates from a raw screen line: the line itself plus, when it looks like a prompt,
+     * the tail after the prompt. Both are kept — cutting is a guess, and the uncut line still holds
+     * the command.
+     *
+     * The cut is at the FIRST prompt terminator, not the last: `cat img > /dev/sda` contains a `>`
+     * of its own, and cutting there would leave `/dev/sda` and lose the very command worth stopping.
+     */
+    fun promptCandidates(rawLine: String): List<String> {
+        val line = rawLine.trim().take(MAX_GUARDED_COMMAND_LENGTH)
+        if (line.isEmpty()) return emptyList()
+        val match = PROMPT_TERMINATOR.find(line) ?: return listOf(line)
+        val tail = line.substring(match.range.last + 1).trim()
+        return if (tail.isEmpty() || tail == line) listOf(line) else listOf(line, tail)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/tag/Tags.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/tag/Tags.kt
@@ -10,6 +10,15 @@ const val MAX_TAG_LENGTH = 32
 const val MAX_TAGS_PER_RECORD = 20
 
 /**
+ * The one tag with behavior attached: a host carrying it is production, which turns on the
+ * production guard (connect confirmation, risky-command confirmation, red accent — see
+ * [app.skerry.shared.guard.ProductionGuard]). Canonical form, so it compares against stored tags
+ * directly. Not localized: the tag is data that syncs between clients and locales, a translated
+ * value would silently disarm the guard for everyone on another language.
+ */
+const val PROD_TAG = "prod"
+
+/**
  * Canonicalize a tag: trim, strip `#` from both ends, lowercase, and truncate to [MAX_TAG_LENGTH];
  * an empty result becomes `null` (tag not added). The canonical form makes chip filtering a plain
  * string comparison and prevents "Prod"/"#prod" duplicates. Lives in `shared` (not the UI layer)
@@ -22,7 +31,18 @@ fun normalizeTag(raw: String): String? =
 
 /**
  * Canonicalize a whole tag list: normalize each entry, drop blanks, collapse duplicates that differ
- * only in case, keep first-seen order and cap the count at [MAX_TAGS_PER_RECORD].
+ * only in case, hoist [PROD_TAG] to the front, keep first-seen order for the rest and cap the count
+ * at [MAX_TAGS_PER_RECORD]. Hoisting happens before the cap, so `prod` can't fall off the end of a
+ * long list and take the production guard with it.
  */
 fun normalizeTags(raw: Iterable<String>): List<String> =
-    raw.mapNotNull(::normalizeTag).distinct().take(MAX_TAGS_PER_RECORD)
+    orderTagsProdFirst(raw.mapNotNull(::normalizeTag).distinct()).take(MAX_TAGS_PER_RECORD)
+
+/**
+ * [PROD_TAG] first, everything else in its original order. Applied on write ([normalizeTags]) and
+ * again on display, since records stored before this rule keep their old order — `prod` is what the
+ * user must see first on a host row, not the tag that happened to be typed first.
+ */
+fun orderTagsProdFirst(tags: List<String>): List<String> =
+    if (tags.firstOrNull() == PROD_TAG || PROD_TAG !in tags) tags
+    else listOf(PROD_TAG) + tags.filterNot { it == PROD_TAG }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ai/CommandRiskClassifierTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ai/CommandRiskClassifierTest.kt
@@ -152,4 +152,14 @@ class CommandRiskClassifierTest {
         assertNull(CommandRiskClassifier.assess("free -h").reason)
         assertNotNull(CommandRiskClassifier.assess("rm -rf /").reason)
     }
+
+    @Test
+    fun `reason names the rule that matched, for the UI to localize`() {
+        // The reason is an enum, not a sentence: the AI bar and the production guard render it
+        // through resources, so a wrong mapping here shows the user the wrong explanation.
+        assertEquals(CommandRiskReason.RecursiveForceDelete, CommandRiskClassifier.assess("rm -rf /var").reason)
+        assertEquals(CommandRiskReason.StopsService, CommandRiskClassifier.assess("systemctl stop nginx").reason)
+        assertEquals(CommandRiskReason.Elevated, CommandRiskClassifier.assess("sudo apt update").reason)
+        assertEquals(CommandRiskReason.PowerOff, CommandRiskClassifier.assess("reboot").reason)
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardPolicyTest.kt
@@ -1,0 +1,72 @@
+package app.skerry.shared.guard
+
+import app.skerry.shared.ai.CommandRisk
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * What the guard actually asks about: the default is Danger only, warnings are opt-in, and a root
+ * session shifts the line — `sudo` stops meaning anything while a destructive Warn loses the sudo
+ * step that used to sit in front of it.
+ */
+class ProductionGuardPolicyTest {
+
+    private val plain = ProductionGuardPolicy(production = true)
+    private val warnings = ProductionGuardPolicy(production = true, confirmWarnings = true)
+    private val root = ProductionGuardPolicy(production = true, rootLogin = true)
+
+    @Test
+    fun a_non_production_session_is_never_guarded() {
+        assertNull(ProductionGuard.inspect("rm -rf /", ProductionGuardPolicy.Off))
+        assertNull(ProductionGuard.inspect("rm -rf /", ProductionGuardPolicy(production = false, confirmWarnings = true)))
+    }
+
+    @Test
+    fun danger_is_confirmed_by_default() {
+        assertEquals(CommandRisk.Danger, ProductionGuard.inspect("rm -rf /var", plain)?.assessment?.risk)
+        assertNotNull(ProductionGuard.inspect("mkfs.ext4 /dev/sda1", plain))
+        assertNotNull(ProductionGuard.inspect("reboot", plain))
+    }
+
+    @Test
+    fun warnings_pass_until_the_user_opts_in() {
+        // sudo is half of what gets typed on a production box: asking every time trains the dialog away.
+        assertNull(ProductionGuard.inspect("sudo systemctl restart nginx", plain))
+        assertNull(ProductionGuard.inspect("systemctl stop postgres", plain))
+        assertNull(ProductionGuard.inspect("rm app.log", plain))
+
+        assertNotNull(ProductionGuard.inspect("sudo systemctl restart nginx", warnings))
+        assertNotNull(ProductionGuard.inspect("systemctl stop postgres", warnings))
+        assertNotNull(ProductionGuard.inspect("rm app.log", warnings))
+    }
+
+    @Test
+    fun sudo_says_nothing_in_a_root_session() {
+        // Nobody types sudo as root; flagging it would be pure noise even with warnings on.
+        assertNull(ProductionGuard.inspect("sudo apt update", root))
+        assertNull(
+            ProductionGuard.inspect(
+                "sudo apt update",
+                ProductionGuardPolicy(production = true, confirmWarnings = true, rootLogin = true),
+            ),
+        )
+    }
+
+    @Test
+    fun a_destructive_warning_is_confirmed_for_root_even_with_warnings_off() {
+        // As root there is no sudo step in front of these — the guard is the only pause left.
+        assertNotNull(ProductionGuard.inspect("rm app.log", root))
+        assertNotNull(ProductionGuard.inspect("git reset --hard HEAD~1", root))
+        assertNotNull(ProductionGuard.inspect("find /var/log -name '*.gz' -delete", root))
+        // A non-destructive warning still passes: stopping a service is undone by starting it.
+        assertNull(ProductionGuard.inspect("systemctl stop postgres", root))
+    }
+
+    @Test
+    fun root_still_confirms_every_danger() {
+        assertNotNull(ProductionGuard.inspect("rm -rf /", root))
+        assertNotNull(ProductionGuard.inspect("iptables --flush", root))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
@@ -1,0 +1,102 @@
+package app.skerry.shared.guard
+
+import app.skerry.shared.ai.CommandRisk
+import app.skerry.shared.tag.PROD_TAG
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProductionGuardTest {
+
+    @Test
+    fun production_is_decided_by_the_prod_tag() {
+        assertTrue(ProductionGuard.isProduction(listOf("web", PROD_TAG)))
+        assertFalse(ProductionGuard.isProduction(listOf("staging", "db")))
+        assertFalse(ProductionGuard.isProduction(emptyList()))
+    }
+
+    @Test
+    fun risky_command_is_flagged_with_its_reason() {
+        val guarded = ProductionGuard.inspect(listOf("rm -rf /var/lib/data"))
+        assertNotNull(guarded)
+        assertEquals(CommandRisk.Danger, guarded.assessment.risk)
+        assertEquals("rm -rf /var/lib/data", guarded.command)
+        assertNotNull(guarded.assessment.reason)
+    }
+
+    @Test
+    fun warn_level_commands_are_confirmed_too() {
+        // sudo/systemctl stop are Warn, not Danger: on production they still ask.
+        val sudo = ProductionGuard.inspect(listOf("sudo systemctl restart nginx"))
+        assertNotNull(sudo)
+        assertEquals(CommandRisk.Warn, sudo.assessment.risk)
+        assertEquals(CommandRisk.Warn, ProductionGuard.inspect(listOf("systemctl stop postgres"))?.assessment?.risk)
+    }
+
+    @Test
+    fun harmless_commands_pass_through() {
+        assertNull(ProductionGuard.inspect(listOf("ls -la")))
+        assertNull(ProductionGuard.inspect(listOf("")))
+        assertNull(ProductionGuard.inspect(emptyList()))
+    }
+
+    @Test
+    fun the_riskiest_candidate_wins() {
+        // The typed line and the line read off the screen can disagree; the worse one decides.
+        val guarded = ProductionGuard.inspect(listOf("systemctl stop nginx", "rm -rf /etc"))
+        assertNotNull(guarded)
+        assertEquals(CommandRisk.Danger, guarded.assessment.risk)
+        assertEquals("rm -rf /etc", guarded.command)
+    }
+
+    @Test
+    fun equally_risky_candidates_are_quoted_without_the_prompt() {
+        val guarded = ProductionGuard.inspect(ProductionGuard.promptCandidates("root@prod:~# rm -rf /srv"))
+        assertEquals("rm -rf /srv", guarded?.command)
+    }
+
+    @Test
+    fun prompt_line_yields_both_the_full_line_and_the_command_after_the_prompt() {
+        val candidates = ProductionGuard.promptCandidates("user@host:~$ rm -rf /tmp/cache")
+        assertTrue("rm -rf /tmp/cache" in candidates)
+        assertTrue(candidates.any { it.startsWith("user@host") })
+    }
+
+    @Test
+    fun prompt_stripping_keeps_a_redirect_inside_the_command() {
+        // Cutting at the LAST prompt-looking character would leave "/dev/sda" and lose the redirect.
+        val candidates = ProductionGuard.promptCandidates("root@db ~ # cat img > /dev/sda")
+        assertTrue(candidates.any { it == "cat img > /dev/sda" })
+        assertNotNull(ProductionGuard.inspect(candidates))
+    }
+
+    @Test
+    fun a_line_without_a_prompt_is_used_as_is() {
+        assertEquals(listOf("rm -rf /tmp"), ProductionGuard.promptCandidates("  rm -rf /tmp  "))
+        assertEquals(emptyList(), ProductionGuard.promptCandidates("   "))
+    }
+
+    @Test
+    fun prompt_with_nothing_typed_yet_produces_no_command() {
+        // Only the prompt on screen: the tail is empty, and the prompt itself is not a command.
+        assertNull(ProductionGuard.inspect(ProductionGuard.promptCandidates("user@host:~$ ")))
+    }
+
+    @Test
+    fun the_number_of_candidates_is_capped() {
+        // Pasting a log file into a terminal must not run thousands of regex passes inline.
+        val many = List(MAX_GUARDED_CANDIDATES + 50) { "echo line $it" } + "rm -rf /"
+        assertNull(ProductionGuard.inspect(many)) // the tail past the cap is not classified
+        assertNotNull(ProductionGuard.inspect(listOf("rm -rf /") + many))
+    }
+
+    @Test
+    fun candidates_are_capped_by_length() {
+        // A pathological line (a screen row full of output) must not reach the regex engine whole.
+        val long = "x".repeat(MAX_GUARDED_COMMAND_LENGTH + 500)
+        assertTrue(ProductionGuard.promptCandidates(long).all { it.length <= MAX_GUARDED_COMMAND_LENGTH })
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
@@ -103,4 +103,27 @@ class ProductionGuardTest {
         val long = "x".repeat(MAX_GUARDED_COMMAND_LENGTH + 500)
         assertTrue(ProductionGuard.promptCandidates(long).all { it.length <= MAX_GUARDED_COMMAND_LENGTH })
     }
+
+    @Test
+    fun splitting_an_input_block_caps_the_work_before_the_list_exists() {
+        // A paste can be a whole log file. Splitting it eagerly would allocate a String per line
+        // before the cap in inspect() ever applies — the cap has to happen while splitting.
+        val text = (0 until MAX_GUARDED_CANDIDATES + 500).joinToString("\n") { "echo line $it" }
+        assertEquals(MAX_GUARDED_CANDIDATES, ProductionGuard.candidatesOf(text).size)
+        val longLine = "x".repeat(MAX_GUARDED_COMMAND_LENGTH + 500)
+        assertTrue(ProductionGuard.candidatesOf(longLine).all { it.length <= MAX_GUARDED_COMMAND_LENGTH })
+    }
+
+    @Test
+    fun splitting_handles_every_line_ending() {
+        assertEquals(listOf("a", "b", "c"), ProductionGuard.candidatesOf("a\nb\rc"))
+        assertEquals(listOf("a", "b"), ProductionGuard.candidatesOf("a\r\nb"))
+    }
+
+    @Test
+    fun a_command_split_out_of_a_block_is_still_classified() {
+        // The risky line can sit anywhere in a pasted block, not only on the first line.
+        val guarded = ProductionGuard.inspect(ProductionGuard.candidatesOf("cd /srv\nrm -rf /srv/data\n"), GUARDING)
+        assertEquals("rm -rf /srv/data", guarded?.command)
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
@@ -11,6 +11,10 @@ import kotlin.test.assertTrue
 
 class ProductionGuardTest {
 
+    // A production session with warnings on, so these tests exercise classification rather than the
+    // threshold — the threshold has its own tests in [ProductionGuardPolicyTest].
+    private val GUARDING = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
     @Test
     fun production_is_decided_by_the_prod_tag() {
         assertTrue(ProductionGuard.isProduction(listOf("web", PROD_TAG)))
@@ -20,7 +24,7 @@ class ProductionGuardTest {
 
     @Test
     fun risky_command_is_flagged_with_its_reason() {
-        val guarded = ProductionGuard.inspect(listOf("rm -rf /var/lib/data"))
+        val guarded = ProductionGuard.inspect(listOf("rm -rf /var/lib/data"), GUARDING)
         assertNotNull(guarded)
         assertEquals(CommandRisk.Danger, guarded.assessment.risk)
         assertEquals("rm -rf /var/lib/data", guarded.command)
@@ -30,23 +34,23 @@ class ProductionGuardTest {
     @Test
     fun warn_level_commands_are_confirmed_too() {
         // sudo/systemctl stop are Warn, not Danger: on production they still ask.
-        val sudo = ProductionGuard.inspect(listOf("sudo systemctl restart nginx"))
+        val sudo = ProductionGuard.inspect(listOf("sudo systemctl restart nginx"), GUARDING)
         assertNotNull(sudo)
         assertEquals(CommandRisk.Warn, sudo.assessment.risk)
-        assertEquals(CommandRisk.Warn, ProductionGuard.inspect(listOf("systemctl stop postgres"))?.assessment?.risk)
+        assertEquals(CommandRisk.Warn, ProductionGuard.inspect(listOf("systemctl stop postgres"), GUARDING)?.assessment?.risk)
     }
 
     @Test
     fun harmless_commands_pass_through() {
-        assertNull(ProductionGuard.inspect(listOf("ls -la")))
-        assertNull(ProductionGuard.inspect(listOf("")))
-        assertNull(ProductionGuard.inspect(emptyList()))
+        assertNull(ProductionGuard.inspect(listOf("ls -la"), GUARDING))
+        assertNull(ProductionGuard.inspect(listOf(""), GUARDING))
+        assertNull(ProductionGuard.inspect(emptyList(), GUARDING))
     }
 
     @Test
     fun the_riskiest_candidate_wins() {
         // The typed line and the line read off the screen can disagree; the worse one decides.
-        val guarded = ProductionGuard.inspect(listOf("systemctl stop nginx", "rm -rf /etc"))
+        val guarded = ProductionGuard.inspect(listOf("systemctl stop nginx", "rm -rf /etc"), GUARDING)
         assertNotNull(guarded)
         assertEquals(CommandRisk.Danger, guarded.assessment.risk)
         assertEquals("rm -rf /etc", guarded.command)
@@ -54,7 +58,7 @@ class ProductionGuardTest {
 
     @Test
     fun equally_risky_candidates_are_quoted_without_the_prompt() {
-        val guarded = ProductionGuard.inspect(ProductionGuard.promptCandidates("root@prod:~# rm -rf /srv"))
+        val guarded = ProductionGuard.inspect(ProductionGuard.promptCandidates("root@prod:~# rm -rf /srv"), GUARDING)
         assertEquals("rm -rf /srv", guarded?.command)
     }
 
@@ -70,7 +74,7 @@ class ProductionGuardTest {
         // Cutting at the LAST prompt-looking character would leave "/dev/sda" and lose the redirect.
         val candidates = ProductionGuard.promptCandidates("root@db ~ # cat img > /dev/sda")
         assertTrue(candidates.any { it == "cat img > /dev/sda" })
-        assertNotNull(ProductionGuard.inspect(candidates))
+        assertNotNull(ProductionGuard.inspect(candidates, GUARDING))
     }
 
     @Test
@@ -82,15 +86,15 @@ class ProductionGuardTest {
     @Test
     fun prompt_with_nothing_typed_yet_produces_no_command() {
         // Only the prompt on screen: the tail is empty, and the prompt itself is not a command.
-        assertNull(ProductionGuard.inspect(ProductionGuard.promptCandidates("user@host:~$ ")))
+        assertNull(ProductionGuard.inspect(ProductionGuard.promptCandidates("user@host:~$ "), GUARDING))
     }
 
     @Test
     fun the_number_of_candidates_is_capped() {
         // Pasting a log file into a terminal must not run thousands of regex passes inline.
         val many = List(MAX_GUARDED_CANDIDATES + 50) { "echo line $it" } + "rm -rf /"
-        assertNull(ProductionGuard.inspect(many)) // the tail past the cap is not classified
-        assertNotNull(ProductionGuard.inspect(listOf("rm -rf /") + many))
+        assertNull(ProductionGuard.inspect(many, GUARDING)) // the tail past the cap is not classified
+        assertNotNull(ProductionGuard.inspect(listOf("rm -rf /") + many, GUARDING))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/tag/TagsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/tag/TagsTest.kt
@@ -29,12 +29,34 @@ class TagsTest {
 
     @Test
     fun normalize_tags_drops_blanks_and_collapses_case_duplicates() {
-        assertEquals(listOf("db", "prod"), normalizeTags(listOf("DB", "  ", "#db", "Prod")))
+        assertEquals(listOf("prod", "db"), normalizeTags(listOf("DB", "  ", "#db", "Prod")))
     }
 
     @Test
     fun normalize_tags_keeps_first_seen_order() {
         assertEquals(listOf("web", "db", "cache"), normalizeTags(listOf("Web", "DB", "cache", "web")))
+    }
+
+    @Test
+    fun normalize_tags_hoists_prod_to_the_front() {
+        assertEquals(listOf("prod", "web", "db"), normalizeTags(listOf("Web", "db", "#PROD")))
+        assertEquals(listOf("prod", "web"), normalizeTags(listOf("prod", "web")))
+    }
+
+    @Test
+    fun order_tags_prod_first_keeps_the_rest_untouched() {
+        assertEquals(listOf("prod", "web", "db"), orderTagsProdFirst(listOf("web", "prod", "db")))
+        assertEquals(listOf("web", "db"), orderTagsProdFirst(listOf("web", "db")))
+        assertEquals(emptyList(), orderTagsProdFirst(emptyList()))
+    }
+
+    @Test
+    fun normalize_tags_keeps_prod_when_the_cap_is_hit() {
+        // `prod` arms the production guard: it must not be the tag that falls off a long list.
+        val many = (1..MAX_TAGS_PER_RECORD + 5).map { "tag$it" } + "prod"
+        val out = normalizeTags(many)
+        assertEquals("prod", out.first())
+        assertEquals(MAX_TAGS_PER_RECORD, out.size)
     }
 
     @Test


### PR DESCRIPTION
A host tagged `prod` guards its session: connecting asks first, the terminal is outlined red, and a risky command is confirmed before it reaches the shell.

## The tag

`prod` is the one tag with behavior attached, so it is always available: first chip in the Hosts filter and first tag suggestion in the connection form, even when no host carries it yet. On a record it is hoisted to the front of the tag list before the per-record cap applies, so a long list can't push it off the end.

## What the guard does

- **Connect** — a confirmation in front of every path: new tab, split pane, VNC, "Run snippet on host", and the mobile Connect/Files taps. Returning to a session that is already live on mobile does not re-ask.
- **Marking** — red outline around the terminal (and the split pane), sunset session tab, `PROD` badge on host rows in the sidebar, the mobile list, and the broadcast target list.
- **Commands** — a command the classifier rates Danger (`CommandRiskClassifier`, static rules, no AI) is held before it reaches the PTY. The dialog quotes the command verbatim with the reason. Alt-screen (vim/htop) is exempt, and so is a password prompt.
- **Threshold** — Danger by default; warnings (`sudo`, `kill`, stopping a service) are opt-in via "Confirm warnings on production" in Settings → Terminal. `sudo` is a warning and makes up half of what gets typed on a production box, and a dialog that frequent stops being read. A root session drops the `sudo` rule entirely (it says nothing there) but confirms destructive warnings even with the setting off, since nothing else stands in front of them.
- **Other ways in** — paste, snippets, the command palette, the AI bar, and broadcast. Broadcast confirms once for the whole fan-out instead of holding per session, so commands never sit waiting in background tabs.

The command is a guess: the client judges the locally tracked line and the screen line up to the cursor (which covers a command recalled with arrow-up) and takes the worse of the two. False positives are preferred over misses; this is a wrong-window guard, not a security boundary.

## Also in this PR

Risk reasons were hardcoded English sentences in `shared`. They are now a `CommandRiskReason` enum resolved through resources (en/ru/zh), which localizes the reasons the AI bar has always shown as well.

