### PR TITLE
Prometheus /metrics, /readyz and the skerry-admin CLI for the sync server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       # REQUIRED: set a stable secret in production (otherwise tokens are invalidated on restart):
       SKERRY_JWT_SECRET: ${SKERRY_JWT_SECRET:-dev-insecure-change-me}
       SKERRY_ADMIN_TOKEN: ${SKERRY_ADMIN_TOKEN:-}
+      # --- Prometheus /metrics (optional) ---
+      # Off by default. `token` requires SKERRY_METRICS_TOKEN and is what a scraper should use;
+      # `open` publishes instance metadata (account/device counts, storage size) to anyone who asks.
+      # SKERRY_METRICS: token
+      # SKERRY_METRICS_TOKEN: ${SKERRY_METRICS_TOKEN:-}
       # --- PostgreSQL (optional) ---
       # SKERRY_DB_URL: jdbc:postgresql://db:5432/skerry
       # SKERRY_DB_USER: skerry

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,10 @@ postgresql = "42.7.13"
 hikari = "7.1.0"
 # Nimbus SRP6a — an audited SRP-6a implementation, used by the server and the JVM sync client
 nimbus-srp = "2.1.0"
+# Micrometer + its Prometheus registry — the sync server's /metrics exposition. 1.16.5 is the
+# version ktor-server-metrics-micrometer 3.5.1 is built against; keeping them equal avoids a
+# mixed-version registry. Server-only: the clients ship no metrics.
+micrometer = "1.16.5"
 # --- Fast device pairing (option B): QR generation + camera scanner ---
 # ZXing core — pure Java (works on both desktop JVM and Android), generates the pairing QR matrix
 zxing = "3.5.4"
@@ -109,6 +113,8 @@ ktor-server-call-logging = { module = "io.ktor:ktor-server-call-logging", versio
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-rate-limit = { module = "io.ktor:ktor-server-rate-limit", version.ref = "ktor" }
 ktor-server-default-headers = { module = "io.ktor:ktor-server-default-headers", version.ref = "ktor" }
+ktor-server-metrics-micrometer = { module = "io.ktor:ktor-server-metrics-micrometer", version.ref = "ktor" }
+micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }

--- a/server/.env.example
+++ b/server/.env.example
@@ -43,7 +43,26 @@ SKERRY_PAIRING_TTL=300
 SKERRY_TOMBSTONE_DAYS=90
 
 # Admin console token (/console and /admin/stats). Empty ⇒ stats endpoints are closed.
+# Also the credential for the `skerry-admin` CLI (SKERRY_ADMIN_TOKEN in its environment).
 SKERRY_ADMIN_TOKEN=
+
+# Prometheus exposition on /metrics: off | token | open. Default: off, and while off the endpoint
+# answers 404 — it doesn't announce itself.
+#   token ⇒ requires "Authorization: Bearer $SKERRY_METRICS_TOKEN"; the server refuses to start if
+#           the token is empty (a typo must not publish the exposition).
+#   open  ⇒ no credential. Only when /metrics is unreachable from outside the host: the exposition
+#           tells anyone how many accounts and devices the instance has, how much ciphertext it
+#           stores, how often logins fail, and which version is running.
+# The metrics token is deliberately separate from SKERRY_ADMIN_TOKEN: that one also authorizes
+# account deletion, and a scraper's config file has no business holding it.
+SKERRY_METRICS=off
+SKERRY_METRICS_TOKEN=
+
+# How often the inventory gauges (accounts, devices, records, storage size) are refreshed in the
+# background. They are never computed during a scrape: the default SQLite pool is a single
+# connection, so summing blob sizes per scrape would compete with every push and pull.
+# Minimum 15 seconds; 0 disables the inventory (counters, JVM and pool metrics keep working).
+SKERRY_METRICS_INVENTORY_SECONDS=60
 
 # Local development only: SKERRY_DEV=1 lifts the fail-fast guard on the default
 # JWT secret. Production must set a real SKERRY_JWT_SECRET instead.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -20,9 +20,11 @@ RUN groupadd --system --gid 999 skerry && useradd --system --uid 999 --gid skerr
 USER skerry
 
 # SQLite file lives in the /data volume by default; mount a volume for persistence.
+# /app/bin on PATH so the admin CLI is callable by name: `docker exec <c> skerry-admin stats`.
 ENV SKERRY_HOST=0.0.0.0 \
     SKERRY_PORT=8080 \
-    SKERRY_DB_URL=jdbc:sqlite:/data/skerry-sync.db
+    SKERRY_DB_URL=jdbc:sqlite:/data/skerry-sync.db \
+    PATH="/app/bin:${PATH}"
 VOLUME ["/data"]
 EXPOSE 8080
 

--- a/server/README.md
+++ b/server/README.md
@@ -53,7 +53,8 @@ volume (SQLite). To switch to PostgreSQL, uncomment the `db` service and the pos
 variables in `docker-compose.yml`.
 
 The container runs as an unprivileged user, exposes a `/healthz` healthcheck, and the image
-builds with `-PserverOnly` — no Android SDK required.
+builds with `-PserverOnly` — no Android SDK required. The administration CLI ships alongside it:
+`docker exec skerry-sync skerry-admin --help`.
 
 ### Local (Gradle)
 
