### PR TITLE
Give remote desktops their own section

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- Левый icon-rail desktop-оболочки: подписи пунктов. -->
     <string name="rail_terminal">Терминал</string>
+    <string name="rail_desktops">Удалённые рабочие столы</string>
     <string name="rail_tunnels">Туннели</string>
     <string name="rail_snippets">Сниппеты</string>
     <string name="rail_vault">Хранилище</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -106,4 +106,6 @@
     <string name="shell_tip_play">Воспроизвести запись</string>
     <string name="shell_tip_info">Сведения о сессии</string>
     <string name="shell_tip_disconnect">Отключить</string>
+    <string name="shell_no_hosts_yet">Пока нет хостов</string>
+    <string name="shell_add_first_host">Добавьте подключение, и оно появится здесь.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -13,4 +13,15 @@
     <string name="vnc_view_only">Только просмотр</string>
     <string name="vnc_resize_to_window">Подгонять под окно</string>
     <string name="vnc_reset_zoom">Сбросить масштаб</string>
+    <string name="rd_section">РАБОЧИЕ СТОЛЫ</string>
+    <string name="rd_search_placeholder">Поиск столов, тегов, IP…</string>
+    <string name="rd_no_session">Нет открытого рабочего стола</string>
+    <string name="rd_pick_to_connect">Выберите подключение в боковой панели, чтобы открыть рабочий стол.</string>
+    <string name="rd_no_desktops">Пока нет удалённых рабочих столов</string>
+    <string name="rd_add_first">Добавьте VNC-подключение, и оно появится здесь.</string>
+    <string name="conn_title_new_desktop">Новый рабочий стол</string>
+    <string name="conn_title_edit_desktop">Изменение рабочего стола</string>
+    <string name="conn_subtitle_new_desktop">Добавьте удалённый рабочий стол. Пароль шифруется мастер-паролем.</string>
+    <string name="nav_tab_desktops">Столы</string>
+    <string name="rd_screen_title">Рабочие столы</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -40,6 +40,7 @@
 
     <!-- 桌面端左侧图标栏 -->
     <string name="rail_terminal">终端</string>
+    <string name="rail_desktops">远程桌面</string>
     <string name="rail_tunnels">隧道</string>
     <string name="rail_snippets">片段</string>
     <string name="rail_vault">保险库</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -106,4 +106,6 @@
     <string name="shell_tip_play">播放录制</string>
     <string name="shell_tip_info">会话详情</string>
     <string name="shell_tip_disconnect">断开连接</string>
+    <string name="shell_no_hosts_yet">还没有主机</string>
+    <string name="shell_add_first_host">添加连接后会显示在这里。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -13,4 +13,15 @@
     <string name="vnc_view_only">仅查看</string>
     <string name="vnc_resize_to_window">调整为窗口大小</string>
     <string name="vnc_reset_zoom">重置缩放</string>
+    <string name="rd_section">桌面</string>
+    <string name="rd_search_placeholder">搜索桌面、标签、IP…</string>
+    <string name="rd_no_session">没有打开的远程桌面</string>
+    <string name="rd_pick_to_connect">在侧栏中选择一个连接以打开其桌面。</string>
+    <string name="rd_no_desktops">还没有远程桌面</string>
+    <string name="rd_add_first">添加 VNC 连接后会显示在这里。</string>
+    <string name="conn_title_new_desktop">新建远程桌面</string>
+    <string name="conn_title_edit_desktop">编辑远程桌面</string>
+    <string name="conn_subtitle_new_desktop">添加远程桌面。其密码将使用主密码加密。</string>
+    <string name="nav_tab_desktops">桌面</string>
+    <string name="rd_screen_title">远程桌面</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,6 +41,7 @@
 
     <!-- Левый icon-rail desktop-оболочки: подписи пунктов. -->
     <string name="rail_terminal">Terminal</string>
+    <string name="rail_desktops">Remote desktops</string>
     <string name="rail_tunnels">Tunnels</string>
     <string name="rail_snippets">Snippets</string>
     <string name="rail_vault">Vault</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -106,4 +106,6 @@
     <string name="shell_tip_play">Play recording</string>
     <string name="shell_tip_info">Session details</string>
     <string name="shell_tip_disconnect">Disconnect</string>
+    <string name="shell_no_hosts_yet">No hosts yet</string>
+    <string name="shell_add_first_host">Add a connection to see it here.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -13,4 +13,15 @@
     <string name="vnc_view_only">View only</string>
     <string name="vnc_resize_to_window">Resize to window</string>
     <string name="vnc_reset_zoom">Reset zoom</string>
+    <string name="rd_section">DESKTOPS</string>
+    <string name="rd_search_placeholder">Search desktops, tags, IPs…</string>
+    <string name="rd_no_session">No remote desktop open</string>
+    <string name="rd_pick_to_connect">Pick a connection from the sidebar to open its desktop.</string>
+    <string name="rd_no_desktops">No remote desktops yet</string>
+    <string name="rd_add_first">Add a VNC connection to see it here.</string>
+    <string name="conn_title_new_desktop">New remote desktop</string>
+    <string name="conn_title_edit_desktop">Edit remote desktop</string>
+    <string name="conn_subtitle_new_desktop">Add a remote desktop. Its password is encrypted with your master password.</string>
+    <string name="nav_tab_desktops">Desktops</string>
+    <string name="rd_screen_title">Remote desktops</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -5,10 +5,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.host.Host
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.section
 import app.skerry.ui.i18n.UiLanguage
 import app.skerry.ui.settings.SETTINGS_NAV
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.ui.session.BroadcastController
+import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.snippet.SnippetLibraryState
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
@@ -60,6 +63,15 @@ fun SessionView.asDesktopView(): DesktopView = when (this) {
     SessionView.Vnc -> DesktopView.Terminal
     SessionView.Player -> DesktopView.Terminal
 }
+
+/**
+ * Work-area section a session tab belongs to: a remote-desktop tab ([Session.isVnc]) renders in the
+ * remote-desktop section, everything else (shells, SFTP, recording player) in the terminal one.
+ * Activating a tab moves the shell to its section, so the rail, the sidebar and the work area never
+ * disagree about what is on screen.
+ */
+fun sectionOf(session: Session?): HostSection =
+    if (session?.isVnc == true) HostSection.RemoteDesktops else HostSection.Terminal
 
 /** Settings panel tabs. */
 enum class SettingsTab { AI, Sync, Security, Appearance, Terminal, Keyboard, Trash, About }
