### PR TITLE
Granular sharing in Teams: access scopes

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -525,7 +525,7 @@ class MainActivity : FragmentActivity() {
                 now = { Instant.now().toString() },
             ),
             teamState = FileSyncStateStore(File(dir, "team-cursor.json").toPath()),
-            newTeamId = { UUID.randomUUID().toString() },
+            newId = { UUID.randomUUID().toString() },
             onTeamsChanged = {
                 lifecycleScope.launch(Dispatchers.Main) {
                     hosts.reload(); snippets.reload(); tunnels.reload()

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -144,4 +144,21 @@
     <string name="lib_teams_err_server_error">Сервер отвечает с ошибкой — попробуйте позже</string>
     <string name="lib_teams_err_forbidden">Недоступно для вашей роли в команде</string>
     <string name="lib_teams_err_vault_unreadable">Локальный файл командного хранилища нечитаем — он сохранён, не удалён</string>
+    <string name="lib_teams_scopes">Области доступа</string>
+    <string name="lib_teams_scope_all">Вся команда</string>
+    <string name="lib_teams_scope_new">Новая область</string>
+    <string name="lib_teams_scope_create_title">Новая область доступа</string>
+    <string name="lib_teams_scope_create_hint">Записи в области шифруются собственным ключом и остаются нечитаемыми для участников без доступа.</string>
+    <string name="lib_teams_scope_name">Название области</string>
+    <string name="lib_teams_scope_delete">Удалить область</string>
+    <string name="lib_teams_scope_delete_message">Область, её список доступа и всё, чем в ней поделились, исчезнут у всех участников.</string>
+    <string name="lib_teams_scope_access">Доступ</string>
+    <string name="lib_teams_scope_access_title">Доступ к «%1$s»</string>
+    <string name="lib_teams_scope_access_hint">Только перечисленные участники могут получить и расшифровать эту область. Отзыв доступа ротирует её ключ.</string>
+    <string name="lib_teams_scope_grant">Выдать</string>
+    <string name="lib_teams_scope_revoke">Отозвать</string>
+    <string name="lib_teams_scope_no_key">У вас нет ключа этой области — её записи на этом устройстве не прочитать</string>
+    <string name="lib_teams_scope_members_count">с доступом: %1$d</string>
+    <string name="lib_teams_err_already_shared">Эта запись уже расшарена в другой области этой команды — сначала уберите её оттуда</string>
+    <string name="lib_teams_err_scopes_unsupported">Этот sync-сервер слишком старый для областей доступа — обновите сервер</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -144,4 +144,21 @@
     <string name="lib_teams_err_server_error">服务器响应异常，请稍后重试</string>
     <string name="lib_teams_err_forbidden">你的角色不允许此操作</string>
     <string name="lib_teams_err_vault_unreadable">本地团队保险库文件不可读 — 已保留，未删除</string>
+    <string name="lib_teams_scopes">访问范围</string>
+    <string name="lib_teams_scope_all">整个团队</string>
+    <string name="lib_teams_scope_new">新建范围</string>
+    <string name="lib_teams_scope_create_title">新建访问范围</string>
+    <string name="lib_teams_scope_create_hint">共享到范围中的记录使用自己的密钥加密，没有访问权限的成员无法读取。</string>
+    <string name="lib_teams_scope_name">范围名称</string>
+    <string name="lib_teams_scope_delete">删除范围</string>
+    <string name="lib_teams_scope_delete_message">该范围、其访问列表以及其中共享的全部内容将对所有成员删除。</string>
+    <string name="lib_teams_scope_access">访问权限</string>
+    <string name="lib_teams_scope_access_title">“%1$s”的访问权限</string>
+    <string name="lib_teams_scope_access_hint">只有列出的成员才能获取并解密此范围。撤销访问会轮换该范围的密钥。</string>
+    <string name="lib_teams_scope_grant">授予</string>
+    <string name="lib_teams_scope_revoke">撤销</string>
+    <string name="lib_teams_scope_no_key">你没有此范围的密钥 — 在本设备上无法读取其记录</string>
+    <string name="lib_teams_scope_members_count">%1$d 人可访问</string>
+    <string name="lib_teams_err_already_shared">该记录已共享到此团队的另一个范围 — 请先在那里取消共享</string>
+    <string name="lib_teams_err_scopes_unsupported">此同步服务器版本过旧，不支持访问范围 — 请更新服务器</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -144,4 +144,21 @@
     <string name="lib_teams_err_server_error">The server isn't responding correctly — try again later</string>
     <string name="lib_teams_err_forbidden">Not allowed for your role in this team</string>
     <string name="lib_teams_err_vault_unreadable">The local team vault file is unreadable — it was kept, not deleted</string>
+    <string name="lib_teams_scopes">Access scopes</string>
+    <string name="lib_teams_scope_all">Whole team</string>
+    <string name="lib_teams_scope_new">New scope</string>
+    <string name="lib_teams_scope_create_title">New access scope</string>
+    <string name="lib_teams_scope_create_hint">Records shared into a scope get their own key and stay unreadable for members without access.</string>
+    <string name="lib_teams_scope_name">Scope name</string>
+    <string name="lib_teams_scope_delete">Delete scope</string>
+    <string name="lib_teams_scope_delete_message">The scope, its access list and everything shared into it will be removed for all members.</string>
+    <string name="lib_teams_scope_access">Access</string>
+    <string name="lib_teams_scope_access_title">Access to “%1$s”</string>
+    <string name="lib_teams_scope_access_hint">Only members listed here can fetch and decrypt this scope. Revoking access rotates the scope key.</string>
+    <string name="lib_teams_scope_grant">Grant</string>
+    <string name="lib_teams_scope_revoke">Revoke</string>
+    <string name="lib_teams_scope_no_key">You have no key for this scope — its records can't be read on this device</string>
+    <string name="lib_teams_scope_members_count">%1$d with access</string>
+    <string name="lib_teams_err_already_shared">This record is already shared into another scope of this team — unshare it there first</string>
+    <string name="lib_teams_err_scopes_unsupported">This sync server is too old for access scopes — update the server</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -43,6 +43,9 @@ import app.skerry.ui.host.HostSection
 import app.skerry.ui.host.inSection
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.ui.app.LocalConnectHost
+import app.skerry.ui.generated.resources.lib_teams_scope_delete_message
+import app.skerry.ui.generated.resources.lib_teams_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_scopes
 import app.skerry.ui.generated.resources.lib_teams_sidebar
 import androidx.compose.ui.text.style.TextOverflow
 import app.skerry.shared.snippet.VaultSnippetStore
@@ -51,6 +54,7 @@ import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeRef
 import app.skerry.shared.vault.RecordType
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
@@ -109,7 +113,11 @@ import app.skerry.ui.teams.teamRoleLabel
 import app.skerry.ui.teams.InvitePreview
 import app.skerry.ui.teams.ShareItem
 import app.skerry.ui.teams.SharePickerDialog
+import app.skerry.ui.teams.TeamScopeUi
 import app.skerry.ui.teams.TeamUi
+import app.skerry.ui.teams.CreateScopeDialog
+import app.skerry.ui.teams.ScopeAccessDialog
+import app.skerry.ui.teams.ScopeSection
 import app.skerry.ui.teams.TeamsCoordinator
 import app.skerry.ui.teams.teamsFailureText
 import kotlinx.coroutines.launch
@@ -121,6 +129,7 @@ private sealed interface MobileTeamsConfirm {
     data class Leave(val teamId: String) : MobileTeamsConfirm
     data class Delete(val teamId: String) : MobileTeamsConfirm
     data class Remove(val teamId: String, val accountId: String) : MobileTeamsConfirm
+    data class DeleteScope(val teamId: String, val scopeId: String) : MobileTeamsConfirm
 }
 
 /**
@@ -211,6 +220,10 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     var confirm by remember { mutableStateOf<MobileTeamsConfirm?>(null) }
     var showHistory by remember { mutableStateOf(false) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
+    // Selected share space of the current team ("" = team-wide), like the desktop screen.
+    var selectedScope by remember { mutableStateOf("") }
+    var showCreateScope by remember { mutableStateOf(false) }
+    var scopeAccess by remember { mutableStateOf<TeamScopeUi?>(null) }
 
     val selected = teams.firstOrNull { it.id == selectedId } ?: teams.firstOrNull()
 
@@ -238,6 +251,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
             selected != null -> MobileTeamDetail(
                 tc = tc,
                 team = selected,
+                scopeId = selected.scopes.firstOrNull { it.id == selectedScope }?.id ?: "",
                 tick = tick,
                 busy = busy,
                 onInvite = { showInvite = true; invitePreview = null },
@@ -246,14 +260,46 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                 onAccept = { scope.launch { tc.accept(selected.id); tick++ } },
                 onDecline = { scope.launch { tc.decline(selected.id); tick++ } },
                 onSync = { scope.launch { tc.refresh(); tc.syncTeam(selected.id); tick++ } },
-                onUnshare = { recordId -> scope.launch { tc.unshareRecord(selected.id, recordId); tick++ } },
+                onUnshare = { recordId ->
+                    val ref = TeamScopeRef(selected.id, selected.scopes.firstOrNull { it.id == selectedScope }?.id ?: "")
+                    scope.launch { tc.unshareRecord(ref, recordId); tick++ }
+                },
                 onShowHistory = { showHistory = true },
                 onChangeRole = { member -> rolePicker = member },
+                onSelectScope = { selectedScope = it },
+                onNewScope = { showCreateScope = true },
+                onScopeAccess = { scopeAccess = it },
             )
         }
         Spacer(Modifier.height(40.dp))
     }
 
+    val scopeTeam = selected
+    if (showCreateScope && scopeTeam != null) {
+        CreateScopeDialog(
+            onDismiss = { showCreateScope = false },
+            onCreate = { name -> showCreateScope = false; scope.launch { tc.createScope(scopeTeam.id, name); tick++ } },
+        )
+    }
+    val accessScope = scopeAccess
+    if (accessScope != null && scopeTeam != null) {
+        val scopeMembers by produceState(emptyList<TeamMember>(), scopeTeam.id, tick) { value = tc.members(scopeTeam.id) }
+        val granted by produceState(emptySet<String>(), scopeTeam.id, accessScope.id, tick) {
+            value = tc.scopeGrants(scopeTeam.id, accessScope.id).toSet()
+        }
+        ScopeAccessDialog(
+            scopeName = accessScope.name,
+            members = scopeMembers.filter { it.status == TeamMemberStatus.ACTIVE },
+            granted = granted,
+            // Sealing the key to someone requires holding it, so a manager without a grant can
+            // revoke but not hand out.
+            canGrant = accessScope.hasKey,
+            busy = busy,
+            onGrant = { accountId -> scope.launch { tc.grantScope(scopeTeam.id, accessScope.id, accountId); tick++ } },
+            onRevoke = { accountId -> scope.launch { tc.revokeScope(scopeTeam.id, accessScope.id, accountId); tick++ } },
+            onDismiss = { scopeAccess = null },
+        )
+    }
     if (showCreate) {
         MobileCreateTeamDialog(
             onDismiss = { showCreate = false },
@@ -294,13 +340,15 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     val shareTeam = selected
     val shareKind = sharePicker
     if (shareKind != null && shareTeam != null) {
-        MobileSharePicker(tc, shareTeam.id, shareKind, tick, onDone = { sharePicker = null; tick++ }, onDismiss = { sharePicker = null })
+        val shareRef = TeamScopeRef(shareTeam.id, shareTeam.scopes.firstOrNull { it.id == selectedScope }?.id ?: "")
+        MobileSharePicker(tc, shareRef, shareKind, tick, onDone = { sharePicker = null; tick++ }, onDismiss = { sharePicker = null })
     }
     confirm?.let { c ->
         val (title, message) = when (c) {
             is MobileTeamsConfirm.Leave -> stringResource(Res.string.lib_teams_leave) to stringResource(Res.string.lib_teams_leave_message)
             is MobileTeamsConfirm.Delete -> stringResource(Res.string.lib_teams_delete) to stringResource(Res.string.lib_teams_delete_message)
             is MobileTeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, c.accountId)
+            is MobileTeamsConfirm.DeleteScope -> stringResource(Res.string.lib_teams_scope_delete) to stringResource(Res.string.lib_teams_scope_delete_message)
         }
         ConfirmActionDialog(
             title = title,
@@ -313,6 +361,10 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                         is MobileTeamsConfirm.Leave -> tc.leave(c.teamId)
                         is MobileTeamsConfirm.Delete -> tc.deleteTeam(c.teamId)
                         is MobileTeamsConfirm.Remove -> tc.removeMember(c.teamId, c.accountId)
+                        is MobileTeamsConfirm.DeleteScope -> {
+                            tc.deleteScope(c.teamId, c.scopeId)
+                            selectedScope = ""
+                        }
                     }
                     tick++
                 }
@@ -326,7 +378,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
 @Composable
 private fun MobileSharePicker(
     tc: TeamsCoordinator,
-    teamId: String,
+    ref: TeamScopeRef,
     kind: RecordType,
     tick: Int,
     onDone: () -> Unit,
@@ -335,14 +387,8 @@ private fun MobileSharePicker(
     val scope = rememberCoroutineScope()
     val hosts = LocalHosts.current
     val snippets = LocalSnippets.current
-    val sharedIds = remember(teamId, kind, tick) {
-        val vault = tc.teamVault(teamId)
-        when {
-            vault == null -> emptySet()
-            kind == RecordType.HOST -> VaultHostStore(vault).all().map { it.id }.toSet()
-            else -> VaultSnippetStore(vault).all().map { it.id }.toSet()
-        }
-    }
+    // Across every space of the team, not just the selected one: a record lives in exactly one space.
+    val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
     val items = if (kind == RecordType.HOST) {
         (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
     } else {
@@ -354,7 +400,7 @@ private fun MobileSharePicker(
         emptyText = stringResource(Res.string.lib_teams_share_empty),
         onPick = { item ->
             scope.launch {
-                tc.shareRecord(teamId, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
+                tc.shareRecord(ref, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
                 onDone()
             }
         },
@@ -366,6 +412,7 @@ private fun MobileSharePicker(
 private fun MobileTeamDetail(
     tc: TeamsCoordinator,
     team: TeamUi,
+    scopeId: String,
     tick: Int,
     busy: Boolean,
     onInvite: () -> Unit,
@@ -377,19 +424,28 @@ private fun MobileTeamDetail(
     onUnshare: (String) -> Unit,
     onShowHistory: () -> Unit,
     onChangeRole: (TeamMember) -> Unit,
+    onSelectScope: (String) -> Unit,
+    onNewScope: () -> Unit,
+    onScopeAccess: (TeamScopeUi) -> Unit,
 ) {
     val mono = LocalFonts.current.mono
     val invited = team.status == TeamMemberStatus.INVITED
     val owner = team.role == TeamRole.OWNER && !invited
     val canManage = team.role.canManageMembers && !invited
-    val canWrite = team.role.canWrite && !invited && team.hasKey
+    val activeScope = team.scopes.firstOrNull { it.id == scopeId }
+    val canWrite = team.role.canWrite && !invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)
     val canAudit = team.role.canViewAudit && !invited
     val members by produceState(emptyList<TeamMember>(), team.id, team.memberCount, tick) {
         value = tc.members(team.id)
     }
-    val teamVault = if (!invited && team.hasKey) tc.teamVault(team.id) else null
-    val sharedHosts = remember(team.id, tick, teamVault) { teamVault?.let { VaultHostStore(it).all() } ?: emptyList() }
-    val sharedSnippets = remember(team.id, tick, teamVault) { teamVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
+    // Records of the selected space only; a scope we hold no key for has nothing readable to show.
+    val spaceVault = if (!invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)) {
+        tc.spaceVault(TeamScopeRef(team.id, scopeId))
+    } else {
+        null
+    }
+    val sharedHosts = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultHostStore(it).all() } ?: emptyList() }
+    val sharedSnippets = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
 
     Txt(team.name, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, modifier = Modifier.padding(top = 10.dp))
     Txt(stringResource(Res.string.lib_teams_members_count, team.memberCount), color = Skerry.colors.dim, size = 12.sp, modifier = Modifier.padding(top = 2.dp))
@@ -424,6 +480,17 @@ private fun MobileTeamDetail(
         if (canAudit) GhostButton(stringResource(Res.string.lib_teams_history), onClick = onShowHistory, icon = "history")
         if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
     }
+
+    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_scopes))
+    ScopeSection(
+        scopes = team.scopes,
+        selected = scopeId,
+        canManage = canManage,
+        onSelect = onSelectScope,
+        onNew = onNewScope,
+        onAccess = onScopeAccess,
+        onDelete = { onConfirm(MobileTeamsConfirm.DeleteScope(team.id, it.id)) },
+    )
 
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_members))
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -543,11 +610,16 @@ internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>, section: HostSec
     // appear until a manual sync (the personal catalog is unchanged and sections read the vault imperatively).
     val revision by teams.revision.collectAsState()
     val sections = remember(teamList, hostsSnapshot, revision, section) {
-        teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.mapNotNull { team ->
-            val vault = teams.teamVault(team.id) ?: return@mapNotNull null
-            // Split by section like the personal catalog (desktop parity).
-            val shared = VaultHostStore(vault).all().inSection(section)
-            if (shared.isEmpty()) null else team.name to shared
+        teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.flatMap { team ->
+            // One group per share space: the team itself plus every scope whose key we hold.
+            val spaces = listOf(TeamScopeRef(team.id) to team.name) +
+                team.scopes.filter { it.hasKey }.map { TeamScopeRef(team.id, it.id) to "${team.name} · ${it.name}" }
+            spaces.mapNotNull { (ref, label) ->
+                val vault = teams.spaceVault(ref) ?: return@mapNotNull null
+                // Split by section like the personal catalog (desktop parity).
+                val shared = VaultHostStore(vault).all().inSection(section)
+                if (shared.isEmpty()) null else label to shared
+            }
         }
     }
     if (sections.isEmpty()) return

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
@@ -1,0 +1,239 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.TeamMember
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_scope_access_hint
+import app.skerry.ui.generated.resources.lib_teams_scope_access_title
+import app.skerry.ui.generated.resources.lib_teams_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_scope_no_key
+import app.skerry.ui.generated.resources.lib_teams_scope_access
+import app.skerry.ui.generated.resources.lib_teams_scope_all
+import app.skerry.ui.generated.resources.lib_teams_scope_create_hint
+import app.skerry.ui.generated.resources.lib_teams_scope_create_title
+import app.skerry.ui.generated.resources.lib_teams_scope_grant
+import app.skerry.ui.generated.resources.lib_teams_scope_members_count
+import app.skerry.ui.generated.resources.lib_teams_scope_name
+import app.skerry.ui.generated.resources.lib_teams_scope_new
+import app.skerry.ui.generated.resources.lib_teams_scope_revoke
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.generated.resources.shell_create
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Scope selector: which share space of the team the records below belong to. The team-wide space is
+ * always first — records without a scope stay visible to everyone, as they were before scopes
+ * existed. A scope whose key never reached us is shown greyed out: a manager may see it listed and
+ * delete it, but its records are ciphertext to them.
+ */
+@Composable
+private fun ScopeChipRow(
+    scopes: List<TeamScopeUi>,
+    selected: String,
+    canManage: Boolean,
+    onSelect: (String) -> Unit,
+    onNew: () -> Unit,
+) {
+    FlowRow(
+        Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ScopeChip(stringResource(Res.string.lib_teams_scope_all), active = selected.isEmpty(), muted = false) { onSelect("") }
+        scopes.forEach { scope ->
+            ScopeChip(scope.name, active = selected == scope.id, muted = !scope.hasKey) { onSelect(scope.id) }
+        }
+        if (canManage) {
+            GhostButton(stringResource(Res.string.lib_teams_scope_new), onClick = onNew, icon = "add")
+        }
+    }
+}
+
+/**
+ * The team's scope block: which space the records below belong to, plus the manager actions on the
+ * selected scope. Shared verbatim by the desktop and the mobile team screen — the only thing that
+ * differs between them is the section label above it, which each screen draws in its own style.
+ */
+@Composable
+internal fun ScopeSection(
+    scopes: List<TeamScopeUi>,
+    selected: String,
+    canManage: Boolean,
+    onSelect: (String) -> Unit,
+    onNew: () -> Unit,
+    onAccess: (TeamScopeUi) -> Unit,
+    onDelete: (TeamScopeUi) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        ScopeChipRow(scopes = scopes, selected = selected, canManage = canManage, onSelect = onSelect, onNew = onNew)
+        val active = scopes.firstOrNull { it.id == selected } ?: return@Column
+        if (canManage) {
+            Row(Modifier.padding(top = 10.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                GhostButton(stringResource(Res.string.lib_teams_scope_access), onClick = { onAccess(active) }, icon = "key")
+                GhostButton(
+                    stringResource(Res.string.lib_teams_scope_delete),
+                    onClick = { onDelete(active) },
+                    icon = "delete",
+                    fg = Skerry.colors.sunset,
+                    border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                )
+            }
+        }
+        if (!active.hasKey) {
+            Txt(
+                stringResource(Res.string.lib_teams_scope_no_key),
+                color = Skerry.colors.amber, size = 11.5.sp,
+                modifier = Modifier.padding(top = 10.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun ScopeChip(label: String, active: Boolean, muted: Boolean, onClick: () -> Unit) {
+    val fg = when {
+        active -> Skerry.colors.cyanBright
+        muted -> Skerry.colors.faint
+        else -> Skerry.colors.dim
+    }
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(if (active) Skerry.colors.cyan10 else Color.Transparent)
+            .border(1.dp, if (active) Skerry.colors.cyan14 else Skerry.colors.line, RoundedCornerShape(20.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        if (muted) Sym("lock", size = 12.sp, color = fg)
+        Txt(label, color = fg, size = 12.sp)
+    }
+}
+
+/** Create a scope: a name only. Its key is generated locally and sealed to us, like a team's. */
+@Composable
+internal fun CreateScopeDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
+    var name by remember { mutableStateOf("") }
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focus.requestFocus() }
+    fun save() {
+        if (name.trim().isNotEmpty()) onCreate(name.trim())
+    }
+    TeamsDialogCard(onDismiss) {
+        Txt(stringResource(Res.string.lib_teams_scope_create_title), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+        Txt(
+            stringResource(Res.string.lib_teams_scope_create_hint),
+            color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
+        )
+        TeamsTextField(name, { name = it }, stringResource(Res.string.lib_teams_scope_name), ::save, focus)
+        Row(
+            Modifier.fillMaxWidth().padding(top = 18.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+            PrimaryButton(stringResource(Res.string.shell_create), onClick = ::save, enabled = name.trim().isNotEmpty())
+        }
+    }
+}
+
+/**
+ * Who may read a scope. Granting seals the scope key to the member, so only someone who holds the
+ * key can hand it out — a manager without a grant sees the list but can't add to it ([canGrant]).
+ */
+@Composable
+internal fun ScopeAccessDialog(
+    scopeName: String,
+    members: List<TeamMember>,
+    granted: Set<String>,
+    canGrant: Boolean,
+    busy: Boolean,
+    onGrant: (String) -> Unit,
+    onRevoke: (String) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    TeamsDialogCard(onDismiss) {
+        Txt(stringResource(Res.string.lib_teams_scope_access_title, scopeName), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+        Txt(
+            stringResource(Res.string.lib_teams_scope_access_hint),
+            color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
+        )
+        Column(
+            Modifier.fillMaxWidth().heightIn(max = 320.dp).verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            members.forEach { member ->
+                val has = member.accountId in granted
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(7.dp))
+                        .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(7.dp))
+                        .padding(horizontal = 12.dp, vertical = 9.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Txt(member.accountId, color = if (has) Skerry.colors.textBright else Skerry.colors.dim, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+                    if (has) {
+                        GhostButton(
+                            stringResource(Res.string.lib_teams_scope_revoke),
+                            onClick = { if (!busy) onRevoke(member.accountId) },
+                            fg = Skerry.colors.sunset,
+                            border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                        )
+                    } else if (canGrant) {
+                        GhostButton(stringResource(Res.string.lib_teams_scope_grant), onClick = { if (!busy) onGrant(member.accountId) })
+                    }
+                }
+            }
+        }
+        Txt(
+            stringResource(Res.string.lib_teams_scope_members_count, granted.size),
+            color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.padding(top = 10.dp),
+        )
+        Row(
+            Modifier.fillMaxWidth().padding(top = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+        ) {
+            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSpaces.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSpaces.kt
@@ -1,0 +1,277 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountIdentity
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultCrypto
+
+/** A scope as the UI sees it: the server's metadata plus whether its key actually reached us. */
+data class TeamScopeUi(
+    val id: String,
+    val name: String,
+    val memberCount: Int,
+    /** false = we're listed as a manager but hold no key, so the scope's records stay unreadable. */
+    val hasKey: Boolean,
+)
+
+/**
+ * Everything about a team's **share spaces** — the team itself and each of its scopes: where their
+ * keys live, how their vaults open, how a key is rotated, and how a scope's sealed key is adopted
+ * from the server.
+ *
+ * The team and a scope are the same thing at this level (see [TeamScopeRef]), which is the point:
+ * key rotation and envelope verification exist once and are parameterized by the space, instead of
+ * a scope growing a parallel copy of the team's machinery.
+ */
+internal class TeamSpaces(
+    private val keyStore: TeamKeyStore,
+    private val teamVaults: TeamVaults,
+    private val crypto: VaultCrypto,
+    private val inviteCodec: TeamInviteCodec,
+    private val accountVaultUnlocked: () -> Boolean,
+    private val markError: (TeamsFailure) -> Unit,
+    private val syncSpace: suspend (TeamScopeRef) -> Unit,
+) {
+
+    // --- keys ---
+
+    /** The space's key, or null if we don't hold it (never granted, or the local record lost it). */
+    fun key(ref: TeamScopeRef): DataKey? =
+        if (ref.isTeamWide) keyStore.get(ref.teamId)?.dataKey()
+        else keyStore.scope(ref.teamId, ref.scopeId)?.dataKey()
+
+    fun epoch(ref: TeamScopeRef): Int =
+        if (ref.isTeamWide) keyStore.get(ref.teamId)?.epoch ?: 0
+        else keyStore.scope(ref.teamId, ref.scopeId)?.epoch ?: 0
+
+    fun name(ref: TeamScopeRef): String =
+        (if (ref.isTeamWide) keyStore.get(ref.teamId)?.name else keyStore.scope(ref.teamId, ref.scopeId)?.name)
+            ?: ref.key
+
+    private fun storeKey(ref: TeamScopeRef, key: DataKey, epoch: Int) {
+        if (ref.isTeamWide) keyStore.rekey(ref.teamId, key, epoch)
+        else keyStore.rekeyScope(ref.teamId, ref.scopeId, key, epoch)
+    }
+
+    // --- vaults ---
+
+    /** The space's vault; null when the account vault is locked or the key isn't here. */
+    fun vault(ref: TeamScopeRef): Vault? {
+        if (!accountVaultUnlocked()) return null
+        val key = key(ref) ?: return null
+        return teamVaults.open(ref, key)
+    }
+
+    /**
+     * Like [vault] but rebuilds the file if it is under a **superseded** key (a rotation adopted on
+     * another device). A structurally unreadable file is left alone and surfaced — resetting it
+     * would silently drop local records that were never pushed. Used by sync paths, not UI reads.
+     */
+    fun vaultResettingStale(ref: TeamScopeRef): Vault? {
+        if (!accountVaultUnlocked()) return null
+        val key = key(ref) ?: return null
+        return when (val r = teamVaults.openOrClassify(ref, key)) {
+            is TeamVaults.OpenResult.Opened -> r.vault
+            TeamVaults.OpenResult.StaleKey -> {
+                teamVaults.reset(ref)
+                teamVaults.open(ref, key)
+            }
+            TeamVaults.OpenResult.Unreadable -> {
+                markError(TeamsFailure.VaultUnreadable)
+                null
+            }
+        }
+    }
+
+    // --- scopes ---
+
+    /**
+     * Reconciles the server's scope list into local state and returns what the UI should show.
+     * Adopts keys we've been granted (or re-keyed), drops the ones we've lost. [canManage] members
+     * also see scopes they hold no key for — they can delete such a scope but not hand it out, since
+     * sealing an envelope needs the key itself.
+     */
+    suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, identity: AccountIdentity?): List<TeamScopeUi> {
+        val remote = c.listScopes(s, teamId)
+        val adopted = mutableListOf<TeamScopeRef>()
+        for (scope in remote) {
+            val ref = TeamScopeRef(teamId, scope.scopeId)
+            val envelope = scope.envelope ?: continue
+            if (identity == null) continue
+            val payload = inviteCodec.open(identity.sharing, envelope) ?: continue
+            if (payload.teamId != teamId || payload.scopeId != scope.scopeId) continue
+            if (payload.inviteeAccountId != s.accountId) continue
+            val local = keyStore.scope(teamId, scope.scopeId)
+            if (local != null && payload.epoch <= local.epoch) continue
+            val granterKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: continue
+            // The scope id is part of the signed binding: an envelope filed under another scope by
+            // the server doesn't verify here (see TeamInviteCodec).
+            if (!inviteCodec.verify(payload, granterKeys.signing, scopeId = scope.scopeId)) continue
+            if (local == null) {
+                keyStore.putScope(teamId, scope.scopeId, payload.teamName, payload.teamKey, payload.epoch)
+            } else {
+                keyStore.rekeyScope(teamId, scope.scopeId, payload.teamKey, payload.epoch)
+            }
+            teamVaults.reset(ref) // the file (if any) is under the previous key — rebuild on pull
+            adopted += ref
+        }
+        // Scopes we no longer appear in: the key is useless and the local copy has no right to exist.
+        val liveIds = remote.map { it.scopeId }.toSet()
+        keyStore.scopes(teamId).keys.filter { it !in liveIds }.forEach { gone ->
+            keyStore.removeScope(teamId, gone)
+            teamVaults.reset(TeamScopeRef(teamId, gone))
+        }
+        adopted.forEach { syncSpace(it) }
+        val keys = keyStore.scopes(teamId)
+        return remote.map { scope ->
+            TeamScopeUi(
+                id = scope.scopeId,
+                name = keys[scope.scopeId]?.name ?: scope.scopeId,
+                memberCount = scope.memberCount,
+                hasKey = keys.containsKey(scope.scopeId),
+            )
+        }
+    }
+
+    /**
+     * Creates a scope with a fresh key, sealed to ourselves: that envelope is what the server hands
+     * back to our other devices (and to this one if the local record ever loses the key).
+     *
+     * The recipient key is our **local** public half, never the copy the server publishes for us —
+     * asking the server for our own key would let it answer with someone else's and have us seal the
+     * scope key to them.
+     */
+    suspend fun createScope(s: SyncSession, c: TeamClient, teamId: String, scopeId: String, name: String, identity: AccountIdentity) {
+        val scopeKey = crypto.newDataKey()
+        val envelope = seal(identity.sharing.publicKey, identity, s.accountId, s.accountId, teamId, scopeId, scopeKey, name, epoch = 0)
+        c.createScope(s, teamId, scopeId, envelope)
+        keyStore.putScope(teamId, scopeId, name, scopeKey, epoch = 0)
+    }
+
+    /** Grants a member the scope: its current key, sealed and signed to them. */
+    suspend fun grantScope(s: SyncSession, c: TeamClient, teamId: String, scopeId: String, accountId: String, identity: AccountIdentity) {
+        val entry = keyStore.scope(teamId, scopeId) ?: return markError(TeamsFailure.KeyMissing)
+        val scopeKey = entry.dataKey() ?: return markError(TeamsFailure.KeyMissing)
+        val recipient = c.fetchPublicKey(s, accountId) ?: return markError(TeamsFailure.NoRecipientKey)
+        val envelope = seal(
+            recipient.sharing, identity, s.accountId, accountId, teamId, scopeId, scopeKey, entry.name, entry.epoch,
+        )
+        c.grantScope(s, teamId, scopeId, accountId, envelope)
+    }
+
+    /** Deletes a scope on the server and forgets it locally (key and vault file). */
+    suspend fun deleteScope(s: SyncSession, c: TeamClient, teamId: String, scopeId: String) {
+        c.deleteScope(s, teamId, scopeId)
+        forgetScope(teamId, scopeId)
+    }
+
+    fun forgetScope(teamId: String, scopeId: String) {
+        keyStore.removeScope(teamId, scopeId)
+        teamVaults.reset(TeamScopeRef(teamId, scopeId))
+    }
+
+    // --- rotation ---
+
+    /**
+     * Rotates a share space's key: a fresh key is re-sealed (signed) to every remaining recipient,
+     * the server epoch is bumped, and only then are the local records re-encrypted so they win LWW
+     * over the server's old-key copies.
+     *
+     * Fails closed. The vault is opened under the CURRENT key *before* the server is touched: if it
+     * can't be opened (locked, or already under a superseded key), nothing happens at all and the old
+     * key stays authoritative — better than a server holding blobs nobody can read. The next epoch
+     * comes from the server, not from a possibly stale local one, and a lost race is retried a
+     * bounded number of times.
+     *
+     * The team key and a scope key rotate through this one implementation; [target] is what differs.
+     */
+    suspend fun rotate(s: SyncSession, c: TeamClient, target: RotationTarget) {
+        val ref = target.ref
+        val currentKey = key(ref) ?: return markError(TeamsFailure.KeyMissing)
+        val spaceName = name(ref)
+        val vault = openUnder(ref, currentKey) ?: return markError(TeamsFailure.KeyMissing)
+        val identity = target.identity
+        var attempt = 0
+        while (true) {
+            val serverEpoch = target.serverEpoch(s, c) ?: return markError(TeamsFailure.KeyMissing)
+            val newEpoch = (serverEpoch + 1).toInt()
+            val newKey = crypto.newDataKey()
+            val envelopes = mutableMapOf<String, ByteArray>()
+            for (accountId in target.recipients(s, c)) {
+                if (accountId == s.accountId) continue // we adopt the key locally, no self-envelope
+                val keys = c.fetchPublicKey(s, accountId) ?: continue // unpublished key: can't re-seal
+                envelopes[accountId] = seal(
+                    keys.sharing, identity, s.accountId, accountId, ref.teamId, ref.scopeId, newKey, spaceName, newEpoch,
+                )
+            }
+            try {
+                target.commit(s, c, newEpoch.toLong(), envelopes)
+            } catch (e: SyncException) {
+                newKey.zeroize() // rotation didn't commit — don't leave the unused key dangling
+                // A stale-epoch conflict means someone rotated meanwhile: refetch the epoch and retry.
+                // Give up after a few tries and surface it — the revocation stands regardless.
+                if (e.kind == SyncException.Kind.CONFLICT && attempt++ < REKEY_MAX_ATTEMPTS) continue
+                throw e
+            }
+            // Committed: store the new key (the store base64-copies it) and re-encrypt the records
+            // (version+1 wins LWW over the server's old-key copies), then push. rekeyRecords takes
+            // ownership of newKey.
+            storeKey(ref, newKey, newEpoch)
+            vault.rekeyRecords(newKey)
+            syncSpace(ref)
+            return
+        }
+    }
+
+    /** Open the space's vault under a known key (no stale-file handling — the key is the current one). */
+    private fun openUnder(ref: TeamScopeRef, key: DataKey): Vault? {
+        if (!accountVaultUnlocked()) return null
+        return teamVaults.open(ref, key)
+    }
+
+    private fun seal(
+        recipientPublicKey: ByteArray,
+        identity: AccountIdentity,
+        senderId: String,
+        recipientId: String,
+        teamId: String,
+        scopeId: String,
+        key: DataKey,
+        name: String,
+        epoch: Int,
+    ): ByteArray = inviteCodec.seal(
+        recipientPublicKey = recipientPublicKey,
+        inviter = identity.signing,
+        inviterId = senderId,
+        inviteeId = recipientId,
+        teamId = teamId,
+        teamKey = key,
+        teamName = name,
+        epoch = epoch,
+        scopeId = scopeId,
+    )
+
+    private companion object {
+        /** Bounded retries when a rotation loses the epoch race to a concurrent rotation. */
+        const val REKEY_MAX_ATTEMPTS = 3
+    }
+}
+
+/**
+ * What differs between rotating the team key and rotating a scope key: where the authoritative
+ * epoch is read, who must receive the new key, and which endpoint commits the bump.
+ */
+internal class RotationTarget(
+    val ref: TeamScopeRef,
+    val identity: AccountIdentity,
+    val serverEpoch: suspend (SyncSession, TeamClient) -> Long?,
+    val recipients: suspend (SyncSession, TeamClient) -> List<String>,
+    val commit: suspend (SyncSession, TeamClient, Long, Map<String, ByteArray>) -> Unit,
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -16,11 +16,11 @@ import app.skerry.shared.team.TeamIdentityStore
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeRef
 import app.skerry.shared.team.TeamScopedSyncClient
 import app.skerry.shared.team.TeamSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.team.accountKeyFingerprint
-import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
@@ -40,7 +40,7 @@ import app.skerry.shared.team.stripShareFields
 enum class TeamsFailure {
     NotConnected, VaultLocked, NoRecipientKey, AlreadyInvited, NoSuchAccount,
     KeyMissing, Network, Protocol, Forbidden, VaultUnreadable,
-    TooManyRequests, ServerError,
+    TooManyRequests, ServerError, AlreadyShared, ScopesUnsupported,
 }
 
 /**
@@ -69,6 +69,8 @@ data class TeamUi(
     val memberCount: Int,
     /** false for an active team = the key didn't arrive (or the envelope didn't open) — records inaccessible. */
     val hasKey: Boolean,
+    /** Scopes of this team we may see: everything for a manager, our grants otherwise. */
+    val scopes: List<TeamScopeUi> = emptyList(),
 )
 
 /** Invite confirmation data: the invitee's key fingerprint is verified over voice/chat. */
@@ -79,6 +81,10 @@ data class InvitePreview(val accountId: String, val fingerprint: String)
  * vaults, and a team-scoped [SyncEngine]. All operations report [TeamsFailure] in [lastError] instead
  * of throwing (except CancellationException). Concurrency conventions as in SyncCoordinator: one
  * [opMutex] for mutations, [syncMutex] for sync cycles.
+ *
+ * A team's records live in **share spaces** ([TeamScopeRef]): the team itself, plus one per scope for
+ * granular sharing. Everything about their keys and vaults is in [TeamSpaces]; this class
+ * orchestrates.
  */
 class TeamsCoordinator(
     private val session: () -> SyncSession?,
@@ -87,7 +93,8 @@ class TeamsCoordinator(
     private val crypto: VaultCrypto,
     private val teamVaults: TeamVaults,
     private val teamState: SyncStateStore,
-    private val newTeamId: () -> String,
+    /** Generator of client-side ids (teams and scopes) — a UUID in production. */
+    private val newId: () -> String,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     private val onTeamsChanged: () -> Unit = {},
 ) {
@@ -95,6 +102,16 @@ class TeamsCoordinator(
     private val keyStore = TeamKeyStore(vault)
     private val identityStore = TeamIdentityStore(vault, crypto)
     private val inviteCodec = TeamInviteCodec(crypto)
+
+    private val spaces = TeamSpaces(
+        keyStore = keyStore,
+        teamVaults = teamVaults,
+        crypto = crypto,
+        inviteCodec = inviteCodec,
+        accountVaultUnlocked = { vault.isUnlocked },
+        markError = { markError(it) },
+        syncSpace = { syncSpace(it) },
+    )
 
     private val opMutex = Mutex()
     private val syncMutex = Mutex()
@@ -110,15 +127,15 @@ class TeamsCoordinator(
     val teams: StateFlow<List<TeamUi>> = _teams
 
     /**
-     * Monotonic counter bumped on every actual change to team-vault contents: a pull brought remote
-     * records ([syncTeam] with `pulled > 0`) or we shared/unshared a record
+     * Monotonic counter bumped on every actual change to a team space's contents: a pull brought
+     * remote records ([syncSpace] with `pulled > 0`) or we shared/unshared a record
      * ([shareRecord]/[unshareRecord]). The shared-host UI sections read the team vault imperatively (not
      * via a records StateFlow), so without this signal a live-sync that pulled new records wouldn't
      * repaint the list: [_teams] doesn't change and the personal catalog (which the sections were tied
      * to indirectly) stays the same — Compose would skip recomposition. Sections key `remember` on this.
      *
-     * Bump only on actual changes (not every [syncTeam]): [syncAll] on each Online transition runs all
-     * teams, and an unconditional ++ would invalidate the sections' `remember` (→ recompute
+     * Bump only on actual changes (not every [syncSpace]): [syncAll] on each Online transition runs all
+     * spaces, and an unconditional ++ would invalidate the sections' `remember` (→ recompute
      * `VaultHostStore.all()` for all teams) even on an empty delta.
      */
     private val _revision = MutableStateFlow(0)
@@ -146,12 +163,22 @@ class TeamsCoordinator(
     // otherwise run a full re-pull for nothing.
     private val recoveryRequested = mutableSetOf<String>()
 
+    /**
+     * The connected server predates scopes: it answers 404 on `/teams/{id}/scopes` even for a team
+     * we're an active member of. Remembered so scope operations can say "update the server" instead
+     * of failing as "no such account" — and cleared as soon as a listing succeeds, so it can't stick
+     * after the server is upgraded mid-session.
+     */
+    private var scopesUnsupported = false
+
     /** Wire to SyncCoordinator's WS signals (`sync.onTeamSignal = teams::onSignal`). */
     fun onSignal(signal: SyncSignal) {
         when (signal) {
             is SyncSignal.Team -> scope.launch {
                 // Cursor guard, like the account watch: our own echo doesn't run a redundant cycle.
-                if (signal.cursor > teamState.cursor(cursorKey(signal.teamId))) syncTeam(signal.teamId)
+                // The cursor is the team's, shared by all its spaces, so any space lagging behind it
+                // has something to fetch.
+                if (spacesOf(signal.teamId).any { signal.cursor > teamState.cursor(it.key) }) syncTeam(signal.teamId)
             }
             SyncSignal.Membership -> scope.launch { refresh() }
             is SyncSignal.Account -> Unit // the account channel is handled by SyncCoordinator
@@ -194,13 +221,10 @@ class TeamsCoordinator(
             val identity = publishIdentity(s, c)
             val remote = c.listTeams(s)
             adoptRotatedKeys(s, c, remote, identity)
-            publishTeams(remote, identity)
+            publishTeams(s, c, remote, identity)
             // Keys of teams we were removed from (or that were deleted) are no longer needed.
             val liveIds = remote.map { it.id }.toSet()
-            keyStore.list().keys.filter { it !in liveIds }.forEach { gone ->
-                keyStore.remove(gone)
-                teamVaults.reset(gone)
-            }
+            keyStore.list().keys.filter { it !in liveIds }.forEach { gone -> forgetTeamLocally(gone) }
             // A cached invite of a vanished team holds teamKey material — drop it with the team.
             verifiedInvites.update { cached -> cached.filterKeys { it in liveIds } }
             onTeamsChanged()
@@ -228,7 +252,7 @@ class TeamsCoordinator(
         if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
         op {
             publishIdentity(s, c)
-            val teamId = newTeamId()
+            val teamId = newId()
             c.createTeam(s, teamId)
             keyStore.put(teamId, name.ifBlank { teamId }, TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
             refreshUnlocked(s, c)
@@ -361,16 +385,31 @@ class TeamsCoordinator(
         val sess = session() ?: return markError(TeamsFailure.NotConnected)
         val c = client() ?: return markError(TeamsFailure.NotConnected)
         op {
+            // Which scopes the member holds has to be read before the removal: the server drops their
+            // grants along with the membership, and afterwards there is no way to tell which keys they
+            // walked away with.
+            val heldScopes = if (accountId == sess.accountId) emptyList() else scopesHeldBy(sess, c, teamId, accountId)
             c.removeMember(sess, teamId, accountId)
             if (accountId == sess.accountId) {
                 // Voluntary leave/decline: we can't rotate (we're gone). A remaining manager rotates.
                 forgetTeamLocally(teamId)
             } else {
-                // Removing someone else revokes their server ACL but not their copy of teamKey. Rotate
-                // so records shared after removal are encrypted under a key the removed member lacks
+                // Removing someone else revokes their server ACL but not their copy of the keys. Rotate
+                // so records shared after removal are encrypted under keys the removed member lacks
                 // (forward secrecy against a leaked backup / compromised server). Best-effort: a rotation
                 // failure still leaves the member removed — surfaced via lastError.
                 rotateTeamKey(sess, c, teamId)
+                // Each scope rotates independently: one failing must not leave the rest un-rotated,
+                // since every skipped scope is a key the removed member still holds.
+                heldScopes.forEach { scopeId ->
+                    try {
+                        rotateScopeKey(sess, c, TeamScopeRef(teamId, scopeId))
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        markError(e.toFailure())
+                    }
+                }
             }
             refreshUnlocked(sess, c)
         }
@@ -386,51 +425,140 @@ class TeamsCoordinator(
         }
     }
 
-    /** Team vault (for shared-record stores in the UI); null — no key/not active/vault locked. */
-    fun teamVault(teamId: String): Vault? {
-        if (!vault.isUnlocked) return null
-        val key = keyStore.get(teamId)?.dataKey() ?: return null
-        return teamVaults.open(teamId, key)
+    // --- scopes ---
+
+    /** Create a scope with its own key: what is shared into it stays unreadable outside its grants. */
+    suspend fun createScope(teamId: String, name: String) {
+        val s = session() ?: return markError(TeamsFailure.NotConnected)
+        val c = client() ?: return markError(TeamsFailure.NotConnected)
+        if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
+        if (scopesUnsupported) return markError(TeamsFailure.ScopesUnsupported)
+        op {
+            val identity = identityStore.ensure()
+            val scopeId = newId()
+            spaces.createScope(s, c, teamId, scopeId, name.ifBlank { scopeId }, identity)
+            refreshUnlocked(s, c)
+        }
+    }
+
+    suspend fun deleteScope(teamId: String, scopeId: String) {
+        val s = session() ?: return markError(TeamsFailure.NotConnected)
+        val c = client() ?: return markError(TeamsFailure.NotConnected)
+        op {
+            spaces.deleteScope(s, c, teamId, scopeId)
+            refreshUnlocked(s, c)
+        }
+    }
+
+    /** Give a team member access to a scope: its current key, sealed and signed to them. */
+    suspend fun grantScope(teamId: String, scopeId: String, accountId: String) {
+        val s = session() ?: return markError(TeamsFailure.NotConnected)
+        val c = client() ?: return markError(TeamsFailure.NotConnected)
+        if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
+        if (scopesUnsupported) return markError(TeamsFailure.ScopesUnsupported)
+        op {
+            spaces.grantScope(s, c, teamId, scopeId, accountId, identityStore.ensure())
+            refreshUnlocked(s, c)
+        }
     }
 
     /**
-     * Share an account-vault record with a team: a copy of the decrypted payload is placed in the team
-     * vault under the same id. [stripFields] are fields meaningless outside the personal workspace
-     * (e.g. a host's `groupId`). Returns false if the vault/record is inaccessible.
+     * Take a member's scope access away and rotate the scope key: the ACL row is gone, but they keep
+     * their copy of the old key, so anything shared afterwards must be under a new one.
+     */
+    suspend fun revokeScope(teamId: String, scopeId: String, accountId: String) {
+        val s = session() ?: return markError(TeamsFailure.NotConnected)
+        val c = client() ?: return markError(TeamsFailure.NotConnected)
+        if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
+        op {
+            c.revokeScope(s, teamId, scopeId, accountId)
+            if (accountId == s.accountId) {
+                spaces.forgetScope(teamId, scopeId) // gave up our own access: the local copy must go
+            } else {
+                rotateScopeKey(s, c, TeamScopeRef(teamId, scopeId))
+            }
+            refreshUnlocked(s, c)
+        }
+    }
+
+    /** Accounts holding a grant on the scope (managers only); empty list plus [lastError] on failure. */
+    suspend fun scopeGrants(teamId: String, scopeId: String): List<String> {
+        val s = session() ?: return emptyList()
+        val c = client() ?: return emptyList()
+        return try {
+            c.scopeGrants(s, teamId, scopeId).map { it.accountId }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            markError(e.toFailure())
+            emptyList()
+        }
+    }
+
+    // --- records ---
+
+    /** Vault of one share space (for shared-record stores in the UI); null — no key/vault locked. */
+    fun spaceVault(ref: TeamScopeRef): Vault? = spaces.vault(ref)
+
+    /**
+     * Ids of records already shared into **any** space of the team, by type. A record belongs to
+     * exactly one space (the server refuses to move one, see TeamRecordRepository.upsert), so the
+     * share picker has to hide what is already shared elsewhere in the team — offering it again would
+     * write a local copy the server then silently declines.
+     */
+    fun sharedRecordIds(teamId: String, type: RecordType): Set<String> =
+        spacesOf(teamId).mapNotNull { spaces.vault(it) }
+            .flatMapTo(mutableSetOf()) { space ->
+                space.records().filter { it.type == type && !it.deleted }.map { it.id }
+            }
+
+    /**
+     * Share an account-vault record with a team space: a copy of the decrypted payload is placed in
+     * that space's vault under the same id. [stripFields] are fields meaningless outside the personal
+     * workspace (e.g. a host's `groupId`). Returns false if the vault/record is inaccessible, or if
+     * the record is already shared into another space of this team — the server keeps a record in the
+     * space it was first shared into, so writing it here would be a local copy nobody else ever sees.
+     * Moving a record between spaces is an unshare followed by a share.
      */
     suspend fun shareRecord(
-        teamId: String,
+        ref: TeamScopeRef,
         recordId: String,
         type: RecordType,
         stripFields: Set<String> = emptySet(),
     ): Boolean {
-        val target = teamVault(teamId) ?: run { markError(TeamsFailure.KeyMissing); return false }
+        val target = spaceVault(ref) ?: run { markError(TeamsFailure.KeyMissing); return false }
+        val elsewhere = spacesOf(ref.teamId).filter { it != ref }
+            .any { space -> spaces.vault(space)?.records()?.any { it.id == recordId && !it.deleted } == true }
+        if (elsewhere) {
+            markError(TeamsFailure.AlreadyShared)
+            return false
+        }
         val payload = runCatching { vault.openPayload(recordId) }.getOrNull() ?: return false
         val cleaned = stripShareFields(payload, stripFields)
         target.put(recordId, type, cleaned)
-        _revision.value++ // local mutation: syncTeam below yields pulled==0 on our own record
-        syncTeam(teamId)
+        _revision.value++ // local mutation: syncSpace below yields pulled==0 on our own record
+        syncSpace(ref)
         return true
     }
 
-    /** Remove a record from a team (the tombstone reaches all members). */
-    suspend fun unshareRecord(teamId: String, recordId: String) {
-        teamVault(teamId)?.remove(recordId) ?: return
-        _revision.value++ // local mutation: syncTeam below yields pulled==0 on our own tombstone
-        syncTeam(teamId)
+    /** Remove a record from a team space (the tombstone reaches everyone holding that space's key). */
+    suspend fun unshareRecord(ref: TeamScopeRef, recordId: String) {
+        spaceVault(ref)?.remove(recordId) ?: return
+        _revision.value++ // local mutation: syncSpace below yields pulled==0 on our own tombstone
+        syncSpace(ref)
     }
 
-    /** Sync one team (team-scoped pull+push via the shared SyncEngine). */
-    suspend fun syncTeam(teamId: String) {
+    /** Sync one share space (scoped pull+push via the shared SyncEngine). */
+    suspend fun syncSpace(ref: TeamScopeRef) {
         val s = session() ?: return
         val c = client() ?: return
-        val teamVault = openTeamVaultResettingStale(teamId) ?: return
+        val spaceVault = spaces.vaultResettingStale(ref) ?: return
         syncMutex.withLock {
             try {
                 val engine = SyncEngine(
-                    TeamScopedSyncClient(c, teamId),
-                    teamVault,
-                    KeyedStateStore(teamState, cursorKey(teamId)),
+                    TeamScopedSyncClient(c, ref),
+                    spaceVault,
+                    KeyedStateStore(teamState, ref.key),
                     settings = { SyncSettings() },
                 )
                 val outcome = engine.sync(s)
@@ -448,6 +576,9 @@ class TeamsCoordinator(
         }
     }
 
+    /** Sync every space of one team: the team itself plus each scope we hold a key for. */
+    suspend fun syncTeam(teamId: String) = spacesOf(teamId).forEach { syncSpace(it) }
+
     suspend fun syncAll() {
         _teams.value.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }
             .forEach { syncTeam(it.id) }
@@ -462,10 +593,17 @@ class TeamsCoordinator(
 
     // --- internals ---
 
+    /** Spaces of a team whose key we hold: the team itself and each granted scope. */
+    private fun spacesOf(teamId: String): List<TeamScopeRef> =
+        listOf(TeamScopeRef(teamId)) + keyStore.scopes(teamId).keys.map { TeamScopeRef(teamId, it) }
+
     private fun forgetTeamLocally(teamId: String) {
+        // Read the spaces first: removing the TEAM record takes the nested scope keys with it, and
+        // their cursors would then never be cleared (a re-join would resume mid-stream and miss records).
+        val spaceKeys = spacesOf(teamId).map { it.key }
         keyStore.remove(teamId)
-        teamVaults.reset(teamId)
-        teamState.setCursor(cursorKey(teamId), 0)
+        teamVaults.resetTeam(teamId) // the team's vault and every scope vault under it
+        spaceKeys.forEach { teamState.setCursor(it, 0) }
         verifiedInvites.update { it - teamId } // decline/leave: drop any cached invite for this team
     }
 
@@ -474,7 +612,7 @@ class TeamsCoordinator(
         val identity = identityStore.load()
         val remote = c.listTeams(s)
         if (identity != null) adoptRotatedKeys(s, c, remote, identity)
-        publishTeams(remote, identity)
+        publishTeams(s, c, remote, identity)
         onTeamsChanged()
         maybeRecoverKeys()
     }
@@ -487,22 +625,69 @@ class TeamsCoordinator(
     }
 
     /** Map server summaries to [TeamUi]; the display name comes from the local key or the invite envelope. */
-    private fun publishTeams(remote: List<TeamSummary>, identity: AccountIdentity?) {
+    private suspend fun publishTeams(s: SyncSession, c: TeamClient, remote: List<TeamSummary>, identity: AccountIdentity?) {
         val keys = keyStore.list()
         _teams.value = remote.map { t ->
             val entry = keys[t.id]
             val name = entry?.name ?: t.envelope?.let { env ->
                 identity?.let { inviteCodec.open(it.sharing, env)?.teamName }
             } ?: t.id
-            TeamUi(t.id, name, t.ownerAccountId, t.role, t.status, t.memberCount, entry != null)
+            val scopes = if (t.status == TeamMemberStatus.ACTIVE) refreshScopes(s, c, t.id, identity) else emptyList()
+            TeamUi(t.id, name, t.ownerAccountId, t.role, t.status, t.memberCount, entry != null, scopes)
         }
     }
 
     /**
+     * Scopes of one team, tolerating a server that doesn't know about them: a self-hosted deployment
+     * older than granular sharing answers 404, and losing the whole team list over an optional feature
+     * would be a far worse trade (same reasoning as the trash-record push batch in SyncEngine).
+     *
+     * The two failure modes are kept apart. A 404 means "this server has no scopes" — the list is
+     * genuinely empty and [scopesUnsupported] is raised so a later create/grant can explain itself.
+     * Anything else (network blip, 5xx) says nothing about whether scopes exist, so the ones we
+     * already know are kept on screen rather than blinking out, and the failure is surfaced.
+     */
+    private suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, identity: AccountIdentity?): List<TeamScopeUi> =
+        try {
+            spaces.refreshScopes(s, c, teamId, identity).also { scopesUnsupported = false }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if ((e as? SyncException)?.kind == SyncException.Kind.NOT_FOUND) {
+                scopesUnsupported = true
+                emptyList()
+            } else {
+                markError(e.toFailure())
+                _teams.value.firstOrNull { it.id == teamId }?.scopes ?: emptyList()
+            }
+        }
+
+    /**
+     * Scope ids [accountId] holds in the team, read **before** the removal — the server drops their
+     * grants along with the membership, and afterwards there is no way to tell which keys they walked
+     * away with.
+     *
+     * Fails safe: if the grant lists can't be read, every scope we hold a key for is rotated instead
+     * of none. Over-rotating costs the other members a re-pull; under-rotating would leave the removed
+     * member with a live key, which is the thing this exists to prevent. Best-effort against one race:
+     * a grant handed out from another device between this read and the removal isn't covered.
+     */
+    private suspend fun scopesHeldBy(s: SyncSession, c: TeamClient, teamId: String, accountId: String): List<String> =
+        try {
+            c.listScopes(s, teamId)
+                .filter { scope -> c.scopeGrants(s, teamId, scope.scopeId).any { it.accountId == accountId } }
+                .map { it.scopeId }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            keyStore.scopes(teamId).keys.toList()
+        }
+
+    /**
      * Adopt a rotated teamKey delivered by the server ([TeamSummary.keyEnvelope]): open+verify the
      * signed rekey envelope and, if its epoch is newer than the locally stored key, replace the key.
-     * The stale local team-vault file (still under the old key) is dropped so [syncTeam] re-pulls the
-     * re-encrypted records. A forged/unverifiable envelope is ignored (the old key is kept).
+     * The stale local team-vault file (still under the old key) is dropped so the next sync re-pulls
+     * the re-encrypted records. A forged/unverifiable envelope is ignored (the old key is kept).
      */
     private suspend fun adoptRotatedKeys(s: SyncSession, c: TeamClient, remote: List<TeamSummary>, identity: AccountIdentity) {
         val adopted = mutableListOf<String>()
@@ -515,73 +700,41 @@ class TeamsCoordinator(
             val rotatorKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: continue
             if (!inviteCodec.verify(payload, rotatorKeys.signing)) continue
             keyStore.rekey(summary.id, payload.teamKey, payload.epoch)
-            teamVaults.reset(summary.id) // old-key file is unreadable under the new key — rebuild on pull
+            teamVaults.reset(TeamScopeRef(summary.id)) // old-key file is unreadable under the new key
             adopted += summary.id
         }
         // Re-pull the re-encrypted records under the freshly adopted key (the reset dropped the stale file).
-        adopted.forEach { syncTeam(it) }
+        adopted.forEach { syncSpace(TeamScopeRef(it)) }
     }
 
-    /**
-     * Rotate the teamKey after a member removal: generate a fresh key, re-seal it (signed) to every
-     * remaining member, bump the server epoch, then re-encrypt local records under the new key so they
-     * win LWW and overwrite the server's old-key copies.
-     *
-     * Fails closed: re-encrypting local records is mandatory (otherwise the server keeps old-key blobs
-     * while members adopt the new key, leaving every shared record unreadable for everyone). So the
-     * team vault is opened under the CURRENT key *before* the server epoch is bumped — if it can't be
-     * opened (vault locked, or the on-disk file is already under a superseded key), rotation aborts
-     * before touching the server: the old key stays authoritative and records stay readable. The next
-     * epoch is derived from the server's epoch, not the (possibly stale) local one, so a lagging device
-     * doesn't 409 while the member is already removed; a genuine concurrent rotation is retried a
-     * bounded number of times.
-     */
+    /** Rotate the team key (member removal). See [TeamSpaces.rotate] for the fail-closed contract. */
     private suspend fun rotateTeamKey(s: SyncSession, c: TeamClient, teamId: String) {
-        val entry = keyStore.get(teamId) ?: return
-        val oldKey = entry.dataKey() ?: return markError(TeamsFailure.KeyMissing)
-        // Open under the current key up front (before keyStore.rekey swaps it) — the returned vault is
-        // what we re-encrypt after the server accepts the rotation. Abort here means nothing changed.
-        val teamVault = openTeamVault(teamId, oldKey) ?: return markError(TeamsFailure.KeyMissing)
         val identity = identityStore.ensure()
-        var attempt = 0
-        while (true) {
-            val serverEpoch = c.listTeams(s).firstOrNull { it.id == teamId }?.keyEpoch
-                ?: return markError(TeamsFailure.KeyMissing)
-            val newEpoch = (serverEpoch + 1).toInt()
-            val newKey = crypto.newDataKey()
-            val envelopes = mutableMapOf<String, ByteArray>()
-            for (member in c.members(s, teamId)) {
-                if (member.accountId == s.accountId) continue // we adopt the key locally, no self-envelope
-                val keys = c.fetchPublicKey(s, member.accountId) ?: continue // unpublished key: can't re-seal
-                envelopes[member.accountId] = inviteCodec.seal(
-                    recipientPublicKey = keys.sharing,
-                    inviter = identity.signing,
-                    inviterId = s.accountId,
-                    inviteeId = member.accountId,
-                    teamId = teamId,
-                    teamKey = newKey,
-                    teamName = entry.name,
-                    epoch = newEpoch,
-                )
-            }
-            try {
-                c.rekey(s, teamId, newEpoch.toLong(), envelopes)
-            } catch (e: SyncException) {
-                newKey.zeroize() // rotation didn't commit — don't leave the unused key dangling
-                // A stale-epoch conflict means someone else rotated meanwhile: refetch the epoch and
-                // retry (their rotation may already cover the removal, but ours re-encrypts our local
-                // records). Give up after a few tries and surface — the member stays removed regardless.
-                if (e.kind == SyncException.Kind.CONFLICT && attempt++ < REKEY_MAX_ATTEMPTS) continue
-                throw e
-            }
-            // Server bumped and envelopes delivered. Commit locally: store the new key (keyStore.rekey
-            // base64-copies it) and re-encrypt records (version+1 wins LWW, overwriting the server's
-            // old-key copies), then push. rekeyRecords takes ownership of newKey.
-            keyStore.rekey(teamId, newKey, newEpoch)
-            teamVault.rekeyRecords(newKey)
-            syncTeam(teamId)
-            return
-        }
+        spaces.rotate(
+            s, c,
+            RotationTarget(
+                ref = TeamScopeRef(teamId),
+                identity = identity,
+                serverEpoch = { sess, cl -> cl.listTeams(sess).firstOrNull { it.id == teamId }?.keyEpoch },
+                recipients = { sess, cl -> cl.members(sess, teamId).map { it.accountId } },
+                commit = { sess, cl, epoch, envelopes -> cl.rekey(sess, teamId, epoch, envelopes) },
+            ),
+        )
+    }
+
+    /** Rotate one scope's key (grant revoked, or its holder removed from the team). */
+    private suspend fun rotateScopeKey(s: SyncSession, c: TeamClient, ref: TeamScopeRef) {
+        val identity = identityStore.ensure()
+        spaces.rotate(
+            s, c,
+            RotationTarget(
+                ref = ref,
+                identity = identity,
+                serverEpoch = { sess, cl -> cl.listScopes(sess, ref.teamId).firstOrNull { it.scopeId == ref.scopeId }?.keyEpoch },
+                recipients = { sess, cl -> cl.scopeGrants(sess, ref.teamId, ref.scopeId).map { it.accountId } },
+                commit = { sess, cl, epoch, envelopes -> cl.rekeyScope(sess, ref.teamId, ref.scopeId, epoch, envelopes) },
+            ),
+        )
     }
 
     internal class VerifiedInvite(val payload: TeamInvitePayload)
@@ -605,34 +758,6 @@ class TeamsCoordinator(
     }
 
     internal fun cachedInvite(teamId: String): VerifiedInvite? = verifiedInvites.value[teamId]
-
-    /** Open the team vault under [key] (no stale-file handling — used where the exact key is known). */
-    private fun openTeamVault(teamId: String, key: DataKey): Vault? {
-        if (!vault.isUnlocked) return null
-        return teamVaults.open(teamId, key)
-    }
-
-    /**
-     * Open the team vault under the current key, rebuilding it ONLY if the on-disk file is under a
-     * superseded key (a rotation adopted on another device left the local file stale). A structurally
-     * unreadable file is left in place and surfaced — resetting it would silently drop any local
-     * records that were never pushed. Used by sync paths, not by UI reads.
-     */
-    private fun openTeamVaultResettingStale(teamId: String): Vault? {
-        if (!vault.isUnlocked) return null
-        val key = keyStore.get(teamId)?.dataKey() ?: return null
-        return when (val r = teamVaults.openOrClassify(teamId, key)) {
-            is TeamVaults.OpenResult.Opened -> r.vault
-            TeamVaults.OpenResult.StaleKey -> {
-                teamVaults.reset(teamId) // old-key file → drop it and rebuild empty; syncTeam re-pulls
-                teamVaults.open(teamId, key)
-            }
-            TeamVaults.OpenResult.Unreadable -> {
-                markError(TeamsFailure.VaultUnreadable) // don't destroy a corrupt-but-maybe-unpushed file
-                null
-            }
-        }
-    }
 
     /**
      * Active team without a key → ask the account sync for a full re-pull once (per team per process):
@@ -667,15 +792,9 @@ class TeamsCoordinator(
     }
 
     private fun Exception.toFailure(): TeamsFailure = (this as? SyncException)?.kind.toTeamsFailure()
-
-    private companion object {
-        /** Bounded retries when a rotation loses the epoch race to a concurrent rotation. */
-        const val REKEY_MAX_ATTEMPTS = 3
-        fun cursorKey(teamId: String) = "team:$teamId"
-    }
 }
 
-/** [SyncStateStore] with a fixed key — so SyncEngine keeps a per-team cursor. */
+/** [SyncStateStore] with a fixed key — so SyncEngine keeps a per-space cursor. */
 private class KeyedStateStore(
     private val backing: SyncStateStore,
     private val key: String,
@@ -683,4 +802,3 @@ private class KeyedStateStore(
     override fun cursor(accountId: String): Long = backing.cursor(key)
     override fun setCursor(accountId: String, cursor: Long) = backing.setCursor(key, cursor)
 }
-

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
@@ -82,7 +82,7 @@ internal fun TeamsDialogCard(onDismiss: () -> Unit, content: @Composable () -> U
 
 /** Hand-rolled dialog field: border in decorationBox + fillMaxWidth (a click anywhere places the caret). */
 @Composable
-private fun TeamsTextField(
+internal fun TeamsTextField(
     value: String,
     onValueChange: (String) -> Unit,
     placeholder: String,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -42,6 +42,7 @@ import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeRef
 import app.skerry.shared.vault.RecordType
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSnippets
@@ -66,6 +67,8 @@ import app.skerry.ui.generated.resources.lib_teams_delete_message
 import app.skerry.ui.generated.resources.lib_teams_empty_subtitle
 import app.skerry.ui.generated.resources.lib_teams_empty_title
 import app.skerry.ui.generated.resources.lib_teams_err_already_invited
+import app.skerry.ui.generated.resources.lib_teams_err_already_shared
+import app.skerry.ui.generated.resources.lib_teams_err_scopes_unsupported
 import app.skerry.ui.generated.resources.lib_teams_err_forbidden
 import app.skerry.ui.generated.resources.lib_teams_err_key_missing
 import app.skerry.ui.generated.resources.lib_teams_err_network
@@ -100,6 +103,9 @@ import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
 import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
 import app.skerry.ui.generated.resources.lib_teams_sidebar
+import app.skerry.ui.generated.resources.lib_teams_scope_delete_message
+import app.skerry.ui.generated.resources.lib_teams_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_scopes
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.generated.resources.lib_teams_sync_now
 import kotlinx.coroutines.CoroutineScope
@@ -119,6 +125,7 @@ private sealed interface TeamsConfirm {
     data class Leave(val teamId: String) : TeamsConfirm
     data class Delete(val teamId: String) : TeamsConfirm
     data class Remove(val teamId: String, val accountId: String) : TeamsConfirm
+    data class DeleteScope(val teamId: String, val scopeId: String) : TeamsConfirm
 }
 
 @Composable
@@ -139,8 +146,16 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     var confirm by remember { mutableStateOf<TeamsConfirm?>(null) }
     var showHistory by remember { mutableStateOf(false) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
+    // Selected share space of the current team ("" = team-wide). Kept per team so switching teams
+    // doesn't land on a scope id that belongs to another one.
+    var selectedScope by remember { mutableStateOf("") }
+    var showCreateScope by remember { mutableStateOf(false) }
+    var scopeAccess by remember { mutableStateOf<TeamScopeUi?>(null) }
 
     val selected = teams.firstOrNull { it.id == selectedId } ?: teams.firstOrNull()
+    // A scope that vanished (revoked, deleted, or simply another team's) falls back to team-wide.
+    val activeScope = selected?.scopes?.firstOrNull { it.id == selectedScope }
+    val scopeId = activeScope?.id ?: ""
     fun afterOp() {
         tick++
     }
@@ -167,6 +182,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                 else -> TeamDetail(
                     tc = tc,
                     team = selected,
+                    scopeId = scopeId,
                     tick = tick,
                     busy = busy,
                     onInvite = { showInvite = true; invitePreview = null },
@@ -175,9 +191,12 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                     onAccept = { scope.launch2 { tc.accept(selected.id); afterOp() } },
                     onDecline = { scope.launch2 { tc.decline(selected.id); afterOp() } },
                     onSync = { scope.launch2 { tc.refresh(); tc.syncTeam(selected.id); afterOp() } },
-                    onUnshare = { recordId -> scope.launch2 { tc.unshareRecord(selected.id, recordId); afterOp() } },
+                    onUnshare = { recordId -> scope.launch2 { tc.unshareRecord(TeamScopeRef(selected.id, scopeId), recordId); afterOp() } },
                     onShowHistory = { showHistory = true },
                     onChangeRole = { member -> rolePicker = member },
+                    onSelectScope = { selectedScope = it },
+                    onNewScope = { showCreateScope = true },
+                    onScopeAccess = { scopeAccess = it },
                 )
             }
         }
@@ -205,13 +224,14 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     val shareTeam = selected
     val shareKind = sharePicker
     if (shareKind != null && shareTeam != null) {
-        SharePicker(tc, shareTeam.id, shareKind, tick, onDone = { sharePicker = null; afterOp() }, onDismiss = { sharePicker = null })
+        SharePicker(tc, TeamScopeRef(shareTeam.id, scopeId), shareKind, tick, onDone = { sharePicker = null; afterOp() }, onDismiss = { sharePicker = null })
     }
     confirm?.let { c ->
         val (title, message) = when (c) {
             is TeamsConfirm.Leave -> stringResource(Res.string.lib_teams_leave) to stringResource(Res.string.lib_teams_leave_message)
             is TeamsConfirm.Delete -> stringResource(Res.string.lib_teams_delete) to stringResource(Res.string.lib_teams_delete_message)
             is TeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, c.accountId)
+            is TeamsConfirm.DeleteScope -> stringResource(Res.string.lib_teams_scope_delete) to stringResource(Res.string.lib_teams_scope_delete_message)
         }
         ConfirmActionDialog(
             title = title,
@@ -224,6 +244,10 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                         is TeamsConfirm.Leave -> tc.leave(c.teamId)
                         is TeamsConfirm.Delete -> tc.deleteTeam(c.teamId)
                         is TeamsConfirm.Remove -> tc.removeMember(c.teamId, c.accountId)
+                        is TeamsConfirm.DeleteScope -> {
+                            tc.deleteScope(c.teamId, c.scopeId)
+                            selectedScope = ""
+                        }
                     }
                     afterOp()
                 }
@@ -237,6 +261,32 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
             value = tc.teamActivity(historyTeam.id)
         }
         AuditLogDialog(entries, onDismiss = { showHistory = false })
+    }
+    val scopeTeam = selected
+    if (showCreateScope && scopeTeam != null) {
+        CreateScopeDialog(
+            onDismiss = { showCreateScope = false },
+            onCreate = { name -> showCreateScope = false; scope.launch2 { tc.createScope(scopeTeam.id, name); afterOp() } },
+        )
+    }
+    val accessScope = scopeAccess
+    if (accessScope != null && scopeTeam != null) {
+        val members by produceState(emptyList<TeamMember>(), scopeTeam.id, tick) { value = tc.members(scopeTeam.id) }
+        val granted by produceState(emptySet<String>(), scopeTeam.id, accessScope.id, tick) {
+            value = tc.scopeGrants(scopeTeam.id, accessScope.id).toSet()
+        }
+        ScopeAccessDialog(
+            scopeName = accessScope.name,
+            members = members.filter { it.status == TeamMemberStatus.ACTIVE },
+            granted = granted,
+            // Sealing the scope key to someone requires holding it: a manager without a grant can
+            // see and revoke, but has nothing to hand out.
+            canGrant = accessScope.hasKey,
+            busy = busy,
+            onGrant = { accountId -> scope.launch2 { tc.grantScope(scopeTeam.id, accessScope.id, accountId); afterOp() } },
+            onRevoke = { accountId -> scope.launch2 { tc.revokeScope(scopeTeam.id, accessScope.id, accountId); afterOp() } },
+            onDismiss = { scopeAccess = null },
+        )
     }
     val roleTeam = selected
     val roleTarget = rolePicker
@@ -255,7 +305,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
 @Composable
 private fun SharePicker(
     tc: TeamsCoordinator,
-    teamId: String,
+    ref: TeamScopeRef,
     kind: RecordType,
     tick: Int,
     onDone: () -> Unit,
@@ -264,14 +314,8 @@ private fun SharePicker(
     val scope = rememberCoroutineScope()
     val hosts = LocalHosts.current
     val snippets = LocalSnippets.current
-    val sharedIds = remember(teamId, kind, tick) {
-        val vault = tc.teamVault(teamId)
-        when {
-            vault == null -> emptySet()
-            kind == RecordType.HOST -> VaultHostStore(vault).all().map { it.id }.toSet()
-            else -> VaultSnippetStore(vault).all().map { it.id }.toSet()
-        }
-    }
+    // Across every space of the team, not just the selected one: a record lives in exactly one space.
+    val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
     val items = if (kind == RecordType.HOST) {
         (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
     } else {
@@ -283,7 +327,7 @@ private fun SharePicker(
         emptyText = stringResource(Res.string.lib_teams_share_empty),
         onPick = { item ->
             scope.launch2 {
-                tc.shareRecord(teamId, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
+                tc.shareRecord(ref, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
                 onDone()
             }
         },
@@ -295,6 +339,7 @@ private fun SharePicker(
 private fun TeamDetail(
     tc: TeamsCoordinator,
     team: TeamUi,
+    scopeId: String,
     tick: Int,
     busy: Boolean,
     onInvite: () -> Unit,
@@ -306,19 +351,28 @@ private fun TeamDetail(
     onUnshare: (String) -> Unit,
     onShowHistory: () -> Unit,
     onChangeRole: (TeamMember) -> Unit,
+    onSelectScope: (String) -> Unit,
+    onNewScope: () -> Unit,
+    onScopeAccess: (TeamScopeUi) -> Unit,
 ) {
     val mono = LocalFonts.current.mono
     val invited = team.status == TeamMemberStatus.INVITED
     val owner = team.role == TeamRole.OWNER && !invited
     val canManage = team.role.canManageMembers && !invited
-    val canWrite = team.role.canWrite && !invited && team.hasKey
+    val activeScope = team.scopes.firstOrNull { it.id == scopeId }
+    val canWrite = team.role.canWrite && !invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)
     val canAudit = team.role.canViewAudit && !invited
     val members by produceState(emptyList<TeamMember>(), team.id, team.memberCount, tick) {
         value = tc.members(team.id)
     }
-    val teamVault = if (!invited && team.hasKey) tc.teamVault(team.id) else null
-    val sharedHosts = remember(team.id, tick, teamVault) { teamVault?.let { VaultHostStore(it).all() } ?: emptyList() }
-    val sharedSnippets = remember(team.id, tick, teamVault) { teamVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
+    // Records of the selected space only. A scope we hold no key for has nothing readable to show.
+    val spaceVault = if (!invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)) {
+        tc.spaceVault(TeamScopeRef(team.id, scopeId))
+    } else {
+        null
+    }
+    val sharedHosts = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultHostStore(it).all() } ?: emptyList() }
+    val sharedSnippets = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
 
     SectionHeader(
         title = team.name,
@@ -384,6 +438,18 @@ private fun TeamDetail(
             }
         }
         if (!invited) {
+            Column(Modifier.padding(top = 24.dp)) {
+                LiveSectionLabel(stringResource(Res.string.lib_teams_scopes))
+                ScopeSection(
+                    scopes = team.scopes,
+                    selected = scopeId,
+                    canManage = canManage,
+                    onSelect = onSelectScope,
+                    onNew = onNewScope,
+                    onAccess = onScopeAccess,
+                    onDelete = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) },
+                )
+            }
             Row(Modifier.padding(top = 24.dp), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
                 Column(Modifier.weight(1f)) {
                     LiveSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
@@ -505,6 +571,8 @@ internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
     TeamsFailure.VaultUnreadable -> stringResource(Res.string.lib_teams_err_vault_unreadable)
     TeamsFailure.TooManyRequests -> stringResource(Res.string.lib_teams_err_too_many_requests)
     TeamsFailure.ServerError -> stringResource(Res.string.lib_teams_err_server_error)
+    TeamsFailure.AlreadyShared -> stringResource(Res.string.lib_teams_err_already_shared)
+    TeamsFailure.ScopesUnsupported -> stringResource(Res.string.lib_teams_err_scopes_unsupported)
 }
 
 /** launch from click handlers: a param-less suspend block, shorter than a lambda with CoroutineScope. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -76,6 +76,7 @@ import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTeams
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamScopeRef
 import androidx.compose.runtime.collectAsState
 import app.skerry.ui.teams.AutoPullTeamsOnOnline
 import app.skerry.ui.generated.resources.lib_teams_sidebar
@@ -529,12 +530,18 @@ private fun TeamHostsSection(hostsSnapshot: List<Host>, state: DesktopDesignStat
     // manual sync (the personal catalog doesn't change, and these sections read the vault directly).
     val revision by teams.revision.collectAsState()
     val sections = remember(teamList, hostsSnapshot, revision, section) {
-        teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.mapNotNull { team ->
-            val vault = teams.teamVault(team.id) ?: return@mapNotNull null
-            // Shared hosts are split by section like the personal catalog: a team's VNC box belongs
-            // to the desktops list, its servers to the terminal one.
-            val shared = VaultHostStore(vault).all().inSection(section)
-            if (shared.isEmpty()) null else team.name to shared
+        teamList.filter { it.status == TeamMemberStatus.ACTIVE && it.hasKey }.flatMap { team ->
+            // One group per share space: the team itself, plus every scope whose key we hold. A scope
+            // we're merely told about (manager without a grant) has no readable records, so no group.
+            val spaces = listOf(TeamScopeRef(team.id) to team.name) +
+                team.scopes.filter { it.hasKey }.map { TeamScopeRef(team.id, it.id) to "${team.name} · ${it.name}" }
+            spaces.mapNotNull { (ref, label) ->
+                val vault = teams.spaceVault(ref) ?: return@mapNotNull null
+                // Shared hosts are split by section like the personal catalog: a team's VNC box belongs
+                // to the desktops list, its servers to the terminal one.
+                val shared = VaultHostStore(vault).all().inSection(section)
+                if (shared.isEmpty()) null else label to shared
+            }
         }
     }
     if (sections.isEmpty()) return

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -245,7 +245,7 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
             now = { Instant.now().toString() },
         ),
         teamState = FileSyncStateStore(dir.resolve("team-cursor.json")),
-        newTeamId = { UUID.randomUUID().toString() },
+        newId = { UUID.randomUUID().toString() },
         onTeamsChanged = { reloadManagers() },
     )
     teamsForSync = teams

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
@@ -12,6 +12,9 @@ import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
 import app.skerry.shared.team.TeamSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.vault.FileVault
@@ -49,10 +52,17 @@ class TeamsCoordinatorInviteCacheTest {
             if (accountId == inviterId) inviterKeys else null
         override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
         override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = emptyList()
-        override suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage =
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage =
             RecordPage(emptyList(), since)
-        override suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage =
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage =
             RecordPage(emptyList(), 0)
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = emptyList()
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> = emptyList()
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
         override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
         override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) = error("unused")
         override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
@@ -99,7 +109,7 @@ class TeamsCoordinatorInviteCacheTest {
             crypto = crypto,
             teamVaults = TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }),
             teamState = InMemorySyncStateStore(),
-            newTeamId = { "unused" },
+            newId = { "unused" },
         )
 
         assertNotNull(coord.acceptPreview(teamId)) // banner shown: the verified invite is now cached

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRotationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRotationTest.kt
@@ -12,6 +12,9 @@ import app.skerry.shared.team.TeamKeyStore
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
 import app.skerry.shared.team.TeamSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.vault.DataKey
@@ -82,12 +85,12 @@ class TeamsCoordinatorRotationTest {
             removed += accountId
         }
 
-        override suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage {
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage {
             val page = store.values.filter { it.second > since }.sortedBy { it.second }
             return RecordPage(page.map { it.first }, page.lastOrNull()?.second ?: since)
         }
 
-        override suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage {
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage {
             val result = records.map { rec ->
                 val existing = store[rec.id]?.first
                 val wins = existing == null || rec.version > existing.version ||
@@ -104,6 +107,13 @@ class TeamsCoordinatorRotationTest {
         override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
         override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = emptyList()
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> = emptyList()
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
     }
 
     private class Fixture(
@@ -131,7 +141,7 @@ class TeamsCoordinatorRotationTest {
         crypto = crypto,
         teamVaults = f.teamVaults,
         teamState = InMemorySyncStateStore(),
-        newTeamId = { "unused" },
+        newId = { "unused" },
     )
 
     @Test
@@ -142,7 +152,7 @@ class TeamsCoordinatorRotationTest {
         val oldKey = crypto.newDataKey()
         ks.put(teamId, "Ops", TeamRole.OWNER, oldKey, epoch = 0)
         // Seed a shared record, then corrupt the on-disk team vault so it can't be opened under oldKey.
-        f.teamVaults.open(teamId, oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        f.teamVaults.open(TeamScopeRef(teamId), oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
         f.teamVaults.lockAll()
         val teamFile = f.teamDir / "$teamId.vault"
         FileSystem.SYSTEM.write(teamFile) { writeUtf8("corrupted") }
@@ -168,7 +178,7 @@ class TeamsCoordinatorRotationTest {
         val ks = TeamKeyStore(f.vault)
         val oldKey = crypto.newDataKey()
         ks.put(teamId, "Ops", TeamRole.OWNER, oldKey, epoch = 0) // local epoch lags behind the server
-        f.teamVaults.open(teamId, oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        f.teamVaults.open(TeamScopeRef(teamId), oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
 
         val client = FakeTeamClient(self, teamId, listOf(carol to carolKeys()))
         client.serverEpoch = 2 // server is two rotations ahead of this device's local key
@@ -181,7 +191,7 @@ class TeamsCoordinatorRotationTest {
         assertNull(coord.lastError.value)
         // The record was re-encrypted under the new key and is still readable through it.
         val newKey = ks.get(teamId)!!.dataKey()!!
-        assertContentEquals("secret".encodeToByteArray(), f.teamVaults.open(teamId, newKey)!!.openPayload("h1"))
+        assertContentEquals("secret".encodeToByteArray(), f.teamVaults.open(TeamScopeRef(teamId), newKey)!!.openPayload("h1"))
     }
 
     @Test
@@ -191,7 +201,7 @@ class TeamsCoordinatorRotationTest {
         val ks = TeamKeyStore(f.vault)
         val oldKey = crypto.newDataKey()
         ks.put(teamId, "Ops", TeamRole.OWNER, oldKey, epoch = 0)
-        f.teamVaults.open(teamId, oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        f.teamVaults.open(TeamScopeRef(teamId), oldKey)!!.put("h1", RecordType.HOST, "secret".encodeToByteArray())
 
         val client = FakeTeamClient(self, teamId, listOf(carol to carolKeys()))
         client.rekeyOutcomes.addAll(listOf(false, true)) // first attempt conflicts, second wins

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
@@ -1,0 +1,429 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamIdentityStore
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.VaultCrypto
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Granular sharing in [TeamsCoordinator]: a scope is a share space with its own key, so what is
+ * shared into it must be unreadable — not merely unlisted — for members without a grant. Only the
+ * network is faked; vaults and crypto are real.
+ */
+class TeamsCoordinatorScopeTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val teamId = "team-scoped"
+    private val self = "alice@example.com"
+    private val bob = "bob@example.com"
+
+    /** Fake team network with scope support: stores grants and per-space records like the server. */
+    private class FakeTeamClient(
+        private val self: String,
+        private val teamId: String,
+        private val bobKeys: AccountKeys? = null,
+        private val bobId: String = "bob@example.com",
+    ) : TeamClient {
+        val scopes = linkedMapOf<String, MutableMap<String, ByteArray>>() // scopeId -> account -> envelope
+        val epochs = mutableMapOf<String, Long>()
+        val rekeyCalls = mutableListOf<Pair<String, Long>>()
+        val revoked = mutableListOf<Pair<String, String>>()
+        val deletedScopes = mutableListOf<String>()
+        val teamRekeyCalls = mutableListOf<Long>()
+        val removed = mutableListOf<String>()
+        /** Set to make listScopes fail — a server without scope routes (404) or a transient error. */
+        var listScopesFailure: SyncException? = null
+
+        private val store = linkedMapOf<String, Triple<RemoteRecord, Long, String>>() // id -> (rec, seq, scope)
+        private var seq = 0L
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = self, role = TeamRole.OWNER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 2,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> =
+            scopes.also { listScopesFailure?.let { failure -> throw failure } }.map { (scopeId, grants) ->
+                TeamScopeSummary(scopeId, epochs[scopeId] ?: 0, grants.size, grants[session.accountId])
+            }
+
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
+            scopes[scopeId] = mutableMapOf(session.accountId to envelope)
+            epochs[scopeId] = 0
+        }
+
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) {
+            deletedScopes += scopeId
+            scopes.remove(scopeId)
+            store.entries.removeAll { it.value.third == scopeId }
+        }
+
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
+            scopes[scopeId]?.keys?.map { TeamScopeGrantEntry(it, 0) } ?: emptyList()
+
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) {
+            scopes[scopeId]?.put(accountId, envelope)
+        }
+
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) {
+            revoked += scopeId to accountId
+            scopes[scopeId]?.remove(accountId)
+        }
+
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            rekeyCalls += scopeId to newEpoch
+            epochs[scopeId] = newEpoch
+            val grants = scopes[scopeId] ?: return
+            envelopes.forEach { (account, env) -> if (grants.containsKey(account)) grants[account] = env }
+        }
+
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> =
+            listOf(
+                TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+                TeamMember(bobId, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            )
+
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? =
+            if (accountId == bobId) bobKeys else null
+
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage {
+            val page = store.values.filter { it.second > since && it.third == ref.scopeId }.sortedBy { it.second }
+            return RecordPage(page.map { it.first }, page.lastOrNull()?.second ?: since)
+        }
+
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage {
+            val result = records.map { rec ->
+                val existing = store[rec.id]
+                val wins = existing == null || rec.version > existing.first.version
+                if (wins) { seq += 1; store[rec.id] = Triple(rec, seq, ref.scopeId); rec } else existing.first
+            }
+            return RecordPage(result, seq)
+        }
+
+        /** Ciphertext of a record as the server holds it — used to prove a scope's blob stays sealed. */
+        fun blobOf(id: String): ByteArray? = store[id]?.first?.blob
+
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) = error("unused")
+        override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            teamRekeyCalls += newEpoch
+        }
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {
+            removed += accountId
+            scopes.values.forEach { it.remove(accountId) } // the server drops grants with the membership
+        }
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+    }
+
+    private class Fixture(val vault: FileVault, val teamVaults: TeamVaults, val teamDir: okio.Path)
+
+    private fun newFixture(): Fixture {
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile)
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }), teamDir)
+    }
+
+    private fun coordinator(f: Fixture, client: TeamClient, ids: Iterator<String>) = TeamsCoordinator(
+        session = { SyncSession(self, "access", "refresh") },
+        client = { client },
+        vault = f.vault,
+        crypto = crypto,
+        teamVaults = f.teamVaults,
+        teamState = InMemorySyncStateStore(),
+        newId = { ids.next() },
+    )
+
+    private fun seedTeam(f: Fixture) =
+        TeamKeyStore(f.vault).also { it.put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0) }
+
+    @Test
+    fun `creating a scope stores its own key and lists it on the team`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+
+        coord.createScope(teamId, "Production")
+
+        val scope = ks.scope(teamId, "prod")
+        assertEquals("Production", scope?.name)
+        assertNotEquals(ks.get(teamId)!!.teamKey, scope!!.key) // a key of its own, not the team's
+        assertTrue(client.scopes["prod"]!!.containsKey(self)) // the creator's own recovery envelope
+        assertNull(coord.lastError.value)
+
+        coord.refresh()
+        val ui = coord.teams.value.single().scopes.single()
+        assertEquals("prod", ui.id)
+        assertEquals("Production", ui.name)
+        assertTrue(ui.hasKey)
+    }
+
+    @Test
+    fun `a record shared into a scope is sealed under the scope key, not the team key`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, """{"name":"db-prod"}""".encodeToByteArray())
+
+        assertTrue(coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST))
+
+        // It lands in the scope's vault, and the team-wide vault knows nothing about it.
+        val scopeKey = ks.scope(teamId, "prod")!!.dataKey()!!
+        assertContentEquals(
+            """{"name":"db-prod"}""".encodeToByteArray(),
+            f.teamVaults.open(TeamScopeRef(teamId, "prod"), scopeKey)!!.openPayload("h1"),
+        )
+        assertNull(f.teamVaults.open(TeamScopeRef(teamId), ks.get(teamId)!!.dataKey()!!)!!.openPayload("h1"))
+        // What reached the server is ciphertext the team key does not open — the guarantee that
+        // survives a server that ignores its own ACL.
+        val blob = client.blobOf("h1")
+        assertTrue(blob != null && !blob.contentEquals("""{"name":"db-prod"}""".encodeToByteArray()))
+    }
+
+    @Test
+    fun `revoking a grant rotates only that scope key and re-encrypts its records`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val bobIdentity = crypto.newSharingKeyPair()
+        val client = FakeTeamClient(self, teamId, AccountKeys(bobIdentity.publicKey, crypto.newSigningKeyPair().publicKey))
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST)
+        coord.grantScope(teamId, "prod", bob)
+        val keyBeforeRevoke = ks.scope(teamId, "prod")!!.key
+        val teamKeyBefore = ks.get(teamId)!!.teamKey
+
+        coord.revokeScope(teamId, "prod", bob)
+
+        assertEquals(listOf("prod" to bob), client.revoked)
+        assertEquals(listOf("prod" to 1L), client.rekeyCalls)
+        assertEquals(1, ks.scope(teamId, "prod")!!.epoch)
+        assertNotEquals(keyBeforeRevoke, ks.scope(teamId, "prod")!!.key)
+        // The team key is untouched: a revoke inside one scope must not churn everyone else's key.
+        assertEquals(teamKeyBefore, ks.get(teamId)!!.teamKey)
+        // Records survive the rotation, re-encrypted under the new key.
+        val newKey = ks.scope(teamId, "prod")!!.dataKey()!!
+        assertContentEquals("secret".encodeToByteArray(), f.teamVaults.open(TeamScopeRef(teamId, "prod"), newKey)!!.openPayload("h1"))
+        assertNull(coord.lastError.value)
+    }
+
+    @Test
+    fun `a scope grant is adopted only when properly signed and bound to that scope`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        // Our own identity is what a grant is sealed to; the granter (bob) signs it, so bob's
+        // published signing key is what verification must match.
+        val identity = TeamIdentityStore(f.vault, crypto).ensure()
+        val granter = crypto.newSigningKeyPair()
+        val impostor = crypto.newSigningKeyPair()
+        val client = FakeTeamClient(self, teamId, AccountKeys(crypto.newSharingKeyPair().publicKey, granter.publicKey))
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        val codec = TeamInviteCodec(crypto)
+        val scopeKey = crypto.newDataKey()
+
+        fun envelope(signer: app.skerry.shared.vault.SigningKeyPair, scopeId: String) = codec.seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = signer, inviterId = bob, inviteeId = self, teamId = teamId,
+            teamKey = scopeKey, teamName = "Production", epoch = 0, scopeId = scopeId,
+        )
+
+        // Signed by someone whose published key isn't the one we verify against → ignored.
+        client.scopes["prod"] = mutableMapOf(self to envelope(impostor, "prod"))
+        coord.refresh()
+        assertNull(ks.scope(teamId, "prod"))
+
+        // Correctly signed but bound to a different scope (a server filing it under the wrong slot).
+        client.scopes["prod"] = mutableMapOf(self to envelope(granter, "staging"))
+        coord.refresh()
+        assertNull(ks.scope(teamId, "prod"))
+
+        // Properly signed and bound → adopted, and the adopted key really is the granted one.
+        val probe = crypto.seal(scopeKey, "probe".encodeToByteArray(), VaultCrypto.EMPTY_AAD)
+        client.scopes["prod"] = mutableMapOf(self to envelope(granter, "prod"))
+        coord.refresh()
+        val adopted = assertNotNull(ks.scope(teamId, "prod")?.dataKey())
+        assertContentEquals("probe".encodeToByteArray(), crypto.open(adopted, probe, VaultCrypto.EMPTY_AAD))
+    }
+
+    @Test
+    fun `losing a grant drops the local scope key and its vault file`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST)
+        val scopeFile = f.teamDir / TeamScopeRef(teamId, "prod").fileName
+        assertTrue(FileSystem.SYSTEM.exists(scopeFile))
+
+        client.scopes.clear() // access revoked elsewhere
+        coord.refresh()
+
+        assertNull(ks.scope(teamId, "prod"))
+        assertTrue(!FileSystem.SYSTEM.exists(scopeFile))
+        assertTrue(coord.teams.value.single().scopes.isEmpty())
+    }
+
+    @Test
+    fun `deleting a scope removes it locally with its records`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST)
+
+        coord.deleteScope(teamId, "prod")
+
+        assertEquals(listOf("prod"), client.deletedScopes)
+        assertNull(ks.scope(teamId, "prod"))
+        assertTrue(!FileSystem.SYSTEM.exists(f.teamDir / TeamScopeRef(teamId, "prod").fileName))
+    }
+
+    @Test
+    fun `locking the coordinator locks the scope vault itself`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, "secret".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST)
+        // Hold the instance: asserting spaceVault() == null afterwards would pass on the locked
+        // account vault alone and prove nothing about the scope's own file.
+        val scopeVault = assertNotNull(coord.spaceVault(TeamScopeRef(teamId, "prod")))
+        assertTrue(scopeVault.isUnlocked)
+
+        coord.lock()
+
+        assertFalse(scopeVault.isUnlocked)
+    }
+
+    @Test
+    fun `removing a member rotates the key of every scope they held`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId, AccountKeys(crypto.newSharingKeyPair().publicKey, crypto.newSigningKeyPair().publicKey))
+        val coord = coordinator(f, client, listOf("prod", "staging", "sandbox").iterator())
+        coord.createScope(teamId, "Production")
+        coord.createScope(teamId, "Staging")
+        coord.createScope(teamId, "Sandbox")
+        coord.grantScope(teamId, "prod", bob)
+        coord.grantScope(teamId, "staging", bob)
+        val untouchedKey = ks.scope(teamId, "sandbox")!!.key
+
+        coord.removeMember(teamId, bob)
+
+        assertEquals(listOf(bob), client.removed)
+        // Every scope the removed member held is rotated — leaving one out leaves them a live key.
+        assertEquals(listOf("prod" to 1L, "staging" to 1L), client.rekeyCalls.sortedBy { it.first })
+        assertEquals(1, ks.scope(teamId, "prod")!!.epoch)
+        assertEquals(1, ks.scope(teamId, "staging")!!.epoch)
+        // A scope they never had is left alone: rotation churns every grantee, so it isn't free.
+        assertEquals(0, ks.scope(teamId, "sandbox")!!.epoch)
+        assertEquals(untouchedKey, ks.scope(teamId, "sandbox")!!.key)
+        // The team key rotates too, as it did before scopes existed.
+        assertEquals(listOf(1L), client.teamRekeyCalls)
+    }
+
+    @Test
+    fun `a server without scope support is named as such instead of failing as a missing account`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        // A self-hosted deployment older than granular sharing has no /teams/{id}/scopes route.
+        client.listScopesFailure = SyncException(SyncException.Kind.NOT_FOUND, "no route")
+
+        coord.refresh()
+
+        // The team list survives — scopes are optional, losing the whole screen over them would be worse.
+        assertEquals(1, coord.teams.value.size)
+        assertTrue(coord.teams.value.single().scopes.isEmpty())
+
+        coord.createScope(teamId, "Production")
+
+        assertEquals(TeamsFailure.ScopesUnsupported, coord.lastError.value)
+        assertNull(ks.scope(teamId, "prod")) // nothing half-created locally
+    }
+
+    @Test
+    fun `a transient failure keeps the known scopes on screen instead of blanking them`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client, listOf("prod").iterator())
+        seedTeam(f)
+        coord.createScope(teamId, "Production")
+        coord.refresh()
+        assertEquals(listOf("prod"), coord.teams.value.single().scopes.map { it.id })
+
+        // A network blip says nothing about whether scopes exist — unlike a 404, it must not read as
+        // "this team has none", or the scope selector would blink out under a flaky connection.
+        client.listScopesFailure = SyncException(SyncException.Kind.NETWORK, "offline")
+        coord.refresh()
+
+        assertEquals(listOf("prod"), coord.teams.value.single().scopes.map { it.id })
+        assertEquals(TeamsFailure.Network, coord.lastError.value)
+    }
+
+    private companion object {
+        const val NOW = "2026-07-26T00:00:00Z"
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -9,6 +9,7 @@ import app.skerry.server.routes.pairingClaimRoute
 import app.skerry.server.routes.pairingStartRoute
 import app.skerry.server.routes.syncWebSocket
 import app.skerry.server.routes.teamRoutes
+import app.skerry.server.routes.teamScopeRoutes
 import app.skerry.server.routes.vaultRoutes
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
@@ -219,6 +220,7 @@ fun Application.configureServer(services: Services) {
             deviceRoutes(services)
             pairingStartRoute(services)
             teamRoutes(services)
+            teamScopeRoutes(services)
             syncWebSocket(services)
         }
     }

--- a/server/src/main/kotlin/app/skerry/server/Services.kt
+++ b/server/src/main/kotlin/app/skerry/server/Services.kt
@@ -12,6 +12,7 @@ import app.skerry.server.db.RecordRepository
 import app.skerry.server.db.StatsRepository
 import app.skerry.server.db.TeamRecordRepository
 import app.skerry.server.db.TeamRepository
+import app.skerry.server.db.TeamScopeRepository
 import app.skerry.server.sync.ChangeNotifier
 import org.jetbrains.exposed.v1.jdbc.Database
 
@@ -24,6 +25,7 @@ class Services(val config: ServerConfig, private val database: Database) {
     val pairing = PairingRepository(database)
     val teams = TeamRepository(database)
     val teamRecords = TeamRecordRepository(database, lockTeamRow = config.isPostgres)
+    val teamScopes = TeamScopeRepository(database)
     val stats = StatsRepository(database)
     val activity = ActivityRepository(database)
     val admin = AdminRepository(database)

--- a/server/src/main/kotlin/app/skerry/server/db/Database.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Database.kt
@@ -38,7 +38,7 @@ object Db {
     fun createSchema(database: Database) {
         val tables = arrayOf(
             Accounts, Devices, Records, Pairing, ActivityLog,
-            AccountKeys, Teams, TeamMembers, TeamRecords,
+            AccountKeys, Teams, TeamMembers, TeamRecords, TeamScopes, TeamScopeGrants,
         )
         transaction(database) {
             val isSqlite = currentDialect is SQLiteDialect

--- a/server/src/main/kotlin/app/skerry/server/db/Tables.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Tables.kt
@@ -154,6 +154,13 @@ object TeamMembers : Table("team_members") {
 object TeamRecords : Table("team_records") {
     val teamId = varchar("team_id", 64).references(Teams.id)
     val recordId = varchar("record_id", 64)
+    /**
+     * Share space inside the team: `""` = team-wide (readable by every active member), otherwise a
+     * [TeamScopes] id whose members hold a grant. Not part of the primary key — the key of an
+     * existing deployment can't be altered in place, and a record belonging to exactly one space is
+     * the model anyway (moving it between spaces is an unshare plus a share).
+     */
+    val scopeId = varchar("scope_id", 64).default("")
     val type = varchar("type", 32)
     val version = long("version")
     val updatedAt = text("updated_at")
@@ -167,6 +174,37 @@ object TeamRecords : Table("team_records") {
     init {
         index("idx_team_records_delta", false, teamId, teamSeq)
     }
+}
+
+/**
+ * Scopes: share spaces inside a team, each with its own key (granular sharing — "juniors see
+ * staging, not prod"). Zero-knowledge as everywhere: the scope's **name** is not stored here, it
+ * travels inside the sealed key envelope. [keyEpoch] is that scope's own key generation, bumped by
+ * a rotation when a grant is revoked.
+ */
+object TeamScopes : Table("team_scopes") {
+    val teamId = varchar("team_id", 64).references(Teams.id)
+    val scopeId = varchar("scope_id", 64)
+    val keyEpoch = long("key_epoch").default(0)
+    val createdAt = long("created_at")
+
+    override val primaryKey = PrimaryKey(teamId, scopeId)
+}
+
+/**
+ * Who may read a scope. A row is both the ACL entry and the delivery slot for that account's
+ * scopeKey ([envelope], a signed sealed box like [TeamMembers.envelope]). Unlike an invite envelope
+ * it is kept after adoption: it is how a client recovers a scope key its local vault record lost.
+ * Revoking access deletes the row; the manager then rotates the scope key.
+ */
+object TeamScopeGrants : Table("team_scope_grants") {
+    val teamId = varchar("team_id", 64)
+    val scopeId = varchar("scope_id", 64)
+    val accountId = varchar("account_id", 320).references(Accounts.id)
+    val envelope = blob("envelope")
+    val createdAt = long("created_at")
+
+    override val primaryKey = PrimaryKey(teamId, scopeId, accountId)
 }
 
 /** One-time pairing sessions (variant B): dataKey encrypted with a transferKey, with a TTL. */

--- a/server/src/main/kotlin/app/skerry/server/db/TeamRecordRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamRecordRepository.kt
@@ -4,6 +4,7 @@ import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -12,24 +13,35 @@ import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.update
 
+/** A page of one share space's delta plus the cursor to resume from (see [TeamRecordRepository.delta]). */
+data class TeamDeltaPage(val records: List<StoredRecord>, val cursor: Long)
+
 /**
- * Encrypted team records — the same LWW core as [RecordRepository], but team-scoped: the delta
- * cursor is [Teams.teamSeq]. Tombstones aren't watermark-compacted (team membership is unstable);
- * [purgeTombstones] cleans them up by `updatedAt` age (ISO-8601 UTC, comparable lexicographically).
- * Clients apply a redelivered tombstone idempotently.
+ * Encrypted team records — the same LWW core as [RecordRepository], but scoped to one share space
+ * of a team: the team itself (`scopeId` empty) or one of its scopes. The delta cursor is
+ * [Teams.teamSeq], shared by every space of the team; a per-space cursor is just a watermark on it.
+ * Tombstones aren't watermark-compacted (team membership is unstable); [purgeTombstones] cleans
+ * them up by `updatedAt` age (ISO-8601 UTC, comparable lexicographically). Clients apply a
+ * redelivered tombstone idempotently.
  */
 class TeamRecordRepository(private val db: Database, private val lockTeamRow: Boolean = false) {
 
     /** Batch upsert with LWW by (`version`, `deviceId`) — same semantics as [RecordRepository.upsert]. */
-    suspend fun upsert(teamId: String, incoming: List<IncomingRecord>): UpsertResult = dbTransaction(db) {
+    suspend fun upsert(teamId: String, scopeId: String, incoming: List<IncomingRecord>): UpsertResult = dbTransaction(db) {
         val teamQuery = Teams.selectAll().where { Teams.id eq teamId }
         val seqBefore = (if (lockTeamRow) teamQuery.forUpdate() else teamQuery).single()[Teams.teamSeq]
         var seq = seqBefore
 
-        val result = incoming.map { rec ->
+        val result = incoming.mapNotNull { rec ->
             val existing = TeamRecords.selectAll()
                 .where { (TeamRecords.teamId eq teamId) and (TeamRecords.recordId eq rec.id) }
                 .singleOrNull()
+
+            // A record belongs to exactly one space. A push from another one is dropped, not applied:
+            // it would replace the ciphertext with one encrypted under a key this space's members
+            // don't hold (a member with a stale local copy re-pushes it on every cycle), leaving the
+            // record unreadable for everyone. The stored space stays authoritative.
+            if (existing != null && existing[TeamRecords.scopeId] != scopeId) return@mapNotNull null
 
             val wins = existing == null ||
                 rec.version > existing[TeamRecords.version] ||
@@ -41,6 +53,7 @@ class TeamRecordRepository(private val db: Database, private val lockTeamRow: Bo
                 if (existing == null) {
                     TeamRecords.insert {
                         it[TeamRecords.teamId] = teamId
+                        it[TeamRecords.scopeId] = scopeId
                         it[recordId] = rec.id
                         it[type] = rec.type
                         it[version] = rec.version
@@ -74,12 +87,30 @@ class TeamRecordRepository(private val db: Database, private val lockTeamRow: Bo
         UpsertResult(result, seq, changed)
     }
 
-    /** Team delta: records with `teamSeq > since`, ordered by ascending cursor. */
-    suspend fun delta(teamId: String, since: Long): List<StoredRecord> = dbTransaction(db) {
-        TeamRecords.selectAll()
-            .where { (TeamRecords.teamId eq teamId) and (TeamRecords.teamSeq greater since) }
+    /**
+     * One space's delta: its records in `since < teamSeq <= cursor`, ascending, where the cursor is
+     * the team's [Teams.teamSeq]. Returning the counter rather than the last delivered row is what
+     * keeps a scope from re-scanning records of other spaces on every pull.
+     *
+     * **The counter is read first and the record query is bounded by it** — the order is the whole
+     * correctness argument, and a same-transaction read is not enough to replace it: PostgreSQL runs
+     * READ COMMITTED by default, so a second statement sees a newer snapshot than the first. Reading
+     * the records first would let a push commit in between and be reported as covered by a cursor that
+     * never delivered it — lost for that client forever. With this order a push that lands in between
+     * gets a `teamSeq` above the bound, is excluded, and arrives on the next pull. The reverse skew is
+     * harmless: a record already committed at the time of the counter read is visible to the later
+     * query too, because a record row and its team's counter are updated in one transaction.
+     */
+    suspend fun delta(teamId: String, scopeId: String, since: Long): TeamDeltaPage = dbTransaction(db) {
+        val cursor = Teams.selectAll().where { Teams.id eq teamId }.singleOrNull()?.get(Teams.teamSeq) ?: since
+        val records = TeamRecords.selectAll()
+            .where {
+                (TeamRecords.teamId eq teamId) and (TeamRecords.scopeId eq scopeId) and
+                    (TeamRecords.teamSeq greater since) and (TeamRecords.teamSeq lessEq cursor)
+            }
             .orderBy(TeamRecords.teamSeq to SortOrder.ASC)
             .map { it.toStoredRecord() }
+        TeamDeltaPage(records, cursor)
     }
 
     /** Deletes tombstones older than [beforeIso] (ISO-8601 UTC) across all teams. Returns row count. */

--- a/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
@@ -178,9 +178,11 @@ class TeamRepository(private val db: Database) {
         } > 0
     }
 
-    /** Deletes a team entirely: records, members, and the team itself. */
+    /** Deletes a team entirely: records (of every scope), scopes, grants, members, and the team itself. */
     suspend fun deleteTeam(teamId: String): Boolean = dbTransaction(db) {
         TeamRecords.deleteWhere { TeamRecords.teamId eq teamId }
+        TeamScopeGrants.deleteWhere { TeamScopeGrants.teamId eq teamId }
+        TeamScopes.deleteWhere { TeamScopes.teamId eq teamId }
         TeamMembers.deleteWhere { TeamMembers.teamId eq teamId }
         Teams.deleteWhere { Teams.id eq teamId } > 0
     }

--- a/server/src/main/kotlin/app/skerry/server/db/TeamScopeRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamScopeRepository.kt
@@ -1,0 +1,189 @@
+package app.skerry.server.db
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.update
+
+/** A scope as reported to one account: [envelope] is that account's sealed key, null without a grant. */
+data class TeamScopeRow(
+    val scopeId: String,
+    val keyEpoch: Long,
+    val memberCount: Int,
+    val envelope: ByteArray?,
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TeamScopeRow) return false
+        return scopeId == other.scopeId && keyEpoch == other.keyEpoch && memberCount == other.memberCount &&
+            (envelope?.contentEquals(other.envelope) ?: (other.envelope == null))
+    }
+
+    override fun hashCode(): Int {
+        var result = scopeId.hashCode()
+        result = 31 * result + keyEpoch.hashCode()
+        result = 31 * result + memberCount
+        result = 31 * result + (envelope?.contentHashCode() ?: 0)
+        return result
+    }
+}
+
+/** One account's grant on a scope (manager view; the envelope stays private to its owner). */
+data class TeamScopeGrantRow(val accountId: String, val createdAt: Long)
+
+/**
+ * Scopes of a team and their grants. Granular sharing is enforced on two independent levels: this
+ * repository is the ACL the routes consult, and the scope key (which the server never sees) is what
+ * actually keeps a scope's records unreadable to anyone without a grant.
+ */
+class TeamScopeRepository(private val db: Database) {
+
+    /** Creates a scope and grants it to [accountId] ([envelope] = scopeKey sealed to them). False if it exists. */
+    suspend fun create(teamId: String, scopeId: String, accountId: String, envelope: ByteArray, now: Long): Boolean =
+        dbTransaction(db) {
+            val exists = TeamScopes.selectAll()
+                .where { (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) }
+                .any()
+            if (exists) return@dbTransaction false
+            TeamScopes.insert {
+                it[TeamScopes.teamId] = teamId
+                it[TeamScopes.scopeId] = scopeId
+                it[keyEpoch] = 0
+                it[createdAt] = now
+            }
+            insertGrant(teamId, scopeId, accountId, envelope, now)
+            true
+        }
+
+    /** Deletes the scope with its grants and its records. */
+    suspend fun delete(teamId: String, scopeId: String): Boolean = dbTransaction(db) {
+        TeamRecords.deleteWhere { (TeamRecords.teamId eq teamId) and (TeamRecords.scopeId eq scopeId) }
+        TeamScopeGrants.deleteWhere { (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) }
+        TeamScopes.deleteWhere { (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) } > 0
+    }
+
+    /**
+     * Scopes of the team as [accountId] may see them. With [all] (a manager) every scope is listed,
+     * otherwise only the ones they hold a grant for — the mere existence of a scope already
+     * describes how the team is organised.
+     */
+    suspend fun scopesFor(teamId: String, accountId: String, all: Boolean): List<TeamScopeRow> = dbTransaction(db) {
+        val grants = TeamScopeGrants.selectAll().where { TeamScopeGrants.teamId eq teamId }.map {
+            Triple(it[TeamScopeGrants.scopeId], it[TeamScopeGrants.accountId], it[TeamScopeGrants.envelope].bytes)
+        }
+        val counts = grants.groupingBy { it.first }.eachCount()
+        val mine = grants.filter { it.second == accountId }.associate { it.first to it.third }
+        TeamScopes.selectAll().where { TeamScopes.teamId eq teamId }
+            .map { it[TeamScopes.scopeId] to it[TeamScopes.keyEpoch] }
+            .filter { (scopeId, _) -> all || scopeId in mine }
+            .map { (scopeId, epoch) -> TeamScopeRow(scopeId, epoch, counts[scopeId] ?: 0, mine[scopeId]) }
+    }
+
+    suspend fun exists(teamId: String, scopeId: String): Boolean = dbTransaction(db) {
+        TeamScopes.selectAll().where { (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) }.any()
+    }
+
+    suspend fun hasGrant(teamId: String, scopeId: String, accountId: String): Boolean = dbTransaction(db) {
+        grantExists(teamId, scopeId, accountId)
+    }
+
+    suspend fun grants(teamId: String, scopeId: String): List<TeamScopeGrantRow> = dbTransaction(db) {
+        TeamScopeGrants.selectAll()
+            .where { (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) }
+            .map { TeamScopeGrantRow(it[TeamScopeGrants.accountId], it[TeamScopeGrants.createdAt]) }
+    }
+
+    /** Grants (or re-seals) the scope to [accountId]. False if the scope doesn't exist. */
+    suspend fun grant(teamId: String, scopeId: String, accountId: String, envelope: ByteArray, now: Long): Boolean =
+        dbTransaction(db) {
+            val scopeExists = TeamScopes.selectAll()
+                .where { (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) }
+                .any()
+            if (!scopeExists) return@dbTransaction false
+            insertGrant(teamId, scopeId, accountId, envelope, now)
+            true
+        }
+
+    suspend fun revoke(teamId: String, scopeId: String, accountId: String): Boolean = dbTransaction(db) {
+        TeamScopeGrants.deleteWhere {
+            (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) and
+                (TeamScopeGrants.accountId eq accountId)
+        } > 0
+    }
+
+    /**
+     * Revokes every grant [accountId] held in the team (they were removed from the team itself) and
+     * returns the affected scope ids — the caller rotates those keys, since a removed member keeps
+     * their copy of every key they ever received.
+     */
+    suspend fun revokeAll(teamId: String, accountId: String): List<String> = dbTransaction(db) {
+        val held = TeamScopeGrants.selectAll()
+            .where { (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.accountId eq accountId) }
+            .map { it[TeamScopeGrants.scopeId] }
+        if (held.isNotEmpty()) {
+            TeamScopeGrants.deleteWhere {
+                (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.accountId eq accountId)
+            }
+        }
+        held
+    }
+
+    /**
+     * Rotates a scope's key: bumps its epoch to [newEpoch] and stores the re-sealed key per grantee.
+     * Monotonicity is an atomic compare-and-set on the epoch, exactly as in [TeamRepository.rekey] —
+     * two rotations racing to the same epoch would otherwise commit different keys at one epoch and
+     * leave the scope unreadable. Envelopes for accounts without a grant are ignored: a rotation
+     * must never resurrect access that was just revoked.
+     */
+    suspend fun rekey(teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>): RekeyOutcome =
+        dbTransaction(db) {
+            val bumped = TeamScopes.update({
+                (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) and
+                    (TeamScopes.keyEpoch eq newEpoch - 1)
+            }) { it[keyEpoch] = newEpoch } > 0
+            if (!bumped) {
+                val exists = TeamScopes.selectAll()
+                    .where { (TeamScopes.teamId eq teamId) and (TeamScopes.scopeId eq scopeId) }
+                    .any()
+                return@dbTransaction if (exists) RekeyOutcome.EPOCH_CONFLICT else RekeyOutcome.NO_TEAM
+            }
+            envelopes.forEach { (accountId, envelope) ->
+                TeamScopeGrants.update({
+                    (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) and
+                        (TeamScopeGrants.accountId eq accountId)
+                }) {
+                    it[TeamScopeGrants.envelope] = ExposedBlob(envelope)
+                }
+            }
+            RekeyOutcome.OK
+        }
+
+    private fun grantExists(teamId: String, scopeId: String, accountId: String): Boolean =
+        TeamScopeGrants.selectAll().where {
+            (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) and
+                (TeamScopeGrants.accountId eq accountId)
+        }.any()
+
+    /** Upsert of a grant: re-granting replaces the sealed key instead of failing on the primary key. */
+    private fun insertGrant(teamId: String, scopeId: String, accountId: String, envelope: ByteArray, now: Long) {
+        val updated = TeamScopeGrants.update({
+            (TeamScopeGrants.teamId eq teamId) and (TeamScopeGrants.scopeId eq scopeId) and
+                (TeamScopeGrants.accountId eq accountId)
+        }) {
+            it[TeamScopeGrants.envelope] = ExposedBlob(envelope)
+        }
+        if (updated == 0) {
+            TeamScopeGrants.insert {
+                it[TeamScopeGrants.teamId] = teamId
+                it[TeamScopeGrants.scopeId] = scopeId
+                it[TeamScopeGrants.accountId] = accountId
+                it[TeamScopeGrants.envelope] = ExposedBlob(envelope)
+                it[createdAt] = now
+            }
+        }
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -43,7 +43,7 @@ private val TEAM_ALLOWED_TYPES = setOf("HOST", "GROUP", "IDENTITY", "CREDENTIAL"
 
 /** Public X25519 key is exactly 32 bytes; a crypto_box_seal envelope is 48 bytes overhead + payload. */
 private const val PUBLIC_KEY_BYTES = 32
-private const val MAX_ENVELOPE_BYTES = 4096
+internal const val MAX_ENVELOPE_BYTES = 4096
 
 /**
  * Teams: account keys, team membership, and team-scoped records. Zero-knowledge: the server
@@ -242,7 +242,12 @@ fun Route.teamRoutes(services: Services) {
             call.respond(HttpStatusCode.NotFound, ErrorResponse("no such member (owner cannot be removed)"))
             return@delete
         }
-        services.activity.record(principal.accountId, "team.remove", target, teamId = teamId)
+        // Leaving the team takes every scope grant with it — otherwise a former member would keep
+        // pulling a scope's records through an ACL row nobody thinks to clean up. The client rotates
+        // the affected scope keys (the removed member still holds their copies).
+        val lostScopes = services.teamScopes.revokeAll(teamId, target)
+        val scopeNote = if (lostScopes.isEmpty()) "" else " · scopes ${lostScopes.joinToString(",")}"
+        services.activity.record(principal.accountId, "team.remove", "$target$scopeNote", teamId = teamId)
         services.notifier.publishMembership(target)
         call.respond(HttpStatusCode.OK)
     }
@@ -261,29 +266,33 @@ fun Route.teamRoutes(services: Services) {
     get("/teams/{id}/records") {
         val principal = call.jwtPrincipal()
         val teamId = call.requiredPathId("id") ?: return@get
+        val scopeId = call.scopeParam() ?: return@get
         call.requireActiveMember(services, teamId, principal.accountId) ?: return@get
+        if (!call.requireScopeAccess(services, teamId, scopeId, principal.accountId)) return@get
         val since = call.request.queryParameters["since"]?.toLongOrNull() ?: 0L
-        val delta = services.teamRecords.delta(teamId, since)
-        val cursor = delta.lastOrNull()?.serverSeq ?: since
+        val delta = services.teamRecords.delta(teamId, scopeId, since)
         // Team scope has no compactedIds: tombstones are cleaned up by age, redelivery is idempotent.
-        call.respond(RecordsResponse(delta.map { it.toDto() }, cursor, emptyList()))
+        call.respond(RecordsResponse(delta.records.map { it.toDto() }, delta.cursor, emptyList()))
     }
 
     put("/teams/{id}/records") {
         val principal = call.jwtPrincipal()
         val teamId = call.requiredPathId("id") ?: return@put
+        val scopeId = call.scopeParam() ?: return@put
         // Write is gated by role: viewer is active but canWrite=false -> 403.
         call.requireActiveMember(
             services, teamId, principal.accountId, TeamRoles::canWrite, "write role required",
         ) ?: return@put
+        if (!call.requireScopeAccess(services, teamId, scopeId, principal.accountId)) return@put
         val req = call.receive<PushRequest>()
         val unknown = req.records.firstOrNull { it.type !in TEAM_ALLOWED_TYPES }
         if (unknown != null) throw BadRequestException("unknown record type: ${unknown.type}")
 
-        val result = services.teamRecords.upsert(teamId, req.records.map { it.toIncoming() })
+        val result = services.teamRecords.upsert(teamId, scopeId, req.records.map { it.toIncoming() })
         val ids = req.records.joinToString(" ") { it.id }.take(200)
+        val where = if (scopeId.isEmpty()) "" else " · scope $scopeId"
         services.activity.record(
-            principal.accountId, "team.push", "${req.records.size} records · $ids", teamId = teamId,
+            principal.accountId, "team.push", "${req.records.size} records$where · $ids", teamId = teamId,
         )
         if (result.changed) services.notifier.publishTeam(teamId, result.cursor)
         call.respond(PushResponse(result.records.map { it.toDto() }, result.cursor))
@@ -307,7 +316,7 @@ fun Route.teamRoutes(services: Services) {
  * is given) their role passes the check; otherwise responds 404 (not a member, don't reveal the
  * team) / 403 and returns null. The team owner also goes through capability checks (see [TeamRoles]).
  */
-private suspend fun ApplicationCall.requireActiveMember(
+internal suspend fun ApplicationCall.requireActiveMember(
     services: Services,
     teamId: String,
     accountId: String,
@@ -328,4 +337,32 @@ private suspend fun ApplicationCall.requireActiveMember(
         return null
     }
     return membership
+}
+
+/**
+ * `?scope=` on the record endpoints: empty/absent means the team-wide space. Validated here so a
+ * malformed id is a 400 before any lookup.
+ */
+private suspend fun ApplicationCall.scopeParam(): String? {
+    val raw = request.queryParameters["scope"] ?: return ""
+    if (raw.isEmpty()) return ""
+    return validScopeId(raw)
+}
+
+/**
+ * Granular read/write ACL: a scoped space is served only to accounts holding a grant. Responds 404
+ * (not 403) on a missing grant — same reasoning as for a team the caller isn't a member of: the
+ * existence of a scope is itself information about how the team is organised. Team-wide records
+ * (empty [scopeId]) are open to every active member, as before.
+ */
+private suspend fun ApplicationCall.requireScopeAccess(
+    services: Services,
+    teamId: String,
+    scopeId: String,
+    accountId: String,
+): Boolean {
+    if (scopeId.isEmpty()) return true
+    if (services.teamScopes.hasGrant(teamId, scopeId, accountId)) return true
+    respond(HttpStatusCode.NotFound, ErrorResponse("no such scope"))
+    return false
 }

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamScopeRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamScopeRoutes.kt
@@ -1,0 +1,218 @@
+package app.skerry.server.routes
+
+import app.skerry.server.Services
+import app.skerry.server.accountId
+import app.skerry.server.db.RekeyOutcome
+import app.skerry.server.db.TeamMemberStatus
+import app.skerry.server.db.TeamRoles
+import app.skerry.server.jwtPrincipal
+import app.skerry.server.model.ErrorResponse
+import app.skerry.server.model.b64
+import app.skerry.server.model.unb64
+import app.skerry.sync.wire.TeamRekeyRequest
+import app.skerry.sync.wire.TeamScopeCreateRequest
+import app.skerry.sync.wire.TeamScopeDto
+import app.skerry.sync.wire.TeamScopeGrantDto
+import app.skerry.sync.wire.TeamScopeGrantRequest
+import app.skerry.sync.wire.TeamScopeGrantsResponse
+import app.skerry.sync.wire.TeamScopesResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+
+/**
+ * Scopes: granular sharing inside a team. A scope has its own key, so a member without a grant can
+ * neither fetch its records (this ACL) nor decrypt them (the key they never received) — the two
+ * guarantees are independent, and only the second survives a compromised server.
+ *
+ * Handing a scope out (grant, rekey) requires **both** the manage-members role and a grant of one's
+ * own. The role alone is not enough, and that is not a formality: an admin deliberately left out of
+ * a scope could otherwise self-grant an ACL row and rekey the scope with a key of their own making.
+ * Their signature over that envelope is genuine, so every real grantee would adopt it and everything
+ * shared afterwards would be readable by them — the exact separation the feature exists to provide.
+ * Deleting a scope needs the role only: when everyone holding the key is gone, a manager still has
+ * to be able to clear the leftovers away.
+ */
+fun Route.teamScopeRoutes(services: Services) {
+
+    get("/teams/{id}/scopes") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@get
+        val membership = call.requireActiveMember(services, teamId, principal.accountId) ?: return@get
+        val scopes = services.teamScopes
+            .scopesFor(teamId, principal.accountId, all = TeamRoles.canManageMembers(membership.role))
+            .map { TeamScopeDto(it.scopeId, it.keyEpoch, it.memberCount, it.envelope?.b64()) }
+        call.respond(TeamScopesResponse(scopes))
+    }
+
+    post("/teams/{id}/scopes") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@post
+        val req = call.receive<TeamScopeCreateRequest>()
+        val scopeId = call.validScopeId(req.scopeId) ?: return@post
+        val envelope = call.validEnvelope(req.envelope) ?: return@post
+        call.requireActiveMember(
+            services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+        ) ?: return@post
+        if (!services.teamScopes.create(teamId, scopeId, principal.accountId, envelope, System.currentTimeMillis())) {
+            call.respond(HttpStatusCode.Conflict, ErrorResponse("scope already exists"))
+            return@post
+        }
+        services.activity.record(principal.accountId, "team.scope_create", scopeId, teamId = teamId)
+        call.respond(HttpStatusCode.Created)
+    }
+
+    delete("/teams/{id}/scopes/{scopeId}") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@delete
+        val scopeId = call.requiredPathId("scopeId")?.let { call.validScopeId(it) } ?: return@delete
+        call.requireActiveMember(
+            services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+        ) ?: return@delete
+        val grantees = services.teamScopes.grants(teamId, scopeId).map { it.accountId }
+        if (!services.teamScopes.delete(teamId, scopeId)) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("no such scope"))
+            return@delete
+        }
+        services.activity.record(principal.accountId, "team.scope_delete", scopeId, teamId = teamId)
+        grantees.forEach { services.notifier.publishMembership(it) }
+        call.respond(HttpStatusCode.OK)
+    }
+
+    get("/teams/{id}/scopes/{scopeId}/grants") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@get
+        val scopeId = call.requiredPathId("scopeId")?.let { call.validScopeId(it) } ?: return@get
+        call.requireActiveMember(
+            services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+        ) ?: return@get
+        val grants = services.teamScopes.grants(teamId, scopeId).map { TeamScopeGrantDto(it.accountId, it.createdAt) }
+        call.respond(TeamScopeGrantsResponse(grants))
+    }
+
+    post("/teams/{id}/scopes/{scopeId}/grants") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@post
+        val scopeId = call.requiredPathId("scopeId")?.let { call.validScopeId(it) } ?: return@post
+        val req = call.receive<TeamScopeGrantRequest>()
+        if (req.accountId.isBlank() || req.accountId.length > MAX_ACCOUNT_ID) throw BadRequestException("bad accountId")
+        val envelope = call.validEnvelope(req.envelope) ?: return@post
+        call.requireActiveMember(
+            services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+        ) ?: return@post
+        if (!call.requireScopeHolder(services, teamId, scopeId, principal.accountId)) return@post
+        // Only an accepted member of the team can hold a scope grant: an invitee has no teamKey yet,
+        // and a stranger has no business in the team's ACL at all.
+        val target = services.teams.membership(teamId, req.accountId)
+        if (target == null || target.status != TeamMemberStatus.ACTIVE) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("no such active member"))
+            return@post
+        }
+        if (!services.teamScopes.grant(teamId, scopeId, req.accountId, envelope, System.currentTimeMillis())) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("no such scope"))
+            return@post
+        }
+        services.activity.record(principal.accountId, "team.scope_grant", "${req.accountId} · $scopeId", teamId = teamId)
+        services.notifier.publishMembership(req.accountId)
+        call.respond(HttpStatusCode.Created)
+    }
+
+    delete("/teams/{id}/scopes/{scopeId}/grants/{accountId}") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@delete
+        val scopeId = call.requiredPathId("scopeId")?.let { call.validScopeId(it) } ?: return@delete
+        val target = call.requiredPathId("accountId") ?: return@delete
+        // Self-revoke (giving up access voluntarily) needs no management role; revoking someone else does.
+        if (target != principal.accountId) {
+            call.requireActiveMember(
+                services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+            ) ?: return@delete
+        } else {
+            call.requireActiveMember(services, teamId, principal.accountId) ?: return@delete
+        }
+        if (!services.teamScopes.revoke(teamId, scopeId, target)) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("no such grant"))
+            return@delete
+        }
+        services.activity.record(principal.accountId, "team.scope_revoke", "$target · $scopeId", teamId = teamId)
+        services.notifier.publishMembership(target)
+        call.respond(HttpStatusCode.OK)
+    }
+
+    post("/teams/{id}/scopes/{scopeId}/rekey") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@post
+        val scopeId = call.requiredPathId("scopeId")?.let { call.validScopeId(it) } ?: return@post
+        val req = call.receive<TeamRekeyRequest>()
+        call.requireActiveMember(
+            services, teamId, principal.accountId, TeamRoles::canManageMembers, "manage-members role required",
+        ) ?: return@post
+        if (!call.requireScopeHolder(services, teamId, scopeId, principal.accountId)) return@post
+        val envelopes = mutableMapOf<String, ByteArray>()
+        for (e in req.envelopes) {
+            envelopes[e.accountId] = call.validEnvelope(e.envelope) ?: return@post
+        }
+        // Monotonic epoch enforced as a compare-and-set inside the repository (see TeamScopeRepository.rekey).
+        when (services.teamScopes.rekey(teamId, scopeId, req.newEpoch, envelopes)) {
+            RekeyOutcome.NO_TEAM -> {
+                call.respond(HttpStatusCode.NotFound, ErrorResponse("no such scope"))
+                return@post
+            }
+            RekeyOutcome.EPOCH_CONFLICT -> {
+                call.respond(HttpStatusCode.Conflict, ErrorResponse("stale epoch (concurrent rotation); refetch and retry"))
+                return@post
+            }
+            RekeyOutcome.OK -> Unit
+        }
+        services.activity.record(principal.accountId, "team.scope_rekey", "$scopeId · epoch ${req.newEpoch}", teamId = teamId)
+        envelopes.keys.forEach { services.notifier.publishMembership(it) }
+        call.respond(HttpStatusCode.OK)
+    }
+}
+
+/**
+ * Whoever hands a scope key out must already hold it. Responds 403 (the caller is a manager of this
+ * team and already knows the scope exists — there is nothing left to hide), and refuses before any
+ * ACL row or epoch is touched. See the class doc for the escalation this closes.
+ */
+private suspend fun ApplicationCall.requireScopeHolder(
+    services: Services,
+    teamId: String,
+    scopeId: String,
+    accountId: String,
+): Boolean {
+    if (services.teamScopes.hasGrant(teamId, scopeId, accountId)) return true
+    respond(HttpStatusCode.Forbidden, ErrorResponse("scope access required"))
+    return false
+}
+
+/**
+ * A scope id is client-generated and ends up in a vault file name on every member's device, so it is
+ * held to the same charset as a team id (`[a-z0-9-]`). Rejected before any side effect.
+ */
+internal suspend fun ApplicationCall.validScopeId(value: String): String? {
+    val ok = value.isNotEmpty() && value.length <= MAX_SCOPE_ID &&
+        value.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }
+    if (!ok) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("bad scopeId"))
+        return null
+    }
+    return value
+}
+
+private suspend fun ApplicationCall.validEnvelope(value: String): ByteArray? {
+    val bytes = value.unb64()
+    if (bytes.isEmpty() || bytes.size > MAX_ENVELOPE_BYTES) {
+        respond(HttpStatusCode.BadRequest, ErrorResponse("bad envelope"))
+        return null
+    }
+    return bytes
+}
+
+internal const val MAX_SCOPE_ID = 64

--- a/server/src/test/kotlin/app/skerry/server/db/TeamRecordRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/TeamRecordRepositoryTest.kt
@@ -1,5 +1,7 @@
 package app.skerry.server.db
 
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -9,6 +11,9 @@ import kotlin.test.assertTrue
 class TeamRecordRepositoryTest {
 
     private val alice = "alice@example.com"
+
+    /** Team-wide space; scopes are addressed by their id (see [TeamScopeRepositoryTest]). */
+    private val teamWide = ""
 
     private fun rec(
         id: String,
@@ -29,25 +34,25 @@ class TeamRecordRepositoryTest {
     fun `upsert assigns monotonic teamSeq and delta follows the cursor`() = withTestDb { db ->
         val repo = seedTeam(db)
 
-        val first = repo.upsert("team-1", listOf(rec("r1", 1), rec("r2", 1)))
+        val first = repo.upsert("team-1", teamWide, listOf(rec("r1", 1), rec("r2", 1)))
         assertEquals(listOf(1L, 2L), first.records.map { it.serverSeq })
         assertEquals(2L, first.cursor)
         assertTrue(first.changed)
 
-        assertEquals(listOf("r1", "r2"), repo.delta("team-1", 0).map { it.id })
-        assertEquals(listOf("r2"), repo.delta("team-1", 1).map { it.id })
+        assertEquals(listOf("r1", "r2"), repo.delta("team-1", teamWide, 0).records.map { it.id })
+        assertEquals(listOf("r2"), repo.delta("team-1", teamWide, 1).records.map { it.id })
 
-        val second = repo.upsert("team-1", listOf(rec("r1", 2)))
+        val second = repo.upsert("team-1", teamWide, listOf(rec("r1", 2)))
         assertEquals(3L, second.cursor)
-        assertEquals(listOf("r2", "r1"), repo.delta("team-1", 1).map { it.id })
+        assertEquals(listOf("r2", "r1"), repo.delta("team-1", teamWide, 1).records.map { it.id })
     }
 
     @Test
     fun `LWW rejects stale writes and no-op push does not advance the cursor`() = withTestDb { db ->
         val repo = seedTeam(db)
-        repo.upsert("team-1", listOf(rec("r1", 5, blob = byteArrayOf(5))))
+        repo.upsert("team-1", teamWide, listOf(rec("r1", 5, blob = byteArrayOf(5))))
 
-        val stale = repo.upsert("team-1", listOf(rec("r1", 3, blob = byteArrayOf(3))))
+        val stale = repo.upsert("team-1", teamWide, listOf(rec("r1", 3, blob = byteArrayOf(3))))
         assertEquals(5L, stale.records.single().version)
         assertContentEquals(byteArrayOf(5), stale.records.single().blob)
         assertFalse(stale.changed)
@@ -57,12 +62,12 @@ class TeamRecordRepositoryTest {
     @Test
     fun `LWW breaks version ties by lexicographically greater deviceId`() = withTestDb { db ->
         val repo = seedTeam(db)
-        repo.upsert("team-1", listOf(rec("r1", 7, deviceId = "devB", blob = byteArrayOf(11))))
+        repo.upsert("team-1", teamWide, listOf(rec("r1", 7, deviceId = "devB", blob = byteArrayOf(11))))
 
-        val lose = repo.upsert("team-1", listOf(rec("r1", 7, deviceId = "devA", blob = byteArrayOf(22))))
+        val lose = repo.upsert("team-1", teamWide, listOf(rec("r1", 7, deviceId = "devA", blob = byteArrayOf(22))))
         assertEquals("devB", lose.records.single().deviceId)
 
-        val win = repo.upsert("team-1", listOf(rec("r1", 7, deviceId = "devC", blob = byteArrayOf(33))))
+        val win = repo.upsert("team-1", teamWide, listOf(rec("r1", 7, deviceId = "devC", blob = byteArrayOf(33))))
         assertEquals("devC", win.records.single().deviceId)
     }
 
@@ -71,11 +76,80 @@ class TeamRecordRepositoryTest {
         val repo = seedTeam(db)
         TeamRepository(db).create("team-2", alice, now = 11)
 
-        repo.upsert("team-1", listOf(rec("r1", 1)))
-        repo.upsert("team-2", listOf(rec("x1", 1)))
+        repo.upsert("team-1", teamWide, listOf(rec("r1", 1)))
+        repo.upsert("team-2", teamWide, listOf(rec("x1", 1)))
 
-        assertEquals(listOf("r1"), repo.delta("team-1", 0).map { it.id })
-        assertEquals(listOf("x1"), repo.delta("team-2", 0).map { it.id })
+        assertEquals(listOf("r1"), repo.delta("team-1", teamWide, 0).records.map { it.id })
+        assertEquals(listOf("x1"), repo.delta("team-2", teamWide, 0).records.map { it.id })
+    }
+
+    @Test
+    fun `records of different scopes are isolated within a team`() = withTestDb { db ->
+        val repo = seedTeam(db)
+        TeamScopeRepository(db).create("team-1", "prod", alice, byteArrayOf(1), now = 11)
+
+        repo.upsert("team-1", teamWide, listOf(rec("shared", 1)))
+        repo.upsert("team-1", "prod", listOf(rec("secret", 1)))
+
+        assertEquals(listOf("shared"), repo.delta("team-1", teamWide, 0).records.map { it.id })
+        assertEquals(listOf("secret"), repo.delta("team-1", "prod", 0).records.map { it.id })
+    }
+
+    @Test
+    fun `a push cannot move a record into another scope`() = withTestDb { db ->
+        // A member still holding a stale local copy of a record that has since moved into a scope
+        // pushes it every sync cycle. Applying it would overwrite the scope's ciphertext with one
+        // encrypted under a key the scope's members don't have — the record would go unreadable
+        // for everyone. Such a write is skipped, leaving the stored scope authoritative.
+        val repo = seedTeam(db)
+        TeamScopeRepository(db).create("team-1", "prod", alice, byteArrayOf(1), now = 11)
+        repo.upsert("team-1", "prod", listOf(rec("h1", 1, blob = byteArrayOf(42))))
+
+        val intruder = repo.upsert("team-1", teamWide, listOf(rec("h1", 99, blob = byteArrayOf(7))))
+
+        assertTrue(intruder.records.isEmpty())
+        assertFalse(intruder.changed)
+        val stored = repo.delta("team-1", "prod", 0).records.single()
+        assertEquals(1L, stored.version)
+        assertContentEquals(byteArrayOf(42), stored.blob)
+        assertTrue(repo.delta("team-1", teamWide, 0).records.isEmpty())
+    }
+
+    @Test
+    fun `delta cursor skips over records of other scopes instead of rescanning them`() = withTestDb { db ->
+        // The cursor is the team's current teamSeq, not the last delivered row: without that, records
+        // the caller may not see would be re-scanned on every single pull.
+        val repo = seedTeam(db)
+        TeamScopeRepository(db).create("team-1", "prod", alice, byteArrayOf(1), now = 11)
+
+        repo.upsert("team-1", "prod", listOf(rec("p1", 1)))
+        val page = repo.upsert("team-1", teamWide, listOf(rec("s1", 1)))
+        repo.upsert("team-1", "prod", listOf(rec("p2", 1)))
+
+        val teamWidePage = repo.delta("team-1", teamWide, 0)
+        assertEquals(listOf("s1"), teamWidePage.records.map { it.id })
+        assertEquals(3L, teamWidePage.cursor)
+        assertEquals(2L, page.cursor)
+        assertTrue(repo.delta("team-1", teamWide, teamWidePage.cursor).records.isEmpty())
+    }
+
+    @Test
+    fun `delta never reports a cursor covering a record it did not deliver`() = withTestDb { db ->
+        // The counter is read before the rows, and the rows are bounded by it. Simulated here by
+        // pinning the team counter below an existing record: under PostgreSQL's READ COMMITTED the
+        // same skew happens for real when a push commits between the two statements. Without the
+        // bound, the record below would be withheld yet declared covered — lost for that client.
+        val repo = seedTeam(db)
+        repo.upsert("team-1", teamWide, listOf(rec("r1", 1), rec("r2", 1)))
+        dbTransaction(db) { Teams.update({ Teams.id eq "team-1" }) { it[teamSeq] = 1 } }
+
+        val page = repo.delta("team-1", teamWide, 0)
+
+        assertEquals(listOf("r1"), page.records.map { it.id })
+        assertEquals(1L, page.cursor)
+        // And the withheld record still arrives once the counter catches up.
+        dbTransaction(db) { Teams.update({ Teams.id eq "team-1" }) { it[teamSeq] = 2 } }
+        assertEquals(listOf("r2"), repo.delta("team-1", teamWide, page.cursor).records.map { it.id })
     }
 
     @Test
@@ -83,6 +157,7 @@ class TeamRecordRepositoryTest {
         val repo = seedTeam(db)
         repo.upsert(
             "team-1",
+            teamWide,
             listOf(
                 rec("old-dead", 2, deleted = true, updatedAt = "2026-01-01T00:00:00Z"),
                 rec("new-dead", 2, deleted = true, updatedAt = "2026-07-01T00:00:00Z"),
@@ -91,6 +166,9 @@ class TeamRecordRepositoryTest {
         )
 
         assertEquals(1, repo.purgeTombstones(beforeIso = "2026-04-01T00:00:00Z"))
-        assertEquals(listOf("new-dead", "alive").sorted(), repo.delta("team-1", 0).map { it.id }.sorted())
+        assertEquals(
+            listOf("new-dead", "alive").sorted(),
+            repo.delta("team-1", teamWide, 0).records.map { it.id }.sorted(),
+        )
     }
 }

--- a/server/src/test/kotlin/app/skerry/server/db/TeamRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/TeamRepositoryTest.kt
@@ -164,7 +164,7 @@ class TeamRepositoryTest {
         val records = TeamRecordRepository(db)
         repo.create("team-1", alice, now = 10)
         repo.invite("team-1", bob, TeamRoles.VIEWER, byteArrayOf(1), alice, now = 20)
-        records.upsert("team-1", listOf(IncomingRecord("r1", "HOST", 1, "2026-07-04T00:00:00Z", "devA", false, byteArrayOf(1))))
+        records.upsert("team-1", "", listOf(IncomingRecord("r1", "HOST", 1, "2026-07-04T00:00:00Z", "devA", false, byteArrayOf(1))))
 
         assertTrue(repo.deleteTeam("team-1"))
         assertFalse(repo.deleteTeam("team-1"))

--- a/server/src/test/kotlin/app/skerry/server/db/TeamScopeRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/TeamScopeRepositoryTest.kt
@@ -1,0 +1,182 @@
+package app.skerry.server.db
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Scopes: a share space inside a team with its own key, its own epoch, and an explicit grant list.
+ * The server stores grants and sealed keys; it never sees a scope key or a scope name.
+ */
+class TeamScopeRepositoryTest {
+
+    private val alice = "alice@example.com"
+    private val bob = "bob@example.com"
+    private val carol = "carol@example.com"
+
+    private suspend fun seed(db: org.jetbrains.exposed.v1.jdbc.Database): TeamScopeRepository {
+        seedAccount(db, alice)
+        seedAccount(db, bob)
+        seedAccount(db, carol)
+        val teams = TeamRepository(db)
+        teams.create("team-1", alice, now = 10)
+        teams.invite("team-1", bob, TeamRoles.EDITOR, byteArrayOf(1), alice, now = 11)
+        teams.accept("team-1", bob)
+        teams.invite("team-1", carol, TeamRoles.VIEWER, byteArrayOf(1), alice, now = 12)
+        teams.accept("team-1", carol)
+        return TeamScopeRepository(db)
+    }
+
+    @Test
+    fun `creating a scope grants it to the creator and is visible only to grantees`() = withTestDb { db ->
+        val scopes = seed(db)
+
+        assertTrue(scopes.create("team-1", "prod", alice, envelope = byteArrayOf(9), now = 20))
+
+        val forAlice = scopes.scopesFor("team-1", alice, all = false).single()
+        assertEquals("prod", forAlice.scopeId)
+        assertEquals(0L, forAlice.keyEpoch)
+        assertEquals(1, forAlice.memberCount)
+        assertContentEquals(byteArrayOf(9), forAlice.envelope)
+
+        // A member without a grant is not even told the scope exists.
+        assertTrue(scopes.scopesFor("team-1", bob, all = false).isEmpty())
+        // A manager listing all scopes sees it, but without a key envelope of their own.
+        val forManager = scopes.scopesFor("team-1", bob, all = true).single()
+        assertEquals("prod", forManager.scopeId)
+        assertNull(forManager.envelope)
+    }
+
+    @Test
+    fun `a scope id is unique per team but free across teams`() = withTestDb { db ->
+        val scopes = seed(db)
+        TeamRepository(db).create("team-2", alice, now = 13)
+
+        assertTrue(scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20))
+        assertFalse(scopes.create("team-1", "prod", alice, byteArrayOf(2), now = 21))
+        assertTrue(scopes.create("team-2", "prod", alice, byteArrayOf(3), now = 22))
+    }
+
+    @Test
+    fun `grant and revoke move a member in and out of the scope`() = withTestDb { db ->
+        val scopes = seed(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+
+        assertTrue(scopes.grant("team-1", "prod", bob, envelope = byteArrayOf(2), now = 21))
+        assertTrue(scopes.hasGrant("team-1", "prod", bob))
+        assertEquals(listOf(alice, bob).sorted(), scopes.grants("team-1", "prod").map { it.accountId }.sorted())
+
+        assertTrue(scopes.revoke("team-1", "prod", bob))
+        assertFalse(scopes.hasGrant("team-1", "prod", bob))
+        assertFalse(scopes.revoke("team-1", "prod", bob))
+        assertEquals(listOf(alice), scopes.grants("team-1", "prod").map { it.accountId })
+    }
+
+    @Test
+    fun `granting an unknown scope fails instead of creating one`() = withTestDb { db ->
+        val scopes = seed(db)
+
+        assertFalse(scopes.grant("team-1", "ghost", bob, byteArrayOf(2), now = 21))
+        assertFalse(scopes.hasGrant("team-1", "ghost", bob))
+    }
+
+    @Test
+    fun `regranting replaces the envelope rather than duplicating the grant`() = withTestDb { db ->
+        val scopes = seed(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        scopes.grant("team-1", "prod", bob, byteArrayOf(2), now = 21)
+
+        assertTrue(scopes.grant("team-1", "prod", bob, byteArrayOf(3), now = 22))
+
+        assertEquals(2, scopes.grants("team-1", "prod").size)
+        assertContentEquals(byteArrayOf(3), scopes.scopesFor("team-1", bob, all = false).single().envelope)
+    }
+
+    @Test
+    fun `rekey is a monotonic compare-and-set and re-seals the key to grantees`() = withTestDb { db ->
+        val scopes = seed(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        scopes.grant("team-1", "prod", bob, byteArrayOf(2), now = 21)
+
+        assertEquals(
+            RekeyOutcome.OK,
+            scopes.rekey("team-1", "prod", newEpoch = 1, envelopes = mapOf(alice to byteArrayOf(11), bob to byteArrayOf(12))),
+        )
+        assertEquals(1L, scopes.scopesFor("team-1", alice, all = false).single().keyEpoch)
+        assertContentEquals(byteArrayOf(12), scopes.scopesFor("team-1", bob, all = false).single().envelope)
+
+        // Replaying the same epoch (or skipping one) must not split the key across grantees.
+        assertEquals(RekeyOutcome.EPOCH_CONFLICT, scopes.rekey("team-1", "prod", 1, mapOf(alice to byteArrayOf(13))))
+        assertEquals(RekeyOutcome.EPOCH_CONFLICT, scopes.rekey("team-1", "prod", 3, mapOf(alice to byteArrayOf(13))))
+        assertEquals(RekeyOutcome.NO_TEAM, scopes.rekey("team-1", "ghost", 1, mapOf(alice to byteArrayOf(13))))
+        assertContentEquals(byteArrayOf(11), scopes.scopesFor("team-1", alice, all = false).single().envelope)
+    }
+
+    @Test
+    fun `rekey does not resurrect a revoked grant`() = withTestDb { db ->
+        val scopes = seed(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        scopes.grant("team-1", "prod", bob, byteArrayOf(2), now = 21)
+        scopes.revoke("team-1", "prod", bob)
+
+        scopes.rekey("team-1", "prod", 1, mapOf(alice to byteArrayOf(11), bob to byteArrayOf(12)))
+
+        assertFalse(scopes.hasGrant("team-1", "prod", bob))
+        assertTrue(scopes.scopesFor("team-1", bob, all = false).isEmpty())
+    }
+
+    @Test
+    fun `deleting a scope drops its grants and its records`() = withTestDb { db ->
+        val scopes = seed(db)
+        val records = TeamRecordRepository(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        records.upsert("team-1", "prod", listOf(incoming("r1")))
+        records.upsert("team-1", "", listOf(incoming("r2")))
+
+        assertTrue(scopes.delete("team-1", "prod"))
+
+        assertTrue(scopes.scopesFor("team-1", alice, all = true).isEmpty())
+        assertTrue(scopes.grants("team-1", "prod").isEmpty())
+        assertTrue(records.delta("team-1", "prod", 0).records.isEmpty())
+        // Team-wide records are untouched.
+        assertEquals(listOf("r2"), records.delta("team-1", "", 0).records.map { it.id })
+    }
+
+    @Test
+    fun `removing a member from the team revokes every scope grant they held`() = withTestDb { db ->
+        val scopes = seed(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        scopes.create("team-1", "staging", alice, byteArrayOf(1), now = 21)
+        scopes.grant("team-1", "prod", bob, byteArrayOf(2), now = 22)
+        scopes.grant("team-1", "staging", bob, byteArrayOf(3), now = 23)
+        scopes.grant("team-1", "prod", carol, byteArrayOf(4), now = 24)
+
+        // Returned so the caller knows which scope keys need rotating.
+        assertEquals(listOf("prod", "staging"), scopes.revokeAll("team-1", bob).sorted())
+
+        assertFalse(scopes.hasGrant("team-1", "prod", bob))
+        assertFalse(scopes.hasGrant("team-1", "staging", bob))
+        assertTrue(scopes.hasGrant("team-1", "prod", carol))
+    }
+
+    @Test
+    fun `deleting the team removes its scopes, grants and scoped records`() = withTestDb { db ->
+        val scopes = seed(db)
+        val records = TeamRecordRepository(db)
+        scopes.create("team-1", "prod", alice, byteArrayOf(1), now = 20)
+        scopes.grant("team-1", "prod", bob, byteArrayOf(2), now = 21)
+        records.upsert("team-1", "prod", listOf(incoming("r1")))
+
+        assertTrue(TeamRepository(db).deleteTeam("team-1"))
+
+        assertTrue(scopes.scopesFor("team-1", alice, all = true).isEmpty())
+        assertTrue(scopes.grants("team-1", "prod").isEmpty())
+        assertTrue(records.delta("team-1", "prod", 0).records.isEmpty())
+    }
+
+    private fun incoming(id: String) =
+        IncomingRecord(id, "HOST", 1, "2026-07-26T00:00:00Z", "devA", deleted = false, blob = byteArrayOf(1))
+}

--- a/server/src/test/kotlin/app/skerry/server/routes/TeamScopeAclTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/TeamScopeAclTest.kt
@@ -1,0 +1,358 @@
+package app.skerry.server.routes
+
+import app.skerry.server.configureServer
+import app.skerry.server.model.b64
+import app.skerry.sync.wire.PushRequest
+import app.skerry.sync.wire.RecordDto
+import app.skerry.sync.wire.RecordsResponse
+import app.skerry.sync.wire.RekeyEnvelopeDto
+import app.skerry.sync.wire.TeamCreateRequest
+import app.skerry.sync.wire.TeamInviteRequest
+import app.skerry.sync.wire.TeamRekeyRequest
+import app.skerry.sync.wire.TeamScopeCreateRequest
+import app.skerry.sync.wire.TeamScopeGrantRequest
+import app.skerry.sync.wire.TeamScopeGrantsResponse
+import app.skerry.sync.wire.TeamScopesResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * ACL of granular sharing. The server enforcement checked here is the first of two independent
+ * layers: a member without a grant can't fetch a scope's records. The second — that they couldn't
+ * decrypt them anyway — lives in the client and is what survives a compromised server.
+ */
+class TeamScopeAclTest {
+
+    private val teamId = "team-scope-1"
+    private val pw = "auth-key-hex"
+
+    private suspend fun HttpClient.createTeam(token: String) = post("/teams") {
+        bearerAuth(token)
+        contentType(ContentType.Application.Json)
+        setBody(TeamCreateRequest(teamId))
+    }
+
+    private suspend fun HttpClient.invite(token: String, target: String, role: String) =
+        post("/teams/$teamId/members") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(TeamInviteRequest(target, byteArrayOf(1, 2, 3).b64(), role))
+        }
+
+    private suspend fun HttpClient.accept(token: String) = post("/teams/$teamId/accept") { bearerAuth(token) }
+
+    private suspend fun HttpClient.createScope(token: String, scopeId: String, envelope: Byte = 1) =
+        post("/teams/$teamId/scopes") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeCreateRequest(scopeId, byteArrayOf(envelope).b64()))
+        }
+
+    private suspend fun HttpClient.grantScope(token: String, scopeId: String, target: String, envelope: Byte = 2) =
+        post("/teams/$teamId/scopes/$scopeId/grants") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeGrantRequest(target, byteArrayOf(envelope).b64()))
+        }
+
+    private suspend fun HttpClient.revokeScope(token: String, scopeId: String, target: String) =
+        delete("/teams/$teamId/scopes/$scopeId/grants/$target") { bearerAuth(token) }
+
+    private suspend fun HttpClient.listScopes(token: String) =
+        get("/teams/$teamId/scopes") { bearerAuth(token) }
+
+    private suspend fun HttpClient.rekey(token: String, epoch: Long) = post("/teams/$teamId/scopes/prod/rekey") {
+        bearerAuth(token)
+        contentType(ContentType.Application.Json)
+        setBody(TeamRekeyRequest(epoch, listOf(RekeyEnvelopeDto("owner@x.io", byteArrayOf(3).b64()))))
+    }
+
+    private suspend fun HttpClient.pull(token: String, scope: String?) =
+        get("/teams/$teamId/records${if (scope == null) "" else "?scope=$scope"}") { bearerAuth(token) }
+
+    private suspend fun HttpClient.push(token: String, scope: String?, id: String = "r1") =
+        put("/teams/$teamId/records${if (scope == null) "" else "?scope=$scope"}") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(PushRequest(listOf(RecordDto(id, "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, byteArrayOf(9).b64()))))
+        }
+
+    @Test
+    fun `a member without a grant can neither read nor write the scope`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val junior = client.registerAccount("junior@x.io", pw, deviceId = "d-junior")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "junior@x.io", "editor")
+        client.accept(junior.accessToken)
+        assertEquals(HttpStatusCode.Created, client.createScope(owner.accessToken, "prod").status)
+        assertEquals(HttpStatusCode.OK, client.push(owner.accessToken, "prod").status)
+
+        // 404 rather than 403: the existence of a scope is itself information about the team.
+        assertEquals(HttpStatusCode.NotFound, client.pull(junior.accessToken, "prod").status)
+        assertEquals(HttpStatusCode.NotFound, client.push(junior.accessToken, "prod", id = "r2").status)
+        // Team-wide sharing is unaffected — that is what an unscoped record still means.
+        assertEquals(HttpStatusCode.OK, client.pull(junior.accessToken, null).status)
+        assertTrue(client.pull(junior.accessToken, null).body<RecordsResponse>().records.isEmpty())
+    }
+
+    @Test
+    fun `a granted member reads the scope and stops after a revoke`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val senior = client.registerAccount("senior@x.io", pw, deviceId = "d-senior")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "senior@x.io", "editor")
+        client.accept(senior.accessToken)
+        client.createScope(owner.accessToken, "prod")
+        client.push(owner.accessToken, "prod")
+
+        assertEquals(HttpStatusCode.Created, client.grantScope(owner.accessToken, "prod", "senior@x.io").status)
+        val page = client.pull(senior.accessToken, "prod")
+        assertEquals(HttpStatusCode.OK, page.status)
+        assertEquals(listOf("r1"), page.body<RecordsResponse>().records.map { it.id })
+
+        assertEquals(HttpStatusCode.OK, client.revokeScope(owner.accessToken, "prod", "senior@x.io").status)
+        assertEquals(HttpStatusCode.NotFound, client.pull(senior.accessToken, "prod").status)
+    }
+
+    @Test
+    fun `scopes are listed with keys only for grantees and in full only for managers`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "editor@x.io", "editor")
+        client.accept(editor.accessToken)
+        client.createScope(owner.accessToken, "prod", envelope = 5)
+        client.createScope(owner.accessToken, "staging", envelope = 6)
+        client.grantScope(owner.accessToken, "staging", "editor@x.io", envelope = 7)
+
+        // An editor sees only what they were granted, with their own sealed key.
+        val mine = client.listScopes(editor.accessToken).body<TeamScopesResponse>().scopes
+        assertEquals(listOf("staging"), mine.map { it.scopeId })
+        assertEquals(byteArrayOf(7).b64(), mine.single().envelope)
+
+        // The owner (a manager) sees every scope; keys of scopes they hold, none of the others.
+        val all = client.listScopes(owner.accessToken).body<TeamScopesResponse>().scopes.sortedBy { it.scopeId }
+        assertEquals(listOf("prod", "staging"), all.map { it.scopeId })
+        assertEquals(listOf(1, 2), all.map { it.memberCount })
+    }
+
+    @Test
+    fun `managing scopes requires the manage-members role`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        val outsider = client.registerAccount("outsider@x.io", pw, deviceId = "d-out")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "editor@x.io", "editor")
+        client.accept(editor.accessToken)
+        client.createScope(owner.accessToken, "prod")
+
+        assertEquals(HttpStatusCode.Forbidden, client.createScope(editor.accessToken, "rogue").status)
+        assertEquals(HttpStatusCode.Forbidden, client.grantScope(editor.accessToken, "prod", "editor@x.io").status)
+        assertEquals(HttpStatusCode.Forbidden, client.revokeScope(editor.accessToken, "prod", "owner@x.io").status)
+        assertEquals(
+            HttpStatusCode.Forbidden,
+            client.delete("/teams/$teamId/scopes/prod") { bearerAuth(editor.accessToken) }.status,
+        )
+        // A non-member gets the team's own 404, not a hint that the scope exists.
+        assertEquals(HttpStatusCode.NotFound, client.listScopes(outsider.accessToken).status)
+    }
+
+    @Test
+    fun `a member may give up their own scope access without a management role`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "editor@x.io", "editor")
+        client.accept(editor.accessToken)
+        client.createScope(owner.accessToken, "prod")
+        client.grantScope(owner.accessToken, "prod", "editor@x.io")
+
+        assertEquals(HttpStatusCode.OK, client.revokeScope(editor.accessToken, "prod", "editor@x.io").status)
+        assertEquals(HttpStatusCode.NotFound, client.pull(editor.accessToken, "prod").status)
+    }
+
+    @Test
+    fun `a scope cannot be granted to someone who is not an accepted member`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.registerAccount("pending@x.io", pw, deviceId = "d-pending")
+        client.registerAccount("stranger@x.io", pw, deviceId = "d-stranger")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "pending@x.io", "editor") // invited, not accepted
+        client.createScope(owner.accessToken, "prod")
+
+        assertEquals(HttpStatusCode.NotFound, client.grantScope(owner.accessToken, "prod", "pending@x.io").status)
+        assertEquals(HttpStatusCode.NotFound, client.grantScope(owner.accessToken, "prod", "stranger@x.io").status)
+    }
+
+    @Test
+    fun `removing a member from the team drops their scope grants`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "editor@x.io", "editor")
+        client.accept(editor.accessToken)
+        client.createScope(owner.accessToken, "prod")
+        client.grantScope(owner.accessToken, "prod", "editor@x.io")
+
+        assertEquals(
+            HttpStatusCode.OK,
+            client.delete("/teams/$teamId/members/editor@x.io") { bearerAuth(owner.accessToken) }.status,
+        )
+
+        val grants = client.get("/teams/$teamId/scopes/prod/grants") { bearerAuth(owner.accessToken) }
+            .body<TeamScopeGrantsResponse>().grants
+        assertEquals(listOf("owner@x.io"), grants.map { it.accountId })
+        assertEquals(HttpStatusCode.NotFound, client.pull(editor.accessToken, "prod").status)
+    }
+
+    @Test
+    fun `scope rekey is monotonic and only for managers`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "editor@x.io", "editor")
+        client.accept(editor.accessToken)
+        client.createScope(owner.accessToken, "prod")
+
+        assertEquals(HttpStatusCode.Forbidden, client.rekey(editor.accessToken, 1).status)
+        assertEquals(HttpStatusCode.OK, client.rekey(owner.accessToken, 1).status)
+        assertEquals(HttpStatusCode.Conflict, client.rekey(owner.accessToken, 1).status)
+        assertEquals(HttpStatusCode.Conflict, client.rekey(owner.accessToken, 3).status)
+        assertEquals(1L, client.listScopes(owner.accessToken).body<TeamScopesResponse>().scopes.single().keyEpoch)
+    }
+
+    @Test
+    fun `a manager without the scope key can neither grant it nor rotate it`() = testApplication {
+        // The escalation this guards: an admin deliberately left out of "prod" self-grants an ACL row,
+        // then rekeys the scope with a key of their own making. Their signature is genuine, so every
+        // real grantee adopts it and everything shared afterwards is readable by them. Managing the
+        // team must not imply access to a scope its members were never given.
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val admin = client.registerAccount("admin@x.io", pw, deviceId = "d-admin")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "admin@x.io", "admin")
+        client.accept(admin.accessToken)
+        client.createScope(owner.accessToken, "prod") // granted to the owner only
+        client.push(owner.accessToken, "prod", id = "secret")
+
+        assertEquals(HttpStatusCode.Forbidden, client.grantScope(admin.accessToken, "prod", "admin@x.io").status)
+        assertEquals(HttpStatusCode.Forbidden, client.grantScope(admin.accessToken, "prod", "owner@x.io").status)
+        assertEquals(HttpStatusCode.Forbidden, client.rekey(admin.accessToken, 1).status)
+
+        // No ACL row was created and the scope key generation is untouched.
+        assertEquals(HttpStatusCode.NotFound, client.pull(admin.accessToken, "prod").status)
+        val scope = client.listScopes(owner.accessToken).body<TeamScopesResponse>().scopes.single()
+        assertEquals(0L, scope.keyEpoch)
+        assertEquals(1, scope.memberCount)
+    }
+
+    @Test
+    fun `a manager without the key may still delete an orphaned scope`() = testApplication {
+        // The escape hatch that must survive the check above: if everyone holding a scope key leaves,
+        // nobody can rotate or re-grant it, so a manager has to be able to clear it away.
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val admin = client.registerAccount("admin@x.io", pw, deviceId = "d-admin")
+        client.createTeam(owner.accessToken)
+        client.invite(owner.accessToken, "admin@x.io", "admin")
+        client.accept(admin.accessToken)
+        client.createScope(owner.accessToken, "prod")
+
+        assertEquals(
+            HttpStatusCode.OK,
+            client.delete("/teams/$teamId/scopes/prod") { bearerAuth(admin.accessToken) }.status,
+        )
+        assertTrue(client.listScopes(owner.accessToken).body<TeamScopesResponse>().scopes.isEmpty())
+    }
+
+    @Test
+    fun `a malformed scope id is rejected before anything is stored`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.createTeam(owner.accessToken)
+
+        // The id becomes a vault file name on every member's device.
+        assertEquals(HttpStatusCode.BadRequest, client.createScope(owner.accessToken, "../etc/passwd").status)
+        assertEquals(HttpStatusCode.BadRequest, client.createScope(owner.accessToken, "Prod").status)
+        assertEquals(HttpStatusCode.BadRequest, client.pull(owner.accessToken, "../x").status)
+        assertTrue(client.listScopes(owner.accessToken).body<TeamScopesResponse>().scopes.isEmpty())
+    }
+
+    @Test
+    fun `a record stays in its own scope when pushed from another one`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.createTeam(owner.accessToken)
+        client.createScope(owner.accessToken, "prod")
+        client.push(owner.accessToken, "prod", id = "h1")
+
+        // A stale local copy re-pushed team-wide must not drag the record out of the scope: it would
+        // land there encrypted under a key the scope's members don't hold.
+        client.push(owner.accessToken, null, id = "h1")
+
+        assertTrue(client.pull(owner.accessToken, null).body<RecordsResponse>().records.isEmpty())
+        assertEquals(listOf("h1"), client.pull(owner.accessToken, "prod").body<RecordsResponse>().records.map { it.id })
+        assertNull(client.pull(owner.accessToken, null).body<RecordsResponse>().records.firstOrNull())
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
@@ -126,7 +126,42 @@ interface TeamClient {
 
     suspend fun deleteTeam(session: SyncSession, teamId: String)
 
-    suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage
+    suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage
 
-    suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage
+    suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage
+
+    // --- scopes (granular sharing inside a team) ---
+
+    /**
+     * Scopes of the team. Managers see every scope; a plain member sees only the ones they hold a
+     * grant for (a scope's existence is itself a hint about the team's structure).
+     */
+    suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary>
+
+    /** Creates a scope and grants it to the creator ([envelope] = scopeKey sealed to themselves). */
+    suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray)
+
+    /** Deletes a scope with its grants and records (manage-members role). */
+    suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String)
+
+    /** Accounts holding a grant on the scope (manage-members role). */
+    suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry>
+
+    /** Grants [accountId] access to the scope, delivering the sealed current-epoch scopeKey. */
+    suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray)
+
+    /** Revokes [accountId]'s grant. The caller rotates the scope key afterwards (forward secrecy). */
+    suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String)
+
+    /**
+     * Rotates a scope's key: bumps it to [newEpoch] and stores one re-sealed key per remaining
+     * grantee. Same monotonicity contract as [rekey], scoped to the scope's own epoch.
+     */
+    suspend fun rekeyScope(
+        session: SyncSession,
+        teamId: String,
+        scopeId: String,
+        newEpoch: Long,
+        envelopes: Map<String, ByteArray>,
+    )
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamInvite.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamInvite.kt
@@ -24,9 +24,10 @@ class TeamInvitePayload(
     val inviterAccountId: String,
     val inviteeAccountId: String,
     val epoch: Int,
-    /** Detached signature over [signedBytes]; verified via [TeamInviteCodec.verify]. */
+    /** Scope this key belongs to; empty for the team-wide key. See [TeamInviteCodec] on why it's signed. */
+    val scopeId: String = "",
+    /** Detached signature over the canonical binding; checked by [TeamInviteCodec.verify]. */
     internal val signature: ByteArray,
-    internal val signedBytes: ByteArray,
 )
 
 /**
@@ -40,6 +41,13 @@ class TeamInvitePayload(
  *   alone is anonymous — a malicious server could fabricate an invite to a fake team it controls the
  *   key for. The signature binds the envelope to a specific inviter, teamId, and invitee, so the
  *   server can neither forge one without the inviter's secret key nor retarget an existing one.
+ *
+ * The same envelope carries a **scope** key ([scopeId] non-empty), signed under a different domain
+ * tag. Domain separation, not just an extra field, because crypto_box_seal is anonymous: anyone can
+ * seal to the recipient. Without it a member who legitimately holds a scope key could re-seal the
+ * inviter's signature over that key as a team-wide rekey envelope; the recipient would adopt an
+ * attacker-known key as teamKey and everything they wrote afterwards would be readable by them.
+ * Keeping the team-wide layout byte-identical also means envelopes in flight stay verifiable.
  *
  * Format version 2 (signed). Version 1 (unsigned, anonymous) is rejected — there are no released
  * clients holding v1 envelopes.
@@ -56,6 +64,8 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
         val inviteeId: String,
         val epoch: Int,
         val sig: String,
+        /** Empty (and absent in team-wide envelopes) — see the class doc on domain separation. */
+        val scope: String = "",
     )
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -73,8 +83,9 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
         teamKey: DataKey,
         teamName: String,
         epoch: Int,
