### PR TITLE
Team activity feed for Teams: who changed which host, and who opened a session

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -163,6 +163,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalFontSizeChange = { writeTerminalFontSize(dir, it) },
                     initialAllowServerClipboardWrite = readClipboardWrite(dir),
                     onAllowServerClipboardWriteChange = { writeClipboardWrite(dir, it) },
+                    initialReportTeamSessions = readReportTeamSessions(dir),
+                    onReportTeamSessionsChange = { writeReportTeamSessions(dir, it) },
                     initialOpenFilePathsInSftp = readOpenFilePaths(dir),
                     onOpenFilePathsInSftpChange = { writeOpenFilePaths(dir, it) },
                     initialConfirmProductionWarnings = readProdWarnings(dir),
@@ -268,6 +270,17 @@ class MainActivity : FragmentActivity() {
     private fun writeClipboardWrite(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_clipboard_write").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Reporting sessions on team-shared hosts: `teams_report_sessions`, default on. */
+    private fun readReportTeamSessions(dir: File): Boolean = runCatching {
+        File(dir, "teams_report_sessions").readText().trim().toBoolean()
+    }.getOrDefault(true)
+
+    private fun writeReportTeamSessions(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "teams_report_sessions").writeText(enabled.toString()) }
         }
     }
 
@@ -578,6 +591,7 @@ class MainActivity : FragmentActivity() {
                 writeTerminalTheme(dir, TerminalThemes.DEFAULT)
                 writeThemeMode(dir, ThemeMode.DEFAULT)
                 writeClipboardWrite(dir, false)
+                writeReportTeamSessions(dir, true)
                 writeProdWarnings(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -113,6 +113,47 @@
     <string name="lib_teams_event_role_change">Сменил роль</string>
     <string name="lib_teams_event_share">Поделился записями</string>
     <string name="lib_teams_event_delete">Удалил команду</string>
+    <!-- Фид активности: подписи событий. Субъект записи (имя хоста/сниппета) показывается рядом. -->
+    <string name="lib_teams_event_rekey">Сменил ключ команды</string>
+    <string name="lib_teams_event_scope_create">Создал область</string>
+    <string name="lib_teams_event_scope_delete">Удалил область</string>
+    <string name="lib_teams_event_scope_grant">Выдал доступ к области</string>
+    <string name="lib_teams_event_scope_revoke">Отозвал доступ к области</string>
+    <string name="lib_teams_event_scope_rekey">Сменил ключ области</string>
+    <string name="lib_teams_event_record_share">Поделился</string>
+    <string name="lib_teams_event_record_change">Изменил</string>
+    <string name="lib_teams_event_record_remove">Убрал</string>
+    <string name="lib_teams_event_session_open">Открыл сессию</string>
+    <string name="lib_teams_event_session_record">Записал сессию</string>
+    <string name="lib_teams_record_host">хост</string>
+    <string name="lib_teams_record_snippet">сниппет</string>
+    <string name="lib_teams_record_credential">пароль</string>
+    <string name="lib_teams_record_identity">ключ</string>
+    <string name="lib_teams_record_tunnel">туннель</string>
+    <string name="lib_teams_record_group">группу</string>
+    <string name="lib_teams_record_other">запись</string>
+    <!-- Автор события, если это текущий аккаунт -->
+    <string name="lib_teams_actor_you">вы</string>
+    <!-- Область, в которой произошло событие; %1$s — её имя -->
+    <string name="lib_teams_feed_in_scope">область %1$s</string>
+    <string name="lib_teams_feed_day_today">Сегодня</string>
+    <string name="lib_teams_feed_day_yesterday">Вчера</string>
+    <string name="lib_teams_filter_all">Все</string>
+    <string name="lib_teams_filter_records">Записи</string>
+    <string name="lib_teams_filter_members">Участники</string>
+    <string name="lib_teams_filter_access">Доступ</string>
+    <string name="lib_teams_filter_sessions">Сессии</string>
+    <!-- Длительность записанной сессии; %1$s — например «12» -->
+    <string name="lib_teams_feed_duration">%1$s мин</string>
+    <string name="lib_teams_feed_duration_short">меньше минуты</string>
+    <!-- Честная сноска под фидом: сессии сообщают приложения участников, сервер их не проверяет -->
+    <string name="lib_teams_feed_reported_note">О сессиях сообщают приложения участников — сервер не участвует в подключении и не может его подтвердить.</string>
+    <!-- История одной записи; %1$s — имя записи -->
+    <string name="lib_teams_feed_record_title">История · %1$s</string>
+    <string name="lib_teams_feed_record_empty">С этой записью пока ничего не происходило.</string>
+    <string name="lib_teams_feed_record_history">История этой записи</string>
+    <!-- Свёрнутый массовый пуш; %1$d — сколько записей изменилось разом -->
+    <string name="lib_teams_event_records_bulk">Обновил записей: %1$d</string>
     <!-- Фолбэк для неизвестного клиенту кода события аудита; %1$s — исходный код с сервера -->
     <string name="lib_teams_event_unknown">Другое событие (%1$s)</string>
     <string name="lib_teams_shared_hosts_count">Общие хосты · %1$d</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -138,6 +138,8 @@
     <string name="settings_autolock_never">Никогда</string>
     <string name="settings_security_2fa">Двухфакторная аутентификация</string>
     <string name="settings_security_2fa_desc">TOTP через приложение-аутентификатор.</string>
+    <string name="settings_security_report_team_sessions">Сообщать о сессиях на общих хостах</string>
+    <string name="settings_security_report_team_sessions_desc">Сообщать команде, когда вы открываете сессию на расшаренном с ней хосте. Свои хосты не сообщаются никогда.</string>
     <string name="settings_recent_security_events">НЕДАВНИЕ СОБЫТИЯ БЕЗОПАСНОСТИ</string>
     <string name="settings_security_no_events">Пока событий безопасности нет.</string>
     <string name="settings_event_vault_created">Хранилище создано</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -113,6 +113,47 @@
     <string name="lib_teams_event_role_change">更改了角色</string>
     <string name="lib_teams_event_share">共享了记录</string>
     <string name="lib_teams_event_delete">删除了团队</string>
+    <!-- 活动动态：事件标签。记录事件的主体（主机/片段名称）显示在标签旁边。 -->
+    <string name="lib_teams_event_rekey">轮换了团队密钥</string>
+    <string name="lib_teams_event_scope_create">创建了区域</string>
+    <string name="lib_teams_event_scope_delete">删除了区域</string>
+    <string name="lib_teams_event_scope_grant">授予了区域访问权限</string>
+    <string name="lib_teams_event_scope_revoke">撤销了区域访问权限</string>
+    <string name="lib_teams_event_scope_rekey">轮换了区域密钥</string>
+    <string name="lib_teams_event_record_share">共享了</string>
+    <string name="lib_teams_event_record_change">修改了</string>
+    <string name="lib_teams_event_record_remove">移除了</string>
+    <string name="lib_teams_event_session_open">开启了会话</string>
+    <string name="lib_teams_event_session_record">录制了会话</string>
+    <string name="lib_teams_record_host">主机</string>
+    <string name="lib_teams_record_snippet">片段</string>
+    <string name="lib_teams_record_credential">密码</string>
+    <string name="lib_teams_record_identity">密钥</string>
+    <string name="lib_teams_record_tunnel">隧道</string>
+    <string name="lib_teams_record_group">分组</string>
+    <string name="lib_teams_record_other">记录</string>
+    <!-- 事件作者为当前账户时 -->
+    <string name="lib_teams_actor_you">您</string>
+    <!-- 事件发生的区域；%1$s — 区域名称 -->
+    <string name="lib_teams_feed_in_scope">区域 %1$s</string>
+    <string name="lib_teams_feed_day_today">今天</string>
+    <string name="lib_teams_feed_day_yesterday">昨天</string>
+    <string name="lib_teams_filter_all">全部</string>
+    <string name="lib_teams_filter_records">记录</string>
+    <string name="lib_teams_filter_members">成员</string>
+    <string name="lib_teams_filter_access">访问</string>
+    <string name="lib_teams_filter_sessions">会话</string>
+    <!-- 已报告录制会话的时长；%1$s — 例如 “12” -->
+    <string name="lib_teams_feed_duration">%1$s 分钟</string>
+    <string name="lib_teams_feed_duration_short">不到一分钟</string>
+    <!-- 动态下方的说明：会话由成员的应用报告，服务器无法验证 -->
+    <string name="lib_teams_feed_reported_note">会话由成员的应用报告 — 服务器不参与连接，也无法确认连接。</string>
+    <!-- 单条记录的历史；%1$s — 记录名称 -->
+    <string name="lib_teams_feed_record_title">历史 · %1$s</string>
+    <string name="lib_teams_feed_record_empty">此记录尚无任何变更。</string>
+    <string name="lib_teams_feed_record_history">此记录的历史</string>
+    <!-- 折叠的批量推送；%1$d — 一次变更了多少条记录 -->
+    <string name="lib_teams_event_records_bulk">更新了 %1$d 条记录</string>
     <!-- 客户端未知的审计事件代码的回退文案；%1$s — 服务器返回的原始代码 -->
     <string name="lib_teams_event_unknown">其他事件（%1$s）</string>
     <string name="lib_teams_shared_hosts_count">共享的主机 · %1$d</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -138,6 +138,8 @@
     <string name="settings_autolock_never">从不</string>
     <string name="settings_security_2fa">双因素认证</string>
     <string name="settings_security_2fa_desc">通过身份验证器应用使用 TOTP。</string>
+    <string name="settings_security_report_team_sessions">报告共享主机上的会话</string>
+    <string name="settings_security_report_team_sessions_desc">当您在与团队共享的主机上开启会话时通知团队。您自己的主机永远不会被报告。</string>
     <string name="settings_recent_security_events">最近安全事件</string>
     <string name="settings_security_no_events">暂无安全事件。</string>
     <string name="settings_event_vault_created">保险库已创建</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -113,6 +113,47 @@
     <string name="lib_teams_event_role_change">Changed a role</string>
     <string name="lib_teams_event_share">Shared records</string>
     <string name="lib_teams_event_delete">Deleted team</string>
+    <!-- Activity feed: event labels. A record event's subject (host/snippet name) is shown beside the label. -->
+    <string name="lib_teams_event_rekey">Rotated the team key</string>
+    <string name="lib_teams_event_scope_create">Created an area</string>
+    <string name="lib_teams_event_scope_delete">Deleted an area</string>
+    <string name="lib_teams_event_scope_grant">Granted access to an area</string>
+    <string name="lib_teams_event_scope_revoke">Revoked access to an area</string>
+    <string name="lib_teams_event_scope_rekey">Rotated an area key</string>
+    <string name="lib_teams_event_record_share">Shared</string>
+    <string name="lib_teams_event_record_change">Changed</string>
+    <string name="lib_teams_event_record_remove">Removed</string>
+    <string name="lib_teams_event_session_open">Opened a session</string>
+    <string name="lib_teams_event_session_record">Recorded a session</string>
+    <string name="lib_teams_record_host">host</string>
+    <string name="lib_teams_record_snippet">snippet</string>
+    <string name="lib_teams_record_credential">password</string>
+    <string name="lib_teams_record_identity">key</string>
+    <string name="lib_teams_record_tunnel">tunnel</string>
+    <string name="lib_teams_record_group">group</string>
+    <string name="lib_teams_record_other">record</string>
+    <!-- Actor of an event when it was this account -->
+    <string name="lib_teams_actor_you">you</string>
+    <!-- Area (scope) an event happened in; %1$s — its name -->
+    <string name="lib_teams_feed_in_scope">area %1$s</string>
+    <string name="lib_teams_feed_day_today">Today</string>
+    <string name="lib_teams_feed_day_yesterday">Yesterday</string>
+    <string name="lib_teams_filter_all">All</string>
+    <string name="lib_teams_filter_records">Records</string>
+    <string name="lib_teams_filter_members">Members</string>
+    <string name="lib_teams_filter_access">Access</string>
+    <string name="lib_teams_filter_sessions">Sessions</string>
+    <!-- Length of a reported session recording; %1$s — like "12 min" -->
+    <string name="lib_teams_feed_duration">%1$s min</string>
+    <string name="lib_teams_feed_duration_short">under a minute</string>
+    <!-- Honesty note under the feed: sessions are asserted by members' apps, the server cannot verify them -->
+    <string name="lib_teams_feed_reported_note">Sessions are reported by member apps — the server takes no part in a connection and cannot confirm one.</string>
+    <!-- Per-record history; %1$s — the record's name -->
+    <string name="lib_teams_feed_record_title">History · %1$s</string>
+    <string name="lib_teams_feed_record_empty">Nothing has happened to this record yet.</string>
+    <string name="lib_teams_feed_record_history">History of this record</string>
+    <!-- Bulk push summary row; %1$d — how many records changed at once -->
+    <string name="lib_teams_event_records_bulk">Updated %1$d records</string>
     <!-- Fallback for an audit event code this client doesn't know; %1$s — the raw server code -->
     <string name="lib_teams_event_unknown">Other event (%1$s)</string>
     <string name="lib_teams_shared_hosts_count">Shared hosts · %1$d</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -138,6 +138,8 @@
     <string name="settings_autolock_never">Never</string>
     <string name="settings_security_2fa">Two-factor authentication</string>
     <string name="settings_security_2fa_desc">TOTP via an authenticator app.</string>
+    <string name="settings_security_report_team_sessions">Report sessions on shared hosts</string>
+    <string name="settings_security_report_team_sessions_desc">Tell the team when you open a session on a host shared with it. Your own hosts are never reported.</string>
     <string name="settings_recent_security_events">RECENT SECURITY EVENTS</string>
     <string name="settings_security_no_events">No security events yet.</string>
     <string name="settings_event_vault_created">Vault created</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -181,6 +181,8 @@ class DesktopDesignState(
     // [app.skerry.ui.terminal.TerminalSessionPrefs] and pushed live into open ones.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    initialReportTeamSessions: Boolean = true,
+    private val onReportTeamSessionsChange: (Boolean) -> Unit = {},
     // Whether a file path in terminal output is clickable (Ctrl+click) and opens in the SFTP panel
     // (Settings → Terminal). On by default; off also removes the hover highlight.
     initialOpenFilePathsInSftp: Boolean = true,
@@ -350,6 +352,14 @@ class DesktopDesignState(
      * write). Off by default; snapshotted into new sessions and pushed live into open ones.
      */
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
+
+    /**
+     * Whether opening a session on a host **shared with a team** is reported to that team's activity
+     * feed (Security → Report sessions on shared hosts). On by default: a host somebody shared into a
+     * team is shared infrastructure, and the feed is only useful if it is not full of holes. Never
+     * covers hosts of one's own — those are reported nowhere regardless of this setting.
+     */
+    var reportTeamSessions: Boolean by mutableStateOf(initialReportTeamSessions); private set
 
     /**
      * Whether file paths printed in terminal output are clickable and open in the SFTP panel
@@ -764,6 +774,12 @@ class DesktopDesignState(
     fun toggleAllowServerClipboardWrite() {
         allowServerClipboardWrite = !allowServerClipboardWrite
         onAllowServerClipboardWriteChange(allowServerClipboardWrite)
+    }
+
+    /** Toggle reporting sessions on team-shared hosts and report outward (for persistence). */
+    fun toggleReportTeamSessions() {
+        reportTeamSessions = !reportTeamSessions
+        onReportTeamSessionsChange(reportTeamSessions)
     }
 
     fun toggleSanitize() { sanitize = !sanitize }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -116,6 +116,8 @@ class MobileDesignState(
     // and pushed live into open ones. Persisted on Android; no-op default for previews/tests.
     initialAllowServerClipboardWrite: Boolean = false,
     private val onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    initialReportTeamSessions: Boolean = true,
+    private val onReportTeamSessionsChange: (Boolean) -> Unit = {},
     // Whether a file path selected in terminal output offers "Open in Files" (More → Terminal).
     // Desktop parity (Ctrl+click there). On by default; persisted on Android.
     initialOpenFilePathsInSftp: Boolean = true,
@@ -336,6 +338,12 @@ class MobileDesignState(
     var allowServerClipboardWrite: Boolean by mutableStateOf(initialAllowServerClipboardWrite); private set
 
     /**
+     * Whether a session on a team-shared host is reported to that team's activity feed (More →
+     * Security). Desktop parity, see [app.skerry.ui.app.DesktopDesignState.reportTeamSessions].
+     */
+    var reportTeamSessions: Boolean by mutableStateOf(initialReportTeamSessions); private set
+
+    /**
      * Whether a file path selected in terminal output offers "Open in Files" (More → Terminal).
      * On by default; desktop parity, see [app.skerry.ui.app.DesktopDesignState.openFilePathsInSftp].
      */
@@ -409,6 +417,12 @@ class MobileDesignState(
     fun toggleAllowServerClipboardWrite() {
         allowServerClipboardWrite = !allowServerClipboardWrite
         onAllowServerClipboardWriteChange(allowServerClipboardWrite)
+    }
+
+    /** Toggle reporting sessions on team-shared hosts and report outward (for persistence). */
+    fun toggleReportTeamSessions() {
+        reportTeamSessions = !reportTeamSessions
+        onReportTeamSessionsChange(reportTeamSessions)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -286,6 +286,9 @@ fun DesktopDesignApp(
     // OSC 52 server clipboard-write gate (Settings → Terminal) — persisted externally (desktop main).
     initialAllowServerClipboardWrite: Boolean = false,
     onAllowServerClipboardWriteChange: (Boolean) -> Unit = {},
+    // Reporting sessions on team-shared hosts (Settings → Security) — persisted externally (desktop main).
+    initialReportTeamSessions: Boolean = true,
+    onReportTeamSessionsChange: (Boolean) -> Unit = {},
     // Clickable file paths in terminal output (Settings → Terminal) — persisted externally (desktop main).
     initialOpenFilePathsInSftp: Boolean = true,
     onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
@@ -323,6 +326,7 @@ fun DesktopDesignApp(
             initialShowTerminalTitleOnTabs, onShowTerminalTitleOnTabsChange,
             initialHostClickConnectMode, onHostClickConnectModeChange,
             initialAllowServerClipboardWrite, onAllowServerClipboardWriteChange,
+            initialReportTeamSessions, onReportTeamSessionsChange,
             initialOpenFilePathsInSftp, onOpenFilePathsInSftpChange,
             initialConfirmProductionWarnings, onConfirmProductionWarningsChange,
             initialTerminalTheme, onTerminalThemeChange,
@@ -422,12 +426,15 @@ fun DesktopDesignApp(
     // Per-host terminal command history persistence (autocomplete + the command palette) on top of
     // the encrypted vault. Hoisted out of the sessions factory: the palette reads it directly.
     val termHistory = remember(vault) { vault?.let { VaultTerminalHistoryStore(it) } }
-    val liveSessions = sessions ?: remember(transport, vncTransport, scope, vault) {
+    val liveSessions = sessions ?: remember(transport, vncTransport, scope, vault, teams) {
         transport?.let { t ->
             var counter = 0
             SessionsController(
                 newId = { "sess-${counter++}" },
                 vncControllerFactory = vncTransport?.let { vt -> { app.skerry.ui.vnc.VncSessionController(vt, scope) } },
+                // Session half of the Teams activity feed. Both privacy rules (the setting, and
+                // "never a host of our own") live in the coordinator, not here.
+                onHostSessionOpened = { hostId -> teams?.reportSessionOpened(hostId) },
                 controllerFactory = {
                     ConnectionController(
                         t, scope, history = termHistory,
@@ -473,6 +480,9 @@ fun DesktopDesignApp(
             s.splitSession?.liveTerminal?.applyScrollback(scrollbackLines)
         }
     }
+    // The Teams session-report gate reads the live setting: it lives in this screen's state, while
+    // the coordinator is built at startup, so it is handed a getter rather than a value.
+    LaunchedEffect(teams, state) { teams?.reportSessionsEnabled = { state.reportTeamSessions } }
     // Toggling the OSC 52 clipboard-write gate applies to ALREADY open sessions live: turning it off
     // stops honoring server clipboard writes immediately, turning it on lets them through. New
     // sessions pick up the value at connect via terminalPrefs.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -146,12 +146,15 @@ fun MobileDesignApp(
     // Per-host terminal command history over the encrypted vault: autocomplete writes it, the
     // command palette reads every host's. Hoisted out of the sessions factory so both can see it.
     val termHistory = remember(deps.vault) { deps.vault?.let { VaultTerminalHistoryStore(it) } }
-    val liveSessions = sessions ?: remember(deps.transport, scope, deps.vault) {
+    val liveSessions = sessions ?: remember(deps.transport, scope, deps.vault, deps.teams) {
         deps.transport?.let { t ->
             var counter = 0
             SessionsController(
                 newId = { "sess-${counter++}" },
                 vncControllerFactory = deps.vncTransport?.let { vt -> { app.skerry.ui.vnc.VncSessionController(vt, scope) } },
+                // Desktop parity: the session half of the Teams activity feed (the coordinator holds
+                // the privacy gates).
+                onHostSessionOpened = { hostId -> deps.teams?.reportSessionOpened(hostId) },
                 controllerFactory = {
                     ConnectionController(
                         t, scope, history = termHistory,
@@ -192,6 +195,8 @@ fun MobileDesignApp(
             s.splitSession?.liveTerminal?.applyScrollback(scrollbackLines)
         }
     }
+    // Desktop parity: the Teams session-report gate reads the live setting (see DesktopDesignApp).
+    LaunchedEffect(deps.teams, state) { deps.teams?.reportSessionsEnabled = { state.reportTeamSessions } }
     // Toggling the OSC 52 clipboard-write gate applies to ALREADY open sessions live; new sessions
     // pick the value up at connect via terminalPrefs above.
     val allowClipboardWrite = state.allowServerClipboardWrite

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -116,6 +116,8 @@ import app.skerry.ui.generated.resources.settings_recent_security_events
 import app.skerry.ui.generated.resources.settings_security_2fa
 import app.skerry.ui.generated.resources.settings_security_2fa_desc
 import app.skerry.ui.generated.resources.settings_security_auto_lock
+import app.skerry.ui.generated.resources.settings_security_report_team_sessions
+import app.skerry.ui.generated.resources.settings_security_report_team_sessions_desc
 import app.skerry.ui.generated.resources.settings_security_auto_lock_desc
 import app.skerry.ui.generated.resources.settings_security_account_password
 import app.skerry.ui.generated.resources.settings_security_account_password_desc
@@ -463,6 +465,18 @@ fun MobileSecurityScreen(state: MobileDesignState) {
                         Txt(stringResource(Res.string.settings_security_2fa_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
                     }
                     Txt(stringResource(Res.string.settings_manage), color = Skerry.colors.faint, size = 13.sp)
+                }
+
+                HLine()
+
+                // Desktop parity (Settings -> Security): what this device tells a team about our
+                // own sessions on hosts shared with it.
+                Row(Modifier.fillMaxWidth().padding(vertical = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Column(Modifier.weight(1f)) {
+                        Txt(stringResource(Res.string.settings_security_report_team_sessions), color = Skerry.colors.text, size = 14.5.sp)
+                        Txt(stringResource(Res.string.settings_security_report_team_sessions_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 3.dp))
+                    }
+                    Toggle(on = state.reportTeamSessions, onToggle = state::toggleReportTeamSessions)
                 }
 
                 // Recent security events from the real log (or "no events yet").

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -103,7 +103,8 @@ import app.skerry.ui.generated.resources.lib_teams_sync_now
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.generated.resources.shell_create
 import app.skerry.ui.generated.resources.shell_route_team
-import app.skerry.ui.teams.AuditLogDialog
+import app.skerry.ui.teams.HistoryTarget
+import app.skerry.ui.teams.TeamActivityDialog
 import app.skerry.ui.teams.InviteMemberDialog
 import app.skerry.ui.teams.RoleBadge
 import app.skerry.ui.teams.RolePickerDialog
@@ -120,7 +121,9 @@ import app.skerry.ui.teams.ScopeAccessDialog
 import app.skerry.ui.teams.ScopeSection
 import app.skerry.ui.teams.TeamsCoordinator
 import app.skerry.ui.teams.teamsFailureText
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
@@ -219,6 +222,8 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     var sharePicker by remember { mutableStateOf<RecordType?>(null) }
     var confirm by remember { mutableStateOf<MobileTeamsConfirm?>(null) }
     var showHistory by remember { mutableStateOf(false) }
+    // One record's history instead of the team's whole feed (desktop parity).
+    var historyRecord by remember { mutableStateOf<HistoryTarget?>(null) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
     // Selected share space of the current team ("" = team-wide), like the desktop screen.
     var selectedScope by remember { mutableStateOf("") }
@@ -265,6 +270,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                     scope.launch { tc.unshareRecord(ref, recordId); tick++ }
                 },
                 onShowHistory = { showHistory = true },
+                onShowRecordHistory = { historyRecord = it },
                 onChangeRole = { member -> rolePicker = member },
                 onSelectScope = { selectedScope = it },
                 onNewScope = { showCreateScope = true },
@@ -320,11 +326,27 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
         )
     }
     val historyTeam = selected
-    if (showHistory && historyTeam != null) {
+    val recordFocus = historyRecord
+    if ((showHistory || recordFocus != null) && historyTeam != null) {
         val entries by produceState(emptyList<TeamActivityEntry>(), historyTeam.id, tick) {
             value = tc.teamActivity(historyTeam.id)
         }
-        AuditLogDialog(entries, onDismiss = { showHistory = false })
+        // Record names come from our own copy of each share space — the server holds only ids.
+        // Fetched like the entries above rather than in a bare remember{}: resolving them decrypts
+        // every shared record of the team, which has no business blocking a frame.
+        val recordNames by produceState(emptyMap<String, Map<String, String>>(), historyTeam.id, tick) {
+            value = withContext(Dispatchers.Default) { tc.sharedRecordNames(historyTeam.id) }
+        }
+        val scopeNames = remember(historyTeam.scopes) { historyTeam.scopes.associate { it.id to it.name } }
+        TeamActivityDialog(
+            entries = entries,
+            selfAccountId = tc.selfAccountId(),
+            recordNames = recordNames,
+            scopeNames = scopeNames,
+            focusRecordId = recordFocus?.recordId,
+            focusRecordLabel = recordFocus?.label,
+            onDismiss = { showHistory = false; historyRecord = null },
+        )
     }
     val roleTeam = selected
     val roleTarget = rolePicker
@@ -423,6 +445,7 @@ private fun MobileTeamDetail(
     onSync: () -> Unit,
     onUnshare: (String) -> Unit,
     onShowHistory: () -> Unit,
+    onShowRecordHistory: (HistoryTarget) -> Unit,
     onChangeRole: (TeamMember) -> Unit,
     onSelectScope: (String) -> Unit,
     onNewScope: () -> Unit,
@@ -509,7 +532,12 @@ private fun MobileTeamDetail(
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
     sharedHosts.forEach { host ->
-        MobileSharedRow(host.label, host.rowSubtitle(), canUnshare = canWrite) { onUnshare(host.id) }
+        MobileSharedRow(
+            host.label, host.rowSubtitle(),
+            canUnshare = canWrite,
+            onHistory = if (canAudit) { { onShowRecordHistory(HistoryTarget(host.id, host.label)) } } else null,
+            onUnshare = { onUnshare(host.id) },
+        )
     }
     if (canWrite) {
         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
@@ -518,7 +546,12 @@ private fun MobileTeamDetail(
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
     if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
     sharedSnippets.forEach { snippet ->
-        MobileSharedRow(snippet.label, snippet.command, canUnshare = canWrite) { onUnshare(snippet.id) }
+        MobileSharedRow(
+            snippet.label, snippet.command,
+            canUnshare = canWrite,
+            onHistory = if (canAudit) { { onShowRecordHistory(HistoryTarget(snippet.id, snippet.label)) } } else null,
+            onUnshare = { onUnshare(snippet.id) },
+        )
     }
     if (canWrite) {
         GhostButton(stringResource(Res.string.lib_teams_share_snippet), onClick = { onShare(RecordType.SNIPPET) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
@@ -688,7 +721,13 @@ private fun MobileTeamHostRow(host: Host, mono: androidx.compose.ui.text.font.Fo
 }
 
 @Composable
-private fun MobileSharedRow(label: String, detail: String, canUnshare: Boolean, onUnshare: () -> Unit) {
+private fun MobileSharedRow(
+    label: String,
+    detail: String,
+    canUnshare: Boolean,
+    onHistory: (() -> Unit)? = null,
+    onUnshare: () -> Unit,
+) {
     val mono = LocalFonts.current.mono
     Row(
         Modifier.fillMaxWidth().padding(vertical = 7.dp),
@@ -697,6 +736,12 @@ private fun MobileSharedRow(label: String, detail: String, canUnshare: Boolean, 
     ) {
         Txt(label, color = Skerry.colors.textBright, size = 12.5.sp, font = mono)
         Txt(detail, color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.weight(1f))
+        // "What happened to this one" — only for readers who may see the audit log at all.
+        if (onHistory != null) {
+            Box(Modifier.clip(CircleShape).clickable(onClick = onHistory).padding(3.dp)) {
+                Sym("history", size = 14.sp, color = Skerry.colors.faint)
+            }
+        }
         if (canUnshare) {
             Box(Modifier.clip(CircleShape).clickable(onClick = onUnshare).padding(3.dp)) {
                 Sym("close", size = 14.sp, color = Skerry.colors.faint)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -103,6 +103,7 @@ import app.skerry.ui.app.LocalAi
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
+import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.MobileDesignState
@@ -147,6 +148,8 @@ private val TOP_EDGE_STRIP = 72.dp
 fun MobileTerminalScreen(state: MobileDesignState) {
     val sessions = LocalSessions.current
     val active = sessions?.active
+    // Teams: a saved recording of a shared host is reported to its team (see the record toggle below).
+    val teams = LocalTeams.current
     // Stable Disconnect lambda (recreated only on session change): drops the connection and returns to
     // the list — the back arrow leaves the session alive, Disconnect closes it.
     val onDisconnect = remember(active?.id, sessions) {
@@ -402,7 +405,11 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                                             recordingNotice = RecordingOutcome.Empty
                                         } else {
                                             val name = castFileName(active?.displayTitle.orEmpty().ifBlank { active?.subtitle.orEmpty() }, recordingStamp())
+                                            val seconds = activeTerminal.recordingSeconds
                                             val saved = exportTextFile(name, cast)
+                                            // Desktop parity: report a saved recording of a shared
+                                            // host to its team. A cancelled Save-As kept nothing.
+                                            if (saved) active.hostId?.let { teams?.reportSessionRecorded(it, seconds) }
                                             recordingNotice = when {
                                                 !saved -> null
                                                 truncated -> RecordingOutcome.SavedTruncated

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -178,6 +178,13 @@ class SessionsController(
     // points that don't wire a VNC transport keep compiling; the desktop/Android entry points pass a
     // real one (VncSessionController over VncTcpTransport).
     private val vncControllerFactory: (() -> VncSessionController)? = null,
+    /**
+     * Called with the catalog host id whenever a session to it actually starts — every path here
+     * that opens a connection, and no others (a blank tab, a player, or an ad-hoc target typed into
+     * the form belong to no host). Wired by the entry points to the Teams activity report; must not
+     * throw or block, since a connection is already under way.
+     */
+    private val onHostSessionOpened: (String) -> Unit = {},
 ) {
     var sessions: List<Session> by mutableStateOf(emptyList())
         private set
@@ -218,6 +225,7 @@ class SessionsController(
         val session = Session(newId(), hostId, title, subtitle, controller)
         sessions = sessions + session
         activeId = session.id
+        reportHostSession(hostId)
         controller.connect(target, auth, onConnected)
         return session.id
     }
@@ -253,6 +261,7 @@ class SessionsController(
         val blank = active?.takeIf { it.isBlank }
         if (blank != null) {
             blank.bind(hostId, title, subtitle)
+            reportHostSession(hostId)
             blank.controller.connect(target, auth, onConnected)
             return blank.id
         }
@@ -280,6 +289,7 @@ class SessionsController(
         session.setView(SessionView.Vnc)
         sessions = sessions + session
         activeId = session.id
+        reportHostSession(hostId)
         vnc.connect(target, auth, remoteResize, onRemoteResizeChanged)
         return session.id
     }
@@ -347,7 +357,16 @@ class SessionsController(
         parent.setSplitOpen(true)
         parent.setSplitSession(secondary)
         parent.setFocusedSplit(true)
+        reportHostSession(hostId)
         secondary.controller.connect(target, auth)
+    }
+
+    /**
+     * Reports a starting session on a catalog host (see [onHostSessionOpened]). A null [hostId] is an
+     * ad-hoc target with no catalog record behind it, so there is nothing to report it against.
+     */
+    private fun reportHostSession(hostId: String?) {
+        if (hostId != null) onHostSessionOpened(hostId)
     }
 
     /** Close the split pane of tab [id]: tear down the secondary connection and reset split flags. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
@@ -71,6 +71,8 @@ import app.skerry.ui.generated.resources.settings_event_vault_created
 import app.skerry.ui.generated.resources.settings_event_with_detail
 import app.skerry.ui.generated.resources.settings_manage
 import app.skerry.ui.generated.resources.settings_recent_security_events
+import app.skerry.ui.generated.resources.settings_security_report_team_sessions
+import app.skerry.ui.generated.resources.settings_security_report_team_sessions_desc
 import app.skerry.ui.generated.resources.settings_security_2fa
 import app.skerry.ui.generated.resources.settings_security_2fa_desc
 import app.skerry.ui.generated.resources.settings_security_auto_lock
@@ -241,6 +243,16 @@ internal fun SecuritySection(
         // Inert (dimmed) button: feature not ready yet.
         GhostButton(stringResource(Res.string.settings_manage), onClick = {}, fg = Skerry.colors.faint, border = Skerry.colors.line)
     }
+    HLine()
+
+    // What this device tells a team about our own sessions. Sits here rather than under Teams: it is
+    // about what leaves this machine, and it is where someone looks to turn that off.
+    SettingToggleRow(
+        stringResource(Res.string.settings_security_report_team_sessions),
+        stringResource(Res.string.settings_security_report_team_sessions_desc),
+        on = state.reportTeamSessions,
+        onToggle = state::toggleReportTeamSessions,
+    )
     HLine()
 
     // Recent security events from the real log (or "no events yet").

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
@@ -1,0 +1,330 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.TeamActivityCategory
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamActivityKind
+import app.skerry.shared.team.TeamActivityRow
+import app.skerry.shared.team.buildTeamActivityFeed
+import app.skerry.shared.terminal.epochMillis
+import app.skerry.shared.vault.RecordType
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_actor_you
+import app.skerry.ui.generated.resources.lib_teams_event_accept
+import app.skerry.ui.generated.resources.lib_teams_event_create
+import app.skerry.ui.generated.resources.lib_teams_event_delete
+import app.skerry.ui.generated.resources.lib_teams_event_invite
+import app.skerry.ui.generated.resources.lib_teams_event_record_change
+import app.skerry.ui.generated.resources.lib_teams_event_record_remove
+import app.skerry.ui.generated.resources.lib_teams_event_record_share
+import app.skerry.ui.generated.resources.lib_teams_event_records_bulk
+import app.skerry.ui.generated.resources.lib_teams_event_rekey
+import app.skerry.ui.generated.resources.lib_teams_event_remove
+import app.skerry.ui.generated.resources.lib_teams_event_role_change
+import app.skerry.ui.generated.resources.lib_teams_event_scope_create
+import app.skerry.ui.generated.resources.lib_teams_event_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_event_scope_grant
+import app.skerry.ui.generated.resources.lib_teams_event_scope_rekey
+import app.skerry.ui.generated.resources.lib_teams_event_scope_revoke
+import app.skerry.ui.generated.resources.lib_teams_event_session_open
+import app.skerry.ui.generated.resources.lib_teams_event_session_record
+import app.skerry.ui.generated.resources.lib_teams_event_unknown
+import app.skerry.ui.generated.resources.lib_teams_feed_day_today
+import app.skerry.ui.generated.resources.lib_teams_feed_day_yesterday
+import app.skerry.ui.generated.resources.lib_teams_feed_duration
+import app.skerry.ui.generated.resources.lib_teams_feed_duration_short
+import app.skerry.ui.generated.resources.lib_teams_feed_in_scope
+import app.skerry.ui.generated.resources.lib_teams_feed_record_empty
+import app.skerry.ui.generated.resources.lib_teams_feed_record_title
+import app.skerry.ui.generated.resources.lib_teams_feed_reported_note
+import app.skerry.ui.generated.resources.lib_teams_filter_access
+import app.skerry.ui.generated.resources.lib_teams_filter_all
+import app.skerry.ui.generated.resources.lib_teams_filter_members
+import app.skerry.ui.generated.resources.lib_teams_filter_records
+import app.skerry.ui.generated.resources.lib_teams_filter_sessions
+import app.skerry.ui.generated.resources.lib_teams_history_empty
+import app.skerry.ui.generated.resources.lib_teams_history_title
+import app.skerry.ui.generated.resources.lib_teams_record_credential
+import app.skerry.ui.generated.resources.lib_teams_record_group
+import app.skerry.ui.generated.resources.lib_teams_record_host
+import app.skerry.ui.generated.resources.lib_teams_record_identity
+import app.skerry.ui.generated.resources.lib_teams_record_other
+import app.skerry.ui.generated.resources.lib_teams_record_snippet
+import app.skerry.ui.generated.resources.lib_teams_record_tunnel
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Team activity feed (owner/admin): who changed which host, who was let in, whose key was rotated,
+ * and — reported by the members' own apps — who opened a session on a shared host.
+ *
+ * Record **names** are resolved here, on the reader's device: the server stores only ids (it has no
+ * way to know a name), so [recordNames] is `scopeId -> recordId -> name` built from the share spaces
+ * this member can actually read. A record whose name can't be resolved (unshared since, or in a
+ * scope we hold no grant for) still gets its row, keyed by a short id.
+ *
+ * With [focusRecordId] set the dialog is one record's history instead of the whole team's, and the
+ * category filter is out of the way — the question there is already "what happened to this host".
+ */
+@Composable
+internal fun TeamActivityDialog(
+    entries: List<TeamActivityEntry>,
+    selfAccountId: String?,
+    recordNames: Map<String, Map<String, String>>,
+    scopeNames: Map<String, String>,
+    onDismiss: () -> Unit,
+    focusRecordId: String? = null,
+    focusRecordLabel: String? = null,
+) {
+    val mono = LocalFonts.current.mono
+    var category by remember { mutableStateOf(TeamActivityCategory.ALL) }
+    val effectiveCategory = if (focusRecordId != null) TeamActivityCategory.ALL else category
+    val days = remember(entries, effectiveCategory, focusRecordId, recordNames, scopeNames, selfAccountId) {
+        buildTeamActivityFeed(
+            entries = entries,
+            selfAccountId = selfAccountId,
+            category = effectiveCategory,
+            onlyRecordId = focusRecordId,
+            resolveRecordName = { scopeId, recordId -> recordNames[scopeId]?.get(recordId) },
+            resolveScopeName = { scopeId -> scopeNames[scopeId] },
+        )
+    }
+    // "Today"/"Yesterday" need a reference point; read once per dialog opening, not per row.
+    val todayIndex = remember { epochMillis().floorDiv(MILLIS_PER_DAY) }
+
+    TeamsDialogCard(onDismiss) {
+        Txt(
+            focusRecordLabel?.let { stringResource(Res.string.lib_teams_feed_record_title, it) }
+                ?: stringResource(Res.string.lib_teams_history_title),
+            color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        if (focusRecordId == null) {
+            ActivityFilterChips(category, onSelect = { category = it })
+        }
+        if (days.isEmpty()) {
+            Txt(
+                if (focusRecordId != null) stringResource(Res.string.lib_teams_feed_record_empty)
+                else stringResource(Res.string.lib_teams_history_empty),
+                color = Skerry.colors.dim, size = 12.5.sp, modifier = Modifier.padding(top = 12.dp),
+            )
+        } else {
+            Column(
+                Modifier.fillMaxWidth().heightIn(max = 380.dp).verticalScroll(rememberScrollState()).padding(top = 4.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                days.forEach { day ->
+                    Txt(
+                        dayLabel(day.dayIndex, todayIndex, day.rows.first().createdAt),
+                        color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold,
+                        letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 8.dp, bottom = 2.dp),
+                    )
+                    day.rows.forEach { row -> ActivityRow(row, mono) }
+                }
+            }
+        }
+        if (days.any { day -> day.rows.any { it.clientReported } }) {
+            Txt(
+                stringResource(Res.string.lib_teams_feed_reported_note),
+                color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.padding(top = 12.dp),
+            )
+        }
+        Row(Modifier.fillMaxWidth().padding(top = 16.dp), horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End)) {
+            CancelButton(stringResource(Res.string.shell_cancel), onDismiss)
+        }
+    }
+}
+
+@Composable
+private fun ActivityFilterChips(selected: TeamActivityCategory, onSelect: (TeamActivityCategory) -> Unit) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        TeamActivityCategory.entries.forEach { category ->
+            val active = category == selected
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(if (active) Skerry.colors.cyan.copy(alpha = 0.12f) else Color.Transparent)
+                    .border(1.dp, if (active) Skerry.colors.cyan else Skerry.colors.line, RoundedCornerShape(6.dp))
+                    .clickable { onSelect(category) }
+                    .padding(horizontal = 9.dp, vertical = 5.dp),
+            ) {
+                Txt(
+                    categoryLabel(category),
+                    color = if (active) Skerry.colors.cyanBright else Skerry.colors.dim,
+                    size = 10.5.sp, weight = FontWeight.SemiBold,
+                )
+            }
+        }
+    }
+}
+
+/** One event: icon, what happened (with the record's name), who and where, and the time. */
+@Composable
+private fun ActivityRow(row: TeamActivityRow, mono: androidx.compose.ui.text.font.FontFamily) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(8.dp))
+            .padding(horizontal = 12.dp, vertical = 9.dp),
+    ) {
+        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Sym(rowIcon(row.kind), size = 15.sp, color = rowColor(row.kind))
+            Txt(eventLabel(row), color = Skerry.colors.textBright, size = 12.5.sp, weight = FontWeight.Medium)
+            row.subject?.let { subject ->
+                Txt(
+                    subject,
+                    // A name we resolved reads as a name; a bare short id is shown as the id it is.
+                    color = if (row.subjectResolved) Skerry.colors.cyanBright else Skerry.colors.faint,
+                    size = 12.sp, font = mono, modifier = Modifier.weight(1f),
+                )
+            } ?: Box(Modifier.weight(1f))
+            Txt(timeOfDay(row.createdAt), color = Skerry.colors.faint, size = 10.5.sp, font = mono)
+        }
+        Txt(
+            metaLine(row),
+            color = Skerry.colors.dim, size = 10.5.sp, font = mono,
+            modifier = Modifier.padding(top = 3.dp),
+        )
+    }
+}
+
+/** Actor, share space, and reported length — everything about the row that isn't the event itself. */
+@Composable
+private fun metaLine(row: TeamActivityRow): String {
+    val actor = if (row.isSelf) stringResource(Res.string.lib_teams_actor_you) else row.actorAccountId
+    val parts = mutableListOf(actor)
+    row.scopeName?.let { parts += stringResource(Res.string.lib_teams_feed_in_scope, it) }
+    row.durationSec?.let { seconds ->
+        parts += if (seconds < 60) stringResource(Res.string.lib_teams_feed_duration_short)
+        else stringResource(Res.string.lib_teams_feed_duration, (seconds / 60).toString())
+    }
+    // A bulk summary and an unknown event carry the server's own wording; nothing else does.
+    if (row.kind == TeamActivityKind.UNKNOWN && row.detail.isNotBlank()) parts += row.detail
+    return parts.joinToString(" · ")
+}
+
+/**
+ * What happened, in words. A record event names the type of thing it touched ("Changed host") and
+ * the row shows the name beside it; everything else is a complete sentence on its own.
+ */
+@Composable
+private fun eventLabel(row: TeamActivityRow): String = when (row.kind) {
+    TeamActivityKind.TEAM_CREATE -> stringResource(Res.string.lib_teams_event_create)
+    TeamActivityKind.TEAM_DELETE -> stringResource(Res.string.lib_teams_event_delete)
+    TeamActivityKind.MEMBER_INVITE -> stringResource(Res.string.lib_teams_event_invite)
+    TeamActivityKind.MEMBER_JOIN -> stringResource(Res.string.lib_teams_event_accept)
+    TeamActivityKind.MEMBER_REMOVE -> stringResource(Res.string.lib_teams_event_remove)
+    TeamActivityKind.MEMBER_ROLE -> stringResource(Res.string.lib_teams_event_role_change)
+    TeamActivityKind.KEY_ROTATE -> stringResource(Res.string.lib_teams_event_rekey)
+    TeamActivityKind.SCOPE_CREATE -> stringResource(Res.string.lib_teams_event_scope_create)
+    TeamActivityKind.SCOPE_DELETE -> stringResource(Res.string.lib_teams_event_scope_delete)
+    TeamActivityKind.SCOPE_GRANT -> stringResource(Res.string.lib_teams_event_scope_grant)
+    TeamActivityKind.SCOPE_REVOKE -> stringResource(Res.string.lib_teams_event_scope_revoke)
+    TeamActivityKind.SCOPE_KEY_ROTATE -> stringResource(Res.string.lib_teams_event_scope_rekey)
+    TeamActivityKind.RECORD_SHARE ->
+        "${stringResource(Res.string.lib_teams_event_record_share)} ${recordNoun(row.recordType)}"
+    TeamActivityKind.RECORD_CHANGE ->
+        "${stringResource(Res.string.lib_teams_event_record_change)} ${recordNoun(row.recordType)}"
+    TeamActivityKind.RECORD_REMOVE ->
+        "${stringResource(Res.string.lib_teams_event_record_remove)} ${recordNoun(row.recordType)}"
+    // The count lives in the server's summary text; a plain number is all it needs to carry.
+    TeamActivityKind.RECORDS_BULK ->
+        stringResource(Res.string.lib_teams_event_records_bulk, row.detail.takeWhile { it.isDigit() }.toIntOrNull() ?: 0)
+    TeamActivityKind.SESSION_OPEN -> stringResource(Res.string.lib_teams_event_session_open)
+    TeamActivityKind.SESSION_RECORD -> stringResource(Res.string.lib_teams_event_session_record)
+    TeamActivityKind.UNKNOWN -> stringResource(Res.string.lib_teams_event_unknown, row.event)
+}
+
+/** The kind of thing a record event touched, as a noun to follow the verb. */
+@Composable
+private fun recordNoun(type: RecordType?): String = when (type) {
+    RecordType.HOST -> stringResource(Res.string.lib_teams_record_host)
+    RecordType.SNIPPET -> stringResource(Res.string.lib_teams_record_snippet)
+    RecordType.CREDENTIAL -> stringResource(Res.string.lib_teams_record_credential)
+    RecordType.IDENTITY -> stringResource(Res.string.lib_teams_record_identity)
+    RecordType.TUNNEL -> stringResource(Res.string.lib_teams_record_tunnel)
+    RecordType.GROUP -> stringResource(Res.string.lib_teams_record_group)
+    else -> stringResource(Res.string.lib_teams_record_other)
+}
+
+@Composable
+private fun categoryLabel(category: TeamActivityCategory): String = when (category) {
+    TeamActivityCategory.ALL -> stringResource(Res.string.lib_teams_filter_all)
+    TeamActivityCategory.RECORDS -> stringResource(Res.string.lib_teams_filter_records)
+    TeamActivityCategory.MEMBERS -> stringResource(Res.string.lib_teams_filter_members)
+    TeamActivityCategory.ACCESS -> stringResource(Res.string.lib_teams_filter_access)
+    TeamActivityCategory.SESSIONS -> stringResource(Res.string.lib_teams_filter_sessions)
+}
+
+private fun rowIcon(kind: TeamActivityKind): String = when (kind) {
+    TeamActivityKind.TEAM_CREATE, TeamActivityKind.TEAM_DELETE -> "group"
+    TeamActivityKind.MEMBER_INVITE -> "person_add"
+    TeamActivityKind.MEMBER_JOIN -> "how_to_reg"
+    TeamActivityKind.MEMBER_REMOVE -> "person_remove"
+    TeamActivityKind.MEMBER_ROLE -> "badge"
+    TeamActivityKind.KEY_ROTATE, TeamActivityKind.SCOPE_KEY_ROTATE -> "sync_lock"
+    TeamActivityKind.SCOPE_CREATE, TeamActivityKind.SCOPE_DELETE -> "workspaces"
+    TeamActivityKind.SCOPE_GRANT -> "key"
+    TeamActivityKind.SCOPE_REVOKE -> "key_off"
+    TeamActivityKind.RECORD_SHARE -> "add_circle"
+    TeamActivityKind.RECORD_CHANGE -> "edit"
+    // `remove_circle` is absent from the bundled Material Symbols subset — a missing ligature would
+    // render as its own name in plain text, so every icon here must exist in the shipped font.
+    TeamActivityKind.RECORD_REMOVE -> "do_not_disturb_on"
+    TeamActivityKind.RECORDS_BULK -> "sync"
+    TeamActivityKind.SESSION_OPEN -> "terminal"
+    TeamActivityKind.SESSION_RECORD -> "radio_button_checked"
+    TeamActivityKind.UNKNOWN -> "help"
+}
+
+@Composable
+private fun rowColor(kind: TeamActivityKind): Color = when (kind) {
+    TeamActivityKind.RECORD_REMOVE, TeamActivityKind.MEMBER_REMOVE, TeamActivityKind.SCOPE_REVOKE,
+    TeamActivityKind.TEAM_DELETE, TeamActivityKind.SCOPE_DELETE -> Skerry.colors.sunset
+    TeamActivityKind.RECORD_SHARE, TeamActivityKind.MEMBER_JOIN, TeamActivityKind.SCOPE_GRANT -> Skerry.colors.moss
+    TeamActivityKind.KEY_ROTATE, TeamActivityKind.SCOPE_KEY_ROTATE -> Skerry.colors.amber
+    else -> Skerry.colors.cyanBright
+}
+
+/** Day header: Today/Yesterday, else the date (UTC, like the row times). */
+@Composable
+private fun dayLabel(dayIndex: Long, todayIndex: Long, anyTimestampOfDay: Long): String = when (todayIndex - dayIndex) {
+    0L -> stringResource(Res.string.lib_teams_feed_day_today)
+    1L -> stringResource(Res.string.lib_teams_feed_day_yesterday)
+    else -> formatEpochUtc(anyTimestampOfDay).substringBefore(' ')
+}
+
+/** `HH:MM` of a timestamp, from the same UTC formatter the rest of the feed uses. */
+private fun timeOfDay(millis: Long): String = formatEpochUtc(millis).substringAfter(' ')
+
+private const val MILLIS_PER_DAY = 86_400_000L

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
@@ -8,11 +8,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Alignment
@@ -22,23 +19,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamRole
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_cancel
-import app.skerry.ui.generated.resources.lib_teams_event_accept
-import app.skerry.ui.generated.resources.lib_teams_event_create
-import app.skerry.ui.generated.resources.lib_teams_event_delete
-import app.skerry.ui.generated.resources.lib_teams_event_invite
-import app.skerry.ui.generated.resources.lib_teams_event_remove
-import app.skerry.ui.generated.resources.lib_teams_event_role_change
-import app.skerry.ui.generated.resources.lib_teams_event_share
-import app.skerry.ui.generated.resources.lib_teams_event_unknown
-import app.skerry.ui.generated.resources.lib_teams_history_empty
-import app.skerry.ui.generated.resources.lib_teams_history_title
 import app.skerry.ui.generated.resources.lib_teams_role_admin
 import app.skerry.ui.generated.resources.lib_teams_role_editor
 import app.skerry.ui.generated.resources.lib_teams_role_owner
@@ -74,19 +60,6 @@ internal fun roleBadgeColors(role: TeamRole): Pair<Color, Color> = when (role) {
     TeamRole.ADMIN -> Skerry.colors.cyanBright to Skerry.colors.cyan.copy(alpha = 0.12f)
     TeamRole.EDITOR -> Skerry.colors.moss to Skerry.colors.moss.copy(alpha = 0.14f)
     TeamRole.VIEWER -> Skerry.colors.dim to Skerry.colors.overlayMed
-}
-
-/** Localized audit event summary; an unknown code goes into a localized fallback as a detail. */
-@Composable
-internal fun teamEventLabel(event: String): String = when (event) {
-    "team.create" -> stringResource(Res.string.lib_teams_event_create)
-    "team.invite" -> stringResource(Res.string.lib_teams_event_invite)
-    "team.remove" -> stringResource(Res.string.lib_teams_event_remove)
-    "team.accept" -> stringResource(Res.string.lib_teams_event_accept)
-    "team.role_change" -> stringResource(Res.string.lib_teams_event_role_change)
-    "team.push" -> stringResource(Res.string.lib_teams_event_share)
-    "team.delete" -> stringResource(Res.string.lib_teams_event_delete)
-    else -> stringResource(Res.string.lib_teams_event_unknown, event)
 }
 
 /** Member role/status badge (shared visual language for desktop and mobile). */
@@ -148,45 +121,6 @@ internal fun RolePickerDialog(
                     if (active) {
                         Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.CenterEnd) {
                             Txt("✓", color = Skerry.colors.cyanBright, size = 13.sp)
-                        }
-                    }
-                }
-            }
-        }
-        Row(Modifier.fillMaxWidth().padding(top = 16.dp), horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End)) {
-            CancelButton(stringResource(Res.string.shell_cancel), onDismiss)
-        }
-    }
-}
-
-/** Team audit-log dialog (owner/admin): newest events first, metadata only. */
-@Composable
-internal fun AuditLogDialog(entries: List<TeamActivityEntry>, onDismiss: () -> Unit) {
-    val mono = LocalFonts.current.mono
-    TeamsDialogCard(onDismiss) {
-        Txt(stringResource(Res.string.lib_teams_history_title), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp, modifier = Modifier.padding(bottom = 14.dp))
-        if (entries.isEmpty()) {
-            Txt(stringResource(Res.string.lib_teams_history_empty), color = Skerry.colors.dim, size = 12.5.sp)
-        } else {
-            Column(
-                Modifier.fillMaxWidth().heightIn(max = 360.dp).verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                entries.forEach { e ->
-                    Column(
-                        Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(8.dp))
-                            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(8.dp))
-                            .padding(horizontal = 12.dp, vertical = 9.dp),
-                    ) {
-                        Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            Txt(teamEventLabel(e.event), color = Skerry.colors.textBright, size = 12.5.sp, weight = FontWeight.Medium, modifier = Modifier.weight(1f))
-                            Txt(formatEpochUtc(e.createdAt), color = Skerry.colors.faint, size = 10.5.sp, font = mono)
-                        }
-                        Txt(e.actorAccountId, color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
-                        if (e.detail.isNotBlank()) {
-                            Txt(e.detail, color = Skerry.colors.faint, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 2.dp))
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -18,6 +18,7 @@ import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
 import app.skerry.shared.team.TeamScopeRef
 import app.skerry.shared.team.TeamScopedSyncClient
+import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.team.accountKeyFingerprint
@@ -35,6 +36,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import app.skerry.shared.team.stripShareFields
+import app.skerry.shared.host.VaultHostStore
+import app.skerry.shared.snippet.VaultSnippetStore
 
 /** Typed cause of a Teams operation failure (text in the UI layer, syncFailureText style). */
 enum class TeamsFailure {
@@ -158,6 +161,17 @@ class TeamsCoordinator(
      * teamsForSync: sync is created before teams.
      */
     var onKeyMissing: (() -> Unit)? = null
+
+    /**
+     * Whether this device may tell a team about our sessions on its shared hosts (Settings →
+     * Security). Late-bound like [onKeyMissing]: the setting lives in the platform's UI state, which
+     * is built after this coordinator.
+     *
+     * The gate belongs here rather than at each call site so it cannot drift between the platforms or
+     * between the connect and the recording path — and so it sits beside the other privacy rule, that
+     * a host of our own is reported nowhere at all ([spaceHoldingHost]).
+     */
+    var reportSessionsEnabled: () -> Boolean = { true }
 
     // Recover a key once per team per process: if it's also missing on the server, every refresh would
     // otherwise run a full re-pull for nothing.
@@ -329,6 +343,78 @@ class TeamsCoordinator(
             emptyList()
         }
     }
+
+    /**
+     * Reports to the owning team that a session on shared host [hostId] just started — the session
+     * half of the activity feed (see [TeamClient.reportSessionEvent]).
+     *
+     * Fire-and-forget and deliberately silent: a connection is already under way, the user asked for
+     * nothing here, and the server may be older than the endpoint. Nothing at all is sent for a host
+     * that isn't shared with a team — connecting to one's own hosts is private, and the feature would
+     * be indefensible otherwise.
+     */
+    fun reportSessionOpened(hostId: String) = reportSession(hostId, TeamSessionKind.OPEN, null)
+
+    /** Reports that a recording of a session on shared host [hostId] was saved. See [reportSessionOpened]. */
+    fun reportSessionRecorded(hostId: String, durationSec: Long) =
+        reportSession(hostId, TeamSessionKind.RECORD, durationSec.coerceAtLeast(0))
+
+    private fun reportSession(hostId: String, kind: TeamSessionKind, durationSec: Long?) {
+        val s = session() ?: return
+        val c = client() ?: return
+        if (!reportSessionsEnabled()) return
+        // Everything past this point runs off the caller's thread. This is called straight from a
+        // Connect click, and finding the owning space means decrypting the account's team records and
+        // opening each space's vault — on the UI thread that is a stutter on desktop and an ANR risk
+        // on Android, the more so while a background sync holds the same vault's lock.
+        scope.launch {
+            if (!vault.isUnlocked) return@launch
+            val ref = spaceHoldingHost(hostId) ?: return@launch
+            try {
+                c.reportSessionEvent(s, ref.teamId, hostId, kind, durationSec)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Best-effort by contract: never surfaced in lastError, never retried. A report that
+                // didn't land leaves a gap in the feed, which is why the UI presents session events
+                // as reported rather than as an authoritative record.
+            }
+        }
+    }
+
+    /**
+     * The share space whose vault holds [hostId] as a live host, across every team we hold a key
+     * for — or null when the host is ours alone. Read from the key store rather than [teams] so a
+     * report works before the first refresh and while offline.
+     */
+    private fun spaceHoldingHost(hostId: String): TeamScopeRef? =
+        keyStore.list().keys.asSequence()
+            .flatMap { teamId -> spacesOf(teamId).asSequence() }
+            .firstOrNull { ref ->
+                spaces.vault(ref)?.records()?.any { it.id == hostId && it.type == RecordType.HOST && !it.deleted } == true
+            }
+
+    /** The signed-in account, for marking our own actions in the activity feed. */
+    fun selfAccountId(): String? = session()?.accountId
+
+    /**
+     * Names of the records shared in this team, per share space: `scopeId -> recordId -> name`
+     * (team-wide space under an empty key). This is what makes the activity feed readable — the
+     * server logs record ids and never learns a name, so the reader's own copy of each space is the
+     * only place one can come from.
+     *
+     * A space we hold no key for contributes nothing, and neither does a record that has since been
+     * unshared (its tombstone carries no payload) — the feed falls back to a short id for those.
+     */
+    fun sharedRecordNames(teamId: String): Map<String, Map<String, String>> =
+        spacesOf(teamId).mapNotNull { ref ->
+            val vault = spaces.vault(ref) ?: return@mapNotNull null
+            val names = buildMap {
+                VaultHostStore(vault).all().forEach { put(it.id, it.label) }
+                VaultSnippetStore(vault).all().forEach { put(it.id, it.label) }
+            }
+            if (names.isEmpty()) null else ref.scopeId to names
+        }.toMap()
 
     /**
      * Invite step (invitee side): open+verify the envelope and return the **verified inviter's**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -109,7 +109,9 @@ import app.skerry.ui.generated.resources.lib_teams_scopes
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.generated.resources.lib_teams_sync_now
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
@@ -145,6 +147,8 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     var sharePicker by remember { mutableStateOf<RecordType?>(null) }
     var confirm by remember { mutableStateOf<TeamsConfirm?>(null) }
     var showHistory by remember { mutableStateOf(false) }
+    // Set to look at one record's history instead of the team's whole feed ("who touched this host").
+    var historyRecord by remember { mutableStateOf<HistoryTarget?>(null) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
     // Selected share space of the current team ("" = team-wide). Kept per team so switching teams
     // doesn't land on a scope id that belongs to another one.
@@ -193,6 +197,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                     onSync = { scope.launch2 { tc.refresh(); tc.syncTeam(selected.id); afterOp() } },
                     onUnshare = { recordId -> scope.launch2 { tc.unshareRecord(TeamScopeRef(selected.id, scopeId), recordId); afterOp() } },
                     onShowHistory = { showHistory = true },
+                    onShowRecordHistory = { historyRecord = it },
                     onChangeRole = { member -> rolePicker = member },
                     onSelectScope = { selectedScope = it },
                     onNewScope = { showCreateScope = true },
@@ -256,11 +261,27 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
         )
     }
     val historyTeam = selected
-    if (showHistory && historyTeam != null) {
+    val recordFocus = historyRecord
+    if ((showHistory || recordFocus != null) && historyTeam != null) {
         val entries by produceState(emptyList<TeamActivityEntry>(), historyTeam.id, tick) {
             value = tc.teamActivity(historyTeam.id)
         }
-        AuditLogDialog(entries, onDismiss = { showHistory = false })
+        // Record names come from our own copy of each share space — the server holds only ids.
+        // Fetched like the entries above rather than in a bare remember{}: resolving them decrypts
+        // every shared record of the team, which has no business blocking a frame.
+        val recordNames by produceState(emptyMap<String, Map<String, String>>(), historyTeam.id, tick) {
+            value = withContext(Dispatchers.Default) { tc.sharedRecordNames(historyTeam.id) }
+        }
+        val scopeNames = remember(historyTeam.scopes) { historyTeam.scopes.associate { it.id to it.name } }
+        TeamActivityDialog(
+            entries = entries,
+            selfAccountId = tc.selfAccountId(),
+            recordNames = recordNames,
+            scopeNames = scopeNames,
+            focusRecordId = recordFocus?.recordId,
+            focusRecordLabel = recordFocus?.label,
+            onDismiss = { showHistory = false; historyRecord = null },
+        )
     }
     val scopeTeam = selected
     if (showCreateScope && scopeTeam != null) {
@@ -350,6 +371,7 @@ private fun TeamDetail(
     onSync: () -> Unit,
     onUnshare: (String) -> Unit,
     onShowHistory: () -> Unit,
+    onShowRecordHistory: (HistoryTarget) -> Unit,
     onChangeRole: (TeamMember) -> Unit,
     onSelectScope: (String) -> Unit,
     onNewScope: () -> Unit,
@@ -455,7 +477,16 @@ private fun TeamDetail(
                     LiveSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
                     if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
                     sharedHosts.forEach { host ->
-                        SharedRecordRow(host.label, host.rowSubtitle(), mono, canUnshare = canWrite) { onUnshare(host.id) }
+                        SharedRecordRow(
+                            host.label, host.rowSubtitle(), mono,
+                            canUnshare = canWrite,
+                            onHistory = if (canAudit) {
+                                { onShowRecordHistory(HistoryTarget(host.id, host.label)) }
+                            } else {
+                                null
+                            },
+                            onUnshare = { onUnshare(host.id) },
+                        )
                     }
                     if (canWrite) {
                         GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
@@ -465,7 +496,16 @@ private fun TeamDetail(
                     LiveSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
                     if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
                     sharedSnippets.forEach { snippet ->
-                        SharedRecordRow(snippet.label, snippet.command, mono, canUnshare = canWrite) { onUnshare(snippet.id) }
+                        SharedRecordRow(
+                            snippet.label, snippet.command, mono,
+                            canUnshare = canWrite,
+                            onHistory = if (canAudit) {
+                                { onShowRecordHistory(HistoryTarget(snippet.id, snippet.label)) }
+                            } else {
+                                null
+                            },
+                            onUnshare = { onUnshare(snippet.id) },
+                        )
                     }
                     if (canWrite) {
                         GhostButton(stringResource(Res.string.lib_teams_share_snippet), onClick = { onShare(RecordType.SNIPPET) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
@@ -539,8 +579,18 @@ private fun LiveMemberRow(
     }
 }
 
+/** A record to show the history of: its id, plus the name to put in the dialog's title. */
+internal data class HistoryTarget(val recordId: String, val label: String)
+
 @Composable
-private fun SharedRecordRow(label: String, detail: String, mono: androidx.compose.ui.text.font.FontFamily, canUnshare: Boolean, onUnshare: () -> Unit) {
+private fun SharedRecordRow(
+    label: String,
+    detail: String,
+    mono: androidx.compose.ui.text.font.FontFamily,
+    canUnshare: Boolean,
+    onHistory: (() -> Unit)? = null,
+    onUnshare: () -> Unit,
+) {
     Row(
         Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 7.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -548,6 +598,12 @@ private fun SharedRecordRow(label: String, detail: String, mono: androidx.compos
     ) {
         Txt(label, color = Skerry.colors.textBright, size = 12.sp, font = mono)
         Txt(detail, color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.weight(1f))
+        // "What happened to this one" — only for readers who may see the audit log at all.
+        if (onHistory != null) {
+            Box(Modifier.clip(CircleShape).clickable(onClick = onHistory).padding(3.dp)) {
+                Sym("history", size = 14.sp, color = Skerry.colors.faint)
+            }
+        }
         if (canUnshare) {
             Box(Modifier.clip(CircleShape).clickable(onClick = onUnshare).padding(3.dp)) {
                 Sym("close", size = 14.sp, color = Skerry.colors.faint)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -33,6 +33,11 @@ import app.skerry.ui.theme.Skerry
 fun RecordSessionButton(
     session: Session?,
     requests: SharedFlow<Unit>? = null,
+    /**
+     * A recording of a catalog host was saved: `(hostId, wall-clock seconds)`. Reported to the team
+     * that host is shared with, if any (see [app.skerry.ui.teams.TeamsCoordinator.reportSessionRecorded]).
+     */
+    onSaved: (String, Long) -> Unit = { _, _ -> },
     onDone: (RecordingOutcome) -> Unit,
 ) {
     val terminal = (session?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
@@ -54,7 +59,11 @@ fun RecordSessionButton(
                     return@launch
                 }
                 val name = castFileName(session.displayTitle.ifBlank { session.subtitle }, recordingStamp())
+                val seconds = live.recordingSeconds
                 val saved = exportTextFile(name, cast)
+                // Only an actually exported recording is reported: a cancelled Save-As wrote nothing,
+                // and announcing a recording nobody kept would be a plain falsehood in the feed.
+                if (saved) session.hostId?.let { onSaved(it, seconds) }
                 onDone(
                     when {
                         !saved -> RecordingOutcome.Cancelled

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -175,12 +175,25 @@ class TerminalScreenState(
      */
     fun startRecording(title: String?) {
         if (recording) return
-        val queued = commands.trySend(TerminalCommand.StartRecording(title, epochMillis(), cols, rows))
+        val startedAt = epochMillis()
+        val queued = commands.trySend(TerminalCommand.StartRecording(title, startedAt, cols, rows))
         // The queue is closed once the session's output ends: there is nothing left to record.
         if (queued.isFailure) return
         recording = true
         recordingTruncated = false
+        recordingStartedAtMillis = startedAt
     }
+
+    private var recordingStartedAtMillis: Long = 0
+
+    /**
+     * Wall-clock length of the running (or last finished) recording in seconds; 0 when this session
+     * was never recorded. Read right after [stopRecording] for the length to report to a team — the
+     * clock keeps running for a recording that hit its size limit, so a truncated take reads as the
+     * window it covered rather than as the bytes it kept.
+     */
+    val recordingSeconds: Long
+        get() = if (recordingStartedAtMillis == 0L) 0 else (epochMillis() - recordingStartedAtMillis) / 1000
 
     /**
      * Stop recording and return the asciicast, or `null` if nothing was being recorded. The caller

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -57,6 +57,7 @@ import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalConnectSplit
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
+import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.connectionErrorText
 import app.skerry.ui.design.Dot
@@ -122,7 +123,12 @@ private fun SessionActions(state: DesktopDesignState, modifier: Modifier = Modif
         // Quick snippet launch into the active session without leaving for the Snippets section.
         SnippetPaletteButton(active, state.snippetPaletteRequests)
         // Asciinema recording of this session; the stop click offers a Save-As for the .cast.
-        RecordSessionButton(active, state.recordingToggleRequests) { state.showRecordingNotice(it) }
+        val teams = LocalTeams.current
+        RecordSessionButton(
+            active,
+            state.recordingToggleRequests,
+            onSaved = { hostId, seconds -> teams?.reportSessionRecorded(hostId, seconds) },
+        ) { state.showRecordingNotice(it) }
         // Plays a .cast back. Not tied to a session (a recording is watched, not run), which is why
         // it sits here rather than behind a connected-only guard. Live mode opens the recording in
         // its own tab, so the shells stay reachable while it plays; the mock/preview path (no

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -487,6 +487,42 @@ class SessionsControllerTest {
     }
 
     @Test
+    fun `every real connection to a host is reported once, blank tabs and players never`() = runTest {
+        // Feeds the Teams activity log (see TeamsCoordinator.reportSessionOpen): every path that
+        // actually opens a session to a catalog host must report, and only those.
+        val opened = mutableListOf<String>()
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var n = 0
+        val vncTransport = FakeVncTransport()
+        val sessions = SessionsController(
+            newId = { "s${n++}" },
+            controllerFactory = {
+                ConnectionController(
+                    transport = FakeTransport(),
+                    scope = scope,
+                    newSessionScope = { CoroutineScope(UnconfinedTestDispatcher(testScheduler)) },
+                )
+            },
+            vncControllerFactory = { VncSessionController(vncTransport, scope) },
+            onHostSessionOpened = { opened += it },
+        )
+
+        val blank = sessions.openBlank()
+        assertTrue(opened.isEmpty()) // no connection started yet
+        sessions.connect(hostId = "host-a", title = "a", subtitle = "u@h:22", target = target, auth = auth)
+        sessions.connect(hostId = "host-b", title = "b", subtitle = "u@h:22", target = target, auth = auth)
+        sessions.open(hostId = "host-c")
+        sessions.connectSplit(parentId = blank, hostId = "host-d", title = "d", subtitle = "u@h:22", target = target, auth = auth)
+        sessions.openVnc(hostId = "host-e")
+        sessions.openPlayer("recording", Asciicast(80, 24, "cast", emptyList()))
+        // An ad-hoc connection typed into the form belongs to no catalog host: nothing to report.
+        sessions.open(hostId = null)
+
+        assertEquals(listOf("host-a", "host-b", "host-c", "host-d", "host-e"), opened)
+        scope.cancel()
+    }
+
+    @Test
     fun `connect opens a new tab when the active one is not blank`() = runTest {
         val (sessions, scope) = sessionsWith(FakeTransport())
         val a = sessions.open(hostId = "host-a") // connected, not blank

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -484,6 +484,8 @@ fun main(args: Array<String>) {
                     onHostClickConnectModeChange = { prefs.set("host_click_connect", it.id) },
                     initialAllowServerClipboardWrite = prefs.bool("terminal_clipboard_write", false),
                     onAllowServerClipboardWriteChange = { prefs.set("terminal_clipboard_write", it) },
+                    initialReportTeamSessions = prefs.bool("teams_report_sessions", true),
+                    onReportTeamSessionsChange = { prefs.set("teams_report_sessions", it) },
                     initialOpenFilePathsInSftp = prefs.bool("terminal_open_paths", true),
                     onOpenFilePathsInSftpChange = { prefs.set("terminal_open_paths", it) },
                     initialConfirmProductionWarnings = prefs.bool("terminal_prod_warnings", false),

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
@@ -6,6 +6,7 @@ import app.skerry.shared.sync.RemoteRecord
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.team.AccountKeys
 import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamIdentityStore
 import app.skerry.shared.team.TeamInviteCodec
@@ -70,6 +71,13 @@ class TeamsCoordinatorInviteCacheTest {
         override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
         override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
         override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRotationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRotationTest.kt
@@ -7,6 +7,7 @@ import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.team.AccountKeys
 import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamKeyStore
 import app.skerry.shared.team.TeamMember
@@ -106,6 +107,13 @@ class TeamsCoordinatorRotationTest {
         override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
         override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
         override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
         override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = emptyList()
         override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
@@ -7,6 +7,7 @@ import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.team.AccountKeys
 import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamIdentityStore
@@ -147,6 +148,13 @@ class TeamsCoordinatorScopeTest {
             teamRekeyCalls += newEpoch
         }
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
         override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {
             removed += accountId
             scopes.values.forEach { it.remove(accountId) } // the server drops grants with the membership

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorSessionReportTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorSessionReportTest.kt
@@ -1,0 +1,298 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
+import app.skerry.shared.team.TeamSessionKind
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Reporting a session to the team's activity feed. What matters here is *what never gets reported*:
+ * a host in the personal catalog is nobody else's business, and a report must not surface an error
+ * or take a connection down with it.
+ */
+class TeamsCoordinatorSessionReportTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val teamId = "team-report"
+    private val self = "alice@example.com"
+
+    private class Report(val teamId: String, val recordId: String, val kind: TeamSessionKind, val durationSec: Long?)
+
+    private class FakeTeamClient(private val self: String, private val teamId: String) : TeamClient {
+        val reports = mutableListOf<Report>()
+        var reportFailure: Exception? = null
+        private val store = linkedMapOf<String, Triple<RemoteRecord, Long, String>>()
+        private val scopeGrants = linkedMapOf<String, MutableMap<String, ByteArray>>()
+        private var seq = 0L
+
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) {
+            reportFailure?.let { throw it }
+            reports += Report(teamId, recordId, kind, durationSec)
+        }
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = self, role = TeamRole.OWNER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 1,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> =
+            scopeGrants.map { (id, grants) -> TeamScopeSummary(id, 0, grants.size, grants[session.accountId]) }
+
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
+            scopeGrants[scopeId] = mutableMapOf(session.accountId to envelope)
+        }
+
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage {
+            val page = store.values.filter { it.second > since && it.third == ref.scopeId }.sortedBy { it.second }
+            return RecordPage(page.map { it.first }, page.lastOrNull()?.second ?: since)
+        }
+
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage {
+            val result = records.map { rec ->
+                val existing = store[rec.id]
+                val wins = existing == null || rec.version > existing.first.version
+                if (wins) { seq += 1; store[rec.id] = Triple(rec, seq, ref.scopeId); rec } else existing.first
+            }
+            return RecordPage(result, seq)
+        }
+
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? = null
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> =
+            listOf(TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0))
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) = error("unused")
+        override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
+            scopeGrants[scopeId]?.keys?.map { TeamScopeGrantEntry(it, 0) } ?: emptyList()
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+    }
+
+    private class Fixture(val vault: FileVault, val teamVaults: TeamVaults)
+
+    private fun newFixture(): Fixture {
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile)
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }))
+    }
+
+    private fun coordinator(f: Fixture, client: TeamClient, ids: Iterator<String> = listOf("prod").iterator()) =
+        TeamsCoordinator(
+            session = { SyncSession(self, "access", "refresh") },
+            client = { client },
+            vault = f.vault,
+            crypto = crypto,
+            teamVaults = f.teamVaults,
+            teamState = InMemorySyncStateStore(),
+            newId = { ids.next() },
+            // Unconfined: a report is launched into this scope, and the assertions must not race it.
+            scope = CoroutineScope(Dispatchers.Unconfined),
+        )
+
+    private fun seedTeam(f: Fixture) =
+        TeamKeyStore(f.vault).also { it.put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0) }
+
+    @Test
+    fun `a session on a shared host is reported to the team that holds it`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+
+        coord.reportSessionOpened("h1")
+        coord.reportSessionRecorded("h1", durationSec = 754)
+
+        assertEquals(listOf(TeamSessionKind.OPEN, TeamSessionKind.RECORD), client.reports.map { it.kind })
+        assertEquals(teamId, client.reports.first().teamId)
+        assertEquals("h1", client.reports.first().recordId)
+        assertNull(client.reports.first().durationSec)
+        assertEquals(754, client.reports.last().durationSec)
+    }
+
+    @Test
+    fun `with reporting turned off nothing leaves the device`() = runBlocking {
+        // Settings -> Security. The gate lives in the coordinator rather than at each call site, so a
+        // user who turns it off is not relying on four separate `if`s staying in agreement.
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        coord.reportSessionsEnabled = { false }
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+
+        coord.reportSessionOpened("h1")
+        coord.reportSessionRecorded("h1", durationSec = 60)
+
+        assertTrue(client.reports.isEmpty())
+        assertNull(coord.lastError.value)
+    }
+
+    @Test
+    fun `record names for the feed come from each space we can read`() = runBlocking {
+        // What makes the feed readable: the server logs ids only, so names are resolved from the
+        // member's own copy of every share space, keyed by scope.
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, """{"id":"h1","label":"team-wide-db","address":"a","username":"u"}""".encodeToByteArray())
+        f.vault.put("h2", RecordType.HOST, """{"id":"h2","label":"prod-db","address":"a","username":"u"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h2", RecordType.HOST)
+
+        val names = coord.sharedRecordNames(teamId)
+
+        assertEquals(mapOf("h1" to "team-wide-db"), names[""])
+        assertEquals(mapOf("h2" to "prod-db"), names["prod"])
+        // An unshared record has no payload left, so its name is gone — the feed shows a short id.
+        coord.unshareRecord(TeamScopeRef(teamId), "h1")
+        assertTrue(coord.sharedRecordNames(teamId)[""].isNullOrEmpty())
+    }
+
+    @Test
+    fun `a host of our own is never reported anywhere`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        // In the personal vault only: connecting to it is private, and the whole feature is worthless
+        // if it leaks that.
+        f.vault.put("private", RecordType.HOST, """{"label":"my-nas"}""".encodeToByteArray())
+
+        coord.reportSessionOpened("private")
+
+        assertTrue(client.reports.isEmpty())
+    }
+
+    @Test
+    fun `an unshared host stops being reported`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+        coord.unshareRecord(TeamScopeRef(teamId), "h1")
+
+        coord.reportSessionOpened("h1")
+
+        assertTrue(client.reports.isEmpty())
+    }
+
+    @Test
+    fun `a scoped host is reported for its own team`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId, "prod"), "h1", RecordType.HOST)
+
+        coord.reportSessionOpened("h1")
+
+        assertEquals(listOf("h1"), client.reports.map { it.recordId })
+        assertEquals(teamId, client.reports.single().teamId)
+    }
+
+    @Test
+    fun `a failed report stays quiet - it must not surface as a Teams error`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+        client.reportFailure = SyncException(SyncException.Kind.NETWORK, "offline")
+
+        coord.reportSessionOpened("h1")
+
+        // The session itself is fine and the user asked for nothing here; an audit ping that didn't
+        // land is not something to interrupt them with (and the server it goes to may be older).
+        assertNull(coord.lastError.value)
+    }
+
+    @Test
+    fun `a locked vault reports nothing rather than failing`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val client = FakeTeamClient(self, teamId)
+        val coord = coordinator(f, client)
+        f.vault.put("h1", RecordType.HOST, """{"label":"db"}""".encodeToByteArray())
+        coord.shareRecord(TeamScopeRef(teamId), "h1", RecordType.HOST)
+        // The account vault locking is what drives coord.lock() in the app, and it is the real
+        // precondition here: with no keys readable there is no way to tell a shared host from a
+        // private one, so the safe answer is to say nothing.
+        f.vault.lock()
+        coord.lock()
+
+        coord.reportSessionOpened("h1")
+
+        assertTrue(client.reports.isEmpty())
+        assertNull(coord.lastError.value)
+    }
+
+    private companion object {
+        const val NOW = "2026-07-26T00:00:00Z"
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -58,6 +58,7 @@ object RateLimits {
     val REFRESH = RateLimitName("auth-refresh")
     val CHANGE_PASSWORD = RateLimitName("auth-change-password")
     val ADMIN = RateLimitName("admin")
+    val TEAM_SESSION_EVENTS = RateLimitName("team-session-events")
 }
 
 /**
@@ -139,6 +140,21 @@ fun Application.configureServer(services: Services) {
         // The admin console uses a constant-time static token compare, which doesn't stop brute
         // forcing the token itself, hence a rate limit on /admin/*.
         perIp(RateLimits.ADMIN, limit = 30)
+        // Session reports are a member-driven write into an audit log with a bounded retention
+        // window, so they get a budget of their own — keyed by **account**, not by IP: an attacker
+        // can't buy more of it by changing address, and members behind one NAT don't share one.
+        // Generous for real use (a report per connect, per recording) and low enough that flooding
+        // the feed takes sustained, plainly visible effort.
+        register(RateLimits.TEAM_SESSION_EVENTS) {
+            rateLimiter(limit = 60, refillPeriod = 60.seconds)
+            requestKey { call ->
+                call.principal<JWTPrincipal>()?.accountId ?: rateLimitClientKey(
+                    directPeer = call.request.origin.remoteHost,
+                    forwardedFor = call.request.header(HttpHeaders.XForwardedFor),
+                    trustedProxies = trustedProxies,
+                )
+            }
+        }
     }
     // Hard upper bound on request body size. Content-Length lets us reject oversized bodies with
     // 413 before reading. Content-Length alone isn't enough: a chunked-encoded body has none, so

--- a/server/src/main/kotlin/app/skerry/server/db/ActivityRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/ActivityRepository.kt
@@ -1,6 +1,8 @@
 package app.skerry.server.db
 
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -8,12 +10,36 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.selectAll
 
+/** One row to append to the audit log (see [ActivityRepository.recordAll]). */
+data class ActivityEvent(
+    val accountId: String,
+    val event: String,
+    val detail: String,
+    val deviceId: String? = null,
+    val teamId: String? = null,
+    val recordId: String? = null,
+    val recordType: String? = null,
+    val scopeId: String? = null,
+    val durationSec: Long? = null,
+)
+
 /**
- * Metadata audit log for the admin console. Append-only, retains the last [maxRows] events so
- * the log doesn't grow unbounded on a long-lived self-hosted instance. Contains no record
- * content — only event, device, and a human-readable summary ([detail]).
+ * Metadata audit log: the admin console's recent activity plus each team's own history. Append-only
+ * and bounded, so it can't grow without limit on a long-lived self-hosted instance. Contains no
+ * record content — only the event, the device, ids, and a human-readable summary ([ActivityEvent.detail]).
+ *
+ * Retention is **per bucket**, not global: account-level rows keep the newest [maxRows], and every
+ * team keeps the newest [teamMaxRows] of its own. That partition is what stops one team's traffic
+ * from evicting another team's history — or the admin console's — which matters here because any
+ * active member (a viewer included) can append to their team's bucket by reporting sessions. Within
+ * one team's own bucket the window is still finite, as any bounded log's is; the endpoint that feeds
+ * it is rate-limited per account so filling it takes sustained and plainly visible effort.
  */
-class ActivityRepository(private val db: Database, private val maxRows: Int = 2_000) {
+class ActivityRepository(
+    private val db: Database,
+    private val maxRows: Int = 2_000,
+    private val teamMaxRows: Int = 500,
+) {
 
     suspend fun record(
         accountId: String,
@@ -21,17 +47,79 @@ class ActivityRepository(private val db: Database, private val maxRows: Int = 2_
         detail: String,
         deviceId: String? = null,
         teamId: String? = null,
+        recordId: String? = null,
+        recordType: String? = null,
+        scopeId: String? = null,
+        durationSec: Long? = null,
         now: Long = System.currentTimeMillis(),
-    ): Unit = dbTransaction(db) {
-        ActivityLog.insert {
-            it[ActivityLog.accountId] = accountId
-            it[ActivityLog.deviceId] = deviceId
-            it[ActivityLog.event] = event
-            it[ActivityLog.detail] = detail
-            it[ActivityLog.teamId] = teamId
-            it[createdAt] = now
+    ): Unit = recordAll(
+        listOf(
+            ActivityEvent(accountId, event, detail, deviceId, teamId, recordId, recordType, scopeId, durationSec),
+        ),
+        now,
+    )
+
+    /**
+     * Appends [events] in **one** transaction: a batch describing a single action (one push, one
+     * event per changed record) lands whole or not at all. Written row by row it could fail halfway,
+     * and the client's retry is a no-op by LWW — the missing entries would never be written again,
+     * leaving an audit trail that silently disagrees with the data.
+     */
+    suspend fun recordAll(events: List<ActivityEvent>, now: Long = System.currentTimeMillis()): Unit =
+        dbTransaction(db) {
+            if (events.isEmpty()) return@dbTransaction
+            events.forEach { insert(it, now) }
+            // Each bucket the batch touched, pruned once.
+            events.map { it.teamId }.distinct().forEach { prune(it) }
         }
-        prune()
+
+    /**
+     * Records a client-reported session event, collapsing a repeat of the same (member, team, event,
+     * record, space) inside [SESSION_DEDUP_MS]. Returns whether a row was written.
+     *
+     * A dropped link reopens a session as many times as it takes, and each attempt is a genuine
+     * report — but writing them all would push the rest of the team's history out of the retention
+     * window. The window is deliberately short: it swallows a reconnect storm, not a member coming
+     * back to a host later. The space is part of the key because a record can move between spaces
+     * (an unshare plus a share), and a session in its new space is a different fact.
+     */
+    suspend fun recordTeamSession(
+        accountId: String,
+        teamId: String,
+        event: String,
+        recordId: String,
+        recordType: String?,
+        scopeId: String,
+        durationSec: Long?,
+        now: Long = System.currentTimeMillis(),
+    ): Boolean = dbTransaction(db) {
+        val last = ActivityLog.selectAll()
+            .where {
+                (ActivityLog.teamId eq teamId) and (ActivityLog.accountId eq accountId) and
+                    (ActivityLog.event eq event) and (ActivityLog.recordId eq recordId) and
+                    (ActivityLog.scopeId eq scopeId)
+            }
+            .orderBy(ActivityLog.seq to SortOrder.DESC)
+            .limit(1)
+            .firstOrNull()
+        // Only a *recent* duplicate is dropped; a clock that jumped backwards must not wedge the
+        // log shut, so a row stamped in the future is not treated as recent.
+        if (last != null && now - last[ActivityLog.createdAt] in 0 until SESSION_DEDUP_MS) return@dbTransaction false
+        insert(
+            ActivityEvent(
+                accountId = accountId,
+                event = event,
+                detail = "",
+                teamId = teamId,
+                recordId = recordId,
+                recordType = recordType,
+                scopeId = scopeId,
+                durationSec = durationSec,
+            ),
+            now,
+        )
+        prune(teamId)
+        true
     }
 
     /** Most recent events first (descending monotonic `seq`). */
@@ -52,21 +140,48 @@ class ActivityRepository(private val db: Database, private val maxRows: Int = 2_
                 .map { it.toRow() }
         }
 
-    /** Total retained events (≤ maxRows), for an accurate "N of M" in the console. */
+    /** Total retained events (all buckets), for an accurate "N of M" in the console. */
     suspend fun count(): Long = dbTransaction(db) {
         ActivityLog.selectAll().count()
     }
 
-    /** Deletes everything older than the last [maxRows] events (gap-safe: bounded by actual seq). */
-    private fun prune() {
-        // Cheap count-gate: only run the expensive OFFSET scan once the cap is actually
-        // exceeded, not on every recorded event.
-        if (ActivityLog.selectAll().count() <= maxRows) return
-        val keepFrom = ActivityLog.selectAll()
+    private fun insert(event: ActivityEvent, now: Long) {
+        ActivityLog.insert {
+            it[accountId] = event.accountId
+            it[deviceId] = event.deviceId
+            it[ActivityLog.event] = event.event
+            it[detail] = event.detail
+            it[teamId] = event.teamId
+            it[recordId] = event.recordId
+            it[recordType] = event.recordType
+            it[scopeId] = event.scopeId
+            it[durationSec] = event.durationSec
+            it[createdAt] = now
+        }
+    }
+
+    /**
+     * Trims one bucket — a single team's rows, or the account-level ones ([teamId] null) — to its
+     * cap, deleting the oldest beyond it. Gap-safe: the boundary is an actual `seq`, not arithmetic
+     * on a row count.
+     */
+    private fun prune(teamId: String?) {
+        val cap = if (teamId == null) maxRows else teamMaxRows
+        fun bucket() =
+            if (teamId == null) ActivityLog.selectAll().where { ActivityLog.teamId.isNull() }
+            else ActivityLog.selectAll().where { ActivityLog.teamId eq teamId }
+        // Cheap count-gate: only run the expensive OFFSET scan once the cap is actually exceeded,
+        // not on every recorded event.
+        if (bucket().count() <= cap) return
+        val keepFrom = bucket()
             .orderBy(ActivityLog.seq to SortOrder.DESC)
-            .limit(1).offset((maxRows - 1).toLong())
+            .limit(1).offset((cap - 1).toLong())
             .firstOrNull()?.get(ActivityLog.seq) ?: return
-        ActivityLog.deleteWhere { seq lessEq keepFrom - 1 }
+        if (teamId == null) {
+            ActivityLog.deleteWhere { ActivityLog.teamId.isNull() and (seq lessEq keepFrom - 1) }
+        } else {
+            ActivityLog.deleteWhere { (ActivityLog.teamId eq teamId) and (seq lessEq keepFrom - 1) }
+        }
     }
 
     private fun org.jetbrains.exposed.v1.core.ResultRow.toRow() = ActivityRow(
@@ -76,5 +191,14 @@ class ActivityRepository(private val db: Database, private val maxRows: Int = 2_
         event = this[ActivityLog.event],
         detail = this[ActivityLog.detail],
         createdAt = this[ActivityLog.createdAt],
+        recordId = this[ActivityLog.recordId],
+        recordType = this[ActivityLog.recordType],
+        scopeId = this[ActivityLog.scopeId],
+        durationSec = this[ActivityLog.durationSec],
     )
+
+    companion object {
+        /** How long a repeated session report of the same subject is treated as the same event. */
+        const val SESSION_DEDUP_MS = 60_000L
+    }
 }

--- a/server/src/main/kotlin/app/skerry/server/db/Models.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Models.kt
@@ -110,4 +110,9 @@ data class ActivityRow(
     val event: String,
     val detail: String,
     val createdAt: Long,
+    /** Record subject of a team event (see [ActivityLog.recordId]); null when the event has none. */
+    val recordId: String? = null,
+    val recordType: String? = null,
+    val scopeId: String? = null,
+    val durationSec: Long? = null,
 )

--- a/server/src/main/kotlin/app/skerry/server/db/Tables.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Tables.kt
@@ -81,6 +81,17 @@ object ActivityLog : Table("activity_log") {
     val detail = text("detail")
     /** Team the event belongs to (for team-scoped history); null for account-level events. */
     val teamId = varchar("team_id", 64).nullable()
+    /**
+     * Subject of a team event, for the members' activity feed: which record it was about, its type,
+     * and the share space it lives in (empty = team-wide). Ids and types are the plaintext metadata
+     * the server already holds; the record's **name** stays unknown to it — clients resolve it from
+     * their own copy of the team vault. Null for events with no record subject.
+     */
+    val recordId = varchar("record_id", 64).nullable()
+    val recordType = varchar("record_type", 32).nullable()
+    val scopeId = varchar("scope_id", 64).nullable()
+    /** Reported session length in seconds (client-reported session events only). */
+    val durationSec = long("duration_sec").nullable()
     val createdAt = long("created_at")
 
     override val primaryKey = PrimaryKey(seq)

--- a/server/src/main/kotlin/app/skerry/server/db/TeamRecordRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamRecordRepository.kt
@@ -17,6 +17,34 @@ import org.jetbrains.exposed.v1.jdbc.update
 data class TeamDeltaPage(val records: List<StoredRecord>, val cursor: Long)
 
 /**
+ * What a winning write did to a record, as the team audit log reports it. The distinction is drawn
+ * from what the space could see before, not from the row's existence: a write over a tombstone puts
+ * the record back in front of the team, so it counts as [SHARED] again rather than an edit.
+ */
+enum class TeamRecordChange { SHARED, CHANGED, REMOVED }
+
+/** Which share space of a team holds a record, and its (plaintext) record type. */
+data class TeamRecordLocation(val scopeId: String, val type: String)
+
+/** One record a push actually applied, with what it did. Records whose write lost LWW are absent. */
+data class AppliedTeamRecord(val record: StoredRecord, val change: TeamRecordChange)
+
+/**
+ * Outcome of a team push: every pushed record as it now stands ([records], including the ones whose
+ * write lost), the space cursor, and [applied] — what this push actually changed. A client pushes
+ * all of its local records on every sync cycle, so [applied], not [records], is what the audit log
+ * is built from.
+ */
+data class TeamUpsertResult(
+    val records: List<StoredRecord>,
+    val cursor: Long,
+    val applied: List<AppliedTeamRecord>,
+) {
+    /** Whether anything moved at all — equivalently, whether the team's `teamSeq` advanced. */
+    val changed: Boolean get() = applied.isNotEmpty()
+}
+
+/**
  * Encrypted team records — the same LWW core as [RecordRepository], but scoped to one share space
  * of a team: the team itself (`scopeId` empty) or one of its scopes. The delta cursor is
  * [Teams.teamSeq], shared by every space of the team; a per-space cursor is just a watermark on it.
@@ -27,10 +55,11 @@ data class TeamDeltaPage(val records: List<StoredRecord>, val cursor: Long)
 class TeamRecordRepository(private val db: Database, private val lockTeamRow: Boolean = false) {
 
     /** Batch upsert with LWW by (`version`, `deviceId`) — same semantics as [RecordRepository.upsert]. */
-    suspend fun upsert(teamId: String, scopeId: String, incoming: List<IncomingRecord>): UpsertResult = dbTransaction(db) {
+    suspend fun upsert(teamId: String, scopeId: String, incoming: List<IncomingRecord>): TeamUpsertResult = dbTransaction(db) {
         val teamQuery = Teams.selectAll().where { Teams.id eq teamId }
         val seqBefore = (if (lockTeamRow) teamQuery.forUpdate() else teamQuery).single()[Teams.teamSeq]
         var seq = seqBefore
+        val applied = mutableListOf<AppliedTeamRecord>()
 
         val result = incoming.mapNotNull { rec ->
             val existing = TeamRecords.selectAll()
@@ -50,6 +79,12 @@ class TeamRecordRepository(private val db: Database, private val lockTeamRow: Bo
             if (wins) {
                 seq += 1
                 val newSeq = seq
+                val change = when {
+                    rec.deleted -> TeamRecordChange.REMOVED
+                    // Nothing was visible here before: a new row, or one holding a tombstone.
+                    existing == null || existing[TeamRecords.deleted] -> TeamRecordChange.SHARED
+                    else -> TeamRecordChange.CHANGED
+                }
                 if (existing == null) {
                     TeamRecords.insert {
                         it[TeamRecords.teamId] = teamId
@@ -75,16 +110,16 @@ class TeamRecordRepository(private val db: Database, private val lockTeamRow: Bo
                     }
                 }
                 StoredRecord(rec.id, rec.type, rec.version, rec.updatedAt, rec.deviceId, rec.deleted, rec.blob, newSeq)
+                    .also { applied += AppliedTeamRecord(it, change) }
             } else {
                 existing.toStoredRecord()
             }
         }
 
-        val changed = seq != seqBefore
-        if (changed) {
+        if (applied.isNotEmpty()) {
             Teams.update({ Teams.id eq teamId }) { it[teamSeq] = seq }
         }
-        UpsertResult(result, seq, changed)
+        TeamUpsertResult(result, seq, applied)
     }
 
     /**
@@ -111,6 +146,18 @@ class TeamRecordRepository(private val db: Database, private val lockTeamRow: Bo
             .orderBy(TeamRecords.teamSeq to SortOrder.ASC)
             .map { it.toStoredRecord() }
         TeamDeltaPage(records, cursor)
+    }
+
+    /**
+     * Where a record of the team lives and what it is, without its ciphertext — for validating a
+     * report about it (see the session-event route). Null if the team never held such a record.
+     * A tombstoned record still answers: a session on a host that was just unshared is real.
+     */
+    suspend fun locate(teamId: String, recordId: String): TeamRecordLocation? = dbTransaction(db) {
+        TeamRecords.selectAll()
+            .where { (TeamRecords.teamId eq teamId) and (TeamRecords.recordId eq recordId) }
+            .singleOrNull()
+            ?.let { TeamRecordLocation(it[TeamRecords.scopeId], it[TeamRecords.type]) }
     }
 
     /** Deletes tombstones older than [beforeIso] (ISO-8601 UTC) across all teams. Returns row count. */

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -2,10 +2,14 @@ package app.skerry.server.routes
 
 import app.skerry.server.Services
 import app.skerry.server.accountId
+import app.skerry.server.db.ActivityEvent
+import app.skerry.server.db.AppliedTeamRecord
 import app.skerry.server.db.RekeyOutcome
 import app.skerry.server.db.TeamMemberRow
+import app.skerry.server.db.TeamRecordChange
 import app.skerry.server.db.TeamMemberStatus
 import app.skerry.server.db.TeamRoles
+import app.skerry.server.RateLimits
 import app.skerry.server.jwtPrincipal
 import app.skerry.server.model.ErrorResponse
 import app.skerry.server.model.b64
@@ -26,10 +30,12 @@ import app.skerry.sync.wire.TeamActivityResponse
 import app.skerry.sync.wire.TeamMembersResponse
 import app.skerry.sync.wire.TeamRekeyRequest
 import app.skerry.sync.wire.TeamRoleChangeRequest
+import app.skerry.sync.wire.TeamSessionEventRequest
 import app.skerry.sync.wire.TeamsResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.plugins.BadRequestException
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -289,15 +295,27 @@ fun Route.teamRoutes(services: Services) {
         if (unknown != null) throw BadRequestException("unknown record type: ${unknown.type}")
 
         val result = services.teamRecords.upsert(teamId, scopeId, req.records.map { it.toIncoming() })
-        val ids = req.records.joinToString(" ") { it.id }.take(200)
-        val where = if (scopeId.isEmpty()) "" else " · scope $scopeId"
-        services.activity.record(
-            principal.accountId, "team.push", "${req.records.size} records$where · $ids", teamId = teamId,
-        )
+        // The records are committed; the audit trail is written after them and must not undo that.
+        // A failure here is logged and swallowed on purpose: answering 500 would have the client
+        // retry a push that LWW now treats as a no-op, so `applied` would come back empty and the
+        // entries would never be written anyway — the same audit gap, plus a failed sync on top.
+        try {
+            logRecordChanges(services, principal.accountId, teamId, scopeId, result.applied)
+        } catch (e: Exception) {
+            call.application.environment.log.error("team audit write failed for $teamId (records are committed)", e)
+        }
         if (result.changed) services.notifier.publishTeam(teamId, result.cursor)
         call.respond(PushResponse(result.records.map { it.toDto() }, result.cursor))
     }
 
+    /**
+     * The team's audit log (owner/admin). Rows are **not** filtered by the reader's scope grants: a
+     * manager sees that a record of some type changed in some scope, exactly as they already see the
+     * scope itself and its member count. What a grant gates is the records' contents — a manager
+     * without one still cannot read a name (the feed resolves those locally, and their vault has no
+     * key for that space) let alone a payload. Filtering the log by grant instead would leave the
+     * team's owner unable to audit their own team.
+     */
     get("/teams/{id}/activity") {
         val principal = call.jwtPrincipal()
         val teamId = call.requiredPathId("id") ?: return@get
@@ -305,10 +323,124 @@ fun Route.teamRoutes(services: Services) {
             services, teamId, principal.accountId, TeamRoles::canViewAudit, "audit role required",
         ) ?: return@get
         val entries = services.activity.recentForTeam(teamId).map {
-            TeamActivityDto(it.accountId, it.event, it.detail, it.createdAt)
+            TeamActivityDto(
+                actorAccountId = it.accountId,
+                event = it.event,
+                detail = it.detail,
+                createdAt = it.createdAt,
+                recordId = it.recordId,
+                recordType = it.recordType,
+                scopeId = it.scopeId,
+                durationSec = it.durationSec,
+            )
         }
         call.respond(TeamActivityResponse(entries))
     }
+
+    /**
+     * A member reporting that they opened a session on a shared record, or saved a recording of one.
+     * Any active member may report (connecting is not a privileged act); reading the feed back is
+     * still owner/admin only.
+     *
+     * The record must be one the team actually holds **and** one the caller can see: the space comes
+     * from the stored row, so a report can't file itself under a scope of the reporter's choosing,
+     * and a member without the grant gets the same 404 as anywhere else rather than a confirmation
+     * that the record exists.
+     */
+    // Rate-limited per account (see RateLimits.TEAM_SESSION_EVENTS): unlike every other write here
+    // this one needs no role at all, and it appends to a log with a bounded retention window.
+    rateLimit(RateLimits.TEAM_SESSION_EVENTS) {
+      post("/teams/{id}/session-events") {
+        val principal = call.jwtPrincipal()
+        val teamId = call.requiredPathId("id") ?: return@post
+        val req = call.receive<TeamSessionEventRequest>()
+        // Membership first, as everywhere else in this file: a caller who is not a member gets the
+        // same "no such team" 404 whatever they sent, rather than a 400 confirming the route exists.
+        call.requireActiveMember(services, teamId, principal.accountId) ?: return@post
+        if (req.recordId.isBlank() || anyTooLong(req.recordId)) throw BadRequestException("bad recordId")
+        val event = SESSION_EVENTS[req.kind] ?: throw BadRequestException("unknown kind: ${req.kind}")
+        val duration = req.durationSec?.coerceIn(0, MAX_SESSION_DURATION_SEC)
+        val location = services.teamRecords.locate(teamId, req.recordId)
+        if (location == null) {
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("no such record"))
+            return@post
+        }
+        if (!call.requireScopeAccess(services, teamId, location.scopeId, principal.accountId)) return@post
+        services.activity.recordTeamSession(
+            accountId = principal.accountId,
+            teamId = teamId,
+            event = event,
+            recordId = req.recordId,
+            recordType = location.type,
+            scopeId = location.scopeId,
+            durationSec = duration,
+        )
+        // Created even when the report was collapsed as a duplicate: from the client's side the
+        // report landed, and a retry loop over "already known" would be pointless traffic.
+        call.respond(HttpStatusCode.Created)
+      }
+    }
+}
+
+/** Reportable session kinds (wire value -> audit event). */
+private val SESSION_EVENTS = mapOf("open" to "team.session_open", "record" to "team.session_record")
+
+/** A reported recording longer than this is clamped: a bogus number must not read as fact. */
+private const val MAX_SESSION_DURATION_SEC = 30L * 24 * 3600
+
+/**
+ * How many changed records a push may report one by one. Past it the push gets a single summary
+ * event: a key rotation re-encrypts and re-pushes the whole space at once, and spelling out every
+ * record would flood the feed with "changed" rows that say nothing about anyone's intent (and would
+ * push the rest of the team's history out of retention).
+ */
+internal const val TEAM_RECORD_EVENT_LIMIT = 10
+
+/**
+ * Audit trail of a push: one event per record that actually changed, so the feed can say who touched
+ * which host. Only [applied] records are logged — a client re-pushes all of its records on every
+ * sync cycle, and the ones that lost LWW changed nothing.
+ *
+ * [detail] keeps the human-readable summary for readers with no structured fields (the admin
+ * console, an older client); the record's name is not among them and never leaves the members'
+ * devices.
+ */
+private suspend fun logRecordChanges(
+    services: Services,
+    accountId: String,
+    teamId: String,
+    scopeId: String,
+    applied: List<AppliedTeamRecord>,
+) {
+    if (applied.isEmpty()) return
+    val where = if (scopeId.isEmpty()) "" else " · scope $scopeId"
+    if (applied.size > TEAM_RECORD_EVENT_LIMIT) {
+        services.activity.record(
+            accountId, "team.push", "${applied.size} records$where", teamId = teamId, scopeId = scopeId,
+        )
+        return
+    }
+    // One transaction for the whole batch: these rows describe a single push, and half of them is
+    // worse than none — the client's retry is a no-op by LWW, so a partial write could never be
+    // completed later (see ActivityRepository.recordAll).
+    services.activity.recordAll(
+        applied.map { entry ->
+            val event = when (entry.change) {
+                TeamRecordChange.SHARED -> "team.record_share"
+                TeamRecordChange.CHANGED -> "team.record_change"
+                TeamRecordChange.REMOVED -> "team.record_remove"
+            }
+            ActivityEvent(
+                accountId = accountId,
+                event = event,
+                detail = "${entry.record.type} ${entry.record.id}$where",
+                teamId = teamId,
+                recordId = entry.record.id,
+                recordType = entry.record.type,
+                scopeId = scopeId,
+            )
+        },
+    )
 }
 
 /**

--- a/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
@@ -67,10 +67,15 @@ fun Route.vaultRoutes(services: Services) {
 
         val result = services.records.upsert(principal.accountId, req.records.map { it.toIncoming() })
         services.devices.touch(principal.accountId, principal.deviceId, syncVersion = result.cursor)
-        services.activity.record(
-            principal.accountId, "sync.push", "${req.records.size} records · cursor ${result.cursor}",
-            deviceId = principal.deviceId,
-        )
+        // Log only pushes that changed something, mirroring the empty-pull rule above. A client
+        // re-pushes all of its records on every sync cycle, so without this the log is mostly no-ops
+        // — and its retention window would evict the events (team history) somebody actually reads.
+        if (result.changed) {
+            services.activity.record(
+                principal.accountId, "sync.push", "${req.records.size} records · cursor ${result.cursor}",
+                deviceId = principal.deviceId,
+            )
+        }
         // Notify other devices on the account: "changes exist up to cursor" (no payload). Published only
         // when the cursor actually advanced; a no-op push (same version+deviceId, wins=false) publishes
         // nothing, otherwise live-sync would loop push -> WS -> push (another/the same device pulls the

--- a/server/src/test/kotlin/app/skerry/server/db/ActivityRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/ActivityRepositoryTest.kt
@@ -2,6 +2,8 @@ package app.skerry.server.db
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class ActivityRepositoryTest {
 
@@ -24,6 +26,117 @@ class ActivityRepositoryTest {
         val repo = ActivityRepository(db)
         repo.record("alice@example.com", "device.stale", "no sync for 6 days", now = 5_000)
         assertEquals(null, repo.recent(1).single().deviceId)
+    }
+
+    @Test
+    fun `a team event carries its record subject`() = withTestDb { db ->
+        val repo = ActivityRepository(db)
+        repo.record(
+            "alice@example.com", "team.record_change", "HOST h-1",
+            teamId = "team-1", recordId = "h-1", recordType = "HOST", scopeId = "prod", now = 1_000,
+        )
+
+        val row = repo.recentForTeam("team-1").single()
+        assertEquals("h-1", row.recordId)
+        assertEquals("HOST", row.recordType)
+        assertEquals("prod", row.scopeId)
+        assertEquals(null, row.durationSec)
+    }
+
+    @Test
+    fun `session events collapse repeats inside the dedup window`() = withTestDb { db ->
+        // Reconnect storms (a flapping link reopens the session over and over) must not bury the
+        // rest of the team's history under identical rows.
+        val repo = ActivityRepository(db)
+        val first = repo.recordTeamSession(
+            "alice@example.com", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 100_000,
+        )
+        val repeat = repo.recordTeamSession(
+            "alice@example.com", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 130_000,
+        )
+        assertTrue(first)
+        assertFalse(repeat)
+        assertEquals(1, repo.recentForTeam("team-1").size)
+
+        // Past the window the next connect is news again.
+        assertTrue(
+            repo.recordTeamSession(
+                "alice@example.com", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 300_000,
+            ),
+        )
+        // Another host, another member, and another kind of event are all distinct subjects.
+        assertTrue(
+            repo.recordTeamSession(
+                "alice@example.com", "team-1", "team.session_open", "h-2", "HOST", "", null, now = 300_100,
+            ),
+        )
+        assertTrue(
+            repo.recordTeamSession(
+                "bob@example.com", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 300_200,
+            ),
+        )
+        assertTrue(
+            repo.recordTeamSession(
+                "alice@example.com", "team-1", "team.session_record", "h-1", "HOST", "", 42, now = 300_300,
+            ),
+        )
+        assertEquals(5, repo.recentForTeam("team-1").size)
+        assertEquals(42, repo.recentForTeam("team-1").first().durationSec)
+    }
+
+    @Test
+    fun `a clock that jumped backwards does not wedge the dedup shut`() = withTestDb { db ->
+        // NTP correction or a suspend/resume can stamp a report earlier than the previous one. Treating
+        // that as "recent" would silently drop genuine reports until the clock caught up again.
+        val repo = ActivityRepository(db)
+        assertTrue(repo.recordTeamSession("a", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 300_000))
+        assertTrue(repo.recordTeamSession("a", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 280_000))
+        assertEquals(2, repo.recentForTeam("team-1").size)
+    }
+
+    @Test
+    fun `the same record in another space is a separate subject`() = withTestDb { db ->
+        // A record can move between spaces (an unshare plus a share), and a session in its new space
+        // is a different fact — not a duplicate of the one before the move.
+        val repo = ActivityRepository(db)
+        assertTrue(repo.recordTeamSession("a", "team-1", "team.session_open", "h-1", "HOST", "", null, now = 1_000))
+        assertTrue(repo.recordTeamSession("a", "team-1", "team.session_open", "h-1", "HOST", "prod", null, now = 1_500))
+        assertEquals(2, repo.recentForTeam("team-1").size)
+    }
+
+    @Test
+    fun `one team cannot evict another team's history, nor the account log`() = withTestDb { db ->
+        // Any active member (a viewer included) can append to their team's bucket by reporting
+        // sessions. With one global cap that traffic would push everybody else's audit trail out.
+        val repo = ActivityRepository(db, maxRows = 3, teamMaxRows = 2)
+        repeat(3) { i -> repo.record("a", "auth.login", "login $i", now = i.toLong()) }
+        repeat(2) { i -> repo.record("a", "team.record_change", "b $i", teamId = "team-b", now = 100L + i) }
+
+        repeat(20) { i ->
+            repo.recordTeamSession("flood", "team-a", "team.session_open", "h-$i", "HOST", "", null, now = 200L + i)
+        }
+
+        assertEquals(2, repo.recentForTeam("team-a").size) // the flooder only trims their own bucket
+        assertEquals(listOf("b 1", "b 0"), repo.recentForTeam("team-b").map { it.detail })
+        assertEquals(
+            listOf("login 2", "login 1", "login 0"),
+            repo.recent(50).filter { it.event == "auth.login" }.map { it.detail },
+        )
+    }
+
+    @Test
+    fun `a batch of events lands in one transaction`() = withTestDb { db ->
+        val repo = ActivityRepository(db)
+        repo.recordAll(
+            listOf(
+                ActivityEvent("a", "team.record_share", "HOST h-1", teamId = "team-1", recordId = "h-1"),
+                ActivityEvent("a", "team.record_share", "HOST h-2", teamId = "team-1", recordId = "h-2"),
+            ),
+            now = 5_000,
+        )
+        val rows = repo.recentForTeam("team-1")
+        assertEquals(listOf("h-2", "h-1"), rows.map { it.recordId })
+        assertTrue(rows.all { it.createdAt == 5_000L })
     }
 
     @Test

--- a/server/src/test/kotlin/app/skerry/server/db/TeamRecordRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/TeamRecordRepositoryTest.kt
@@ -60,6 +60,48 @@ class TeamRecordRepositoryTest {
     }
 
     @Test
+    fun `upsert reports which records changed and how`() = withTestDb { db ->
+        // What the team audit log is built from. A push carries every local record on every sync
+        // cycle (SyncEngine pushes all of them), so only the ones that actually won LWW are events.
+        val repo = seedTeam(db)
+
+        val shared = repo.upsert("team-1", teamWide, listOf(rec("r1", 1), rec("r2", 1)))
+        assertEquals(
+            listOf("r1" to TeamRecordChange.SHARED, "r2" to TeamRecordChange.SHARED),
+            shared.applied.map { it.record.id to it.change },
+        )
+
+        val noop = repo.upsert("team-1", teamWide, listOf(rec("r1", 1), rec("r2", 1)))
+        assertTrue(noop.applied.isEmpty())
+        assertFalse(noop.changed)
+
+        val edited = repo.upsert("team-1", teamWide, listOf(rec("r1", 2), rec("r2", 1)))
+        assertEquals(listOf("r1" to TeamRecordChange.CHANGED), edited.applied.map { it.record.id to it.change })
+
+        val removed = repo.upsert("team-1", teamWide, listOf(rec("r1", 3, deleted = true)))
+        assertEquals(listOf("r1" to TeamRecordChange.REMOVED), removed.applied.map { it.record.id to it.change })
+
+        // Sharing over a tombstone is a share again, not an edit of something the team could see.
+        val reshared = repo.upsert("team-1", teamWide, listOf(rec("r1", 4)))
+        assertEquals(listOf("r1" to TeamRecordChange.SHARED), reshared.applied.map { it.record.id to it.change })
+
+        // A stale write that loses LWW changed nothing and must not show up as somebody's edit.
+        val stale = repo.upsert("team-1", teamWide, listOf(rec("r2", 1, blob = byteArrayOf(9))))
+        assertTrue(stale.applied.isEmpty())
+    }
+
+    @Test
+    fun `a push into the wrong scope is not reported as a change`() = withTestDb { db ->
+        val repo = seedTeam(db)
+        TeamScopeRepository(db).create("team-1", "prod", alice, byteArrayOf(1), now = 11)
+        repo.upsert("team-1", "prod", listOf(rec("h1", 1)))
+
+        val intruder = repo.upsert("team-1", teamWide, listOf(rec("h1", 99)))
+
+        assertTrue(intruder.applied.isEmpty())
+    }
+
+    @Test
     fun `LWW breaks version ties by lexicographically greater deviceId`() = withTestDb { db ->
         val repo = seedTeam(db)
         repo.upsert("team-1", teamWide, listOf(rec("r1", 7, deviceId = "devB", blob = byteArrayOf(11))))

--- a/server/src/test/kotlin/app/skerry/server/routes/TeamActivityRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/TeamActivityRoutesTest.kt
@@ -1,0 +1,267 @@
+package app.skerry.server.routes
+
+import app.skerry.server.configureServer
+import app.skerry.server.model.b64
+import app.skerry.sync.wire.PushRequest
+import app.skerry.sync.wire.RecordDto
+import app.skerry.sync.wire.TeamActivityResponse
+import app.skerry.sync.wire.TeamCreateRequest
+import app.skerry.sync.wire.TeamInviteRequest
+import app.skerry.sync.wire.TeamScopeCreateRequest
+import app.skerry.sync.wire.TeamScopeGrantRequest
+import app.skerry.sync.wire.TeamSessionEventRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The team activity feed: what a push writes into the audit log (one event per record that actually
+ * changed) and the client-reported session events.
+ */
+class TeamActivityRoutesTest {
+
+    private val teamId = "team-feed-1"
+    private val pw = "auth-key-hex"
+
+    private suspend fun HttpClient.createTeam(token: String) = post("/teams") {
+        bearerAuth(token)
+        contentType(ContentType.Application.Json)
+        setBody(TeamCreateRequest(teamId))
+    }
+
+    private suspend fun HttpClient.push(
+        token: String,
+        records: List<RecordDto>,
+        scope: String = "",
+    ): HttpResponse {
+        val query = if (scope.isEmpty()) "" else "?scope=$scope"
+        return put("/teams/$teamId/records$query") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(PushRequest(records))
+        }
+    }
+
+    private fun host(id: String, version: Long, deleted: Boolean = false, type: String = "HOST") =
+        RecordDto(id, type, version, "2026-07-26T00:00:00Z", "devA", deleted, byteArrayOf(version.toByte()).b64())
+
+    private suspend fun HttpClient.activity(token: String): TeamActivityResponse =
+        get("/teams/$teamId/activity") { bearerAuth(token) }.body()
+
+    private suspend fun HttpClient.reportSession(
+        token: String,
+        recordId: String,
+        kind: String,
+        durationSec: Long? = null,
+    ) = post("/teams/$teamId/session-events") {
+        bearerAuth(token)
+        contentType(ContentType.Application.Json)
+        setBody(TeamSessionEventRequest(recordId, kind, durationSec))
+    }
+
+    @Test
+    fun `each changed record becomes its own event, unchanged ones none`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.createTeam(owner.accessToken)
+
+        client.push(owner.accessToken, listOf(host("h-1", 1), host("h-2", 1)))
+        client.push(owner.accessToken, listOf(host("h-1", 2), host("h-2", 1))) // h-2 unchanged
+        client.push(owner.accessToken, listOf(host("h-1", 3, deleted = true)))
+
+        val events = client.activity(owner.accessToken).entries
+        // Newest first. The second push must not report h-2 again: a client pushes all of its
+        // records on every sync cycle, and an unchanged one is not somebody's edit.
+        assertEquals(
+            listOf(
+                "team.record_remove" to "h-1",
+                "team.record_change" to "h-1",
+                "team.record_share" to "h-2",
+                "team.record_share" to "h-1",
+            ),
+            events.filter { it.event.startsWith("team.record") }.map { it.event to it.recordId },
+        )
+        val newest = events.first()
+        assertEquals("HOST", newest.recordType)
+        assertEquals("", newest.scopeId)
+        assertEquals("owner@x.io", newest.actorAccountId)
+    }
+
+    @Test
+    fun `a scoped push carries its scope, and a bulk push collapses into one event`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.createTeam(owner.accessToken)
+        assertEquals(
+            HttpStatusCode.Created,
+            client.post("/teams/$teamId/scopes") {
+                bearerAuth(owner.accessToken)
+                contentType(ContentType.Application.Json)
+                setBody(TeamScopeCreateRequest("prod", byteArrayOf(1, 2, 3).b64()))
+            }.status,
+        )
+
+        client.push(owner.accessToken, listOf(host("s-1", 1)), scope = "prod")
+        assertEquals("prod", client.activity(owner.accessToken).entries.first().scopeId)
+
+        // Batch sizes are literal on purpose: derived from TEAM_RECORD_EVENT_LIMIT they would follow
+        // the constant around and stop testing the threshold at all. A limit change should land here.
+        assertEquals(10, TEAM_RECORD_EVENT_LIMIT)
+
+        // A batch at the limit still names every record.
+        client.push(owner.accessToken, (1..10).map { host("a-$it", 1) })
+        val listed = client.activity(owner.accessToken).entries
+        assertEquals(10, listed.count { it.recordId?.startsWith("a-") == true })
+
+        // A key rotation re-encrypts every record in the space and pushes them all at once. Listing
+        // those would bury the feed in "changed" rows that say nothing about anyone's intent, so a
+        // batch past the limit is summarised instead.
+        client.push(owner.accessToken, (1..11).map { host("b-$it", 1) })
+        val events = client.activity(owner.accessToken).entries
+        assertEquals("team.push", events.first().event)
+        assertTrue(events.first().detail.contains("11"))
+        assertNull(events.first().recordId)
+        assertTrue(events.none { it.recordId?.startsWith("b-") == true })
+    }
+
+    @Test
+    fun `session events are reported by members and shown with the record subject`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.post("/teams/$teamId/members") {
+            bearerAuth(owner.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamInviteRequest("editor@x.io", byteArrayOf(1, 2, 3).b64(), "editor"))
+        }
+        client.post("/teams/$teamId/accept") { bearerAuth(editor.accessToken) }
+        client.push(owner.accessToken, listOf(host("h-1", 1)))
+
+        assertEquals(HttpStatusCode.Created, client.reportSession(editor.accessToken, "h-1", "open").status)
+        assertEquals(
+            HttpStatusCode.Created,
+            client.reportSession(editor.accessToken, "h-1", "record", durationSec = 90).status,
+        )
+
+        val events = client.activity(owner.accessToken).entries
+        val recorded = events.first()
+        assertEquals("team.session_record", recorded.event)
+        assertEquals("h-1", recorded.recordId)
+        assertEquals("HOST", recorded.recordType)
+        assertEquals(90, recorded.durationSec)
+        assertEquals("editor@x.io", recorded.actorAccountId)
+        assertEquals("team.session_open", events[1].event)
+    }
+
+    @Test
+    fun `a session event needs a real record of the team and an unknown kind is refused`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val stranger = client.registerAccount("stranger@x.io", pw, deviceId = "d-stranger")
+        client.createTeam(owner.accessToken)
+        client.push(owner.accessToken, listOf(host("h-1", 1)))
+
+        // A record nobody shared into this team: nothing to report about.
+        assertEquals(HttpStatusCode.NotFound, client.reportSession(owner.accessToken, "nope", "open").status)
+        assertEquals(HttpStatusCode.BadRequest, client.reportSession(owner.accessToken, "h-1", "sudo").status)
+        // Not a member — the team must not even be confirmed to exist.
+        assertEquals(HttpStatusCode.NotFound, client.reportSession(stranger.accessToken, "h-1", "open").status)
+        assertTrue(client.activity(owner.accessToken).entries.none { it.event.startsWith("team.session") })
+    }
+
+    @Test
+    fun `a reported duration is clamped, and a malformed report is refused`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        client.createTeam(owner.accessToken)
+        client.push(owner.accessToken, listOf(host("h-1", 1)))
+
+        // A client's number is not to be trusted: a negative one is not a duration, and a month-long
+        // "session" must not be presented to a reader as fact.
+        client.reportSession(owner.accessToken, "h-1", "record", durationSec = -30)
+        assertEquals(0, client.activity(owner.accessToken).entries.first().durationSec)
+        client.reportSession(owner.accessToken, "h-1", "open", durationSec = Long.MAX_VALUE)
+        assertEquals(30L * 24 * 3600, client.activity(owner.accessToken).entries.first().durationSec)
+
+        assertEquals(HttpStatusCode.BadRequest, client.reportSession(owner.accessToken, "", "open").status)
+        assertEquals(
+            HttpStatusCode.BadRequest,
+            client.reportSession(owner.accessToken, "x".repeat(500), "open").status,
+        )
+    }
+
+    @Test
+    fun `a non-member learns nothing from a malformed report either`() = testApplication {
+        // Membership is checked before the body: otherwise a stranger sending a bad kind would get a
+        // 400 confirming the route (and the team) exists, where a well-formed one gets 404.
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val stranger = client.registerAccount("stranger@x.io", pw, deviceId = "d-stranger")
+        client.createTeam(owner.accessToken)
+        client.push(owner.accessToken, listOf(host("h-1", 1)))
+
+        assertEquals(HttpStatusCode.NotFound, client.reportSession(stranger.accessToken, "h-1", "sudo").status)
+        assertEquals(HttpStatusCode.NotFound, client.reportSession(stranger.accessToken, "", "open").status)
+    }
+
+    @Test
+    fun `a scoped record can only be reported by someone holding the scope`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val owner = client.registerAccount("owner@x.io", pw, deviceId = "d-owner")
+        val editor = client.registerAccount("editor@x.io", pw, deviceId = "d-editor")
+        client.createTeam(owner.accessToken)
+        client.post("/teams/$teamId/members") {
+            bearerAuth(owner.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamInviteRequest("editor@x.io", byteArrayOf(1, 2, 3).b64(), "editor"))
+        }
+        client.post("/teams/$teamId/accept") { bearerAuth(editor.accessToken) }
+        client.post("/teams/$teamId/scopes") {
+            bearerAuth(owner.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeCreateRequest("prod", byteArrayOf(1, 2, 3).b64()))
+        }
+        client.push(owner.accessToken, listOf(host("p-1", 1)), scope = "prod")
+
+        // Without a grant the record is invisible: reporting a session on it would confirm it exists.
+        assertEquals(HttpStatusCode.NotFound, client.reportSession(editor.accessToken, "p-1", "open").status)
+
+        client.post("/teams/$teamId/scopes/prod/grants") {
+            bearerAuth(owner.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamScopeGrantRequest("editor@x.io", byteArrayOf(4, 5, 6).b64()))
+        }
+        assertEquals(HttpStatusCode.Created, client.reportSession(editor.accessToken, "p-1", "open").status)
+        assertEquals("prod", client.activity(owner.accessToken).entries.first().scopeId)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamActivityFeed.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamActivityFeed.kt
@@ -1,0 +1,162 @@
+package app.skerry.shared.team
+
+import app.skerry.shared.vault.RecordType
+
+/**
+ * What a team event is, resolved from the server's event code. The code stays on the row ([UNKNOWN]
+ * carries it) so a client older than the server it talks to shows the event instead of hiding it.
+ */
+enum class TeamActivityKind {
+    TEAM_CREATE, TEAM_DELETE,
+    MEMBER_INVITE, MEMBER_JOIN, MEMBER_REMOVE, MEMBER_ROLE,
+    KEY_ROTATE,
+    SCOPE_CREATE, SCOPE_DELETE, SCOPE_GRANT, SCOPE_REVOKE, SCOPE_KEY_ROTATE,
+
+    /** One record shared into the space, edited there, or taken out of it. */
+    RECORD_SHARE, RECORD_CHANGE, RECORD_REMOVE,
+
+    /** A push too large to list record by record (a key rotation re-encrypts the whole space). */
+    RECORDS_BULK,
+
+    /** Client-reported: a session was opened on a shared host, or a recording of one was saved. */
+    SESSION_OPEN, SESSION_RECORD,
+
+    UNKNOWN,
+    ;
+
+    /** Which filter chip the event belongs to; [TeamActivityCategory.ALL] never filters anything out. */
+    val category: TeamActivityCategory
+        get() = when (this) {
+            RECORD_SHARE, RECORD_CHANGE, RECORD_REMOVE, RECORDS_BULK -> TeamActivityCategory.RECORDS
+            TEAM_CREATE, TEAM_DELETE, MEMBER_INVITE, MEMBER_JOIN, MEMBER_REMOVE, MEMBER_ROLE ->
+                TeamActivityCategory.MEMBERS
+            KEY_ROTATE, SCOPE_CREATE, SCOPE_DELETE, SCOPE_GRANT, SCOPE_REVOKE, SCOPE_KEY_ROTATE ->
+                TeamActivityCategory.ACCESS
+            SESSION_OPEN, SESSION_RECORD -> TeamActivityCategory.SESSIONS
+            UNKNOWN -> TeamActivityCategory.ALL
+        }
+
+    /**
+     * Whether the event was asserted by a member's client rather than observed by the server. The
+     * server has no part in an SSH connection, so a session event is a collaboration signal, not
+     * proof — the feed says so rather than presenting the two on equal footing.
+     */
+    val clientReported: Boolean get() = this == SESSION_OPEN || this == SESSION_RECORD
+}
+
+/** Filter chips over the feed. [ALL] keeps everything, including events this client can't name. */
+enum class TeamActivityCategory { ALL, RECORDS, MEMBERS, ACCESS, SESSIONS }
+
+/**
+ * One readable line of the feed. [subject] is the record's name resolved from the member's own copy
+ * of the share space, falling back to a short id when the name is gone ([subjectResolved] says
+ * which) — an unshared record leaves a tombstone with no payload, and "someone removed something"
+ * still belongs in an audit log. [detail] is the server's raw summary, kept for [TeamActivityKind
+ * .UNKNOWN] and bulk rows.
+ */
+class TeamActivityRow(
+    val kind: TeamActivityKind,
+    /** Raw server event code — for [TeamActivityKind.UNKNOWN], the only thing there is to show. */
+    val event: String,
+    val actorAccountId: String,
+    /** The actor is this account (any of its devices), so the UI can say "you". */
+    val isSelf: Boolean,
+    val createdAt: Long,
+    val recordId: String? = null,
+    val recordType: RecordType? = null,
+    val subject: String? = null,
+    val subjectResolved: Boolean = false,
+    /** Name of the scope the event happened in; null for the team-wide space. */
+    val scopeName: String? = null,
+    val detail: String = "",
+    val durationSec: Long? = null,
+) {
+    val clientReported: Boolean get() = kind.clientReported
+}
+
+/** Rows of one UTC day, newest first. [dayIndex] is whole days since the epoch (a grouping key). */
+class TeamActivityDay(val dayIndex: Long, val rows: List<TeamActivityRow>)
+
+/** Length of the id prefix standing in for a name that can no longer be resolved. */
+private const val SHORT_ID_LENGTH = 8
+
+private const val MILLIS_PER_DAY = 86_400_000L
+
+private val EVENT_KINDS = mapOf(
+    "team.create" to TeamActivityKind.TEAM_CREATE,
+    "team.delete" to TeamActivityKind.TEAM_DELETE,
+    "team.invite" to TeamActivityKind.MEMBER_INVITE,
+    "team.accept" to TeamActivityKind.MEMBER_JOIN,
+    "team.remove" to TeamActivityKind.MEMBER_REMOVE,
+    "team.role_change" to TeamActivityKind.MEMBER_ROLE,
+    "team.rekey" to TeamActivityKind.KEY_ROTATE,
+    "team.scope_create" to TeamActivityKind.SCOPE_CREATE,
+    "team.scope_delete" to TeamActivityKind.SCOPE_DELETE,
+    "team.scope_grant" to TeamActivityKind.SCOPE_GRANT,
+    "team.scope_revoke" to TeamActivityKind.SCOPE_REVOKE,
+    "team.scope_rekey" to TeamActivityKind.SCOPE_KEY_ROTATE,
+    "team.record_share" to TeamActivityKind.RECORD_SHARE,
+    "team.record_change" to TeamActivityKind.RECORD_CHANGE,
+    "team.record_remove" to TeamActivityKind.RECORD_REMOVE,
+    // Written by this server for an oversized push, and by any server older than per-record events.
+    "team.push" to TeamActivityKind.RECORDS_BULK,
+    "team.session_open" to TeamActivityKind.SESSION_OPEN,
+    "team.session_record" to TeamActivityKind.SESSION_RECORD,
+)
+
+/**
+ * Builds the members' activity feed out of the server's audit metadata: names the events, resolves
+ * record and scope names locally (the server holds neither), and groups the result by UTC day,
+ * newest first.
+ *
+ * The resolvers are the zero-knowledge seam. [resolveRecordName] is handed `(scopeId, recordId)` and
+ * looks the record up in that share space's own vault — which is why the same id may be nameless for
+ * one reader (a manager holding no grant on the scope) and named for another, and why a name never
+ * has to travel through the server for this feed to be readable.
+ *
+ * [onlyRecordId] narrows the feed to one record's history ("who touched this host"); a bulk summary
+ * covers a whole space and is dropped from it, since it says nothing about that record in particular.
+ */
+fun buildTeamActivityFeed(
+    entries: List<TeamActivityEntry>,
+    selfAccountId: String?,
+    category: TeamActivityCategory = TeamActivityCategory.ALL,
+    onlyRecordId: String? = null,
+    resolveRecordName: (scopeId: String, recordId: String) -> String? = { _, _ -> null },
+    resolveScopeName: (scopeId: String) -> String? = { null },
+): List<TeamActivityDay> = entries
+    .asSequence()
+    .filter { onlyRecordId == null || it.recordId == onlyRecordId }
+    .map { entry -> entry.toRow(selfAccountId, resolveRecordName, resolveScopeName) }
+    .filter { category == TeamActivityCategory.ALL || it.kind.category == category }
+    .toList()
+    // Stable, so events written in the same millisecond (one push logs several) keep the server's
+    // own order — its descending sequence is the only ordering they have.
+    .sortedByDescending { it.createdAt }
+    .groupBy { it.createdAt.floorDiv(MILLIS_PER_DAY) }
+    .map { (day, rows) -> TeamActivityDay(day, rows) }
+    .sortedByDescending { it.dayIndex }
+
+private fun TeamActivityEntry.toRow(
+    selfAccountId: String?,
+    resolveRecordName: (String, String) -> String?,
+    resolveScopeName: (String) -> String?,
+): TeamActivityRow {
+    val scope = scopeId.orEmpty()
+    val name = recordId?.let { resolveRecordName(scope, it) }
+    return TeamActivityRow(
+        kind = EVENT_KINDS[event] ?: TeamActivityKind.UNKNOWN,
+        event = event,
+        actorAccountId = actorAccountId,
+        isSelf = selfAccountId != null && actorAccountId == selfAccountId,
+        createdAt = createdAt,
+        recordId = recordId,
+        recordType = recordType?.let { type -> RecordType.entries.firstOrNull { it.name == type } },
+        subject = name ?: recordId?.take(SHORT_ID_LENGTH),
+        subjectResolved = name != null,
+        // The team-wide space has no name of its own; only a scope is worth pointing at.
+        scopeName = scope.takeIf { it.isNotEmpty() }?.let { resolveScopeName(it) ?: it },
+        detail = detail,
+        durationSec = durationSec,
+    )
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
@@ -41,13 +41,32 @@ enum class TeamRole {
     }
 }
 
-/** Team audit log entry: actor, event, human-readable summary (no record contents). */
+/**
+ * Team audit log entry: actor, event, human-readable summary (no record contents), and — for events
+ * about one record — which record it was ([recordId], [recordType]) and the share space it lives in
+ * ([scopeId], empty = team-wide). The record's **name** is deliberately absent: the server never
+ * learns it, so each client resolves it from its own copy of the space (see [TeamActivityFeed]).
+ */
 class TeamActivityEntry(
     val actorAccountId: String,
     val event: String,
     val detail: String,
     val createdAt: Long,
+    val recordId: String? = null,
+    val recordType: String? = null,
+    val scopeId: String? = null,
+    /** Length of a reported session recording, in seconds. */
+    val durationSec: Long? = null,
 )
+
+/** What a member reports about a session on a shared record (see [TeamClient.reportSessionEvent]). */
+enum class TeamSessionKind(val wire: String) {
+    /** A session to the shared host was opened. */
+    OPEN("open"),
+
+    /** A recording of a session on the shared host was saved. */
+    RECORD("record"),
+}
 
 /** Membership status. Unknown string degrades to [INVITED] (no record access). */
 enum class TeamMemberStatus { INVITED, ACTIVE;
@@ -120,6 +139,23 @@ interface TeamClient {
 
     /** Team audit log (owner/admin); newest events first. */
     suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry>
+
+    /**
+     * Reports a session on a record shared with the team, for the members' activity feed. Any active
+     * member may report; the server derives the share space from the record itself and rejects a
+     * record the team doesn't hold (or the caller can't see).
+     *
+     * Unverifiable by design — the server takes no part in an SSH connection — so this is a
+     * collaboration signal rather than proof, and a member who turns reporting off simply sends
+     * nothing.
+     */
+    suspend fun reportSessionEvent(
+        session: SyncSession,
+        teamId: String,
+        recordId: String,
+        kind: TeamSessionKind,
+        durationSec: Long? = null,
+    )
 
     /** Removes a member as owner, leaves the team, or declines an invite (target = self). */
     suspend fun removeMember(session: SyncSession, teamId: String, accountId: String)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamActivityFeedTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamActivityFeedTest.kt
@@ -1,0 +1,250 @@
+package app.skerry.shared.team
+
+import app.skerry.shared.vault.RecordType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Turning the server's audit metadata into rows a member can read. */
+class TeamActivityFeedTest {
+
+    private val day = 86_400_000L
+    private val self = "me@x.io"
+
+    private fun entry(
+        event: String,
+        actor: String = "bob@x.io",
+        at: Long = day * 20_000,
+        recordId: String? = null,
+        recordType: String? = null,
+        scopeId: String? = null,
+        detail: String = "",
+        durationSec: Long? = null,
+    ) = TeamActivityEntry(actor, event, detail, at, recordId, recordType, scopeId, durationSec)
+
+    private fun feed(
+        entries: List<TeamActivityEntry>,
+        category: TeamActivityCategory = TeamActivityCategory.ALL,
+        onlyRecordId: String? = null,
+        names: Map<String, String> = emptyMap(),
+        scopes: Map<String, String> = emptyMap(),
+    ) = buildTeamActivityFeed(
+        entries = entries,
+        selfAccountId = self,
+        category = category,
+        onlyRecordId = onlyRecordId,
+        resolveRecordName = { _, id -> names[id] },
+        resolveScopeName = { id -> scopes[id] },
+    )
+
+    @Test
+    fun `a record event reads as who did what to which host`() {
+        val rows = feed(
+            listOf(entry("team.record_change", recordId = "h-1", recordType = "HOST", scopeId = "prod")),
+            names = mapOf("h-1" to "prod-db-01"),
+            scopes = mapOf("prod" to "Production"),
+        ).single().rows.single()
+
+        assertEquals(TeamActivityKind.RECORD_CHANGE, rows.kind)
+        assertEquals("prod-db-01", rows.subject)
+        assertTrue(rows.subjectResolved)
+        assertEquals(RecordType.HOST, rows.recordType)
+        assertEquals("Production", rows.scopeName)
+        assertFalse(rows.isSelf)
+    }
+
+    @Test
+    fun `a name we cannot resolve degrades to a short id, never to nothing`() {
+        // An unshared record leaves a tombstone with no payload, so its name is gone from the space.
+        // Showing the row anyway is the point of an audit log — "someone removed something" beats
+        // silence, and the short id still ties several rows about the same record together.
+        val row = feed(
+            listOf(entry("team.record_remove", recordId = "0123456789abcdef", recordType = "HOST")),
+        ).single().rows.single()
+
+        assertEquals("01234567", row.subject)
+        assertFalse(row.subjectResolved)
+        assertEquals("0123456789abcdef", row.recordId)
+        // Team-wide space: no scope to name.
+        assertNull(row.scopeName)
+    }
+
+    @Test
+    fun `an unnamed scope falls back to its id and an empty scope means team-wide`() {
+        val rows = feed(
+            listOf(
+                entry("team.record_share", recordId = "h-1", scopeId = "staging", at = day * 20_000 + 2),
+                entry("team.record_share", recordId = "h-2", scopeId = "", at = day * 20_000 + 1),
+            ),
+        ).single().rows
+
+        assertEquals("staging", rows[0].scopeName)
+        assertNull(rows[1].scopeName)
+    }
+
+    @Test
+    fun `own actions are marked as ours`() {
+        val row = feed(listOf(entry("team.record_share", actor = self, recordId = "h-1"))).single().rows.single()
+        assertTrue(row.isSelf)
+    }
+
+    @Test
+    fun `every event the server can write has a kind, and an unknown one still shows up`() {
+        val known = listOf(
+            "team.create" to TeamActivityKind.TEAM_CREATE,
+            "team.delete" to TeamActivityKind.TEAM_DELETE,
+            "team.invite" to TeamActivityKind.MEMBER_INVITE,
+            "team.accept" to TeamActivityKind.MEMBER_JOIN,
+            "team.remove" to TeamActivityKind.MEMBER_REMOVE,
+            "team.role_change" to TeamActivityKind.MEMBER_ROLE,
+            "team.rekey" to TeamActivityKind.KEY_ROTATE,
+            "team.scope_create" to TeamActivityKind.SCOPE_CREATE,
+            "team.scope_delete" to TeamActivityKind.SCOPE_DELETE,
+            "team.scope_grant" to TeamActivityKind.SCOPE_GRANT,
+            "team.scope_revoke" to TeamActivityKind.SCOPE_REVOKE,
+            "team.scope_rekey" to TeamActivityKind.SCOPE_KEY_ROTATE,
+            "team.record_share" to TeamActivityKind.RECORD_SHARE,
+            "team.record_change" to TeamActivityKind.RECORD_CHANGE,
+            "team.record_remove" to TeamActivityKind.RECORD_REMOVE,
+            "team.push" to TeamActivityKind.RECORDS_BULK,
+            "team.session_open" to TeamActivityKind.SESSION_OPEN,
+            "team.session_record" to TeamActivityKind.SESSION_RECORD,
+        )
+        known.forEach { (event, kind) ->
+            assertEquals(kind, feed(listOf(entry(event))).single().rows.single().kind, event)
+        }
+
+        // A self-hosted server newer than this client: the event is unreadable but not invisible.
+        val unknown = feed(listOf(entry("team.quantum_leap", detail = "42"))).single().rows.single()
+        assertEquals(TeamActivityKind.UNKNOWN, unknown.kind)
+        assertEquals("team.quantum_leap", unknown.event)
+        assertEquals("42", unknown.detail)
+    }
+
+    @Test
+    fun `rows are grouped by day, newest day first`() {
+        val rows = listOf(
+            entry("team.create", at = day * 20_000 + 3_600_000),
+            entry("team.invite", at = day * 20_001 + 60_000),
+            entry("team.accept", at = day * 20_001 + 120_000),
+        )
+        val days = feed(rows)
+
+        assertEquals(2, days.size)
+        assertEquals(20_001, days[0].dayIndex)
+        assertEquals(listOf(TeamActivityKind.MEMBER_JOIN, TeamActivityKind.MEMBER_INVITE), days[0].rows.map { it.kind })
+        assertEquals(20_000, days[1].dayIndex)
+    }
+
+    @Test
+    fun `events sharing a timestamp keep the order the server sent them in`() {
+        // One push writes an event per record with the same millisecond; the server's own order
+        // (descending seq) is the only sequence there is, so sorting must not shuffle them.
+        val same = day * 20_000
+        val days = feed(
+            listOf(
+                entry("team.record_share", recordId = "c", at = same),
+                entry("team.record_share", recordId = "b", at = same),
+                entry("team.record_share", recordId = "a", at = same),
+            ),
+        )
+        assertEquals(listOf("c", "b", "a"), days.single().rows.map { it.recordId })
+    }
+
+    @Test
+    fun `entries out of order are sorted newest first`() {
+        val days = feed(
+            listOf(
+                entry("team.create", at = day * 20_000),
+                entry("team.invite", at = day * 20_000 + 5),
+            ),
+        )
+        assertEquals(listOf(TeamActivityKind.MEMBER_INVITE, TeamActivityKind.TEAM_CREATE), days.single().rows.map { it.kind })
+    }
+
+    @Test
+    fun `a category filter keeps only its own events`() {
+        val entries = listOf(
+            entry("team.record_change", recordId = "h-1"),
+            entry("team.invite"),
+            entry("team.rekey"),
+            entry("team.session_open", recordId = "h-1"),
+            entry("team.scope_grant"),
+        )
+        fun kinds(c: TeamActivityCategory) = feed(entries, category = c).flatMap { it.rows }.map { it.kind }
+
+        assertEquals(listOf(TeamActivityKind.RECORD_CHANGE), kinds(TeamActivityCategory.RECORDS))
+        assertEquals(listOf(TeamActivityKind.MEMBER_INVITE), kinds(TeamActivityCategory.MEMBERS))
+        assertEquals(
+            listOf(TeamActivityKind.KEY_ROTATE, TeamActivityKind.SCOPE_GRANT),
+            kinds(TeamActivityCategory.ACCESS),
+        )
+        assertEquals(listOf(TeamActivityKind.SESSION_OPEN), kinds(TeamActivityCategory.SESSIONS))
+        assertEquals(5, kinds(TeamActivityCategory.ALL).size)
+    }
+
+    @Test
+    fun `the history of one record shows only what happened to it`() {
+        val entries = listOf(
+            entry("team.record_change", recordId = "h-1"),
+            entry("team.session_open", recordId = "h-1"),
+            entry("team.record_change", recordId = "h-2"),
+            entry("team.rekey"),
+            // A bulk summary covers the whole space, so it says nothing about this record in particular.
+            entry("team.push", detail = "40 records"),
+        )
+        val rows = feed(entries, onlyRecordId = "h-1").flatMap { it.rows }
+
+        assertEquals(
+            listOf(TeamActivityKind.RECORD_CHANGE, TeamActivityKind.SESSION_OPEN),
+            rows.map { it.kind },
+        )
+        assertTrue(rows.all { it.recordId == "h-1" })
+    }
+
+    @Test
+    fun `a reported recording keeps its length and a session event is flagged as client-reported`() {
+        val rows = feed(
+            listOf(
+                entry("team.session_record", recordId = "h-1", durationSec = 754),
+                entry("team.record_change", recordId = "h-1", at = day * 20_000 - 1),
+            ),
+        ).flatMap { it.rows }
+
+        assertEquals(754, rows[0].durationSec)
+        assertTrue(rows[0].clientReported)
+        assertFalse(rows[1].clientReported)
+        assertNull(rows[1].durationSec)
+    }
+
+    @Test
+    fun `the reportable session kinds keep the wire values the server accepts`() {
+        // The server's own map of accepted kinds lives in another module (TeamRoutes.SESSION_EVENTS)
+        // and is keyed by these literals, so nothing but this assertion ties the two together: a
+        // rename here would turn every session report into a silently swallowed 400.
+        assertEquals("open", TeamSessionKind.OPEN.wire)
+        assertEquals("record", TeamSessionKind.RECORD.wire)
+    }
+
+    @Test
+    fun `an empty log is an empty feed, not a day with no rows`() {
+        assertTrue(feed(emptyList()).isEmpty())
+        assertTrue(feed(listOf(entry("team.invite")), category = TeamActivityCategory.SESSIONS).isEmpty())
+    }
+
+    @Test
+    fun `the record type comes through as the vault's own, unknown ones as none`() {
+        fun typeOf(type: String?) =
+            feed(listOf(entry("team.record_change", recordId = "x", recordType = type)))
+                .single().rows.single().recordType
+
+        assertEquals(RecordType.HOST, typeOf("HOST"))
+        assertEquals(RecordType.SNIPPET, typeOf("SNIPPET"))
+        assertEquals(RecordType.CREDENTIAL, typeOf("CREDENTIAL"))
+        // A type this client's vault doesn't know must not break the row it belongs to.
+        assertNull(typeOf("PLASMA_CONDUIT"))
+        assertNull(typeOf(null))
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
@@ -68,6 +68,13 @@ class TeamSyncRoundTripTest {
         override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
         override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
         override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
         override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
         override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = error("unused")

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -25,6 +25,7 @@ import com.nimbusds.srp6.SRP6Exception
 import com.nimbusds.srp6.SRP6VerifierGenerator
 import app.skerry.shared.team.AccountKeys
 import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
@@ -37,6 +38,7 @@ import app.skerry.sync.wire.AccountKeyResponse
 import app.skerry.sync.wire.PublishKeyRequest
 import app.skerry.sync.wire.RekeyEnvelopeDto
 import app.skerry.sync.wire.TeamActivityResponse
+import app.skerry.sync.wire.TeamSessionEventRequest
 import app.skerry.sync.wire.TeamCreateRequest
 import app.skerry.sync.wire.TeamInviteRequest
 import app.skerry.sync.wire.TeamMembersResponse
@@ -359,7 +361,32 @@ class KtorSyncClient(
         val resp: TeamActivityResponse = get("/teams/${teamId.encodeURLPathPart()}/activity") {
             bearerAuth(session.accessToken)
         }.bodyChecked()
-        return resp.entries.map { TeamActivityEntry(it.actorAccountId, it.event, it.detail, it.createdAt) }
+        return resp.entries.map {
+            TeamActivityEntry(
+                actorAccountId = it.actorAccountId,
+                event = it.event,
+                detail = it.detail,
+                createdAt = it.createdAt,
+                recordId = it.recordId,
+                recordType = it.recordType,
+                scopeId = it.scopeId,
+                durationSec = it.durationSec,
+            )
+        }
+    }
+
+    override suspend fun reportSessionEvent(
+        session: SyncSession,
+        teamId: String,
+        recordId: String,
+        kind: TeamSessionKind,
+        durationSec: Long?,
+    ) {
+        post("/teams/${teamId.encodeURLPathPart()}/session-events") {
+            bearerAuth(session.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamSessionEventRequest(recordId, kind.wire, durationSec))
+        }.expectSuccess()
     }
 
     override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
@@ -92,6 +92,13 @@ data class RekeyEnvelopeDto(val accountId: String, val envelope: String)
 /**
  * Team audit entry (`GET /teams/{id}/activity`). Zero-knowledge: metadata only — actor, event,
  * and a human-readable summary ([detail], no record contents).
+ *
+ * [recordId]/[recordType]/[scopeId] name the *subject* of a record event (`team.record_share`,
+ * `team.record_change`, `team.record_remove`) or of a session event. Ids and types are metadata the
+ * server already stores; the record's **name** is not here and never reaches the server — each
+ * client resolves it from its own copy of the share space. Absent for events with no record subject
+ * (membership, keys, and a bulk `team.push` summary). [durationSec] is set only on a reported
+ * session recording. All four default to null so an older client keeps parsing the response.
  */
 @Serializable
 data class TeamActivityDto(
@@ -99,10 +106,31 @@ data class TeamActivityDto(
     val event: String,
     val detail: String,
     val createdAt: Long,
+    val recordId: String? = null,
+    val recordType: String? = null,
+    val scopeId: String? = null,
+    val durationSec: Long? = null,
 )
 
 @Serializable
 data class TeamActivityResponse(val entries: List<TeamActivityDto>)
+
+/**
+ * A client's report that it opened a session on a shared record, or saved a recording of one
+ * (`POST /teams/{id}/session-events`). [kind] is `open` or `record`; [durationSec] belongs to a
+ * recording.
+ *
+ * Unlike everything else in the feed, this is **asserted by the client**, not observed by the
+ * server: the server has no part in an SSH connection and cannot verify (or miss) one. A member who
+ * turns reporting off simply reports nothing, so the session part of the feed is a collaboration
+ * signal, not proof — the UI says so where it shows it.
+ */
+@Serializable
+data class TeamSessionEventRequest(
+    val recordId: String,
+    val kind: String,
+    val durationSec: Long? = null,
+)
 
 // --- scopes (granular sharing inside a team) ---
 


### PR DESCRIPTION
The team's audit log becomes readable: every change to a shared record shows up as "changed host prod-db-01" with the actor, the area and the time, and members' apps report sessions opened on shared hosts.

**Where**
- Teams → a team → **History** (owner/admin), with filter chips: All / Records / Members / Access / Sessions.
- The history icon on a shared host or snippet row opens that record's own history.
- Settings → Security → **Report sessions on shared hosts** (on by default). Android: More → Security.

**Behavior**
- A push writes one event per record that actually changed (`team.record_share` / `team.record_change` / `team.record_remove`), carrying the record id, its type and its share space. A client re-pushes all of its records on every sync cycle, so unchanged ones produce nothing; a batch past ten records (a key rotation re-encrypts a whole space) collapses into one summary.
- Record **names** never reach the server. The feed resolves an id to a name from the reader's own copy of the share space; a record that has since been unshared, or one in an area the reader holds no grant for, falls back to a short id and keeps its row.
- `POST /teams/{id}/session-events`: any active member may report that they opened a session on a shared record or saved a recording of one. The share space comes from the stored record, so a report cannot be filed under someone else's area; a member without the grant gets the same 404 as anywhere else. Repeats of the same subject inside a minute collapse, so a reconnect storm doesn't bury the rest of the history.
- Session events are asserted by the member's client — the server takes no part in an SSH connection and cannot confirm one. The feed says so, and hosts that are not shared with a team are reported nowhere at all, whatever the setting.
- Rekey, role changes and every area event now have their own labels; previously they rendered as "other event".

**Also in this PR**
- The audit log's retention is per bucket: each team keeps its own newest rows, account-level events keep theirs. Under one global cap, any member could evict another team's history — or the admin console's — by reporting sessions.
- `/session-events` has a rate-limit budget of its own, keyed by account rather than by IP.
- The events of one push are written in a single transaction: written row by row a failure halfway could never be completed, since the client's retry is a no-op by LWW.
- `sync.push` in the personal vault is logged only when something changed.
- New nullable columns on `activity_log` (record id, type, area, duration) — added by the existing schema migration; no manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