@@ -257,11 +269,11 @@ class DesktopDesignState(
     var sidebarHidden: Boolean by mutableStateOf(false); private set
 
     /**
-     * Whether the VNC view's slide-over host drawer is open. Separate from [sidebarHidden]: the VNC
-     * framebuffer wants the full work area, so its drawer overlays the render and defaults to closed
-     * instead of reserving layout space like the terminal sidebar.
+     * Which catalog the work area is showing: terminal-style connections or remote desktops (the
+     * rail's two session-level items). Each section has its own host sidebar, its own "New
+     * connection" form and its own session tabs; [appOverlay] renders over whichever is selected.
      */
-    var vncSidebar: Boolean by mutableStateOf(false); private set
+    var section: HostSection by mutableStateOf(HostSection.Terminal); private set
     var infoPanel: Boolean by mutableStateOf(initialInfoPanel); private set
 
     /**
@@ -376,6 +388,9 @@ class DesktopDesignState(
     /** Host open in the modal for editing (null means the modal is in "New connection" mode). */
     var editingHost: Host? by mutableStateOf(null); private set
 
+    /** Which section's protocols the open connection form offers (see [openModal]). */
+    var modalSection: HostSection by mutableStateOf(HostSection.Terminal); private set
+
     /** Host the modal is prefilled from as a copy ("Duplicate"); saving creates a new profile. */
     var duplicatingHost: Host? by mutableStateOf(null); private set
 
@@ -431,6 +446,18 @@ class DesktopDesignState(
      * is only a mock/preview fallback and must not be overwritten when navigating with live sessions.
      */
     fun clearOverlay() { appOverlay = null }
+
+    /**
+     * Open a work-area section from the rail (terminal / remote desktops). Clears the app overlay —
+     * the click asks for the work area, which an open Vault/Teams section would otherwise hide. The
+     * session sub-view ([view]) is left alone, so returning to the terminal lands on the SFTP panel
+     * if that is where the user was. Activating the section's newest tab is the caller's job (it
+     * holds the session manager), see [app.skerry.ui.desktop.openRailSection].
+     */
+    fun showSection(s: HostSection) {
+        appOverlay = null
+        section = s
+    }
     fun selectHost(name: String) { selectedHost = name }
     fun onHostSearch(value: String) { hostSearchQuery = value }
     fun setTab(i: Int) { if (i in tabs.indices) activeTab = i }
@@ -451,9 +478,22 @@ class DesktopDesignState(
 
     fun lock() { locked = true; hostSearchQuery = "" }
     fun unlock() { locked = false }
-    fun openModal() { editingHost = null; duplicatingHost = null; modalOpen = true }
-    fun openEditModal(host: Host) { editingHost = host; duplicatingHost = null; modalOpen = true }
-    fun openDuplicateModal(host: Host) { editingHost = null; duplicatingHost = host; modalOpen = true }
+    /**
+     * Open the connection form for [section]: it offers only that section's protocols and starts on
+     * its default one, so the list a profile is created from decides what kind of profile it is.
+     */
+    fun openModal(section: HostSection = HostSection.Terminal) {
+        editingHost = null; duplicatingHost = null; modalSection = section; modalOpen = true
+    }
+
+    // Editing/duplicating follows the profile itself: its transport already says which section it
+    // belongs to, whichever list the action was invoked from.
+    fun openEditModal(host: Host) {
+        editingHost = host; duplicatingHost = null; modalSection = host.section; modalOpen = true
+    }
+    fun openDuplicateModal(host: Host) {
+        editingHost = null; duplicatingHost = host; modalSection = host.section; modalOpen = true
+    }
     fun closeModal() { modalOpen = false; editingHost = null; duplicatingHost = null }
     fun beginSshImport(result: app.skerry.shared.ssh.SshConfigParseResult) { sshImport = result }
     fun closeSshImport() { sshImport = null }
@@ -489,7 +529,6 @@ class DesktopDesignState(
     fun showSettingsTab(t: SettingsTab) { settingsTab = t }
     fun toggleSplit() { split = !split }
     fun toggleSidebar() { sidebarHidden = !sidebarHidden }
-    fun toggleVncSidebar() { vncSidebar = !vncSidebar }
     fun toggleInfo() { infoPanel = !infoPanel; onInfoPanelChange(infoPanel) }
 
     // Signal to focus the AI bar's input (hotkey Cmd// Ctrl+Shift+/). SharedFlow rather than a counter

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -5,6 +5,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.host.Host
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.section
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
@@ -27,23 +29,28 @@ import app.skerry.ui.terminal.TerminalThemes
 
 /**
  * Bottom navigation — exactly 4 root tabs ([showTabs]=true). [icon] is a Material Symbols ligature
- * (see [Sym]), aligned with the desktop rail ([RAIL]) where the section matches (Snippets/Vault).
+ * (see [Sym]), aligned with the desktop rail ([RAIL]) where the section matches (Hosts/Desktops/Vault).
  * No Files tab: SFTP opens as a push screen ([MobileRoute.Files]) from a host card's SFTP button —
  * a separate root tab would duplicate the terminal.
+ *
+ * Snippets is not a root tab either: the bar holds four, and the two catalogs (hosts and remote
+ * desktops) come first — the library is reached from More ([MobileRoute.Snippets]) and, in the
+ * moment it is actually needed, from the terminal's snippet palette.
  */
 // Labels are not part of the enum: they are localized in the tab bar (nav_tab_* resources).
 enum class MobileTab(val icon: String) {
     Hosts("dns"),
-    Snippets("code_blocks"),
+    Desktops("desktop_windows"),
     Vault("vpn_key"),
     More("more_horiz"),
 }
 
 /**
  * Full-screen push screens over the tab navigation (tab bar hidden): terminal and host detail open
- * from Hosts, SFTP (Files) via the host card's SFTP button, and Ports/Known/Team from the More tab.
+ * from Hosts, the framebuffer from Desktops, SFTP (Files) via the host card's SFTP button, and
+ * Snippets/Ports/Known/Team from the More tab.
  */
-enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
+enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Snippets, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
 
 /** What the system back gesture should do in the mobile shell. */
 enum class MobileBackAction {
@@ -135,6 +142,9 @@ class MobileDesignState(
     private val onTerminalCursorStyleChange: (TerminalCursorStyle) -> Unit = {},
 ) {
     var tab: MobileTab by mutableStateOf(MobileTab.Hosts); private set
+
+    /** Which section's protocols the open New connection sheet offers (see [openNewConn]). */
+    var sheetSection: HostSection by mutableStateOf(HostSection.Terminal); private set
     var route: MobileRoute? by mutableStateOf(null); private set
     var sheetNewConn: Boolean by mutableStateOf(false); private set
 
@@ -274,14 +284,24 @@ class MobileDesignState(
         }
     }
 
-    /** Open the sheet in create-new-host mode (empty form). */
-    fun openNewConn() { editingHost = null; duplicatingHost = null; sheetNewConn = true }
+    /**
+     * Open the sheet in create-new-host mode (empty form) for [section]: it offers only that
+     * section's protocols and starts on its default one — desktop parity, see
+     * [app.skerry.ui.app.DesktopDesignState.openModal].
+     */
+    fun openNewConn(section: HostSection = HostSection.Terminal) {
+        editingHost = null; duplicatingHost = null; sheetSection = section; sheetNewConn = true
+    }
 
     /** Open the sheet in edit mode for [host] (form prefilled, save keeps its id). */
-    fun openEditConn(host: Host) { editingHost = host; duplicatingHost = null; sheetNewConn = true }
+    fun openEditConn(host: Host) {
+        editingHost = host; duplicatingHost = null; sheetSection = host.section; sheetNewConn = true
+    }
 
     /** Open the sheet prefilled as a copy of [host] (save creates a new profile). */
-    fun openDuplicateConn(host: Host) { editingHost = null; duplicatingHost = host; sheetNewConn = true }
+    fun openDuplicateConn(host: Host) {
+        editingHost = null; duplicatingHost = host; sheetSection = host.section; sheetNewConn = true
+    }
 
     fun closeSheet() { sheetNewConn = false; editingHost = null; duplicatingHost = null }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -1,10 +1,5 @@
 package app.skerry.ui.desktop
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -218,6 +213,7 @@ import app.skerry.ui.design.rememberUiFont
 import app.skerry.ui.session.sessionDotColor
 import app.skerry.ui.session.tabBoundsAnchor
 import app.skerry.ui.app.asDesktopView
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.session.draggableTab
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.host.isProdHostId
@@ -648,11 +644,13 @@ private fun DesktopChrome(
                     // "ask every time" (no bound secret) prompts for one first. No ProxyJump/host-key path.
                     val cred = credentials?.find(host.credentialId)
                     if (cred != null) {
+                        state.recordRecentHost(host.id)
                         sessions?.openVnc(
                             host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
                             remoteResize = host.vncResizeToWindow,
                             onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
                         )
+                        state.showSection(HostSection.RemoteDesktops)
                     } else {
                         pendingVncHost = host
                     }
@@ -828,11 +826,13 @@ private fun DesktopChrome(
                     onConnect = { pw ->
                         pendingVncHost = null
                         val auth = if (pw.isEmpty()) app.skerry.shared.vnc.VncAuth.None else app.skerry.shared.vnc.VncAuth.Password(pw)
+                        state.recordRecentHost(host.id)
                         sessions?.openVnc(
                             host.id, host.label, host.connectionSubtitle(), host.toTarget(), auth,
                             remoteResize = host.vncResizeToWindow,
                             onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
                         )
+                        state.showSection(HostSection.RemoteDesktops)
                     },
                 )
             }
@@ -897,7 +897,7 @@ private fun DesktopChrome(
                         title = stringResource(Res.string.shell_disconnect_title, name),
                         message = stringResource(Res.string.shell_disconnect_message),
                         confirmLabel = stringResource(Res.string.shell_disconnect),
-                        onConfirm = { sessions?.close(pc.id); state.dismissClose() },
+                        onConfirm = { closeSessionTab(state, sessions, pc.id); state.dismissClose() },
                         onDismiss = state::dismissClose,
                     )
                 }
@@ -971,7 +971,9 @@ private fun runDesktopShortcut(
         is DesktopShortcut.SelectTab -> return selectTabByIndex(shortcut.index, state, sessions)
         DesktopShortcut.NextTab -> return cycleTab(+1, state, sessions)
         DesktopShortcut.PrevTab -> return cycleTab(-1, state, sessions)
-        DesktopShortcut.NewConnection -> state.openModal()
+        // Opens the form of the section on screen: pressed over the desktops list it creates a
+        // remote desktop, over the hosts list a shell.
+        DesktopShortcut.NewConnection -> state.openModal(state.section)
         DesktopShortcut.SplitTerminal -> if (sessions != null) sessions.toggleSplit() else state.toggleSplit()
         DesktopShortcut.OpenSftp -> if (sessions != null) {
             state.clearOverlay(); sessions.setActiveView(SessionView.Sftp)
@@ -1024,6 +1026,8 @@ internal fun selectTabByIndex(index: Int, state: DesktopDesignState, sessions: S
     if (sessions != null) {
         val target = sessions.sessions.getOrNull(index) ?: return false
         sessions.activate(target.id)
+        // A tab hotkey can cross sections (Alt+3 onto a remote desktop): the work area follows.
+        followActiveTabSection(state, sessions)
         return true
     }
     if (index !in state.tabs.indices) return false
@@ -1039,6 +1043,7 @@ internal fun cycleTab(delta: Int, state: DesktopDesignState, sessions: SessionsC
         val current = list.indexOfFirst { it.id == sessions.activeId }.coerceAtLeast(0)
         val next = ((current + delta) % list.size + list.size) % list.size
         sessions.activate(list[next].id)
+        followActiveTabSection(state, sessions)
         return true
     }
     val count = state.tabs.size
@@ -1071,9 +1076,9 @@ private fun openHostSession(
         auth = auth,
         onConnected = onConnected,
     )
-    // Live mode: the sub-view is held by the tab itself — just clear the overlay to show its terminal.
-    // Mock/preview (no sessions): fall back to Terminal via showView.
-    if (sessions != null) state.clearOverlay() else state.showView(DesktopView.Terminal)
+    // Live mode: the sub-view is held by the tab itself — showing the terminal section reveals it
+    // (and clears any app overlay). Mock/preview (no sessions): fall back to Terminal via showView.
+    if (sessions != null) state.showSection(HostSection.Terminal) else state.showView(DesktopView.Terminal)
 }
 
 /**
@@ -1157,8 +1162,10 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                         accent = if (s.isPlayer || prodTab) Skerry.colors.sunset else Skerry.colors.cyan,
                         split = s.splitOpen,
                         active = s.id == sessions.activeId,
-                        onClick = { sessions.activate(s.id) },
-                        onClose = { tabDrag.tabClosed(s.id); sessions.close(s.id) },
+                        // Chips of both sections share one row, so selecting one also moves the work
+                        // area to the section that tab belongs to.
+                        onClick = { sessions.activate(s.id); followActiveTabSection(state, sessions) },
+                        onClose = { tabDrag.tabClosed(s.id); closeSessionTab(state, sessions, s.id) },
                         dragging = tabDrag.draggingTabId == s.id,
                         modifier = Modifier
                             .tabBoundsAnchor(tabDrag, s.id)
@@ -1179,10 +1186,10 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                 "add",
                 onClick = {
                     if (sessions != null) {
-                        // A new blank tab starts on the Terminal sub-view (Session.view's default);
-                        // clear the overlay to show its terminal placeholder.
+                        // A new blank tab starts on the Terminal sub-view (Session.view's default),
+                        // so the work area moves to the terminal section to show its placeholder.
                         sessions.openBlank(newTabTitle)
-                        state.clearOverlay()
+                        state.showSection(HostSection.Terminal)
                     } else {
                         state.openModal()
                     }
@@ -1330,9 +1337,6 @@ private fun TabInsertLine() {
 @Composable
 private fun IconRail(state: DesktopDesignState) {
     val sessions = LocalSessions.current
-    // Current session-level item to highlight: the active tab's subview (live mode) or the mock fallback
-    // [state.view]. Under an open app overlay, session items aren't highlighted.
-    val currentSessionView = sessions?.active?.view?.asDesktopView() ?: state.view
     Column(
         Modifier
             .width(52.dp)
@@ -1342,33 +1346,19 @@ private fun IconRail(state: DesktopDesignState) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
-        // The terminal's hosts-sidebar collapse now lives in the sidebar header itself (a chevron
-        // next to search), so the rail no longer carries it. Only VNC keeps a rail toggle: its
-        // framebuffer view has no header to host one, and the host drawer overlays the framebuffer.
-        // It fades and collapses to zero height so entering and leaving VNC doesn't jolt the icons.
-        val showVncDrawerToggle = state.appOverlay == null && sessions?.active?.view == SessionView.Vnc
-        AnimatedVisibility(
-            visible = showVncDrawerToggle,
-            enter = fadeIn() + expandVertically(),
-            exit = fadeOut() + shrinkVertically(),
-        ) {
-            SidebarToggle(hidden = !state.vncSidebar, onToggle = state::toggleVncSidebar)
-        }
+        // No sidebar toggle here: both work-area sections carry their collapse chevron in the
+        // sidebar header itself (next to search).
         RAIL.forEach { item ->
-            val active = if (state.appOverlay != null) item.view == state.appOverlay
-            else item.view == currentSessionView
             RailButton(
                 icon = item.icon,
                 label = stringResource(item.label),
-                active = active,
+                active = railItemActive(item, state),
                 onClick = {
-                    // App-level (Vault/Known/Teams/Snippets) → overlay. Session-level: in live mode edits
-                    // only the active tab's subview (source of truth) + clears the overlay, without
-                    // touching the mock fallback state.view; with no sessions — the mock path via showView.
-                    when {
-                        item.view.isAppLevel -> state.showView(item.view)
-                        sessions != null -> { state.clearOverlay(); sessions.setActiveView(item.view.asSessionView()) }
-                        else -> state.showView(item.view)
+                    when (val target = item.target) {
+                        // App-level (Vault/Known/Teams/Tunnels/Snippets) → overlay over the tabs.
+                        is RailTarget.View -> state.showView(target.view)
+                        // Work-area section: switch the shell and land on that section's newest tab.
+                        is RailTarget.Section -> openRailSection(state, sessions, target.section)
                     }
                 },
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Rail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Rail.kt
@@ -1,7 +1,12 @@
 package app.skerry.ui.desktop
 
+import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
+import app.skerry.ui.app.sectionOf
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.session.SessionsController
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rail_desktops
 import app.skerry.ui.generated.resources.rail_hosts
 import app.skerry.ui.generated.resources.rail_snippets
 import app.skerry.ui.generated.resources.rail_team
@@ -10,16 +15,70 @@ import app.skerry.ui.generated.resources.rail_tunnels
 import app.skerry.ui.generated.resources.rail_vault
 import org.jetbrains.compose.resources.StringResource
 
+/**
+ * What a rail button opens: a work-area section (its own host catalog and session tabs) or an
+ * app-level section rendered over the tabs ([DesktopView.isAppLevel]).
+ */
+sealed interface RailTarget {
+    /** Terminal-style connections or remote desktops — see [HostSection]. */
+    data class Section(val section: HostSection) : RailTarget
+
+    /** Vault/Known hosts/Teams/Tunnels/Snippets: shared sections that open over the tabs. */
+    data class View(val view: DesktopView) : RailTarget
+}
+
 /** Item of the desktop shell's left icon rail. Label is a resource, localized to the UI language. */
-data class RailItem(val view: DesktopView, val icon: String, val label: StringResource)
+data class RailItem(val target: RailTarget, val icon: String, val label: StringResource)
 
 // Files is intentionally absent from the rail: SFTP opens via a quick button (folder icon) on the
 // active session's terminal; a separate rail item would duplicate it. [DesktopView.Sftp] stays a session view.
 val RAIL = listOf(
-    RailItem(DesktopView.Terminal, "terminal", Res.string.rail_terminal),
-    RailItem(DesktopView.Ports, "lan", Res.string.rail_tunnels),
-    RailItem(DesktopView.Snippets, "code_blocks", Res.string.rail_snippets),
-    RailItem(DesktopView.Vault, "vpn_key", Res.string.rail_vault),
-    RailItem(DesktopView.Known, "fingerprint", Res.string.rail_hosts),
-    RailItem(DesktopView.Teams, "groups", Res.string.rail_team),
+    RailItem(RailTarget.Section(HostSection.Terminal), "terminal", Res.string.rail_terminal),
+    RailItem(RailTarget.Section(HostSection.RemoteDesktops), "desktop_windows", Res.string.rail_desktops),
+    RailItem(RailTarget.View(DesktopView.Ports), "lan", Res.string.rail_tunnels),
+    RailItem(RailTarget.View(DesktopView.Snippets), "code_blocks", Res.string.rail_snippets),
+    RailItem(RailTarget.View(DesktopView.Vault), "vpn_key", Res.string.rail_vault),
+    RailItem(RailTarget.View(DesktopView.Known), "fingerprint", Res.string.rail_hosts),
+    RailItem(RailTarget.View(DesktopView.Teams), "groups", Res.string.rail_team),
 )
+
+/**
+ * Whether [item] is the one currently on screen: an app-level section is active while its overlay
+ * is up, a work-area section only once no overlay hides it.
+ */
+fun railItemActive(item: RailItem, state: DesktopDesignState): Boolean = when (val t = item.target) {
+    is RailTarget.View -> state.appOverlay == t.view
+    is RailTarget.Section -> state.appOverlay == null && state.section == t.section
+}
+
+/**
+ * Open a work-area section from the rail: switch the shell to it and activate that section's newest
+ * tab, so returning to a section lands back on its live session instead of an empty work area. With
+ * no tab of that section the active tab is left alone — the work area shows the section's empty
+ * state, and the other section's tab stays selected for when the user switches back.
+ */
+fun openRailSection(state: DesktopDesignState, sessions: SessionsController?, section: HostSection) {
+    state.showSection(section)
+    sessions?.lastSessionIn(remoteDesktop = section == HostSection.RemoteDesktops)
+        ?.let { sessions.activate(it.id) }
+}
+
+/**
+ * Follow a tab selection (chip click, tab hotkey, a session opening): the work area moves to the
+ * section the now-active tab belongs to, so clicking a remote-desktop chip shows the framebuffer
+ * rather than leaving the terminal on screen.
+ */
+fun followActiveTabSection(state: DesktopDesignState, sessions: SessionsController?) {
+    state.showSection(sectionOf(sessions?.active))
+}
+
+/**
+ * Close tab [id] and follow whatever tab becomes active. Every close path goes through here (chip
+ * "×", the disconnect confirmation): closing hands the selection to a neighbour, which may belong
+ * to the other section, and a close that forgot to follow would leave the rail, the tab row and
+ * the work area pointing at three different things.
+ */
+fun closeSessionTab(state: DesktopDesignState, sessions: SessionsController?, id: String) {
+    sessions?.close(id)
+    followActiveTabSection(state, sessions)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.known.KnownHostsView
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.sftp.SftpView
@@ -13,12 +14,14 @@ import app.skerry.ui.terminal.CastPlayerView
 import app.skerry.ui.terminal.TerminalView
 import app.skerry.ui.tunnel.TunnelsView
 import app.skerry.ui.vault.VaultView
-import app.skerry.ui.vnc.VncView
+import app.skerry.ui.vnc.RemoteDesktopsView
 import app.skerry.ui.app.asSessionView
 
 /**
- * Switches the main content area. App-level views (Vault/Known/Teams/Snippets) render over tabs
- * per [DesktopDesignState.appOverlay]; otherwise renders the active tab's subview
+ * Switches the main content area. App-level views (Vault/Known/Teams/Snippets) render over
+ * everything per [DesktopDesignState.appOverlay]; otherwise the selected work-area section
+ * ([DesktopDesignState.section]) decides: remote desktops render their own catalog + framebuffer,
+ * the terminal section renders the active terminal tab's subview
  * ([app.skerry.ui.session.Session.view]), falling back to [state.view] with no live sessions.
  */
 @Composable
@@ -29,15 +32,21 @@ fun Viewport(state: DesktopDesignState) {
         DesktopView.Vault -> VaultView()
         DesktopView.Known -> KnownHostsView()
         DesktopView.Teams -> TeamsView()
-        // overlay == null: renders the active tab's subview (showView only stores app-level values in appOverlay).
-        else -> {
-            val sessions = LocalSessions.current
-            val view = sessions?.active?.view ?: state.view.asSessionView()
-            when (view) {
-                SessionView.Terminal -> TerminalView(state)
-                SessionView.Sftp -> SftpView()
-                SessionView.Vnc -> VncView(state)
-                SessionView.Player -> CastPlayerView()
+        // overlay == null: renders the selected section (showView only stores app-level values in appOverlay).
+        else -> when (state.section) {
+            HostSection.RemoteDesktops -> RemoteDesktopsView(state)
+            HostSection.Terminal -> {
+                val sessions = LocalSessions.current
+                // activeTerminal, not active: a remote-desktop tab may still be the selected one
+                // (its section has no tab to fall back to), and it is not this section's to render.
+                val view = sessions?.activeTerminal?.view ?: state.view.asSessionView()
+                when (view) {
+                    SessionView.Terminal -> TerminalView(state)
+                    SessionView.Sftp -> SftpView()
+                    // A remote desktop never renders here (see activeTerminal); keep the branch total.
+                    SessionView.Vnc -> TerminalView(state)
+                    SessionView.Player -> CastPlayerView()
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -139,9 +139,43 @@ class HostManagerController(
         hosts = store.all()
     }
 
+    /**
+     * Manual reorder from a section sidebar: [targetIndexInGroup] counts only the rows of [section]
+     * the user can see, so it is translated into the catalog's own index first. Dropping a shell
+     * host below the last visible one must not push it past a remote desktop filed in the same
+     * folder — that profile is invisible here and its place is not the user's to change.
+     */
+    fun moveHostInSection(hostId: String, targetGroup: String?, targetIndexInGroup: Int, section: HostSection) {
+        store.reorder { all ->
+            val group = targetGroup?.takeIf { it.isNotBlank() }
+            // Same basis as moveHostToGroup's insertion: the target group without the dragged host.
+            val siblings = all.filter { it.id != hostId && it.group?.takeIf(String::isNotBlank) == group }
+            val visible = siblings.withIndex().filter { it.value.section == section }.map { it.index }
+            moveHostToGroup(all, hostId, targetGroup, filteredIndexToFull(siblings.size, visible, targetIndexInGroup))
+        }
+        hosts = store.all()
+    }
+
     /** Manual reorder: move folder [group] as a whole to [targetGroupIndex] among folders. */
     fun moveFolder(group: String?, targetGroupIndex: Int) {
         store.reorder { moveGroup(it, group, targetGroupIndex) }
+        hosts = store.all()
+    }
+
+    /**
+     * Folder reorder from a section sidebar: [targetGroupIndex] counts only folders that hold
+     * profiles of [section] (the ones on screen), and is translated into the catalog's folder order
+     * — a folder belonging entirely to the other section keeps its place.
+     */
+    fun moveFolderInSection(group: String?, targetGroupIndex: Int, section: HostSection) {
+        store.reorder { all ->
+            val moving = group?.takeIf { it.isNotBlank() }
+            val folders = all.map { it.group?.takeIf(String::isNotBlank) }.distinct().filterNot { it == moving }
+            val visible = folders.withIndex()
+                .filter { (_, name) -> all.any { it.group?.takeIf(String::isNotBlank) == name && it.section == section } }
+                .map { it.index }
+            moveGroup(all, group, filteredIndexToFull(folders.size, visible, targetGroupIndex))
+        }
         hosts = store.all()
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostReordering.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostReordering.kt
@@ -18,6 +18,22 @@ import app.skerry.shared.host.Host
  */
 private fun String?.canonicalGroup(): String? = this?.takeIf { it.isNotBlank() }
 
+/**
+ * Translate a drop index taken over a filtered view into an index in the full list.
+ *
+ * The sidebars show one [HostSection] at a time, while order lives in the single catalog: dropping
+ * "after the second visible row" must not count the rows of the other section, or a profile invisible
+ * here would be jumped over and silently reordered. [visiblePositions] are the full-list positions of
+ * the rows the user can see, in order; [visibleIndex] is the insertion point among them (0 = before
+ * the first, size = after the last). With nothing visible the item goes to the end ([fullSize]).
+ */
+fun filteredIndexToFull(fullSize: Int, visiblePositions: List<Int>, visibleIndex: Int): Int = when {
+    visiblePositions.isEmpty() -> fullSize
+    visibleIndex <= 0 -> visiblePositions.first()
+    visibleIndex >= visiblePositions.size -> visiblePositions.last() + 1
+    else -> visiblePositions[visibleIndex]
+}
+
 /** "Group -> hosts" buckets in order of the group's first appearance (null-group is its own key). */
 private fun bucketize(hosts: List<Host>): LinkedHashMap<String?, MutableList<Host>> {
     val buckets = LinkedHashMap<String?, MutableList<Host>>()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
@@ -1,0 +1,52 @@
+package app.skerry.ui.host
+
+import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.isRemoteDesktop
+
+/**
+ * Which part of the shell a saved profile belongs to. The catalog is one store (a profile is a
+ * [Host] either way, with the same groups/tags/sync), but the UI is split: terminal-style
+ * connections and remote desktops have separate lists, separate creation forms and separate
+ * navigation entries (desktop rail item / mobile bottom tab).
+ *
+ * The split is derived from [Host.connectionType] rather than stored, so an existing VNC profile
+ * moves to its new home with no migration, and changing a profile's transport re-files it.
+ */
+enum class HostSection { Terminal, RemoteDesktops }
+
+/** Section this profile is filed under (see [HostSection]). */
+val Host.section: HostSection
+    get() = if (connectionType.isRemoteDesktop) HostSection.RemoteDesktops else HostSection.Terminal
+
+/** The profiles of [section], in catalog order (the order the lists and manual reordering rely on). */
+fun List<Host>.inSection(section: HostSection): List<Host> = filter { it.section == section }
+
+/**
+ * Secondary caption for a profile in the host lists: `user@address` where there is a user, and
+ * `address:port` where there isn't — a remote desktop authenticates with a password and has no
+ * username, so the usual form would render as a bare "@10.0.0.5". A port of 0 (local shell) drops
+ * the suffix, leaving just the shell path (blank for the system default).
+ */
+fun Host.rowSubtitle(): String = when {
+    username.isNotBlank() -> "$username@$address"
+    port > 0 -> "$address:$port"
+    else -> address
+}
+
+/** Section a transport is filed under — the profile-level [Host.section] follows it. */
+val ConnectionType.section: HostSection
+    get() = if (isRemoteDesktop) HostSection.RemoteDesktops else HostSection.Terminal
+
+/**
+ * Transports the "New connection" form of [section] offers, in [ConnectionType] order.
+ *
+ * [ConnectionType.LOCAL] is in neither: a local shell isn't a saved profile — it's launched from the
+ * empty-tab placeholder and configured in Settings → Terminal → Local shell.
+ */
+fun connectionTypesIn(section: HostSection): List<ConnectionType> =
+    ConnectionType.entries.filter { it != ConnectionType.LOCAL && it.section == section }
+
+/** The transport a new profile of [section] starts on (first one the form offers). */
+fun defaultConnectionTypeIn(section: HostSection): ConnectionType =
+    connectionTypesIn(section).first()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -255,6 +255,15 @@ class NewConnectionFormState {
     )
 
     companion object {
+        /**
+         * Empty form for creating a profile in [section]: it starts on that section's default
+         * transport (with its default port), and the picker offers no other section's protocols —
+         * a remote desktop is created from the desktops list, a shell from the hosts list.
+         */
+        fun forSection(section: HostSection): NewConnectionFormState = NewConnectionFormState().apply {
+            chooseConnectionType(defaultConnectionTypeIn(section))
+        }
+
         /** Default port/speed by type: SSH/Mosh->22 (the SSH hop's port), Telnet->23, Serial->9600 (baud), VNC->5900 (RFB display :0). */
         fun defaultPortFor(type: ConnectionType): Int = when (type) {
             // Container profiles dial the host over SSH; the port is that hop's.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -146,6 +146,9 @@ import app.skerry.ui.generated.resources.conn_test_connected
 import app.skerry.ui.generated.resources.conn_test_rtt_ms
 import app.skerry.ui.generated.resources.conn_title_edit
 import app.skerry.ui.generated.resources.conn_title_new
+import app.skerry.ui.generated.resources.conn_title_new_desktop
+import app.skerry.ui.generated.resources.conn_title_edit_desktop
+import app.skerry.ui.generated.resources.conn_subtitle_new_desktop
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.AnchoredDropdown
@@ -193,11 +196,14 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
     val copyName = duplicateOf?.let { stringResource(Res.string.conn_duplicate_name, it.label) }
     // Keyed by editHost/duplicateOf: opening the modal for editing or duplicating (or switching target)
     // rebuilds the form from the profile.
-    val form = remember(editHost, duplicateOf) {
+    // Which catalog this form belongs to (the list its button was pressed in, or the edited
+    // profile's own section): it fixes the protocols offered and the wording of the header.
+    val section = state.modalSection
+    val form = remember(editHost, duplicateOf, section) {
         when {
             editHost != null -> NewConnectionFormState.fromHost(editHost)
             duplicateOf != null -> NewConnectionFormState.duplicateOf(duplicateOf, copyName.orEmpty())
-            else -> NewConnectionFormState()
+            else -> NewConnectionFormState.forSection(section)
         }
     }
     // Guards repeated Save (Enter/double click) until the modal closes, otherwise a duplicate secret+host in the vault.
@@ -256,9 +262,21 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
         ) {
             Box(Modifier.fillMaxWidth().padding(start = 26.dp, end = 26.dp, top = 22.dp, bottom = 14.dp)) {
                 Column {
-                    Txt(if (editHost != null) stringResource(Res.string.conn_title_edit) else stringResource(Res.string.conn_title_new), color = Skerry.colors.text, size = 18.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+                    val remote = section == HostSection.RemoteDesktops
+                    Txt(
+                        stringResource(
+                            when {
+                                editHost != null && remote -> Res.string.conn_title_edit_desktop
+                                editHost != null -> Res.string.conn_title_edit
+                                remote -> Res.string.conn_title_new_desktop
+                                else -> Res.string.conn_title_new
+                            },
+                        ),
+                        color = Skerry.colors.text, size = 18.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+                    )
                     Txt(
                         if (editHost != null) stringResource(Res.string.conn_subtitle_edit)
+                        else if (remote) stringResource(Res.string.conn_subtitle_new_desktop)
                         else stringResource(Res.string.conn_subtitle_new),
                         color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp, modifier = Modifier.padding(top = 6.dp),
                     )
@@ -266,9 +284,16 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                 IconBtn("close", onClick = state::closeModal, modifier = Modifier.align(Alignment.TopEnd))
             }
             Column(Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState()).padding(start = 26.dp, end = 26.dp, top = 6.dp, bottom = 22.dp)) {
-                Field(stringResource(Res.string.conn_field_name)) { ModalTextField(form.name, { form.name = it }, "e.g. prod-web-01") }
+                val namePlaceholder = if (section == HostSection.RemoteDesktops) "e.g. lab-desktop" else "e.g. prod-web-01"
+                Field(stringResource(Res.string.conn_field_name)) { ModalTextField(form.name, { form.name = it }, namePlaceholder) }
                 Spacer14()
-                Field(stringResource(Res.string.conn_field_protocol)) { ProtocolPicker(form) }
+                // A section with a single protocol has nothing to pick: VNC is the only remote
+                // desktop today, and a one-segment switch would just be chrome. It comes back on
+                // its own once RDP lands beside it.
+                val protocols = remember(section) { connectionTypesIn(section) }
+                if (protocols.size > 1) {
+                    Field(stringResource(Res.string.conn_field_protocol)) { ProtocolPicker(form, protocols) }
+                }
                 // Telnet has no transport encryption (unlike SSH/Mosh) — warn inline, mirroring the
                 // insecure-URL notices on the Sync/AI forms. The transport itself is correct (no creds
                 // auto-sent), this is a heads-up, not a block.
@@ -720,16 +745,15 @@ private fun BrowseNote(icon: String, text: String, color: Color) {
 }
 
 @Composable
-private fun ProtocolPicker(form: NewConnectionFormState) {
+private fun ProtocolPicker(form: NewConnectionFormState, protocols: List<ConnectionType>) {
     Row(
         Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(3.dp),
         horizontalArrangement = Arrangement.spacedBy(3.dp),
     ) {
-        // Driven off ConnectionType.entries: a new protocol gets its segment for free, and the
-        // exhaustive `when`s behind labelRes/icon fail the build until it's given a label and an icon.
-        // LOCAL is excluded: the local shell isn't a user-created profile — it's launched from the
-        // empty-tab placeholder and configured in Settings → Terminal → Local shell, not here.
-        ConnectionType.entries.filter { it != ConnectionType.LOCAL }.forEach { type ->
+        // [protocols] is this section's set (see connectionTypesIn): a new transport gets its segment
+        // for free once it declares a section, and the exhaustive `when`s behind labelRes/icon fail
+        // the build until it's given a label and an icon.
+        protocols.forEach { type ->
             ProtocolSegment(stringResource(type.labelRes), type.icon, form.connectionType == type, Modifier.weight(1f)) {
                 form.chooseConnectionType(type)
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -604,7 +604,7 @@ private fun openMobileSession(
 private fun MobileTabPane(state: MobileDesignState, onLock: (() -> Unit)?) {
     when (state.tab) {
         MobileTab.Hosts -> MobileHostsScreen(state)
-        MobileTab.Snippets -> MobileSnippetsScreen(state)
+        MobileTab.Desktops -> MobileDesktopsScreen(state)
         MobileTab.Vault -> MobileVaultScreen(state)
         MobileTab.More -> MobileMoreScreen(state, onLock)
     }
@@ -621,6 +621,7 @@ private fun MobileRoutePane(state: MobileDesignState, route: MobileRoute) {
         MobileRoute.Terminal -> MobileTerminalScreen(state)
         MobileRoute.Vnc -> MobileVncScreen(state)
         MobileRoute.Files -> MobileFilesScreen(onBack = state::pop)
+        MobileRoute.Snippets -> MobileSnippetsScreen(state)
         MobileRoute.Ports -> MobilePortsScreen(state)
         MobileRoute.Known -> MobileKnownScreen(state)
         MobileRoute.Team -> MobileTeamsScreen(state)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -27,6 +27,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.host.section
 import app.skerry.shared.host.Host
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shtail_host_address
@@ -128,7 +131,7 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
             Txt(host.label, color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
             Spacer(Modifier.height(3.dp))
             Txt(
-                "${host.username}@${host.address}",
+                host.rowSubtitle(),
                 color = Skerry.colors.dim,
                 size = 12.5.sp,
                 font = LocalFonts.current.mono,
@@ -136,8 +139,9 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
         }
 
         // Connect: opens a live session via LocalConnectHost (resolves identity or prompts for a
-        // password) and pushes the terminal screen; a no-op in preview/outside the gate.
+        // password) and pushes the terminal (or framebuffer) screen; a no-op in preview/outside the gate.
         val connect = LocalConnectHost.current
+        val remoteDesktop = host.section == HostSection.RemoteDesktops
         Box(Modifier.padding(horizontal = 22.dp)) {
             Row(
                 Modifier
@@ -153,7 +157,8 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
             ) {
-                Sym("terminal", size = 21.sp, color = Skerry.colors.ink)
+                // A remote desktop opens a framebuffer, not a shell — the button says so.
+                Sym(if (remoteDesktop) "desktop_windows" else "terminal", size = 21.sp, color = Skerry.colors.ink)
                 Txt(stringResource(Res.string.shell_connect), color = Skerry.colors.ink, size = 16.sp, weight = FontWeight.Bold)
             }
         }
@@ -166,7 +171,12 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
             Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 14.dp, bottom = 6.dp),
             horizontalArrangement = Arrangement.spacedBy(9.dp),
         ) {
-            QuickAction("folder", stringResource(Res.string.shell_quick_sftp), Modifier.weight(1f), onClick = { openSftp(host) })
+            // No SFTP over RFB: a remote desktop has no file channel, so the action is inert there
+            // rather than opening a browser that can never list anything.
+            QuickAction(
+                "folder", stringResource(Res.string.shell_quick_sftp), Modifier.weight(1f),
+                onClick = if (remoteDesktop) null else ({ openSftp(host) }),
+            )
             QuickAction("lan", stringResource(Res.string.shell_quick_tunnels), Modifier.weight(1f), onClick = { state.push(MobileRoute.Ports) })
             QuickAction("code_blocks", stringResource(Res.string.shell_quick_snippets), Modifier.weight(1f), onClick = null)
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.runtime.collectAsState
+import app.skerry.ui.host.rowSubtitle
 import app.skerry.ui.sync.SyncIndicatorLevel
 import app.skerry.ui.sync.syncIndicatorLocalized
 import androidx.compose.foundation.layout.Box
@@ -45,11 +46,19 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.ui.host.HostFolder
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.inSection
 import app.skerry.ui.host.ProdBadge
 import app.skerry.ui.host.isProdHost
 import app.skerry.ui.host.UNGROUPED_LABEL
 import app.skerry.ui.host.ungroupedLabel
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_add_first
+import app.skerry.ui.generated.resources.rd_search_placeholder
+import app.skerry.ui.generated.resources.shell_no_hosts_yet
+import app.skerry.ui.generated.resources.shell_add_first_host
+import app.skerry.ui.generated.resources.rd_no_desktops
+import app.skerry.ui.generated.resources.rd_screen_title
 import app.skerry.ui.generated.resources.shell_hosts
 import app.skerry.ui.generated.resources.shell_search_hosts
 import org.jetbrains.compose.resources.stringResource
@@ -81,16 +90,28 @@ internal val MOBILE_PREVIEW_HOSTS = listOf(
     Host("p4", "nas-truenas", "10.0.0.20", 22, "admin", "Homelab"),
 )
 
+/** Root screen of the Hosts tab: the terminal-style half of the catalog. */
+@Composable
+fun MobileHostsScreen(state: MobileDesignState) = MobileCatalogScreen(state, HostSection.Terminal)
+
+/** Root screen of the Desktops tab: remote desktops, the same list over the other half of the catalog. */
+@Composable
+fun MobileDesktopsScreen(state: MobileDesignState) = MobileCatalogScreen(state, HostSection.RemoteDesktops)
+
 /**
- * Root screen of the Hosts tab: header with title and sync indicator, search field, tag
- * filter-chip row, host sections, and "new connection" FAB. Catalog is the live [LocalHosts]
- * (behind the vault gate) or [MOBILE_PREVIEW_HOSTS] on the preview path. Tapping a host opens
+ * One catalog screen, shown once per [section] (Hosts / Desktops): header with title and sync
+ * indicator, search field, tag filter-chip row, folder sections, and a "new connection" FAB that
+ * opens the form on this section's protocols. Catalog is the live [LocalHosts] (behind the vault
+ * gate) or [MOBILE_PREVIEW_HOSTS] on the preview path, narrowed to [section]. Tapping a host opens
  * [MobileRoute.HostDetail].
  */
 @Composable
-fun MobileHostsScreen(state: MobileDesignState) {
+private fun MobileCatalogScreen(state: MobileDesignState, section: HostSection) {
     val controller = LocalHosts.current
-    val hosts = controller?.hosts ?: MOBILE_PREVIEW_HOSTS
+    val allHosts = controller?.hosts ?: MOBILE_PREVIEW_HOSTS
+    // Memoized like the desktop sidebar's slice: the filter would otherwise rerun on every
+    // recomposition (every drag frame) over the whole catalog.
+    val hosts = remember(allHosts, section) { allHosts.inSection(section) }
     // Pulls shared team hosts when sync goes Online (see AutoPullTeamsOnOnline): the screen is
     // recreated on tab selection (MobileDesignApp `when(tab)`), so the effect runs on every entry,
     // keyed on Online so it fires once per connection.
@@ -106,8 +127,8 @@ fun MobileHostsScreen(state: MobileDesignState) {
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
-            HostsHeader()
-            HostsSearch(query, onChange = { query = it })
+            HostsHeader(section)
+            HostsSearch(query, section, onChange = { query = it })
             HostsChips(list.chips, active = chip, onSelect = { chip = it })
             Spacer(Modifier.height(2.dp))
             // Insertion line while dragging a folder: before the folder at the target index (or at the end).
@@ -117,21 +138,25 @@ fun MobileHostsScreen(state: MobileDesignState) {
             list.sections.forEach { folder ->
                 key(folder.name) {
                     if (folder.name == folderLineBefore) MobileDropLine()
-                    MobileHostFolder(folder, state, controller, dragState) { foldersUpdated.value }
+                    MobileHostFolder(folder, state, section, controller, dragState) { foldersUpdated.value }
                 }
             }
             if (folderLineIndex != null && folderLineIndex == otherFolders.size) MobileDropLine()
             // Shared team hosts (Teams): sections below the personal catalog, outside search/filter
             // (parity with the desktop sidebar). Tap connects directly (LocalConnectHost).
             if (query.isBlank() && chip == ALL_HOSTS_CHIP) {
-                MobileTeamHostsSections(hosts)
+                MobileTeamHostsSections(hosts, section)
+            }
+            // An empty catalog says so rather than leaving a blank screen under the FAB.
+            if (list.sections.isEmpty() && query.isBlank() && chip == ALL_HOSTS_CHIP) {
+                MobileEmptyCatalogNote(section)
             }
             // Room for the tab bar AND the FAB above it (bottom 104dp + 56dp size + 16dp margin): anything less
             // leaves the last rows permanently stuck under the "+" button at full scroll.
             Spacer(Modifier.height(176.dp))
         }
         MobileFabButton(
-            onClick = state::openNewConn,
+            onClick = { state.openNewConn(section) },
             modifier = Modifier.align(Alignment.BottomEnd).padding(end = 22.dp, bottom = 104.dp),
         )
     }
@@ -146,6 +171,7 @@ fun MobileHostsScreen(state: MobileDesignState) {
 private fun MobileHostFolder(
     folder: HostFolder,
     state: MobileDesignState,
+    section: HostSection,
     controller: HostManagerController?,
     dragState: HostDragState,
     foldersProvider: () -> List<HostFolder>,
@@ -175,8 +201,9 @@ private fun MobileHostFolder(
         val headerMod = if (controller != null) {
             Modifier
                 .folderHeaderAnchor(dragState, folder.name)
+                // Section-aware, like desktop: the index counts only the folders on screen.
                 .draggableFolderHeader(dragState, folder.name, foldersProvider, longPress = true) { index ->
-                    controller.moveFolder(group, index)
+                    controller.moveFolderInSection(group, index, section)
                 }
         } else {
             Modifier
@@ -204,7 +231,7 @@ private fun MobileHostFolder(
                                 .alpha(if (dragState.draggingHostId == host.id) 0.4f else 1f)
                                 .hostBoundsAnchor(dragState, host.id)
                                 .draggableHostRow(dragState, host.id, foldersProvider, longPress = true) { drop ->
-                                    controller.moveHost(host.id, drop.group, drop.index)
+                                    controller.moveHostInSection(host.id, drop.group, drop.index, section)
                                 }
                         } else {
                             Modifier
@@ -239,15 +266,45 @@ private fun MobileDropLine(horizontal: Dp = 18.dp) {
     )
 }
 
-/** Header: "Hosts" (28sp) + sync indicator on the right. */
+/**
+ * Note shown when a section's catalog is empty (before any filtering): an empty screen under a lone
+ * "+" button doesn't say whether anything was hidden by a filter or never created.
+ */
 @Composable
-private fun HostsHeader() {
+private fun MobileEmptyCatalogNote(section: HostSection) {
+    val title = when (section) {
+        HostSection.Terminal -> Res.string.shell_no_hosts_yet
+        HostSection.RemoteDesktops -> Res.string.rd_no_desktops
+    }
+    val subtitle = when (section) {
+        HostSection.Terminal -> Res.string.shell_add_first_host
+        HostSection.RemoteDesktops -> Res.string.rd_add_first
+    }
+    Column(
+        Modifier.fillMaxWidth().padding(horizontal = 22.dp, vertical = 30.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Txt(stringResource(title), color = Skerry.colors.dim, size = 14.sp)
+        Txt(stringResource(subtitle), color = Skerry.colors.faint, size = 12.5.sp, lineHeight = 18.sp)
+    }
+}
+
+/** Header: the section title (28sp) + sync indicator on the right. */
+@Composable
+private fun HostsHeader(section: HostSection) {
     Row(
         Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        MobileScreenTitle(stringResource(Res.string.shell_hosts))
+        MobileScreenTitle(
+            stringResource(
+                when (section) {
+                    HostSection.Terminal -> Res.string.shell_hosts
+                    HostSection.RemoteDesktops -> Res.string.rd_screen_title
+                },
+            ),
+        )
         // Sync indicator driven by session status (see syncIndicator), not just server
         // reachability: shows "paused/error" without a working session instead of a false green online.
         val syncC = LocalSync.current
@@ -262,9 +319,9 @@ private fun HostsHeader() {
     }
 }
 
-/** Search field over host name/address/username/group. */
+/** Search field over host name/address/username/group of this section. */
 @Composable
-private fun HostsSearch(query: String, onChange: (String) -> Unit) {
+private fun HostsSearch(query: String, section: HostSection, onChange: (String) -> Unit) {
     // Outer padding is on the wrapper; the border lives in decorationBox so a click anywhere places the caret.
     BasicTextField(
         value = query,
@@ -288,7 +345,13 @@ private fun HostsSearch(query: String, onChange: (String) -> Unit) {
             ) {
                 Sym("search", size = 19.sp, color = Skerry.colors.faint)
                 Box(Modifier.weight(1f)) {
-                    if (query.isEmpty()) Txt(stringResource(Res.string.shell_search_hosts), color = Skerry.colors.faint, size = 15.sp)
+                    if (query.isEmpty()) {
+                        val placeholder = when (section) {
+                            HostSection.Terminal -> Res.string.shell_search_hosts
+                            HostSection.RemoteDesktops -> Res.string.rd_search_placeholder
+                        }
+                        Txt(stringResource(placeholder), color = Skerry.colors.faint, size = 15.sp)
+                    }
                     inner()
                 }
             }
@@ -437,7 +500,7 @@ private fun MobileHostRow(host: Host, onClick: () -> Unit) {
             }
             Spacer(Modifier.height(2.dp))
             Txt(
-                "${host.username}@${host.address}",
+                host.rowSubtitle(),
                 color = Skerry.colors.dim,
                 size = 11.5.sp,
                 font = LocalFonts.current.mono,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -69,6 +69,7 @@ import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.appearance_title
+import app.skerry.ui.generated.resources.lib_snippets_screen_title
 import app.skerry.ui.generated.resources.more_about
 import app.skerry.ui.generated.resources.more_ai_privacy
 import app.skerry.ui.generated.resources.more_ai_subtitle_byok
@@ -200,6 +201,9 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             val known = if (preview) mobileMoreKnownSubtitle(1) else knownSubtitle()
             val knownWarn = if (preview) true else knownChanged() > 0
 
+            // Snippet library: it lost its root tab to the remote-desktops one, so this is its home
+            // in the shell (the terminal's snippet palette still reaches it mid-session).
+            MoreRow("code_blocks", Skerry.colors.cyanBright, stringResource(Res.string.lib_snippets_screen_title), null, Skerry.colors.dim, onClick = { state.push(MobileRoute.Snippets) })
             MoreRow("lan", Skerry.colors.cyanBright, stringResource(Res.string.more_port_forwarding), ports, Skerry.colors.moss, onClick = { state.push(MobileRoute.Ports) })
             MoreRow("fingerprint", Skerry.colors.cyanBright, stringResource(Res.string.more_known_hosts), known, if (knownWarn) Skerry.colors.sunset else Skerry.colors.moss, onClick = { state.push(MobileRoute.Known) })
             MoreRow("groups", Skerry.colors.cyanBright, stringResource(Res.string.more_team), if (preview) "Platform crew" else null, Skerry.colors.dim, onClick = { state.push(MobileRoute.Team) })

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -53,6 +53,8 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isVnc
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.connectionTypesIn
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.host.AuthMode
 import app.skerry.ui.host.NewConnectionFormState
@@ -121,6 +123,9 @@ import app.skerry.ui.generated.resources.conn_tag_add_placeholder
 import app.skerry.ui.generated.resources.conn_duplicate_name
 import app.skerry.ui.generated.resources.conn_title_edit
 import app.skerry.ui.generated.resources.conn_title_new
+import app.skerry.ui.generated.resources.conn_title_new_desktop
+import app.skerry.ui.generated.resources.conn_title_edit_desktop
+import app.skerry.ui.generated.resources.conn_protocol_local
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.AiPolicy
 import app.skerry.ui.ai.shortLabel
@@ -180,11 +185,14 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
     val copyName = duplicateOf?.let { stringResource(Res.string.conn_duplicate_name, it.label) }
     // Keyed on editHost/duplicateOf: opening the sheet to edit or duplicate (or switching target)
     // rebuilds the form from the profile.
-    val form = remember(editHost, duplicateOf) {
+    // Which catalog this sheet belongs to (the tab its FAB was tapped on, or the edited profile's
+    // own section): it fixes the protocols offered and the header wording. Desktop parity.
+    val section = state.sheetSection
+    val form = remember(editHost, duplicateOf, section) {
         when {
             editHost != null -> NewConnectionFormState.fromHost(editHost)
             duplicateOf != null -> NewConnectionFormState.duplicateOf(duplicateOf, copyName.orEmpty())
-            else -> NewConnectionFormState()
+            else -> NewConnectionFormState.forSection(section)
         }
     }
     val canSave = hosts == null || form.canSave
@@ -248,7 +256,18 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                Txt(if (editHost != null) stringResource(Res.string.conn_title_edit) else stringResource(Res.string.conn_title_new), color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
+                val remote = section == HostSection.RemoteDesktops
+                Txt(
+                    stringResource(
+                        when {
+                            editHost != null && remote -> Res.string.conn_title_edit_desktop
+                            editHost != null -> Res.string.conn_title_edit
+                            remote -> Res.string.conn_title_new_desktop
+                            else -> Res.string.conn_title_new
+                        },
+                    ),
+                    color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold,
+                )
                 Sym(
                     "close",
                     size = 24.sp,
@@ -268,9 +287,15 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                 modifier = Modifier.padding(top = 4.dp, bottom = 18.dp),
             )
 
-            MobileFormField(stringResource(Res.string.conn_field_name)) { MobileFormInput(form.name, { form.name = it }, "prod-web-01") }
+            val namePlaceholder = if (section == HostSection.RemoteDesktops) "lab-desktop" else "prod-web-01"
+            MobileFormField(stringResource(Res.string.conn_field_name)) { MobileFormInput(form.name, { form.name = it }, namePlaceholder) }
             Spacer(Modifier.height(14.dp))
-            MobileFormField(stringResource(Res.string.conn_field_protocol)) { MobileProtocolPicker(form) }
+            // A single-protocol section has nothing to pick (VNC is the only remote desktop today);
+            // the picker returns on its own once RDP joins it.
+            val protocols = remember(section) { connectionTypesIn(section) }
+            if (protocols.size > 1) {
+                MobileFormField(stringResource(Res.string.conn_field_protocol)) { MobileProtocolPicker(form, protocols) }
+            }
             Spacer(Modifier.height(14.dp))
             val serial = form.connectionType == ConnectionType.SERIAL
             MobileFormField(if (serial) stringResource(Res.string.conn_field_device) else stringResource(Res.string.conn_field_host_address)) {
@@ -445,25 +470,34 @@ private fun MobileSerialPortPicker(form: NewConnectionFormState) {
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun MobileProtocolPicker(form: NewConnectionFormState) {
-    // Six protocols don't fit one phone-width row, so they wrap three per row (a segment narrower
-    // than its label reads as a truncated mess).
+private fun MobileProtocolPicker(form: NewConnectionFormState, protocols: List<ConnectionType>) {
+    // Protocols don't fit one phone-width row, so they wrap three per row (a segment narrower than
+    // its label reads as a truncated mess). Driven off the section's set, like the desktop picker.
     FlowRow(
         Modifier.fillMaxWidth().clip(RoundedCornerShape(11.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(11.dp)).padding(4.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
         maxItemsInEachRow = 3,
     ) {
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_ssh), form.connectionType == ConnectionType.SSH, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.SSH) }
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_mosh), form.connectionType == ConnectionType.MOSH, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.MOSH) }
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_telnet), form.connectionType == ConnectionType.TELNET, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.TELNET) }
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_serial), form.connectionType == ConnectionType.SERIAL, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.SERIAL) }
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_vnc), form.connectionType == ConnectionType.VNC, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.VNC) }
-        MobileProtocolSegment(stringResource(Res.string.conn_protocol_container), form.connectionType == ConnectionType.CONTAINER, Modifier.weight(1f)) { form.chooseConnectionType(ConnectionType.CONTAINER) }
-        // LOCAL is intentionally absent — the local shell isn't a user-created profile; it's launched
-        // from the empty-tab placeholder and configured in Settings, not created here.
+        protocols.forEach { type ->
+            MobileProtocolSegment(stringResource(type.protocolLabel), form.connectionType == type, Modifier.weight(1f)) {
+                form.chooseConnectionType(type)
+            }
+        }
     }
 }
+
+/** Localized protocol name for a picker segment (LOCAL is never offered — see [connectionTypesIn]). */
+private val ConnectionType.protocolLabel: org.jetbrains.compose.resources.StringResource
+    get() = when (this) {
+        ConnectionType.SSH -> Res.string.conn_protocol_ssh
+        ConnectionType.MOSH -> Res.string.conn_protocol_mosh
+        ConnectionType.TELNET -> Res.string.conn_protocol_telnet
+        ConnectionType.SERIAL -> Res.string.conn_protocol_serial
+        ConnectionType.VNC -> Res.string.conn_protocol_vnc
+        ConnectionType.CONTAINER -> Res.string.conn_protocol_container
+        ConnectionType.LOCAL -> Res.string.conn_protocol_local
+    }
 
 /**
  * Auth for the container listing probe, materialized at tap time (like the desktop modal's) so the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.forward.rateFraction
@@ -330,7 +331,8 @@ private fun MobileTunnelEditorSheet(
 
     val draft = form.draft
     val (badgeBg, badgeFg) = form.direction.badgeColors()
-    val hostList = hosts?.hosts ?: emptyList()
+    // The tunnel dials this host over SSH, so remote desktops are not candidates.
+    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
     val hostName = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
 
     MobileBottomSheet(
@@ -439,7 +441,8 @@ private fun MobileServicesSheet(
     onDismiss: () -> Unit,
 ) {
     val scan = manager.services
-    val hostList = hosts?.hosts ?: emptyList()
+    // The tunnel dials this host over SSH, so remote desktops are not candidates.
+    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
     var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
     val hostName = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
         ?: stringResource(Res.string.ports_select_host)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -122,9 +122,9 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
-            Box(Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp)) {
-                MobileScreenTitle(stringResource(Res.string.lib_snippets_screen_title))
-            }
+            // A push screen since the library left the tab bar (More → Snippets), so it carries a
+            // back arrow instead of a bare title.
+            MobilePushHeader(stringResource(Res.string.lib_snippets_screen_title), onBack = state::pop)
             if (snippets.isEmpty()) {
                 Column(
                     Modifier.fillMaxWidth().padding(horizontal = 22.dp, vertical = 30.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTabBar.kt
@@ -26,9 +26,9 @@ import app.skerry.ui.app.MobileTab
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.nav_tab_desktops
 import app.skerry.ui.generated.resources.nav_tab_hosts
 import app.skerry.ui.generated.resources.nav_tab_more
-import app.skerry.ui.generated.resources.nav_tab_snippets
 import app.skerry.ui.generated.resources.nav_tab_vault
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
@@ -73,7 +73,7 @@ private fun MobileTabItem(tab: MobileTab, active: Boolean, onClick: () -> Unit) 
         Sym(tab.icon, size = 24.sp, color = color)
         val label = when (tab) {
             MobileTab.Hosts -> stringResource(Res.string.nav_tab_hosts)
-            MobileTab.Snippets -> stringResource(Res.string.nav_tab_snippets)
+            MobileTab.Desktops -> stringResource(Res.string.nav_tab_desktops)
             MobileTab.Vault -> stringResource(Res.string.nav_tab_vault)
             MobileTab.More -> stringResource(Res.string.nav_tab_more)
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -37,7 +37,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.host.rowSubtitle
 import app.skerry.shared.host.Host
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.inSection
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.generated.resources.lib_teams_sidebar
@@ -439,7 +442,7 @@ private fun MobileTeamDetail(
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
     sharedHosts.forEach { host ->
-        MobileSharedRow(host.label, "${host.username}@${host.address}", canUnshare = canWrite) { onUnshare(host.id) }
+        MobileSharedRow(host.label, host.rowSubtitle(), canUnshare = canWrite) { onUnshare(host.id) }
     }
     if (canWrite) {
         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
@@ -531,7 +534,7 @@ private fun MobileMemberRow(
  * via [LocalConnectHost].
  */
 @Composable
-internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>) {
+internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>, section: HostSection) {
     val teams = LocalTeams.current ?: return
     val mono = LocalFonts.current.mono
     val connect = LocalConnectHost.current
@@ -539,10 +542,11 @@ internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>) {
     // revision changes on every team sync — otherwise hosts live-pulled into the team vault wouldn't
     // appear until a manual sync (the personal catalog is unchanged and sections read the vault imperatively).
     val revision by teams.revision.collectAsState()
-    val sections = remember(teamList, hostsSnapshot, revision) {
+    val sections = remember(teamList, hostsSnapshot, revision, section) {
         teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.mapNotNull { team ->
             val vault = teams.teamVault(team.id) ?: return@mapNotNull null
-            val shared = VaultHostStore(vault).all()
+            // Split by section like the personal catalog (desktop parity).
+            val shared = VaultHostStore(vault).all().inSection(section)
             if (shared.isEmpty()) null else team.name to shared
         }
     }
@@ -605,7 +609,7 @@ private fun MobileTeamHostRow(host: Host, mono: androidx.compose.ui.text.font.Fo
         Column(Modifier.weight(1f)) {
             Txt(host.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Spacer(Modifier.height(2.dp))
-            Txt("${host.username}@${host.address}", color = Skerry.colors.dim, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Txt(host.rowSubtitle(), color = Skerry.colors.dim, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
         Box(Modifier.size(8.dp).clip(CircleShape).background(dotColor))
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -187,6 +187,24 @@ class SessionsController(
 
     val active: Session? get() = sessions.firstOrNull { it.id == activeId }
 
+    /**
+     * The active tab as seen by the terminal section — `null` when a remote-desktop tab is active.
+     * The two sections have their own work areas, so each reads the active tab through its own lens
+     * instead of rendering a tab that belongs to the other one (a VNC tab under the terminal would
+     * show its idle placeholder controller as "not connected"). A player tab counts as terminal: it
+     * lives beside the shells, not in the remote-desktop catalog.
+     */
+    val activeTerminal: Session? get() = active?.takeIf { !it.isVnc }
+
+    /** The active tab as seen by the remote-desktop section, `null` when a terminal tab is active. */
+    val activeDesktop: Session? get() = active?.takeIf { it.isVnc }
+
+    /**
+     * Newest tab of a section, or `null` if it has none. Switching sections from the rail activates
+     * this one, so returning to a section lands back on a live session instead of an empty area.
+     */
+    fun lastSessionIn(remoteDesktop: Boolean): Session? = sessions.lastOrNull { it.isVnc == remoteDesktop }
+
     /** Open a new session to [target] and make it active; connects immediately. Returns the new tab's id. */
     fun open(
         hostId: String?,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -197,7 +197,7 @@ private fun mockFileIconTint(icon: String): Color = when (icon) {
 fun SftpView() {
     val mono = LocalFonts.current.mono
     val sessions = LocalSessions.current
-    val active = sessions?.active
+    val active = sessions?.activeTerminal
 
     when {
         sessions == null -> MockSftpView(mono)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.host.rowSubtitle
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.snippet.VaultSnippetStore
 import app.skerry.shared.team.HOST_SHARE_STRIP
@@ -388,7 +389,7 @@ private fun TeamDetail(
                     LiveSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
                     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
                     sharedHosts.forEach { host ->
-                        SharedRecordRow(host.label, "${host.username}@${host.address}", mono, canUnshare = canWrite) { onUnshare(host.id) }
+                        SharedRecordRow(host.label, host.rowSubtitle(), mono, canUnshare = canWrite) { onUnshare(host.id) }
                     }
                     if (canWrite) {
                         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CastPlayerView.kt
@@ -76,7 +76,7 @@ fun CastPlayerOverlay(cast: Asciicast, onDismiss: () -> Unit) {
  */
 @Composable
 fun CastPlayerView() {
-    val playback = LocalSessions.current?.active?.playback ?: return
+    val playback = LocalSessions.current?.activeTerminal?.playback ?: return
     // Start on first display only ([CastPlayback.start]) — returning to the tab must not rewind.
     LaunchedEffect(playback) { playback.start() }
     Column(Modifier.fillMaxSize().background(Skerry.colors.surface)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -61,9 +61,11 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import app.skerry.ui.host.rowSubtitle
 import app.skerry.shared.host.Host
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.isRemoteDesktop
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.HostClickConnectMode
@@ -93,6 +95,10 @@ import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_add_first
+import app.skerry.ui.generated.resources.rd_no_desktops
+import app.skerry.ui.generated.resources.rd_search_placeholder
+import app.skerry.ui.generated.resources.rd_section
 import app.skerry.ui.generated.resources.term_hosts_section
 import app.skerry.ui.generated.resources.term_menu_delete
 import app.skerry.ui.generated.resources.term_menu_duplicate
@@ -108,6 +114,8 @@ import app.skerry.ui.host.HostDragState
 import app.skerry.ui.host.HostFolder
 import app.skerry.ui.host.HostGroup
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.inSection
 import app.skerry.ui.host.MockHost
 import app.skerry.ui.host.ProdBadge
 import app.skerry.ui.host.isProdHost
@@ -231,8 +239,14 @@ private fun Modifier.hostConnectClick(
         }
     }
 
+/**
+ * Host sidebar of a work-area section. [section] narrows the catalog to the profiles that belong
+ * here (terminal-style connections or remote desktops) — everything else (search, tag chips,
+ * folders, drag-and-drop, RECENT, team hosts) then works within that slice, so the two sections
+ * read as separate lists over one store.
+ */
 @Composable
-internal fun HostsSidebar(state: DesktopDesignState) {
+internal fun HostsSidebar(state: DesktopDesignState, section: HostSection = HostSection.Terminal) {
     val mono = LocalFonts.current.mono
     val liveHosts = LocalHosts.current
     // Manual reorder (drag-and-drop) state for the live catalog; unused on the mock path.
@@ -241,9 +255,13 @@ internal fun HostsSidebar(state: DesktopDesignState) {
     // connect mode (file-manager convention: click selects, double-click opens). Also updated on
     // connect so the row that just opened reads as selected. Null = no selection.
     var selectedHostId by remember { mutableStateOf<String?>(null) }
+    // This section's slice of the catalog: everything below (chips, folders, RECENT, drag targets)
+    // is derived from it, so a remote desktop never shows up among the shells and vice versa.
+    val sectionHosts = liveHosts?.let { remember(it.hosts, section) { it.hosts.inSection(section) } } ?: emptyList()
     // Active filter chip (tag); live catalog only, chips are static on the mock path.
     var activeChip by remember { mutableStateOf(ALL_HOSTS_CHIP) }
-    val chips = liveHosts?.let { remember(it.hosts) { hostTagChips(it.hosts) } } ?: emptyList()
+    // Tags of THIS section only: a chip that would filter the list down to nothing is noise.
+    val chips = liveHosts?.let { remember(sectionHosts) { hostTagChips(sectionHosts) } } ?: emptyList()
     // If the active tag disappears (host edited/deleted), the filter falls back to "All".
     val effectiveChip = if (activeChip in chips) activeChip else ALL_HOSTS_CHIP
     Column(Modifier.width(SIDEBAR_WIDTH).fillMaxHeight().background(Skerry.colors.surface2)) {
@@ -252,7 +270,7 @@ internal fun HostsSidebar(state: DesktopDesignState) {
             // in from the right edge (it no longer runs to the panel border) and collapses the
             // sidebar; the reopen handle then lives at the terminal's left edge (SidebarReopenHandle).
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                HostSearchField(state, Modifier.weight(1f))
+                HostSearchField(state, section, Modifier.weight(1f))
                 IconBtn("chevron_left", onClick = state::toggleSidebar, box = 30, icon = 18.sp, tint = Skerry.colors.faint)
             }
             // The filter-tag row overflows the narrow sidebar, so it scrolls horizontally. Desktop's
@@ -301,8 +319,16 @@ internal fun HostsSidebar(state: DesktopDesignState) {
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
-                SidebarSectionTitle(stringResource(Res.string.term_hosts_section))
+                SidebarSectionTitle(
+                    stringResource(
+                        when (section) {
+                            HostSection.Terminal -> Res.string.term_hosts_section
+                            HostSection.RemoteDesktops -> Res.string.rd_section
+                        },
+                    ),
+                )
                 // Create a new (initially empty) group in the live catalog; decorative on the mock path.
+                // Groups are shared by both sections (one catalog), so the button belongs to either.
                 if (liveHosts != null) {
                     IconBtn("create_new_folder", onClick = state::openCreateGroup, box = 20, icon = 14.sp, tint = Skerry.colors.faint)
                 } else {
@@ -313,16 +339,26 @@ internal fun HostsSidebar(state: DesktopDesignState) {
             // mock data (offscreen render/preview path). Folders are grouped and narrowed by the active tag.
             if (liveHosts != null) {
                 val query = state.hostSearchQuery
-                val folders = remember(liveHosts.hosts, effectiveChip, query, state.customGroups) {
-                    val base = groupHostsByFolder(filterHosts(liveHosts.hosts, effectiveChip, query))
+                val folders = remember(sectionHosts, effectiveChip, query, state.customGroups, section) {
+                    val base = groupHostsByFolder(filterHosts(sectionHosts, effectiveChip, query))
                     // Empty user groups are shown as folders with no hosts, but only outside a filter
-                    // (search/tag narrow by host, and an empty folder has nothing to match).
+                    // (search/tag narrow by host, and an empty folder has nothing to match). Both
+                    // sections show them: a folder has no section of its own, and the "+folder"
+                    // button sits in both sidebars — hiding it in one would make the folder just
+                    // created there vanish, with nothing to drop a host onto.
                     if (query.isNotBlank() || effectiveChip != ALL_HOSTS_CHIP) {
                         base
                     } else {
                         val present = base.map { it.name }.toSet()
                         base + state.customGroups.filter { it !in present }.map { HostFolder(it, emptyList()) }
                     }
+                }
+                // An empty remote-desktop catalog says so, instead of leaving a blank column above
+                // the "New connection" button (the terminal section always has the local shell path).
+                if (folders.isEmpty() && section == HostSection.RemoteDesktops &&
+                    query.isBlank() && effectiveChip == ALL_HOSTS_CHIP
+                ) {
+                    EmptyCatalogNote()
                 }
                 // Search/tag narrowing found nothing: show a hint instead of silent emptiness (unlike an
                 // empty catalog, where the RECENT section/New connection button still appear below).
@@ -342,17 +378,17 @@ internal fun HostsSidebar(state: DesktopDesignState) {
                 folders.forEach { folder ->
                     key(folder.name) {
                         if (folder.name == folderLineBefore) DropLine()
-                        LiveHostFolder(folder, state, mono, dragState, liveHosts, selectedHostId, { selectedHostId = it }) { foldersUpdated.value }
+                        LiveHostFolder(folder, state, section, mono, dragState, liveHosts, selectedHostId, { selectedHostId = it }) { foldersUpdated.value }
                     }
                 }
                 if (folderLineIndex != null && folderLineIndex == otherFolders.size) DropLine()
                 // Shared team hosts: per-team sections below the personal catalog, shown only outside
                 // search/filter since those narrow the personal catalog.
                 if (query.isBlank() && effectiveChip == ALL_HOSTS_CHIP) {
-                    TeamHostsSection(liveHosts.hosts, state, mono)
+                    TeamHostsSection(liveHosts.hosts, state, section, mono)
                 }
             } else {
-                HOST_GROUPS.forEach { group -> HostGroupBlock(group, state, mono) }
+                HOST_GROUPS.forEach { group -> HostGroupBlock(group, state, section, mono) }
             }
             // Live catalog: RECENT section from actual connection history ([DesktopDesignState.recentHostIds]),
             // resolved against current profiles; deleted/unknown ids are simply hidden, empty means no section.
@@ -361,8 +397,13 @@ internal fun HostsSidebar(state: DesktopDesignState) {
                 // The section can be hidden entirely (Settings -> Appearance -> Interface) and size-limited.
                 // Memoized by (recent order, catalog contents, limit), like the `folders` above, so the
                 // resolve doesn't rerun on every sidebar recomposition (drag/chip switch/tab switch).
-                val recent = remember(state.recentHostIds, liveHosts.hosts, state.recentLimit) {
-                    state.recentHostIds.mapNotNull { liveHosts.find(it) }.take(state.recentLimit)
+                // Narrowed to this section: history is per catalog too, so the desktops list doesn't
+                // offer to reconnect a shell. The limit applies after narrowing, so a section with
+                // few recents still fills its quota.
+                val recent = remember(state.recentHostIds, liveHosts.hosts, state.recentLimit, section) {
+                    state.recentHostIds.mapNotNull { liveHosts.find(it) }
+                        .inSection(section)
+                        .take(state.recentLimit)
                 }
                 if (state.showRecent && recent.isNotEmpty()) {
                     // Divider belongs to the section: hidden together with it when RECENT is off/empty.
@@ -388,11 +429,19 @@ internal fun HostsSidebar(state: DesktopDesignState) {
         val importScope = rememberCoroutineScope()
         Box(Modifier.height(BOTTOM_BAR_HEIGHT).padding(horizontal = 12.dp), contentAlignment = Alignment.Center) {
             Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                PrimaryButton(stringResource(Res.string.term_new_connection), onClick = state::openModal, icon = "add_link", modifier = Modifier.weight(1f))
+                // The form opens on this section's protocols: a remote desktop is never created from
+                // the terminal list, and a shell never from the desktops list.
+                PrimaryButton(
+                    stringResource(Res.string.term_new_connection),
+                    onClick = { state.openModal(section) },
+                    icon = "add_link",
+                    modifier = Modifier.weight(1f),
+                )
                 // Import hosts from an OpenSSH ~/.ssh/config: pick + parse off the main thread, then the
                 // preview modal (rendered at the app root) handles selection and persistence. Shown only
-                // on the live path — importing needs a host store to write to (mock/preview has none).
-                if (liveHosts != null) {
+                // on the live path — importing needs a host store to write to (mock/preview has none)
+                // and only under the terminal section: an ssh_config holds SSH hosts, not desktops.
+                if (liveHosts != null && section == HostSection.Terminal) {
                     IconBtn(
                         "download",
                         onClick = { importScope.launch { pickAndParseSshConfig()?.let(state::beginSshImport) } },
@@ -410,8 +459,12 @@ internal fun HostsSidebar(state: DesktopDesignState) {
  * cross once text is entered.
  */
 @Composable
-private fun HostSearchField(state: DesktopDesignState, modifier: Modifier = Modifier) {
-    SidebarSearchField(state.hostSearchQuery, state::onHostSearch, stringResource(Res.string.term_search_hosts_placeholder), modifier)
+private fun HostSearchField(state: DesktopDesignState, section: HostSection, modifier: Modifier = Modifier) {
+    val placeholder = when (section) {
+        HostSection.Terminal -> Res.string.term_search_hosts_placeholder
+        HostSection.RemoteDesktops -> Res.string.rd_search_placeholder
+    }
+    SidebarSearchField(state.hostSearchQuery, state::onHostSearch, stringResource(placeholder), modifier)
 }
 
 /**
@@ -467,7 +520,7 @@ private fun TeamHostsSectionHeader() {
  * links are stripped on share).
  */
 @Composable
-private fun TeamHostsSection(hostsSnapshot: List<Host>, state: DesktopDesignState, mono: FontFamily) {
+private fun TeamHostsSection(hostsSnapshot: List<Host>, state: DesktopDesignState, section: HostSection, mono: FontFamily) {
     val teams = LocalTeams.current ?: return
     // Pulls shared team hosts when sync transitions to Online, see AutoPullTeamsOnOnline.
     AutoPullTeamsOnOnline()
@@ -475,10 +528,12 @@ private fun TeamHostsSection(hostsSnapshot: List<Host>, state: DesktopDesignStat
     // Changes on every team sync, so hosts freshly pulled into the team vault appear without a
     // manual sync (the personal catalog doesn't change, and these sections read the vault directly).
     val revision by teams.revision.collectAsState()
-    val sections = remember(teamList, hostsSnapshot, revision) {
+    val sections = remember(teamList, hostsSnapshot, revision, section) {
         teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.mapNotNull { team ->
             val vault = teams.teamVault(team.id) ?: return@mapNotNull null
-            val shared = VaultHostStore(vault).all()
+            // Shared hosts are split by section like the personal catalog: a team's VNC box belongs
+            // to the desktops list, its servers to the terminal one.
+            val shared = VaultHostStore(vault).all().inSection(section)
             if (shared.isEmpty()) null else team.name to shared
         }
     }
@@ -543,7 +598,7 @@ private fun TeamHostRow(host: Host, mono: FontFamily) {
         Sym(host.connectionType.icon, size = 14.sp, color = Skerry.colors.faint)
         Column(Modifier.weight(1f)) {
             Txt(host.label, color = Skerry.colors.dim, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            Txt("${host.username}@${host.address}", color = Skerry.colors.faint, size = 10.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Txt(host.rowSubtitle(), color = Skerry.colors.faint, size = 10.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }
@@ -577,7 +632,7 @@ private fun RecentHostRow(host: Host, mono: FontFamily) {
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
             )
             Txt(
-                "${host.username}@${host.address}",
+                host.rowSubtitle(),
                 color = Skerry.colors.faint, size = 10.5.sp, font = mono,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
             )
@@ -586,16 +641,37 @@ private fun RecentHostRow(host: Host, mono: FontFamily) {
 }
 
 @Composable
-private fun HostGroupBlock(group: HostGroup, state: DesktopDesignState, mono: FontFamily) {
+private fun HostGroupBlock(group: HostGroup, state: DesktopDesignState, section: HostSection, mono: FontFamily) {
+    // The mock catalog is split by section too, so the preview of each sidebar shows its own kind of
+    // host; a folder left with nothing to show is skipped entirely.
+    val hosts = group.hosts.filter { mockHostSection(it) == section }
+    if (hosts.isEmpty()) return
     val collapsed = state.isGroupCollapsed(group.name)
     val onToggleCollapsed = remember(state, group.name) { { state.toggleGroupCollapsed(group.name) } }
     Column(Modifier.padding(bottom = 2.dp)) {
-        FolderHeader(group.name, group.hosts.size, collapsed, onToggleCollapsed)
+        FolderHeader(group.name, hosts.size, collapsed, onToggleCollapsed)
         if (!collapsed) {
             Column(Modifier.padding(start = 22.dp)) {
-                group.hosts.forEach { host -> HostRow(host, state, mono) }
+                hosts.forEach { host -> HostRow(host, state, mono) }
             }
         }
+    }
+}
+
+/** Section of a preview-catalog row ([MockHost] carries a transport but is not a saved profile). */
+private fun mockHostSection(host: MockHost): HostSection =
+    if (host.connectionType.isRemoteDesktop) HostSection.RemoteDesktops else HostSection.Terminal
+
+/** Note shown instead of an empty column when a section's catalog holds nothing yet. */
+@Composable
+private fun EmptyCatalogNote() {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 12.dp)) {
+        Txt(stringResource(Res.string.rd_no_desktops), color = Skerry.colors.dim, size = 12.sp)
+        Txt(
+            stringResource(Res.string.rd_add_first),
+            color = Skerry.colors.faint, size = 11.5.sp, lineHeight = 16.sp,
+            modifier = Modifier.padding(top = 4.dp),
+        )
     }
 }
 
@@ -612,6 +688,7 @@ private fun HostGroupBlock(group: HostGroup, state: DesktopDesignState, mono: Fo
 private fun LiveHostFolder(
     folder: HostFolder,
     state: DesktopDesignState,
+    section: HostSection,
     mono: FontFamily,
     dragState: HostDragState,
     controller: HostManagerController,
@@ -650,8 +727,10 @@ private fun LiveHostFolder(
     ) {
         Box(
             Modifier.folderHeaderAnchor(dragState, folder.name)
+                // Section-aware: the drop index counts the folders this sidebar shows, not the
+                // catalog's (a folder of the other section is invisible here and keeps its place).
                 .draggableFolderHeader(dragState, folder.name, foldersProvider) { index ->
-                    controller.moveFolder(group, index)
+                    controller.moveFolderInSection(group, index, section)
                 },
         ) {
             // The synthetic bucket shows the localized "no group" label; real folders show their name.
@@ -668,7 +747,7 @@ private fun LiveHostFolder(
                     HostTypeSubheader(connectionTypeLabel(type))
                     typeHosts.forEach { host ->
                         key(host.id) {
-                            HostRow(host, state, controller, sessions, connect, mono, selectedHostId, onSelectHost, dragState, foldersProvider)
+                            HostRow(host, state, section, controller, sessions, connect, mono, selectedHostId, onSelectHost, dragState, foldersProvider)
                         }
                     }
                 }
@@ -678,7 +757,7 @@ private fun LiveHostFolder(
                 folder.hosts.forEach { host ->
                     key(host.id) {
                         if (host.id == lineBeforeId) DropLine()
-                        HostRow(host, state, controller, sessions, connect, mono, selectedHostId, onSelectHost, dragState, foldersProvider)
+                        HostRow(host, state, section, controller, sessions, connect, mono, selectedHostId, onSelectHost, dragState, foldersProvider)
                     }
                 }
                 // Drop at the folder's end: the line goes after the last row.
@@ -706,6 +785,7 @@ private fun HostTypeSubheader(label: String) {
 private fun HostRow(
     host: Host,
     state: DesktopDesignState,
+    section: HostSection,
     controller: HostManagerController,
     sessions: SessionsController?,
     connect: (Host) -> Unit,
@@ -729,7 +809,8 @@ private fun HostRow(
             .alpha(if (dragState.draggingHostId == host.id) 0.4f else 1f)
             .hostBoundsAnchor(dragState, host.id)
             .draggableHostRow(dragState, host.id, foldersProvider) { drop ->
-                controller.moveHost(host.id, drop.group, drop.index)
+                // Index is relative to the rows this sidebar shows; the controller translates it.
+                controller.moveHostInSection(host.id, drop.group, drop.index, section)
             },
     ) {
         HostEntryRow(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
@@ -67,7 +67,7 @@ internal fun InfoPanel() {
     val sessions = LocalSessions.current
     val hosts = LocalHosts.current
     val credentials = LocalCredentials.current
-    val active = sessions?.active
+    val active = sessions?.activeTerminal
     val host = active?.hostId?.let { id -> hosts?.find(id) }
     val live = sessions != null
     val connected = active?.controller?.uiState is ConnectionUiState.Connected

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -93,6 +93,8 @@ import app.skerry.ui.session.SessionsController
 import app.skerry.ui.session.sessionDotColor
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.host.inSection
 import app.skerry.ui.host.isProdHostId
 import app.skerry.ui.host.prodOutline
 
@@ -104,7 +106,7 @@ import app.skerry.ui.host.prodOutline
 @Composable
 private fun SessionActions(state: DesktopDesignState, modifier: Modifier = Modifier) {
     val sessions = LocalSessions.current
-    val active = sessions?.active
+    val active = sessions?.activeTerminal
     Row(
         modifier.height(PANE_HEADER_HEIGHT).padding(horizontal = 16.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -173,7 +175,7 @@ fun TerminalView(state: DesktopDesignState) {
             // input row; key() recreates it when the active host/policy changes. Off/mock -> null
             // (falls back to the slot below).
             val liveAi = LocalAi.current
-            val aiSession = LocalSessions.current?.active
+            val aiSession = LocalSessions.current?.activeTerminal
             val aiPolicy = aiSession?.hostId?.let { LocalHosts.current?.find(it)?.aiPolicy } ?: AiPolicy.Strict
             val aiTerminal = (aiSession?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
             // liveAi.enabled is in the key: toggling the global OFF setting shows/hides the bar
@@ -192,11 +194,11 @@ fun TerminalView(state: DesktopDesignState) {
                 // Live mode: split is tied to the active tab (its own secondary session).
                 // Mock/preview uses a global flag.
                 val sessions = LocalSessions.current
-                val activeId = sessions?.active?.id
-                val showSplit = if (sessions != null) sessions.active?.splitOpen == true else state.split
+                val activeId = sessions?.activeTerminal?.id
+                val showSplit = if (sessions != null) sessions.activeTerminal?.splitOpen == true else state.split
                 // In split mode, an accent border (primary cyan) outlines the focused pane.
                 // focusedSplit=false means the primary pane.
-                val focusedSplit = sessions?.active?.focusedSplit == true
+                val focusedSplit = sessions?.activeTerminal?.focusedSplit == true
                 val focusBorderColor = Skerry.colors.cyan
                 fun paneFocusBorder(focused: Boolean): Modifier =
                     if (showSplit && focused) Modifier.border(1.dp, focusBorderColor.copy(alpha = 0.35f)) else Modifier
@@ -253,7 +255,7 @@ fun TerminalView(state: DesktopDesignState) {
  * in the sidebar's own surface so it reads as the panel peeking out; clicking it restores the panel.
  */
 @Composable
-private fun SidebarReopenHandle(onClick: () -> Unit) {
+internal fun SidebarReopenHandle(onClick: () -> Unit) {
     Box(
         Modifier.width(16.dp).fillMaxHeight().background(Skerry.colors.surface2).clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
@@ -268,7 +270,7 @@ private fun SidebarReopenHandle(onClick: () -> Unit) {
 private fun SessionToolbar(state: DesktopDesignState) {
     val mono = LocalFonts.current.mono
     val sessions = LocalSessions.current
-    val active = sessions?.active
+    val active = sessions?.activeTerminal
     Column {
         Row(
             // Fixed header height shared with the split pane (PANE_HEADER_HEIGHT) so both
@@ -317,7 +319,7 @@ private fun TerminalPane(state: DesktopDesignState, modifier: Modifier = Modifie
 /** Live terminal of the active tab: renders based on its [ConnectionUiState]. */
 @Composable
 private fun LiveTerminalPane(sessions: SessionsController, state: DesktopDesignState, modifier: Modifier = Modifier) {
-    val active = sessions.active
+    val active = sessions.activeTerminal
     val st = active?.controller?.uiState
     // Ctrl+click on a file path: switch this tab to its file panel and reveal the path there. Only
     // the primary pane gets it — the SFTP view belongs to the tab's primary session, so the split
@@ -428,7 +430,7 @@ private fun LiveSplitPane(
     reserveEnd: Dp = 0.dp,
 ) {
     val mono = LocalFonts.current.mono
-    val parent = sessions.active ?: return
+    val parent = sessions.activeTerminal ?: return
     var pickerOpen by remember { mutableStateOf(false) }
     val split = parent.splitSession
     Column(
@@ -501,7 +503,9 @@ private fun LiveSplitPane(
 @Composable
 private fun SplitHostPicker(onPicked: () -> Unit) {
     val mono = LocalFonts.current.mono
-    val hosts = LocalHosts.current?.hosts ?: emptyList()
+    // Terminal profiles only: the split pane is a second shell, and a remote desktop picked here
+    // would be dialled as SSH on its RFB port.
+    val hosts = LocalHosts.current?.hosts?.inSection(HostSection.Terminal) ?: emptyList()
     val connectSplit = LocalConnectSplit.current
     Column(
         Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
@@ -520,7 +520,8 @@ private fun TunnelEditor(
 
     val draft = form.draft
     val (badgeBg, badgeFg) = form.direction.badgeColors()
-    val hostList = hosts?.hosts ?: emptyList()
+    // The tunnel dials this host over SSH, so remote desktops are not candidates.
+    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
     val hostLabel = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
 
     Column(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -1,8 +1,10 @@
 package app.skerry.ui.vnc
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -12,6 +14,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -57,6 +60,8 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_no_session
+import app.skerry.ui.generated.resources.rd_pick_to_connect
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
 import app.skerry.ui.generated.resources.vnc_quality
@@ -67,7 +72,10 @@ import app.skerry.ui.generated.resources.vnc_quality_medium
 import app.skerry.ui.generated.resources.vnc_resize_to_window
 import app.skerry.ui.generated.resources.vnc_session_closed
 import app.skerry.ui.generated.resources.vnc_view_only
+import app.skerry.ui.design.EmptyState
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.terminal.HostsSidebar
+import app.skerry.ui.terminal.SidebarReopenHandle
 import app.skerry.ui.terminal.plainTextClipEntry
 import app.skerry.ui.terminal.readPlainText
 import kotlin.math.roundToInt
@@ -75,14 +83,49 @@ import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
 /**
+ * The remote-desktop section: its own host sidebar (the desktops catalog) beside the work area,
+ * mirroring how the terminal section is laid out. With no desktop session open the area explains
+ * what to do instead of sitting blank — the sidebar is the only way into one.
+ */
+@Composable
+fun RemoteDesktopsView(state: DesktopDesignState) {
+    Row(Modifier.fillMaxSize()) {
+        // Same collapse behaviour as the terminal sidebar (shared [DesktopDesignState.sidebarHidden]),
+        // so hiding the panel in one section hides it in both — one shell, one preference.
+        AnimatedVisibility(
+            visible = !state.sidebarHidden,
+            enter = expandHorizontally(expandFrom = Alignment.End),
+            exit = shrinkHorizontally(shrinkTowards = Alignment.End),
+        ) { HostsSidebar(state, HostSection.RemoteDesktops) }
+        AnimatedVisibility(
+            visible = state.sidebarHidden,
+            enter = fadeIn() + expandHorizontally(expandFrom = Alignment.Start),
+            exit = fadeOut() + shrinkHorizontally(shrinkTowards = Alignment.Start),
+        ) { SidebarReopenHandle(onClick = state::toggleSidebar) }
+        Box(Modifier.weight(1f).fillMaxHeight()) {
+            if (LocalSessions.current?.activeDesktop != null) {
+                VncView(state)
+            } else {
+                EmptyState(
+                    icon = "desktop_windows",
+                    title = stringResource(Res.string.rd_no_session),
+                    subtitle = stringResource(Res.string.rd_pick_to_connect),
+                    tint = Skerry.colors.dim,
+                )
+            }
+        }
+    }
+}
+
+/**
  * The VNC tab's work area. Renders the active session's [VncSessionController] state: connecting /
- * live framebuffer / error / disconnected. The framebuffer sibling of `TerminalView`; it is its own
- * top-level view (Viewport routes [app.skerry.ui.session.SessionView.Vnc] here).
+ * live framebuffer / error / disconnected. The framebuffer sibling of `TerminalView`, rendered by
+ * [RemoteDesktopsView] beside the desktops sidebar.
  */
 @Composable
 fun VncView(state: DesktopDesignState) {
     val sessions = LocalSessions.current
-    val vnc = sessions?.active?.vncController ?: return
+    val vnc = sessions?.activeDesktop?.vncController ?: return
     Box(Modifier.fillMaxSize()) {
         when (val ui = vnc.uiState) {
             is VncUiState.Connecting -> CenterNotice("hourglass_empty", stringResource(Res.string.vnc_connecting))
@@ -104,16 +147,6 @@ fun VncView(state: DesktopDesignState) {
                 )
             }
         }
-        // Slide-over hosts drawer (rail chevron): overlays the framebuffer instead of shrinking it —
-        // a layout resize would ripple to the remote desktop when "Resize to window" is on.
-        // clipToBounds: slide transitions draw outside the node's bounds, so without it the panel
-        // rides in from off-screen across the icon rail instead of emerging at the work-area edge.
-        AnimatedVisibility(
-            visible = state.vncSidebar,
-            modifier = Modifier.align(Alignment.CenterStart).clipToBounds(),
-            enter = slideInHorizontally { -it },
-            exit = slideOutHorizontally { -it },
-        ) { HostsSidebar(state) }
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.app
 
 import app.skerry.shared.host.Host
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.settings.SETTINGS_NAV
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
@@ -75,13 +76,27 @@ class DesktopDesignStateTest {
     }
 
     @Test
-    fun vnc_sidebar_starts_closed_and_toggles() {
+    fun work_area_starts_on_the_terminal_section() {
+        assertEquals(HostSection.Terminal, DesktopDesignState().section)
+    }
+
+    @Test
+    fun showSection_switches_the_work_area_and_clears_the_overlay() {
         val s = DesktopDesignState()
-        assertFalse(s.vncSidebar)
-        s.toggleVncSidebar()
-        assertTrue(s.vncSidebar)
-        s.toggleVncSidebar()
-        assertFalse(s.vncSidebar)
+        s.showView(DesktopView.Vault)                 // an app-level section is open over the tabs
+        s.showSection(HostSection.RemoteDesktops)
+        assertEquals(HostSection.RemoteDesktops, s.section)
+        assertNull(s.appOverlay)                      // the rail click must reveal the work area
+    }
+
+    @Test
+    fun showSection_keeps_the_session_sub_view() {
+        val s = DesktopDesignState()
+        s.showView(DesktopView.Sftp)
+        s.showSection(HostSection.RemoteDesktops)
+        s.showSection(HostSection.Terminal)
+        // Returning to the terminal lands back on the sub-view that was open, not a reset to Terminal.
+        assertEquals(DesktopView.Sftp, s.view)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -1,6 +1,8 @@
 package app.skerry.ui.app
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_FONT_SIZE
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LETTER_SPACING
 import app.skerry.ui.terminal.DEFAULT_TERMINAL_LINE_HEIGHT
@@ -173,17 +175,39 @@ class MobileDesignStateTest {
 
     @Test
     fun four_tabs_in_template_order() {
-        // Bottom navigation: 4 root tabs in this order. Files isn't in the bar — SFTP opens as a
-        // push screen ([MobileRoute.Files]) from the host card, like the terminal.
+        // Bottom navigation: 4 root tabs in this order — the two catalogs first, then the vault and
+        // the More hub. Files isn't in the bar (SFTP is a push screen from the host card), and
+        // neither is the snippet library ([MobileRoute.Snippets], reached from More).
         assertEquals(
             listOf(
                 MobileTab.Hosts,
-                MobileTab.Snippets,
+                MobileTab.Desktops,
                 MobileTab.Vault,
                 MobileTab.More,
             ),
             MobileTab.entries.toList(),
         )
+    }
+
+    @Test
+    fun the_new_connection_sheet_opens_on_the_section_it_was_started_from() {
+        val s = MobileDesignState()
+        s.openNewConn(HostSection.RemoteDesktops)
+        assertEquals(HostSection.RemoteDesktops, s.sheetSection)
+        s.closeSheet()
+        s.openNewConn()
+        assertEquals(HostSection.Terminal, s.sheetSection)
+    }
+
+    @Test
+    fun editing_a_profile_opens_the_sheet_on_that_profile_section() {
+        val s = MobileDesignState()
+        val desktop = Host(
+            id = "d1", label = "lab", address = "10.0.0.5", username = "",
+            connectionType = ConnectionType.VNC,
+        )
+        s.openEditConn(desktop)
+        assertEquals(HostSection.RemoteDesktops, s.sheetSection)
     }
 
     @Test
@@ -241,7 +265,7 @@ class MobileDesignStateTest {
         assertNull(s.selectedHostId) // otherwise 2B would read a stale id
 
         s.openHost("host-7")
-        s.select(MobileTab.Snippets)
+        s.select(MobileTab.Desktops)
         assertNull(s.selectedHostId)
     }
 
@@ -430,8 +454,8 @@ class MobileDesignStateTest {
 
     @Test
     fun back_on_non_hosts_tab_goes_home() {
-        // From a non-root tab (Snippets/Vault/More), back returns to Hosts instead of exiting the app.
-        assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Snippets))
+        // From a non-root tab (Desktops/Vault/More), back returns to Hosts instead of exiting the app.
+        assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Desktops))
         assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Vault))
         assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.More))
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
@@ -1,11 +1,20 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
-private fun host(id: String, label: String = id, group: String? = null) =
-    Host(id = id, label = label, address = "$id.example.com", username = "root", group = group)
+private fun host(
+    id: String,
+    label: String = id,
+    group: String? = null,
+    type: ConnectionType = ConnectionType.SSH,
+) = Host(
+    id = id, label = label, address = "$id.example.com", username = "root", group = group,
+    connectionType = type,
+)
 
 class HostGroupingTest {
 
@@ -36,5 +45,96 @@ class HostGroupingTest {
         val folders = groupHostsByFolder(hosts, ungroupedLabel = "Ungrouped")
         assertEquals(listOf("Ungrouped", "Prod"), folders.map { it.name })
         assertEquals(listOf("loose"), folders[0].hosts.map { it.id })
+    }
+}
+
+class HostSectionTest {
+
+    private val catalog = listOf(
+        host("shell", type = ConnectionType.SSH),
+        host("screen", type = ConnectionType.VNC),
+        host("router", type = ConnectionType.TELNET),
+        host("box", type = ConnectionType.CONTAINER),
+    )
+
+    @Test
+    fun terminal_section_excludes_remote_desktops() {
+        assertEquals(listOf("shell", "router", "box"), catalog.inSection(HostSection.Terminal).map { it.id })
+    }
+
+    @Test
+    fun remote_desktop_section_holds_only_remote_desktops() {
+        assertEquals(listOf("screen"), catalog.inSection(HostSection.RemoteDesktops).map { it.id })
+    }
+
+    @Test
+    fun the_two_sections_partition_the_catalog() {
+        // Nothing hidden, nothing listed twice: a profile the user saved must be reachable in
+        // exactly one section.
+        val terminal = catalog.inSection(HostSection.Terminal).map { it.id }
+        val desktops = catalog.inSection(HostSection.RemoteDesktops).map { it.id }
+        assertEquals(catalog.size, terminal.size + desktops.size)
+        assertTrue((terminal.toSet() intersect desktops.toSet()).isEmpty())
+    }
+
+    @Test
+    fun the_creation_form_offers_only_its_section_protocols() {
+        assertEquals(listOf(ConnectionType.VNC), connectionTypesIn(HostSection.RemoteDesktops))
+        assertEquals(
+            listOf(
+                ConnectionType.SSH,
+                ConnectionType.MOSH,
+                ConnectionType.TELNET,
+                ConnectionType.SERIAL,
+                ConnectionType.CONTAINER,
+            ),
+            connectionTypesIn(HostSection.Terminal),
+        )
+    }
+
+    @Test
+    fun the_local_shell_is_not_offered_in_either_form() {
+        // Not a user-created profile: it is launched from the empty tab and configured in Settings.
+        assertTrue(HostSection.entries.none { ConnectionType.LOCAL in connectionTypesIn(it) })
+    }
+
+    @Test
+    fun section_of_a_host_follows_its_transport() {
+        assertEquals(HostSection.Terminal, host("a", type = ConnectionType.SSH).section)
+        assertEquals(HostSection.RemoteDesktops, host("b", type = ConnectionType.VNC).section)
+    }
+
+    @Test
+    fun filtering_preserves_catalog_order() {
+        val ordered = listOf(
+            host("v1", type = ConnectionType.VNC),
+            host("s1", type = ConnectionType.SSH),
+            host("v2", type = ConnectionType.VNC),
+        )
+        assertEquals(listOf("v1", "v2"), ordered.inSection(HostSection.RemoteDesktops).map { it.id })
+    }
+}
+
+class HostRowSubtitleTest {
+
+    @Test
+    fun a_profile_with_a_user_shows_user_at_host() {
+        val h = host("a", type = ConnectionType.SSH).copy(username = "root", address = "10.0.0.1")
+        assertEquals("root@10.0.0.1", h.rowSubtitle())
+    }
+
+    @Test
+    fun a_remote_desktop_shows_host_and_port_instead_of_a_dangling_at() {
+        // VNC authenticates with a password only — no username, so "@10.0.0.5" would be all it had.
+        val h = host("b", type = ConnectionType.VNC).copy(username = "", address = "10.0.0.5", port = 5901)
+        assertEquals("10.0.0.5:5901", h.rowSubtitle())
+    }
+
+    @Test
+    fun a_local_shell_shows_its_shell_path_or_a_name() {
+        val shell = host("c", type = ConnectionType.LOCAL).copy(username = "", address = "/bin/zsh", port = 0)
+        assertEquals("/bin/zsh", shell.rowSubtitle())
+        val default = host("d", type = ConnectionType.LOCAL).copy(username = "", address = "", port = 0)
+        assertEquals("", default.rowSubtitle())
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
@@ -1,10 +1,12 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.host.HostStore
 import app.skerry.shared.ssh.SshConfigHost
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlin.test.assertNull
 
 class HostManagerControllerTest {
@@ -318,5 +320,81 @@ private class FakeHostStore(vararg initial: Host) : HostStore {
         val updated = transform(entries.toList())
         entries.clear()
         entries += updated
+    }
+}
+
+/**
+ * Reordering from a section sidebar: the user drags among the rows THAT SECTION shows, while the
+ * catalog holds both kinds. The other section's profiles must keep their relative order.
+ */
+class SectionReorderTest {
+
+    private fun shell(id: String) = Host(id, id, "$id.local", 22, "root")
+    private fun desktop(id: String) = Host(id, id, "$id.local", 5900, "", connectionType = ConnectionType.VNC)
+
+    @Test
+    fun `dragging a shell to the top of a mixed folder lands above the first shell`() {
+        val store = FakeHostStore(shell("a"), desktop("x"), shell("b"))
+        val controller = HostManagerController(store) { "gen" }
+
+        // In the hosts sidebar the user sees [a, b] and drops b before a.
+        controller.moveHostInSection("b", targetGroup = null, targetIndexInGroup = 0, section = HostSection.Terminal)
+
+        assertEquals(listOf("b", "a", "x"), controller.hosts.map { it.id })
+    }
+
+    @Test
+    fun `dragging past the last visible row does not jump over a hidden profile`() {
+        // Catalog [a, x, b]: the desktops sidebar shows only x, the hosts one [a, b].
+        val store = FakeHostStore(shell("a"), desktop("x"), shell("b"))
+        val controller = HostManagerController(store) { "gen" }
+
+        // Hosts sidebar: drop a after b (visible index 1 of [b]).
+        controller.moveHostInSection("a", targetGroup = null, targetIndexInGroup = 1, section = HostSection.Terminal)
+
+        // a sits after b, and the shells' order is what the user asked for.
+        val ids = controller.hosts.map { it.id }
+        assertTrue(ids.indexOf("b") < ids.indexOf("a"))
+        assertTrue("x" in ids)
+    }
+
+    @Test
+    fun `a section drag keeps the other section's relative order`() {
+        val store = FakeHostStore(desktop("x"), shell("a"), desktop("y"), shell("b"))
+        val controller = HostManagerController(store) { "gen" }
+
+        controller.moveHostInSection("b", targetGroup = null, targetIndexInGroup = 0, section = HostSection.Terminal)
+
+        val ids = controller.hosts.map { it.id }
+        assertTrue(ids.indexOf("x") < ids.indexOf("y")) // desktops untouched relative to each other
+        assertTrue(ids.indexOf("b") < ids.indexOf("a")) // the drag did what it said
+    }
+
+    @Test
+    fun `moving into a folder that has nothing of this section appends to it`() {
+        val store = FakeHostStore(shell("a"), Host("x", "x", "x.local", 5900, "", "Lab", connectionType = ConnectionType.VNC))
+        val controller = HostManagerController(store) { "gen" }
+
+        controller.moveHostInSection("a", targetGroup = "Lab", targetIndexInGroup = 0, section = HostSection.Terminal)
+
+        assertEquals("Lab", controller.hosts.first { it.id == "a" }.group)
+        assertEquals(listOf("x", "a"), controller.hosts.map { it.id })
+    }
+
+    @Test
+    fun `folder reorder from a section counts only folders it shows`() {
+        // Catalog folder order: Screens (desktops), Shells, Lab. The hosts sidebar shows [Shells, Lab].
+        val store = FakeHostStore(
+            desktop("x").copy(group = "Screens"),
+            shell("a").copy(group = "Shells"),
+            shell("b").copy(group = "Lab"),
+        )
+        val controller = HostManagerController(store) { "gen" }
+
+        // Dropped after the last folder the sidebar shows (index 1 among [Shells]) — i.e. "stay last".
+        controller.moveFolderInSection("Lab", targetGroupIndex = 1, section = HostSection.Terminal)
+
+        // Counting the hidden Screens folder would have landed Lab between Screens and Shells.
+        assertEquals(listOf("Screens", "Shells", "Lab"), controller.hosts.mapNotNull { it.group }.distinct())
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostReorderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostReorderingTest.kt
@@ -198,3 +198,41 @@ class HostReorderingTest {
         assertEquals(hosts, renameHostGroup(hosts, oldName = "Prod", newName = "Prod"))
     }
 }
+
+/**
+ * Drop indices come from a list the user sees, which holds only one section's profiles; the catalog
+ * they are applied to holds both. These cover the translation between the two.
+ */
+class SectionDropIndexTest {
+
+    // Visible (section) rows at catalog positions 0, 2, 3 — position 1 belongs to the other section.
+    private val visible = listOf(0, 2, 3)
+
+    @Test
+    fun dropping_before_the_first_visible_row_lands_at_its_catalog_position() {
+        assertEquals(0, filteredIndexToFull(fullSize = 4, visiblePositions = visible, visibleIndex = 0))
+    }
+
+    @Test
+    fun dropping_between_visible_rows_lands_on_the_following_row() {
+        assertEquals(2, filteredIndexToFull(fullSize = 4, visiblePositions = visible, visibleIndex = 1))
+        assertEquals(3, filteredIndexToFull(fullSize = 4, visiblePositions = visible, visibleIndex = 2))
+    }
+
+    @Test
+    fun dropping_past_the_last_visible_row_lands_right_after_it() {
+        // Not at the end of the catalog: a hidden row may follow, and it must keep its place.
+        assertEquals(4, filteredIndexToFull(fullSize = 6, visiblePositions = visible, visibleIndex = 3))
+    }
+
+    @Test
+    fun a_section_with_nothing_visible_appends_to_the_end() {
+        assertEquals(3, filteredIndexToFull(fullSize = 3, visiblePositions = emptyList(), visibleIndex = 0))
+    }
+
+    @Test
+    fun out_of_range_indices_are_clamped_to_the_visible_ends() {
+        assertEquals(0, filteredIndexToFull(fullSize = 4, visiblePositions = visible, visibleIndex = -3))
+        assertEquals(4, filteredIndexToFull(fullSize = 4, visiblePositions = visible, visibleIndex = 99))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.host.MAX_NOTES_LENGTH
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -489,5 +490,47 @@ class NewConnectionFormStateTest {
         val host = Host(id = "h3", label = "box", address = "a", port = 22, username = "u", tags = listOf("prod", "db"))
         val f = NewConnectionFormState.fromHost(host)
         assertEquals(listOf("prod", "db"), f.tags)
+    }
+}
+
+/** The form is opened per section (hosts list vs remote desktops), which fixes its protocol set. */
+class SectionFormStateTest {
+
+    @Test
+    fun a_terminal_form_starts_on_ssh_with_its_port() {
+        val form = NewConnectionFormState.forSection(HostSection.Terminal)
+        assertEquals(ConnectionType.SSH, form.connectionType)
+        assertEquals("22", form.port)
+    }
+
+    @Test
+    fun a_remote_desktop_form_starts_on_vnc_with_its_port() {
+        val form = NewConnectionFormState.forSection(HostSection.RemoteDesktops)
+        assertEquals(ConnectionType.VNC, form.connectionType)
+        assertEquals("5900", form.port)
+    }
+
+    @Test
+    fun a_remote_desktop_form_saves_a_profile_filed_under_remote_desktops() {
+        // The whole point of the split: what you create here shows up there and nowhere else.
+        val form = NewConnectionFormState.forSection(HostSection.RemoteDesktops).apply {
+            name = "lab-desktop"
+            address = "10.0.0.5"
+        }
+        assertTrue(form.canSave)
+        val draft = form.toDraft()
+        assertEquals(ConnectionType.VNC, draft.connectionType)
+        assertEquals(5900, draft.port)
+    }
+
+    @Test
+    fun a_remote_desktop_form_needs_no_username() {
+        // VNC authenticates with a password only, so requiring a user would block saving.
+        val form = NewConnectionFormState.forSection(HostSection.RemoteDesktops).apply {
+            name = "screen"
+            address = "10.0.0.5"
+        }
+        assertEquals("", form.username)
+        assertTrue(form.canSave)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -24,6 +24,15 @@ import app.skerry.shared.vnc.VncUpdate
 import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.DesktopView
+import app.skerry.ui.desktop.RAIL
+import app.skerry.ui.desktop.RailTarget
+import app.skerry.ui.desktop.closeSessionTab
+import app.skerry.ui.desktop.followActiveTabSection
+import app.skerry.ui.desktop.openRailSection
+import app.skerry.ui.desktop.railItemActive
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.host.prodGuardDialogOpen
 import app.skerry.ui.vnc.VncSessionController
 import kotlinx.coroutines.CoroutineScope
@@ -638,6 +647,56 @@ class SessionsControllerTest {
         scope.cancel()
     }
 
+    // Section-scoped active tab (terminal shell vs remote desktop)
+
+    @Test
+    fun `the active tab is reported to the section it belongs to`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+        val shell = sessions.open(hostId = "host-a")
+
+        assertEquals(shell, sessions.activeTerminal?.id)
+        assertNull(sessions.activeDesktop)
+
+        val desktop = sessions.openVnc(hostId = "screen")!!
+        assertEquals(desktop, sessions.activeDesktop?.id)
+        assertNull(sessions.activeTerminal)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a player tab belongs to the terminal section`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+
+        val id = sessions.openPlayer("deploy", cast)
+
+        assertEquals(id, sessions.activeTerminal?.id)
+        assertNull(sessions.activeDesktop)
+        sessions.close(id)
+        scope.cancel()
+    }
+
+    @Test
+    fun `lastSessionIn finds the newest tab of a section`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+        val shellA = sessions.open(hostId = "a")
+        val desktop = sessions.openVnc(hostId = "screen")!!
+        val shellB = sessions.open(hostId = "b")
+
+        assertEquals(shellB, sessions.lastSessionIn(remoteDesktop = false)?.id)
+        assertEquals(desktop, sessions.lastSessionIn(remoteDesktop = true)?.id)
+        assertTrue(shellA != shellB)
+        scope.cancel()
+    }
+
+    @Test
+    fun `lastSessionIn reports nothing when the section has no tabs`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+        sessions.open(hostId = "a")
+
+        assertNull(sessions.lastSessionIn(remoteDesktop = true))
+        scope.cancel()
+    }
+
     // Player tabs
 
     private val cast = Asciicast(80, 24, "deploy", listOf(CastEvent(0.0, "hi")))
@@ -773,5 +832,133 @@ private class FakeChannel : ShellChannel {
     override suspend fun resize(size: PtySize) {}
     override suspend fun close() {
         emissions.close()
+    }
+}
+
+/**
+ * Rail ⇄ tabs agreement: the work area, the sidebar and the highlighted rail item all read
+ * [DesktopDesignState.section], so switching one must move the others.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DesktopSectionNavigationTest {
+
+    private val target = SshTarget(host = "h", port = 22, username = "u")
+
+    private fun TestScope.sessions(): Pair<SessionsController, CoroutineScope> {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var n = 0
+        val controller = SessionsController(
+            newId = { "s${n++}" },
+            controllerFactory = {
+                ConnectionController(
+                    transport = FakeTransport(),
+                    scope = scope,
+                    newSessionScope = { CoroutineScope(UnconfinedTestDispatcher(testScheduler)) },
+                )
+            },
+            vncControllerFactory = { VncSessionController(FakeVncTransport(), scope) },
+        )
+        return controller to scope
+    }
+
+    @Test
+    fun `opening a section activates its newest tab`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+
+        openRailSection(state, sessions, HostSection.Terminal)
+        assertEquals(HostSection.Terminal, state.section)
+        assertEquals(shell, sessions.activeId)
+
+        openRailSection(state, sessions, HostSection.RemoteDesktops)
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(desktop, sessions.activeId)
+        scope.cancel()
+    }
+
+    @Test
+    fun `opening a section with no tabs still switches the work area`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+
+        openRailSection(state, sessions, HostSection.RemoteDesktops)
+
+        // The section opens on its empty state; the shell tab stays selected for the way back.
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(shell, sessions.activeId)
+        assertNull(sessions.activeDesktop)
+        scope.cancel()
+    }
+
+    @Test
+    fun `selecting a tab moves the work area to its section`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        sessions.openVnc("screen", "screen", "", target, VncAuth.None)
+
+        followActiveTabSection(state, sessions)
+        assertEquals(HostSection.RemoteDesktops, state.section)
+
+        sessions.activate(shell)
+        followActiveTabSection(state, sessions)
+        assertEquals(HostSection.Terminal, state.section)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the rail highlights the open section, and nothing while an overlay is up`() {
+        val state = DesktopDesignState()
+        val terminal = RAIL.first { it.target == RailTarget.Section(HostSection.Terminal) }
+        val desktops = RAIL.first { it.target == RailTarget.Section(HostSection.RemoteDesktops) }
+        val vault = RAIL.first { it.target == RailTarget.View(DesktopView.Vault) }
+
+        assertTrue(railItemActive(terminal, state))
+        assertFalse(railItemActive(desktops, state))
+
+        state.showSection(HostSection.RemoteDesktops)
+        assertTrue(railItemActive(desktops, state))
+        assertFalse(railItemActive(terminal, state))
+
+        state.showView(DesktopView.Vault)
+        assertTrue(railItemActive(vault, state))
+        assertFalse(railItemActive(desktops, state)) // work-area items dim under an overlay
+    }
+
+    @Test
+    fun `closing a tab hands the work area to the tab that becomes active`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        sessions.openVnc("screen", "screen", "", target, VncAuth.None)
+        sessions.activate(shell)
+        followActiveTabSection(state, sessions)
+        assertEquals(HostSection.Terminal, state.section)
+
+        // Closing the active shell promotes its right neighbour — a remote desktop.
+        closeSessionTab(state, sessions, shell)
+
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(sessions.activeId, sessions.activeDesktop?.id)
+        scope.cancel()
+    }
+
+    @Test
+    fun `closing the last tab of a section falls back to the other one`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+        followActiveTabSection(state, sessions)
+
+        sessions.close(desktop)
+        followActiveTabSection(state, sessions)
+
+        // The shell tab became active, so the shell section is what the work area shows.
+        assertEquals(HostSection.Terminal, state.section)
+        scope.cancel()
     }
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -17,6 +17,8 @@ import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.host.Host
+import app.skerry.shared.ssh.ConnectionType
+import app.skerry.ui.host.HostSection
 import app.skerry.ui.files.FileEditController
 import app.skerry.ui.files.FileEditorScreen
 import app.skerry.shared.host.HostStore
@@ -147,12 +149,15 @@ fun main() {
     }
 
     val state = DesktopDesignState()
-    runCatching { state.showView(DesktopView.valueOf(viewName)) }
+    // view is a DesktopView name, or a HostSection name for the two work-area sections
+    // (Terminal / RemoteDesktops) — those are not rail "views" any more.
+    runCatching { state.showSection(HostSection.valueOf(viewName)) }
+        .onFailure { runCatching { state.showView(DesktopView.valueOf(viewName)) } }
     // Terminal theme for visual review: -Dskerry.screenshot.termTheme=<id> (e.g. tokyo-night).
     System.getProperty("skerry.screenshot.termTheme")?.let { state.chooseTerminalTheme(TerminalThemes.fromId(it)) }
     when (overlay) {
         "lock" -> state.lock()
-        "modal" -> state.openModal()
+        "modal" -> state.openModal(state.section) // form of the section being rendered
         "settings" -> {
             state.openSettings()
             // Settings tab to render: -Dskerry.screenshot.settingsTab=Appearance.
@@ -273,7 +278,8 @@ private fun renderMobile(out: String, viewName: String, overlay: String, live: B
             }
         }
     }
-    if (overlay == "sheet") state.openNewConn() // New connection sheet over the current tab
+    // New connection sheet over the current tab, on that tab's section (Hosts / Desktops).
+    if (overlay == "sheet") state.openNewConn(if (tab == MobileTab.Desktops) HostSection.RemoteDesktops else HostSection.Terminal)
     // Scene width/height are in pixels: 780x1688 at density 2 = logical 390x844dp (phone).
     val themeMode = ThemeMode.fromId(System.getProperty("skerry.screenshot.theme", "dark"))
     val scene = ImageComposeScene(width = 780, height = 1688, density = Density(2f)) {
@@ -429,6 +435,9 @@ private fun seededHosts(boundCredentialId: String? = null): HostManagerControlle
         Host("h2", "db-master", "192.168.1.50", 22, "root", "Production", credentialId = boundCredentialId, tags = listOf("prod", "db")),
         Host("h3", "homelab-pi", "10.0.0.12", 22, "pi", "Homelab", tags = listOf("docker")),
         Host("h4", "vps-edge", "vps.example.com", 2222, "deploy", null, tags = listOf("edge")),
+        // Remote desktops: their own section in the shell, so the demo catalog seeds both kinds.
+        Host("h5", "lab-desktop", "10.0.0.30", 5900, "", "Homelab", connectionType = ConnectionType.VNC),
+        Host("h6", "win-bench", "10.0.0.31", 5901, "", null, connectionType = ConnectionType.VNC, tags = listOf("lab")),
     ).forEach(store::put)
     var seq = 0
     return HostManagerController(store) { "gen-${seq++}" }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
@@ -52,6 +52,25 @@ val ConnectionType.carriedBySsh: Boolean
  * (stored as [app.skerry.shared.vault.CredentialSecret.Password], like SSH) but has no username,
  * private key, jump host or keep-alive — so the form gates auth on this separately from
  * [usesSshAuth].
+ *
+ * Narrower than [isRemoteDesktop]: this one means the RFB protocol specifically (framebuffer stack,
+ * VNC-Auth), the other means the "remote desktop" section a profile is filed under.
  */
 val ConnectionType.isVnc: Boolean
     get() = this == ConnectionType.VNC
+
+/**
+ * Whether the profile is a remote desktop rather than a terminal-style connection — the split the
+ * shell navigates by: remote desktops have their own catalog, their own creation form and their own
+ * rail item / bottom tab, while everything else lives under the terminal section.
+ *
+ * Currently VNC only; RDP joins it here, and the exhaustive `when`s over [ConnectionType] elsewhere
+ * are what force each new transport to declare where it belongs.
+ */
+val ConnectionType.isRemoteDesktop: Boolean
+    get() = when (this) {
+        ConnectionType.VNC -> true
+        ConnectionType.SSH, ConnectionType.MOSH, ConnectionType.TELNET, ConnectionType.SERIAL,
+        ConnectionType.LOCAL, ConnectionType.CONTAINER,
+        -> false
+    }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
@@ -1,0 +1,44 @@
+package app.skerry.shared.ssh
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ConnectionTypeTest {
+
+    @Test
+    fun `vnc is a remote desktop`() {
+        assertTrue(ConnectionType.VNC.isRemoteDesktop)
+    }
+
+    @Test
+    fun `terminal transports are not remote desktops`() {
+        val terminal = listOf(
+            ConnectionType.SSH,
+            ConnectionType.MOSH,
+            ConnectionType.TELNET,
+            ConnectionType.SERIAL,
+            ConnectionType.LOCAL,
+            ConnectionType.CONTAINER,
+        )
+        terminal.forEach { assertFalse(it.isRemoteDesktop, "$it must not be a remote desktop") }
+    }
+
+    @Test
+    fun `every transport belongs to exactly one section`() {
+        // The two catalogs partition ConnectionType: a transport missing from both would be
+        // invisible in the UI, one in both would show up twice.
+        val sections = ConnectionType.entries.groupBy { it.isRemoteDesktop }
+        assertEquals(ConnectionType.entries.size, sections.values.sumOf { it.size })
+    }
+
+    @Test
+    fun `a remote desktop never authenticates over ssh`() {
+        // Remote-desktop profiles have no username/key/jump host; the forms gate on this.
+        ConnectionType.entries.filter { it.isRemoteDesktop }.forEach {
+            assertFalse(it.usesSshAuth, "$it must not use SSH auth")
+            assertFalse(it.carriedBySsh, "$it must not run over an SSH session")
+        }
+    }
+}


### PR DESCRIPTION
Remote desktops get their own section: VNC connections leave the host list and live in a separate catalog with their own creation form, rail item (desktop) and bottom tab (mobile). RDP will join the same section.

## Where

- **Desktop** — new rail item "Remote desktops" under "Terminal". It swaps the work area for the desktops sidebar (search, folders, tags, drag-and-drop, RECENT — narrowed to this catalog) plus the framebuffer or an empty state. Session tabs stay a single row: selecting a tab, `Alt+<digit>`, `Ctrl+Tab` and closing a tab move the shell to the section that tab belongs to. `⌘N` / `Ctrl+Shift+N` opens the form of the section on screen.
- **Mobile** — bottom bar is Hosts · Desktops · Vault · More; the snippet library moves into More as a push screen.

## Behaviour

- Profiles remain `Host` records in the same encrypted store; the section is derived from `ConnectionType.isRemoteDesktop`, so existing VNC profiles move over with no migration and keep their groups, tags, sync and production guard.
- The desktops form offers only remote-desktop protocols, defaults to VNC on port 5900 and drops the fields VNC has no use for (username, private key, jump host, keep-alive, AI policy). The terminal form no longer offers VNC.
- Drag-and-drop translates the drop index from the rows the section shows into the catalog's own order, so reordering shells never steps over a remote desktop filed in the same folder.
- Each section reads its own active tab, so a remote-desktop tab is never rendered by the terminal view (and the reverse).
- Host rows print `address:port` where a profile has no username, instead of a dangling `@host`.

## Also in this PR

- The VNC slide-over host drawer is gone — the section has a permanent sidebar.
- Tunnel "via host" pickers (desktop and mobile) now list SSH-capable profiles only.
- SFTP is inert on a remote desktop's detail screen (RFB has no file channel).
- Screenshot harness renders either section (`-Dskerry.screenshot.view=RemoteDesktops`, mobile `view=Desktops`).

Tests cover the catalog split, section-scoped active tabs, rail/tab agreement, drop-index translation and the form defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