+        scopeId: String = "",
     ): ByteArray {
-        val signed = inviteSignedBytes(teamId, inviterId, inviteeId, teamKey, teamName, epoch)
+        val signed = inviteSignedBytes(teamId, inviterId, inviteeId, teamKey, teamName, epoch, scopeId)
         val sig = crypto.sign(inviter, signed)
         val plain = json.encodeToString(
             WireInvite.serializer(),
@@ -87,6 +98,7 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
                 inviteeId = inviteeId,
                 epoch = epoch,
                 sig = sig.toByteString().base64(),
+                scope = scopeId,
             ),
         ).encodeToByteArray()
         return crypto.sealForRecipient(recipientPublicKey, plain).also { plain.fill(0); signed.fill(0) }
@@ -105,16 +117,15 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
             val keyBytes = wire.teamKey.decodeBase64()?.toByteArray() ?: return null
             if (keyBytes.size != 32) return null
             val sig = wire.sig.decodeBase64()?.toByteArray() ?: return null
-            val teamKey = DataKey(keyBytes)
             TeamInvitePayload(
-                teamKey = teamKey,
+                teamKey = DataKey(keyBytes),
                 teamName = wire.name,
                 teamId = wire.teamId,
                 inviterAccountId = wire.inviterId,
                 inviteeAccountId = wire.inviteeId,
                 epoch = wire.epoch,
+                scopeId = wire.scope,
                 signature = sig,
-                signedBytes = inviteSignedBytes(wire.teamId, wire.inviterId, wire.inviteeId, teamKey, wire.name, wire.epoch),
             )
         } catch (e: kotlinx.serialization.SerializationException) {
             null
@@ -123,10 +134,26 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
         }
     }
 
