### PR TITLE
Open file paths from terminal output in the SFTP panel

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -163,6 +163,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalFontSizeChange = { writeTerminalFontSize(dir, it) },
                     initialAllowServerClipboardWrite = readClipboardWrite(dir),
                     onAllowServerClipboardWriteChange = { writeClipboardWrite(dir, it) },
+                    initialOpenFilePathsInSftp = readOpenFilePaths(dir),
+                    onOpenFilePathsInSftpChange = { writeOpenFilePaths(dir, it) },
                     initialConfirmProductionWarnings = readProdWarnings(dir),
                     onConfirmProductionWarningsChange = { writeProdWarnings(dir, it) },
                     initialUiLanguage = currentUiLanguage.value,
@@ -266,6 +268,17 @@ class MainActivity : FragmentActivity() {
     private fun writeClipboardWrite(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_clipboard_write").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Clickable file paths in terminal output: `terminal_open_paths`, default on. */
+    private fun readOpenFilePaths(dir: File): Boolean = runCatching {
+        File(dir, "terminal_open_paths").readText().trim().toBoolean()
+    }.getOrDefault(true)
+
+    private fun writeOpenFilePaths(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_open_paths").writeText(enabled.toString()) }
         }
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -85,6 +85,9 @@
     <string name="settings_terminal_show_title">Показывать заголовок терминала на вкладках</string>
     <string name="settings_terminal_show_title_desc">Шелл может переименовывать вкладку (OSC-заголовок). Выкл — показывается имя хоста.</string>
     <string name="settings_terminal_clipboard_write">Разрешить серверу писать в буфер обмена (OSC 52)</string>
+    <string name="settings_terminal_open_paths">Открытие файловых путей в SFTP</string>
+    <string name="settings_terminal_open_paths_desc">Ctrl+клик по пути в выводе открывает его в файловой панели.</string>
+    <string name="settings_terminal_open_paths_desc_mobile">Долгое нажатие на путь в выводе, затем «Открыть в Файлах».</string>
     <string name="settings_terminal_host_connect">Подключение к хосту</string>
     <string name="settings_terminal_host_connect_single">Одинарный клик</string>
     <string name="settings_terminal_host_connect_double">Двойной клик (клик выделяет)</string>
@@ -182,6 +185,8 @@
     <string name="settings_kb_accept_autocomplete">Принять подсказку автодополнения</string>
     <string name="settings_kb_cycle_suggestions">Перебрать подсказки</string>
     <string name="settings_kb_search_history">Поиск по истории команд</string>
+    <string name="settings_kb_open_link_or_path">Открыть ссылку или файловый путь</string>
+    <string name="settings_kb_mouse_click">Ctrl+клик</string>
     <string name="settings_kb_search_output">Поиск по выводу</string>
     <string name="settings_kb_copy_selection">Копировать выделение</string>
     <string name="settings_kb_paste">Вставить</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -117,4 +117,5 @@
     <string name="term_broadcast_sent">Отправлено: %1$s</string>
     <string name="local_shell_name">Локальная оболочка</string>
     <string name="term_launch_local_shell">Запустить локальную оболочку</string>
+    <string name="term_open_path_in_files">Открыть в Файлах</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -85,6 +85,9 @@
     <string name="settings_terminal_show_title">在标签页上显示终端标题</string>
     <string name="settings_terminal_show_title_desc">允许 shell 重命名标签页（OSC 标题）。关闭时显示主机名。</string>
     <string name="settings_terminal_clipboard_write">允许服务器写入剪贴板 (OSC 52)</string>
+    <string name="settings_terminal_open_paths">在 SFTP 中打开文件路径</string>
+    <string name="settings_terminal_open_paths_desc">按住 Ctrl 点击输出中的路径，即可在文件面板中定位。</string>
+    <string name="settings_terminal_open_paths_desc_mobile">长按输出中的路径，然后点按“在文件中打开”。</string>
     <string name="settings_terminal_host_connect">连接主机方式</string>
     <string name="settings_terminal_host_connect_single">单击</string>
     <string name="settings_terminal_host_connect_double">双击（单击选中）</string>
@@ -182,6 +185,8 @@
     <string name="settings_kb_accept_autocomplete">接受自动补全建议</string>
     <string name="settings_kb_cycle_suggestions">循环切换建议</string>
     <string name="settings_kb_search_history">搜索命令历史</string>
+    <string name="settings_kb_open_link_or_path">打开链接或文件路径</string>
+    <string name="settings_kb_mouse_click">Ctrl+点击</string>
     <string name="settings_kb_search_output">在输出中查找</string>
     <string name="settings_kb_copy_selection">复制选中内容</string>
     <string name="settings_kb_paste">粘贴</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -117,4 +117,5 @@
     <string name="term_broadcast_sent">已发送到 %1$s</string>
     <string name="local_shell_name">本地 Shell</string>
     <string name="term_launch_local_shell">启动本地 Shell</string>
+    <string name="term_open_path_in_files">在文件中打开</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -85,6 +85,9 @@
     <string name="settings_terminal_show_title">Show terminal title on tabs</string>
     <string name="settings_terminal_show_title_desc">The shell may rename the tab (OSC title). Off: tabs show the host name.</string>
     <string name="settings_terminal_clipboard_write">Allow server clipboard writes (OSC 52)</string>
+    <string name="settings_terminal_open_paths">Open file paths in SFTP</string>
+    <string name="settings_terminal_open_paths_desc">Ctrl+click a file path in the output to reveal it in the file panel.</string>
+    <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap "Open in Files".</string>
     <string name="settings_terminal_host_connect">Connect to host on</string>
     <string name="settings_terminal_host_connect_single">Single click</string>
     <string name="settings_terminal_host_connect_double">Double click (click selects)</string>
@@ -182,6 +185,8 @@
     <string name="settings_kb_accept_autocomplete">Accept autocomplete suggestion</string>
     <string name="settings_kb_cycle_suggestions">Cycle suggestions</string>
     <string name="settings_kb_search_history">Search command history</string>
+    <string name="settings_kb_open_link_or_path">Open a link or file path</string>
+    <string name="settings_kb_mouse_click">Ctrl+click</string>
     <string name="settings_kb_search_output">Find in output</string>
     <string name="settings_kb_copy_selection">Copy selection</string>
     <string name="settings_kb_paste">Paste</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -117,4 +117,5 @@
     <string name="term_broadcast_sent">Sent to %1$s</string>
     <string name="local_shell_name">Local shell</string>
     <string name="term_launch_local_shell">Launch local shell</string>
+    <string name="term_open_path_in_files">Open in Files</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -169,6 +169,10 @@ class DesktopDesignState(
     // [app.skerry.ui.terminal.TerminalSessionPrefs] and pushed live into open ones.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Whether a file path in terminal output is clickable (Ctrl+click) and opens in the SFTP panel
+    // (Settings → Terminal). On by default; off also removes the hover highlight.
+    initialOpenFilePathsInSftp: Boolean = true,
+    private val onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
     // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
@@ -334,6 +338,13 @@ class DesktopDesignState(
      * write). Off by default; snapshotted into new sessions and pushed live into open ones.
      */
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
+
+    /**
+     * Whether file paths printed in terminal output are clickable and open in the SFTP panel
+     * (Terminal → Open file paths in SFTP). On by default; off is the way out for anyone whose
+     * output makes the Ctrl+hover highlight a distraction.
+     */
+    var openFilePathsInSftp: Boolean by mutableStateOf(initialOpenFilePathsInSftp); private set
 
     /**
      * Whether the production guard also confirms [app.skerry.shared.ai.CommandRisk.Warn] commands
@@ -702,6 +713,12 @@ class DesktopDesignState(
     fun toggleConfirmProductionWarnings() {
         confirmProductionWarnings = !confirmProductionWarnings
         onConfirmProductionWarningsChange(confirmProductionWarnings)
+    }
+
+    /** Toggle opening clicked file paths in the SFTP panel and report outward (for persistence). */
+    fun toggleOpenFilePathsInSftp() {
+        openFilePathsInSftp = !openFilePathsInSftp
+        onOpenFilePathsInSftpChange(openFilePathsInSftp)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -109,6 +109,10 @@ class MobileDesignState(
     // and pushed live into open ones. Persisted on Android; no-op default for previews/tests.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Whether a file path selected in terminal output offers "Open in Files" (More → Terminal).
+    // Desktop parity (Ctrl+click there). On by default; persisted on Android.
+    initialOpenFilePathsInSftp: Boolean = true,
+    private val onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
     // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
@@ -312,6 +316,12 @@ class MobileDesignState(
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
 
     /**
+     * Whether a file path selected in terminal output offers "Open in Files" (More → Terminal).
+     * On by default; desktop parity, see [app.skerry.ui.app.DesktopDesignState.openFilePathsInSftp].
+     */
+    var openFilePathsInSftp: Boolean by mutableStateOf(initialOpenFilePathsInSftp); private set
+
+    /**
      * Whether the production guard also confirms Warn-level commands (More → Terminal). Off by
      * default — desktop parity, see [app.skerry.ui.app.DesktopDesignState.confirmProductionWarnings].
      */
@@ -367,6 +377,12 @@ class MobileDesignState(
     fun toggleConfirmProductionWarnings() {
         confirmProductionWarnings = !confirmProductionWarnings
         onConfirmProductionWarningsChange(confirmProductionWarnings)
+    }
+
+    /** Toggle offering "Open in Files" for a selected file path and report outward (for persistence). */
+    fun toggleOpenFilePathsInSftp() {
+        openFilePathsInSftp = !openFilePathsInSftp
+        onOpenFilePathsInSftpChange(openFilePathsInSftp)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -162,6 +162,33 @@ class ConnectionController(
     var historyKey: String? by mutableStateOf(null)
         private set
 
+    /**
+     * Path this session's file view should reveal when it opens — set by a click on a file path in
+     * terminal output, consumed once by the view ([takeRevealRequest]). A request, not a direct
+     * call: the click happens while the file view isn't composed and its transfer coordinator may
+     * not even be open yet, so the path waits here instead of racing the view's own setup.
+     * Snapshot state so an already-open view picks it up on the next recomposition.
+     */
+    var pendingRevealPath: String? by mutableStateOf(null)
+        private set
+
+    /**
+     * Whether this session can open an SFTP channel at all. Only plain SSH can: Mosh, Telnet,
+     * serial, the local shell and container exec all run over [app.skerry.shared.ssh.StreamOnlyConnection],
+     * whose `openSftp` throws. Snapshot state, set at connect from the target's connection type, so
+     * the UI can hide file affordances instead of offering a panel that could only show an error.
+     */
+    var supportsSftp: Boolean by mutableStateOf(false)
+        private set
+
+    /** Asks the file view to reveal [path]; a newer request replaces one still waiting. */
+    fun requestReveal(path: String) {
+        pendingRevealPath = path
+    }
+
+    /** Takes the pending reveal request, clearing it — a request is acted on exactly once. */
+    fun takeRevealRequest(): String? = pendingRevealPath?.also { pendingRevealPath = null }
+
     private var connectJob: Job? = null
     // Target/auth of the last connect — used by auto-reconnect after a drop (reconnects to the same target).
     private var lastTarget: SshTarget? = null
@@ -193,6 +220,7 @@ class ConnectionController(
         // Only starts from the form: while a connect is in progress or a session is open, a repeat
         // connect is ignored — otherwise a scope/connection could leak.
         if (uiState !is ConnectionUiState.Form) return
+        supportsSftp = target.connectionType == ConnectionType.SSH
         lastTarget = target
         lastAuth = auth
         pendingOnConnected = onConnected

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -290,6 +290,9 @@ fun DesktopDesignApp(
     // OSC 52 server clipboard-write gate (Settings → Terminal) — persisted externally (desktop main).
     initialAllowServerClipboardWrite: Boolean = false,
     onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Clickable file paths in terminal output (Settings → Terminal) — persisted externally (desktop main).
+    initialOpenFilePathsInSftp: Boolean = true,
+    onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
     // Production guard: confirm Warn-level commands too (Settings → Terminal) — persisted externally.
     initialConfirmProductionWarnings: Boolean = false,
     onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
@@ -324,6 +327,7 @@ fun DesktopDesignApp(
             initialShowTerminalTitleOnTabs, onShowTerminalTitleOnTabsChange,
             initialHostClickConnectMode, onHostClickConnectModeChange,
             initialAllowServerClipboardWrite, onAllowServerClipboardWriteChange,
+            initialOpenFilePathsInSftp, onOpenFilePathsInSftpChange,
             initialConfirmProductionWarnings, onConfirmProductionWarningsChange,
             initialTerminalTheme, onTerminalThemeChange,
             initialCustomTerminalTheme, onCustomTerminalThemeChange,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
@@ -11,6 +11,8 @@ import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.cancellation.CancellationException
 
 /** Listing state of a single file pane (local or remote). */
@@ -31,8 +33,10 @@ sealed interface FilePaneState {
  * (single/Ctrl-toggle/Shift-range). Cross-pane transfer is not its responsibility (see the
  * screen's transfer coordinator).
  *
- * Operations are serialized via [busy]; a failed operation moves the pane to [FilePaneState.Error]
- * without crashing the controller. Ownership of the source ([FileBrowser]/channel) is external.
+ * Operations are serialized: a user-driven one is dropped while another runs ([op]), an externally
+ * requested one waits its turn ([queuedOp]). A failed operation moves the pane to
+ * [FilePaneState.Error] without crashing the controller. Ownership of the source
+ * ([FileBrowser]/channel) is external.
  */
 @Stable
 class FilePaneController(
@@ -93,6 +97,12 @@ class FilePaneController(
     private var anchor: String? by mutableStateOf(null)
     private var busy = false
 
+    /**
+     * Serializes the actual work of [op]/[queuedOp]. [busy] alone can only drop a racing operation;
+     * the gate is what lets a queued one wait for the in-flight listing to finish.
+     */
+    private val gate = Mutex()
+
     /** Loads the source's starting directory. Call once when the pane opens. */
     fun start() = op {
         path = browser.realpath(".")
@@ -126,6 +136,44 @@ class FilePaneController(
             is FilePaneState.Loaded -> commit(resolved, next)
             else -> state = next
         }
+    }
+
+    /**
+     * Reveals [target] — a path that came from outside the pane (a file path clicked in terminal
+     * output). A directory is opened; anything else is shown *inside its parent* with the cursor on
+     * it, which is what "show me this file" means in a two-pane file manager. `~`/`~/…` is expanded
+     * against the source's start directory (the shell would have done it, the SFTP server won't).
+     *
+     * When neither the path nor its parent can be listed, the pane stays where it is and shows the
+     * original failure — same contract as [goToPath], so a stale path from old output doesn't throw
+     * away the listing being browsed. An entry hidden by [showHidden] gets no cursor: the pane will
+     * not flip a persistent setting on its own.
+     */
+    fun revealPath(target: String) = queuedOp {
+        val trimmed = target.trim()
+        if (trimmed.isEmpty()) return@queuedOp
+        val expanded = when {
+            trimmed == "~" -> browser.realpath(".")
+            trimmed.startsWith("~/") -> childPath(browser.realpath("."), trimmed.removePrefix("~/"))
+            else -> trimmed
+        }
+        val request = if (isAbsolutePathInput(expanded)) expanded else childPath(path, expanded)
+        val resolved = browser.realpath(collapseDotSegments(request))
+        val asDirectory = loadState(resolved)
+        if (asDirectory is FilePaneState.Loaded) {
+            commit(resolved, asDirectory)
+            return@queuedOp
+        }
+        val parent = parentPath(resolved)
+        val inParent = loadState(parent)
+        if (inParent !is FilePaneState.Loaded) {
+            // Report why the target itself failed, not why its parent did — the target is what the
+            // user asked for.
+            state = asDirectory
+            return@queuedOp
+        }
+        commit(parent, inParent)
+        loadedEntries().firstOrNull { it.path == resolved }?.let { setCursor(it) }
     }
 
     /** Reloads the current directory. */
@@ -468,14 +516,40 @@ class FilePaneController(
         busy = true
         scope.launch {
             try {
-                block()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: FileBrowserException) {
-                state = FilePaneState.Error(e.failure)
+                gate.withLock { runOp(block) }
             } finally {
                 busy = false
             }
+        }
+    }
+
+    /**
+     * Like [op], but waits its turn instead of being dropped while another operation runs. For
+     * requests arriving from outside the pane ([revealPath]): they race the pane's own first
+     * listing ([start]) and there is nothing on screen to retry from, whereas dropping a keypress
+     * the user can simply press again is exactly what [op] is for.
+     */
+    private fun queuedOp(block: suspend () -> Unit) {
+        scope.launch {
+            gate.withLock {
+                busy = true
+                try {
+                    runOp(block)
+                } finally {
+                    busy = false
+                }
+            }
+        }
+    }
+
+    /** Body shared by [op]/[queuedOp]: runs the operation, mapping a failure into [FilePaneState.Error]. */
+    private suspend fun runOp(block: suspend () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: FileBrowserException) {
+            state = FilePaneState.Error(e.failure)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -169,6 +169,11 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
     }
 
     val c = coord
+    // A path opened from terminal output ("Open in Files" on a selection): reveal it in the remote
+    // pane once the coordinator is up. Keyed on the request so a repeat click is honoured too.
+    LaunchedEffect(c, controller.pendingRevealPath) {
+        if (c != null) controller.takeRevealRequest()?.let { c.remote.revealPath(it) }
+    }
     val openEditor = editor
     // Built-in viewer/editor (long-press → View/Edit): takes over the screen instead of opening a
     // dialog, so it gets the full height and the same chrome as the file list.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -62,6 +62,8 @@ import app.skerry.ui.generated.resources.appearance_section_theme
 import app.skerry.ui.generated.resources.appearance_custom_term_theme
 import app.skerry.ui.generated.resources.appearance_custom_term_theme_desc
 import app.skerry.ui.generated.resources.appearance_section_terminal
+import app.skerry.ui.generated.resources.settings_terminal_open_paths
+import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc_mobile
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
@@ -587,6 +589,20 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
             HLine()
             FontSettingRow(stringResource(Res.string.settings_terminal_cursor_style)) {
                 MobileCursorStylePicker(state.terminalCursorStyle, onPick = state::chooseTerminalCursorStyle)
+            }
+            // Clickable file paths in output (desktop parity): here the affordance is a chip over a
+            // selected path rather than Ctrl+click, and this switch governs both.
+            HLine()
+            Row(
+                Modifier.fillMaxWidth().padding(vertical = 11.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Column(Modifier.weight(1f)) {
+                    Txt(stringResource(Res.string.settings_terminal_open_paths), color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
+                    Txt(stringResource(Res.string.settings_terminal_open_paths_desc_mobile), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
+                }
+                Toggle(on = state.openFilePathsInSftp, onToggle = state::toggleOpenFilePathsInSftp)
             }
             // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host
             // from silently overwriting the system clipboard. Applies to new and already-open sessions.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -72,6 +73,7 @@ import app.skerry.ui.terminal.RecordingOutcome
 import app.skerry.ui.terminal.recordingOutcomeMessage
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_mobile_title_fallback
+import app.skerry.ui.generated.resources.term_open_path_in_files
 import app.skerry.ui.generated.resources.term_broadcast_title
 import app.skerry.ui.generated.resources.term_monitor_title
 import app.skerry.ui.generated.resources.term_record_start
@@ -104,9 +106,11 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.app.MobileRoute
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.terminal.arrowSequence
+import app.skerry.ui.terminal.filePathFromSelection
 import app.skerry.ui.session.broadcastTargets
 import app.skerry.ui.session.sessionDotColor
 import kotlinx.coroutines.delay
@@ -245,6 +249,25 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             imeInput = true,
                             imeTransform = imeTransform,
                         )
+                    }
+                    // Desktop opens a path on Ctrl+click; touch has no such chord, so the affordance is
+                    // a chip: long-press picks the path (word selection stops at whitespace, so a path
+                    // comes out whole), the chip reveals it in Files. derivedStateOf keeps streaming
+                    // output from recomposing the row while the selection hasn't changed.
+                    // Gated on supportsSftp for the same reason as desktop: a Mosh/Telnet/serial/
+                    // local/container session has no SFTP channel to reveal anything in.
+                    val selectedPath by remember(st.terminal, active.controller) {
+                        derivedStateOf {
+                            if (!state.openFilePathsInSftp || !active.controller.supportsSftp) null
+                            else filePathFromSelection(st.terminal.selectedText())
+                        }
+                    }
+                    selectedPath?.let { path ->
+                        MobileOpenPathBar(path) {
+                            active.controller.requestReveal(path)
+                            st.terminal.clearSelection()
+                            state.push(MobileRoute.Files)
+                        }
                     }
                     // Raised by the sparkle key; a pending suggestion forces it open so a command the
                     // model proposed can never be waiting behind a collapsed bar.
@@ -526,6 +549,33 @@ private fun MobileAiBarInput(controller: TerminalAiController, terminal: Termina
                 }
             }
         }
+    }
+}
+
+/**
+ * "Open in Files" row over the key panel, shown while the selection is exactly one file path. Full
+ * width and tappable as a whole (a phone-sized target), with the path itself in mono so it reads as
+ * the thing being opened; a long path ellipsizes at the start, keeping the file name visible.
+ */
+@Composable
+private fun MobileOpenPathBar(path: String, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().background(Skerry.colors.surface2).clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Sym("drive_file_move", size = 16.sp, color = Skerry.colors.cyanBright)
+        Txt(stringResource(Res.string.term_open_path_in_files), color = Skerry.colors.text, size = 12.sp, weight = FontWeight.Medium)
+        Txt(
+            path,
+            color = Skerry.colors.dim,
+            size = 11.5.sp,
+            font = LocalFonts.current.mono,
+            maxLines = 1,
+            overflow = TextOverflow.StartEllipsis,
+            modifier = Modifier.weight(1f),
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -56,6 +56,8 @@ import app.skerry.ui.generated.resources.settings_kb_play_recording
 import app.skerry.ui.generated.resources.settings_kb_record_session
 import app.skerry.ui.generated.resources.settings_kb_search_history
 import app.skerry.ui.generated.resources.settings_kb_search_output
+import app.skerry.ui.generated.resources.settings_kb_open_link_or_path
+import app.skerry.ui.generated.resources.settings_kb_mouse_click
 import app.skerry.ui.generated.resources.settings_kb_select_tab_number
 import app.skerry.ui.generated.resources.settings_kb_snippet_palette
 import app.skerry.ui.generated.resources.settings_kb_split_terminal
@@ -105,6 +107,9 @@ internal fun KeyboardSection() {
         // Both conventions work, so both are listed: Ctrl+Shift+C/V and the X11 Insert pair.
         KeyboardBinding(stringResource(Res.string.settings_kb_copy_selection), "${ctrlShift("C")} / ${ctrl("Insert")}", live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_paste), "${ctrlShift("V")} / ${shift("Insert")}", live = true),
+        // Mouse chord rather than a key, but it lives in the terminal and users look for it here:
+        // Ctrl+click opens an OSC 8/plain URL, or a file path in the file panel.
+        KeyboardBinding(stringResource(Res.string.settings_kb_open_link_or_path), stringResource(Res.string.settings_kb_mouse_click), live = true),
     )
 
     // File panel (SFTP view) F-keys, mc/Total Commander style — the same labels the bottom bar uses.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -49,6 +49,8 @@ import app.skerry.ui.generated.resources.settings_terminal_cursor_block_steady
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
 import app.skerry.ui.generated.resources.settings_terminal_cursor_underline_blink
 import app.skerry.ui.generated.resources.settings_terminal_cursor_underline_steady
+import app.skerry.ui.generated.resources.settings_terminal_open_paths
+import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
@@ -181,6 +183,15 @@ internal fun TerminalSection(state: DesktopDesignState) {
         stringResource(Res.string.settings_terminal_prod_warnings_desc),
         on = state.confirmProductionWarnings,
         onToggle = state::toggleConfirmProductionWarnings,
+    )
+    HLine()
+    // Clickable file paths in output (Ctrl+click → reveal in the SFTP panel). On by default; off
+    // also removes the Ctrl+hover highlight, for output where it reads as noise.
+    SettingToggleRow(
+        stringResource(Res.string.settings_terminal_open_paths),
+        stringResource(Res.string.settings_terminal_open_paths_desc),
+        on = state.openFilePathsInSftp,
+        onToggle = state::toggleOpenFilePathsInSftp,
     )
     HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -290,6 +290,11 @@ private fun LiveSftpView(
     val c = coord
     // Once the coordinator is open — give the panes focus so arrows/Tab work without a click.
     LaunchedEffect(c) { if (c != null) focus.requestFocus() }
+    // A path clicked in terminal output: reveal it in the remote pane once the coordinator is open.
+    // Keyed on the request itself, so a second click while this view is already up is honoured too.
+    LaunchedEffect(c, controller.pendingRevealPath) {
+        if (c != null) controller.takeRevealRequest()?.let { c.remote.revealPath(it) }
+    }
     // Apply the saved show-hidden setting to both panes: on coordinator open and on every Ctrl+H toggle
     // (sftpPrefs.showHidden is the effect key).
     LaunchedEffect(c, sftpPrefs.showHidden) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
@@ -1,0 +1,142 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.TermCell
+
+/**
+ * Detection of file paths printed in terminal output, so Ctrl+click (touch: the selection chip) can
+ * reveal them in the SFTP panel. Separate from [TerminalLinks] because the rules differ: a path has
+ * no scheme to anchor on, so the detector is deliberately narrow.
+ *
+ * v1 recognizes only paths that resolve without knowing the shell's working directory — absolute
+ * (`/var/log/syslog`) and home-relative (`~/.ssh/config`). Relative ones (`./x`, `src/App.kt`) are
+ * skipped: there is no cwd tracking (no OSC 7), so they would open the wrong directory as often as
+ * the right one.
+ */
+
+/** Longest path we are willing to hand to the file browser — beyond this it isn't output, it's noise. */
+private const val MAX_PATH_LENGTH = 4096
+
+/** Characters a path may directly follow: a token boundary, a quote, or an opening bracket. */
+private const val PATH_OPENERS = "\"'`([{"
+
+/** Trailing chars that read as sentence punctuation rather than part of the name. */
+private const val PATH_TRAILING_PUNCT = ".,;:!?]}>\"'`"
+
+/**
+ * Invisible characters a hostile server could hide in a path so the glyphs under the pointer read as
+ * one directory while the string handed to SFTP is another: bidi overrides/isolates and zero-width
+ * marks. A real path never needs them, so anything carrying one is not offered.
+ */
+private fun isInvisibleChar(ch: Char): Boolean =
+    ch in '\u202A'..'\u202E' || ch in '\u2066'..'\u2069' || ch in '\u200B'..'\u200F' || ch == '\uFEFF'
+
+/** First character of the first segment: rules out `//` and other slash runs that aren't paths. */
+private fun isPathStartChar(ch: Char): Boolean =
+    ch.isLetterOrDigit() || ch == '.' || ch == '_' || ch == '-'
+
+/**
+ * Cuts a `:line[:col]` suffix (grep -n, compiler diagnostics); the numbers themselves are dropped —
+ * the file panel opens files, not lines. The digits must end the token or be followed by another
+ * `:` (grep's `file:line:text`), otherwise the colon belongs to the name: `:` is legal in a POSIX
+ * filename and shows up in timestamped ones like `2026-07-26T03:00:00.tar.gz`, which must survive
+ * whole.
+ */
+private fun cutLineSuffix(token: String): String {
+    var i = 0
+    while (i < token.length) {
+        if (token[i] != ':' || i + 1 >= token.length || !token[i + 1].isDigit()) { i++; continue }
+        var end = i + 1
+        while (end < token.length && token[end].isDigit()) end++
+        // Optional `:col` right after the line number.
+        if (end + 1 < token.length && token[end] == ':' && token[end + 1].isDigit()) {
+            end++
+            while (end < token.length && token[end].isDigit()) end++
+        }
+        if (end == token.length || token[end] == ':') return token.substring(0, i)
+        // Not a line marker after all — keep looking past it (`/a:2026.log:15` still has a real one).
+        i = end
+    }
+    return token
+}
+
+/**
+ * Normalizes a whitespace-delimited [token] into a path worth opening, or `null` if it isn't one.
+ * The result is always a prefix of [token] (only trailing parts are cut), so callers can map it back
+ * onto the source columns by length.
+ */
+internal fun normalizeFilePath(token: String): String? {
+    if (token.length > MAX_PATH_LENGTH) return null
+    val path = trimTrailingPunct(cutLineSuffix(token), PATH_TRAILING_PUNCT)
+    if (path.isEmpty()) return null
+    // Control bytes would corrupt whatever consumes the path downstream; the output is untrusted.
+    if (path.any { it.code < 0x20 || it.code == 0x7F || isInvisibleChar(it) }) return null
+    return when (path[0]) {
+        // `~` (home) or `~/…`. `~user/…` is not supported: only the session's own home is known.
+        '~' -> path.takeIf { it.length == 1 || it[1] == '/' }
+        '/' -> path.takeIf { it.length > 1 && isPathStartChar(it[1]) }
+        else -> null
+    }
+}
+
+/**
+ * Finds file paths in a line of plain text, returned as string-index spans. A path starts only at a
+ * token boundary (start of line, whitespace, quote, opening bracket), which keeps URL bodies
+ * (`https://host/docs`), shell assignments (`HOST=/dev/null`) and `/etc/passwd`-style colon records
+ * out of the results.
+ */
+internal fun detectFilePaths(text: String): List<TextLinkSpan> {
+    var out: MutableList<TextLinkSpan>? = null
+    var i = 0
+    while (i < text.length) {
+        val ch = text[i]
+        if (ch != '/' && ch != '~') { i++; continue }
+        if (i > 0 && !text[i - 1].isWhitespace() && text[i - 1] !in PATH_OPENERS) { i++; continue }
+        var end = i
+        while (end < text.length && !text[end].isWhitespace()) end++
+        normalizeFilePath(text.substring(i, end))?.let { path ->
+            (out ?: ArrayList<TextLinkSpan>().also { out = it })
+                .add(TextLinkSpan(i, i + path.length, path))
+        }
+        // Skip the whole token even when it wasn't a path: its inner slashes are not path starts.
+        i = end
+    }
+    return out ?: emptyList()
+}
+
+/** Cheap allocation-free scan for a character that could start a path. */
+private fun rowHasPathMarker(row: List<TermCell>): Boolean {
+    for (cell in row) {
+        for (ch in cell.text) if (ch == '/' || ch == '~') return true
+    }
+    return false
+}
+
+/**
+ * Same detection as [detectFilePaths] over a grid row, returning spans in **column** coordinates
+ * (see [rowTextSpans]). Spans touching a cell that already carries an OSC 8 hyperlink are dropped —
+ * the hyperlink owns those cells.
+ */
+internal fun rowFilePathSpans(row: List<TermCell>): List<TextLinkSpan> {
+    // Runs per visible row on every Canvas draw — bail out with zero allocation on rows that cannot
+    // contain a path before touching StringBuilder/detection.
+    if (!rowHasPathMarker(row)) return emptyList()
+    return rowTextSpans(row, ::detectFilePaths).filterNot { span ->
+        (span.start until span.endExclusive).any { row.getOrNull(it)?.hyperlink != null }
+    }
+}
+
+/** The file path under column [col] in [row], or `null`. Used for Ctrl+click hit-testing. */
+internal fun filePathAt(row: List<TermCell>, col: Int): String? =
+    rowFilePathSpans(row).firstOrNull { col >= it.start && col < it.endExclusive }?.uri
+
+/**
+ * The path a touch selection stands for, or `null`. Only a selection that is exactly one path
+ * counts: a phone has no Ctrl+click, so the whole affordance is "long-press a path, tap Open" and
+ * guessing which of several tokens was meant would open the wrong thing.
+ */
+internal fun filePathFromSelection(text: String?): String? {
+    val trimmed = text?.trim() ?: return null
+    if (trimmed.isEmpty() || trimmed.any { it.isWhitespace() }) return null
+    if (trimmed[0] != '/' && trimmed[0] != '~') return null
+    return normalizeFilePath(trimmed)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
@@ -16,34 +16,13 @@ internal fun isSafeLinkUri(uri: String): Boolean {
         uri.startsWith("mailto:", ignoreCase = true)
 }
 
-/** A URL found in plain row text. [start]/[endExclusive] are indices — into the source string for
- *  [detectPlainTextLinks], into grid columns for [rowLinkSpans]. */
-internal data class TextLinkSpan(val start: Int, val endExclusive: Int, val uri: String)
-
 // Explicit web schemes only (no bare `www.`), so a match already carries an authority. The body runs
 // to the next whitespace; trailing sentence punctuation is trimmed afterwards.
 private val PLAIN_LINK_REGEX = Regex("(?i)(?:https?|ftp)://[^\\s]+")
 
-// Trailing chars that are usually sentence punctuation, not part of the URL. ')' is handled
-// separately so balanced parens inside a URL (e.g. Wikipedia's `Foo_(bar)`) survive.
+// Trailing chars that are usually sentence punctuation, not part of the URL. ')' is handled by
+// [trimTrailingPunct], which keeps a ')' closing a '(' inside the URL (e.g. Wikipedia's `Foo_(bar)`).
 private const val LINK_TRAILING_PUNCT = ".,;:!?]}>\"'"
-
-/** Right-trim sentence punctuation from a matched URL, keeping a ')' that closes a '(' in the URL. */
-private fun trimUrlTail(url: String): String {
-    val opens = url.count { it == '(' }
-    var closes = url.count { it == ')' }
-    var end = url.length
-    while (end > 0) {
-        val ch = url[end - 1]
-        when {
-            // A ')' is part of the URL only while there's still an unmatched '(' to its left.
-            ch == ')' -> if (closes > opens) { closes--; end-- } else break
-            ch in LINK_TRAILING_PUNCT -> end--
-            else -> break
-        }
-    }
-    return if (end == url.length) url else url.substring(0, end)
-}
 
 /**
  * Detect bare http(s)/ftp URLs in a line of plain text (URLs the server printed without OSC 8
@@ -53,7 +32,7 @@ private fun trimUrlTail(url: String): String {
 internal fun detectPlainTextLinks(text: String): List<TextLinkSpan> {
     var out: MutableList<TextLinkSpan>? = null
     for (m in PLAIN_LINK_REGEX.findAll(text)) {
-        val uri = trimUrlTail(m.value)
+        val uri = trimTrailingPunct(m.value, LINK_TRAILING_PUNCT)
         if (uri.isEmpty() || !isSafeLinkUri(uri)) continue
         (out ?: ArrayList<TextLinkSpan>().also { out = it })
             .add(TextLinkSpan(m.range.first, m.range.first + uri.length, uri))
@@ -77,22 +56,13 @@ private fun rowHasSchemeMarker(row: List<TermCell>): Boolean {
 
 /**
  * Same detection as [detectPlainTextLinks], but over a grid row, returning spans in **column**
- * coordinates. A wide glyph occupies two columns (its [CellWidth.Continuation] cell has empty text),
- * so string index and column diverge — the char→column map keeps clicks landing on the URL.
+ * coordinates (see [rowTextSpans]).
  */
 internal fun rowLinkSpans(row: List<TermCell>): List<TextLinkSpan> {
     // Runs per visible row on every Canvas draw (scroll, cursor blink, PTY output) — so bail out with
     // zero allocation on the overwhelmingly common URL-free row before touching StringBuilder/regex.
     if (!rowHasSchemeMarker(row)) return emptyList()
-    val sb = StringBuilder(row.size)
-    val colOf = ArrayList<Int>(row.size)
-    for (c in row.indices) {
-        for (ch in row[c].text) { sb.append(ch); colOf.add(c) }
-    }
-    if (colOf.isEmpty()) return emptyList()
-    val found = detectPlainTextLinks(sb.toString())
-    if (found.isEmpty()) return emptyList()
-    return found.map { s -> TextLinkSpan(colOf[s.start], colOf[s.endExclusive - 1] + 1, s.uri) }
+    return rowTextSpans(row, ::detectPlainTextLinks)
 }
 
 /** The plain-text URL under column [col] in [row], or `null`. Used for Ctrl+click hit-testing. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
@@ -1,0 +1,53 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.TermCell
+
+/**
+ * Pieces shared by the two detectors that read clickable things out of terminal output —
+ * [TerminalLinks] (URLs) and [TerminalFilePaths] (file paths). They differ in what they match but
+ * agree on the mechanics: trim trailing punctuation off a match, and map string-index spans of a
+ * grid row onto column coordinates.
+ */
+
+/** A match found in plain row text. [start]/[endExclusive] are string indices or grid columns. */
+internal data class TextLinkSpan(val start: Int, val endExclusive: Int, val uri: String)
+
+/**
+ * Right-trims characters of [punct] off [token], keeping a ')' that closes a '(' inside it (so
+ * `…/Foo_(bar)` survives while `(see …/foo)` loses its paren). The result is always a prefix of
+ * [token], which is what lets callers map it back onto the source columns by length.
+ */
+internal fun trimTrailingPunct(token: String, punct: String): String {
+    val opens = token.count { it == '(' }
+    var closes = token.count { it == ')' }
+    var end = token.length
+    while (end > 0) {
+        val ch = token[end - 1]
+        when {
+            // A ')' is part of the match only while there's still an unmatched '(' to its left.
+            ch == ')' -> if (closes > opens) { closes--; end-- } else break
+            ch in punct -> end--
+            else -> break
+        }
+    }
+    return if (end == token.length) token else token.substring(0, end)
+}
+
+/**
+ * Runs [detect] over a grid row's text and returns its spans in **column** coordinates: a wide glyph
+ * occupies two columns (its continuation cell has empty text), so string index and column diverge,
+ * and clicks would otherwise miss the match. Callers do their own allocation-free "could this row
+ * match at all" prescan first — this builds a StringBuilder, and on a draw pass most rows can't
+ * match anything.
+ */
+internal fun rowTextSpans(row: List<TermCell>, detect: (String) -> List<TextLinkSpan>): List<TextLinkSpan> {
+    val sb = StringBuilder(row.size)
+    val colOf = ArrayList<Int>(row.size)
+    for (c in row.indices) {
+        for (ch in row[c].text) { sb.append(ch); colOf.add(c) }
+    }
+    if (colOf.isEmpty()) return emptyList()
+    val found = detect(sb.toString())
+    if (found.isEmpty()) return emptyList()
+    return found.map { s -> TextLinkSpan(colOf[s.start], colOf[s.endExclusive - 1] + 1, s.uri) }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -191,6 +191,9 @@ private fun terminalMetrics(measurer: TextMeasurer, style: TextStyle, density: D
     )
 }
 
+/** A file path under the pointer while Ctrl is held: [row] in the grid, [span] in columns. */
+private data class HoveredPath(val row: Int, val span: TextLinkSpan)
+
 @Composable
 fun TerminalScreen(
     state: TerminalScreenState,
@@ -198,6 +201,10 @@ fun TerminalScreen(
     imeInput: Boolean = false,
     imeTransform: ((String) -> String)? = null,
     fixedGrid: PtySize? = null,
+    // Ctrl+click on a file path in the output hands it here (the caller reveals it in its session's
+    // file panel). `null` — no path affordance at all: the setting is off, or this pane has no file
+    // panel of its own (split pane, recording playback, preview).
+    onOpenPath: ((String) -> Unit)? = null,
 ) {
     // Terminal font/size from Appearance settings ([LocalTerminalAppearance]); defaults to Hack 13px
     // where no provider is set (mobile target/preview/connection screen). Ligatures always disabled
@@ -281,6 +288,9 @@ fun TerminalScreen(
     // recomputed both on pointer move and on Ctrl press/release so the cursor toggles without moving.
     var hoverPos by remember { mutableStateOf<TerminalPos?>(null) }
     var linkHover by remember { mutableStateOf(false) }
+    // File paths get no underline at rest — a directory listing would turn into a wall of lines —
+    // so the affordance appears only under the pointer while Ctrl is held, like an editor's go-to.
+    var hoveredPath by remember { mutableStateOf<HoveredPath?>(null) }
 
     // Mouse click counting for double (word) / triple (line) selection: tracks time and position of
     // the previous click; a repeat in the same cell within the threshold increments the count.
@@ -494,6 +504,23 @@ fun TerminalScreen(
         val row = state.screen.getOrNull(pos.row) ?: return false
         val uri = row.getOrNull(pos.col)?.hyperlink ?: linkAt(row, pos.col)
         return uri != null && isSafeLinkUri(uri)
+    }
+
+    // The file-path span under this cell, or null. Only consulted after [linkUnderPos] says no: a
+    // URL always wins, so a path is never offered where a link would open instead.
+    fun filePathUnderPos(pos: TerminalPos): TextLinkSpan? {
+        if (onOpenPath == null) return null
+        val row = state.screen.getOrNull(pos.row) ?: return null
+        return rowFilePathSpans(row).firstOrNull { pos.col >= it.start && pos.col < it.endExclusive }
+    }
+
+    // Recomputes both Ctrl+hover affordances (hand cursor, path underline) for [pos]. Called on
+    // pointer move and on Ctrl press/release, so the cursor toggles without moving the mouse.
+    fun updateHoverAffordance(pos: TerminalPos, ctrl: Boolean) {
+        val onLink = ctrl && linkUnderPos(pos)
+        val path = if (ctrl && !onLink) filePathUnderPos(pos) else null
+        hoveredPath = path?.let { HoveredPath(pos.row, it) }
+        linkHover = onLink || path != null
     }
 
     // Mouse report to the application by pointer coordinates. Pixels come from the same content
@@ -730,6 +757,18 @@ fun TerminalScreen(
                           drawCellUnderline(LINK_UNDERLINE_STYLE, runStart * cw, top, (k - runStart) * cw, chh, palette, underlineEffects, termTheme)
                       }
                   }
+                  // 6) The file path under Ctrl+hover — underlined only while pointed at (unlike URLs,
+                  // which are always underlined): every second line of a listing holds a path, and
+                  // marking them all would read as noise rather than as an affordance.
+                  hoveredPath?.takeIf { it.row == r }?.let { hover ->
+                      var k = hover.span.start
+                      while (k < hover.span.endExclusive && k < row.size) {
+                          if (row[k].style.underline) { k++; continue }
+                          val runStart = k
+                          while (k < hover.span.endExclusive && k < row.size && !row[k].style.underline) k++
+                          drawCellUnderline(LINK_UNDERLINE_STYLE, runStart * cw, top, (k - runStart) * cw, chh, palette, underlineEffects, termTheme)
+                      }
+                  }
               }
           }
       }
@@ -751,7 +790,7 @@ fun TerminalScreen(
             .onPreviewKeyEvent { event ->
                 // Toggle the link (hand) cursor as Ctrl is pressed/released without moving the mouse.
                 // Runs before the KeyDown guard so a Ctrl KeyUp also clears it. Never consumes the event.
-                hoverPos?.let { linkHover = event.isCtrlPressed && linkUnderPos(it) }
+                hoverPos?.let { updateHoverAffordance(it, event.isCtrlPressed) }
                 if (event.type != KeyEventType.KeyDown || closed) return@onPreviewKeyEvent false
                 if (isImeOwnedPrintable(imeInput, event.isCtrlPressed, event.isAltPressed, event.utf16CodePoint) &&
                     isSoftKeyboardEvent(event)
@@ -888,13 +927,13 @@ fun TerminalScreen(
                     while (true) {
                         val event = awaitPointerEvent()
                         when (event.type) {
-                            PointerEventType.Exit -> { hoverPos = null; linkHover = false }
+                            PointerEventType.Exit -> { hoverPos = null; linkHover = false; hoveredPath = null }
                             PointerEventType.Move, PointerEventType.Enter -> {
-                                if (event.buttons.areAnyPressed) { linkHover = false; continue }
+                                if (event.buttons.areAnyPressed) { linkHover = false; hoveredPath = null; continue }
                                 val change = event.changes.firstOrNull() ?: continue
                                 val pos = posAt(change.position.x, change.position.y)
                                 hoverPos = pos
-                                linkHover = event.keyboardModifiers.isCtrlPressed && linkUnderPos(pos)
+                                updateHoverAffordance(pos, event.keyboardModifiers.isCtrlPressed)
                             }
                             else -> {}
                         }
@@ -1017,6 +1056,15 @@ fun TerminalScreen(
                                 ?: cellRow?.let { linkAt(it, pos.col) }
                             if (uri != null && isSafeLinkUri(uri)) {
                                 runCatching { uriHandler.openUri(uri) }
+                                down.consume()
+                                return@awaitEachGesture
+                            }
+                            // No URL here: a bare file path opens in this session's file panel. The
+                            // path is server-controlled text, so it goes to the SFTP pane (which
+                            // only ever lists it), never to the platform URI handler.
+                            val path = filePathUnderPos(pos)
+                            if (path != null && onOpenPath != null) {
+                                onOpenPath(path.uri)
                                 down.consume()
                                 return@awaitEachGesture
                             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -319,6 +319,21 @@ private fun TerminalPane(state: DesktopDesignState, modifier: Modifier = Modifie
 private fun LiveTerminalPane(sessions: SessionsController, state: DesktopDesignState, modifier: Modifier = Modifier) {
     val active = sessions.active
     val st = active?.controller?.uiState
+    // Ctrl+click on a file path: switch this tab to its file panel and reveal the path there. Only
+    // the primary pane gets it — the SFTP view belongs to the tab's primary session, so the split
+    // pane's paths would land on the wrong host. Null when the setting is off (also kills the
+    // hover highlight) or there is no session to ask.
+    val openPath: ((String) -> Unit)? = remember(sessions, active?.id, state.openFilePathsInSftp, active?.controller?.supportsSftp) {
+        val controller = active?.controller
+        // No SFTP channel on Mosh/Telnet/serial/local/container sessions — offering the path there
+        // would only open a panel that can't list anything.
+        if (!state.openFilePathsInSftp || controller == null || !controller.supportsSftp) null
+        else ({ path: String ->
+            controller.requestReveal(path)
+            state.clearOverlay()
+            sessions.setActiveView(SessionView.Sftp)
+        })
+    }
     // A live or frozen screen sits on the terminal's own background; every notice (no session /
     // connecting / error) sits on the app background, so the empty terminal matches other sections.
     val onScreen = st is ConnectionUiState.Connected || st is ConnectionUiState.Disconnected
@@ -347,10 +362,12 @@ private fun LiveTerminalPane(sessions: SessionsController, state: DesktopDesignS
             // Form state on the active tab means an empty ("+") tab: connection not yet started.
             ConnectionUiState.Form -> TerminalNotice("terminal", stringResource(Res.string.term_notice_not_connected), stringResource(Res.string.term_notice_pick_or_new), action = launchLocalShell)
             ConnectionUiState.Connecting -> TerminalNotice("sync", stringResource(Res.string.term_connecting), active.subtitle)
-            is ConnectionUiState.Connected -> TerminalScreen(st.terminal, Modifier.fillMaxSize())
+            is ConnectionUiState.Connected -> TerminalScreen(st.terminal, Modifier.fillMaxSize(), onOpenPath = openPath)
             is ConnectionUiState.Error -> TerminalNotice("error", stringResource(Res.string.term_connection_failed), connectionErrorText(st), color = Skerry.colors.sunset)
             // Disconnected: screen is frozen at the moment of loss ([ConnectionUiState.Disconnected.terminal]),
             // shown under the disconnect banner so output isn't lost and status (reconnecting/gave up) stays visible.
+            // No path affordance here: the SFTP channel died with the session, so a click would only
+            // open a panel that can't list anything.
             is ConnectionUiState.Disconnected -> Box(Modifier.fillMaxSize()) {
                 TerminalScreen(st.terminal, Modifier.fillMaxSize())
                 DisconnectedBanner(st, Modifier.align(Alignment.TopCenter))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
@@ -23,6 +23,18 @@ import app.skerry.ui.theme.ThemeMode
 class DesktopDesignStateTest {
 
     @Test
+    fun toggleOpenFilePathsInSftp_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = DesktopDesignState(onOpenFilePathsInSftpChange = { seen += it })
+        assertEquals(true, s.openFilePathsInSftp) // on by default
+        s.toggleOpenFilePathsInSftp()
+        assertEquals(false, s.openFilePathsInSftp)
+        s.toggleOpenFilePathsInSftp()
+        assertEquals(true, s.openFilePathsInSftp)
+        assertEquals(listOf(false, true), seen)
+    }
+
+    @Test
     fun defaults_match_reference() {
         val s = DesktopDesignState()
         assertEquals(DesktopView.Terminal, s.view)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -46,6 +46,18 @@ class MobileDesignStateTest {
     }
 
     @Test
+    fun toggleOpenFilePathsInSftp_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onOpenFilePathsInSftpChange = { seen += it })
+        assertEquals(true, s.openFilePathsInSftp) // on by default
+        s.toggleOpenFilePathsInSftp()
+        assertEquals(false, s.openFilePathsInSftp)
+        s.toggleOpenFilePathsInSftp()
+        assertEquals(true, s.openFilePathsInSftp)
+        assertEquals(listOf(false, true), seen)
+    }
+
+    @Test
     fun toggleAllowServerClipboardWrite_flips_and_reports() {
         val seen = mutableListOf<Boolean>()
         val s = MobileDesignState(onAllowServerClipboardWriteChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -687,6 +687,45 @@ class ConnectionControllerTest {
         scope.cancel()
     }
 
+    @Test
+    fun `only an ssh session reports sftp support`() = runTest {
+        val (ssh, sshScope) = controllerWith(ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel())))))
+        assertFalse(ssh.supportsSftp) // nothing connected yet
+        ssh.connect(target, SshAuth.Password("pw"))
+        assertTrue(ssh.supportsSftp)
+        sshScope.cancel()
+
+        val (local, localScope) = controllerWith(ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel())))))
+        // Local shell / Mosh / Telnet / serial / container are stream-only: openSftp would throw.
+        local.connect(target.copy(connectionType = ConnectionType.LOCAL), SshAuth.Password(""))
+        assertFalse(local.supportsSftp)
+        localScope.cancel()
+    }
+
+    @Test
+    fun `a reveal request is delivered once`() = runTest {
+        val (controller, scope) = controllerWith(ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel())))))
+
+        assertNull(controller.takeRevealRequest())
+        controller.requestReveal("/var/log/syslog")
+        assertEquals("/var/log/syslog", controller.pendingRevealPath)
+        assertEquals("/var/log/syslog", controller.takeRevealRequest())
+        // Taken means gone: reopening the file view must not jump back to an old path.
+        assertNull(controller.takeRevealRequest())
+        assertNull(controller.pendingRevealPath)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a newer reveal request replaces a pending one`() = runTest {
+        val (controller, scope) = controllerWith(ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel())))))
+
+        controller.requestReveal("/etc/hosts")
+        controller.requestReveal("/var/log/syslog")
+        assertEquals("/var/log/syslog", controller.takeRevealRequest())
+        scope.cancel()
+    }
+
 }
 
 /**

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
@@ -847,4 +847,99 @@ class FilePaneControllerTest {
         advanceUntilIdle()
         assertTrue(c.selection.isEmpty())
     }
+
+    // --- revealPath: a path clicked in terminal output ---
+
+    @Test
+    fun `revealPath opens a directory`() = runTest {
+        val c = started(seededBrowserWithNested())
+        c.revealPath("$HOME/alpha")
+        advanceUntilIdle()
+        assertEquals("$HOME/alpha", c.path)
+        assertEquals(listOf("inside.txt"), c.loaded().entries.map { it.name })
+    }
+
+    @Test
+    fun `revealPath on a file opens its directory and puts the cursor on it`() = runTest {
+        val c = started(seededBrowserWithNested())
+        c.revealPath("$HOME/alpha/inside.txt")
+        advanceUntilIdle()
+        assertEquals("$HOME/alpha", c.path)
+        assertEquals("$HOME/alpha/inside.txt", c.cursoredItem()?.path)
+    }
+
+    @Test
+    fun `revealPath on a file in the current directory only moves the cursor`() = runTest {
+        val c = started()
+        c.revealPath("$HOME/readme.txt")
+        advanceUntilIdle()
+        assertEquals(HOME, c.path)
+        assertEquals("readme.txt", c.cursoredItem()?.name)
+    }
+
+    @Test
+    fun `revealPath expands a home-relative path`() = runTest {
+        val c = started(seededBrowserWithNested())
+        c.revealPath("~/alpha/inside.txt")
+        advanceUntilIdle()
+        assertEquals("$HOME/alpha", c.path)
+        assertEquals("inside.txt", c.cursoredItem()?.name)
+
+        c.revealPath("~")
+        advanceUntilIdle()
+        assertEquals(HOME, c.path)
+    }
+
+    @Test
+    fun `revealPath to a missing path surfaces Error and keeps the current directory`() = runTest {
+        val c = started()
+        c.revealPath("$HOME/nope/deeper")
+        advanceUntilIdle()
+        assertIs<FilePaneState.Error>(c.state)
+        assertEquals(HOME, c.path)
+    }
+
+    @Test
+    fun `revealPath ignores blank input`() = runTest {
+        val c = started()
+        c.revealPath("  ")
+        advanceUntilIdle()
+        assertEquals(HOME, c.path)
+        assertIs<FilePaneState.Loaded>(c.state)
+    }
+
+    @Test
+    fun `revealPath waits for the pane's first listing instead of being dropped`() = runTest {
+        // The click that produces a reveal is what opens the pane, so its start() listing is still
+        // in flight when the request lands. A dropped reveal is lost for good (the caller already
+        // handed the path over), which is why revealPath queues where other operations drop.
+        val fake = FakeSftpClient(startDir = HOME).apply {
+            seedDir("$HOME/alpha")
+            seedFile("$HOME/alpha/inside.txt")
+        }
+        val gate = CompletableDeferred<Unit>()
+        fake.listGate = gate
+        val c = controllerOn(SftpFileBrowser(fake, label = "prod-web-01"))
+        c.start()
+        advanceUntilIdle()
+
+        c.revealPath("$HOME/alpha")
+        advanceUntilIdle()
+        assertIs<FilePaneState.Loading>(c.state) // start() still hanging on its listing
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("$HOME/alpha", c.path)
+        assertEquals(listOf("inside.txt"), c.loaded().entries.map { it.name })
+    }
+
+    @Test
+    fun `revealPath clears a name filter hiding the target`() = runTest {
+        val c = started(seededBrowserWithNested())
+        c.setNameFilter("zeta")
+        c.revealPath("$HOME/readme.txt")
+        advanceUntilIdle()
+        assertEquals("", c.nameFilter)
+        assertEquals("readme.txt", c.cursoredItem()?.name)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -41,7 +41,11 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
         register(SftpEntry(nameOf(norm), norm, SftpEntryType.File, size, modifiedEpochSeconds, 0b110_100_100))
     }
 
+    /** When set, [list] blocks until it completes — lets a test hold a pane's load in flight. */
+    var listGate: CompletableDeferred<Unit>? = null
+
     override suspend fun list(path: String): List<SftpEntry> {
+        listGate?.await()
         val dir = children[realpathSync(path)] ?: throw SftpException("No directory $path")
         return dir.values.toList()
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalFilePathsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalFilePathsTest.kt
@@ -1,0 +1,210 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.CellWidth
+import app.skerry.shared.terminal.TermCell
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TerminalFilePathsTest {
+
+    private fun row(text: String): List<TermCell> = text.map { TermCell(it) }
+
+    // --- Detection in plain text ---
+
+    @Test
+    fun `detects an absolute path in surrounding text`() {
+        val text = "tail -f /var/log/syslog now"
+        val hit = detectFilePaths(text).single()
+        assertEquals("/var/log/syslog", hit.uri)
+        assertEquals("/var/log/syslog", text.substring(hit.start, hit.endExclusive))
+    }
+
+    @Test
+    fun `detects several paths on one line`() {
+        assertEquals(
+            listOf("/etc/hosts", "/tmp/out.txt"),
+            detectFilePaths("cp /etc/hosts /tmp/out.txt").map { it.uri },
+        )
+    }
+
+    @Test
+    fun `detects a home-relative path`() {
+        assertEquals("~/.ssh/config", detectFilePaths("edit ~/.ssh/config please").single().uri)
+        // A bare "~" is a real directory reference (home) and worth opening.
+        assertEquals("~", detectFilePaths("cd ~").single().uri)
+    }
+
+    @Test
+    fun `ignores relative paths without an anchor`() {
+        // No cwd tracking (no OSC 7), so a relative path cannot be resolved reliably — v1 skips it
+        // rather than opening the wrong directory.
+        assertTrue(detectFilePaths("open src/main/kotlin/App.kt").isEmpty())
+        assertTrue(detectFilePaths("run ./build.sh and ../other").isEmpty())
+    }
+
+    @Test
+    fun `ignores a lone slash and slash-only tokens`() {
+        assertTrue(detectFilePaths("a / b").isEmpty())
+        assertTrue(detectFilePaths("// comment").isEmpty())
+        assertTrue(detectFilePaths("/**").isEmpty())
+    }
+
+    @Test
+    fun `does not detect the path part of a url`() {
+        assertTrue(detectFilePaths("see https://skerry.app/docs/index.html").isEmpty())
+        assertTrue(detectFilePaths("ftp://files.example.com/pub/x").isEmpty())
+    }
+
+    @Test
+    fun `does not detect a path glued to a preceding word`() {
+        // Only a token boundary starts a path: "a=/b" is a shell assignment, "x/y/z" is relative.
+        assertTrue(detectFilePaths("HOST=/dev/null").isEmpty())
+        assertTrue(detectFilePaths("root:x:0:0::/root:/bin/bash").isEmpty())
+    }
+
+    @Test
+    fun `starts a path after an opening quote or bracket`() {
+        assertEquals("/etc/hosts", detectFilePaths("\"/etc/hosts\"").single().uri)
+        assertEquals("/etc/hosts", detectFilePaths("('/etc/hosts')").single().uri)
+    }
+
+    @Test
+    fun `trims trailing sentence punctuation`() {
+        assertEquals("/etc/hosts", detectFilePaths("look at /etc/hosts.").single().uri)
+        assertEquals("/etc/hosts", detectFilePaths("(see /etc/hosts)").single().uri)
+        assertEquals("/etc/hosts", detectFilePaths("'/etc/hosts',").single().uri)
+    }
+
+    @Test
+    fun `trims a compiler or grep line-number suffix`() {
+        assertEquals("/src/main.kt", detectFilePaths("/src/main.kt:42:7: error").single().uri)
+        assertEquals("/var/log/syslog", detectFilePaths("/var/log/syslog:15:oom killer").single().uri)
+    }
+
+    @Test
+    fun `keeps a colon that belongs to the file name`() {
+        // ':' is legal in a POSIX name and common in timestamped ones — only a real line marker is cut.
+        assertEquals(
+            "/backups/2026-07-26T03:00:00.tar.gz",
+            detectFilePaths("ls -l /backups/2026-07-26T03:00:00.tar.gz").single().uri,
+        )
+        // A name with a colon AND a trailing line marker: only the marker goes.
+        assertEquals("/a:2026.log", detectFilePaths("/a:2026.log:15: warning").single().uri)
+    }
+
+    @Test
+    fun `keeps a trailing slash of a directory path`() {
+        assertEquals("/var/log/", detectFilePaths("ls /var/log/").single().uri)
+    }
+
+    @Test
+    fun `rejects control characters inside a path`() {
+        val esc = 27.toChar()
+        assertTrue(detectFilePaths("/etc/${esc}hosts").isEmpty())
+    }
+
+    @Test
+    fun `rejects a path carrying invisible characters`() {
+        // A server could hide a bidi override or zero-width mark so the glyphs read as one directory
+        // while the string handed to SFTP is another.
+        assertTrue(detectFilePaths("/etc/\u202Ehosts").isEmpty())
+        assertTrue(detectFilePaths("/etc/\u200Bhosts").isEmpty())
+        assertNull(filePathFromSelection("/var/\u2066log"))
+    }
+
+    @Test
+    fun `rejects an implausibly long path`() {
+        assertTrue(detectFilePaths("/" + "a".repeat(5000)).isEmpty())
+    }
+
+    // --- Real output lines: what the detector must and must not offer ---
+
+    @Test
+    fun `ls -l offers only the entry name column when it is absolute`() {
+        // A plain listing has no absolute paths at all — nothing should light up.
+        assertTrue(detectFilePaths("-rw-r--r--  1 root root  1.2K Jul 26 09:12 nginx.conf").isEmpty())
+        // `ls -l /etc/nginx/` prints the directory as a header line: that one is a real path.
+        assertEquals("/etc/nginx/", detectFilePaths("/etc/nginx/:").single().uri)
+    }
+
+    @Test
+    fun `systemd and log lines offer the unit path but not the timestamp`() {
+        val line = "Jul 26 09:12:01 host nginx[123]: config /etc/nginx/nginx.conf test failed"
+        assertEquals(listOf("/etc/nginx/nginx.conf"), detectFilePaths(line).map { it.uri })
+    }
+
+    @Test
+    fun `a json body does not turn into paths`() {
+        // Quoted values start at a token boundary, so they are offered; a URL inside is not.
+        val line = """{"log": "https://a.test/x", "ratio": 3/4, "at": "2026/07/26"}"""
+        assertTrue(detectFilePaths(line).isEmpty())
+    }
+
+    @Test
+    fun `a quoted absolute path inside json is offered without the quote`() {
+        assertEquals("/var/lib/app.db", detectFilePaths("""{"db": "/var/lib/app.db"}""").single().uri)
+    }
+
+    // --- Grid mapping and hit testing ---
+
+    @Test
+    fun `maps a path onto its grid columns`() {
+        val cells = row("x /etc/hosts y")
+        val span = rowFilePathSpans(cells).single()
+        assertEquals(2, span.start)
+        assertEquals(2 + "/etc/hosts".length, span.endExclusive)
+        assertEquals("/etc/hosts", span.uri)
+    }
+
+    @Test
+    fun `filePathAt returns the path only under its columns`() {
+        val cells = row("cat /etc/hosts")
+        assertNull(filePathAt(cells, 0))
+        assertEquals("/etc/hosts", filePathAt(cells, 4))
+        assertEquals("/etc/hosts", filePathAt(cells, cells.lastIndex))
+    }
+
+    @Test
+    fun `wide cells shift columns so mapping still lands on the path`() {
+        val cells = buildList {
+            add(TermCell("世", width = CellWidth.Wide))
+            add(TermCell("", width = CellWidth.Continuation))
+            add(TermCell(' '))
+            "/etc/hosts".forEach { add(TermCell(it)) }
+        }
+        val span = rowFilePathSpans(cells).single()
+        assertEquals(3, span.start)
+        assertEquals("/etc/hosts", filePathAt(cells, 3))
+    }
+
+    @Test
+    fun `rows without a slash yield no spans`() {
+        assertTrue(rowFilePathSpans(row("total 42  drwxr-xr-x root root")).isEmpty())
+    }
+
+    @Test
+    fun `a cell already carrying an osc8 hyperlink is not offered as a path`() {
+        // OSC 8 wins at the click layer; reporting a path there too would underline the same cells twice.
+        val cells = "/etc/hosts".map { TermCell(it.toString(), hyperlink = "https://a.test") }
+        assertTrue(rowFilePathSpans(cells).isEmpty())
+    }
+
+    // --- Selection (touch path) ---
+
+    @Test
+    fun `selection that is exactly one path is offered`() {
+        assertEquals("/var/log/syslog", filePathFromSelection("/var/log/syslog"))
+        assertEquals("/var/log/syslog", filePathFromSelection("  /var/log/syslog \n"))
+        assertEquals("~/.ssh/config", filePathFromSelection("~/.ssh/config"))
+    }
+
+    @Test
+    fun `selection with extra words or no path is not offered`() {
+        assertNull(filePathFromSelection("tail -f /var/log/syslog"))
+        assertNull(filePathFromSelection("just text"))
+        assertNull(filePathFromSelection(null))
+        assertNull(filePathFromSelection(""))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -484,6 +484,8 @@ fun main(args: Array<String>) {
                     onHostClickConnectModeChange = { prefs.set("host_click_connect", it.id) },
                     initialAllowServerClipboardWrite = prefs.bool("terminal_clipboard_write", false),
                     onAllowServerClipboardWriteChange = { prefs.set("terminal_clipboard_write", it) },
+                    initialOpenFilePathsInSftp = prefs.bool("terminal_open_paths", true),
+                    onOpenFilePathsInSftpChange = { prefs.set("terminal_open_paths", it) },
                     initialConfirmProductionWarnings = prefs.bool("terminal_prod_warnings", false),
                     onConfirmProductionWarningsChange = { prefs.set("terminal_prod_warnings", it) },
                     initialAutoLock = prefs.id("auto_lock", AutoLockDuration.DEFAULT, AutoLockDuration::fromId),


### PR DESCRIPTION
A file path printed in terminal output can be opened in the session's file panel.

**Where**
- Desktop: Ctrl+click a path. Holding Ctrl underlines the path under the pointer (paths are not underlined at rest — a listing would turn into a wall of lines).
- Android: long-press a path to select it, then tap the "Open in Files" row above the key panel.
- Setting: Terminal → "Open file paths in SFTP" (Settings on desktop, More on Android), on by default. Off also removes the highlight. Listed in Settings → Keyboard as Ctrl+click.

**Behavior**
- A directory is opened; anything else is shown inside its parent with the cursor on it.
- `~` / `~/…` is expanded against the session's start directory. Relative paths (`./x`, `src/App.kt`) are not detected: without cwd tracking they would open the wrong directory.
- Detection is deliberately narrow — a path starts only at a token boundary, so URL bodies (`https://host/docs`), shell assignments (`HOST=/dev/null`) and `/etc/passwd`-style records are not offered. A `:line[:col]` marker from grep/compiler output is cut, but a colon that belongs to the name (`2026-07-26T03:00:00.tar.gz`) is kept. Control and invisible characters (bidi/zero-width) disqualify a path.
- An OSC 8 hyperlink always wins over a path on the same cells.
- The affordance is hidden for sessions with no SFTP channel (Mosh, Telnet, serial, local shell, container exec) and for the split pane, whose SFTP view belongs to the primary session.

**Also in this PR**
- `FilePaneController.revealPath` queues behind an in-flight listing instead of being dropped, so a click that itself opens the panel is not lost.
- Row-text helpers shared by the URL and path detectors extracted into `TerminalRowText.kt`.
- `FakeSftpClient.listGate` test seam for holding a listing in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)