@@ -83,6 +84,9 @@ runs — production only *requires* a stable `SKERRY_JWT_SECRET`.
 | `SKERRY_CORS_HOSTS` | *(empty)* | Comma-separated allowed CORS origins. Empty disables CORS (native clients aren't subject to it). |
 | `SKERRY_MAX_BODY_BYTES` | `4194304` (4 MiB) | Request-body cap (OOM/abuse guard); larger requests get `413`. |
 | `SKERRY_DEV` | *(unset)* | `1` unlocks the default JWT secret for local development only. |
+| `SKERRY_METRICS` | `off` | Prometheus `/metrics`: `off` (404), `token` (bearer), `open` (no credential). |
+| `SKERRY_METRICS_TOKEN` | *(empty)* | Bearer token for `SKERRY_METRICS=token`. Startup fails if the mode is `token` and this is empty. |
+| `SKERRY_METRICS_INVENTORY_SECONDS` | `60` | Refresh interval of the inventory gauges (min 15, `0` disables them). |
 
 ## How sync works
 
@@ -110,7 +114,9 @@ All cipher blobs (`blob`, `wrappedDataKey`, `encryptedDataKey`) travel as base64
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/healthz` | Liveness (open; used by the container healthcheck). |
+| `GET` | `/healthz` | Liveness (open; used by the container healthcheck). Never touches the database. |
+| `GET` | `/readyz` | Readiness: `200` + `{"status":"ready","db":"up"}`, or `503` when the database probe has failed three times in a row. |
+| `GET` | `/metrics` | Prometheus exposition. Disabled by default — see `SKERRY_METRICS`. |
 | `POST` | `/auth/register` | Registration: SRP salt/verifier + wrapped dataKey → tokens. |
 | `POST` | `/auth/srp/challenge` → `/auth/srp/verify` | SRP-6a login without transmitting the password. |
 | `POST` | `/auth/refresh` | Access/refresh token rotation. |
@@ -173,6 +179,92 @@ never record contents, the master password, or the `dataKey`.
 > events). For a single-user self-host the operator *is* the data subject — acceptable. The
 > admin token travels in the `X-Admin-Token` header in cleartext: put a TLS terminator in
 > front (below), otherwise the token is visible on the wire.
+
+## Admin CLI
+
+`skerry-admin` ships in the same image as the server (`/app/bin/skerry-admin`) and drives the same
+`/admin` endpoints as the console — one implementation and one authorization gate per operation.
+It needs `SKERRY_ADMIN_TOKEN` and a reachable server; it never touches the database directly.
+
+```bash
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin stats
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices list --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices revoke devA --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin accounts delete alice@example.com --yes
+```
+
+| Command | Purpose |
+|---|---|
+| `health` | Liveness and version (no token required). |
+| `stats` | Instance totals: accounts, active devices, records, storage. |
+| `accounts list` / `accounts records <id>` | Accounts with aggregates; per-account record metadata. |
+| `accounts purge-tombstones <id>` | Drop deletion markers every device has synced past. |
+| `accounts delete <id> --yes` | Delete an account with all of its data (irreversible, hence the flag). |
+| `devices list [--account id]` | Active devices, most recently seen first. |
+| `devices revoke <id> --account <id>` | Revoke a device (it may re-authenticate later). |
+| `activity` | Recent audit-log events. |
+| `metrics` | Raw Prometheus exposition (uses `SKERRY_METRICS_TOKEN`). |
+
+Global options: `--url` (default `SKERRY_ADMIN_URL`, else `http://127.0.0.1:$SKERRY_PORT`), `--token`
+/ `--token-file` (a flag is visible in `ps` — prefer the environment variable or a secret file),
+`--limit`, `--json` (prints the server's JSON verbatim, for `jq`), `--help`.
+
+Exit codes are meant for scripts: `0` ok, `1` error, `2` usage, `3` unauthorized, `4` not found,
+`5` server unreachable. Run it against a remote instance with `--url https://sync.example.com`; the
+URL must point at the server root (a reverse-proxy path prefix is not supported).
+
+## Metrics and monitoring
+
+`/metrics` serves a Prometheus exposition — off by default, because on a zero-knowledge server the
+metadata *is* the attack surface. Enable it with a token:
+
+```bash
+-e SKERRY_METRICS=token -e SKERRY_METRICS_TOKEN="$(openssl rand -hex 24)"
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: skerry-sync
+    static_configs: [{ targets: ["sync.example.com:8080"] }]
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/skerry-metrics-token
+```
+
+What you get, beyond the standard `jvm_*`, `process_*` and `hikaricp_*` families:
+
+| Family | What it answers |
+|---|---|
+| `skerry_http_server_requests_seconds` | Latency and volume by `method`, `route` (**template**, never the id), `status`. |
+| `skerry_http_rejected_requests_total`, `skerry_http_unhandled_exceptions_total` | Requests refused before routing (411/413); server-side faults. |
+| `skerry_auth_attempts_total{kind,outcome}`, `skerry_auth_tokens_issued_total` | Login/registration/refresh outcomes — the brute-force signal. |
+| `skerry_admin_auth_failures_total`, `skerry_metrics_auth_failures_total` | Wrong static tokens, i.e. someone probing the console or the scrape endpoint. |
+| `skerry_auth_jwt_rejected_total{reason}`, `skerry_team_authz_denied_total{reason}` | Rejected device tokens; denied team/scope access. |
+| `skerry_sync_records_received_total` / `_pulled_total` / `skerry_sync_push_bytes_total` | Sync volume by scope (`account`, `team`). |
+| `skerry_sync_ws_sessions`, `…_opened_total`, `…_closed_total{reason}`, `…_session_duration_seconds` | Live-push sockets: how many are open, why they close, how long they last. |
+| `skerry_accounts`, `skerry_devices{state}`, `skerry_records{state}`, `skerry_storage_bytes{scope}`, `skerry_db_file_bytes`, `skerry_teams`, `skerry_pairing_sessions{state}` | Inventory, refreshed in the background (see `SKERRY_METRICS_INVENTORY_SECONDS`). |
+| `skerry_inventory_last_success_time_seconds`, `skerry_inventory_errors_total` | Whether the inventory above is still fresh. |
+| `skerry_db_up`, `skerry_db_probe_duration_seconds` | The readiness probe behind `/readyz`. |
+| `skerry_build_info{version}`, `skerry_server_start_time_seconds` | Running version; restart detection. |
+
+**No label ever carries an accountId, deviceId, recordId, teamId, scopeId or IP address.** Those are
+client-chosen values: as labels they would let a user grow the registry until the process dies, and
+they would publish exactly the metadata the design keeps out of the server's reach. Per-account
+figures live behind the admin token, in `/admin/accounts`.
+
+A starting set of alerts:
+
+```promql
+skerry_db_up == 0                                                    # database unreachable
+time() - skerry_inventory_last_success_time_seconds > 300            # inventory gauges went stale
+changes(skerry_server_start_time_seconds[15m]) > 2                   # restart loop
+rate(skerry_admin_auth_failures_total[10m]) > 0                      # someone guessing the admin token
+sum(rate(skerry_auth_attempts_total{outcome="denied"}[10m])) > 0.2   # login brute force
+hikaricp_connections_pending > 0                                     # contention for the single SQLite connection
+predict_linear(skerry_db_file_bytes[6h], 7*24*3600) > 20e9           # volume will fill up this week
+skerry_records{state="tombstone"} / skerry_records{state="live"} > 0.5  # tombstone cleanup is not running
+```
 
 ## Production security
 

--- a/server/README.ru.md
+++ b/server/README.ru.md
@@ -53,7 +53,8 @@ docker compose up -d --build
 postgres-переменные в `docker-compose.yml`.
 
 Контейнер работает от непривилегированного пользователя, отдаёт healthcheck `/healthz`,
-а образ собирается с `-PserverOnly` — Android SDK не нужен.
+а образ собирается с `-PserverOnly` — Android SDK не нужен. Рядом лежит
+административный CLI: `docker exec skerry-sync skerry-admin --help`.
 
 ### Локально (Gradle)
 
@@ -83,6 +84,9 @@ SKERRY_JWT_SECRET=dev-secret SKERRY_ADMIN_TOKEN=admin ./gradlew :server:run -Pse
 | `SKERRY_CORS_HOSTS` | *(пусто)* | Разрешённые CORS-источники через запятую. Пусто — CORS выключен (нативных клиентов он не касается). |
 | `SKERRY_MAX_BODY_BYTES` | `4194304` (4 MiB) | Лимит тела запроса (защита от OOM/абьюза); сверх лимита — `413`. |
 | `SKERRY_DEV` | *(не задана)* | `1` разрешает дефолтный JWT-секрет — только для локальной разработки. |
+| `SKERRY_METRICS` | `off` | Prometheus `/metrics`: `off` (404), `token` (bearer), `open` (без токена). |
+| `SKERRY_METRICS_TOKEN` | *(пусто)* | Bearer-токен для `SKERRY_METRICS=token`. С режимом `token` и пустым токеном сервер не стартует. |
+| `SKERRY_METRICS_INVENTORY_SECONDS` | `60` | Интервал обновления инвентарных gauge (минимум 15, `0` отключает их). |
 
 ## Как работает синхронизация
 
@@ -109,7 +113,9 @@ SKERRY_JWT_SECRET=dev-secret SKERRY_ADMIN_TOKEN=admin ./gradlew :server:run -Pse
 
 | Метод | Путь | Назначение |
 |---|---|---|
-| `GET` | `/healthz` | Liveness (открыт; используется healthcheck'ом контейнера). |
+| `GET` | `/healthz` | Liveness (открыт; используется healthcheck'ом контейнера). БД не трогает. |
+| `GET` | `/readyz` | Readiness: `200` + `{"status":"ready","db":"up"}` либо `503`, если проба БД упала три раза подряд. |
+| `GET` | `/metrics` | Prometheus-экспозиция. По умолчанию выключена — см. `SKERRY_METRICS`. |
 | `POST` | `/auth/register` | Регистрация: SRP-соль/верификатор + обёрнутый dataKey → токены. |
 | `POST` | `/auth/srp/challenge` → `/auth/srp/verify` | Вход по SRP-6a без передачи пароля. |
 | `POST` | `/auth/refresh` | Ротация access/refresh токенов. |
@@ -171,6 +177,92 @@ Zero-knowledge сохраняется: консоль видит только м
 > событий). Для single-user self-host оператор и есть субъект данных — приемлемо. Admin-токен
 > ходит в заголовке `X-Admin-Token` открытым текстом: обязательно поставьте TLS-терминатор
 > (ниже), иначе токен виден в сети.
+
+## Админ-CLI
+
+`skerry-admin` лежит в том же образе, что и сервер (`/app/bin/skerry-admin`), и работает через те же
+эндпоинты `/admin`, что и консоль — одна реализация и один гейт авторизации на каждую операцию.
+Нужен `SKERRY_ADMIN_TOKEN` и доступный сервер; напрямую в БД CLI не лазит.
+
+```bash
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin stats
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices list --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices revoke devA --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin accounts delete alice@example.com --yes
+```
+
+| Команда | Назначение |
+|---|---|
+| `health` | Живость и версия (токен не нужен). |
+| `stats` | Итоги по инстансу: аккаунты, активные устройства, записи, объём. |
+| `accounts list` / `accounts records <id>` | Аккаунты с агрегатами; метаданные записей одного аккаунта. |
+| `accounts purge-tombstones <id>` | Убрать маркеры удаления, которые все устройства уже синхронизировали. |
+| `accounts delete <id> --yes` | Удалить аккаунт со всеми данными (необратимо — потому и флаг). |
+| `devices list [--account id]` | Активные устройства, свежие сверху. |
+| `devices revoke <id> --account <id>` | Отозвать устройство (позже оно может заново аутентифицироваться). |
+| `activity` | Последние события аудит-лога. |
+| `metrics` | Сырая Prometheus-экспозиция (берёт `SKERRY_METRICS_TOKEN`). |
+
+Общие опции: `--url` (по умолчанию `SKERRY_ADMIN_URL`, иначе `http://127.0.0.1:$SKERRY_PORT`),
+`--token` / `--token-file` (флаг видно в `ps` — лучше переменная окружения или файл-секрет),
+`--limit`, `--json` (печатает JSON сервера как есть, под `jq`), `--help`.
+
+Коды выхода рассчитаны на скрипты: `0` ок, `1` ошибка, `2` неверный вызов, `3` не авторизован,
+`4` не найдено, `5` сервер недоступен. Против удалённого инстанса — `--url https://sync.example.com`;
+URL должен указывать на корень сервера (путь-префикс за реверс-прокси не поддерживается).
+
+## Метрики и мониторинг
+
+`/metrics` отдаёт Prometheus-экспозицию — по умолчанию выключено: на zero-knowledge сервере
+метаданные и есть поверхность атаки. Включение с токеном:
+
+```bash
+-e SKERRY_METRICS=token -e SKERRY_METRICS_TOKEN="$(openssl rand -hex 24)"
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: skerry-sync
+    static_configs: [{ targets: ["sync.example.com:8080"] }]
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/skerry-metrics-token
+```
+
+Что есть помимо штатных семейств `jvm_*`, `process_*` и `hikaricp_*`:
+
+| Семейство | На какой вопрос отвечает |
+|---|---|
+| `skerry_http_server_requests_seconds` | Латентность и объём по `method`, `route` (**шаблон**, никогда не id), `status`. |
+| `skerry_http_rejected_requests_total`, `skerry_http_unhandled_exceptions_total` | Запросы, отбитые до маршрутизации (411/413); ошибки на стороне сервера. |
+| `skerry_auth_attempts_total{kind,outcome}`, `skerry_auth_tokens_issued_total` | Исходы логина/регистрации/refresh — сигнал брутфорса. |
+| `skerry_admin_auth_failures_total`, `skerry_metrics_auth_failures_total` | Неверные статические токены, т.е. кто-то щупает консоль или скрейп-эндпоинт. |
+| `skerry_auth_jwt_rejected_total{reason}`, `skerry_team_authz_denied_total{reason}` | Отбитые токены устройств; отказы доступа к команде/области. |
+| `skerry_sync_records_received_total` / `_pulled_total` / `skerry_sync_push_bytes_total` | Объём синхронизации по областям (`account`, `team`). |
+| `skerry_sync_ws_sessions`, `…_opened_total`, `…_closed_total{reason}`, `…_session_duration_seconds` | Сокеты live-push: сколько открыто, почему закрываются, сколько живут. |
+| `skerry_accounts`, `skerry_devices{state}`, `skerry_records{state}`, `skerry_storage_bytes{scope}`, `skerry_db_file_bytes`, `skerry_teams`, `skerry_pairing_sessions{state}` | Инвентарь, обновляется в фоне (см. `SKERRY_METRICS_INVENTORY_SECONDS`). |
+| `skerry_inventory_last_success_time_seconds`, `skerry_inventory_errors_total` | Не устарел ли инвентарь выше. |
+| `skerry_db_up`, `skerry_db_probe_duration_seconds` | Проба БД, стоящая за `/readyz`. |
+| `skerry_build_info{version}`, `skerry_server_start_time_seconds` | Запущенная версия; детект рестартов. |
+
+**Ни в одном лейбле нет accountId, deviceId, recordId, teamId, scopeId или IP-адреса.** Это значения,
+которые выбирает клиент: как лейблы они позволили бы пользователю раздувать реестр до падения
+процесса и опубликовали бы ровно те метаданные, которые архитектура держит вне доступа сервера.
+Цифры по конкретным аккаунтам живут за админ-токеном, в `/admin/accounts`.
+
+Набор алертов для начала:
+
+```promql
+skerry_db_up == 0                                                    # БД недоступна
+time() - skerry_inventory_last_success_time_seconds > 300            # инвентарные gauge устарели
+changes(skerry_server_start_time_seconds[15m]) > 2                   # рестарт-цикл
+rate(skerry_admin_auth_failures_total[10m]) > 0                      # подбирают админ-токен
+sum(rate(skerry_auth_attempts_total{outcome="denied"}[10m])) > 0.2   # брутфорс логина
+hikaricp_connections_pending > 0                                     # конкуренция за единственный коннект SQLite
+predict_linear(skerry_db_file_bytes[6h], 7*24*3600) > 20e9           # том забьётся на этой неделе
+skerry_records{state="tombstone"} / skerry_records{state="live"} > 0.5  # чистка тумбстоунов не работает
+```
 
 ## Безопасность в проде
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -7,8 +7,26 @@ plugins {
 group = "app.skerry"
 version = "0.1.4"
 
+// Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
+// to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install
+// directory. One jar, one classpath, no separate module.
+val adminCliScripts = tasks.register<CreateStartScripts>("adminCliStartScripts") {
+    mainClass.set("app.skerry.server.cli.AdminCliRunnerKt")
+    applicationName = "skerry-admin"
+    // Outside build/scripts on purpose: the `application` plugin copies that whole directory into
+    // bin/, so a subdirectory of it would land in the distribution twice.
+    outputDir = layout.buildDirectory.dir("adminCliScripts").get().asFile
+    classpath = tasks.startScripts.get().classpath
+}
+
 application {
     mainClass.set("app.skerry.server.ApplicationKt")
+    // filePermissions: files added through `from` don't inherit the executable bit that
+    // CreateStartScripts sets, and a non-executable launcher is a silent "command not found".
+    applicationDistribution.from(adminCliScripts) {
+        into("bin")
+        filePermissions { unix("755") }
+    }
 }
 
 kotlin {
@@ -31,7 +49,16 @@ dependencies {
     // Security hardening: rate-limit (anti-flood per IP) and security headers (DefaultHeaders).
     implementation(libs.ktor.server.rate.limit)
     implementation(libs.ktor.server.default.headers)
+    // Observability: Prometheus exposition on /metrics. The Micrometer registry also brings JVM,
+    // process and HikariCP instrumentation under their standard names, so off-the-shelf Grafana
+    // dashboards work — that is the reason for the dependency over a hand-rolled exposition writer.
+    implementation(libs.ktor.server.metrics.micrometer)
+    implementation(libs.micrometer.registry.prometheus)
     implementation(libs.logback.classic)
+    // HTTP client for the `skerry-admin` CLI (second launcher in this module): it drives the same
+    // /admin endpoints as the console instead of reaching into the database behind the server's back.
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
     // Coroutines: Exposed suspend transactions (newSuspendedTransaction) take DB work off the request thread.
     implementation(libs.kotlinx.coroutines.core)
 
@@ -50,6 +77,8 @@ dependencies {
     testImplementation(libs.ktor.client.content.negotiation)
     // WS client for /sync tests: Close-frame handling and revoke are verified with a real handshake.
     testImplementation(libs.ktor.client.websockets)
+    // MockEngine: lets the CLI tests drive responses a real server can't produce (a malformed body).
+    testImplementation(libs.ktor.client.mock)
     testImplementation(kotlin("test"))
 }
 

--- a/server/src/main/kotlin/app/skerry/server/Application.kt
+++ b/server/src/main/kotlin/app/skerry/server/Application.kt
@@ -2,8 +2,10 @@ package app.skerry.server
 
 import app.skerry.server.config.ServerConfig
 import app.skerry.server.db.Db
+import app.skerry.server.metrics.ServerMetrics
 import io.ktor.server.application.Application
 import io.ktor.server.application.log
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
 import kotlinx.coroutines.delay
@@ -24,24 +26,46 @@ fun main() {
 /** Ktor entry point: validates config, connects the DB, wires the server, starts cleanup. */
 fun Application.module(config: ServerConfig = ServerConfig.fromEnv()) {
     guardConfig(config)
-    val database = Db.connect(config)
-    val services = Services(config, database)
+    // Metrics come first: the registry has to exist before the pool so HikariCP can publish into it.
+    val metrics = ServerMetrics(config, version = SERVER_VERSION)
+    monitor.subscribe(ApplicationStopped) { metrics.close() }
+    val database = Db.connect(config, metrics.registry)
+    val services = Services(config, database, metrics)
     configureServer(services)
     scheduleCleanup(services)
+    startObservers(services)
 }
 
 /**
  * Fails fast on a known-unsafe config: the default JWT secret is public, so anyone could forge a
  * token for any account. Startup with it is blocked in prod; local dev unlocks it via explicit
- * `SKERRY_DEV=1`.
+ * `SKERRY_DEV=1`. `SKERRY_METRICS=token` without a token is refused for the same reason — a typo
+ * there would otherwise publish the exposition to anyone who asks.
  */
-private fun guardConfig(config: ServerConfig, env: Map<String, String> = System.getenv()) {
+internal fun guardConfig(config: ServerConfig, env: Map<String, String> = System.getenv()) {
     if (config.usesDefaultJwtSecret && env["SKERRY_DEV"] != "1") {
         error(
             "SKERRY_JWT_SECRET is not set (an insecure default is in use). Provide a strong " +
                 "secret (openssl rand -base64 48) or set SKERRY_DEV=1 for local development.",
         )
     }
+    if (config.metricsTokenMissing) {
+        error(
+            "SKERRY_METRICS=token requires SKERRY_METRICS_TOKEN (openssl rand -hex 24). " +
+                "Use SKERRY_METRICS=open only when /metrics is unreachable from outside the host.",
+        )
+    }
+}
+
+/**
+ * Background observers: the readiness probe (also feeding `skerry_db_up`) and the metrics inventory
+ * snapshot. Both are deliberately off the request path — nothing here may run during a scrape or a
+ * readiness check, because the default SQLite pool is a single connection.
+ */
+private fun Application.startObservers(services: Services) {
+    services.dbProbe.start(this)
+    val interval = services.config.metricsInventoryIntervalSeconds
+    if (interval > 0) services.inventory.start(this, interval)
 }
 
 /** Team tombstones live 90 days (design doc §2 tombstone policy), then are aged out. */

--- a/server/src/main/kotlin/app/skerry/server/Plugins.kt
+++ b/server/src/main/kotlin/app/skerry/server/Plugins.kt
@@ -1,10 +1,16 @@
 package app.skerry.server
 
 import app.skerry.server.auth.TokenService
+import app.skerry.server.config.MetricsExposure
+import app.skerry.server.metrics.HTTP_REQUESTS_METRIC
+import app.skerry.server.metrics.JwtRejection
+import app.skerry.server.metrics.RejectReason
 import app.skerry.server.model.ErrorResponse
+import app.skerry.server.model.ReadyResponse
 import app.skerry.server.routes.adminRoutes
 import app.skerry.server.routes.authRoutes
 import app.skerry.server.routes.deviceRoutes
+import app.skerry.server.routes.metricsRoutes
 import app.skerry.server.routes.pairingClaimRoute
 import app.skerry.server.routes.pairingStartRoute
 import app.skerry.server.routes.syncWebSocket
@@ -29,6 +35,7 @@ import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.plugins.cors.routing.CORS
+import io.ktor.server.metrics.micrometer.MicrometerMetrics
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 import io.ktor.server.plugins.origin
 import io.ktor.server.plugins.ratelimit.RateLimit
@@ -39,6 +46,8 @@ import io.ktor.server.http.content.staticResources
 import io.ktor.server.request.contentLength
 import io.ktor.server.request.header
 import io.ktor.server.request.httpMethod
+import io.ktor.server.request.path
+import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondRedirect
 import io.ktor.server.response.respondText
@@ -48,6 +57,9 @@ import io.ktor.server.websocket.WebSockets
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.serialization.json.Json
 import org.slf4j.event.Level
+
+/** Paths excluded from [CallLogging]: machine polling, one line per call, nothing to learn from it. */
+private val UNLOGGED_PATHS = setOf("/healthz", "/readyz", "/metrics")
 
 /** Rate-limit bucket names (keyed by remote IP). Declared here, used by the routes. */
 object RateLimits {
@@ -59,6 +71,7 @@ object RateLimits {
     val CHANGE_PASSWORD = RateLimitName("auth-change-password")
     val ADMIN = RateLimitName("admin")
     val TEAM_SESSION_EVENTS = RateLimitName("team-session-events")
+    val METRICS = RateLimitName("metrics")
 }
 
 /**
@@ -96,7 +109,33 @@ fun Application.configureServer(services: Services) {
         timeoutMillis = 15_000
         maxFrameSize = 4096
     }
-    install(CallLogging) { level = Level.INFO }
+    // A 15s scrape plus the container healthcheck plus every client's ping() would be thousands of
+    // INFO lines a day about nothing. Neither endpoint carries anything worth logging per call.
+    install(CallLogging) {
+        level = Level.INFO
+        filter { call -> call.request.path() !in UNLOGGED_PATHS }
+    }
+    // HTTP metrics. `distinctNotRegisteredRoutes = false` collapses every unmatched request into one
+    // series: without it an unauthenticated GET /<random> loop would add a series per request and grow
+    // the registry until the process dies.
+    if (services.config.metrics != MetricsExposure.OFF) {
+        install(MicrometerMetrics) {
+            // The plugin's config constructor already built a LoggingMeterRegistry as its default,
+            // and that registry starts a publishing thread — left alone it keeps dumping every meter
+            // into the log once a minute. Close it as we swap ours in.
+            val unusedDefault = registry
+            registry = services.metrics.registry
+            unusedDefault.close()
+            metricName = HTTP_REQUESTS_METRIC
+            distinctNotRegisteredRoutes = false
+            // Our own MeterFilter defines the buckets (see ServerMetrics); letting the plugin register
+            // its distribution config would add a filter after meters already exist, which Micrometer
+            // warns about — and would fight over the same timer.
+            registerDistributionStatisticConfig = false
+            // ServerMetrics owns the JVM/process binders so it can close the GC listener on shutdown.
+            meterBinders = emptyList()
+        }
+    }
     // Security headers on every response. CSP is locked to 'self' (API returns JSON, admin
     // console is same-origin with no external resources); inline style/script are allowed
     // because the console uses them and is embedded in the same page.
@@ -140,6 +179,9 @@ fun Application.configureServer(services: Services) {
         // The admin console uses a constant-time static token compare, which doesn't stop brute
         // forcing the token itself, hence a rate limit on /admin/*.
         perIp(RateLimits.ADMIN, limit = 30)
+        // Same reasoning as the admin bucket: /metrics is guarded by a static token, and a static
+        // token can be brute forced. A 15s scrape is 4 requests a minute, so this leaves 7x headroom.
+        perIp(RateLimits.METRICS, limit = 30)
         // Session reports are a member-driven write into an audit log with a bounded retention
         // window, so they get a budget of their own — keyed by **account**, not by IP: an attacker
         // can't buy more of it by changing address, and members behind one NAT don't share one.
@@ -167,10 +209,12 @@ fun Application.configureServer(services: Services) {
         val carriesBody = method == HttpMethod.Post || method == HttpMethod.Put || method == HttpMethod.Patch
         val len = call.request.contentLength()
         if (carriesBody && len == null) {
+            services.metrics.requestRejected(RejectReason.LENGTH_REQUIRED)
             call.respond(HttpStatusCode.LengthRequired, ErrorResponse("Content-Length required"))
             return@intercept finish()
         }
         if (len != null && len > maxBody) {
+            services.metrics.requestRejected(RejectReason.BODY_TOO_LARGE)
             call.respond(HttpStatusCode.PayloadTooLarge, ErrorResponse("request body too large"))
             return@intercept finish()
         }
@@ -192,6 +236,7 @@ fun Application.configureServer(services: Services) {
             call.respond(HttpStatusCode.BadRequest, ErrorResponse(cause.message ?: "bad request"))
         }
         exception<Throwable> { call, cause ->
+            services.metrics.unhandledException()
             call.application.environment.log.error("Unhandled error", cause)
             call.respond(HttpStatusCode.InternalServerError, ErrorResponse("internal error"))
         }
@@ -205,12 +250,20 @@ fun Application.configureServer(services: Services) {
                 val account = credential.payload.subject
                 val did = credential.payload.getClaim(TokenService.CLAIM_DEVICE).asString()
                 // Valid only if this is an access token and the device (within the account) isn't revoked.
-                if (type == TokenService.TYPE_ACCESS && account != null && did != null &&
-                    !services.devices.isRevoked(account, did)
-                ) {
-                    JWTPrincipal(credential.payload)
-                } else {
-                    null
+                when {
+                    account == null || did == null -> {
+                        services.metrics.jwtRejected(JwtRejection.MISSING_CLAIMS)
+                        null
+                    }
+                    type != TokenService.TYPE_ACCESS -> {
+                        services.metrics.jwtRejected(JwtRejection.WRONG_TYPE)
+                        null
+                    }
+                    services.devices.isRevoked(account, did) -> {
+                        services.metrics.jwtRejected(JwtRejection.DEVICE_REVOKED)
+                        null
+                    }
+                    else -> JWTPrincipal(credential.payload)
                 }
             }
         }
@@ -218,6 +271,22 @@ fun Application.configureServer(services: Services) {
 
     routing {
         get("/healthz") { call.respondText("ok") }
+
+        // Readiness is a separate endpoint on purpose: /healthz is wired to the container healthcheck
+        // and to every client's availability ping, so making it depend on the database would turn a
+        // slow transaction into a restart loop and a client-wide "unreachable" storm.
+        get("/readyz") {
+            val ready = services.dbProbe.ready
+            call.response.header(HttpHeaders.CacheControl, "no-store")
+            call.respond(
+                if (ready) HttpStatusCode.OK else HttpStatusCode.ServiceUnavailable,
+                ReadyResponse(if (ready) "ready" else "not_ready", if (ready) "up" else "down"),
+            )
+        }
+
+        rateLimit(RateLimits.METRICS) {
+            metricsRoutes(services)
+        }
 
         // Root redirects to the admin console so opening the server in a browser isn't a 404.
         get("/") { call.respondRedirect("/console/") }

--- a/server/src/main/kotlin/app/skerry/server/Services.kt
+++ b/server/src/main/kotlin/app/skerry/server/Services.kt
@@ -13,11 +13,28 @@ import app.skerry.server.db.StatsRepository
 import app.skerry.server.db.TeamRecordRepository
 import app.skerry.server.db.TeamRepository
 import app.skerry.server.db.TeamScopeRepository
+import app.skerry.server.metrics.DbProbe
+import app.skerry.server.metrics.InventoryCollector
+import app.skerry.server.metrics.ServerMetrics
 import app.skerry.server.sync.ChangeNotifier
 import org.jetbrains.exposed.v1.jdbc.Database
 
-/** Wired dependencies for one server instance. Created once in [module]. */
-class Services(val config: ServerConfig, private val database: Database) {
+/**
+ * Wired dependencies for one server instance. Created once in [module].
+ *
+ * [metrics] is per instance on purpose: a global registry would accumulate duplicate meters across
+ * the many servers the test suite starts in one JVM.
+ */
+class Services(
+    val config: ServerConfig,
+    private val database: Database,
+    val metrics: ServerMetrics = ServerMetrics(config, version = SERVER_VERSION),
+    /**
+     * What the readiness probe runs. Overridden only by tests: without a seam here, the 503 path of
+     * `/readyz` cannot be exercised through the real route at all.
+     */
+    dbCheck: (suspend () -> Unit)? = null,
+) {
     val accounts = AccountRepository(database)
     val devices = DeviceRepository(database)
     // On PostgreSQL, serialize upserts with an account-row lock; not needed on SQLite (pool=1).
@@ -31,5 +48,9 @@ class Services(val config: ServerConfig, private val database: Database) {
     val admin = AdminRepository(database)
     val srp = SrpService()
     val tokens = TokenService(config)
-    val notifier = ChangeNotifier()
+    val notifier = ChangeNotifier(metrics)
+
+    /** Feeds `GET /readyz` and `skerry_db_up`; started by [module], never queried per request. */
+    val dbProbe = DbProbe(metrics) { dbCheck?.invoke() ?: stats.ping() }
+    val inventory = InventoryCollector(stats, metrics, config.databaseUrl)
 }

--- a/server/src/main/kotlin/app/skerry/server/cli/AdminCliParser.kt
+++ b/server/src/main/kotlin/app/skerry/server/cli/AdminCliParser.kt
@@ -1,0 +1,233 @@
+package app.skerry.server.cli
+
+/**
+ * Argument parsing for `skerry-admin` — pure, so the command surface is testable without a server.
+ * The CLI talks to the same `/admin` HTTP API as the web console (one authorization path, one
+ * implementation of every operation), so it works both inside the container and against a remote
+ * instance.
+ */
+
+/** Global options: where to talk and how to print. */
+data class CliOptions(
+    val baseUrl: String,
+    /** Token from `--token` or `SKERRY_ADMIN_TOKEN`; null means "read [tokenFile]". */
+    val token: String?,
+    /** Path from `--token-file` (docker/k8s secret); read by the runner, not the parser. */
+    val tokenFile: String?,
+    /**
+     * Bearer token for `/metrics` — a different credential from [token] on purpose: the admin token
+     * also authorizes account deletion, so a scrape check must not require it.
+     */
+    val metricsToken: String?,
+    val json: Boolean,
+)
+
+sealed interface AdminCommand {
+    data object Health : AdminCommand
+    data object Stats : AdminCommand
+    data object Metrics : AdminCommand
+    data class Activity(val limit: Int?) : AdminCommand
+    data class AccountsList(val limit: Int?) : AdminCommand
+    data class AccountRecords(val accountId: String, val limit: Int?) : AdminCommand
+    data class AccountPurgeTombstones(val accountId: String) : AdminCommand
+    data class AccountDelete(val accountId: String) : AdminCommand
+    data class DevicesList(val limit: Int?, val accountId: String?) : AdminCommand
+    data class DeviceRevoke(val accountId: String, val deviceId: String) : AdminCommand
+}
+
+sealed interface ParsedCli {
+    data class Run(val command: AdminCommand, val options: CliOptions) : ParsedCli
+    data class Help(val text: String) : ParsedCli
+    data class Invalid(val message: String) : ParsedCli
+}
+
+private const val URL = "--url"
+private const val TOKEN = "--token"
+private const val TOKEN_FILE = "--token-file"
+private const val LIMIT = "--limit"
+private const val ACCOUNT = "--account"
+private const val METRICS_TOKEN = "--metrics-token"
+private const val JSON = "--json"
+private const val YES = "--yes"
+
+private val VALUE_FLAGS = setOf(URL, TOKEN, TOKEN_FILE, LIMIT, ACCOUNT, METRICS_TOKEN)
+private val BOOL_FLAGS = setOf(JSON, YES)
+private val GLOBAL_FLAGS = setOf(URL, TOKEN, TOKEN_FILE, JSON)
+
+fun parseCli(args: List<String>, env: Map<String, String> = System.getenv()): ParsedCli {
+    if (args.isEmpty()) return ParsedCli.Help(USAGE)
+
+    val values = LinkedHashMap<String, String>()
+    val bools = LinkedHashSet<String>()
+    val positional = mutableListOf<String>()
+
+    var i = 0
+    while (i < args.size) {
+        val arg = args[i]
+        // `--flag=value` and `--flag value` are both expected of a CLI; normalize to one form.
+        val eq = if (arg.startsWith("--")) arg.indexOf('=') else -1
+        val name = if (eq > 0) arg.take(eq) else arg
+        val inlineValue = if (eq > 0) arg.drop(eq + 1) else null
+        when {
+            name == "--help" || name == "-h" -> return ParsedCli.Help(USAGE)
+            name in VALUE_FLAGS -> {
+                val value = inlineValue ?: args.getOrNull(i + 1)
+                // `--account=` is a typo, not "no filter": treating it as absent would silently widen
+                // `devices list` to every account, while `devices revoke` rejects the same input.
+                if (value.isNullOrBlank() || (inlineValue == null && value.startsWith("--"))) {
+                    return ParsedCli.Invalid("$name requires a value")
+                }
+                if (values.put(name, value) != null) return ParsedCli.Invalid("$name given twice")
+                i += if (inlineValue == null) 2 else 1
+            }
+            name in BOOL_FLAGS -> {
+                if (inlineValue != null) return ParsedCli.Invalid("$name takes no value")
+                bools += name
+                i++
+            }
+            arg.startsWith("-") && arg != "-" -> return ParsedCli.Invalid("unknown flag $arg")
+            else -> {
+                positional += arg
+                i++
+            }
+        }
+    }
+
+    val limit = values[LIMIT]?.let { raw ->
+        raw.toIntOrNull()?.takeIf { it > 0 } ?: return ParsedCli.Invalid("$LIMIT must be a positive number, got \"$raw\"")
+    }
+    val account = values[ACCOUNT]
+    val yes = YES in bools
+
+    val command = when (val head = positional.firstOrNull()) {
+        null -> return ParsedCli.Help(USAGE)
+        "health" -> AdminCommand.Health.requiring(positional, 1) ?: return arityError(head)
+        "stats" -> AdminCommand.Stats.requiring(positional, 1) ?: return arityError(head)
+        "metrics" -> AdminCommand.Metrics.requiring(positional, 1) ?: return arityError(head)
+        "activity" -> if (positional.size == 1) AdminCommand.Activity(limit) else return arityError(head)
+        "accounts" -> when (val sub = positional.getOrNull(1)) {
+            null -> return ParsedCli.Invalid("accounts needs a subcommand: list, records, purge-tombstones, delete")
+            "list" -> if (positional.size == 2) AdminCommand.AccountsList(limit) else return arityError("accounts list")
+            "records" -> {
+                val id = positional.accountArg(2) ?: return ParsedCli.Invalid("accounts records needs an account id")
+                if (positional.size > 3) return arityError("accounts records")
+                AdminCommand.AccountRecords(id, limit)
+            }
+            "purge-tombstones" -> {
+                val id = positional.accountArg(2)
+                    ?: return ParsedCli.Invalid("accounts purge-tombstones needs an account id")
+                if (positional.size > 3) return arityError("accounts purge-tombstones")
+                AdminCommand.AccountPurgeTombstones(id)
+            }
+            "delete" -> {
+                val id = positional.accountArg(2) ?: return ParsedCli.Invalid("accounts delete needs an account id")
+                if (positional.size > 3) return arityError("accounts delete")
+                // Irreversible, and `docker exec` often has no TTY — confirmation is a flag, not a prompt.
+                if (!yes) {
+                    return ParsedCli.Invalid("accounts delete removes $id and all its data — pass $YES to confirm")
+                }
+                AdminCommand.AccountDelete(id)
+            }
+            else -> return ParsedCli.Invalid("unknown subcommand: accounts $sub")
+        }
+        "devices" -> when (val sub = positional.getOrNull(1)) {
+            null -> return ParsedCli.Invalid("devices needs a subcommand: list, revoke")
+            "list" -> if (positional.size == 2) AdminCommand.DevicesList(limit, account) else return arityError("devices list")
+            "revoke" -> {
+                val deviceId = positional.getOrNull(2)?.takeIf { it.isNotBlank() }
+                    ?: return ParsedCli.Invalid("devices revoke needs a device id")
+                if (positional.size > 3) return arityError("devices revoke")
+                // deviceId is unique only within an account (composite PK), so the account is required.
+                val acct = account?.takeIf { it.isNotBlank() }
+                    ?: return ParsedCli.Invalid("devices revoke needs $ACCOUNT <accountId>")
+                AdminCommand.DeviceRevoke(acct, deviceId)
+            }
+            else -> return ParsedCli.Invalid("unknown subcommand: devices $sub")
+        }
+        else -> return ParsedCli.Invalid("unknown command: $head")
+    }
+
+    // A flag the command ignores is a typo or a wrong expectation, not something to swallow silently.
+    val allowed = GLOBAL_FLAGS + command.acceptedFlags()
+    (values.keys + bools).firstOrNull { it !in allowed }?.let {
+        return ParsedCli.Invalid("$it is not valid for ${command.label()}")
+    }
+
+    return ParsedCli.Run(
+        command,
+        CliOptions(
+            baseUrl = resolveBaseUrl(values[URL], env),
+            token = values[TOKEN] ?: env["SKERRY_ADMIN_TOKEN"]?.takeIf { it.isNotBlank() },
+            tokenFile = values[TOKEN_FILE] ?: env["SKERRY_ADMIN_TOKEN_FILE"]?.takeIf { it.isNotBlank() },
+            metricsToken = values[METRICS_TOKEN] ?: env["SKERRY_METRICS_TOKEN"]?.takeIf { it.isNotBlank() },
+            json = JSON in bools,
+        ),
+    )
+}
+
+/** `--url`, else `SKERRY_ADMIN_URL`, else loopback on the port the server itself listens on. */
+private fun resolveBaseUrl(flag: String?, env: Map<String, String>): String {
+    val raw = flag ?: env["SKERRY_ADMIN_URL"]?.takeIf { it.isNotBlank() }
+    if (raw != null) return raw.trimEnd('/')
+    val port = env["SKERRY_PORT"]?.toIntOrNull() ?: 8080
+    return "http://127.0.0.1:$port"
+}
+
+private fun List<String>.accountArg(index: Int): String? = getOrNull(index)?.takeIf { it.isNotBlank() }
+
+private fun <T : AdminCommand> T.requiring(positional: List<String>, size: Int): T? =
+    takeIf { positional.size == size }
+
+private fun arityError(command: String) = ParsedCli.Invalid("$command takes no extra arguments")
+
+private fun AdminCommand.acceptedFlags(): Set<String> = when (this) {
+    is AdminCommand.Activity, is AdminCommand.AccountsList, is AdminCommand.AccountRecords -> setOf(LIMIT)
+    is AdminCommand.DevicesList -> setOf(LIMIT, ACCOUNT)
+    is AdminCommand.DeviceRevoke -> setOf(ACCOUNT)
+    is AdminCommand.AccountDelete -> setOf(YES)
+    AdminCommand.Metrics -> setOf(METRICS_TOKEN)
+    AdminCommand.Health, AdminCommand.Stats, is AdminCommand.AccountPurgeTombstones -> emptySet()
+}
+
+private fun AdminCommand.label(): String = when (this) {
+    AdminCommand.Health -> "health"
+    AdminCommand.Stats -> "stats"
+    AdminCommand.Metrics -> "metrics"
+    is AdminCommand.Activity -> "activity"
+    is AdminCommand.AccountsList -> "accounts list"
+    is AdminCommand.AccountRecords -> "accounts records"
+    is AdminCommand.AccountPurgeTombstones -> "accounts purge-tombstones"
+    is AdminCommand.AccountDelete -> "accounts delete"
+    is AdminCommand.DevicesList -> "devices list"
+    is AdminCommand.DeviceRevoke -> "devices revoke"
+}
+
+val USAGE: String = """
+    skerry-admin — administration CLI for the Skerry sync server.
+
+    Usage: skerry-admin [global options] <command> [arguments]
+
+    Commands
+      health                              Server liveness and version (no token required)
+      stats                               Instance totals: accounts, devices, records, storage
+      metrics [--metrics-token T]         Raw Prometheus exposition (as the scraper sees it);
+                                          token defaults to SKERRY_METRICS_TOKEN
+      activity [--limit N]                Recent audit-log events
+      accounts list [--limit N]           Accounts with device/record aggregates
+      accounts records <id> [--limit N]   Record envelopes of one account (metadata only)
+      accounts purge-tombstones <id>      Drop deletion markers every device has synced past
+      accounts delete <id> --yes          Delete an account with all of its data (irreversible)
+      devices list [--account id] [--limit N]
+                                          Active devices, most recently seen first
+      devices revoke <deviceId> --account <accountId>
+                                          Revoke a device (it may re-authenticate later)
+
+    Global options
+      --url URL          Server base URL (default: SKERRY_ADMIN_URL, else http://127.0.0.1:SKERRY_PORT)
+      --token TOKEN      Admin token (default: SKERRY_ADMIN_TOKEN). Visible in `ps` — prefer the env var
+      --token-file PATH  Read the admin token from a file (default: SKERRY_ADMIN_TOKEN_FILE)
+      --json             Print the server's JSON response instead of a table
+      --help             This text
+
+    Exit codes: 0 ok · 1 error · 2 usage · 3 unauthorized · 4 not found · 5 unreachable
+""".trimIndent()

--- a/server/src/main/kotlin/app/skerry/server/cli/AdminCliRunner.kt
+++ b/server/src/main/kotlin/app/skerry/server/cli/AdminCliRunner.kt
@@ -1,0 +1,385 @@
+package app.skerry.server.cli
+
+import app.skerry.server.model.AdminAccountsResponse
+import app.skerry.server.model.AdminActivityResponse
+import app.skerry.server.model.AdminDevicesResponse
+import app.skerry.server.model.AdminPurgeResponse
+import app.skerry.server.model.AdminRecordsResponse
+import app.skerry.server.model.ErrorResponse
+import app.skerry.server.model.HealthResponse
+import app.skerry.server.model.StatsResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.url
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.http.encodeURLParameter
+import io.ktor.http.encodeURLPathPart
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.system.exitProcess
+
+/**
+ * `skerry-admin` — the administration CLI. It drives the very same `/admin` HTTP endpoints as the
+ * web console, so there is one implementation and one authorization gate per operation; the CLI
+ * only formats what the server returns.
+ */
+
+const val EXIT_OK = 0
+const val EXIT_ERROR = 1
+const val EXIT_USAGE = 2
+const val EXIT_UNAUTHORIZED = 3
+const val EXIT_NOT_FOUND = 4
+const val EXIT_UNREACHABLE = 5
+
+fun main(args: Array<String>) {
+    val code = runBlocking { runCli(args.toList()) }
+    exitProcess(code)
+}
+
+/**
+ * Runs one CLI invocation and returns its exit code. Everything the process owns is injected so
+ * the tests can drive the real routes over a test client: [clientFactory] builds the HTTP client,
+ * [now] anchors relative timestamps, [out]/[err] capture output.
+ */
+suspend fun runCli(
+    args: List<String>,
+    env: Map<String, String> = System.getenv(),
+    out: Appendable = System.out,
+    err: Appendable = System.err,
+    now: Long = System.currentTimeMillis(),
+    clientFactory: (CliOptions) -> HttpClient = ::defaultHttpClient,
+    readTokenFile: (String) -> String = { Files.readString(Path.of(it)).trim() },
+): Int = when (val parsed = parseCli(args, env)) {
+    is ParsedCli.Help -> {
+        out.appendLine(parsed.text)
+        EXIT_OK
+    }
+    is ParsedCli.Invalid -> {
+        err.appendLine(parsed.message)
+        err.appendLine("Run `skerry-admin --help` for usage.")
+        EXIT_USAGE
+    }
+    is ParsedCli.Run -> {
+        val token = resolveToken(parsed.options, readTokenFile, err)
+        if (token is TokenResult.Failed) {
+            EXIT_ERROR
+        } else {
+            warnAboutCleartext(parsed.options.baseUrl, err)
+            execute(
+                command = parsed.command,
+                options = parsed.options,
+                token = (token as TokenResult.Resolved).value,
+                out = out,
+                err = err,
+                now = now,
+                clientFactory = clientFactory,
+            )
+        }
+    }
+}
+
+/**
+ * A token sent over plain HTTP to anything but the local machine is on the wire in the clear. The
+ * server itself is meant to sit behind a TLS proxy, so this is a misconfiguration worth one line —
+ * not an error, since a LAN-only instance without TLS is a deliberate, documented choice.
+ */
+private fun warnAboutCleartext(baseUrl: String, err: Appendable) {
+    if (!baseUrl.startsWith("http://", ignoreCase = true)) return
+    val host = baseUrl.removePrefix("http://").substringBefore('/').substringBefore(':')
+    if (host in LOOPBACK_HOSTS) return
+    err.appendLine("warning: $baseUrl is plain HTTP — the admin token crosses the network in the clear")
+}
+
+private val LOOPBACK_HOSTS = setOf("127.0.0.1", "localhost", "[::1]", "::1")
+
+private sealed interface TokenResult {
+    data class Resolved(val value: String?) : TokenResult
+    data object Failed : TokenResult
+}
+
+private fun resolveToken(options: CliOptions, readTokenFile: (String) -> String, err: Appendable): TokenResult {
+    if (options.token != null) return TokenResult.Resolved(options.token)
+    val file = options.tokenFile ?: return TokenResult.Resolved(null)
+    return runCatching { readTokenFile(file) }
+        .fold(
+            onSuccess = { TokenResult.Resolved(it.takeIf(String::isNotBlank)) },
+            onFailure = {
+                err.appendLine("cannot read the admin token from $file: ${it.message ?: it::class.simpleName}")
+                TokenResult.Failed
+            },
+        )
+}
+
+/**
+ * The client is not closed: the process exits right after one command, and tests inject their own.
+ * A connection failure surfaces as one line, not a stack trace — a stopped server is the normal
+ * case for a CLI, not a crash.
+ */
+private suspend fun execute(
+    command: AdminCommand,
+    options: CliOptions,
+    token: String?,
+    out: Appendable,
+    err: Appendable,
+    now: Long,
+    clientFactory: (CliOptions) -> HttpClient,
+): Int = try {
+    val api = AdminApi(clientFactory(options), token)
+    when (command) {
+        AdminCommand.Health -> api.render(out, err, options.json, "/admin/health") { body ->
+            val health = jsonCodec.decodeFromString<HealthResponse>(body)
+            keyValues(listOf("Status" to health.status, "Version" to health.version))
+        }
+        AdminCommand.Stats -> api.render(out, err, options.json, "/admin/stats") { body ->
+            val stats = jsonCodec.decodeFromString<StatsResponse>(body)
+            keyValues(
+                listOf(
+                    "Accounts" to stats.accounts.toString(),
+                    "Active devices" to stats.devices.toString(),
+                    "Records" to stats.records.toString(),
+                    "Pairing sessions" to stats.pairingSessions.toString(),
+                    "Storage" to "${humanBytes(stats.storageBytes)} (${stats.storageBytes} bytes)",
+                ),
+            )
+        }
+        // Printed verbatim: the point is to see exactly what a scraper would get. Bearer, not the
+        // admin header — /metrics has its own credential.
+        AdminCommand.Metrics -> api.scrape(out, err, options.metricsToken)
+        is AdminCommand.Activity -> api.render(out, err, options.json, "/admin/activity".withLimit(command.limit)) { body ->
+            val response = jsonCodec.decodeFromString<AdminActivityResponse>(body)
+            if (response.events.isEmpty()) return@render "no events in the audit log"
+            table(
+                listOf("WHEN", "ACCOUNT", "DEVICE", "EVENT", "DETAIL"),
+                response.events.map {
+                    listOf(utcMinutes(it.createdAt), it.accountId, it.deviceId ?: "—", it.event, it.detail)
+                },
+            ) + footer(response.events.size, response.total)
+        }
+        is AdminCommand.AccountsList -> api.render(out, err, options.json, "/admin/accounts".withLimit(command.limit)) { body ->
+            val response = jsonCodec.decodeFromString<AdminAccountsResponse>(body)
+            if (response.accounts.isEmpty()) return@render "no accounts on this server"
+            table(
+                listOf("ACCOUNT", "DEVICES", "RECORDS", "TOMBSTONES", "STORAGE", "LAST SEEN", "CREATED"),
+                response.accounts.map {
+                    listOf(
+                        it.id,
+                        "${it.activeDevices}/${it.devices}",
+                        it.records.toString(),
+                        it.tombstones.toString(),
+                        humanBytes(it.storageBytes),
+                        relativeTime(it.lastSeenAt, now),
+                        utcMinutes(it.createdAt),
+                    )
+                },
+            ) + footer(response.accounts.size, response.total)
+        }
+        is AdminCommand.AccountRecords -> {
+            val path = "/admin/accounts/${command.accountId.encodeURLPathPart()}/records".withLimit(command.limit)
+            api.render(out, err, options.json, path) { body ->
+                val response = jsonCodec.decodeFromString<AdminRecordsResponse>(body)
+                if (response.records.isEmpty()) {
+                    "no records for ${response.accountId}"
+                } else {
+                    table(
+                        listOf("RECORD", "TYPE", "VER", "BYTES", "STATE", "SEQ", "CIPHERTEXT"),
+                        response.records.map {
+                            listOf(
+                                it.id,
+                                it.type,
+                                it.version.toString(),
+                                it.blobBytes.toString(),
+                                if (it.deleted) "tombstone" else "live",
+                                it.serverSeq.toString(),
+                                it.previewHex.take(23) + "…",
+                            )
+                        },
+                    )
+                }
+            }
+        }
+        is AdminCommand.DevicesList -> {
+            val path = "/admin/devices".withLimit(command.limit)
+                .withParam("accountId", command.accountId)
+            api.render(out, err, options.json, path) { body ->
+                val response = jsonCodec.decodeFromString<AdminDevicesResponse>(body)
+                if (response.devices.isEmpty()) return@render "no active devices"
+                table(
+                    listOf("ACCOUNT", "DEVICE", "NAME", "PLATFORM", "LAST SEEN", "CURSOR", "STATUS"),
+                    response.devices.map {
+                        listOf(
+                            it.accountId,
+                            it.id,
+                            it.name,
+                            it.platform ?: "—",
+                            relativeTime(it.lastSeenAt, now),
+                            it.syncVersion?.toString() ?: "—",
+                            if (it.revoked) "revoked" else "active",
+                        )
+                    },
+                ) + footer(response.devices.size, response.total)
+            }
+        }
+        is AdminCommand.DeviceRevoke -> {
+            val path = "/admin/devices/${command.deviceId.encodeURLPathPart()}"
+                .withParam("accountId", command.accountId)
+            api.act(
+                out, err, options.json, path,
+                done = "revoked ${command.deviceId} (${command.accountId})",
+                missing = "no device ${command.deviceId} on account ${command.accountId}",
+            )
+        }
+        is AdminCommand.AccountPurgeTombstones -> {
+            val path = "/admin/accounts/${command.accountId.encodeURLPathPart()}/tombstones"
+            api.delete(path).handle(out, err, options.json) { body ->
+                "purged ${jsonCodec.decodeFromString<AdminPurgeResponse>(body).purged} tombstones"
+            }
+        }
+        is AdminCommand.AccountDelete -> {
+            val path = "/admin/accounts/${command.accountId.encodeURLPathPart()}"
+            api.act(
+                out, err, options.json, path,
+                done = "deleted ${command.accountId} and all of its data",
+                missing = "no account ${command.accountId} on this server",
+            )
+        }
+    }
+} catch (e: IOException) {
+    err.appendLine("cannot reach ${options.baseUrl}: ${e.message ?: e::class.simpleName}")
+    EXIT_UNREACHABLE
+} catch (e: SerializationException) {
+    // An older CLI against a newer server (or vice versa) must fail like every other error path —
+    // one line — rather than dumping a stack trace at an operator.
+    // kotlinx's own message spans several lines (it echoes the input); keep the first, so this path
+    // stays the single line every other CLI error is.
+    val detail = e.message?.lineSequence()?.firstOrNull()?.trim() ?: "could not decode the body"
+    err.appendLine("unexpected response from ${options.baseUrl}: $detail")
+    EXIT_ERROR
+}
+
+/** Ktor client for real runs: base URL from the options, no redirect following, short timeouts. */
+private fun defaultHttpClient(options: CliOptions): HttpClient = HttpClient(CIO) {
+    followRedirects = false
+    expectSuccess = false
+    defaultRequest { url(options.baseUrl) }
+}
+
+private val jsonCodec = Json { ignoreUnknownKeys = true }
+
+private class AdminApi(private val client: HttpClient, private val token: String?) {
+
+    suspend fun get(path: String): HttpResponse = client.get(path) { adminToken() }
+
+    /** GET /metrics with its own bearer token, printed exactly as a scraper would receive it. */
+    suspend fun scrape(out: Appendable, err: Appendable, metricsToken: String?): Int {
+        val response = client.get("/metrics") {
+            metricsToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+        }
+        if (response.status == HttpStatusCode.Unauthorized) {
+            err.appendLine("unauthorized: /metrics needs its own token (SKERRY_METRICS_TOKEN or --metrics-token)")
+            return EXIT_UNAUTHORIZED
+        }
+        if (response.status == HttpStatusCode.NotFound) {
+            err.appendLine("not found: metrics are disabled on this server (set SKERRY_METRICS=token)")
+            return EXIT_NOT_FOUND
+        }
+        return response.handle(out, err, json = true) { it }
+    }
+
+    suspend fun delete(path: String): HttpResponse = client.delete(path) { adminToken() }
+
+    private fun io.ktor.client.request.HttpRequestBuilder.adminToken() {
+        token?.let { header("X-Admin-Token", it) }
+    }
+
+    /** GET [path] and print either the raw body (`--json`) or [format]ted output. */
+    suspend fun render(
+        out: Appendable,
+        err: Appendable,
+        json: Boolean,
+        path: String,
+        format: (String) -> String,
+    ): Int = get(path).handle(out, err, json, format)
+
+    /** DELETE [path] where success carries no body (204): print [done] or `{"ok":true}`. */
+    suspend fun act(
+        out: Appendable,
+        err: Appendable,
+        json: Boolean,
+        path: String,
+        done: String,
+        missing: String,
+    ): Int {
+        val response = delete(path)
+        return when {
+            response.status == HttpStatusCode.NoContent -> {
+                out.appendLine(if (json) """{"ok":true}""" else done)
+                EXIT_OK
+            }
+            // These endpoints answer 404 with no body, so the server has no message to relay.
+            response.status == HttpStatusCode.NotFound -> {
+                err.appendLine("not found: $missing")
+                EXIT_NOT_FOUND
+            }
+            else -> response.reportFailure(err)
+        }
+    }
+}
+
+private suspend fun HttpResponse.handle(
+    out: Appendable,
+    err: Appendable,
+    json: Boolean,
+    format: (String) -> String,
+): Int {
+    if (!status.isSuccess()) return reportFailure(err)
+    val body = bodyAsText()
+    out.appendLine(if (json) body.trimEnd() else format(body))
+    return EXIT_OK
+}
+
+/**
+ * Maps an HTTP failure onto an exit code a shell script can branch on, with the server's own error
+ * message when it sent one.
+ */
+private suspend fun HttpResponse.reportFailure(err: Appendable): Int {
+    val body = runCatching { bodyAsText() }.getOrDefault("")
+    val message = runCatching { jsonCodec.decodeFromString<ErrorResponse>(body).error }
+        .getOrElse { body.takeIf(String::isNotBlank)?.lines()?.first() ?: status.description }
+    return when (status) {
+        HttpStatusCode.Unauthorized -> {
+            err.appendLine("unauthorized: $message (set SKERRY_ADMIN_TOKEN or pass --token)")
+            EXIT_UNAUTHORIZED
+        }
+        HttpStatusCode.NotFound -> {
+            err.appendLine("not found: $message")
+            EXIT_NOT_FOUND
+        }
+        else -> {
+            err.appendLine("server returned ${status.value}: $message")
+            EXIT_ERROR
+        }
+    }
+}
+
+private fun String.withLimit(limit: Int?): String = withParam("limit", limit?.toString())
+
+private fun String.withParam(name: String, value: String?): String = when {
+    value == null -> this
+    '?' in this -> "$this&$name=${value.encodeURLParameter()}"
+    else -> "$this?$name=${value.encodeURLParameter()}"
+}
+
+private fun footer(shown: Int, total: Long): String =
+    if (shown.toLong() >= total) "\n${shown} of $total" else "\n$shown of $total (raise --limit for more)"

--- a/server/src/main/kotlin/app/skerry/server/cli/CliOutput.kt
+++ b/server/src/main/kotlin/app/skerry/server/cli/CliOutput.kt
@@ -1,0 +1,71 @@
+package app.skerry.server.cli
+
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/** Table and value formatting for `skerry-admin`. Pure functions — the runner only prints them. */
+
+private val UTC_MINUTES: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneOffset.UTC)
+
+/**
+ * Left-aligned columns padded to the widest cell; the last column is never padded so trailing
+ * whitespace doesn't show up in pipes. Rows shorter than [headers] are filled with blanks.
+ */
+fun table(headers: List<String>, rows: List<List<String>>): String {
+    if (headers.isEmpty()) return ""
+    val widths = IntArray(headers.size) { column ->
+        maxOf(headers[column].length, rows.maxOfOrNull { it.getOrElse(column) { "" }.length } ?: 0)
+    }
+    fun line(cells: List<String>) = headers.indices
+        .joinToString("  ") { column ->
+            val cell = cells.getOrElse(column) { "" }
+            if (column == headers.lastIndex) cell else cell.padEnd(widths[column])
+        }
+        .trimEnd()
+    return (listOf(line(headers)) + rows.map(::line)).joinToString("\n")
+}
+
+/** Two-column key/value block for single-object output (`stats`, `health`). */
+fun keyValues(pairs: List<Pair<String, String>>): String {
+    val width = pairs.maxOfOrNull { it.first.length } ?: 0
+    return pairs.joinToString("\n") { (key, value) -> key.padEnd(width) + "  " + value }
+}
+
+/** Binary units, as the console shows them — a self-hosted operator compares this against `du`. */
+fun humanBytes(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val units = listOf("KiB", "MiB", "GiB", "TiB")
+    var value = bytes.toDouble() / 1024
+    var unit = 0
+    while (value >= 1024 && unit < units.lastIndex) {
+        value /= 1024
+        unit++
+    }
+    // Locale.ROOT: the operator's JVM locale must not turn "1.2 MiB" into "1,2 MiB" in output that
+    // gets grepped and compared against `du`.
+    val pattern = if (value >= 100) "%.0f %s" else "%.1f %s"
+    return String.format(Locale.ROOT, pattern, value, units[unit])
+}
+
+/**
+ * Coarse "how long ago", which is what a device list is read for. A timestamp in the future (clock
+ * skew between the server and the CLI host) is reported as such instead of a negative age.
+ */
+fun relativeTime(timestamp: Long?, now: Long): String {
+    if (timestamp == null) return "—"
+    val delta = now - timestamp
+    val minutes = delta / 60_000
+    return when {
+        delta < -60_000 -> "in the future"
+        minutes < 1 -> "just now"
+        minutes < 60 -> "${minutes}m ago"
+        minutes < 60 * 48 -> "${minutes / 60}h ago"
+        else -> "${minutes / 1440}d ago"
+    }
+}
+
+/** Absolute timestamps are printed in UTC so they don't depend on the container's timezone. */
+fun utcMinutes(timestamp: Long): String = UTC_MINUTES.format(Instant.ofEpochMilli(timestamp)) + " UTC"

--- a/server/src/main/kotlin/app/skerry/server/config/ServerConfig.kt
+++ b/server/src/main/kotlin/app/skerry/server/config/ServerConfig.kt
@@ -8,6 +8,29 @@ package app.skerry.server.config
 data class CorsHost(val host: String, val schemes: List<String>)
 
 /**
+ * Who may scrape `GET /metrics`. Closed by default: the exposition is metadata about the instance
+ * (how many accounts, how much ciphertext, how often logins fail), and metadata is the whole attack
+ * surface of a zero-knowledge server.
+ */
+enum class MetricsExposure {
+    /** No endpoint at all — the route answers 404, so it doesn't even announce itself. */
+    OFF,
+
+    /** Requires `Authorization: Bearer <SKERRY_METRICS_TOKEN>` (Prometheus `authorization`). */
+    TOKEN,
+
+    /** Open. Only for a metrics port that is unreachable from outside the host. */
+    OPEN,
+    ;
+
+    companion object {
+        /** Anything unrecognized means OFF: a typo must not open the endpoint. */
+        fun parse(raw: String): MetricsExposure =
+            entries.firstOrNull { it.name.equals(raw.trim(), ignoreCase = true) } ?: OFF
+    }
+}
+
+/**
  * Server config from environment variables (single-.env model). All values have sane defaults for local runs; production only requires a stable [jwtSecret]
  * — otherwise a restart invalidates every issued token.
  *
@@ -45,10 +68,26 @@ data class ServerConfig(
     val registrationOpen: Boolean,
     /** Hard cap on total accounts (backstop for an instance left open). 0 ⇒ unlimited. */
     val maxAccounts: Int,
+    /** Who may scrape `/metrics`. Default [MetricsExposure.OFF]. */
+    val metrics: MetricsExposure,
+    /** Bearer token for [MetricsExposure.TOKEN]. Deliberately separate from [adminToken]. */
+    val metricsToken: String,
+    /**
+     * How often the inventory gauges (accounts, records, ciphertext size) are refreshed in the
+     * background. Never computed during a scrape: on SQLite the pool is a single connection, so a
+     * `SUM(LENGTH(blob))` per scrape would compete with every push and pull. 0 ⇒ no inventory.
+     */
+    val metricsInventoryIntervalSeconds: Long,
 ) {
     val isPostgres: Boolean get() = databaseUrl.startsWith("jdbc:postgresql")
 
     val usesDefaultJwtSecret: Boolean get() = jwtSecret == DEFAULT_JWT_SECRET
+
+    /**
+     * `SKERRY_METRICS=token` with no token set: the guard in `Application.module` refuses to start,
+     * because the alternative is a typo quietly publishing the exposition to anyone who asks.
+     */
+    val metricsTokenMissing: Boolean get() = metrics == MetricsExposure.TOKEN && metricsToken.isBlank()
 
     companion object {
         /** Known-unsafe default; production must override it (see the guard in Application.module). */
@@ -82,6 +121,12 @@ data class ServerConfig(
                 // Default open for backward compatibility; anything other than "open" (case-insensitive) closes it.
                 registrationOpen = str("SKERRY_REGISTRATION", "open").equals("open", ignoreCase = true),
                 maxAccounts = int("SKERRY_MAX_ACCOUNTS", 0).coerceAtLeast(0),
+                metrics = MetricsExposure.parse(str("SKERRY_METRICS", "off")),
+                metricsToken = str("SKERRY_METRICS_TOKEN", ""),
+                // Floor of 15s: below that the collector scans `records` more often than the numbers
+                // change. 0 disables it entirely (counters and JVM metrics still work).
+                metricsInventoryIntervalSeconds = long("SKERRY_METRICS_INVENTORY_SECONDS", 60)
+                    .let { if (it <= 0) 0 else it.coerceAtLeast(15) },
             )
         }
 

--- a/server/src/main/kotlin/app/skerry/server/db/Database.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Database.kt
@@ -3,6 +3,8 @@ package app.skerry.server.db
 import app.skerry.server.config.ServerConfig
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory
+import io.micrometer.core.instrument.MeterRegistry
 import org.jetbrains.exposed.v1.core.vendors.SQLiteDialect
 import org.jetbrains.exposed.v1.core.vendors.currentDialect
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -12,7 +14,12 @@ import org.jetbrains.exposed.v1.jdbc.vendors.currentDialectMetadata
 
 /** Database connection and schema creation. SQLite by default, PostgreSQL via URL. */
 object Db {
-    fun connect(config: ServerConfig): Database {
+    /**
+     * [meterRegistry] (when given) makes HikariCP publish `hikaricp_connections*` — on the default
+     * SQLite deployment that is the most informative metric there is, since the pool is a single
+     * connection and `hikaricp_connections_pending` is therefore direct evidence of contention.
+     */
+    fun connect(config: ServerConfig, meterRegistry: MeterRegistry? = null): Database {
         val hikari = HikariConfig().apply {
             jdbcUrl = config.databaseUrl
             if (config.databaseUser.isNotEmpty()) username = config.databaseUser
@@ -20,6 +27,7 @@ object Db {
             // SQLite is single-writer: one connection avoids "database is locked".
             // PostgreSQL uses a normal pool.
             maximumPoolSize = if (config.isPostgres) 10 else 1
+            if (meterRegistry != null) metricsTrackerFactory = MicrometerMetricsTrackerFactory(meterRegistry)
         }
         val database = Database.connect(HikariDataSource(hikari))
         createSchema(database)

--- a/server/src/main/kotlin/app/skerry/server/db/DeviceRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/DeviceRepository.kt
@@ -71,18 +71,24 @@ class DeviceRepository(private val db: Database) {
      * never deleted, so including them would let the list grow without bound. A revoked device that
      * re-authenticates clears its revocation and reappears here.
      */
-    suspend fun listAll(limit: Int = 200): List<DeviceRow> = dbTransaction(db) {
+    suspend fun listAll(limit: Int = 200, accountId: String? = null): List<DeviceRow> = dbTransaction(db) {
         Devices.selectAll()
-            .where { Devices.revoked eq false }
+            .where { activeDevices(accountId) }
             .orderBy(Devices.lastSeenAt to SortOrder.DESC)
             .limit(limit)
             .map { it.toDeviceRow() }
     }
 
     /** Active (non-revoked) devices on the instance, matching [listAll] for an accurate "N of M". */
-    suspend fun count(): Long = dbTransaction(db) {
-        Devices.selectAll().where { Devices.revoked eq false }.count()
+    suspend fun count(accountId: String? = null): Long = dbTransaction(db) {
+        Devices.selectAll().where { activeDevices(accountId) }.count()
     }
+
+    /** The listing predicate, shared by [listAll] and [count] so a page and its total can't disagree. */
+    private fun activeDevices(accountId: String?) =
+        (Devices.revoked eq false).let { active ->
+            if (accountId == null) active else active and (Devices.accountId eq accountId)
+        }
 
     suspend fun find(accountId: String, deviceId: String): DeviceRow? = dbTransaction(db) {
         Devices.selectAll()

--- a/server/src/main/kotlin/app/skerry/server/db/StatsRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/StatsRepository.kt
@@ -1,8 +1,12 @@
 package app.skerry.server.db
 
+import app.skerry.server.metrics.InventorySnapshot
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.nio.file.Files
+import java.nio.file.Path
 
 /** Aggregates for the admin console: counts and total ciphertext size only, no content. */
 class StatsRepository(private val db: Database) {
@@ -13,6 +17,11 @@ class StatsRepository(private val db: Database) {
         val pairingSessions: Long,
         val storageBytes: Long,
     )
+
+    /** Cheapest possible liveness check for the database, used by the readiness probe. */
+    suspend fun ping(): Unit = dbTransaction(db) {
+        exec("SELECT 1") { }
+    }
 
     suspend fun counts(): Counts = dbTransaction(db) {
         Counts(
@@ -29,5 +38,99 @@ class StatsRepository(private val db: Database) {
                 if (rs.next()) rs.getLong("total") else 0L
             } ?: 0L,
         )
+    }
+
+    /**
+     * Everything the metrics inventory gauges need, in **one** transaction and one grouped query per
+     * table rather than a count per number. Called only by the background collector — never during a
+     * scrape: on the default SQLite deployment the pool is a single connection, so scanning `records`
+     * on every scrape would compete with every push and pull.
+     *
+     * `CASE WHEN` over booleans and `LENGTH(blob)` are portable between SQLite (0/1, BLOB) and
+     * PostgreSQL (boolean, bytea) — the same approach as [AdminRepository.accountSummaries].
+     */
+    suspend fun inventory(
+        databaseUrl: String,
+        now: Long = System.currentTimeMillis(),
+    ): InventorySnapshot = dbTransaction(db) {
+        fun row(sql: String, columns: List<String>): List<Long> =
+            exec(sql) { rs -> if (rs.next()) columns.map { rs.getLong(it) } else columns.map { 0L } }
+                ?: columns.map { 0L }
+
+        val devices = row(
+            """SELECT COUNT(*) AS total,
+                      SUM(CASE WHEN revoked THEN 0 ELSE 1 END) AS active
+               FROM devices""",
+            listOf("total", "active"),
+        )
+        val records = row(
+            """SELECT COUNT(*) AS total,
+                      SUM(CASE WHEN deleted THEN 1 ELSE 0 END) AS tombstones,
+                      COALESCE(SUM(LENGTH(blob)), 0) AS bytes
+               FROM records""",
+            listOf("total", "tombstones", "bytes"),
+        )
+        val teamRecords = row(
+            """SELECT COUNT(*) AS total,
+                      SUM(CASE WHEN deleted THEN 1 ELSE 0 END) AS tombstones,
+                      COALESCE(SUM(LENGTH(blob)), 0) AS bytes
+               FROM team_records""",
+            listOf("total", "tombstones", "bytes"),
+        )
+        val pairing = row(
+            """SELECT COUNT(*) AS total,
+                      SUM(CASE WHEN expires_at < $now THEN 1 ELSE 0 END) AS expired
+               FROM pairing""",
+            listOf("total", "expired"),
+        )
+        val members = row(
+            """SELECT COUNT(*) AS total,
+                      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active
+               FROM team_members""",
+            listOf("total", "active"),
+        )
+
+        InventorySnapshot(
+            accounts = Accounts.selectAll().count(),
+            activeDevices = devices[1],
+            revokedDevices = devices[0] - devices[1],
+            liveRecords = records[0] - records[1],
+            tombstones = records[1],
+            storageBytes = records[2],
+            liveTeamRecords = teamRecords[0] - teamRecords[1],
+            teamTombstones = teamRecords[1],
+            teamStorageBytes = teamRecords[2],
+            pendingPairings = pairing[0] - pairing[1],
+            expiredPairings = pairing[1],
+            teams = Teams.selectAll().count(),
+            activeMembers = members[1],
+            invitedMembers = members[0] - members[1],
+            activityRows = ActivityLog.selectAll().count(),
+            databaseBytes = databaseSizeBytes(databaseUrl),
+        )
+    }
+
+    /**
+     * Size on disk — more useful than the sum of blob lengths, because it includes indexes, the WAL
+     * and free pages, i.e. what actually fills the volume. 0 when it can't be determined (an
+     * in-memory database, or a PostgreSQL role without permission).
+     */
+    private fun JdbcTransaction.databaseSizeBytes(databaseUrl: String): Long = when {
+        databaseUrl.startsWith("jdbc:postgresql") ->
+            exec("SELECT pg_database_size(current_database()) AS bytes") { rs ->
+                if (rs.next()) rs.getLong("bytes") else 0L
+            } ?: 0L
+        databaseUrl.startsWith("jdbc:sqlite:") -> {
+            val file = databaseUrl.removePrefix("jdbc:sqlite:").substringBefore('?')
+            runCatching {
+                val path = Path.of(file)
+                // A WAL-mode database keeps recent pages in the sidecar files; ignoring them would
+                // under-report right after a write burst.
+                listOf(path, Path.of("$file-wal"), Path.of("$file-shm"))
+                    .filter { Files.exists(it) }
+                    .sumOf { Files.size(it) }
+            }.getOrDefault(0L)
+        }
+        else -> 0L
     }
 }

--- a/server/src/main/kotlin/app/skerry/server/metrics/DbProbe.kt
+++ b/server/src/main/kotlin/app/skerry/server/metrics/DbProbe.kt
@@ -1,0 +1,73 @@
+package app.skerry.server.metrics
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import org.slf4j.LoggerFactory
+
+/**
+ * Background database probe behind `GET /readyz` and `skerry_db_up`.
+ *
+ * Two design constraints, both learned from what readiness probes usually get wrong:
+ *
+ * 1. **The probe never runs inside the request.** An orchestrator polling `/readyz` every couple of
+ *    seconds would otherwise spend the single SQLite connection on probing and then report its own
+ *    contention as a database failure. `/readyz` reads [ready], which this loop maintains.
+ * 2. **Hysteresis.** One slow transaction must not take the instance out of rotation, so it takes
+ *    [failureThreshold] consecutive failures to become not-ready and a single success to come back.
+ */
+class DbProbe(
+    private val metrics: ServerMetrics,
+    private val timeoutMillis: Long = 2_000,
+    private val failureThreshold: Int = 3,
+    private val check: suspend () -> Unit,
+) {
+    /** Starts ready: schema creation at startup already proved the database answers. */
+    @Volatile
+    var ready: Boolean = true
+        private set
+
+    /** Touched only from the probe loop (or a test calling [probeOnce] sequentially). */
+    private var consecutiveFailures = 0
+
+    suspend fun probeOnce(nanoTime: () -> Long = System::nanoTime) {
+        val startedAt = nanoTime()
+        val failure = try {
+            withTimeout(timeoutMillis) { check() }
+            null
+        } catch (timeout: TimeoutCancellationException) {
+            timeout
+        } catch (cancelled: CancellationException) {
+            throw cancelled // shutdown, not a database fault
+        } catch (error: Exception) {
+            error
+        }
+        metrics.dbProbe(up = failure == null, durationSeconds = (nanoTime() - startedAt) / 1_000_000_000.0)
+        if (failure == null) {
+            if (!ready) log.info("database probe recovered")
+            consecutiveFailures = 0
+            ready = true
+        } else {
+            consecutiveFailures++
+            // Logged every time: unlike the periodic cleanup, a probe failure is exactly the kind of
+            // thing an operator is looking for when the instance misbehaves.
+            log.warn("database probe failed ($consecutiveFailures in a row): {}", failure.message ?: failure::class.simpleName)
+            if (consecutiveFailures >= failureThreshold) ready = false
+        }
+    }
+
+    fun start(scope: CoroutineScope, intervalMillis: Long = 10_000): Job = scope.launch {
+        while (true) {
+            probeOnce()
+            delay(intervalMillis)
+        }
+    }
+
+    private companion object {
+        val log = LoggerFactory.getLogger(DbProbe::class.java)!!
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/metrics/InventoryCollector.kt
+++ b/server/src/main/kotlin/app/skerry/server/metrics/InventoryCollector.kt
@@ -1,0 +1,47 @@
+package app.skerry.server.metrics
+
+import app.skerry.server.db.StatsRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * Refreshes the inventory gauges (accounts, records, ciphertext size, database file size) in the
+ * background, so a scrape never triggers a table scan — see [StatsRepository.inventory] for why that
+ * matters on a single-connection SQLite pool.
+ *
+ * On failure the gauges keep their previous values and the freshness timestamp is deliberately left
+ * behind: the honest signal is `time() - skerry_inventory_last_success_time_seconds`, which an alert
+ * can act on. Zeroing the gauges would look like data loss; refusing to say anything would hide it.
+ */
+class InventoryCollector(
+    private val stats: StatsRepository,
+    private val metrics: ServerMetrics,
+    private val databaseUrl: String,
+) {
+    suspend fun collectOnce(now: () -> Long = System::currentTimeMillis) {
+        try {
+            val at = now()
+            metrics.inventoryCollected(stats.inventory(databaseUrl, at), at)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            metrics.inventoryFailed()
+            log.warn("metrics inventory collection failed", error)
+        }
+    }
+
+    fun start(scope: CoroutineScope, intervalSeconds: Long): Job = scope.launch {
+        while (true) {
+            collectOnce()
+            delay(intervalSeconds * 1_000)
+        }
+    }
+
+    private companion object {
+        val log = LoggerFactory.getLogger(InventoryCollector::class.java)!!
+    }
+}

--- a/server/src/main/kotlin/app/skerry/server/metrics/ServerMetrics.kt
+++ b/server/src/main/kotlin/app/skerry/server/metrics/ServerMetrics.kt
@@ -1,0 +1,323 @@
+package app.skerry.server.metrics
+
+import app.skerry.server.config.MetricsExposure
+import app.skerry.server.config.ServerConfig
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.Tags
+import io.micrometer.core.instrument.binder.MeterBinder
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics
+import io.micrometer.core.instrument.binder.system.UptimeMetrics
+import io.micrometer.core.instrument.config.MeterFilter
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import java.io.Closeable
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Prometheus metrics for one server instance. Deliberate boundaries:
+ *
+ * - **No unbounded labels.** Every label value comes from an enum or a fixed route allow-list, never
+ *   from client input: `accountId`, `deviceId`, `recordId`, `teamId`, `scopeId` and IPs are all
+ *   client-chosen, so a label carrying one would let a user grow the registry until it OOMs — and on
+ *   a zero-knowledge server it would also publish the very metadata the design protects.
+ * - **Nothing expensive at scrape time.** Inventory gauges read a snapshot refreshed in the
+ *   background ([InventoryCollector]); the SQLite pool is a single connection.
+ * - **Per instance, not a singleton.** The tests start `configureServer` many times in one JVM, so a
+ *   global registry would accumulate duplicate meters and leak the GC notification listener.
+ */
+class ServerMetrics(
+    private val config: ServerConfig,
+    val registry: PrometheusMeterRegistry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT),
+    version: String = "unknown",
+    startTimeMillis: Long = System.currentTimeMillis(),
+) : Closeable {
+
+    // AutoCloseable, not Closeable: that is what Micrometer's JvmGcMetrics implements.
+    private val binders = mutableListOf<AutoCloseable>()
+
+    private val wsSessions = AtomicInteger()
+    /** Null until the first successful collection: an absent number must not read as zero. */
+    @Volatile
+    private var inventory: InventorySnapshot? = null
+    private val inventoryLastSuccessSeconds = AtomicLong(0)
+    /** NaN until the first probe: "not measured yet" is not the same fact as "down". */
+    private val dbUp = AtomicReference(Double.NaN)
+
+    init {
+        // The HTTP timer's own tags are enough; `address` is constant per instance and `throwable`
+        // duplicates skerry_http_unhandled_exceptions_total.
+        registry.config().meterFilter(MeterFilter.ignoreTags("address", "throwable"))
+        registry.config().meterFilter(HistogramBuckets)
+
+        Gauge.builder("skerry.build.info") { 1.0 }
+            .description("Server build information")
+            .tag("version", version)
+            .register(registry)
+        Gauge.builder("skerry.server.start.time") { startTimeMillis / 1000.0 }
+            .description("Process start, unix epoch seconds")
+            .baseUnit("seconds")
+            .register(registry)
+
+        Gauge.builder("skerry.sync.ws.sessions") { wsSessions.get().toDouble() }
+            .description("Open /sync WebSocket sessions")
+            .register(registry)
+
+        registerInventoryGauges()
+
+        // JVM/process instrumentation is only worth its listeners when someone can actually scrape.
+        if (config.metrics != MetricsExposure.OFF) bindRuntimeMetrics()
+    }
+
+    // --- HTTP ---
+
+    fun requestRejected(reason: RejectReason) = count("skerry.http.rejected.requests", "reason" to reason.label)
+
+    fun unhandledException() = count("skerry.http.unhandled.exceptions")
+
+    // --- auth / security ---
+
+    fun authAttempt(kind: AuthKind, outcome: AuthOutcome) =
+        count("skerry.auth.attempts", "kind" to kind.label, "outcome" to outcome.label)
+
+    fun tokensIssued(type: TokenType) = count("skerry.auth.tokens.issued", "type" to type.label)
+
+    fun jwtRejected(reason: JwtRejection) = count("skerry.auth.jwt.rejected", "reason" to reason.label)
+
+    fun adminAuthFailure() = count("skerry.admin.auth.failures")
+
+    fun metricsAuthFailure() = count("skerry.metrics.auth.failures")
+
+    fun registrationRejected(reason: RegistrationRejection) =
+        count("skerry.registration.rejected", "reason" to reason.label)
+
+    fun deviceRevoked(by: RevokedBy) = count("skerry.devices.revoked", "by" to by.label)
+
+    fun teamAuthzDenied(reason: TeamDenial) = count("skerry.team.authz.denied", "reason" to reason.label)
+
+    // --- sync ---
+
+    fun recordsReceived(scope: SyncScope, records: Int, bytes: Long) {
+        count("skerry.sync.records.received", "scope" to scope.label, amount = records.toDouble())
+        count("skerry.sync.push.bytes", "scope" to scope.label, amount = bytes.toDouble())
+    }
+
+    fun recordsPulled(scope: SyncScope, records: Int) =
+        count("skerry.sync.records.pulled", "scope" to scope.label, amount = records.toDouble())
+
+    fun notificationPublished(kind: NotifyKind) = count("skerry.sync.notify.published", "kind" to kind.label)
+
+    fun wsSessionOpened() {
+        wsSessions.incrementAndGet()
+        count("skerry.sync.ws.sessions.opened")
+    }
+
+    fun wsSessionClosed(reason: WsCloseReason, durationSeconds: Double) {
+        wsSessions.decrementAndGet()
+        count("skerry.sync.ws.sessions.closed", "reason" to reason.label)
+        registry.timer("skerry.sync.ws.session.duration")
+            .record((durationSeconds * 1_000).toLong(), TimeUnit.MILLISECONDS)
+    }
+
+    fun wsFrameSent(kind: NotifyKind) = count("skerry.sync.ws.frames.sent", "kind" to kind.label)
+
+    // --- database probe (fed by DbProbe) ---
+
+    fun dbProbe(up: Boolean, durationSeconds: Double) {
+        dbUp.set(if (up) 1.0 else 0.0)
+        registry.timer("skerry.db.probe.duration")
+            .record((durationSeconds * 1_000).toLong(), TimeUnit.MILLISECONDS)
+    }
+
+    // --- inventory ---
+
+    fun inventoryCollected(snapshot: InventorySnapshot, atMillis: Long = System.currentTimeMillis()) {
+        inventory = snapshot
+        inventoryLastSuccessSeconds.set(atMillis / 1000)
+    }
+
+    /**
+     * A failed collection deliberately leaves the previous snapshot in place *and* leaves the
+     * freshness timestamp behind: alerting on `time() - …last_success_seconds` is what turns a stale
+     * gauge into a visible fault instead of a silent lie.
+     */
+    fun inventoryFailed() = count("skerry.inventory.errors")
+
+    /** Unix seconds of the last successful inventory collection, or null if there has never been one. */
+    val inventoryLastSuccessSecondsOrNull: Long?
+        get() = inventoryLastSuccessSeconds.get().takeIf { it > 0 }
+
+    fun scrape(): String = registry.scrape()
+
+    override fun close() {
+        binders.forEach { runCatching { it.close() } }
+        binders.clear()
+        registry.close()
+    }
+
+    private fun bindRuntimeMetrics() {
+        val gc = JvmGcMetrics()
+        binders += gc
+        listOf<MeterBinder>(
+            ClassLoaderMetrics(),
+            JvmMemoryMetrics(),
+            gc,
+            JvmThreadMetrics(),
+            ProcessorMetrics(),
+            UptimeMetrics(),
+            FileDescriptorMetrics(),
+        ).forEach { it.bindTo(registry) }
+    }
+
+    private fun registerInventoryGauges() {
+        Gauge.builder("skerry.db.up") { dbUp.get() }
+            .description("1 when the database answered the last probe, 0 when it did not")
+            .register(registry)
+        Gauge.builder("skerry.inventory.last.success.time") { inventoryLastSuccessSeconds.get().toDouble() }
+            .description("Last successful inventory collection, unix epoch seconds (0 = never)")
+            .baseUnit("seconds")
+            .register(registry)
+
+        fun inventoryGauge(name: String, description: String, unit: String? = null, tags: Tags = Tags.empty(), value: (InventorySnapshot) -> Number) {
+            Gauge.builder(name) { inventory?.let { value(it).toDouble() } ?: Double.NaN }
+                .description(description)
+                .tags(tags)
+                .apply { if (unit != null) baseUnit(unit) }
+                .register(registry)
+        }
+
+        inventoryGauge("skerry.accounts", "Accounts on the instance") { it.accounts }
+        inventoryGauge("skerry.devices", "Devices", tags = Tags.of("state", "active")) { it.activeDevices }
+        inventoryGauge("skerry.devices", "Devices", tags = Tags.of("state", "revoked")) { it.revokedDevices }
+        inventoryGauge("skerry.records", "Vault records", tags = Tags.of("state", "live")) { it.liveRecords }
+        inventoryGauge("skerry.records", "Vault records", tags = Tags.of("state", "tombstone")) { it.tombstones }
+        inventoryGauge("skerry.team.records", "Team records", tags = Tags.of("state", "live")) { it.liveTeamRecords }
+        inventoryGauge("skerry.team.records", "Team records", tags = Tags.of("state", "tombstone")) { it.teamTombstones }
+        inventoryGauge("skerry.storage.bytes", "Ciphertext stored", "bytes", Tags.of("scope", "account")) { it.storageBytes }
+        inventoryGauge("skerry.storage.bytes", "Ciphertext stored", "bytes", Tags.of("scope", "team")) { it.teamStorageBytes }
+        inventoryGauge("skerry.db.file.bytes", "Database size on disk (includes indexes and free pages)", "bytes") { it.databaseBytes }
+        inventoryGauge("skerry.pairing.sessions", "Pairing sessions", tags = Tags.of("state", "pending")) { it.pendingPairings }
+        inventoryGauge("skerry.pairing.sessions", "Pairing sessions", tags = Tags.of("state", "expired")) { it.expiredPairings }
+        inventoryGauge("skerry.teams", "Teams") { it.teams }
+        inventoryGauge("skerry.team.members", "Team members", tags = Tags.of("status", "active")) { it.activeMembers }
+        inventoryGauge("skerry.team.members", "Team members", tags = Tags.of("status", "invited")) { it.invitedMembers }
+        inventoryGauge("skerry.activity.log.rows", "Retained audit-log rows") { it.activityRows }
+        // Config, not inventory: it is known from the start, so it must not wait for a collection.
+        Gauge.builder("skerry.registration.open") { if (config.registrationOpen) 1.0 else 0.0 }
+            .description("1 when POST /auth/register accepts new accounts")
+            .register(registry)
+    }
+
+    private fun count(name: String, vararg tags: Pair<String, String>, amount: Double = 1.0) {
+        val labels = tags.fold(Tags.empty()) { acc, (key, value) -> acc.and(key, value) }
+        registry.counter(name, labels).increment(amount)
+    }
+
+    private companion object {
+        /**
+         * Explicit SLO buckets instead of Micrometer's percentile histogram: the default would emit
+         * ~70 buckets per series (thousands of series for a handful of routes). Boundaries chosen
+         * against this server's own shape — 5ms is "answered without touching the database", 250ms
+         * is the top of normal for a record push, 5s already looks like a blocked SQLite connection.
+         */
+        val SLO_SECONDS = doubleArrayOf(0.005, 0.025, 0.1, 0.25, 1.0, 5.0)
+    }
+
+    /** Applies [SLO_SECONDS] to the timers we own; Micrometer wants service-level objectives in nanoseconds. */
+    private object HistogramBuckets : MeterFilter {
+        private val timerNames = setOf(HTTP_REQUESTS_METRIC, "skerry.db.probe.duration")
+
+        override fun configure(id: Meter.Id, config: DistributionStatisticConfig): DistributionStatisticConfig =
+            when (id.name) {
+                in timerNames -> DistributionStatisticConfig.builder()
+                    .percentilesHistogram(false)
+                    .serviceLevelObjectives(*SLO_SECONDS.map { it * 1_000_000_000 }.toDoubleArray())
+                    .build()
+                    .merge(config)
+                "skerry.sync.ws.session.duration" -> DistributionStatisticConfig.builder()
+                    .percentilesHistogram(false)
+                    .serviceLevelObjectives(
+                        *doubleArrayOf(1.0, 10.0, 60.0, 300.0, 1_800.0, 7_200.0)
+                            .map { it * 1_000_000_000 }.toDoubleArray(),
+                    )
+                    .build()
+                    .merge(config)
+                else -> config
+            }
+    }
+}
+
+/** Name of the HTTP server timer; also referenced by the route-label allow-list test. */
+const val HTTP_REQUESTS_METRIC = "skerry.http.server.requests"
+
+/** One background snapshot of instance inventory — everything that would need a table scan. */
+data class InventorySnapshot(
+    val accounts: Long,
+    val activeDevices: Long,
+    val revokedDevices: Long,
+    val liveRecords: Long,
+    val tombstones: Long,
+    val storageBytes: Long,
+    val liveTeamRecords: Long,
+    val teamTombstones: Long,
+    val teamStorageBytes: Long,
+    val pendingPairings: Long,
+    val expiredPairings: Long,
+    val teams: Long,
+    val activeMembers: Long,
+    val invitedMembers: Long,
+    val activityRows: Long,
+    val databaseBytes: Long,
+)
+
+enum class AuthKind(val label: String) {
+    REGISTER("register"),
+    SRP_CHALLENGE("srp_challenge"),
+    SRP_VERIFY("srp_verify"),
+    REFRESH("refresh"),
+    CHANGE_PASSWORD("change_password"),
+    PAIRING_CLAIM("pairing_claim"),
+}
+
+enum class AuthOutcome(val label: String) { OK("ok"), DENIED("denied"), ERROR("error") }
+
+enum class TokenType(val label: String) { ACCESS("access"), REFRESH("refresh") }
+
+enum class JwtRejection(val label: String) {
+    WRONG_TYPE("wrong_type"),
+    DEVICE_REVOKED("device_revoked"),
+    MISSING_CLAIMS("missing_claims"),
+}
+
+enum class RegistrationRejection(val label: String) { CLOSED("closed"), CAP_REACHED("cap_reached") }
+
+enum class RevokedBy(val label: String) { USER("user"), ADMIN("admin") }
+
+enum class TeamDenial(val label: String) {
+    NOT_MEMBER("not_member"),
+    NOT_ACCEPTED("not_accepted"),
+    ROLE("role"),
+    SCOPE("scope"),
+}
+
+enum class SyncScope(val label: String) { ACCOUNT("account"), TEAM("team") }
+
+enum class NotifyKind(val label: String) { ACCOUNT("account"), TEAM("team"), MEMBERSHIP("membership") }
+
+enum class WsCloseReason(val label: String) {
+    CLIENT_CLOSE("client_close"),
+    DEVICE_REVOKED("device_revoked"),
+    NO_PRINCIPAL("no_principal"),
+    ERROR("error"),
+}
+
+enum class RejectReason(val label: String) { LENGTH_REQUIRED("length_required"), BODY_TOO_LARGE("body_too_large") }

--- a/server/src/main/kotlin/app/skerry/server/model/Dto.kt
+++ b/server/src/main/kotlin/app/skerry/server/model/Dto.kt
@@ -101,5 +101,25 @@ data class StatsResponse(
 @Serializable
 data class HealthResponse(val status: String, val version: String)
 
+/**
+ * `GET /admin/observability`: is monitoring actually wired up on this instance? The console has no
+ * other way to tell — /metrics may be disabled, and a stale inventory looks fine from the outside.
+ * [inventoryAgeSeconds] is null when nothing has been collected yet: 0 would read as "just now".
+ */
+@Serializable
+data class AdminObservabilityDto(
+    val metrics: String,
+    val ready: Boolean,
+    val inventoryIntervalSeconds: Long,
+    val inventoryAgeSeconds: Long?,
+)
+
+/**
+ * `GET /readyz`: whether this instance can serve sync requests right now. Separate from
+ * [HealthResponse] because liveness must not depend on the database — see the route comment.
+ */
+@Serializable
+data class ReadyResponse(val status: String, val db: String)
+
 @Serializable
 data class ErrorResponse(val error: String)

--- a/server/src/main/kotlin/app/skerry/server/routes/AdminRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AdminRoutes.kt
@@ -2,12 +2,14 @@ package app.skerry.server.routes
 
 import app.skerry.server.SERVER_VERSION
 import app.skerry.server.Services
+import app.skerry.server.metrics.RevokedBy
 import app.skerry.server.model.AdminAccountDto
 import app.skerry.server.model.AdminAccountsResponse
 import app.skerry.server.model.AdminActivityDto
 import app.skerry.server.model.AdminActivityResponse
 import app.skerry.server.model.AdminDeviceDto
 import app.skerry.server.model.AdminDevicesResponse
+import app.skerry.server.model.AdminObservabilityDto
 import app.skerry.server.model.AdminPurgeResponse
 import app.skerry.server.model.AdminRecordDto
 import app.skerry.server.model.AdminRecordsResponse
@@ -29,7 +31,6 @@ import io.ktor.server.routing.RoutingResolveContext
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
-import java.security.MessageDigest
 
 /**
  * Admin endpoints for the self-hosted console. `/admin/health` is open (liveness); the rest of
@@ -49,7 +50,10 @@ fun Route.adminRoutes(services: Services) {
     val guarded = route("/admin") {}.createChild(AdminGuardSelector())
     // Single route-scoped admin-token check for the whole subtree: on failure the plugin
     // responds 401 itself and aborts the pipeline before any route handler runs.
-    guarded.install(AdminAuth) { token = services.config.adminToken }
+    guarded.install(AdminAuth) {
+        token = services.config.adminToken
+        onFailure = { services.metrics.adminAuthFailure() }
+    }
 
     with(guarded) {
         get("/stats") {
@@ -57,10 +61,25 @@ fun Route.adminRoutes(services: Services) {
             call.respond(StatsResponse(c.accounts, c.devices, c.records, c.pairingSessions, c.storageBytes))
         }
 
+        get("/observability") {
+            val lastSuccess = services.metrics.inventoryLastSuccessSecondsOrNull
+            call.respond(
+                AdminObservabilityDto(
+                    metrics = services.config.metrics.name.lowercase(),
+                    ready = services.dbProbe.ready,
+                    inventoryIntervalSeconds = services.config.metricsInventoryIntervalSeconds,
+                    inventoryAgeSeconds = lastSuccess?.let { (System.currentTimeMillis() / 1000 - it).coerceAtLeast(0) },
+                ),
+            )
+        }
+
         get("/devices") {
             val limit = call.limitParam(default = 200, max = 500)
-            val total = services.devices.count()
-            val devices = services.devices.listAll(limit).map {
+            // Optional account filter (`skerry-admin devices list --account`); the total follows it so
+            // the "N of M" line can't disagree with the page.
+            val accountFilter = call.request.queryParameters["accountId"]?.takeIf { it.isNotBlank() }
+            val total = services.devices.count(accountFilter)
+            val devices = services.devices.listAll(limit, accountFilter).map {
                 AdminDeviceDto(
                     accountId = it.accountId,
                     id = it.id,
@@ -94,6 +113,7 @@ fun Route.adminRoutes(services: Services) {
             val revoked = services.devices.revoke(accountId, deviceId)
             if (revoked) {
                 services.activity.record(accountId, "device.revoked", "admin-revoked $deviceId")
+                services.metrics.deviceRevoked(RevokedBy.ADMIN)
             }
             call.respond(if (revoked) HttpStatusCode.NoContent else HttpStatusCode.NotFound)
         }
@@ -166,6 +186,8 @@ private class AdminGuardSelector : RouteSelector() {
 
 private class AdminAuthConfig {
     var token: String = ""
+    /** Called on a rejected request: the counter is the brute-force signal for a static token. */
+    var onFailure: () -> Unit = {}
 }
 
 /**
@@ -183,7 +205,8 @@ private object AdminAuthHook : Hook<suspend (ApplicationCall) -> Boolean> {
 /** Route-scoped guard for the `/admin` subtree: static token from [AdminAuthConfig.token]. */
 private val AdminAuth = createRouteScopedPlugin("AdminAuth", ::AdminAuthConfig) {
     val token = pluginConfig.token
-    on(AdminAuthHook) { call -> call.adminAuthorized(token) }
+    val onFailure = pluginConfig.onFailure
+    on(AdminAuthHook) { call -> call.adminAuthorized(token, onFailure) }
 }
 
 /**
@@ -191,21 +214,13 @@ private val AdminAuth = createRouteScopedPlugin("AdminAuth", ::AdminAuthConfig) 
  * returns false; the calling hook does `finish()`. Constant-time comparison prevents a byte-by-
  * byte timing attack against the long-lived token.
  */
-private suspend fun ApplicationCall.adminAuthorized(token: String): Boolean {
+private suspend fun ApplicationCall.adminAuthorized(token: String, onFailure: () -> Unit): Boolean {
     val provided = request.headers["X-Admin-Token"]
     val ok = token.isNotBlank() && provided != null && constantTimeEquals(provided, token)
-    if (!ok) respond(HttpStatusCode.Unauthorized, ErrorResponse("admin token required"))
+    if (!ok) {
+        onFailure()
+        respond(HttpStatusCode.Unauthorized, ErrorResponse("admin token required"))
+    }
     return ok
 }
 
-/**
- * Constant-time comparison. Both values are hashed to a fixed 32 bytes with SHA-256 first, then
- * compared — otherwise [MessageDigest.isEqual] on differing lengths returns early and leaks the
- * token length via timing.
- */
-private fun constantTimeEquals(a: String, b: String): Boolean {
-    val md = MessageDigest.getInstance("SHA-256")
-    val ha = md.digest(a.toByteArray(Charsets.UTF_8))
-    val hb = md.digest(b.toByteArray(Charsets.UTF_8)) // digest() resets md's state
-    return MessageDigest.isEqual(ha, hb)
-}

--- a/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
@@ -2,6 +2,10 @@ package app.skerry.server.routes
 
 import app.skerry.server.RateLimits
 import app.skerry.server.Services
+import app.skerry.server.metrics.AuthKind
+import app.skerry.server.metrics.AuthOutcome
+import app.skerry.server.metrics.RegistrationRejection
+import app.skerry.server.metrics.TokenType
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
 import app.skerry.sync.wire.ChangePasswordRequest
@@ -33,6 +37,8 @@ fun Route.authRoutes(services: Services) {
             // SIGNUPS_ALLOWED=false) rejects new accounts outright; existing accounts still log in
             // and pair new devices (those paths don't hit /auth/register).
             if (!services.config.registrationOpen) {
+                services.metrics.registrationRejected(RegistrationRejection.CLOSED)
+                services.metrics.authAttempt(AuthKind.REGISTER, AuthOutcome.DENIED)
                 call.respond(HttpStatusCode.Forbidden, ErrorResponse("registration is closed"))
                 return@post
             }
@@ -46,6 +52,8 @@ fun Route.authRoutes(services: Services) {
             // never a security boundary. create() still enforces uniqueness.
             val cap = services.config.maxAccounts
             if (cap > 0 && services.accounts.count() >= cap) {
+                services.metrics.registrationRejected(RegistrationRejection.CAP_REACHED)
+                services.metrics.authAttempt(AuthKind.REGISTER, AuthOutcome.DENIED)
                 call.respond(HttpStatusCode.Forbidden, ErrorResponse("registration limit reached"))
                 return@post
             }
@@ -60,11 +68,15 @@ fun Route.authRoutes(services: Services) {
                 )
             } catch (_: IllegalStateException) {
                 // Existence check inside create() plus catching the PK race (PostgreSQL) -> a single 409.
+                services.metrics.authAttempt(AuthKind.REGISTER, AuthOutcome.ERROR)
                 call.respond(HttpStatusCode.Conflict, ErrorResponse("account already exists"))
                 return@post
             }
             services.devices.register(req.accountId, req.deviceId, req.deviceName, req.platform)
             services.activity.record(req.accountId, "auth.register", "new account + device", deviceId = req.deviceId)
+            services.metrics.authAttempt(AuthKind.REGISTER, AuthOutcome.OK)
+            services.metrics.tokensIssued(TokenType.ACCESS)
+            services.metrics.tokensIssued(TokenType.REFRESH)
             call.respond(
                 TokenResponse(
                     accessToken = services.tokens.issueAccess(req.accountId, req.deviceId),
@@ -95,6 +107,9 @@ fun Route.authRoutes(services: Services) {
             Triple(req.accountId, fakeSalt, fakeVerifier)
         }
         val challenge = services.srp.startChallenge(id, salt, verifier)
+        // Deliberately no "account exists" dimension: it would hand an enumerator exactly the
+        // signal the synthesized challenge above is built to withhold.
+        services.metrics.authAttempt(AuthKind.SRP_CHALLENGE, AuthOutcome.OK)
         call.respond(ChallengeResponse(challenge.challengeId, challenge.salt, challenge.b))
         }
     }
@@ -108,9 +123,13 @@ fun Route.authRoutes(services: Services) {
         }
         val verified = services.srp.verify(req.challengeId, req.a, req.m1)
         if (verified == null) {
+            services.metrics.authAttempt(AuthKind.SRP_VERIFY, AuthOutcome.DENIED)
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse("authentication failed"))
             return@post
         }
+        services.metrics.authAttempt(AuthKind.SRP_VERIFY, AuthOutcome.OK)
+        services.metrics.tokensIssued(TokenType.ACCESS)
+        services.metrics.tokensIssued(TokenType.REFRESH)
         val reactivated = services.devices.register(verified.accountId, req.deviceId, req.deviceName, req.platform)
         services.activity.record(verified.accountId, "auth.login", "srp login", deviceId = req.deviceId)
         // A revoked device returning with the correct password is a separate admin-console event:
@@ -148,6 +167,7 @@ fun Route.authRoutes(services: Services) {
             // The proof also establishes the accountId (from the one-shot challenge).
             val verified = services.srp.verify(req.challengeId, req.a, req.m1)
             if (verified == null) {
+                services.metrics.authAttempt(AuthKind.CHANGE_PASSWORD, AuthOutcome.DENIED)
                 call.respond(HttpStatusCode.Unauthorized, ErrorResponse("authentication failed"))
                 return@post
             }
@@ -165,9 +185,11 @@ fun Route.authRoutes(services: Services) {
             )
             if (syncSeq == null) {
                 // Should not happen (the SRP proof implies the account exists), but stay defensive.
+                services.metrics.authAttempt(AuthKind.CHANGE_PASSWORD, AuthOutcome.ERROR)
                 call.respond(HttpStatusCode.Unauthorized, ErrorResponse("authentication failed"))
                 return@post
             }
+            services.metrics.authAttempt(AuthKind.CHANGE_PASSWORD, AuthOutcome.OK)
             services.activity.record(verified.accountId, "auth.password_changed", "account password rotated", deviceId = req.deviceId)
             // Nudge currently-connected devices: the revoked ones' sockets close on the next
             // emission (per-signal isRevoked check), dropping them to "reconnect" promptly instead
@@ -193,9 +215,13 @@ fun Route.authRoutes(services: Services) {
         if (decoded == null || deviceId == null || accountId == null ||
             services.devices.isRevoked(accountId, deviceId)
         ) {
+            services.metrics.authAttempt(AuthKind.REFRESH, AuthOutcome.DENIED)
             call.respond(HttpStatusCode.Unauthorized, ErrorResponse("invalid refresh token"))
             return@post
         }
+        services.metrics.authAttempt(AuthKind.REFRESH, AuthOutcome.OK)
+        services.metrics.tokensIssued(TokenType.ACCESS)
+        services.metrics.tokensIssued(TokenType.REFRESH)
         call.respond(
             TokenResponse(
                 accessToken = services.tokens.issueAccess(accountId, deviceId),

--- a/server/src/main/kotlin/app/skerry/server/routes/DeviceRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/DeviceRoutes.kt
@@ -4,6 +4,7 @@ import app.skerry.server.Services
 import app.skerry.server.accountId
 import app.skerry.server.deviceId
 import app.skerry.server.jwtPrincipal
+import app.skerry.server.metrics.RevokedBy
 import app.skerry.sync.wire.DeviceDto
 import app.skerry.sync.wire.DevicesResponse
 import app.skerry.server.model.ErrorResponse
@@ -35,6 +36,7 @@ fun Route.deviceRoutes(services: Services) {
         val revoked = services.devices.revoke(principal.accountId, target)
         if (revoked) {
             services.activity.record(principal.accountId, "device.revoked", "revoked $target", deviceId = principal.deviceId)
+            services.metrics.deviceRevoked(RevokedBy.USER)
         }
         call.respond(if (revoked) HttpStatusCode.NoContent else HttpStatusCode.NotFound)
     }

--- a/server/src/main/kotlin/app/skerry/server/routes/MetricsRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/MetricsRoutes.kt
@@ -1,0 +1,49 @@
+package app.skerry.server.routes
+
+import app.skerry.server.Services
+import app.skerry.server.config.MetricsExposure
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.withCharset
+import io.ktor.server.application.call
+import io.ktor.server.request.header
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+
+/**
+ * Prometheus exposition. Not registered at all when metrics are off, so the endpoint answers 404
+ * instead of announcing itself with a 401 — there is no UI behind it that needs a distinguishable
+ * error, and the exposition is instance metadata (account counts, ciphertext volume, failed logins).
+ *
+ * The credential is deliberately **not** [app.skerry.server.config.ServerConfig.adminToken]: that
+ * token also authorizes `DELETE /admin/accounts/{id}`, and a scraper's config file has no business
+ * holding it. `Authorization: Bearer` is what Prometheus supports natively
+ * (`authorization.credentials_file`), unlike a custom header.
+ */
+fun Route.metricsRoutes(services: Services) {
+    if (services.config.metrics == MetricsExposure.OFF) return
+
+    get("/metrics") {
+        // Set before the gate: scraped values are point-in-time, and a caching proxy that pinned the
+        // 401 would keep rejecting legitimate scrapes long after the token was fixed.
+        call.response.header(HttpHeaders.CacheControl, "no-store")
+        if (services.config.metrics == MetricsExposure.TOKEN && !call.hasMetricsToken(services)) {
+            services.metrics.metricsAuthFailure()
+            call.respondText("metrics token required\n", status = HttpStatusCode.Unauthorized)
+            return@get
+        }
+        call.respondText(services.metrics.scrape(), PROMETHEUS_TEXT)
+    }
+}
+
+private val PROMETHEUS_TEXT = ContentType.Text.Plain.withParameter("version", "0.0.4").withCharset(Charsets.UTF_8)
+
+private fun io.ktor.server.application.ApplicationCall.hasMetricsToken(services: Services): Boolean {
+    val expected = services.config.metricsToken
+    if (expected.isBlank()) return false // startup already refuses this combination; belt and braces
+    val provided = request.header(HttpHeaders.Authorization)?.removePrefix("Bearer ")?.trim()
+    return provided != null && constantTimeEquals(provided, expected)
+}

--- a/server/src/main/kotlin/app/skerry/server/routes/PairingRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/PairingRoutes.kt
@@ -2,6 +2,9 @@ package app.skerry.server.routes
 
 import app.skerry.server.RateLimits
 import app.skerry.server.Services
+import app.skerry.server.metrics.AuthKind
+import app.skerry.server.metrics.AuthOutcome
+import app.skerry.server.metrics.TokenType
 import app.skerry.server.accountId
 import app.skerry.server.jwtPrincipal
 import app.skerry.server.model.ErrorResponse
@@ -61,9 +64,13 @@ fun Route.pairingClaimRoute(services: Services) {
             }
             val session = services.pairing.consume(req.code)
             if (session == null) {
+                services.metrics.authAttempt(AuthKind.PAIRING_CLAIM, AuthOutcome.DENIED)
                 call.respond(HttpStatusCode.Gone, ErrorResponse("pairing code invalid or expired"))
                 return@post
             }
+            services.metrics.authAttempt(AuthKind.PAIRING_CLAIM, AuthOutcome.OK)
+            services.metrics.tokensIssued(TokenType.ACCESS)
+            services.metrics.tokensIssued(TokenType.REFRESH)
             services.devices.register(session.accountId, req.deviceId, req.deviceName)
             call.respond(
                 PairingClaimResponse(

--- a/server/src/main/kotlin/app/skerry/server/routes/SyncWebSocket.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/SyncWebSocket.kt
@@ -3,6 +3,8 @@ package app.skerry.server.routes
 import app.skerry.server.Services
 import app.skerry.server.accountId
 import app.skerry.server.deviceId
+import app.skerry.server.metrics.NotifyKind
+import app.skerry.server.metrics.WsCloseReason
 import io.ktor.server.auth.jwt.JWTPrincipal
 import io.ktor.server.auth.principal
 import io.ktor.server.routing.Route
@@ -11,6 +13,7 @@ import io.ktor.websocket.CloseReason
 import io.ktor.websocket.Frame
 import io.ktor.websocket.close
 import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * WS push: the server sends "changes are available, do a delta
@@ -23,6 +26,8 @@ fun Route.syncWebSocket(services: Services) {
     webSocket("/sync") {
         val principal = call.principal<JWTPrincipal>()
         if (principal == null) {
+            services.metrics.wsSessionOpened()
+            services.metrics.wsSessionClosed(WsCloseReason.NO_PRINCIPAL, 0.0)
             // Defense-in-depth: the route sits under authenticate("auth-jwt"), but if it's ever
             // accidentally moved outside that, close with an explicit CloseReason, not a silent drop.
             close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "authentication required"))
@@ -30,6 +35,15 @@ fun Route.syncWebSocket(services: Services) {
         }
         val accountId = principal.accountId
         val deviceId = principal.deviceId
+        // The gauge is maintained here, not from ChangeNotifier.subscriptions: each session collects
+        // three flows, so that counter is three times the number of sockets.
+        services.metrics.wsSessionOpened()
+        val openedAt = System.nanoTime()
+        // Written by the three notification coroutines and by the reader, read in `finally`: an
+        // AtomicReference gives that a happens-before edge, and first-cause-wins keeps the label
+        // truthful when a revoke and a client close race.
+        val closeReason = AtomicReference(WsCloseReason.CLIENT_CLOSE)
+        fun markClosing(reason: WsCloseReason) = closeReason.compareAndSet(WsCloseReason.CLIENT_CLOSE, reason)
 
         // Notifications run in a child coroutine; the main one reads incoming so a client Close
         // frame (or connection drop) ends the session immediately, instead of hanging in collect
@@ -39,9 +53,11 @@ fun Route.syncWebSocket(services: Services) {
                 // JWT is only checked at handshake; device revocation after connecting must be
                 // rechecked on every signal, or a revoked socket would keep receiving pushes forever.
                 if (services.devices.isRevoked(accountId, deviceId)) {
+                    markClosing(WsCloseReason.DEVICE_REVOKED)
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "device revoked"))
                 } else {
                     send(Frame.Text(cursor.toString()))
+                    services.metrics.wsFrameSent(NotifyKind.ACCOUNT)
                 }
             }
         }
@@ -50,18 +66,22 @@ fun Route.syncWebSocket(services: Services) {
                 // Membership can change during the socket's lifetime, so filter per signal rather
                 // than at handshake; also applies the same revoke check as the account channel.
                 if (services.devices.isRevoked(accountId, deviceId)) {
+                    markClosing(WsCloseReason.DEVICE_REVOKED)
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "device revoked"))
                 } else if (change.teamId in services.teams.activeTeamIdsFor(accountId)) {
                     send(Frame.Text("team:${change.teamId}:${change.cursor}"))
+                    services.metrics.wsFrameSent(NotifyKind.TEAM)
                 }
             }
         }
         val membershipNotifications = launch {
             services.notifier.forMembership(accountId).collect {
                 if (services.devices.isRevoked(accountId, deviceId)) {
+                    markClosing(WsCloseReason.DEVICE_REVOKED)
                     close(CloseReason(CloseReason.Codes.VIOLATED_POLICY, "device revoked"))
                 } else {
                     send(Frame.Text("teams"))
+                    services.metrics.wsFrameSent(NotifyKind.MEMBERSHIP)
                 }
             }
         }
@@ -71,10 +91,14 @@ fun Route.syncWebSocket(services: Services) {
             @Suppress("ControlFlowWithEmptyBody")
             for (frame in incoming) {
             }
+        } catch (error: Throwable) {
+            markClosing(WsCloseReason.ERROR)
+            throw error
         } finally {
             notifications.cancel()
             teamNotifications.cancel()
             membershipNotifications.cancel()
+            services.metrics.wsSessionClosed(closeReason.get(), (System.nanoTime() - openedAt) / 1_000_000_000.0)
         }
     }
 }

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -1,6 +1,8 @@
 package app.skerry.server.routes
 
 import app.skerry.server.Services
+import app.skerry.server.metrics.SyncScope
+import app.skerry.server.metrics.TeamDenial
 import app.skerry.server.accountId
 import app.skerry.server.db.ActivityEvent
 import app.skerry.server.db.AppliedTeamRecord
@@ -277,6 +279,7 @@ fun Route.teamRoutes(services: Services) {
         if (!call.requireScopeAccess(services, teamId, scopeId, principal.accountId)) return@get
         val since = call.request.queryParameters["since"]?.toLongOrNull() ?: 0L
         val delta = services.teamRecords.delta(teamId, scopeId, since)
+        services.metrics.recordsPulled(SyncScope.TEAM, delta.records.size)
         // Team scope has no compactedIds: tombstones are cleaned up by age, redelivery is idempotent.
         call.respond(RecordsResponse(delta.records.map { it.toDto() }, delta.cursor, emptyList()))
     }
@@ -294,7 +297,9 @@ fun Route.teamRoutes(services: Services) {
         val unknown = req.records.firstOrNull { it.type !in TEAM_ALLOWED_TYPES }
         if (unknown != null) throw BadRequestException("unknown record type: ${unknown.type}")
 
-        val result = services.teamRecords.upsert(teamId, scopeId, req.records.map { it.toIncoming() })
+        val incoming = req.records.map { it.toIncoming() }
+        services.metrics.recordsReceived(SyncScope.TEAM, incoming.size, incoming.sumOf { it.blob.size.toLong() })
+        val result = services.teamRecords.upsert(teamId, scopeId, incoming)
         // The records are committed; the audit trail is written after them and must not undo that.
         // A failure here is logged and swallowed on purpose: answering 500 would have the client
         // retry a push that LWW now treats as a no-op, so `applied` would come back empty and the
@@ -457,14 +462,17 @@ internal suspend fun ApplicationCall.requireActiveMember(
 ): TeamMemberRow? {
     val membership = services.teams.membership(teamId, accountId)
     if (membership == null) {
+        services.metrics.teamAuthzDenied(TeamDenial.NOT_MEMBER)
         respond(HttpStatusCode.NotFound, ErrorResponse("no such team"))
         return null
     }
     if (membership.status != TeamMemberStatus.ACTIVE) {
+        services.metrics.teamAuthzDenied(TeamDenial.NOT_ACCEPTED)
         respond(HttpStatusCode.Forbidden, ErrorResponse("invite not accepted"))
         return null
     }
     if (capability != null && !capability(membership.role)) {
+        services.metrics.teamAuthzDenied(TeamDenial.ROLE)
         respond(HttpStatusCode.Forbidden, ErrorResponse(forbidMessage))
         return null
     }
@@ -495,6 +503,7 @@ private suspend fun ApplicationCall.requireScopeAccess(
 ): Boolean {
     if (scopeId.isEmpty()) return true
     if (services.teamScopes.hasGrant(teamId, scopeId, accountId)) return true
+    services.metrics.teamAuthzDenied(TeamDenial.SCOPE)
     respond(HttpStatusCode.NotFound, ErrorResponse("no such scope"))
     return false
 }

--- a/server/src/main/kotlin/app/skerry/server/routes/Validation.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/Validation.kt
@@ -4,6 +4,7 @@ import app.skerry.server.model.ErrorResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.response.respond
+import java.security.MessageDigest
 
 // Upper bounds on client identifier length: keeps bloated strings out of the SRP/DB pending maps
 // and out of memory before the overall body limit kicks in. Mirrors the schema (accountId varchar(320)).
@@ -30,3 +31,15 @@ internal suspend fun ApplicationCall.requiredPathId(name: String): String? {
 /** `?limit=` query parameter with a default and hard bounds 1..[max], so lists can't grow unbounded. */
 internal fun ApplicationCall.limitParam(default: Int, max: Int): Int =
     request.queryParameters["limit"]?.toIntOrNull()?.coerceIn(1, max) ?: default
+
+/**
+ * Constant-time comparison of two long-lived static tokens (admin console, metrics scraper). Both
+ * values are hashed to a fixed 32 bytes with SHA-256 first, then compared — otherwise
+ * [MessageDigest.isEqual] on differing lengths returns early and leaks the token length via timing.
+ */
+internal fun constantTimeEquals(a: String, b: String): Boolean {
+    val md = MessageDigest.getInstance("SHA-256")
+    val ha = md.digest(a.toByteArray(Charsets.UTF_8))
+    val hb = md.digest(b.toByteArray(Charsets.UTF_8)) // digest() resets md's state
+    return MessageDigest.isEqual(ha, hb)
+}

--- a/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
@@ -4,6 +4,7 @@ import app.skerry.server.Services
 import app.skerry.server.accountId
 import app.skerry.server.deviceId
 import app.skerry.server.jwtPrincipal
+import app.skerry.server.metrics.SyncScope
 import app.skerry.server.model.ErrorResponse
 import app.skerry.sync.wire.KeysResponse
 import app.skerry.sync.wire.PushRequest
@@ -55,6 +56,7 @@ fun Route.vaultRoutes(services: Services) {
         }
         // After touch, so this device's cursor is already reflected in the watermark. Tombstone ids
         // that all devices have read; the client compacts them locally and stops re-pushing them.
+        services.metrics.recordsPulled(SyncScope.ACCOUNT, delta.size)
         val compactedIds = services.records.compactedTombstoneIds(principal.accountId)
         call.respond(RecordsResponse(delta.map { it.toDto() }, cursor, compactedIds))
     }
@@ -65,7 +67,11 @@ fun Route.vaultRoutes(services: Services) {
         val unknown = req.records.firstOrNull { it.type !in ALLOWED_TYPES }
         if (unknown != null) throw BadRequestException("unknown record type: ${unknown.type}")
 
-        val result = services.records.upsert(principal.accountId, req.records.map { it.toIncoming() })
+        val incoming = req.records.map { it.toIncoming() }
+        // Received, not applied: a client re-pushes its whole vault every cycle, and the ratio between
+        // this and the cursor movement is the honest picture of that.
+        services.metrics.recordsReceived(SyncScope.ACCOUNT, incoming.size, incoming.sumOf { it.blob.size.toLong() })
+        val result = services.records.upsert(principal.accountId, incoming)
         services.devices.touch(principal.accountId, principal.deviceId, syncVersion = result.cursor)
         // Log only pushes that changed something, mirroring the empty-pull rule above. A client
         // re-pushes all of its records on every sync cycle, so without this the log is mostly no-ops

--- a/server/src/main/kotlin/app/skerry/server/sync/ChangeNotifier.kt
+++ b/server/src/main/kotlin/app/skerry/server/sync/ChangeNotifier.kt
@@ -1,5 +1,7 @@
 package app.skerry.server.sync
 
+import app.skerry.server.metrics.NotifyKind
+import app.skerry.server.metrics.ServerMetrics
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,7 +14,7 @@ import kotlinx.coroutines.flow.map
  * payload). Carries only accountId and the new cursor, no data. Single self-hosted instance model;
  * horizontal scaling would need an external broker.
  */
-class ChangeNotifier {
+class ChangeNotifier(private val metrics: ServerMetrics? = null) {
     /**
      * [channel]: `acc:{accountId}` — account vault cursor; `team:{teamId}` — team record cursor;
      * `member:{accountId}` — membership/invites changed (cursor is meaningless, 0).
@@ -33,16 +35,19 @@ class ChangeNotifier {
     /** Non-suspend: tryEmit never blocks the publisher (buffer with DROP_OLDEST). */
     fun publish(accountId: String, cursor: Long) {
         flow.tryEmit(Change("acc:$accountId", cursor))
+        metrics?.notificationPublished(NotifyKind.ACCOUNT)
     }
 
     /** Signals "team has records up to cursor" for active members' WS sessions. */
     fun publishTeam(teamId: String, cursor: Long) {
         flow.tryEmit(Change("team:$teamId", cursor))
+        metrics?.notificationPublished(NotifyKind.TEAM)
     }
 
     /** Signals "account's team membership/invites changed"; client re-reads the team list. */
     fun publishMembership(accountId: String) {
         flow.tryEmit(Change("member:$accountId", 0))
+        metrics?.notificationPublished(NotifyKind.MEMBERSHIP)
     }
 
     /** Cursor stream for a specific account (one WS session). */

--- a/server/src/main/resources/admin/index.html
+++ b/server/src/main/resources/admin/index.html
@@ -153,6 +153,12 @@
     .stat .k { font-size: 12px; color: var(--text-faint); font-weight: 600; }
     .stat .v { font-size: 34px; font-weight: 700; color: var(--text); letter-spacing: -1px; margin-top: 8px; }
     .stat .sub { font-size: 11.5px; color: var(--text-faint); margin-top: 2px; }
+    /* Monitoring tiles hold words, not counts, so three-up with a smaller value. */
+    .stats.mon { grid-template-columns: repeat(3, 1fr); }
+    .stats.mon .v { font-size: 22px; letter-spacing: -0.4px; }
+    .stats.mon .v.off  { color: var(--text-faint); }
+    .stats.mon .v.warn { color: #E8B44A; }
+    .stats.mon .v.bad  { color: #E4685D; }
 
     /* ===== tables ===== */
     .tcard { background: var(--card); border: 1px solid var(--line); border-radius: 16px; overflow: hidden; }
@@ -401,6 +407,26 @@
         <div class="tfoot" id="dev-foot"></div>
       </div>
 
+      <!-- ===== monitoring ===== -->
+      <div class="label sec">Monitoring</div>
+      <div class="stats mon">
+        <div class="stat">
+          <div class="k">Metrics endpoint</div>
+          <div class="v display" id="s-metrics">—</div>
+          <div class="sub" id="s-metrics-sub">&nbsp;</div>
+        </div>
+        <div class="stat">
+          <div class="k">Readiness</div>
+          <div class="v display" id="s-ready">—</div>
+          <div class="sub">/readyz · database probe</div>
+        </div>
+        <div class="stat">
+          <div class="k">Inventory freshness</div>
+          <div class="v display" id="s-inventory">—</div>
+          <div class="sub" id="s-inventory-sub">&nbsp;</div>
+        </div>
+      </div>
+
       <!-- ===== recent activity ===== -->
       <div class="label-row">
         <span class="label">Recent activity</span>
@@ -535,6 +561,38 @@
     if (j.pairingSessions) $("s-devices-sub").textContent =
       j.pairingSessions + (j.pairingSessions === 1 ? " pairing session open" : " pairing sessions open");
     else $("s-devices-sub").innerHTML = "&nbsp;";
+  }
+
+  async function loadObservability() {
+    const j = await adminGet("/admin/observability");
+    if (!j) return;
+    const metrics = $("s-metrics");
+    metrics.textContent = j.metrics;
+    metrics.className = "v display" + (j.metrics === "off" ? " off" : j.metrics === "open" ? " warn" : "");
+    $("s-metrics-sub").textContent =
+      j.metrics === "token" ? "scrape with Authorization: Bearer"
+      : j.metrics === "open" ? "no credential — keep it off the public interface"
+      : "disabled (SKERRY_METRICS=off)";
+
+    const ready = $("s-ready");
+    ready.textContent = j.ready ? "ready" : "not ready";
+    ready.className = "v display" + (j.ready ? "" : " bad");
+
+    const inv = $("s-inventory");
+    const sub = $("s-inventory-sub");
+    if (!j.inventoryIntervalSeconds) {
+      inv.textContent = "disabled";
+      inv.className = "v display off";
+      sub.textContent = "SKERRY_METRICS_INVENTORY_SECONDS=0";
+      return;
+    }
+    // Nothing collected yet is a different fact from "collected long ago" — say so.
+    const age = j.inventoryAgeSeconds;
+    inv.textContent = age === null || age === undefined ? "never" : age < 60 ? age + "s ago" : Math.floor(age / 60) + "m ago";
+    // Stale past twice the interval: the collector is stuck or the database is failing.
+    const stale = age !== null && age !== undefined && age > j.inventoryIntervalSeconds * 2;
+    inv.className = "v display" + (age === null || age === undefined ? " off" : stale ? " warn" : "");
+    sub.textContent = "refreshed every " + j.inventoryIntervalSeconds + "s";
   }
 
   async function loadAccounts() {
@@ -726,6 +784,7 @@
 
   function refreshData() {
     loadStats();
+    loadObservability();
     loadAccounts();
     loadDevices();
     loadActivity();

--- a/server/src/test/kotlin/app/skerry/server/cli/AdminCliParserTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/cli/AdminCliParserTest.kt
@@ -1,0 +1,191 @@
+package app.skerry.server.cli
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class AdminCliParserTest {
+
+    private fun parse(vararg args: String, env: Map<String, String> = emptyMap()) =
+        parseCli(args.toList(), env)
+
+    @Test
+    fun `no arguments prints usage`() {
+        assertIs<ParsedCli.Help>(parse())
+    }
+
+    @Test
+    fun `help flag prints usage`() {
+        assertIs<ParsedCli.Help>(parse("--help"))
+        assertIs<ParsedCli.Help>(parse("devices", "--help"))
+    }
+
+    @Test
+    fun `stats uses loopback default and token from environment`() {
+        val run = assertIs<ParsedCli.Run>(parse("stats", env = mapOf("SKERRY_ADMIN_TOKEN" to "t0k")))
+        assertEquals(AdminCommand.Stats, run.command)
+        assertEquals("http://127.0.0.1:8080", run.options.baseUrl)
+        assertEquals("t0k", run.options.token)
+    }
+
+    /** The CLI runs inside the container by default, where SKERRY_PORT is what the server listens on. */
+    @Test
+    fun `default base url follows SKERRY_PORT`() {
+        val run = assertIs<ParsedCli.Run>(parse("stats", env = mapOf("SKERRY_PORT" to "9090")))
+        assertEquals("http://127.0.0.1:9090", run.options.baseUrl)
+    }
+
+    @Test
+    fun `explicit url wins over environment and loses its trailing slash`() {
+        val env = mapOf("SKERRY_ADMIN_URL" to "http://ignored:1/", "SKERRY_PORT" to "9090")
+        val run = assertIs<ParsedCli.Run>(parse("--url", "https://sync.example.com/", "stats", env = env))
+        assertEquals("https://sync.example.com", run.options.baseUrl)
+    }
+
+    @Test
+    fun `admin url environment variable is honoured`() {
+        val run = assertIs<ParsedCli.Run>(parse("stats", env = mapOf("SKERRY_ADMIN_URL" to "http://sync.internal:8080")))
+        assertEquals("http://sync.internal:8080", run.options.baseUrl)
+    }
+
+    @Test
+    fun `token flag wins over environment`() {
+        val run = assertIs<ParsedCli.Run>(
+            parse("--token", "flag", "stats", env = mapOf("SKERRY_ADMIN_TOKEN" to "env")),
+        )
+        assertEquals("flag", run.options.token)
+    }
+
+    @Test
+    fun `token file is carried through for the runner to read`() {
+        val run = assertIs<ParsedCli.Run>(parse("--token-file", "/run/secrets/admin", "stats"))
+        assertEquals("/run/secrets/admin", run.options.tokenFile)
+        assertEquals(null, run.options.token)
+    }
+
+    @Test
+    fun `flags may follow the command`() {
+        val run = assertIs<ParsedCli.Run>(parse("accounts", "list", "--limit", "5", "--json"))
+        assertEquals(AdminCommand.AccountsList(limit = 5), run.command)
+        assertTrue(run.options.json)
+    }
+
+    @Test
+    fun `devices list accepts an account filter`() {
+        val run = assertIs<ParsedCli.Run>(parse("devices", "list", "--account", "alice@example.com"))
+        assertEquals(AdminCommand.DevicesList(limit = null, accountId = "alice@example.com"), run.command)
+    }
+
+    @Test
+    fun `device revoke needs both ids`() {
+        val run = assertIs<ParsedCli.Run>(
+            parse("devices", "revoke", "dev-1", "--account", "alice@example.com"),
+        )
+        assertEquals(AdminCommand.DeviceRevoke("alice@example.com", "dev-1"), run.command)
+
+        val missing = assertIs<ParsedCli.Invalid>(parse("devices", "revoke", "dev-1"))
+        assertTrue("--account" in missing.message, missing.message)
+    }
+
+    @Test
+    fun `account records and purge take the account as a positional`() {
+        val records = assertIs<ParsedCli.Run>(parse("accounts", "records", "alice@example.com"))
+        assertEquals(AdminCommand.AccountRecords("alice@example.com", limit = null), records.command)
+
+        val purge = assertIs<ParsedCli.Run>(parse("accounts", "purge-tombstones", "alice@example.com"))
+        assertEquals(AdminCommand.AccountPurgeTombstones("alice@example.com"), purge.command)
+    }
+
+    /**
+     * Deleting an account is irreversible and there is no TTY inside `docker exec` half the time,
+     * so confirmation is an explicit flag rather than an interactive prompt.
+     */
+    @Test
+    fun `account delete demands an explicit yes`() {
+        val invalid = assertIs<ParsedCli.Invalid>(parse("accounts", "delete", "alice@example.com"))
+        assertTrue("--yes" in invalid.message, invalid.message)
+
+        val run = assertIs<ParsedCli.Run>(parse("accounts", "delete", "alice@example.com", "--yes"))
+        assertEquals(AdminCommand.AccountDelete("alice@example.com"), run.command)
+    }
+
+    /** /metrics is gated by its own bearer token, not the admin token (different privileges). */
+    @Test
+    fun `metrics reads its own token`() {
+        val fromEnv = assertIs<ParsedCli.Run>(
+            parse("metrics", env = mapOf("SKERRY_METRICS_TOKEN" to "scrape", "SKERRY_ADMIN_TOKEN" to "admin")),
+        )
+        assertEquals("scrape", fromEnv.options.metricsToken)
+        assertEquals("admin", fromEnv.options.token)
+
+        val fromFlag = assertIs<ParsedCli.Run>(parse("metrics", "--metrics-token", "flag"))
+        assertEquals("flag", fromFlag.options.metricsToken)
+
+        // The flag belongs to `metrics` only, so a typo elsewhere is reported rather than ignored.
+        assertIs<ParsedCli.Invalid>(parse("stats", "--metrics-token", "x"))
+    }
+
+    @Test
+    fun `health and metrics are single-word commands`() {
+        assertEquals(AdminCommand.Health, assertIs<ParsedCli.Run>(parse("health")).command)
+        assertEquals(AdminCommand.Metrics, assertIs<ParsedCli.Run>(parse("metrics")).command)
+    }
+
+    @Test
+    fun `activity takes a limit`() {
+        assertEquals(
+            AdminCommand.Activity(limit = 10),
+            assertIs<ParsedCli.Run>(parse("activity", "--limit", "10")).command,
+        )
+    }
+
+    @Test
+    fun `unknown command and unknown subcommand are rejected`() {
+        assertIs<ParsedCli.Invalid>(parse("frobnicate"))
+        assertIs<ParsedCli.Invalid>(parse("devices", "frobnicate"))
+        assertIs<ParsedCli.Invalid>(parse("accounts"))
+    }
+
+    @Test
+    fun `unknown flag is rejected instead of silently ignored`() {
+        val invalid = assertIs<ParsedCli.Invalid>(parse("stats", "--verbose"))
+        assertTrue("--verbose" in invalid.message, invalid.message)
+    }
+
+    @Test
+    fun `limit must be a positive number`() {
+        assertIs<ParsedCli.Invalid>(parse("accounts", "list", "--limit", "0"))
+        assertIs<ParsedCli.Invalid>(parse("accounts", "list", "--limit", "-3"))
+        assertIs<ParsedCli.Invalid>(parse("accounts", "list", "--limit", "many"))
+        assertIs<ParsedCli.Invalid>(parse("accounts", "list", "--limit"))
+    }
+
+    @Test
+    fun `inline flag values are accepted`() {
+        val run = assertIs<ParsedCli.Run>(parse("accounts", "list", "--limit=5", "--url=http://h:1"))
+        assertEquals(AdminCommand.AccountsList(limit = 5), run.command)
+        assertEquals("http://h:1", run.options.baseUrl)
+    }
+
+    /** `--account=` is a typo; silently reading it as "no filter" would widen the listing instead. */
+    @Test
+    fun `an empty inline value is rejected`() {
+        assertIs<ParsedCli.Invalid>(parse("devices", "list", "--account="))
+        assertIs<ParsedCli.Invalid>(parse("accounts", "list", "--limit="))
+        assertIs<ParsedCli.Invalid>(parse("stats", "--token="))
+    }
+
+    @Test
+    fun `a flag the command ignores is an error`() {
+        val invalid = assertIs<ParsedCli.Invalid>(parse("stats", "--limit", "5"))
+        assertTrue("--limit" in invalid.message && "stats" in invalid.message, invalid.message)
+        assertIs<ParsedCli.Invalid>(parse("devices", "list", "--yes"))
+    }
+
+    @Test
+    fun `extra positional arguments are rejected`() {
+        assertIs<ParsedCli.Invalid>(parse("stats", "extra"))
+        assertIs<ParsedCli.Invalid>(parse("accounts", "records", "a@b", "c@d"))
+    }
+}

--- a/server/src/test/kotlin/app/skerry/server/cli/AdminCliRunnerTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/cli/AdminCliRunnerTest.kt
@@ -1,0 +1,333 @@
+package app.skerry.server.cli
+
+import app.skerry.server.Services
+import app.skerry.server.configureServer
+import app.skerry.server.routes.registerAccount
+import app.skerry.server.routes.testServices
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.IOException
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The CLI end to end against a real server: it must exercise the same `/admin` routes the console
+ * uses, so a broken auth gate or a renamed field fails here rather than in production.
+ */
+class AdminCliRunnerTest {
+
+    private class CliRun(val exitCode: Int, val out: String, val err: String)
+
+    private suspend fun ApplicationTestBuilder.cli(
+        vararg args: String,
+        token: String? = ADMIN_TOKEN,
+        url: String? = null,
+        client: HttpClient = createClient { install(ContentNegotiation) { json() } },
+    ): CliRun {
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val env = buildMap {
+            if (token != null) put("SKERRY_ADMIN_TOKEN", token)
+            if (url != null) put("SKERRY_ADMIN_URL", url)
+        }
+        val code = runCli(
+            args = args.toList(),
+            env = env,
+            out = out,
+            err = err,
+            now = NOW,
+            clientFactory = { client },
+        )
+        return CliRun(code, out.toString(), err.toString())
+    }
+
+    /** The docker/k8s secret path: the token comes from a file, never from argv. */
+    @Test
+    fun `token file is read and a missing one is an error`() = withServer {
+        seedAccount()
+        val secret = Files.createTempFile("skerry-admin-token", "")
+        Files.writeString(secret, "$ADMIN_TOKEN\n") // trailing newline as `echo` would leave it
+        secret.toFile().deleteOnExit()
+
+        val ok = cli("stats", "--token-file", secret.toString(), token = null)
+        assertEquals(EXIT_OK, ok.exitCode, ok.err)
+
+        val missing = cli("stats", "--token-file", "/nonexistent/skerry-token", token = null)
+        assertEquals(EXIT_ERROR, missing.exitCode)
+        assertTrue("/nonexistent/skerry-token" in missing.err, missing.err)
+        // One line, no stack trace, and no echo of file contents.
+        assertEquals(1, missing.err.lines().count { it.isNotBlank() }, missing.err)
+    }
+
+    /** Any other server-side failure is exit 1, distinct from unauthorized/not-found/unreachable. */
+    @Test
+    fun `a server error exits with the generic error code`() {
+        val body = """{"error":"internal error"}"""
+        val failing = HttpClient(MockEngine { respond(body, HttpStatusCode.InternalServerError) })
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val code = runBlocking {
+            runCli(
+                args = listOf("stats"),
+                env = mapOf("SKERRY_ADMIN_TOKEN" to ADMIN_TOKEN),
+                out = out,
+                err = err,
+                now = NOW,
+                clientFactory = { failing },
+            )
+        }
+        assertEquals(EXIT_ERROR, code)
+        assertTrue("500" in err.toString() && "internal error" in err.toString(), err.toString())
+    }
+
+    private suspend fun ApplicationTestBuilder.seedAccount(accountId: String = "alice@example.com") {
+        val client = createClient { install(ContentNegotiation) { json() } }
+        client.registerAccount(accountId, "correct horse", deviceId = "devA", deviceName = "Laptop A", platform = "linux")
+    }
+
+    private fun withServer(block: suspend ApplicationTestBuilder.(Services) -> Unit) = testApplication {
+        val services = testServices(adminToken = ADMIN_TOKEN)
+        application { configureServer(services) }
+        block(services)
+    }
+
+    @Test
+    fun `stats prints instance totals`() = withServer {
+        seedAccount()
+        val run = cli("stats")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("Accounts" in run.out, run.out)
+        assertTrue("1" in run.out, run.out)
+    }
+
+    @Test
+    fun `json flag prints the raw server payload`() = withServer {
+        seedAccount()
+        val run = cli("stats", "--json")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        val parsed = Json.parseToJsonElement(run.out).jsonObject
+        assertEquals("1", parsed["accounts"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `devices list shows the registered device`() = withServer {
+        seedAccount()
+        val run = cli("devices", "list")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("devA" in run.out, run.out)
+        assertTrue("alice@example.com" in run.out, run.out)
+        assertTrue("linux" in run.out, run.out)
+    }
+
+    @Test
+    fun `devices list can filter by account`() = withServer {
+        seedAccount("alice@example.com")
+        seedAccount("bob@example.com")
+        val run = cli("devices", "list", "--account", "alice@example.com")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("alice@example.com" in run.out, run.out)
+        assertFalse("bob@example.com" in run.out, run.out)
+    }
+
+    @Test
+    fun `device revoke takes effect on the server`() = withServer { services ->
+        seedAccount()
+        val run = cli("devices", "revoke", "devA", "--account", "alice@example.com")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue(services.devices.isRevoked("alice@example.com", "devA"))
+    }
+
+    @Test
+    fun `revoking an unknown device reports not found`() = withServer {
+        seedAccount()
+        val run = cli("devices", "revoke", "ghost", "--account", "alice@example.com")
+        assertEquals(EXIT_NOT_FOUND, run.exitCode)
+        // The server answers 404 with no body here, so the message has to come from the CLI's own
+        // context — "not found: Not Found" tells the operator nothing.
+        assertTrue("ghost" in run.err && "alice@example.com" in run.err, run.err)
+    }
+
+    @Test
+    fun `empty lists say so instead of printing a bare header`() = withServer {
+        val devices = cli("devices", "list")
+        assertEquals(EXIT_OK, devices.exitCode, devices.err)
+        assertFalse("ACCOUNT" in devices.out, devices.out)
+        assertTrue("no active devices" in devices.out, devices.out)
+
+        val accounts = cli("accounts", "list")
+        assertTrue("no accounts" in accounts.out, accounts.out)
+
+        val activity = cli("activity")
+        assertTrue("no events" in activity.out, activity.out)
+    }
+
+    @Test
+    fun `accounts list and records expose metadata only`() = withServer {
+        seedAccount()
+        val list = cli("accounts", "list")
+        assertEquals(EXIT_OK, list.exitCode, list.err)
+        assertTrue("alice@example.com" in list.out, list.out)
+
+        val records = cli("accounts", "records", "alice@example.com")
+        assertEquals(EXIT_OK, records.exitCode, records.err)
+    }
+
+    @Test
+    fun `account delete removes the account`() = withServer { services ->
+        seedAccount()
+        val run = cli("accounts", "delete", "alice@example.com", "--yes")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertEquals(0, services.admin.accountCount().toInt())
+    }
+
+    @Test
+    fun `deleting an unknown account reports not found`() = withServer {
+        val run = cli("accounts", "delete", "nobody@example.com", "--yes")
+        assertEquals(EXIT_NOT_FOUND, run.exitCode)
+    }
+
+    @Test
+    fun `purge tombstones reports a count`() = withServer {
+        seedAccount()
+        val run = cli("accounts", "purge-tombstones", "alice@example.com")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("0" in run.out, run.out)
+    }
+
+    @Test
+    fun `activity prints audit events`() = withServer {
+        seedAccount()
+        val run = cli("activity", "--limit", "5")
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("alice@example.com" in run.out, run.out)
+    }
+
+    /** The scrape endpoint takes a bearer token of its own; the admin token must not be sent there. */
+    @Test
+    fun `metrics prints the exposition using the metrics token`() = testApplication {
+        val services = testServices(
+            adminToken = ADMIN_TOKEN,
+            extraEnv = mapOf("SKERRY_METRICS" to "token", "SKERRY_METRICS_TOKEN" to "scrape-me"),
+        )
+        application { configureServer(services) }
+
+        val denied = cli("metrics")
+        assertEquals(EXIT_UNAUTHORIZED, denied.exitCode)
+        assertTrue("SKERRY_METRICS_TOKEN" in denied.err, denied.err)
+
+        val ok = cli("metrics", "--metrics-token", "scrape-me")
+        assertEquals(EXIT_OK, ok.exitCode, ok.err)
+        assertTrue("skerry_build_info" in ok.out, ok.out.take(200))
+    }
+
+    /** A token on the wire in the clear is worth a word; a loopback URL is not. */
+    @Test
+    fun `a remote plain-http url is called out`() = withServer {
+        val remote = cli("stats", url = "http://sync.example.com")
+        assertTrue("plain HTTP" in remote.err, remote.err)
+
+        val local = cli("stats", url = "http://127.0.0.1:8080")
+        assertFalse("plain HTTP" in local.err, local.err)
+
+        val tls = cli("stats", url = "https://sync.example.com")
+        assertFalse("plain HTTP" in tls.err, tls.err)
+    }
+
+    @Test
+    fun `health needs no token`() = withServer {
+        val run = cli("health", token = null)
+        assertEquals(EXIT_OK, run.exitCode, run.err)
+        assertTrue("ok" in run.out.lowercase(), run.out)
+    }
+
+    @Test
+    fun `a missing token fails with the unauthorized exit code`() = withServer {
+        seedAccount()
+        val run = cli("stats", token = null)
+        assertEquals(EXIT_UNAUTHORIZED, run.exitCode)
+        assertTrue("token" in run.err.lowercase(), run.err)
+    }
+
+    @Test
+    fun `a wrong token fails with the unauthorized exit code`() = withServer {
+        val run = cli("stats", token = "nope")
+        assertEquals(EXIT_UNAUTHORIZED, run.exitCode)
+    }
+
+    @Test
+    fun `usage errors exit with the usage code and print to stderr`() = withServer {
+        val run = cli("accounts", "delete", "alice@example.com")
+        assertEquals(EXIT_USAGE, run.exitCode)
+        assertTrue("--yes" in run.err, run.err)
+        assertTrue(run.out.isEmpty(), run.out)
+    }
+
+    @Test
+    fun `help goes to stdout and exits ok`() = withServer {
+        val run = cli("--help")
+        assertEquals(EXIT_OK, run.exitCode)
+        assertTrue("skerry-admin" in run.out, run.out)
+    }
+
+    /**
+     * A body the CLI cannot decode (an old CLI against a newer server) must read like every other
+     * error path — one line — instead of a stack trace.
+     */
+    @Test
+    fun `an undecodable response is reported in one line`() {
+        val garbage = HttpClient(MockEngine { respond("{ not json", HttpStatusCode.OK) })
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val code = runBlocking {
+            runCli(
+                args = listOf("stats"),
+                env = mapOf("SKERRY_ADMIN_TOKEN" to ADMIN_TOKEN),
+                out = out,
+                err = err,
+                now = NOW,
+                clientFactory = { garbage },
+            )
+        }
+        assertEquals(EXIT_ERROR, code)
+        assertEquals(1, err.lines().count { it.isNotBlank() }, err.toString())
+        assertTrue("unexpected response" in err.toString(), err.toString())
+    }
+
+    /** A stopped server is the common case for a CLI; it must say so rather than dump a stack trace. */
+    @Test
+    fun `an unreachable server exits with the unreachable code`() {
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val code = runBlocking {
+            runCli(
+                args = listOf("stats"),
+                env = mapOf("SKERRY_ADMIN_TOKEN" to ADMIN_TOKEN),
+                out = out,
+                err = err,
+                now = NOW,
+                clientFactory = { throw IOException("connection refused") },
+            )
+        }
+        assertEquals(EXIT_UNREACHABLE, code)
+        assertTrue(err.isNotBlank())
+        assertFalse("Exception" in err.toString(), err.toString())
+    }
+
+    private companion object {
+        const val ADMIN_TOKEN = "admin-secret"
+        const val NOW = 1_800_000_000_000L
+    }
+}

--- a/server/src/test/kotlin/app/skerry/server/cli/CliOutputTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/cli/CliOutputTest.kt
@@ -1,0 +1,88 @@
+package app.skerry.server.cli
+
+import java.util.Locale
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Formatting helpers: boundaries, and independence from the JVM's locale and timezone. */
+class CliOutputTest {
+
+    private val originalLocale: Locale = Locale.getDefault()
+
+    @AfterTest
+    fun restoreLocale() = Locale.setDefault(originalLocale)
+
+    @Test
+    fun `bytes are formatted in binary units`() {
+        assertEquals("0 B", humanBytes(0))
+        assertEquals("1023 B", humanBytes(1023))
+        assertEquals("1.0 KiB", humanBytes(1024))
+        assertEquals("1.5 KiB", humanBytes(1536))
+        assertEquals("100 KiB", humanBytes(102_400))
+        assertEquals("1.0 MiB", humanBytes(1024L * 1024))
+        assertEquals("1.0 TiB", humanBytes(1024L * 1024 * 1024 * 1024))
+        // Beyond the last unit it keeps scaling in TiB rather than inventing one.
+        assertEquals("1024 TiB", humanBytes(1024L * 1024 * 1024 * 1024 * 1024))
+    }
+
+    /** A comma decimal separator would break both greppability and comparison against `du`. */
+    @Test
+    fun `byte formatting ignores the jvm locale`() {
+        Locale.setDefault(Locale.forLanguageTag("ru-RU"))
+        assertEquals("1.5 KiB", humanBytes(1536))
+    }
+
+    @Test
+    fun `relative time covers its boundaries`() {
+        val now = 1_800_000_000_000L
+        assertEquals("—", relativeTime(null, now))
+        assertEquals("just now", relativeTime(now, now))
+        assertEquals("just now", relativeTime(now - 59_000, now))
+        assertEquals("1m ago", relativeTime(now - 60_000, now))
+        assertEquals("59m ago", relativeTime(now - 59 * 60_000, now))
+        assertEquals("1h ago", relativeTime(now - 60 * 60_000, now))
+        assertEquals("47h ago", relativeTime(now - 47 * 60 * 60_000L, now))
+        assertEquals("2d ago", relativeTime(now - 48 * 60 * 60_000L, now))
+        // Clock skew between the server and the CLI host must not print a negative age.
+        assertEquals("in the future", relativeTime(now + 600_000, now))
+    }
+
+    @Test
+    fun `timestamps are printed in utc regardless of the default timezone`() {
+        val previous = java.util.TimeZone.getDefault()
+        try {
+            java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Tokyo"))
+            assertEquals("2027-01-15 08:00 UTC", utcMinutes(1_800_000_000_000L))
+        } finally {
+            java.util.TimeZone.setDefault(previous)
+        }
+    }
+
+    @Test
+    fun `table pads columns and never leaves trailing spaces`() {
+        val rendered = table(listOf("ID", "NAME"), listOf(listOf("a", "short"), listOf("longer-id", "x")))
+        assertEquals(
+            listOf(
+                "ID         NAME",
+                "a          short",
+                "longer-id  x",
+            ),
+            rendered.lines(),
+        )
+    }
+
+    @Test
+    fun `table tolerates missing cells and no rows`() {
+        assertEquals("ID  NAME", table(listOf("ID", "NAME"), emptyList()))
+        assertEquals(listOf("ID  NAME", "a"), table(listOf("ID", "NAME"), listOf(listOf("a"))).lines())
+    }
+
+    @Test
+    fun `key values align on the widest key`() {
+        assertEquals(
+            listOf("Accounts  1", "Storage   0 B"),
+            keyValues(listOf("Accounts" to "1", "Storage" to "0 B")).lines(),
+        )
+    }
+}

--- a/server/src/test/kotlin/app/skerry/server/config/ServerConfigTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/config/ServerConfigTest.kt
@@ -75,4 +75,41 @@ class ServerConfigTest {
     fun `wildcard passes through`() {
         assertEquals(listOf(CorsHost("*", listOf("http", "https"))), corsHosts("*"))
     }
+
+    // --- metrics exposure ---
+
+    private fun metrics(env: Map<String, String>) = ServerConfig.fromEnv(env).metrics
+
+    @Test
+    fun `metrics are off unless enabled`() {
+        assertEquals(MetricsExposure.OFF, metrics(emptyMap()))
+        assertEquals(MetricsExposure.OFF, metrics(mapOf("SKERRY_METRICS" to "")))
+        // An unrecognized value must not open the endpoint: unknown means off, as with registration.
+        assertEquals(MetricsExposure.OFF, metrics(mapOf("SKERRY_METRICS" to "yes please")))
+    }
+
+    @Test
+    fun `metrics modes are case-insensitive`() {
+        assertEquals(MetricsExposure.TOKEN, metrics(mapOf("SKERRY_METRICS" to "Token")))
+        assertEquals(MetricsExposure.OPEN, metrics(mapOf("SKERRY_METRICS" to "OPEN")))
+        assertEquals(MetricsExposure.OFF, metrics(mapOf("SKERRY_METRICS" to "off")))
+    }
+
+    @Test
+    fun `metrics token is read separately from the admin token`() {
+        val config = ServerConfig.fromEnv(
+            mapOf("SKERRY_METRICS" to "token", "SKERRY_METRICS_TOKEN" to "scrape-me", "SKERRY_ADMIN_TOKEN" to "admin"),
+        )
+        assertEquals("scrape-me", config.metricsToken)
+        assertEquals("admin", config.adminToken)
+    }
+
+    @Test
+    fun `inventory interval has a floor and can be disabled`() {
+        assertEquals(60L, ServerConfig.fromEnv(emptyMap()).metricsInventoryIntervalSeconds)
+        assertEquals(0L, ServerConfig.fromEnv(mapOf("SKERRY_METRICS_INVENTORY_SECONDS" to "0")).metricsInventoryIntervalSeconds)
+        // Below the floor the collector would scan `records` more often than it is worth on SQLite.
+        assertEquals(15L, ServerConfig.fromEnv(mapOf("SKERRY_METRICS_INVENTORY_SECONDS" to "3")).metricsInventoryIntervalSeconds)
+        assertEquals(300L, ServerConfig.fromEnv(mapOf("SKERRY_METRICS_INVENTORY_SECONDS" to "300")).metricsInventoryIntervalSeconds)
+    }
 }

--- a/server/src/test/kotlin/app/skerry/server/metrics/InstrumentationTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/metrics/InstrumentationTest.kt
@@ -1,0 +1,418 @@
+package app.skerry.server.metrics
+
+import app.skerry.server.Services
+import app.skerry.server.configureServer
+import app.skerry.server.model.b64
+import app.skerry.server.routes.changePassword
+import app.skerry.server.routes.pushRecord
+import app.skerry.server.routes.registerAccount
+import app.skerry.server.routes.registerAccountResponse
+import app.skerry.server.routes.srpLogin
+import app.skerry.server.routes.srpLoginResponse
+import app.skerry.server.routes.testServices
+import app.skerry.sync.wire.PairingClaimRequest
+import app.skerry.sync.wire.PushRequest
+import app.skerry.sync.wire.RecordDto
+import app.skerry.sync.wire.TeamCreateRequest
+import app.skerry.sync.wire.TokenResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.webSocket
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import io.ktor.websocket.CloseReason
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Instrumentation is only worth its call sites if the numbers are right, so these tests assert the
+ * exposed **values**, not merely that the response code survived the added counter. A counter that
+ * silently stops incrementing looks exactly like a healthy server otherwise.
+ */
+class InstrumentationTest {
+
+    private val alice = "alice@example.com"
+    private val bob = "bob@example.com"
+    private val password = "correct horse"
+
+    /** A single WS session subscribes to three notifier channels (account, teams, membership). */
+    private val wsSubscriptions = 3
+
+    private fun withServer(
+        extraEnv: Map<String, String> = emptyMap(),
+        block: suspend ApplicationTestBuilder.(Services) -> Unit,
+    ) = testApplication {
+        val services = testServices(
+            adminToken = "s3cret",
+            extraEnv = mapOf("SKERRY_METRICS" to "open") + extraEnv,
+        )
+        application { configureServer(services) }
+        try {
+            block(services)
+        } finally {
+            services.metrics.close()
+        }
+    }
+
+    private fun ApplicationTestBuilder.jsonClient() = createClient { install(ContentNegotiation) { json() } }
+
+    /** Value of one exposed series; 0.0 when the series doesn't exist yet (a counter never touched). */
+    private fun ServerMetrics.value(series: String): Double =
+        scrape().lines().firstOrNull { it.startsWith("$series ") }?.substringAfterLast(' ')?.toDouble() ?: 0.0
+
+    private fun ServerMetrics.has(prefix: String): Boolean = scrape().lines().any { it.startsWith(prefix) }
+
+    // --- sync volume ---
+
+    @Test
+    fun `account push and pull count records and ciphertext bytes`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password)
+        val blobs = listOf(byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6, 7, 8))
+
+        client.put("/vault/records") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(
+                PushRequest(
+                    blobs.mapIndexed { i, blob ->
+                        RecordDto("r$i", "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, blob.b64())
+                    },
+                ),
+            )
+        }
+
+        assertEquals(2.0, services.metrics.value("""skerry_sync_records_received_total{scope="account"}"""))
+        // Bytes of ciphertext, not of the base64 envelope: 3 + 5.
+        assertEquals(
+            blobs.sumOf { it.size }.toDouble(),
+            services.metrics.value("""skerry_sync_push_bytes_total{scope="account"}"""),
+        )
+
+        client.get("/vault/records?since=0") { bearerAuth(tokens.accessToken) }
+        assertEquals(2.0, services.metrics.value("""skerry_sync_records_pulled_total{scope="account"}"""))
+
+        // An empty delta pulls nothing and must not inflate the counter.
+        client.get("/vault/records?since=999") { bearerAuth(tokens.accessToken) }
+        assertEquals(2.0, services.metrics.value("""skerry_sync_records_pulled_total{scope="account"}"""))
+    }
+
+    @Test
+    fun `team push and pull are counted under the team scope`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password)
+        client.post("/teams") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamCreateRequest("team-1"))
+        }
+        client.put("/teams/team-1/records") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(
+                PushRequest(listOf(RecordDto("r1", "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, byteArrayOf(9, 9).b64()))),
+            )
+        }
+        client.get("/teams/team-1/records?since=0") { bearerAuth(tokens.accessToken) }
+
+        assertEquals(1.0, services.metrics.value("""skerry_sync_records_received_total{scope="team"}"""))
+        assertEquals(2.0, services.metrics.value("""skerry_sync_push_bytes_total{scope="team"}"""))
+        assertEquals(1.0, services.metrics.value("""skerry_sync_records_pulled_total{scope="team"}"""))
+        // The account scope must stay untouched by team traffic.
+        assertEquals(0.0, services.metrics.value("""skerry_sync_records_received_total{scope="account"}"""))
+    }
+
+    // --- auth ---
+
+    @Test
+    fun `token issuance and refresh outcomes are counted`() = withServer { services ->
+        val client = jsonClient()
+        val tokens: TokenResponse = client.registerAccount(alice, password)
+        assertEquals(1.0, services.metrics.value("""skerry_auth_tokens_issued_total{type="access"}"""))
+        assertEquals(1.0, services.metrics.value("""skerry_auth_tokens_issued_total{type="refresh"}"""))
+
+        client.post("/auth/refresh") {
+            contentType(ContentType.Application.Json)
+            setBody(app.skerry.sync.wire.RefreshRequest(tokens.refreshToken))
+        }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="refresh",outcome="ok"}"""))
+        assertEquals(2.0, services.metrics.value("""skerry_auth_tokens_issued_total{type="access"}"""))
+
+        client.post("/auth/refresh") {
+            contentType(ContentType.Application.Json)
+            setBody(app.skerry.sync.wire.RefreshRequest("not-a-token"))
+        }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="refresh",outcome="denied"}"""))
+    }
+
+    @Test
+    fun `login and password rotation record both outcomes`() = withServer { services ->
+        val client = jsonClient()
+        client.registerAccount(alice, password)
+
+        client.srpLogin(alice, password, "devB", "Phone B")
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="srp_verify",outcome="ok"}"""))
+        client.srpLoginResponse(alice, "wrong", "devB", "Phone B")
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="srp_verify",outcome="denied"}"""))
+        // Every challenge is counted the same way whether or not the account exists — the synthesized
+        // challenge for an unknown account is what stops enumeration, and this must not undo it.
+        client.srpLoginResponse("nobody@example.com", password, "devB", "Phone B")
+        assertEquals(3.0, services.metrics.value("""skerry_auth_attempts_total{kind="srp_challenge",outcome="ok"}"""))
+
+        client.changePassword(alice, password, "new password", byteArrayOf(2))
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="change_password",outcome="ok"}"""))
+        client.changePassword(alice, "still wrong", "another", byteArrayOf(2))
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="change_password",outcome="denied"}"""))
+    }
+
+    @Test
+    fun `pairing claims are counted per outcome`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password)
+        val start: app.skerry.sync.wire.PairingStartResponse = client.post("/pairing/start") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(app.skerry.sync.wire.PairingStartRequest(byteArrayOf(5).b64(), null))
+        }.body()
+        client.post("/pairing/claim") {
+            contentType(ContentType.Application.Json)
+            setBody(PairingClaimRequest(start.code, "devB", "Phone B"))
+        }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="pairing_claim",outcome="ok"}"""))
+
+        // The code is one-shot: replaying it is a denied claim.
+        client.post("/pairing/claim") {
+            contentType(ContentType.Application.Json)
+            setBody(PairingClaimRequest(start.code, "devC", "Phone C"))
+        }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="pairing_claim",outcome="denied"}"""))
+    }
+
+    @Test
+    fun `a wrong token type and a revoked device are distinguished`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password, deviceId = "devA")
+
+        // A refresh token presented as an access token: valid signature, wrong type.
+        client.get("/devices") { bearerAuth(tokens.refreshToken) }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_jwt_rejected_total{reason="wrong_type"}"""))
+
+        services.devices.revoke(alice, "devA")
+        client.get("/devices") { bearerAuth(tokens.accessToken) }
+        assertEquals(1.0, services.metrics.value("""skerry_auth_jwt_rejected_total{reason="device_revoked"}"""))
+    }
+
+    @Test
+    fun `closed registration and the account cap are told apart`() {
+        withServer(mapOf("SKERRY_REGISTRATION" to "closed")) { services ->
+            jsonClient().registerAccountResponse(alice, password)
+            assertEquals(1.0, services.metrics.value("""skerry_registration_rejected_total{reason="closed"}"""))
+            assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="register",outcome="denied"}"""))
+        }
+        withServer(mapOf("SKERRY_MAX_ACCOUNTS" to "1")) { services ->
+            val client = jsonClient()
+            client.registerAccount(alice, password)
+            client.registerAccountResponse(bob, password, deviceId = "devB")
+            assertEquals(1.0, services.metrics.value("""skerry_registration_rejected_total{reason="cap_reached"}"""))
+        }
+    }
+
+    @Test
+    fun `an existing account gives a register error rather than a denial`() = withServer { services ->
+        val client = jsonClient()
+        client.registerAccount(alice, password)
+        client.registerAccountResponse(alice, password)
+        assertEquals(1.0, services.metrics.value("""skerry_auth_attempts_total{kind="register",outcome="error"}"""))
+        assertEquals(0.0, services.metrics.value("""skerry_auth_attempts_total{kind="register",outcome="denied"}"""))
+    }
+
+    @Test
+    fun `revocations are attributed to the user or the admin`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password, deviceId = "devA")
+        client.srpLogin(alice, password, "devB", "Phone B")
+
+        client.delete("/devices/devB") { bearerAuth(tokens.accessToken) }
+        assertEquals(1.0, services.metrics.value("""skerry_devices_revoked_total{by="user"}"""))
+
+        client.delete("/admin/devices/devA?accountId=$alice") { header("X-Admin-Token", "s3cret") }
+        assertEquals(1.0, services.metrics.value("""skerry_devices_revoked_total{by="admin"}"""))
+
+        // A revoke that matched nothing must not be counted.
+        client.delete("/admin/devices/ghost?accountId=$alice") { header("X-Admin-Token", "s3cret") }
+        assertEquals(1.0, services.metrics.value("""skerry_devices_revoked_total{by="admin"}"""))
+    }
+
+    @Test
+    fun `admin and metrics token failures are counted separately`() = withServer { services ->
+        val client = jsonClient()
+        client.get("/admin/stats")
+        client.get("/metrics") // open mode: no failure expected here
+        assertEquals(1.0, services.metrics.value("skerry_admin_auth_failures_total"))
+        assertEquals(0.0, services.metrics.value("skerry_metrics_auth_failures_total"))
+    }
+
+    @Test
+    fun `team access denials are labelled by reason`() = withServer { services ->
+        val client = jsonClient()
+        val aliceTokens = client.registerAccount(alice, password, deviceId = "devA")
+        val bobTokens = client.registerAccount(bob, password, deviceId = "devB")
+        client.post("/teams") {
+            bearerAuth(aliceTokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamCreateRequest("team-1"))
+        }
+
+        // Bob is not a member at all.
+        client.get("/teams/team-1/records?since=0") { bearerAuth(bobTokens.accessToken) }
+        assertEquals(1.0, services.metrics.value("""skerry_team_authz_denied_total{reason="not_member"}"""))
+
+        // Alice asks for a scope nobody granted her.
+        client.get("/teams/team-1/records?since=0&scope=prod") { bearerAuth(aliceTokens.accessToken) }
+        assertEquals(1.0, services.metrics.value("""skerry_team_authz_denied_total{reason="scope"}"""))
+    }
+
+    @Test
+    fun `an oversized body is counted as a rejected request`() = withServer(mapOf("SKERRY_MAX_BODY_BYTES" to "64")) { services ->
+        val client = jsonClient()
+        client.post("/auth/register") {
+            contentType(ContentType.Application.Json)
+            setBody("x".repeat(500))
+        }
+        assertEquals(1.0, services.metrics.value("""skerry_http_rejected_requests_total{reason="body_too_large"}"""))
+    }
+
+    // --- WebSocket sessions ---
+
+    @Test
+    fun `a websocket session is counted open, closed by the client, and its frames tallied`() = withServer { services ->
+        val client = createClient {
+            install(ContentNegotiation) { json() }
+            install(WebSockets)
+        }
+        val tokens: TokenResponse = client.registerAccount(alice, password, deviceId = "devA")
+
+        client.webSocket("/sync", request = { bearerAuth(tokens.accessToken) }) {
+            withTimeout(2_000) { services.notifier.subscriptions.first { it >= wsSubscriptions } }
+            assertEquals(1.0, services.metrics.value("skerry_sync_ws_sessions"))
+            assertEquals(1.0, services.metrics.value("skerry_sync_ws_sessions_opened_total"))
+
+            services.notifier.publish(alice, 7)
+            withTimeout(2_000) { incoming.receive() } as Frame.Text
+            close(CloseReason(CloseReason.Codes.NORMAL, "done"))
+        }
+        withTimeout(2_000) { services.notifier.subscriptions.first { it == 0 } }
+
+        assertEquals(0.0, services.metrics.value("skerry_sync_ws_sessions"), "the gauge must come back down")
+        assertEquals(1.0, services.metrics.value("""skerry_sync_ws_frames_sent_total{kind="account"}"""))
+        assertEquals(1.0, services.metrics.value("""skerry_sync_notify_published_total{kind="account"}"""))
+        assertEquals(
+            1.0,
+            services.metrics.value("""skerry_sync_ws_sessions_closed_total{reason="client_close"}"""),
+        )
+        assertTrue(services.metrics.has("skerry_sync_ws_session_duration_seconds_count"))
+    }
+
+    @Test
+    fun `a session dropped by revocation is closed under that reason`() = withServer { services ->
+        val client = createClient {
+            install(ContentNegotiation) { json() }
+            install(WebSockets)
+        }
+        val tokens: TokenResponse = client.registerAccount(alice, password, deviceId = "devA")
+
+        client.webSocket("/sync", request = { bearerAuth(tokens.accessToken) }) {
+            withTimeout(2_000) { services.notifier.subscriptions.first { it >= wsSubscriptions } }
+            services.devices.revoke(alice, "devA")
+            services.notifier.publish(alice, 1)
+            withTimeout(2_000) { closeReason.await() }
+        }
+        withTimeout(2_000) { services.notifier.subscriptions.first { it == 0 } }
+
+        // First cause wins: the revoke decided this close, not the client's reaction to it.
+        assertEquals(
+            1.0,
+            services.metrics.value("""skerry_sync_ws_sessions_closed_total{reason="device_revoked"}"""),
+            services.metrics.scrape().lines().filter { "ws_sessions_closed" in it }.toString(),
+        )
+        assertEquals(0.0, services.metrics.value("""skerry_sync_ws_sessions_closed_total{reason="client_close"}"""))
+    }
+
+    // --- inventory and pool ---
+
+    @Test
+    fun `the inventory snapshot reports every field it claims`() = withServer { services ->
+        val client = jsonClient()
+        val tokens = client.registerAccount(alice, password, deviceId = "devA")
+        client.srpLogin(alice, password, "devB", "Phone B")
+        services.devices.revoke(alice, "devB")
+        client.pushRecord(tokens.accessToken, RecordDto("live-1", "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, byteArrayOf(1, 2, 3).b64()))
+        client.pushRecord(tokens.accessToken, RecordDto("dead-1", "HOST", 2, "2026-07-26T00:00:00Z", "devA", true, byteArrayOf().b64()))
+        client.post("/teams") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(TeamCreateRequest("team-1"))
+        }
+        client.put("/teams/team-1/records") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(PushRequest(listOf(RecordDto("t1", "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, byteArrayOf(7, 7, 7, 7).b64()))))
+        }
+        client.post("/pairing/start") {
+            bearerAuth(tokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(app.skerry.sync.wire.PairingStartRequest(byteArrayOf(5).b64(), null))
+        }
+
+        services.inventory.collectOnce()
+        val m = services.metrics
+
+        assertEquals(1.0, m.value("skerry_accounts"))
+        assertEquals(1.0, m.value("""skerry_devices{state="active"}"""))
+        assertEquals(1.0, m.value("""skerry_devices{state="revoked"}"""))
+        assertEquals(1.0, m.value("""skerry_records{state="live"}"""))
+        assertEquals(1.0, m.value("""skerry_records{state="tombstone"}"""))
+        assertEquals(3.0, m.value("""skerry_storage_bytes{scope="account"}"""))
+        assertEquals(1.0, m.value("""skerry_team_records{state="live"}"""))
+        assertEquals(0.0, m.value("""skerry_team_records{state="tombstone"}"""))
+        assertEquals(4.0, m.value("""skerry_storage_bytes{scope="team"}"""))
+        assertEquals(1.0, m.value("""skerry_pairing_sessions{state="pending"}"""))
+        assertEquals(0.0, m.value("""skerry_pairing_sessions{state="expired"}"""))
+        assertEquals(1.0, m.value("skerry_teams"))
+        assertEquals(1.0, m.value("""skerry_team_members{status="active"}"""))
+        assertEquals(0.0, m.value("""skerry_team_members{status="invited"}"""))
+        assertTrue(m.value("skerry_activity_log_rows") > 0, "the audit log has events by now")
+        assertTrue(m.value("skerry_db_file_bytes") > 0, "the SQLite file exists on disk")
+        assertEquals(1.0, m.value("skerry_registration_open"))
+    }
+
+    /** The pool metrics only appear if the registry actually reached HikariCP in Db.connect. */
+    @Test
+    fun `hikari pool metrics reach the exposition`() = withServer { services ->
+        jsonClient().registerAccount(alice, password)
+        val body = services.metrics.scrape()
+        assertTrue("hikaricp_connections" in body, "no HikariCP metrics: the registry never reached the pool")
+        // The pool name is numbered per JVM, so match the series, not "HikariPool-1". SQLite is
+        // single-writer: this instance's pool is deliberately one connection.
+        val poolMax = body.lines().filter { it.startsWith("hikaricp_connections_max{") }
+        assertEquals(1, poolMax.size, poolMax.toString())
+        assertEquals(1.0, poolMax.single().substringAfterLast(' ').toDouble())
+    }
+}

--- a/server/src/test/kotlin/app/skerry/server/metrics/ObserversTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/metrics/ObserversTest.kt
@@ -1,0 +1,109 @@
+package app.skerry.server.metrics
+
+import app.skerry.server.config.ServerConfig
+import app.skerry.server.db.Db
+import app.skerry.server.db.StatsRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.nio.file.Files
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** The readiness probe and the inventory collector: hysteresis, and honesty about stale data. */
+class ObserversTest {
+
+    private val opened = mutableListOf<ServerMetrics>()
+
+    /** Same reason as in the route tests: the JVM binders hold a GC listener until closed. */
+    @AfterTest
+    fun closeRegistries() {
+        opened.forEach { it.close() }
+        opened.clear()
+    }
+
+    private fun metrics(exposure: String = "open"): ServerMetrics =
+        ServerMetrics(ServerConfig.fromEnv(mapOf("SKERRY_METRICS" to exposure))).also { opened += it }
+
+    @Test
+    fun `a single failure does not take the instance out of rotation`() = runTest {
+        val probe = DbProbe(metrics(), failureThreshold = 3) { error("locked") }
+        probe.probeOnce()
+        assertTrue(probe.ready, "one failure must not flip readiness — a slow transaction is not an outage")
+        probe.probeOnce()
+        assertTrue(probe.ready)
+        probe.probeOnce()
+        assertFalse(probe.ready, "three consecutive failures should")
+    }
+
+    @Test
+    fun `one success restores readiness and the counter starts over`() = runTest {
+        var failing = true
+        val probe = DbProbe(metrics(), failureThreshold = 3) { if (failing) error("locked") }
+        repeat(3) { probe.probeOnce() }
+        assertFalse(probe.ready)
+
+        failing = false
+        probe.probeOnce()
+        assertTrue(probe.ready)
+
+        // The failure count reset, so two fresh failures are still not enough.
+        failing = true
+        probe.probeOnce()
+        probe.probeOnce()
+        assertTrue(probe.ready)
+    }
+
+    @Test
+    fun `a probe that hangs counts as a failure rather than blocking`() = runTest {
+        val probe = DbProbe(metrics(), timeoutMillis = 50, failureThreshold = 1) { delay(10_000) }
+        probe.probeOnce()
+        assertFalse(probe.ready)
+    }
+
+    @Test
+    fun `probe results reach the exposition`() = runTest {
+        val metrics = metrics()
+        DbProbe(metrics, failureThreshold = 1) { }.probeOnce()
+        assertTrue(metrics.scrape().lines().any { it == "skerry_db_up 1.0" }, metrics.scrape())
+
+        DbProbe(metrics, failureThreshold = 1) { error("down") }.probeOnce()
+        assertTrue(metrics.scrape().lines().any { it == "skerry_db_up 0.0" })
+    }
+
+    /**
+     * A failed collection must not update the freshness timestamp: alerting on
+     * `time() - skerry_inventory_last_success_time_seconds` is the only thing that keeps a stale
+     * gauge from reading as current.
+     */
+    @Test
+    fun `a failed collection is visible and does not refresh the timestamp`() = runTest {
+        val metrics = metrics()
+        val file = Files.createTempFile("skerry-observers-", ".db")
+        file.toFile().deleteOnExit()
+        val config = ServerConfig.fromEnv(mapOf("SKERRY_DB_URL" to "jdbc:sqlite:${file.toAbsolutePath()}"))
+        val database = Db.connect(config)
+        val collector = InventoryCollector(StatsRepository(database), metrics, config.databaseUrl)
+        collector.collectOnce { 1_700_000_000_000 }
+        val afterSuccess = metrics.gaugeValue("skerry_inventory_last_success_time_seconds")
+        assertEquals(1_700_000_000.0, afterSuccess)
+        assertEquals(0.0, metrics.gaugeValue("skerry_accounts"))
+
+        // Break a table the inventory query needs, so the failure happens where it would in
+        // production — inside the collection, not while opening the pool.
+        transaction(database) { exec("DROP TABLE records") }
+        collector.collectOnce { 1_900_000_000_000 }
+
+        assertEquals(afterSuccess, metrics.gaugeValue("skerry_inventory_last_success_time_seconds"))
+        assertTrue(
+            metrics.scrape().lines().any { it.startsWith("skerry_inventory_errors_total") && !it.endsWith(" 0.0") },
+            metrics.scrape().lines().filter { "inventory" in it }.toString(),
+        )
+    }
+
+    private fun ServerMetrics.gaugeValue(name: String): Double =
+        scrape().lines().first { it.startsWith("$name ") }.substringAfterLast(' ').toDouble()
+}

--- a/server/src/test/kotlin/app/skerry/server/routes/MetricsRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/MetricsRoutesTest.kt
@@ -1,0 +1,255 @@
+package app.skerry.server.routes
+
+import app.skerry.server.Services
+import app.skerry.server.configureServer
+import app.skerry.server.guardConfig
+import app.skerry.server.config.ServerConfig
+import app.skerry.sync.wire.RecordDto
+import app.skerry.server.model.b64
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The metrics endpoint carries instance metadata, which on a zero-knowledge server is the whole
+ * attack surface — so these tests are as much about what the exposition must *not* contain (account
+ * ids, per-request path values) as about what it does.
+ */
+class MetricsRoutesTest {
+
+    private val accountId = "alice@example.com"
+    private val password = "correct horse"
+
+    private fun withServer(
+        metrics: String,
+        metricsToken: String = "",
+        adminToken: String = "s3cret",
+        block: suspend ApplicationTestBuilder.(Services) -> Unit,
+    ) = testApplication {
+        val services = testServices(
+            adminToken = adminToken,
+            extraEnv = mapOf("SKERRY_METRICS" to metrics, "SKERRY_METRICS_TOKEN" to metricsToken),
+        )
+        application { configureServer(services) }
+        // JvmGcMetrics registers a GC notification listener; the suite starts dozens of servers in one
+        // JVM, so each one has to give it back.
+        try {
+            block(services)
+        } finally {
+            services.metrics.close()
+        }
+    }
+
+    @Test
+    fun `metrics are absent when disabled`() = withServer(metrics = "off") {
+        // 404, not 401: a disabled endpoint should not announce that it exists.
+        assertEquals(HttpStatusCode.NotFound, client.get("/metrics").status)
+    }
+
+    @Test
+    fun `token mode rejects a missing or wrong bearer token`() = withServer("token", metricsToken = "scrape-me") {
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/metrics").status)
+        assertEquals(
+            HttpStatusCode.Unauthorized,
+            client.get("/metrics") { header(HttpHeaders.Authorization, "Bearer nope") }.status,
+        )
+        // The admin token must not open it: that credential also authorizes DELETE /admin/accounts.
+        assertEquals(
+            HttpStatusCode.Unauthorized,
+            client.get("/metrics") { header("X-Admin-Token", "s3cret") }.status,
+        )
+    }
+
+    @Test
+    fun `token mode serves the exposition and counts rejected scrapes`() = withServer("token", metricsToken = "scrape-me") {
+        client.get("/metrics") { header(HttpHeaders.Authorization, "Bearer nope") }
+        val response = client.get("/metrics") { header(HttpHeaders.Authorization, "Bearer scrape-me") }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue("skerry_build_info" in body, body.take(400))
+        assertTrue("jvm_memory_used_bytes" in body, "JVM binders should be attached when metrics are on")
+        assertTrue("skerry_metrics_auth_failures_total 1.0" in body, body.lines().filter { "auth_failures" in it }.toString())
+        assertEquals("no-store", response.headers[HttpHeaders.CacheControl])
+    }
+
+    @Test
+    fun `open mode needs no credential`() = withServer("open") {
+        assertEquals(HttpStatusCode.OK, client.get("/metrics").status)
+    }
+
+    @Test
+    fun `token mode without a token refuses to start`() {
+        val config = ServerConfig.fromEnv(mapOf("SKERRY_METRICS" to "token", "SKERRY_JWT_SECRET" to "x"))
+        val failure = assertFailsWith<IllegalStateException> { guardConfig(config, emptyMap()) }
+        assertTrue("SKERRY_METRICS_TOKEN" in (failure.message ?: ""), failure.message ?: "")
+    }
+
+    /**
+     * The whole point of the label rules: no account id, device id or record id may reach the
+     * exposition, whether as a label value or inside a route label.
+     */
+    @Test
+    fun `exposition never contains account device or record identifiers`() = withServer("open") { services ->
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val tokens = client.registerAccount(accountId, password, deviceId = "devA", platform = "linux")
+        client.pushRecord(tokens.accessToken, RecordDto("secret-record-id", "HOST", 1, "2026-07-26T00:00:00Z", "devA", false, byteArrayOf(7).b64()))
+        client.get("/vault/records?since=0") { header(HttpHeaders.Authorization, "Bearer ${tokens.accessToken}") }
+        client.delete("/admin/devices/devA?accountId=$accountId") { header("X-Admin-Token", "s3cret") }
+        services.inventory.collectOnce()
+
+        val body = services.metrics.scrape()
+        assertFalse(accountId in body, "accountId leaked into the exposition")
+        assertFalse("devA" in body, "deviceId leaked into the exposition")
+        assertFalse("secret-record-id" in body, "recordId leaked into the exposition")
+        // The path parameter must appear as a template, never as its value.
+        assertTrue("""route="/admin/devices/{id}"""" in body, body.lines().filter { "admin_devices" in it || "route=" in it }.take(8).toString())
+    }
+
+    /**
+     * Cardinality guard. `/console` is a tailcard route and `/anything` doesn't match at all, both
+     * reachable without a credential — if either produced one series per request, an attacker could
+     * grow the registry until the process dies.
+     */
+    @Test
+    fun `unmatched and static paths do not create a series per request`() = withServer("open") { services ->
+        client.get("/console/one")
+        client.get("/nope-one")
+        val baseline = services.metrics.scrape().lines().count { it.startsWith("skerry_http_server_requests") }
+
+        repeat(50) { i ->
+            client.get("/console/junk-$i")
+            client.get("/nope-$i")
+        }
+        val after = services.metrics.scrape().lines().count { it.startsWith("skerry_http_server_requests") }
+        assertEquals(baseline, after, "series count grew with the number of distinct paths")
+    }
+
+    /**
+     * Explicit SLO buckets, not Micrometer's percentile histogram: the default emits ~70 buckets per
+     * series, which is thousands of series for a handful of routes.
+     */
+    @Test
+    fun `request timer uses the explicit slo buckets`() = withServer("open") { services ->
+        client.get("/healthz")
+        val buckets = services.metrics.scrape().lines()
+            .filter { it.startsWith("skerry_http_server_requests_seconds_bucket") && """route="/healthz"""" in it }
+        assertEquals(7, buckets.size, buckets.toString()) // 6 objectives + +Inf
+        assertTrue(buckets.any { """le="0.25"""" in it }, buckets.toString())
+    }
+
+    @Test
+    fun `inventory gauges stay unknown until the first collection`() = withServer("open") { services ->
+        val before = services.metrics.scrape().lines().first { it.startsWith("skerry_accounts ") }
+        assertTrue("NaN" in before, before)
+
+        val client = createClient { install(ContentNegotiation) { json() } }
+        client.registerAccount(accountId, password)
+        services.inventory.collectOnce()
+
+        val after = services.metrics.scrape().lines().first { it.startsWith("skerry_accounts ") }
+        assertEquals("skerry_accounts 1.0", after)
+        assertTrue(
+            services.metrics.scrape().lines().any { it.startsWith("skerry_inventory_last_success_time_seconds") && !it.endsWith(" 0.0") },
+        )
+    }
+
+    @Test
+    fun `admin token failures are counted`() = withServer("open") { services ->
+        client.get("/admin/stats") // no token
+        client.get("/admin/stats") { header("X-Admin-Token", "wrong") }
+        val body = services.metrics.scrape()
+        assertTrue("skerry_admin_auth_failures_total 2.0" in body, body.lines().filter { "admin_auth" in it }.toString())
+    }
+
+    @Test
+    fun `failed logins are counted by outcome`() = withServer("open") { services ->
+        val client = createClient { install(ContentNegotiation) { json() } }
+        client.registerAccount(accountId, password)
+        client.srpLoginResponse(accountId, "wrong password", "devB", "Phone B")
+
+        val body = services.metrics.scrape()
+        assertTrue("""skerry_auth_attempts_total{kind="register",outcome="ok"} 1.0""" in body, body.lines().filter { "auth_attempts" in it }.toString())
+        assertTrue(
+            body.lines().any { it.startsWith("""skerry_auth_attempts_total{kind="srp_verify",outcome="denied"}""") },
+            body.lines().filter { "auth_attempts" in it }.toString(),
+        )
+    }
+
+    /**
+     * The console needs to show whether monitoring is actually wired up; this endpoint is the only
+     * place it can learn that, and it stays behind the admin token like the rest of /admin.
+     */
+    @Test
+    fun `observability status is admin-gated and reports the metrics mode`() = withServer("token", metricsToken = "scrape-me") { services ->
+        assertEquals(HttpStatusCode.Unauthorized, client.get("/admin/observability").status)
+
+        val body = client.get("/admin/observability") { header("X-Admin-Token", "s3cret") }.bodyAsText()
+        assertTrue(""""metrics":"token"""" in body, body)
+        assertTrue(""""ready":true""" in body, body)
+        // Never collected yet: the age must be absent, not zero — zero would read as "just now".
+        assertTrue(""""inventoryAgeSeconds":null""" in body, body)
+
+        services.inventory.collectOnce()
+        val after = client.get("/admin/observability") { header("X-Admin-Token", "s3cret") }.bodyAsText()
+        assertFalse(""""inventoryAgeSeconds":null""" in after, after)
+    }
+
+    /**
+     * Readiness through the real route, driven by the service's own probe: three consecutive failures
+     * must answer 503, and `/healthz` must keep answering 200 on that same instance — the container
+     * healthcheck and every client's availability ping hang off it, so tying it to the database would
+     * turn a slow transaction into a restart loop and a client-wide "unreachable" storm.
+     */
+    @Test
+    fun `readiness turns 503 after repeated failures while healthz keeps answering`() = testApplication {
+        var databaseDown = false
+        val services = testServices(adminToken = "s3cret", dbCheck = { if (databaseDown) error("locked") })
+        application { configureServer(services) }
+
+        services.dbProbe.probeOnce()
+        assertEquals(HttpStatusCode.OK, client.get("/readyz").status)
+        assertTrue("\"status\":\"ready\"" in client.get("/readyz").bodyAsText())
+
+        databaseDown = true
+        repeat(2) { services.dbProbe.probeOnce() }
+        assertEquals(HttpStatusCode.OK, client.get("/readyz").status, "two failures must not flip readiness")
+
+        services.dbProbe.probeOnce()
+        val notReady = client.get("/readyz")
+        assertEquals(HttpStatusCode.ServiceUnavailable, notReady.status)
+        val body = notReady.bodyAsText()
+        assertTrue("\"status\":\"not_ready\"" in body && "\"db\":\"down\"" in body, body)
+        // Liveness is deliberately independent of the database.
+        assertEquals(HttpStatusCode.OK, client.get("/healthz").status)
+        assertEquals("ok", client.get("/healthz").bodyAsText())
+
+        databaseDown = false
+        services.dbProbe.probeOnce()
+        assertEquals(HttpStatusCode.OK, client.get("/readyz").status, "one success should restore readiness")
+    }
+
+    /** The console's only window into whether monitoring is wired up must follow the probe too. */
+    @Test
+    fun `observability status follows the probe`() = testApplication {
+        var databaseDown = false
+        val services = testServices(adminToken = "s3cret", dbCheck = { if (databaseDown) error("locked") })
+        application { configureServer(services) }
+
+        databaseDown = true
+        repeat(3) { services.dbProbe.probeOnce() }
+        val body = client.get("/admin/observability") { header("X-Admin-Token", "s3cret") }.bodyAsText()
+        assertTrue("\"ready\":false" in body, body)
+    }
+}

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTest.kt
@@ -385,6 +385,18 @@ class RoutesTest {
         assertEquals(1L, d.syncVersion)
         assertEquals(false, d.revoked)
 
+        // an account filter narrows both the page and the total (the CLI's `devices list --account`)
+        client.registerAccount("bob@example.com", password, deviceId = "devB", deviceName = "Laptop B")
+        val filtered: AdminDevicesResponse = client.get("/admin/devices?accountId=$accountId") {
+            header("X-Admin-Token", "s3cret")
+        }.body()
+        assertEquals(listOf("devA"), filtered.devices.map { it.id })
+        assertEquals(1, filtered.total)
+        val unfiltered: AdminDevicesResponse = client.get("/admin/devices") {
+            header("X-Admin-Token", "s3cret")
+        }.body()
+        assertEquals(2, unfiltered.total)
+
         // revoke is also token-gated
         assertEquals(
             HttpStatusCode.Unauthorized,
@@ -397,7 +409,7 @@ class RoutesTest {
 
         // after revoke the device is hidden from the admin list (revoked devices are inert, so the
         // list — and the "N of M" total — count only active devices)
-        val after: AdminDevicesResponse = client.get("/admin/devices") {
+        val after: AdminDevicesResponse = client.get("/admin/devices?accountId=$accountId") {
             header("X-Admin-Token", "s3cret")
         }.body()
         assertTrue(after.devices.isEmpty())

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
@@ -1,6 +1,8 @@
 package app.skerry.server.routes
 
+import app.skerry.server.SERVER_VERSION
 import app.skerry.server.Services
+import app.skerry.server.metrics.ServerMetrics
 import app.skerry.server.config.ServerConfig
 import app.skerry.server.db.Db
 import app.skerry.sync.wire.ChallengeRequest
@@ -32,14 +34,21 @@ import java.security.SecureRandom
 
 val SRP_PARAMS: SRP6CryptoParams = SRP6CryptoParams.getInstance(2048, "SHA-256")
 
-fun testServices(adminToken: String = "", extraEnv: Map<String, String> = emptyMap()): Services {
+fun testServices(
+    adminToken: String = "",
+    extraEnv: Map<String, String> = emptyMap(),
+    dbCheck: (suspend () -> Unit)? = null,
+): Services {
     val file = Files.createTempFile("skerry-routes-", ".db")
     file.toFile().deleteOnExit()
     val config = ServerConfig.fromEnv(
         mapOf("SKERRY_DB_URL" to "jdbc:sqlite:${file.toAbsolutePath()}", "SKERRY_ADMIN_TOKEN" to adminToken) + extraEnv,
     )
-    val database: Database = Db.connect(config)
-    return Services(config, database)
+    // Same order as Application.module: the registry has to exist before the pool, or HikariCP has
+    // nothing to publish into and hikaricp_* silently disappears from the exposition.
+    val metrics = ServerMetrics(config, version = SERVER_VERSION)
+    val database: Database = Db.connect(config, metrics.registry)
+    return Services(config, database, metrics, dbCheck)
 }
 
 /** SRP registration material, as the client would compute it before /auth/register. */


### PR DESCRIPTION
Adds the three pieces the self-hosted sync server was missing next to its web console: a Prometheus exposition, a readiness endpoint, and an administration CLI.

## Metrics

`GET /metrics` (Micrometer + Prometheus registry), **closed by default**.

- `SKERRY_METRICS=off | token | open`. While `off` the route isn't registered at all, so it answers 404 instead of announcing itself.
- `token` mode uses its own `SKERRY_METRICS_TOKEN` as `Authorization: Bearer` — what Prometheus supports natively (`authorization.credentials_file`). Deliberately **not** the admin token: that credential also authorizes `DELETE /admin/accounts/{id}`, and a scraper's config file has no business holding it. Token mode with an empty token refuses to start.
- Own per-IP rate-limit bucket; `/metrics`, `/healthz` and `/readyz` are excluded from request logging.

Exposed: HTTP latency and volume by `method` / `route` / `status`; auth, admin-token, JWT and team-authz outcomes; sync volume by scope; WebSocket sessions with close reasons; instance inventory; plus `jvm_*`, `process_*`, `hikaricp_*` under their standard names, so off-the-shelf dashboards work. README documents the full table, a `scrape_config` sample and a starting set of alerts.

Two invariants that shape the design and are pinned by tests:

- **No label carries an accountId, deviceId, recordId, teamId, scopeId or IP.** All of those are client-chosen: as a label one would let any user grow the registry until the process dies, and would publish the metadata a zero-knowledge server exists not to hold. `route` is the route template (`/admin/devices/{id}`), and unmatched paths — including the unauthenticated `/console/*` tailcard — collapse into one series.
- **Nothing expensive at scrape time.** Inventory gauges come from a background collector; the default SQLite pool is a single connection, so summing blob sizes per scrape would compete with every push and pull. Before the first collection they read `NaN`, not `0`, and `skerry_inventory_last_success_time_seconds` makes a stale snapshot visible rather than silently current.

Buckets are explicit SLO boundaries — Micrometer's default percentile histogram would emit ~70 buckets per series.

## Readiness

`GET /readyz` reports a background database probe with hysteresis: three consecutive failures to answer 503, one success to return. The probe never runs inside the request, so an orchestrator polling it can't spend the single SQLite connection on probing and then read its own contention as a database failure.

`/healthz` is untouched on purpose — the container healthcheck, CI and every client's availability ping hang off it, so tying it to the database would turn a slow transaction into a restart loop and a client-wide reconnect storm.

## skerry-admin CLI

A second launcher in the same distribution, so the Docker image gets it for free (`/app/bin` is on `PATH`):

```
docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices list --account alice@example.com
```

It drives the same `/admin` endpoints as the console — one implementation and one authorization gate per operation, no second path into the database. Commands: `health`, `stats`, `accounts list|records|purge-tombstones|delete`, `devices list|revoke`, `activity`, `metrics`. Exit codes are meant for scripts (`0` ok, `1` error, `2` usage, `3` unauthorized, `4` not found, `5` unreachable), `--json` passes the server's response through for `jq`, and `accounts delete` requires `--yes` because `docker exec` often has no TTY. It warns when a token would cross the network over plain HTTP to a non-loopback host.

## Also in this PR

- `/admin/devices` takes an `accountId` filter (page and total agree).
- `/admin/observability` tells the console whether monitoring is wired up; the console shows it as a **Monitoring** section (metrics mode, readiness, inventory freshness — with `never` and `disabled` as distinct states).
- The constant-time token comparison is shared between the admin and metrics gates.
- `.env.example`, `README.md` and `README.ru.md` document every new variable and endpoint.

## Verification

223 tests. Every guard above was checked by reverting it and confirming the matching test fails — the cardinality guard, the SLO buckets, the NaN semantics, the `/readyz` 503 path, the WebSocket close reason, the inventory arithmetic and the HikariCP wiring.

Checked live, not only in tests: the exposition read by hand against a running server (253 series, route templates, no identifiers), the CLI against both a local instance and inside the container, the image on PostgreSQL (`pg_database_size`, pool of 10), the container healthcheck reporting `healthy`, and the request log staying quiet for scrapes and probes.

Live checks caught three defects tests didn't: `skerry-admin` wasn't on the container's `PATH`; the Ktor plugin's default `LoggingMeterRegistry` kept publishing every meter into the log once a minute after its registry was swapped out; and the plugin registered a distribution config over our buckets. Review found three more: a `closeReason` race across the three `/sync` coroutines (a revoke could be recorded as `client_close`), `--account=` silently widening a listing, and locale-dependent byte formatting (`1,2 MiB` on a ru-locale JVM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