-    /** True if [payload]'s signature is valid for [inviterSignPublicKey] (the inviter's published Ed25519 key). */
-    fun verify(payload: TeamInvitePayload, inviterSignPublicKey: ByteArray): Boolean =
-        crypto.verifySignature(inviterSignPublicKey, payload.signedBytes, payload.signature)
+    /**
+     * True if [payload] is signed by [inviterSignPublicKey] **as the key of [scopeId]** (empty =
+     * team-wide). The expected scope is an argument rather than read off the payload on purpose: the
+     * binding is only meaningful when the caller pins the slot it is about to store the key into, so
+     * an envelope filed under the wrong scope by the server can't be adopted.
+     */
+    fun verify(payload: TeamInvitePayload, inviterSignPublicKey: ByteArray, scopeId: String = ""): Boolean {
+        val signed = inviteSignedBytes(
+            payload.teamId, payload.inviterAccountId, payload.inviteeAccountId,
+            payload.teamKey, payload.teamName, payload.epoch, scopeId,
+        )
+        return crypto.verifySignature(inviterSignPublicKey, signed, payload.signature)
+            .also { signed.fill(0) }
+    }
 
+    /**
+     * Canonical bytes of the binding. A scope key is signed under its own domain tag with the scope
+     * id as an extra field; the team-wide layout is left exactly as it was so v2 envelopes sealed by
+     * an older client still verify.
+     */
     private fun inviteSignedBytes(
         teamId: String,
         inviterId: String,
@@ -134,18 +161,33 @@ class TeamInviteCodec(private val crypto: VaultCrypto) {
         teamKey: DataKey,
         teamName: String,
         epoch: Int,
-    ): ByteArray = canonicalBytes(
-        "skerry.team.invite.v$VERSION",
-        teamId.encodeToByteArray(),
-        inviterId.encodeToByteArray(),
-        inviteeId.encodeToByteArray(),
-        teamKey.bytes,
-        teamName.encodeToByteArray(),
-        intBytes(epoch),
-    )
+        scopeId: String,
+    ): ByteArray = if (scopeId.isEmpty()) {
+        canonicalBytes(
+            "skerry.team.invite.v$VERSION",
+            teamId.encodeToByteArray(),
+            inviterId.encodeToByteArray(),
+            inviteeId.encodeToByteArray(),
+            teamKey.bytes,
+            teamName.encodeToByteArray(),
+            intBytes(epoch),
+        )
+    } else {
+        canonicalBytes(
+            "skerry.team.scope.v$SCOPE_VERSION",
+            teamId.encodeToByteArray(),
+            scopeId.encodeToByteArray(),
+            inviterId.encodeToByteArray(),
+            inviteeId.encodeToByteArray(),
+            teamKey.bytes,
+            teamName.encodeToByteArray(),
+            intBytes(epoch),
+        )
+    }
 
     private companion object {
         const val VERSION = 2
+        const val SCOPE_VERSION = 1
     }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScope.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScope.kt
@@ -1,0 +1,45 @@
+package app.skerry.shared.team
+
+/**
+ * Identity of a keyed share space inside a team: the team itself ([scopeId] empty — every active
+ * member reads it) or one of its scopes (only members holding a grant read it).
+ *
+ * A scope is deliberately not a subsystem of its own: it has exactly what a team has — a key, an
+ * epoch, sealed envelopes, a vault file, a sync cursor — so all of that machinery is parameterized
+ * by this reference instead of duplicated. `scopeId` is client-generated and constrained to the same
+ * charset as a teamId, because both end up in a file name.
+ */
+data class TeamScopeRef(val teamId: String, val scopeId: String = "") {
+
+    val isTeamWide: Boolean get() = scopeId.isEmpty()
+
+    /** Stable key for maps and sync cursors: `team-1` or `team-1/prod`. */
+    val key: String get() = if (isTeamWide) teamId else "$teamId/$scopeId"
+
+    /** Vault file name. `__` can't appear inside an id (see [isSafeId]), so the split is unambiguous. */
+    val fileName: String get() = if (isTeamWide) "$teamId.vault" else "${teamId}__$scopeId.vault"
+
+    companion object {
+        /** Team and scope ids are client-generated: `[a-z0-9-]` only, or the file name becomes a path injection. */
+        fun isSafeId(id: String): Boolean =
+            id.isNotEmpty() && id.length <= 64 && id.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }
+    }
+}
+
+/** A team scope as the server reports it to one account. */
+class TeamScopeSummary(
+    val scopeId: String,
+    /** Current scopeKey generation; a revoke-driven rotation bumps it (same contract as the team epoch). */
+    val keyEpoch: Long,
+    /** Number of accounts holding a grant (managers see it for every scope). */
+    val memberCount: Int,
+    /**
+     * Our sealed scopeKey, or null when we hold no grant. Unlike an invite envelope this is NOT
+     * cleared after adoption: it is the recovery path when the local TEAM record loses its scope map
+     * (e.g. an older client of the same account rewrote that record without the `scopes` field).
+     */
+    val envelope: ByteArray?,
+)
+
+/** An account's grant on a scope (manager view). */
+class TeamScopeGrantEntry(val accountId: String, val createdAt: Long)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
@@ -12,20 +12,21 @@ import app.skerry.shared.sync.SyncSignal
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Adapts team scope to [SyncClient]: pull/push close over `/teams/{id}/records`, letting team
- * records run through the same [app.skerry.shared.sync.SyncEngine] (LWW, paging, cursor) as the
- * account vault. The rest of the contract is deliberately unsupported — the engine never calls it.
+ * Adapts one team share space (the team itself or one of its scopes, see [TeamScopeRef]) to
+ * [SyncClient]: pull/push close over `/teams/{id}/records`, letting team records run through the
+ * same [app.skerry.shared.sync.SyncEngine] (LWW, paging, cursor) as the account vault. The rest of
+ * the contract is deliberately unsupported — the engine never calls it.
  */
 class TeamScopedSyncClient(
     private val teams: TeamClient,
-    private val teamId: String,
+    private val ref: TeamScopeRef,
 ) : SyncClient {
 
     override suspend fun pull(session: SyncSession, since: Long): RecordPage =
-        teams.pullTeam(session, teamId, since)
+        teams.pullTeam(session, ref, since)
 
     override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage =
-        teams.pushTeam(session, teamId, records)
+        teams.pushTeam(session, ref, records)
 
     override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()
     override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamStores.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamStores.kt
@@ -26,11 +26,30 @@ data class TeamKeyEntry(
     val role: String,
     val teamKey: String,
     val epoch: Int = 0,
+    /**
+     * Keys of the team's scopes we hold a grant for, by scopeId. Nested in this record rather than
+     * given a [RecordType] of its own: a client that doesn't know a record type drops it while
+     * advancing the sync cursor (see `SyncEngine`), which would lose a scope key for good. Here a
+     * scope key shares the TEAM record's fate — including its recovery path.
+     */
+    val scopes: Map<String, TeamScopeKeyEntry> = emptyMap(),
 ) {
-    fun dataKey(): DataKey? {
-        val bytes = teamKey.decodeBase64()?.toByteArray() ?: return null
-        return if (bytes.size == 32) DataKey(bytes) else null
-    }
+    fun dataKey(): DataKey? = decodeDataKey(teamKey)
+}
+
+/** One scope's key inside [TeamKeyEntry]. [epoch] is its own generation, independent of the team's. */
+@Serializable
+data class TeamScopeKeyEntry(
+    val name: String,
+    val key: String,
+    val epoch: Int = 0,
+) {
+    fun dataKey(): DataKey? = decodeDataKey(key)
+}
+
+private fun decodeDataKey(base64: String): DataKey? {
+    val bytes = base64.decodeBase64()?.toByteArray() ?: return null
+    return if (bytes.size == 32) DataKey(bytes) else null
 }
 
 /** Store of [RecordType.TEAM] records: one per team, record id = teamId. */
@@ -77,6 +96,46 @@ class TeamKeyStore(private val vault: Vault) {
 
     fun remove(teamId: String) {
         vault.transaction { codec.remove(teamId) }
+    }
+
+    // --- scopes (nested in the team's own record, see [TeamKeyEntry.scopes]) ---
+
+    fun scopes(teamId: String): Map<String, TeamScopeKeyEntry> {
+        if (!vault.isUnlocked) return emptyMap()
+        return codec.get(teamId)?.scopes ?: emptyMap()
+    }
+
+    fun scope(teamId: String, scopeId: String): TeamScopeKeyEntry? = scopes(teamId)[scopeId]
+
+    /** Store (or replace) a scope's key. No-op if the team itself is unknown. */
+    fun putScope(teamId: String, scopeId: String, name: String, key: DataKey, epoch: Int = 0) =
+        editScopes(teamId) { it + (scopeId to TeamScopeKeyEntry(name, key.bytes.toByteString().base64(), epoch)) }
+
+    /** Replace a scope's key and epoch on rotation, keeping its name. No-op if the scope is unknown. */
+    fun rekeyScope(teamId: String, scopeId: String, key: DataKey, epoch: Int) =
+        editScopes(teamId) { current ->
+            val scope = current[scopeId] ?: return@editScopes current
+            current + (scopeId to scope.copy(key = key.bytes.toByteString().base64(), epoch = epoch))
+        }
+
+    fun renameScope(teamId: String, scopeId: String, name: String) =
+        editScopes(teamId) { current ->
+            val scope = current[scopeId] ?: return@editScopes current
+            current + (scopeId to scope.copy(name = name))
+        }
+
+    fun removeScope(teamId: String, scopeId: String) = editScopes(teamId) { it - scopeId }
+
+    /**
+     * Read-modify-write of the scope map under the vault transaction (guideline §3): without it a
+     * background merge landing between the read and the write would drop a concurrently added scope.
+     */
+    private fun editScopes(teamId: String, transform: (Map<String, TeamScopeKeyEntry>) -> Map<String, TeamScopeKeyEntry>) {
+        vault.transaction {
+            val current = codec.get(teamId) ?: return@transaction
+            val updated = transform(current.scopes)
+            if (updated != current.scopes) codec.put(teamId, current.copy(scopes = updated))
+        }
     }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamVaults.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamVaults.kt
@@ -9,10 +9,12 @@ import okio.FileSystem
 import okio.Path
 
 /**
- * File-backed team vaults: `<dir>/<teamId>.vault`, dataKey = teamKey (record blobs are
- * wire-compatible between members: the server and other members decrypt with the same key).
- * The key lives in a TEAM record in the account vault; this only opens/creates the files.
- * Instances are cached: one [Vault] per team per process (FileVault has its own internal lock).
+ * File-backed vaults of team share spaces: `<dir>/<teamId>.vault` for the team itself and
+ * `<dir>/<teamId>__<scopeId>.vault` for each scope (see [TeamScopeRef]). The vault's dataKey is that
+ * space's key, so record blobs stay wire-compatible between members: the server and every member
+ * holding the key decrypt the same bytes. The keys themselves live in a TEAM record in the account
+ * vault; this only opens/creates the files.
+ * Instances are cached: one [Vault] per space per process (FileVault has its own internal lock).
  */
 class TeamVaults(
     private val dir: Path,
@@ -40,24 +42,24 @@ class TeamVaults(
     }
 
     /**
-     * Open (creating if needed) the team's vault. Returns null if the file can't be opened under
-     * [teamKey] — either a superseded key or a corrupt file. Callers that must distinguish the two
+     * Open (creating if needed) the space's vault. Returns null if the file can't be opened under
+     * [key] — either a superseded key or a corrupt file. Callers that must distinguish the two
      * (to avoid deleting recoverable data) use [openOrClassify].
      */
-    fun open(teamId: String, teamKey: DataKey): Vault? =
-        (openOrClassify(teamId, teamKey) as? OpenResult.Opened)?.vault
+    fun open(ref: TeamScopeRef, key: DataKey): Vault? =
+        (openOrClassify(ref, key) as? OpenResult.Opened)?.vault
 
     /** Like [open] but classifies a failure as [OpenResult.StaleKey] vs [OpenResult.Unreadable]. */
-    fun openOrClassify(teamId: String, teamKey: DataKey): OpenResult {
-        require(isSafeTeamId(teamId)) { "unsafe teamId" }
-        open[teamId]?.let { cached ->
+    fun openOrClassify(ref: TeamScopeRef, key: DataKey): OpenResult {
+        requireSafe(ref)
+        open[ref.key]?.let { cached ->
             if (cached.isUnlocked) return OpenResult.Opened(cached)
         }
         // FileVault takes ownership of the passed key (and wipes it on lock), so hand it a copy
         // to keep the caller's instance valid across repeated open/lock cycles.
-        val ownedKey = DataKey(teamKey.bytes.copyOf())
+        val ownedKey = DataKey(key.bytes.copyOf())
         val vault = FileVault(
-            path = dir / "$teamId.vault",
+            path = dir / ref.fileName,
             crypto = crypto,
             deviceId = deviceId,
             fileSystem = fileSystem,
@@ -80,7 +82,7 @@ class TeamVaults(
                 return OpenResult.StaleKey
             }
         }
-        open[teamId] = vault
+        open[ref.key] = vault
         return OpenResult.Opened(vault)
     }
 
@@ -90,17 +92,34 @@ class TeamVaults(
         open.clear()
     }
 
-    /** Delete the team's file (leave/delete/access revoked): the local copy is no longer needed. */
-    fun reset(teamId: String) {
-        require(isSafeTeamId(teamId)) { "unsafe teamId" }
-        open.remove(teamId)?.lock()
-        fileSystem.delete(dir / "$teamId.vault", mustExist = false)
+    /** Delete one space's file (left/deleted/access revoked): the local copy is no longer needed. */
+    fun reset(ref: TeamScopeRef) {
+        requireSafe(ref)
+        open.remove(ref.key)?.lock()
+        fileSystem.delete(dir / ref.fileName, mustExist = false)
+    }
+
+    /**
+     * Delete the team's file **and every scope file under it**. Used when the team itself is gone
+     * (leave/delete/removal): dropping only the team vault would leave a scope's records — which the
+     * account no longer has any right to — sitting on disk.
+     */
+    fun resetTeam(teamId: String) {
+        require(TeamScopeRef.isSafeId(teamId)) { "unsafe teamId" }
+        reset(TeamScopeRef(teamId))
+        val prefix = "${teamId}__"
+        val files = runCatching { fileSystem.list(dir) }.getOrDefault(emptyList())
+        files.map { it.name }
+            .filter { it.startsWith(prefix) && it.endsWith(SUFFIX) }
+            .forEach { reset(TeamScopeRef(teamId, it.removePrefix(prefix).removeSuffix(SUFFIX))) }
+    }
+
+    private fun requireSafe(ref: TeamScopeRef) {
+        require(TeamScopeRef.isSafeId(ref.teamId)) { "unsafe teamId" }
+        require(ref.isTeamWide || TeamScopeRef.isSafeId(ref.scopeId)) { "unsafe scopeId" }
     }
 
     private companion object {
-        /** teamId is a client-generated UUID: [a-z0-9-] only, or the filename becomes a path injection. */
-        fun isSafeTeamId(teamId: String): Boolean =
-            teamId.isNotEmpty() && teamId.length <= 64 &&
-                teamId.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }
+        const val SUFFIX = ".vault"
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamInviteCodecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamInviteCodecTest.kt
@@ -105,6 +105,56 @@ class TeamInviteCodecTest {
     }
 
     @Test
+    fun `scope grant round-trips its scope id and verifies only under that scope`() = cryptoTest {
+        val alice = crypto.newSigningKeyPair()
+        val bob = crypto.newSharingKeyPair()
+        val scopeKey = crypto.newDataKey()
+
+        val envelope = codec.seal(
+            bob.publicKey, alice, "alice@x", "bob@y", "team-1", scopeKey, "Production", epoch = 1, scopeId = "prod",
+        )
+        val opened = assertNotNull(codec.open(bob, envelope))
+
+        assertEquals("prod", opened.scopeId)
+        assertEquals("Production", opened.teamName)
+        assertTrue(codec.verify(opened, alice.publicKey, scopeId = "prod"))
+        // Bound to its scope: the same signature doesn't authenticate the key for a different scope,
+        // so a server that files this grant under another scope's slot is caught.
+        assertFalse(codec.verify(opened, alice.publicKey, scopeId = "staging"))
+    }
+
+    @Test
+    fun `a scope key cannot be re-sealed as a team-wide key`() = cryptoTest {
+        // Domain separation. Without it, a member who legitimately holds a scope key could re-seal
+        // alice's signature over that key as a team-wide rekey envelope (crypto_box_seal is anonymous
+        // — anyone can seal to bob). Bob would adopt the attacker's key as teamKey and every team
+        // record he writes afterwards would be readable by the attacker.
+        val alice = crypto.newSigningKeyPair()
+        val bob = crypto.newSharingKeyPair()
+        val scopeKey = crypto.newDataKey()
+
+        val scopeGrant = codec.seal(
+            bob.publicKey, alice, "alice@x", "bob@y", "team-1", scopeKey, "Production", epoch = 1, scopeId = "prod",
+        )
+        val opened = assertNotNull(codec.open(bob, scopeGrant))
+
+        assertFalse(codec.verify(opened, alice.publicKey))
+    }
+
+    @Test
+    fun `a team-wide envelope cannot be presented as a scope grant`() = cryptoTest {
+        val alice = crypto.newSigningKeyPair()
+        val bob = crypto.newSharingKeyPair()
+
+        val teamEnvelope = codec.seal(bob.publicKey, alice, "alice@x", "bob@y", "team-1", crypto.newDataKey(), "Crew", epoch = 0)
+        val opened = assertNotNull(codec.open(bob, teamEnvelope))
+
+        assertEquals("", opened.scopeId)
+        assertTrue(codec.verify(opened, alice.publicKey))
+        assertFalse(codec.verify(opened, alice.publicKey, scopeId = "prod"))
+    }
+
+    @Test
     fun `fingerprint covers both halves, is stable per identity, and is 128-bit`() = cryptoTest {
         val box = crypto.newSharingKeyPair()
         val sign = crypto.newSigningKeyPair()

--- a/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamScopeStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamScopeStoreTest.kt
@@ -1,0 +1,131 @@
+package app.skerry.shared.team
+
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.FakeVault
+import app.skerry.shared.vault.RecordType
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Scope keys live inside the team's own TEAM record, not in a record type of their own: an older
+ * client drops records of an unknown type while advancing the sync cursor (see SyncEngine), which
+ * would lose a scope key permanently. Nested in TEAM they share that record's fate — and its
+ * existing recovery path.
+ */
+class TeamScopeStoreTest {
+
+    private val vault = FakeVault()
+    private val store = TeamKeyStore(vault)
+
+    private fun key(byte: Byte) = DataKey(ByteArray(32) { byte })
+
+    private fun seedTeam() = store.put("team-1", "Crew", TeamRole.OWNER, key(1), epoch = 0)
+
+    @Test
+    fun `scope key round-trips under its team`() {
+        seedTeam()
+
+        store.putScope("team-1", "prod", "Production", key(7), epoch = 2)
+
+        val scope = store.scope("team-1", "prod")
+        assertEquals("Production", scope?.name)
+        assertEquals(2, scope?.epoch)
+        assertContentEquals(ByteArray(32) { 7 }, scope?.dataKey()?.bytes)
+        // The team key itself is untouched by scope writes.
+        assertContentEquals(ByteArray(32) { 1 }, store.get("team-1")?.dataKey()?.bytes)
+    }
+
+    @Test
+    fun `scopes are listed per team and removed individually`() {
+        seedTeam()
+        store.put("team-2", "Other", TeamRole.EDITOR, key(2))
+        store.putScope("team-1", "prod", "Production", key(7))
+        store.putScope("team-1", "staging", "Staging", key(8))
+        store.putScope("team-2", "prod", "Production", key(9))
+
+        assertEquals(setOf("prod", "staging"), store.scopes("team-1").keys)
+        assertEquals(setOf("prod"), store.scopes("team-2").keys)
+
+        store.removeScope("team-1", "prod")
+
+        assertEquals(setOf("staging"), store.scopes("team-1").keys)
+        assertNull(store.scope("team-1", "prod"))
+        // Same scope id in another team is a different scope.
+        assertEquals(1, store.scopes("team-2").size)
+    }
+
+    @Test
+    fun `rekeyScope replaces key and epoch but keeps the name`() {
+        seedTeam()
+        store.putScope("team-1", "prod", "Production", key(7), epoch = 1)
+
+        store.rekeyScope("team-1", "prod", key(9), epoch = 2)
+
+        val scope = store.scope("team-1", "prod")
+        assertEquals("Production", scope?.name)
+        assertEquals(2, scope?.epoch)
+        assertContentEquals(ByteArray(32) { 9 }, scope?.dataKey()?.bytes)
+    }
+
+    @Test
+    fun `scope writes are read-modify-write on the TEAM record and stay in one transaction`() {
+        seedTeam()
+
+        store.putScope("team-1", "prod", "Production", key(7))
+
+        // Guideline §3: a read-modify-write on the vault must hold the transaction, otherwise a
+        // background merge landing between read and write drops the concurrent scope.
+        assertTrue(vault.lastPutInTransaction)
+        assertEquals(1, vault.records().count { it.type == RecordType.TEAM && it.id == "team-1" })
+    }
+
+    @Test
+    fun `scope operations on an unknown team are no-ops`() {
+        store.putScope("team-gone", "prod", "Production", key(7))
+        store.rekeyScope("team-gone", "prod", key(8), epoch = 1)
+        store.removeScope("team-gone", "prod")
+
+        assertNull(store.scope("team-gone", "prod"))
+        assertTrue(store.scopes("team-gone").isEmpty())
+    }
+
+    @Test
+    fun `forgetting a team forgets its scope keys with it`() {
+        seedTeam()
+        store.putScope("team-1", "prod", "Production", key(7))
+
+        store.remove("team-1")
+
+        assertTrue(store.scopes("team-1").isEmpty())
+    }
+
+    @Test
+    fun `a team record written before scopes existed still decodes`() {
+        // Old payload shape: no `scopes` key at all.
+        vault.put(
+            "team-old",
+            RecordType.TEAM,
+            """{"name":"Legacy","role":"owner","teamKey":"AAAA","epoch":1}""".encodeToByteArray(),
+        )
+
+        assertEquals("Legacy", store.get("team-old")?.name)
+        assertTrue(store.scopes("team-old").isEmpty())
+    }
+
+    @Test
+    fun `scope ref identifies a share space and separates team-wide from scoped`() {
+        val teamWide = TeamScopeRef("team-1")
+        val prod = TeamScopeRef("team-1", "prod")
+
+        assertTrue(teamWide.isTeamWide)
+        assertTrue(!prod.isTeamWide)
+        assertEquals("team-1", teamWide.key)
+        assertEquals("team-1/prod", prod.key)
+        // Distinct storage per space: a scope vault must never collide with the team vault.
+        assertEquals("team-1.vault", teamWide.fileName)
+        assertEquals("team-1__prod.vault", prod.fileName)
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
@@ -16,6 +16,7 @@ import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -29,25 +30,29 @@ class TeamSyncRoundTripTest {
 
     /** Mini team-scope LWW server with the same semantics as TeamRecordRepository. */
     private class FakeTeamServer : TeamClient {
-        private val records = linkedMapOf<String, Pair<RemoteRecord, Long>>() // id -> (record, seq)
+        /** id -> (record, seq, scopeId): one counter per team, records filed under one space each. */
+        private val records = linkedMapOf<String, Triple<RemoteRecord, Long, String>>()
         private var seq = 0L
 
-        override suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage {
-            val page = records.values.filter { it.second > since }.sortedBy { it.second }
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage {
+            val page = records.values.filter { it.second > since && it.third == ref.scopeId }.sortedBy { it.second }
             return RecordPage(page.map { it.first }, page.lastOrNull()?.second ?: since)
         }
 
-        override suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage {
-            val result = records.map { rec ->
-                val existing = this.records[rec.id]?.first
-                val wins = existing == null || rec.version > existing.version ||
-                    (rec.version == existing.version && rec.deviceId > existing.deviceId)
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage {
+            val result = records.mapNotNull { rec ->
+                val existing = this.records[rec.id]
+                // A record stays in the space it was first pushed into (see TeamRecordRepository).
+                if (existing != null && existing.third != ref.scopeId) return@mapNotNull null
+                val current = existing?.first
+                val wins = current == null || rec.version > current.version ||
+                    (rec.version == current.version && rec.deviceId > current.deviceId)
                 if (wins) {
                     seq += 1
-                    this.records[rec.id] = rec to seq
+                    this.records[rec.id] = Triple(rec, seq, ref.scopeId)
                     rec
                 } else {
-                    existing
+                    current
                 }
             }
             return RecordPage(result, seq)
@@ -65,6 +70,13 @@ class TeamSyncRoundTripTest {
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
         override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
         override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = error("unused")
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> = error("unused")
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
     }
 
     private val crypto = IonspinVaultCrypto()
@@ -78,8 +90,12 @@ class TeamSyncRoundTripTest {
         now = { "2026-07-04T00:00:00Z" },
     )
 
-    private fun engineFor(vault: app.skerry.shared.vault.Vault, server: TeamClient) = SyncEngine(
-        TeamScopedSyncClient(server, teamId),
+    private fun engineFor(
+        vault: app.skerry.shared.vault.Vault,
+        server: TeamClient,
+        ref: TeamScopeRef = TeamScopeRef(teamId),
+    ) = SyncEngine(
+        TeamScopedSyncClient(server, ref),
         vault,
         InMemorySyncStateStore(),
         settings = { SyncSettings() },
@@ -93,13 +109,13 @@ class TeamSyncRoundTripTest {
         val session = SyncSession("acct", "access", "refresh")
 
         // A: puts a host into the team vault and syncs
-        val aliceVault = vaultsFor("alice").open(teamId, teamKey)!!
+        val aliceVault = vaultsFor("alice").open(TeamScopeRef(teamId), teamKey)!!
         aliceVault.put("h1", RecordType.HOST, """{"name":"prod"}""".encodeToByteArray())
         val aliceEngine = engineFor(aliceVault, server)
         aliceEngine.sync(session)
 
         // B: got teamKey from the invitation, opens its team vault and syncs
-        val bobVault = vaultsFor("bob").open(teamId, teamKey)!!
+        val bobVault = vaultsFor("bob").open(TeamScopeRef(teamId), teamKey)!!
         val bobEngine = engineFor(bobVault, server)
         bobEngine.sync(session)
 
@@ -119,13 +135,13 @@ class TeamSyncRoundTripTest {
         initializeVaultCrypto()
         val vaults = vaultsFor("carol")
         val rightKey = crypto.newDataKey()
-        val vault = vaults.open(teamId, rightKey)!!
+        val vault = vaults.open(TeamScopeRef(teamId), rightKey)!!
         vault.put("h1", RecordType.HOST, "x".encodeToByteArray())
         vault.lock()
         vaults.lockAll()
 
-        assertNull(vaults.open(teamId, crypto.newDataKey()))
-        assertEquals(true, vaults.open(teamId, rightKey)?.isUnlocked)
+        assertNull(vaults.open(TeamScopeRef(teamId), crypto.newDataKey()))
+        assertEquals(true, vaults.open(TeamScopeRef(teamId), rightKey)?.isUnlocked)
     }
 
     @Test
@@ -141,22 +157,137 @@ class TeamSyncRoundTripTest {
         )
         val key = crypto.newDataKey()
         // A non-empty vault under the right key opens.
-        val opened = vaults.openOrClassify(teamId, key)
+        val opened = vaults.openOrClassify(TeamScopeRef(teamId), key)
         assertTrue(opened is TeamVaults.OpenResult.Opened)
         opened.vault.put("h1", RecordType.HOST, "x".encodeToByteArray())
         opened.vault.lock()
         vaults.lockAll()
 
         // A wrong key on a non-empty file is a superseded key (safe to reset), not corruption.
-        assertEquals(TeamVaults.OpenResult.StaleKey, vaults.openOrClassify(teamId, crypto.newDataKey()))
+        assertEquals(TeamVaults.OpenResult.StaleKey, vaults.openOrClassify(TeamScopeRef(teamId), crypto.newDataKey()))
         vaults.lockAll()
 
         // A structurally unreadable file must be reported as Unreadable — and left on disk (deleting
         // it would silently drop any local records that were never pushed).
         val file = dir / "$teamId.vault"
         FileSystem.SYSTEM.write(file) { writeUtf8("not a vault at all") }
-        assertEquals(TeamVaults.OpenResult.Unreadable, vaults.openOrClassify(teamId, key))
+        assertEquals(TeamVaults.OpenResult.Unreadable, vaults.openOrClassify(TeamScopeRef(teamId), key))
         assertTrue(FileSystem.SYSTEM.exists(file))
+    }
+
+    @Test
+    fun `a scope record reaches another holder of the scope key and no one else`() = runBlocking {
+        initializeVaultCrypto()
+        val server = FakeTeamServer()
+        val teamKey = crypto.newDataKey()
+        val scopeKey = crypto.newDataKey()
+        val prod = TeamScopeRef(teamId, "prod")
+        val teamWide = TeamScopeRef(teamId)
+        val session = SyncSession("acct", "access", "refresh")
+        val public = """{"name":"wiki"}""".encodeToByteArray()
+        val secret = """{"name":"db-prod"}""".encodeToByteArray()
+
+        // Alice holds both keys: one host shared with the whole team, one only into the scope.
+        val aliceVaults = vaultsFor("alice-scoped")
+        val aliceTeam = aliceVaults.open(teamWide, teamKey)!!
+        val aliceProd = aliceVaults.open(prod, scopeKey)!!
+        aliceTeam.put("wiki", RecordType.HOST, public)
+        aliceProd.put("db", RecordType.HOST, secret)
+        engineFor(aliceTeam, server).sync(session)
+        engineFor(aliceProd, server, prod).sync(session)
+
+        // Bob was granted the scope: he gets both, decrypted.
+        val bobVaults = vaultsFor("bob-scoped")
+        val bobTeam = bobVaults.open(teamWide, teamKey)!!
+        val bobProd = bobVaults.open(prod, scopeKey)!!
+        engineFor(bobTeam, server).sync(session)
+        val bobProdEngine = engineFor(bobProd, server, prod)
+        bobProdEngine.sync(session)
+        assertContentEquals(public, bobTeam.openPayload("wiki"))
+        assertContentEquals(secret, bobProd.openPayload("db"))
+
+        // Carol is in the team but not in the scope: the scoped record never enters her team space,
+        // and she has no key that would open it if it did.
+        val carolVaults = vaultsFor("carol-scoped")
+        val carolTeam = carolVaults.open(teamWide, teamKey)!!
+        engineFor(carolTeam, server).sync(session)
+        assertEquals(listOf("wiki"), carolTeam.records().map { it.id })
+        assertNull(carolTeam.openPayload("db"))
+        assertEquals(TeamVaults.OpenResult.StaleKey, bobVaults.also { it.lockAll() }.openOrClassify(prod, teamKey))
+
+        // And the round trip closes: Bob's removal inside the scope reaches Alice, not the team space.
+        val bobProd2 = bobVaults.open(prod, scopeKey)!!
+        bobProd2.remove("db")
+        engineFor(bobProd2, server, prod).sync(session)
+        engineFor(aliceProd, server, prod).sync(session)
+        assertNull(aliceProd.openPayload("db"))
+        assertTrue(aliceProd.records().first { it.id == "db" }.deleted)
+        assertContentEquals(public, aliceTeam.openPayload("wiki"))
+    }
+
+    @Test
+    fun `a scope vault is a separate file under its own key`() = runBlocking {
+        initializeVaultCrypto()
+        val vaults = vaultsFor("erin")
+        val teamKey = crypto.newDataKey()
+        val scopeKey = crypto.newDataKey()
+        val teamWide = TeamScopeRef(teamId)
+        val prod = TeamScopeRef(teamId, "prod")
+
+        vaults.open(teamWide, teamKey)!!.put("h1", RecordType.HOST, """{"name":"shared"}""".encodeToByteArray())
+        vaults.open(prod, scopeKey)!!.put("h2", RecordType.HOST, """{"name":"prod"}""".encodeToByteArray())
+
+        // Separate stores: a member without the scope key sees nothing of it in the team vault.
+        assertNull(vaults.open(teamWide, teamKey)!!.openPayload("h2"))
+        assertContentEquals("""{"name":"prod"}""".encodeToByteArray(), vaults.open(prod, scopeKey)!!.openPayload("h2"))
+
+        // And the team key does not open the scope's file.
+        vaults.lockAll()
+        assertEquals(TeamVaults.OpenResult.StaleKey, vaults.openOrClassify(prod, teamKey))
+    }
+
+    @Test
+    fun `resetting one scope leaves the team vault and other scopes intact`() = runBlocking {
+        initializeVaultCrypto()
+        val vaults = vaultsFor("frank")
+        val teamKey = crypto.newDataKey()
+        val prodKey = crypto.newDataKey()
+        val stagingKey = crypto.newDataKey()
+        vaults.open(TeamScopeRef(teamId), teamKey)!!.put("h1", RecordType.HOST, "a".encodeToByteArray())
+        vaults.open(TeamScopeRef(teamId, "prod"), prodKey)!!.put("h2", RecordType.HOST, "b".encodeToByteArray())
+        vaults.open(TeamScopeRef(teamId, "staging"), stagingKey)!!.put("h3", RecordType.HOST, "c".encodeToByteArray())
+
+        vaults.reset(TeamScopeRef(teamId, "prod"))
+
+        assertEquals(0, vaults.open(TeamScopeRef(teamId, "prod"), prodKey)!!.records().size)
+        assertEquals(1, vaults.open(TeamScopeRef(teamId), teamKey)!!.records().size)
+        assertEquals(1, vaults.open(TeamScopeRef(teamId, "staging"), stagingKey)!!.records().size)
+    }
+
+    @Test
+    fun `resetting the team drops its scope vaults too`() = runBlocking {
+        initializeVaultCrypto()
+        val vaults = vaultsFor("grace")
+        val teamKey = crypto.newDataKey()
+        val prodKey = crypto.newDataKey()
+        vaults.open(TeamScopeRef(teamId), teamKey)!!.put("h1", RecordType.HOST, "a".encodeToByteArray())
+        vaults.open(TeamScopeRef(teamId, "prod"), prodKey)!!.put("h2", RecordType.HOST, "b".encodeToByteArray())
+
+        // Leaving/being removed from a team must not leave a scope's records behind on disk.
+        vaults.resetTeam(teamId)
+
+        assertEquals(0, vaults.open(TeamScopeRef(teamId), teamKey)!!.records().size)
+        assertEquals(0, vaults.open(TeamScopeRef(teamId, "prod"), prodKey)!!.records().size)
+    }
+
+    @Test
+    fun `an unsafe scope id cannot escape the vault directory`() = runBlocking {
+        initializeVaultCrypto()
+        val vaults = vaultsFor("heidi")
+
+        assertFailsWith<IllegalArgumentException> {
+            vaults.open(TeamScopeRef(teamId, "../../etc/passwd"), crypto.newDataKey())
+        }
     }
 
     @Test
@@ -164,12 +295,12 @@ class TeamSyncRoundTripTest {
         initializeVaultCrypto()
         val vaults = vaultsFor("dave")
         val key = crypto.newDataKey()
-        vaults.open(teamId, key)!!.put("h1", RecordType.HOST, "x".encodeToByteArray())
+        vaults.open(TeamScopeRef(teamId), key)!!.put("h1", RecordType.HOST, "x".encodeToByteArray())
 
-        vaults.reset(teamId)
+        vaults.reset(TeamScopeRef(teamId))
 
         // file removed -> opening recreates an empty vault
-        val fresh = vaults.open(teamId, key)!!
+        val fresh = vaults.open(TeamScopeRef(teamId), key)!!
         assertEquals(0, fresh.records().size)
     }
 }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -29,6 +29,9 @@ import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
 import app.skerry.shared.team.TeamSummary
 import app.skerry.sync.wire.AccountKeyResponse
 import app.skerry.sync.wire.PublishKeyRequest
@@ -38,6 +41,10 @@ import app.skerry.sync.wire.TeamCreateRequest
 import app.skerry.sync.wire.TeamInviteRequest
 import app.skerry.sync.wire.TeamMembersResponse
 import app.skerry.sync.wire.TeamRekeyRequest
+import app.skerry.sync.wire.TeamScopeCreateRequest
+import app.skerry.sync.wire.TeamScopeGrantRequest
+import app.skerry.sync.wire.TeamScopeGrantsResponse
+import app.skerry.sync.wire.TeamScopesResponse
 import app.skerry.sync.wire.TeamRoleChangeRequest
 import app.skerry.sync.wire.TeamsResponse
 import io.ktor.client.HttpClient
@@ -58,6 +65,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLParameter
 import io.ktor.http.encodeURLPathPart
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
@@ -368,20 +376,89 @@ class KtorSyncClient(
         }.expectSuccess()
     }
 
-    override suspend fun pullTeam(session: SyncSession, teamId: String, since: Long): RecordPage {
-        val resp: RecordsResponse = get("/teams/${teamId.encodeURLPathPart()}/records?since=$since") {
+    override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage {
+        val resp: RecordsResponse = get(ref.recordsUrl("since=$since")) {
             bearerAuth(session.accessToken)
         }.bodyChecked()
         return RecordPage(resp.records.map { it.toRemote() }, resp.cursor, resp.compactedIds)
     }
 
-    override suspend fun pushTeam(session: SyncSession, teamId: String, records: List<RemoteRecord>): RecordPage {
-        val resp: PushResponse = put("/teams/${teamId.encodeURLPathPart()}/records") {
+    override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage {
+        val resp: PushResponse = put(ref.recordsUrl()) {
             bearerAuth(session.accessToken)
             contentType(ContentType.Application.Json)
             setBody(PushRequest(records.map { it.toWire() }))
         }.bodyChecked()
         return RecordPage(resp.records.map { it.toRemote() }, resp.cursor)
+    }
+
+    // --- scopes ---
+
+    override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> {
+        val resp: TeamScopesResponse = get("/teams/${teamId.encodeURLPathPart()}/scopes") {
+            bearerAuth(session.accessToken)
+        }.bodyChecked()
+        return resp.scopes.map { TeamScopeSummary(it.scopeId, it.keyEpoch, it.memberCount, it.envelope?.unb64()) }
+    }
+
+    override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
+        post("/teams/${teamId.encodeURLPathPart()}/scopes") {
+            bearerAuth(session.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeCreateRequest(scopeId, envelope.b64()))
+        }.expectSuccess()
+    }
+
+    override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) {
+        request {
+            http.delete("$serverUrl${scopePath(teamId, scopeId)}") { bearerAuth(session.accessToken) }
+        }.expectSuccess()
+    }
+
+    override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> {
+        val resp: TeamScopeGrantsResponse = get("${scopePath(teamId, scopeId)}/grants") {
+            bearerAuth(session.accessToken)
+        }.bodyChecked()
+        return resp.grants.map { TeamScopeGrantEntry(it.accountId, it.createdAt) }
+    }
+
+    override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) {
+        post("${scopePath(teamId, scopeId)}/grants") {
+            bearerAuth(session.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeGrantRequest(accountId, envelope.b64()))
+        }.expectSuccess()
+    }
+
+    override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) {
+        request {
+            http.delete("$serverUrl${scopePath(teamId, scopeId)}/grants/${accountId.encodeURLPathPart()}") {
+                bearerAuth(session.accessToken)
+            }
+        }.expectSuccess()
+    }
+
+    override suspend fun rekeyScope(
+        session: SyncSession,
+        teamId: String,
+        scopeId: String,
+        newEpoch: Long,
+        envelopes: Map<String, ByteArray>,
+    ) {
+        post("${scopePath(teamId, scopeId)}/rekey") {
+            bearerAuth(session.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamRekeyRequest(newEpoch, envelopes.map { (id, env) -> RekeyEnvelopeDto(id, env.b64()) }))
+        }.expectSuccess()
+    }
+
+    private fun scopePath(teamId: String, scopeId: String) =
+        "/teams/${teamId.encodeURLPathPart()}/scopes/${scopeId.encodeURLPathPart()}"
+
+    /** Records URL of one share space; the team-wide space simply omits `scope=`. */
+    private fun TeamScopeRef.recordsUrl(vararg params: String): String {
+        val query = (params.toList() + if (isTeamWide) emptyList() else listOf("scope=${scopeId.encodeURLParameter()}"))
+        return "/teams/${teamId.encodeURLPathPart()}/records" + if (query.isEmpty()) "" else "?" + query.joinToString("&")
     }
 
     override suspend fun ping(): Boolean = try {

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
@@ -104,5 +104,42 @@ data class TeamActivityDto(
 @Serializable
 data class TeamActivityResponse(val entries: List<TeamActivityDto>)
 
+// --- scopes (granular sharing inside a team) ---
+
+/**
+ * A scope of a team (`GET /teams/{id}/scopes`). Granular sharing: records filed under a scope are
+ * encrypted with that scope's own key and served only to accounts holding a grant, so a member
+ * without the grant can neither fetch nor decrypt them.
+ *
+ * Zero-knowledge as everywhere else: the scope's **name** is not here — it travels inside
+ * [envelope] alongside the key. [envelope] is the sealed current-epoch scopeKey for the calling
+ * account (null without a grant) and, unlike an invite envelope, is kept after adoption: it is how a
+ * client recovers a scope key its local vault record lost.
+ */
+@Serializable
+data class TeamScopeDto(
+    val scopeId: String,
+    val keyEpoch: Long = 0,
+    val memberCount: Int = 0,
+    val envelope: String? = null,
+)
+
+@Serializable
+data class TeamScopesResponse(val scopes: List<TeamScopeDto>)
+
+/** Scope creation: [envelope] is the new scopeKey sealed to the creator themselves. */
+@Serializable
+data class TeamScopeCreateRequest(val scopeId: String, val envelope: String)
+
+/** Grant of a scope to an account: [envelope] is the current-epoch scopeKey sealed to them. */
+@Serializable
+data class TeamScopeGrantRequest(val accountId: String, val envelope: String)
+
+@Serializable
+data class TeamScopeGrantDto(val accountId: String, val createdAt: Long)
+
+@Serializable
+data class TeamScopeGrantsResponse(val grants: List<TeamScopeGrantDto>)
+
 // Team records reuse RecordDto/RecordsResponse/PushRequest/PushResponse: format is identical,
-// only the scope changes (`/teams/{id}/records` instead of `/vault/records`).
+// only the scope changes (`/teams/{id}/records[?scope=]` instead of `/vault/records`).


### PR DESCRIPTION
Share part of a team's records instead of all of it: a scope is a share space inside a team with its own key, readable only by members holding a grant. "Juniors see staging, not prod" — with the separation held by the key, not by the server's goodwill.

## Where

Teams → a team → **Access scopes**, above the shared records. The row selects which space the records below belong to: **Whole team** first, then one chip per scope. Managers get **New scope**, plus **Access** and **Delete scope** for the selected one. Shared hosts appear in the host list as `Team · Scope`. Same on desktop and Android.

## Behavior

- Records shared with the team itself keep working exactly as before — scopes are an optional layer on top, and no migration is needed.
- A record lives in exactly one space. The share picker hides what is already shared elsewhere in the team; moving a record is an unshare followed by a share.
- Handing a scope out requires both the manage-members role and a grant of one's own: sealing the key needs the key. Deleting a scope needs the role alone, so a scope nobody holds any more can still be cleared away.
- Revoking a grant rotates that scope's key. Removing a member from the team rotates the team key and every scope they held — they keep their copies otherwise.
- A member without a grant is not told the scope exists. A manager sees it listed but reads nothing from it without the key.
- Against a sync server older than this change, scopes are simply absent and the UI says the server needs updating; everything else in Teams is unaffected.

## What else is in this PR

- `TeamScopeRef(teamId, scopeId)` as the identity of a share space: the key store, vault file, sync cursor, envelope verification and key rotation are parameterized by it instead of a scope growing a parallel copy of the team's machinery.
- Scope keys nested in the team's own TEAM record — a record type of its own would be dropped by a client that doesn't know it while the sync cursor moves past it.
- A scope key is signed under its own domain tag with the scope id in the binding, so a scope envelope cannot be replayed as a team-wide key and vice versa.
- Server: `team_scopes`, `team_scope_grants`, a `scope_id` column on `team_records` (defaults to team-wide, so existing deployments migrate in place), routes under `/teams/{id}/scopes`, and a scope filter on the record endpoints.
- The record delta reads the team counter before the rows and bounds the query by it, so a push committing in between is never reported as covered by a cursor that did not deliver it.
- Tests: scope ACL and grant/rekey authorization at the route level, scope repository and record isolation, envelope domain separation, key rotation cascade on member removal, and an end-to-end round trip of two members through a scope with a third member excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)