### PR TITLE
Certificate from file: key and certificate stay on disk and are re-read on every connection

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -21,6 +21,9 @@ import app.skerry.shared.ssh.VaultKnownHostsStore
 import app.skerry.shared.ssh.ProbeHostKeyVerifier
 import app.skerry.shared.ssh.RoutingTransport
 import app.skerry.shared.ssh.SshjTransport
+import app.skerry.shared.ssh.KeyFileResolver
+import app.skerry.shared.vault.OkioSecretFileReader
+import app.skerry.ui.vault.AndroidSecretFileReader
 import app.skerry.ui.connection.KeyboardInteractivePromptController
 import app.skerry.shared.ssh.TofuHostKeyVerifier
 import app.skerry.shared.snippet.VaultSnippetStore
@@ -452,10 +455,21 @@ class MainActivity : FragmentActivity() {
         // Keyboard-interactive challenges (2FA codes) reach the UI through this controller; shared by
         // every transport that authenticates, so a tunnel or container probe prompts like a session.
         val keyboardInteractive = KeyboardInteractivePromptController().also { this.keyboardInteractive = it }
+        // File-backed credentials (key/certificate kept outside the vault) are read at connect time:
+        // `content://` refs go through the Storage Access Framework, plain paths through okio. Shared
+        // by every transport that authenticates, and carrying the inspector so an expired certificate
+        // is refused here, with its date, rather than as "server rejected the credentials".
+        val certificateInspector = SshjCertificateInspector()
+        val secretFiles = AndroidSecretFileReader(
+            applicationContext,
+            OkioSecretFileReader(FileSystem.SYSTEM, homeDir = null),
+        )
+        val keyFileResolver = KeyFileResolver(files = secretFiles, inspector = certificateInspector)
         val transport = RoutingTransport(
             ssh = SshjTransport(
                 TofuHostKeyVerifier(knownHostsStore, mismatchStore) { Instant.now().toString() },
-                keyboardInteractive.responder,
+                keyFiles = keyFileResolver,
+                keyboardInteractiveResponder = keyboardInteractive.responder,
             ),
         )
         val knownHosts = KnownHostsController(knownHostsStore, mismatchStore) { Instant.now().toString() }
@@ -482,7 +496,11 @@ class MainActivity : FragmentActivity() {
         // Probe transport (read-only verifier, no silent TOFU): activating a saved tunnel and
         // listing a host's containers from the connection form both ride it, so neither can
         // establish trust in a host key on their own.
-        val probeTransport = SshjTransport(ProbeHostKeyVerifier(knownHostsStore), keyboardInteractive.responder)
+        val probeTransport = SshjTransport(
+            ProbeHostKeyVerifier(knownHostsStore),
+            keyFiles = keyFileResolver,
+            keyboardInteractiveResponder = keyboardInteractive.responder,
+        )
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default).also { tunnelScope = it }
         val tunnels = TunnelManager(
             store = VaultTunnelStore(vault, trash),
@@ -645,7 +663,8 @@ class MainActivity : FragmentActivity() {
             // SSH key inspector/generator (BouncyCastle, shared JVM source set): fingerprints/generation in the Vault tab.
             keyGenerator = BouncyCastleSshKeyGenerator(),
             // SSH certificate inspector (sshj): Vault → Certificates parses *-cert.pub.
-            certificateInspector = SshjCertificateInspector(),
+            certificateInspector = certificateInspector,
+            secretFiles = secretFiles,
             biometrics = biometrics,
             tunnels = tunnels,
             snippets = snippets,

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/AndroidSecretFileReader.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/AndroidSecretFileReader.kt
@@ -1,0 +1,73 @@
+package app.skerry.ui.vault
+
+import android.content.Context
+import app.skerry.shared.vault.SecretFileReader
+import app.skerry.shared.vault.SecretFileResult
+import java.io.ByteArrayOutputStream
+import java.io.FileNotFoundException
+
+/**
+ * Android [SecretFileReader]: `content://` refs go through the SAF provider, everything else falls
+ * through to [delegate] (the okio reader) — a path inside the app's own storage, or one the user
+ * has direct access to, still works.
+ *
+ * The stream is read against a hard [maxBytes] ceiling rather than a declared size: a provider can
+ * report anything (or nothing), and a mistyped pick must not be pulled into memory whole. Same rule
+ * as [importTextFile].
+ */
+class AndroidSecretFileReader(
+    private val context: Context,
+    private val delegate: SecretFileReader,
+    private val maxBytes: Int = MAX_BYTES,
+) : SecretFileReader {
+
+    override fun read(ref: String): SecretFileResult {
+        val trimmed = ref.trim()
+        if (!trimmed.startsWith(CONTENT_SCHEME)) return delegate.read(trimmed)
+        val uri = runCatching { android.net.Uri.parse(trimmed) }.getOrNull()
+            ?: return SecretFileResult.Failed("malformed Uri")
+        return try {
+            val stream = context.contentResolver.openInputStream(uri) ?: return SecretFileResult.NotFound
+            stream.use { input ->
+                val buffer = ByteArray(64 * 1024)
+                val collected = ByteArrayOutputStream()
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read <= 0) break
+                    if (collected.size() + read > maxBytes) return SecretFileResult.TooLarge
+                    collected.write(buffer, 0, read)
+                }
+                SecretFileResult.Ok(collected.toString(Charsets.UTF_8.name()))
+            }
+        } catch (e: SecurityException) {
+            // The persisted grant was revoked (the user cleared it, or the provider's app was
+            // reinstalled): the file may well still be there, so this is not "not found".
+            SecretFileResult.Denied
+        } catch (e: FileNotFoundException) {
+            SecretFileResult.NotFound
+        } catch (e: Exception) {
+            // Providers throw a zoo of their own runtime exceptions; none of them should take the
+            // connection attempt down with them.
+            SecretFileResult.Failed(e.message)
+        }
+    }
+
+    /**
+     * Opens the document and closes it immediately: enough to tell "readable" from "the grant is
+     * gone" without draining a private key into memory. Plain paths go to [delegate], which answers
+     * from metadata alone.
+     */
+    override fun probe(ref: String): Boolean {
+        val trimmed = ref.trim()
+        if (!trimmed.startsWith(CONTENT_SCHEME)) return delegate.probe(trimmed)
+        val uri = runCatching { android.net.Uri.parse(trimmed) }.getOrNull() ?: return false
+        return runCatching { context.contentResolver.openInputStream(uri)?.use { true } }.getOrNull() == true
+    }
+
+    private companion object {
+        const val CONTENT_SCHEME = "content://"
+
+        /** 256 KiB — matches the okio reader's ceiling. */
+        const val MAX_BYTES = 256 * 1024
+    }
+}

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/PickSecretFile.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/PickSecretFile.android.kt
@@ -1,0 +1,25 @@
+package app.skerry.ui.vault
+
+import android.content.Intent
+import app.skerry.ui.sftp.SafBridge
+
+/**
+ * Android location picker: Storage Access Framework via [SafBridge], with the read grant *persisted*
+ * ([android.content.ContentResolver.takePersistableUriPermission]). Without that the Uri would only
+ * be readable until the process dies, and a credential meant to be re-read on every connection for
+ * months would start failing after a restart.
+ *
+ * A provider that refuses to persist the grant (SecurityException) still yields the Uri: the
+ * credential works for this session, and the connection reports a denied read plainly if the grant
+ * lapses later — better than dropping a pick the user just made.
+ */
+actual suspend fun pickSecretFileRef(title: String): String? {
+    // title is unused: the Storage Access Framework picker has no custom-title hook.
+    val uri = SafBridge.openDocument() ?: return null
+    SafBridge.context()?.let { ctx ->
+        runCatching {
+            ctx.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+    return uri.toString()
+}

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -141,4 +141,5 @@
     <string name="conn_container_err_command">Хост не смог получить список контейнеров</string>
     <string name="conn_auth_interactive">Интерактивная (2FA)</string>
     <string name="conn_auth_interactive_desc">сервер сам спросит код при подключении</string>
+    <string name="conn_import_keys_note">IdentityFile и CertificateFile связываются по пути — ключи не копируются в волт.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -119,4 +119,5 @@
     <string name="term_launch_local_shell">Запустить локальную оболочку</string>
     <string name="term_open_path_in_files">Открыть в Файлах</string>
     <string name="term_pane_sync_badge">СИНХР</string>
+    <string name="term_auth_key_file">Файл ключа</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -119,4 +119,22 @@
     <string name="vault_reset_scope_everything_subtitle">Также удалить профили хостов, known_hosts и настройки.</string>
     <string name="vault_reset_confirm_label">Впишите %1$s для подтверждения</string>
     <string name="vault_reset_confirm_button">Сбросить безвозвратно</string>
+    <string name="vault_link_key_file">Связать файл ключа</string>
+    <string name="vault_dialog_key_file_subtitle">Ключ и сертификат остаются на диске и перечитываются при каждом подключении</string>
+    <string name="vault_subtitle_key_file">Файл ключа</string>
+    <string name="vault_subtitle_key_file_cert">Файл сертификата</string>
+    <string name="vault_field_key_path">ФАЙЛ ПРИВАТНОГО КЛЮЧА</string>
+    <string name="vault_field_cert_path">ФАЙЛ СЕРТИФИКАТА (НЕОБЯЗАТЕЛЬНО)</string>
+    <string name="vault_placeholder_name_key_file">Рабочий SSH CA</string>
+    <string name="vault_hint_cert_sibling">Пусто: берётся %1$s рядом с ключом, если он есть</string>
+    <string name="vault_hint_cert_sibling_opaque">Пусто: без сертификата — ключ аутентифицируется сам</string>
+    <string name="vault_browse">Обзор…</string>
+    <string name="vault_link">Связать</string>
+    <string name="vault_badge_file">ФАЙЛ</string>
+    <string name="vault_badge_file_missing">ФАЙЛ НЕ НАЙДЕН</string>
+    <string name="vault_label_key_path">ФАЙЛ КЛЮЧА</string>
+    <string name="vault_label_cert_path">ФАЙЛ СЕРТИФИКАТА</string>
+    <string name="vault_key_file_missing">Недоступен с этого устройства</string>
+    <string name="vault_meta_key_file">файл · %1$s</string>
+    <string name="vault_cert_from_file_unreadable">Файл сертификата не читается</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
@@ -45,4 +45,5 @@
     <!-- Строка метаданных карточки секрета: %1$s — принципалы сертификата / отпечаток ключа, %2$s — фрагмент «используется». -->
     <string name="vtail_meta_principals">%1$s · %2$s</string>
     <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
+    <string name="vtail_picker_type_key_file">Файл ключа</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -141,4 +141,5 @@
     <string name="conn_container_err_command">主机无法列出容器</string>
     <string name="conn_auth_interactive">交互式（双因素）</string>
     <string name="conn_auth_interactive_desc">连接时由服务器索取验证码</string>
+    <string name="conn_import_keys_note">IdentityFile 和 CertificateFile 按路径关联 — 密钥不会复制到保险库。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -119,4 +119,5 @@
     <string name="term_launch_local_shell">启动本地 Shell</string>
     <string name="term_open_path_in_files">在文件中打开</string>
     <string name="term_pane_sync_badge">同步</string>
+    <string name="term_auth_key_file">密钥文件</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -119,4 +119,22 @@
     <string name="vault_reset_scope_everything_subtitle">同时删除主机配置、known_hosts 和设置。</string>
     <string name="vault_reset_confirm_label">输入 %1$s 以确认</string>
     <string name="vault_reset_confirm_button">永久重置</string>
+    <string name="vault_link_key_file">关联密钥文件</string>
+    <string name="vault_dialog_key_file_subtitle">密钥和证书保留在磁盘上，每次连接时重新读取</string>
+    <string name="vault_subtitle_key_file">密钥文件</string>
+    <string name="vault_subtitle_key_file_cert">证书文件</string>
+    <string name="vault_field_key_path">私钥文件</string>
+    <string name="vault_field_cert_path">证书文件（可选）</string>
+    <string name="vault_placeholder_name_key_file">工作 SSH CA</string>
+    <string name="vault_hint_cert_sibling">留空：使用密钥旁的 %1$s（若存在）</string>
+    <string name="vault_hint_cert_sibling_opaque">留空：无证书 — 仅用密钥认证</string>
+    <string name="vault_browse">浏览…</string>
+    <string name="vault_link">关联</string>
+    <string name="vault_badge_file">文件</string>
+    <string name="vault_badge_file_missing">文件缺失</string>
+    <string name="vault_label_key_path">密钥文件</string>
+    <string name="vault_label_cert_path">证书文件</string>
+    <string name="vault_key_file_missing">此设备无法读取</string>
+    <string name="vault_meta_key_file">文件 · %1$s</string>
+    <string name="vault_cert_from_file_unreadable">无法读取证书文件</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -45,4 +45,5 @@
     <!-- 密钥卡片元信息行：%1$s — 证书主体 / 密钥指纹，%2$s — “使用者”片段。 -->
     <string name="vtail_meta_principals">%1$s · %2$s</string>
     <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
+    <string name="vtail_picker_type_key_file">密钥文件</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -141,4 +141,5 @@
     <string name="conn_container_err_command">The host could not list containers</string>
     <string name="conn_auth_interactive">Interactive (2FA)</string>
     <string name="conn_auth_interactive_desc">the server asks for a code at connect time</string>
+    <string name="conn_import_keys_note">IdentityFile and CertificateFile are linked by location — no key material is copied into the vault.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -119,4 +119,5 @@
     <string name="term_launch_local_shell">Launch local shell</string>
     <string name="term_open_path_in_files">Open in Files</string>
     <string name="term_pane_sync_badge">SYNC</string>
+    <string name="term_auth_key_file">Key file</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -119,4 +119,22 @@
     <string name="vault_reset_scope_everything_subtitle">Also delete host profiles, known_hosts and settings.</string>
     <string name="vault_reset_confirm_label">Type %1$s to confirm</string>
     <string name="vault_reset_confirm_button">Reset permanently</string>
+    <string name="vault_link_key_file">Link key file</string>
+    <string name="vault_dialog_key_file_subtitle">Key and certificate stay on disk and are re-read on every connection</string>
+    <string name="vault_subtitle_key_file">Key file</string>
+    <string name="vault_subtitle_key_file_cert">Certificate file</string>
+    <string name="vault_field_key_path">PRIVATE KEY FILE</string>
+    <string name="vault_field_cert_path">CERTIFICATE FILE (OPTIONAL)</string>
+    <string name="vault_placeholder_name_key_file">Work SSH CA</string>
+    <string name="vault_hint_cert_sibling">Empty: uses %1$s next to the key, if present</string>
+    <string name="vault_hint_cert_sibling_opaque">Empty: no certificate — the key authenticates on its own</string>
+    <string name="vault_browse">Browse…</string>
+    <string name="vault_link">Link</string>
+    <string name="vault_badge_file">FILE</string>
+    <string name="vault_badge_file_missing">FILE MISSING</string>
+    <string name="vault_label_key_path">KEY FILE</string>
+    <string name="vault_label_cert_path">CERTIFICATE FILE</string>
+    <string name="vault_key_file_missing">Not readable from this device</string>
+    <string name="vault_meta_key_file">file · %1$s</string>
+    <string name="vault_cert_from_file_unreadable">Certificate file not readable</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
@@ -45,4 +45,5 @@
     <!-- Secret card meta line: %1$s — cert principals / key fingerprint, %2$s — "used by" fragment. -->
     <string name="vtail_meta_principals">%1$s · %2$s</string>
     <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
+    <string name="vtail_picker_type_key_file">Key file</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/AppDependencies.kt
@@ -4,6 +4,7 @@ import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.vnc.VncTransport
 import app.skerry.shared.vault.SecurityLog
 import app.skerry.ui.ai.LocalAiDeps
+import app.skerry.shared.vault.SecretFileReader
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.Vault
@@ -44,6 +45,12 @@ data class AppDependencies(
     val keyGenerator: SshKeyGenerator? = null,
     /** SSH certificate inspector (Vault → Certificates); `null` on a platform without cert parsing. */
     val certificateInspector: SshCertificateInspector? = null,
+    /**
+     * Reader for files a credential references rather than stores
+     * ([app.skerry.shared.vault.CredentialSecret.KeyFile]); `null` on a platform that can't read them,
+     * where the Vault shows such a secret without a file status.
+     */
+    val secretFiles: SecretFileReader? = null,
     /** Manager for globally saved tunnels (Tunnels section); `null` if not wired up. */
     val tunnels: TunnelManager? = null,
     /** Manager for saved snippets (Snippets section); `null` if not wired up. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.terminal.TerminalHistoryStore
+import app.skerry.shared.vault.SecretFileReader
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.SecurityLog
@@ -88,6 +89,15 @@ val LocalSshKeyGenerator: ProvidableCompositionLocal<SshKeyGenerator?> = staticC
  * vault gate.
  */
 val LocalSshCertificateInspector: ProvidableCompositionLocal<SshCertificateInspector?> = staticCompositionLocalOf { null }
+
+/**
+ * Reader for key/certificate files a credential only references
+ * ([app.skerry.shared.vault.CredentialSecret.KeyFile]). The Vault section uses it to show whether a
+ * referenced file is actually readable here and to parse the certificate behind it; connections read
+ * the same files through their own resolver. `null` — mock path/preview: file-backed secrets render
+ * without a status. Supplied behind the vault gate.
+ */
+val LocalSecretFileReader: ProvidableCompositionLocal<SecretFileReader?> = staticCompositionLocalOf { null }
 
 /**
  * Manager for open sessions (tabs + live connections). `null` — mock path without a connection

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -59,6 +59,9 @@ fun Credential.toSshAuth(): SshAuth = when (val s = secret) {
     is CredentialSecret.Password -> SshAuth.Password(s.password)
     is CredentialSecret.PrivateKey -> SshAuth.PublicKey(s.privateKeyPem, s.passphrase)
     is CredentialSecret.Certificate -> SshAuth.Certificate(s.privateKeyPem, s.certificate, s.passphrase)
+    // Refs travel as refs: the files behind them are read by the transport at connect time, so a
+    // certificate the issuer rewrote a minute ago is the one presented.
+    is CredentialSecret.KeyFile -> SshAuth.KeyFile(s.privateKeyRef, s.certificateRef, s.passphrase)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -70,6 +70,7 @@ import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshJump
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.vault.SecretFileReader
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.shared.vault.Vault
@@ -193,6 +194,7 @@ import app.skerry.ui.app.LocalRunbookRunner
 import app.skerry.ui.app.LocalRunbooks
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTerminalHistory
+import app.skerry.ui.app.LocalSecretFileReader
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalSync
@@ -371,6 +373,7 @@ fun DesktopDesignApp(
     knownHosts: KnownHostsController? = null,
     keyGenerator: SshKeyGenerator? = null,
     certificateInspector: SshCertificateInspector? = null,
+    secretFiles: SecretFileReader? = null,
     tunnels: TunnelManager? = null,
     snippets: SnippetManager? = null,
     // Runbook library + the one in-flight run. `null` on the mock path (no vault behind them).
@@ -530,6 +533,7 @@ fun DesktopDesignApp(
         LocalKnownHosts provides knownHosts,
         LocalSshKeyGenerator provides keyGenerator,
         LocalSshCertificateInspector provides certificateInspector,
+        LocalSecretFileReader provides secretFiles,
         LocalCredentials provides credentials,
         LocalTestTransport provides (testTransport ?: transport),
         LocalTunnels provides tunnels,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/CredentialPickerSupport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/CredentialPickerSupport.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vtail_picker_type_certificate
+import app.skerry.ui.generated.resources.vtail_picker_type_key_file
 import app.skerry.ui.generated.resources.vtail_picker_type_password
 import app.skerry.ui.generated.resources.vtail_picker_type_ssh_key
 import app.skerry.ui.vault.VaultPresentation
@@ -19,6 +20,7 @@ internal fun CredentialSecret.pickerTypeLabel(): String = when (this) {
     is CredentialSecret.Password -> stringResource(Res.string.vtail_picker_type_password)
     is CredentialSecret.PrivateKey -> stringResource(Res.string.vtail_picker_type_ssh_key)
     is CredentialSecret.Certificate -> stringResource(Res.string.vtail_picker_type_certificate)
+    is CredentialSecret.KeyFile -> stringResource(Res.string.vtail_picker_type_key_file)
 }
 
 /** Secret type icon, from the shared [VaultPresentation.secretIcon] so pickers stay in sync with Vault. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -11,6 +11,7 @@ import app.skerry.shared.host.HostStore
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshConfigHost
 import app.skerry.shared.ssh.SshConfigImport
+import app.skerry.shared.vault.Credential
 
 /**
  * Editable profile fields without [Host.id]: the create/edit form operates on a draft, and
@@ -111,10 +112,19 @@ class HostManagerController(
      * (resolving ProxyJump within the batch, filling [defaultUser] where the config omits `User`)
      * using this controller's id generator, persists them, and returns how many were created.
      */
-    fun importSshConfig(parsed: List<SshConfigHost>, selected: Set<String>, defaultUser: String?): Int {
-        val planned = SshConfigImport.plan(parsed, selected, defaultUser, newId)
-        importHosts(planned)
-        return planned.size
+    fun importSshConfig(
+        parsed: List<SshConfigHost>,
+        selected: Set<String>,
+        defaultUser: String?,
+        existingLabels: Set<String> = emptySet(),
+        saveCredentials: (List<Credential>) -> Unit = {},
+    ): Int {
+        val plan = SshConfigImport.plan(parsed, selected, defaultUser, newId, existingLabels)
+        // Credentials first: the hosts about to be written already reference them by id, and a crash
+        // in between would otherwise leave profiles pointing at secrets that never existed.
+        saveCredentials(plan.credentials)
+        importHosts(plan.hosts)
+        return plan.hosts.size
     }
 
     /** Persist the VNC "Resize to window" toggle changed from a live session (unknown id: no-op). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.ssh.SshConfigParseResult
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.HLine
@@ -41,6 +42,7 @@ import app.skerry.ui.design.consumeClicks
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.conn_cancel
+import app.skerry.ui.generated.resources.conn_import_keys_note
 import app.skerry.ui.generated.resources.conn_import_button
 import app.skerry.ui.generated.resources.conn_import_empty
 import app.skerry.ui.generated.resources.conn_import_select_all
@@ -59,6 +61,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun SshConfigImportModal(state: DesktopDesignState, result: SshConfigParseResult) {
     val hosts = LocalHosts.current
+    val credentials = LocalCredentials.current
     val defaultUser = remember { localOsUserName() }
     var selected by remember(result) { mutableStateOf(result.hosts.map { it.alias }.toSet()) }
     val allSelected = result.hosts.isNotEmpty() && selected.size == result.hosts.size
@@ -140,12 +143,24 @@ fun SshConfigImportModal(state: DesktopDesignState, result: SshConfigParseResult
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
-                Spacer(Modifier.weight(1f))
+                // Says what the import does with keys before it does it: profiles alone would be a
+                // surprise-free import, credentials appearing in the vault would not.
+                if (result.hosts.any { !it.identityFile.isNullOrBlank() }) {
+                    Txt(stringResource(Res.string.conn_import_keys_note), color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.weight(1f))
+                } else {
+                    Spacer(Modifier.weight(1f))
+                }
                 CancelButton(stringResource(Res.string.conn_cancel), onClick = state::closeSshImport)
                 PrimaryButton(
                     stringResource(Res.string.conn_import_button, selected.size),
                     onClick = {
-                        hosts?.importSshConfig(result.hosts, selected, defaultUser)
+                        hosts?.importSshConfig(
+                            result.hosts,
+                            selected,
+                            defaultUser,
+                            existingLabels = credentials?.credentials?.map { it.label }?.toSet().orEmpty(),
+                            saveCredentials = { credentials?.importCredentials(it) },
+                        )
                         state.closeSshImport()
                     },
                     icon = "download",

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -9,7 +9,7 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialStore
 
 /** Kind of keychain secret in the form; expands into [CredentialSecret]. */
-enum class CredentialKind { PASSWORD, PRIVATE_KEY, CERTIFICATE }
+enum class CredentialKind { PASSWORD, PRIVATE_KEY, CERTIFICATE, KEY_FILE }
 
 /**
  * Editable fields of a keychain secret, without [Credential.id]. Fields for all kinds are kept
@@ -26,11 +26,17 @@ data class CredentialDraft(
     val privateKeyPem: String = "",
     val passphrase: String = "",
     val certificate: String = "",
+    /** Location of a key kept outside the vault (for [CredentialKind.KEY_FILE]); path or `content://` Uri. */
+    val privateKeyRef: String = "",
+    /** Location of its certificate; blank means "use the `<key>-cert.pub` sibling, if there is one". */
+    val certificateRef: String = "",
 ) {
     fun toSecret(): CredentialSecret = when (kind) {
         CredentialKind.PASSWORD -> CredentialSecret.Password(password)
         CredentialKind.PRIVATE_KEY -> CredentialSecret.PrivateKey(privateKeyPem, passphrase.ifBlank { null })
         CredentialKind.CERTIFICATE -> CredentialSecret.Certificate(privateKeyPem, certificate, passphrase.ifBlank { null })
+        CredentialKind.KEY_FILE ->
+            CredentialSecret.KeyFile(privateKeyRef.trim(), certificateRef.trim().ifBlank { null }, passphrase.ifBlank { null })
     }
 
     // Secrets must not leak into logs/exception messages: only metadata is exposed.
@@ -72,6 +78,15 @@ class CredentialManagerController(
      */
     fun rename(id: String, label: String) {
         store.rename(id, label)
+        credentials = store.all()
+    }
+
+    /**
+     * Persist a batch of already-built secrets (ids assigned by the caller, e.g. an `ssh_config`
+     * import whose hosts already reference them) and reload once.
+     */
+    fun importCredentials(imported: List<Credential>) {
+        for (credential in imported) store.put(credential)
         credentials = store.all()
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -83,6 +83,7 @@ import app.skerry.ui.runbook.RunbookRunPanel
 import app.skerry.ui.runbook.RunbookStartDialog
 import app.skerry.ui.snippet.SnippetRunDialog
 import app.skerry.ui.app.LocalTerminalHistory
+import app.skerry.ui.app.LocalSecretFileReader
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalSync
@@ -286,6 +287,7 @@ fun MobileDesignApp(
         // SSH key inspector/generator + certificate inspector — Vault tab: fingerprints, generation, cert parsing.
         LocalSshKeyGenerator provides deps.keyGenerator,
         LocalSshCertificateInspector provides deps.certificateInspector,
+        LocalSecretFileReader provides deps.secretFiles,
         LocalTunnels provides deps.tunnels,
         // Saved snippets — Snippets tab (command library + run into the active terminal).
         LocalSnippets provides deps.snippets,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.ssh.SshConfigParseResult
+import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.design.Sym
@@ -39,6 +40,7 @@ import app.skerry.ui.host.sshImportHostSummary
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.conn_import_button
+import app.skerry.ui.generated.resources.conn_import_keys_note
 import app.skerry.ui.generated.resources.conn_import_empty
 import app.skerry.ui.generated.resources.conn_import_select_all
 import app.skerry.ui.generated.resources.conn_import_skipped
@@ -55,6 +57,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult) {
     val hosts = LocalHosts.current
+    val credentials = LocalCredentials.current
     val defaultUser = remember { localOsUserName() }
     var selected by remember(result) { mutableStateOf(result.hosts.map { it.alias }.toSet()) }
     val allSelected = result.hosts.isNotEmpty() && selected.size == result.hosts.size
@@ -121,6 +124,10 @@ fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult)
             }
         }
 
+        if (result.hosts.any { !it.identityFile.isNullOrBlank() }) {
+            Spacer(Modifier.height(12.dp))
+            Txt(stringResource(Res.string.conn_import_keys_note), color = Skerry.colors.faint, size = 11.5.sp, lineHeight = 16.sp)
+        }
         Spacer(Modifier.height(16.dp))
         val enabled = selected.isNotEmpty()
         Box(
@@ -129,7 +136,13 @@ fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult)
                 .clip(RoundedCornerShape(14.dp))
                 .background(if (enabled) Skerry.colors.cyan else Skerry.colors.cyan.copy(alpha = 0.4f))
                 .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, enabled = enabled) {
-                    hosts?.importSshConfig(result.hosts, selected, defaultUser)
+                    hosts?.importSshConfig(
+                        result.hosts,
+                        selected,
+                        defaultUser,
+                        existingLabels = credentials?.credentials?.map { it.label }?.toSet().orEmpty(),
+                        saveCredentials = { credentials?.importCredentials(it) },
+                    )
                     state.closeSshImport()
                 }
                 .padding(15.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -39,6 +39,7 @@ import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vault_add_password
+import app.skerry.ui.generated.resources.vault_any_principal
 import app.skerry.ui.generated.resources.vault_badge_expired
 import app.skerry.ui.generated.resources.vault_banner_encrypted
 import app.skerry.ui.generated.resources.vault_copy_certificate
@@ -57,14 +58,17 @@ import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_fingerprint
 import app.skerry.ui.generated.resources.vault_label_public_key
+import app.skerry.ui.generated.resources.vault_link_key_file
 import app.skerry.ui.generated.resources.vault_meta_any_principal
 import app.skerry.ui.generated.resources.vault_meta_certificate
+import app.skerry.ui.generated.resources.vault_meta_key_file
 import app.skerry.ui.generated.resources.vault_meta_password
 import app.skerry.ui.generated.resources.vault_rename
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
+import app.skerry.ui.generated.resources.vault_subtitle_key_file
+import app.skerry.ui.generated.resources.vault_subtitle_key_file_cert
 import app.skerry.ui.generated.resources.vault_subtitle_password
-import app.skerry.ui.generated.resources.vault_any_principal
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_title
 import app.skerry.ui.generated.resources.vtail_meta_fingerprint
@@ -93,9 +97,15 @@ import app.skerry.ui.vault.DetailLabel
 import app.skerry.ui.vault.GenerateKeyDialog
 import app.skerry.ui.vault.ImportCertificateDialog
 import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalSecretFileReader
+import app.skerry.ui.vault.KeyFileBadges
+import app.skerry.ui.vault.KeyFileDetailBody
+import app.skerry.ui.vault.LinkKeyFileDialog
+import app.skerry.ui.vault.rememberKeyFileState
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalVault
@@ -151,7 +161,9 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     var selectedId by remember { mutableStateOf<String?>(null) }
     var showGenerate by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
+    val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
+    var showLinkKeyFile by remember { mutableStateOf(false) }
     var pendingRename by remember { mutableStateOf<Credential?>(null) }
     var pendingDelete by remember { mutableStateOf<Credential?>(null) }
 
@@ -162,7 +174,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     // over the centered dialog and covers the bottom input fields above the keyboard. LaunchedEffect
     // writes the flag only on value change (not every list recomposition); DisposableEffect clears it
     // on leaving the tab so the tab bar isn't left hidden.
-    val modalOpen = showGenerate || showAddPassword || showImportCert || pendingRename != null || pendingDelete != null ||
+    val modalOpen = showGenerate || showAddPassword || showImportCert || showLinkKeyFile || pendingRename != null || pendingDelete != null ||
         selectedCred != null || copyAuth.passwordPromptVisible
     LaunchedEffect(modalOpen) { state.modalOverlay(modalOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
@@ -184,7 +196,9 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 canImportCert = inspector != null,
                 onGenerate = { showGenerate = true },
                 onAddPassword = { showAddPassword = true },
+                canLinkFile = secretFiles != null,
                 onImportCert = { showImportCert = true },
+                onLinkKeyFile = { showLinkKeyFile = true },
             )
             Column(
                 Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 6.dp),
@@ -251,6 +265,24 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                     )
                     category = VaultCategoryKind.CERTIFICATES
                     showImportCert = false
+                },
+            )
+        }
+        if (showLinkKeyFile) {
+            LinkKeyFileDialog(
+                onDismiss = { showLinkKeyFile = false },
+                onCreate = { name, keyRef, certRef, passphrase ->
+                    selectedId = credentials.save(
+                        CredentialDraft(
+                            label = name,
+                            kind = CredentialKind.KEY_FILE,
+                            privateKeyRef = keyRef,
+                            certificateRef = certRef ?: "",
+                            passphrase = passphrase ?: "",
+                        ),
+                    )
+                    category = if (certRef == null) VaultCategoryKind.SSH_KEYS else VaultCategoryKind.CERTIFICATES
+                    showLinkKeyFile = false
                 },
             )
         }
@@ -370,15 +402,21 @@ private fun MobileVaultAction(
     category: VaultCategoryKind,
     canGenerate: Boolean,
     canImportCert: Boolean,
+    canLinkFile: Boolean,
     onGenerate: () -> Unit,
     onAddPassword: () -> Unit,
     onImportCert: () -> Unit,
+    onLinkKeyFile: () -> Unit,
 ) {
-    Box(Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 10.dp)) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 18.dp, vertical = 10.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
         when (category) {
             VaultCategoryKind.SSH_KEYS -> if (canGenerate) PrimaryButton(stringResource(Res.string.vault_generate_key), onClick = onGenerate, icon = "add", modifier = Modifier.fillMaxWidth())
             VaultCategoryKind.PASSWORDS -> PrimaryButton(stringResource(Res.string.vault_add_password), onClick = onAddPassword, icon = "add", modifier = Modifier.fillMaxWidth())
             VaultCategoryKind.CERTIFICATES -> if (canImportCert) PrimaryButton(stringResource(Res.string.vault_import_certificate), onClick = onImportCert, icon = "add", modifier = Modifier.fillMaxWidth())
+        }
+        // Same rule as desktop: a file-backed secret can be either kind, so the action shows in both.
+        if (canLinkFile && category != VaultCategoryKind.PASSWORDS) {
+            GhostButton(stringResource(Res.string.vault_link_key_file), onClick = onLinkKeyFile, modifier = Modifier.fillMaxWidth())
         }
     }
 }
@@ -418,9 +456,10 @@ private fun MobileSecretCard(credential: Credential, usedBy: String?, mono: Font
                         if (certInfo?.expired == true) Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, size = 9.sp)
                     }
                     is CredentialSecret.Password -> Unit
+                    is CredentialSecret.KeyFile -> KeyFileBadges(rememberKeyFileState(credential.secret as CredentialSecret.KeyFile, LocalSecretFileReader.current, LocalSshCertificateInspector.current))
                 }
             }
-            val meta = when (credential.secret) {
+            val meta = when (val secret = credential.secret) {
                 is CredentialSecret.PrivateKey -> when {
                     keyInfo != null && usedBy != null ->
                         stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(keyInfo.fingerprintSha256), usedBy)
@@ -437,6 +476,7 @@ private fun MobileSecretCard(credential: Credential, usedBy: String?, mono: Font
                 }
                 is CredentialSecret.Password ->
                     usedBy?.let { stringResource(Res.string.vault_meta_password, it) } ?: stringResource(Res.string.vault_subtitle_password)
+                is CredentialSecret.KeyFile -> stringResource(Res.string.vault_meta_key_file, secret.privateKeyRef)
             }
             Txt(meta, color = Skerry.colors.dim, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
         }
@@ -485,11 +525,15 @@ private fun MobileSecretDetailSheet(
     val secret = credential.secret
     val keyInfo = rememberKeyInfo(credential, generator)
     val certInfo = rememberCertInfo(credential, inspector)
+    val keyFileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
     val (icon, color, tinted) = VaultPresentation.secretStyle(secret, Skerry.colors)
     val subtitle = when (secret) {
         is CredentialSecret.Certificate -> certInfo?.keyTypeLabel?.let { stringResource(Res.string.vault_subtitle_certificate_typed, it) } ?: stringResource(Res.string.vault_subtitle_certificate)
         is CredentialSecret.PrivateKey -> keyInfo?.keyTypeLabel ?: stringResource(Res.string.vault_subtitle_private_key)
         is CredentialSecret.Password -> stringResource(Res.string.vault_subtitle_password)
+        is CredentialSecret.KeyFile ->
+            if (secret.certificateRef.isNullOrBlank()) stringResource(Res.string.vault_subtitle_key_file)
+            else stringResource(Res.string.vault_subtitle_key_file_cert)
     }
     // Full-screen scrim; a tap outside the sheet closes it. The sheet swallows clicks so it doesn't
     // close. It fits its content (a short password ⇒ short sheet) but not above 85% of the screen —
@@ -516,6 +560,7 @@ private fun MobileSecretDetailSheet(
                         Txt(keyInfo?.fingerprintSha256 ?: "—", color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = 16.dp))
                     }
                     is CredentialSecret.Password -> Unit
+                    is CredentialSecret.KeyFile -> KeyFileDetailBody(secret, keyFileState, mono)
                 }
                 UsedByHosts(hosts, snippetLabels, mono)
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
@@ -531,6 +576,8 @@ private fun MobileSecretDetailSheet(
                         // sensitive clip + auto-clear), not the normal clipboard like cert/public key.
                         is CredentialSecret.Password ->
                             MobileSheetButton(stringResource(Res.string.vault_copy_password), onClick = { onCopyPassword(secret.password) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
+                        // Nothing to copy: the material is on disk, and the refs are already spelled out above.
+                        is CredentialSecret.KeyFile -> Unit
                     }
                     MobileSheetButton(stringResource(Res.string.vault_rename), onClick = onRename, filled = false, modifier = Modifier.fillMaxWidth())
                     when (secret) {
@@ -542,7 +589,7 @@ private fun MobileSecretDetailSheet(
                             MobileSheetButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, filled = false, modifier = Modifier.weight(1f))
                             MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
                         }
-                        is CredentialSecret.Password ->
+                        is CredentialSecret.Password, is CredentialSecret.KeyFile ->
                             MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.fillMaxWidth())
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/InfoPanel.kt
@@ -35,6 +35,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_auth_ask
 import app.skerry.ui.generated.resources.term_auth_certificate
 import app.skerry.ui.generated.resources.term_auth_identity
+import app.skerry.ui.generated.resources.term_auth_key_file
 import app.skerry.ui.generated.resources.term_auth_password
 import app.skerry.ui.generated.resources.term_info_address
 import app.skerry.ui.generated.resources.term_info_auth
@@ -104,6 +105,7 @@ internal fun InfoPanel() {
                     is CredentialSecret.Password -> stringResource(Res.string.term_auth_password)
                     is CredentialSecret.PrivateKey -> stringResource(Res.string.term_auth_identity)
                     is CredentialSecret.Certificate -> stringResource(Res.string.term_auth_certificate)
+                    is CredentialSecret.KeyFile -> stringResource(Res.string.term_auth_key_file)
                     null -> stringResource(Res.string.term_auth_ask)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/KeyFileState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/KeyFileState.kt
@@ -1,0 +1,77 @@
+package app.skerry.ui.vault
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import app.skerry.shared.ssh.keyFileSiblingRef
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.SecretFileReader
+import app.skerry.shared.vault.SecretFileResult
+import app.skerry.shared.vault.SshCertificateInfo
+import app.skerry.shared.vault.SshCertificateInspector
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * What the vault UI can say about a file-backed secret *on this device*: whether the referenced
+ * files are readable here and what the certificate behind them contains. Everything is derived by
+ * reading the same refs a connection would, so the list can show "file missing" before the user
+ * finds out the hard way.
+ *
+ * [certificateRef] is the certificate that actually applies — the explicit ref, or the
+ * `<key>-cert.pub` sibling when one exists — and is null when the key authenticates on its own.
+ * [certificateExpected] separates "the user named a certificate" from "we looked for a sibling":
+ * only the first makes an unreadable file a broken credential.
+ */
+data class KeyFileState(
+    val keyReadable: Boolean,
+    val certificateRef: String?,
+    val certificateExpected: Boolean,
+    val certificateReadable: Boolean,
+    val certificate: SshCertificateInfo?,
+)
+
+/**
+ * Reads the refs of [secret] through [files] and parses the certificate with [inspector]. Pure of
+ * Compose (blocking I/O on small files) so it can be tested and called off the main thread.
+ */
+internal fun inspectKeyFile(
+    secret: CredentialSecret.KeyFile,
+    files: SecretFileReader,
+    inspector: SshCertificateInspector?,
+): KeyFileState {
+    // Probe, not read: the list needs "is it there", not the key itself.
+    val keyReadable = files.probe(secret.privateKeyRef)
+    val explicit = secret.certificateRef?.takeIf { it.isNotBlank() }
+    val ref = explicit ?: keyFileSiblingRef(secret.privateKeyRef)
+    val read = ref?.let { files.read(it) }
+    val certificate = (read as? SecretFileResult.Ok)?.text
+    // Mirrors the connection ([app.skerry.shared.ssh.KeyFileResolver]): a sibling that isn't there
+    // applies to nothing, but one that exists and can't be read is a broken credential, not a
+    // plain-key one — and must be flagged even though the user never named it.
+    val siblingBroken = explicit == null && read != null && read !is SecretFileResult.Ok &&
+        read != SecretFileResult.NotFound
+    return KeyFileState(
+        keyReadable = keyReadable,
+        certificateRef = ref?.takeIf { explicit != null || certificate != null || siblingBroken },
+        certificateExpected = explicit != null || siblingBroken,
+        certificateReadable = certificate != null,
+        certificate = certificate?.let { inspector?.inspect(it) },
+    )
+}
+
+/**
+ * [inspectKeyFile] as Compose state: null while the read is in flight or when the platform has no
+ * reader. Runs on [Dispatchers.Default] (the same choice as the other vault inspections — commonMain
+ * has no IO dispatcher, and these files are a few kilobytes).
+ */
+@Composable
+internal fun rememberKeyFileState(
+    secret: CredentialSecret.KeyFile,
+    files: SecretFileReader?,
+    inspector: SshCertificateInspector?,
+): KeyFileState? {
+    if (files == null) return null
+    return produceState<KeyFileState?>(null, secret, files, inspector) {
+        value = withContext(Dispatchers.Default) { inspectKeyFile(secret, files, inspector) }
+    }.value
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/PickSecretFile.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/PickSecretFile.kt
@@ -1,0 +1,15 @@
+package app.skerry.ui.vault
+
+/**
+ * Asks the user for a key/certificate *location* and returns it as a ref for
+ * [app.skerry.shared.vault.CredentialSecret.KeyFile] — a filesystem path on desktop, a persisted
+ * `content://` document Uri on Android. Null on cancel (or when no picker is available).
+ *
+ * Deliberately not [importTextFile]: that one reads the contents once, which is exactly what a
+ * file-backed credential must not do — the point is to re-read the file on every connection, so
+ * only the location is kept.
+ *
+ * [title] labels the desktop picker window; Android's Storage Access Framework has no custom-title
+ * hook and ignores it.
+ */
+expect suspend fun pickSecretFileRef(title: String): String?

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultPresentation.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultPresentation.kt
@@ -57,10 +57,15 @@ object VaultPresentation {
     val sidebarCategories: List<VaultCategoryKind> = VaultCategoryKind.entries
 
     /** Keychain category of a secret: private key -> [SSH_KEYS], password -> [PASSWORDS], cert -> [CERTIFICATES]. */
-    fun categoryOf(credential: Credential): VaultCategoryKind = when (credential.secret) {
+    fun categoryOf(credential: Credential): VaultCategoryKind = when (val secret = credential.secret) {
         is CredentialSecret.PrivateKey -> VaultCategoryKind.SSH_KEYS
         is CredentialSecret.Password -> VaultCategoryKind.PASSWORDS
         is CredentialSecret.Certificate -> VaultCategoryKind.CERTIFICATES
+        // A file-backed secret is filed by what it authenticates with: an explicit certificate ref
+        // makes it a certificate, otherwise a key. A sibling `*-cert.pub` can't be taken into
+        // account here — that needs disk access, and categorising must stay pure.
+        is CredentialSecret.KeyFile ->
+            if (secret.certificateRef.isNullOrBlank()) VaultCategoryKind.SSH_KEYS else VaultCategoryKind.CERTIFICATES
     }
 
     /** Icon for a secret type. Theme-independent, so callers outside composition can use it. */
@@ -68,6 +73,7 @@ object VaultPresentation {
         is CredentialSecret.Certificate -> "workspace_premium"
         is CredentialSecret.PrivateKey -> "key"
         is CredentialSecret.Password -> "password"
+        is CredentialSecret.KeyFile -> if (secret.certificateRef.isNullOrBlank()) "key" else "workspace_premium"
     }
 
     /** Style for a secret type: icon/accent color/tint (see [SecretTypeStyle]) in the active [colors]. */
@@ -75,6 +81,11 @@ object VaultPresentation {
         is CredentialSecret.Certificate -> SecretTypeStyle(secretIcon(secret), colors.moss, tinted = true)
         is CredentialSecret.PrivateKey -> SecretTypeStyle(secretIcon(secret), colors.cyanBright, tinted = true)
         is CredentialSecret.Password -> SecretTypeStyle(secretIcon(secret), colors.dim, tinted = false)
+        is CredentialSecret.KeyFile -> SecretTypeStyle(
+            secretIcon(secret),
+            if (secret.certificateRef.isNullOrBlank()) colors.cyanBright else colors.moss,
+            tinted = true,
+        )
     }
 
     /** Credentials belonging to the given category. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -68,7 +68,11 @@ import app.skerry.ui.generated.resources.vault_add
 import app.skerry.ui.generated.resources.vault_add_password
 import app.skerry.ui.generated.resources.vault_any_principal
 import app.skerry.ui.generated.resources.vault_badge_expired
+import app.skerry.ui.generated.resources.vault_badge_file
+import app.skerry.ui.generated.resources.vault_badge_file_missing
+import app.skerry.ui.generated.resources.vault_browse
 import app.skerry.ui.generated.resources.vault_cancel
+import app.skerry.ui.generated.resources.vault_cert_from_file_unreadable
 import app.skerry.ui.generated.resources.vault_cert_key_id
 import app.skerry.ui.generated.resources.vault_cert_read_error
 import app.skerry.ui.generated.resources.vault_cert_unreadable
@@ -87,6 +91,7 @@ import app.skerry.ui.generated.resources.vault_dialog_add_password_subtitle
 import app.skerry.ui.generated.resources.vault_dialog_generate_subtitle
 import app.skerry.ui.generated.resources.vault_dialog_generate_title
 import app.skerry.ui.generated.resources.vault_dialog_import_subtitle
+import app.skerry.ui.generated.resources.vault_dialog_key_file_subtitle
 import app.skerry.ui.generated.resources.vault_e2e_description
 import app.skerry.ui.generated.resources.vault_e2e_encrypted
 import app.skerry.ui.generated.resources.vault_empty_certificates_hint
@@ -97,7 +102,9 @@ import app.skerry.ui.generated.resources.vault_empty_ssh_hint
 import app.skerry.ui.generated.resources.vault_empty_ssh_title
 import app.skerry.ui.generated.resources.vault_export
 import app.skerry.ui.generated.resources.vault_field_algorithm
+import app.skerry.ui.generated.resources.vault_field_cert_path
 import app.skerry.ui.generated.resources.vault_field_certificate
+import app.skerry.ui.generated.resources.vault_field_key_path
 import app.skerry.ui.generated.resources.vault_field_master_password
 import app.skerry.ui.generated.resources.vault_field_name
 import app.skerry.ui.generated.resources.vault_field_passphrase
@@ -105,23 +112,32 @@ import app.skerry.ui.generated.resources.vault_field_password
 import app.skerry.ui.generated.resources.vault_field_private_key_pem
 import app.skerry.ui.generated.resources.vault_generate
 import app.skerry.ui.generated.resources.vault_generate_key
+import app.skerry.ui.generated.resources.vault_hint_cert_sibling
+import app.skerry.ui.generated.resources.vault_hint_cert_sibling_opaque
 import app.skerry.ui.generated.resources.vault_import
 import app.skerry.ui.generated.resources.vault_import_certificate
+import app.skerry.ui.generated.resources.vault_key_file_missing
 import app.skerry.ui.generated.resources.vault_key_unreadable
+import app.skerry.ui.generated.resources.vault_label_cert_path
 import app.skerry.ui.generated.resources.vault_label_fingerprint
+import app.skerry.ui.generated.resources.vault_label_key_path
 import app.skerry.ui.generated.resources.vault_label_principals
 import app.skerry.ui.generated.resources.vault_label_public_key
 import app.skerry.ui.generated.resources.vault_label_serial
 import app.skerry.ui.generated.resources.vault_label_signing_ca
 import app.skerry.ui.generated.resources.vault_label_valid
+import app.skerry.ui.generated.resources.vault_link
+import app.skerry.ui.generated.resources.vault_link_key_file
 import app.skerry.ui.generated.resources.vault_meta_any_principal
 import app.skerry.ui.generated.resources.vault_meta_certificate
+import app.skerry.ui.generated.resources.vault_meta_key_file
 import app.skerry.ui.generated.resources.vault_meta_password
 import app.skerry.ui.generated.resources.vault_not_attached
 import app.skerry.ui.generated.resources.vault_password_mismatch_retry
 import app.skerry.ui.generated.resources.vault_placeholder_master_password
 import app.skerry.ui.generated.resources.vault_placeholder_name_cert
 import app.skerry.ui.generated.resources.vault_placeholder_name_key
+import app.skerry.ui.generated.resources.vault_placeholder_name_key_file
 import app.skerry.ui.generated.resources.vault_placeholder_name_password
 import app.skerry.ui.generated.resources.vault_placeholder_optional
 import app.skerry.ui.generated.resources.vault_placeholder_password
@@ -130,6 +146,8 @@ import app.skerry.ui.generated.resources.vault_rename_title
 import app.skerry.ui.generated.resources.vault_sidebar_header
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
+import app.skerry.ui.generated.resources.vault_subtitle_key_file
+import app.skerry.ui.generated.resources.vault_subtitle_key_file_cert
 import app.skerry.ui.generated.resources.vault_subtitle_password
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_used_by
@@ -166,6 +184,8 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalSecretFileReader
+import app.skerry.shared.ssh.keyFileSiblingRef
 import app.skerry.ui.app.LocalSshCertificateInspector
 import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.app.LocalVault
@@ -217,7 +237,9 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     var selectedId by remember { mutableStateOf<String?>(null) }
     var showGenerate by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
+    val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
+    var showLinkKeyFile by remember { mutableStateOf(false) }
     var pendingRenameCred by remember { mutableStateOf<Credential?>(null) }
     var pendingDeleteCred by remember { mutableStateOf<Credential?>(null) }
 
@@ -233,9 +255,11 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                     category = category,
                     canGenerate = generator != null,
                     canImportCert = inspector != null,
+                    canLinkFile = secretFiles != null,
                     onGenerate = { showGenerate = true },
                     onAddPassword = { showAddPassword = true },
                     onImportCert = { showImportCert = true },
+                    onLinkKeyFile = { showLinkKeyFile = true },
                 )
                 Row(Modifier.weight(1f).fillMaxWidth()) {
                     if (credItems.isEmpty()) {
@@ -325,6 +349,24 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                     )
                     category = VaultCategoryKind.CERTIFICATES
                     showImportCert = false
+                },
+            )
+        }
+        if (showLinkKeyFile) {
+            LinkKeyFileDialog(
+                onDismiss = { showLinkKeyFile = false },
+                onCreate = { name, keyRef, certRef, passphrase ->
+                    selectedId = credentials.save(
+                        CredentialDraft(
+                            label = name,
+                            kind = CredentialKind.KEY_FILE,
+                            privateKeyRef = keyRef,
+                            certificateRef = certRef ?: "",
+                            passphrase = passphrase ?: "",
+                        ),
+                    )
+                    category = if (certRef == null) VaultCategoryKind.SSH_KEYS else VaultCategoryKind.CERTIFICATES
+                    showLinkKeyFile = false
                 },
             )
         }
@@ -433,17 +475,27 @@ private fun VaultHeader(
     category: VaultCategoryKind,
     canGenerate: Boolean,
     canImportCert: Boolean,
+    canLinkFile: Boolean,
     onGenerate: () -> Unit,
     onAddPassword: () -> Unit,
     onImportCert: () -> Unit,
+    onLinkKeyFile: () -> Unit,
 ) {
     SectionHeader(
         title = category.title(),
         actions = {
             when (category) {
-                VaultCategoryKind.SSH_KEYS -> if (canGenerate) PrimaryButton(stringResource(Res.string.vault_generate_key), onClick = onGenerate, icon = "add")
+                // "Link file" sits in both key and certificate categories: which one a file-backed
+                // secret lands in depends on whether it names a certificate.
+                VaultCategoryKind.SSH_KEYS -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                    if (canLinkFile) GhostButton(stringResource(Res.string.vault_link_key_file), onClick = onLinkKeyFile)
+                    if (canGenerate) PrimaryButton(stringResource(Res.string.vault_generate_key), onClick = onGenerate, icon = "add")
+                }
                 VaultCategoryKind.PASSWORDS -> PrimaryButton(stringResource(Res.string.vault_add_password), onClick = onAddPassword, icon = "add")
-                VaultCategoryKind.CERTIFICATES -> if (canImportCert) PrimaryButton(stringResource(Res.string.vault_import_certificate), onClick = onImportCert, icon = "add")
+                VaultCategoryKind.CERTIFICATES -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                    if (canLinkFile) GhostButton(stringResource(Res.string.vault_link_key_file), onClick = onLinkKeyFile)
+                    if (canImportCert) PrimaryButton(stringResource(Res.string.vault_import_certificate), onClick = onImportCert, icon = "add")
+                }
             }
         },
     )
@@ -487,6 +539,20 @@ private fun LiveSecretCard(
                             ?: info.principals.joinToString(", ")
                     }
                     Txt(meta, color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
+                }
+            }
+            is CredentialSecret.KeyFile -> {
+                val state = rememberKeyFileState(secret, LocalSecretFileReader.current, inspector)
+                SecretIcon(VaultPresentation.secretIcon(secret), tinted = true, color = if (secret.certificateRef.isNullOrBlank()) Skerry.colors.cyanBright else Skerry.colors.moss)
+                Column(Modifier.weight(1f)) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Txt(credential.label, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
+                        KeyFileBadges(state)
+                    }
+                    Txt(
+                        stringResource(Res.string.vault_meta_key_file, secret.privateKeyRef),
+                        color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp),
+                    )
                 }
             }
             is CredentialSecret.PrivateKey -> {
@@ -588,11 +654,15 @@ private fun LiveSecretDetail(
     val secret = credential.secret
     val keyInfo = rememberKeyInfo(credential, generator)
     val certInfo = rememberCertInfo(credential, inspector)
+    val keyFileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
     val (icon, color, tinted) = VaultPresentation.secretStyle(secret, Skerry.colors)
     val subtitle = when (secret) {
         is CredentialSecret.Certificate -> certInfo?.keyTypeLabel?.let { stringResource(Res.string.vault_subtitle_certificate_typed, it) } ?: stringResource(Res.string.vault_subtitle_certificate)
         is CredentialSecret.PrivateKey -> keyInfo?.keyTypeLabel ?: stringResource(Res.string.vault_subtitle_private_key)
         is CredentialSecret.Password -> stringResource(Res.string.vault_subtitle_password)
+        is CredentialSecret.KeyFile ->
+            if (secret.certificateRef.isNullOrBlank()) stringResource(Res.string.vault_subtitle_key_file)
+            else stringResource(Res.string.vault_subtitle_key_file_cert)
     }
     Column(Modifier.width(340.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
         Row(Modifier.padding(bottom = 18.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(11.dp)) {
@@ -613,6 +683,7 @@ private fun LiveSecretDetail(
                 Txt(keyInfo?.fingerprintSha256 ?: "—", color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = 16.dp))
             }
             is CredentialSecret.Password -> Unit
+            is CredentialSecret.KeyFile -> KeyFileDetailBody(secret, keyFileState, mono)
         }
         UsedByHosts(hosts, snippetLabels, mono)
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -628,6 +699,8 @@ private fun LiveSecretDetail(
                 // auto-clear) rather than the plain clipboard used for cert/public key.
                 is CredentialSecret.Password ->
                     PrimaryButton(stringResource(Res.string.vault_copy_password), onClick = { onCopyPassword(secret.password) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
+                // Nothing to copy: the material is on disk, and the refs are already spelled out above.
+                is CredentialSecret.KeyFile -> Unit
             }
             GhostButton(stringResource(Res.string.vault_rename), onClick = onRename, modifier = Modifier.fillMaxWidth())
             when (secret) {
@@ -639,7 +712,7 @@ private fun LiveSecretDetail(
                     GhostButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, modifier = Modifier.weight(1f))
                     GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
                 }
-                is CredentialSecret.Password ->
+                is CredentialSecret.Password, is CredentialSecret.KeyFile ->
                     GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.fillMaxWidth())
             }
         }
@@ -779,6 +852,122 @@ internal fun ImportCertificateDialog(
             }
         }
         DialogButtons(confirmLabel = stringResource(Res.string.vault_import), confirmEnabled = valid, onDismiss = onDismiss, onConfirm = { onCreate(name.trim(), pem.trim(), certificate.trim(), passphrase.ifBlank { null }) })
+    }
+}
+
+/**
+ * Badges for a file-backed secret in the list: the certificate's key type, whether it has expired,
+ * and — loudest of the three — whether the files it points at can be read here at all. A credential
+ * whose issuer hasn't run today looks identical to a working one until something says so.
+ *
+ * A null [state] (read still in flight, or a platform with no reader) shows nothing rather than
+ * flashing a wrong verdict.
+ */
+@Composable
+internal fun KeyFileBadges(state: KeyFileState?) {
+    if (state == null) return
+    val broken = !state.keyReadable || (state.certificateExpected && !state.certificateReadable)
+    if (broken) {
+        Badge(stringResource(Res.string.vault_badge_file_missing), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, radius = 3, size = 9.5.sp)
+        return
+    }
+    state.certificate?.keyTypeLabel?.let { Badge(it, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, radius = 3, size = 9.5.sp) }
+    if (state.certificate?.expired == true) {
+        Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, radius = 3, size = 9.5.sp)
+    } else {
+        Badge(stringResource(Res.string.vault_badge_file), bg = Skerry.colors.cyan.copy(alpha = 0.14f), fg = Skerry.colors.cyanBright, radius = 3, size = 9.5.sp)
+    }
+}
+
+/**
+ * Detail body for a file-backed secret: the refs themselves (that's the whole secret, as far as the
+ * vault is concerned), whether each is readable here, and the certificate metadata parsed off disk —
+ * the same [CertificateDetailBody] a vault-stored certificate gets, so both kinds read alike.
+ */
+@Composable
+internal fun KeyFileDetailBody(secret: CredentialSecret.KeyFile, state: KeyFileState?, mono: FontFamily) {
+    DetailLabel(stringResource(Res.string.vault_label_key_path))
+    RefRow(secret.privateKeyRef, missing = state?.keyReadable == false, mono = mono)
+    val certRef = state?.certificateRef ?: secret.certificateRef?.takeIf { it.isNotBlank() }
+    if (certRef != null) {
+        DetailLabel(stringResource(Res.string.vault_label_cert_path))
+        RefRow(certRef, missing = state?.certificateReadable == false, mono = mono)
+    }
+    if (state?.certificateExpected == true && !state.certificateReadable) {
+        Txt(stringResource(Res.string.vault_cert_from_file_unreadable), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(bottom = 16.dp))
+    }
+    state?.certificate?.let { CertificateDetailBody(it, mono) }
+}
+
+/** One ref line in the detail panel, in monospace, with a note when the file isn't readable here. */
+@Composable
+private fun RefRow(ref: String, missing: Boolean, mono: FontFamily) {
+    Txt(ref, color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = if (missing) 4.dp else 16.dp))
+    if (missing) {
+        Txt(stringResource(Res.string.vault_key_file_missing), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(bottom = 16.dp))
+    }
+}
+
+/**
+ * Links a key (and optionally a certificate) that stays on disk. Unlike [ImportCertificateDialog]
+ * nothing is read here: only the locations are kept, which is what lets a short-lived certificate
+ * keep working while its issuer rewrites the file.
+ *
+ * The certificate field may be left empty — the hint spells out which sibling would be used instead,
+ * or that there'd be no certificate at all for a ref with no siblings to guess at (an Android
+ * document Uri).
+ */
+@Composable
+internal fun LinkKeyFileDialog(
+    onDismiss: () -> Unit,
+    onCreate: (name: String, keyRef: String, certificateRef: String?, passphrase: String?) -> Unit,
+) {
+    var name by remember { mutableStateOf("") }
+    var keyRef by remember { mutableStateOf("") }
+    var certRef by remember { mutableStateOf("") }
+    var passphrase by remember { mutableStateOf("") }
+    val scope = rememberCoroutineScope()
+    val valid = name.isNotBlank() && keyRef.isNotBlank()
+    val browseTitle = stringResource(Res.string.vault_link_key_file)
+
+    VaultDialogScaffold(stringResource(Res.string.vault_link_key_file), stringResource(Res.string.vault_dialog_key_file_subtitle), onDismiss) {
+        DialogField(stringResource(Res.string.vault_field_name), name, { name = it }, placeholder = stringResource(Res.string.vault_placeholder_name_key_file))
+        Box(Modifier.padding(top = 16.dp)) {
+            RefField(stringResource(Res.string.vault_field_key_path), keyRef, { keyRef = it }, "~/.ssh/id_ed25519") {
+                scope.launch { pickSecretFileRef(browseTitle)?.let { keyRef = it } }
+            }
+        }
+        Box(Modifier.padding(top = 16.dp)) {
+            RefField(stringResource(Res.string.vault_field_cert_path), certRef, { certRef = it }, "~/.ssh/id_ed25519-cert.pub") {
+                scope.launch { pickSecretFileRef(browseTitle)?.let { certRef = it } }
+            }
+        }
+        if (certRef.isBlank()) {
+            val sibling = keyFileSiblingRef(keyRef)
+            Txt(
+                if (sibling != null) stringResource(Res.string.vault_hint_cert_sibling, sibling)
+                else stringResource(Res.string.vault_hint_cert_sibling_opaque),
+                color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        Box(Modifier.padding(top = 16.dp)) {
+            DialogField(stringResource(Res.string.vault_field_passphrase), passphrase, { passphrase = it }, placeholder = stringResource(Res.string.vault_placeholder_optional), password = true)
+        }
+        DialogButtons(
+            confirmLabel = stringResource(Res.string.vault_link),
+            confirmEnabled = valid,
+            onDismiss = onDismiss,
+            onConfirm = { onCreate(name.trim(), keyRef.trim(), certRef.trim().ifBlank { null }, passphrase.ifBlank { null }) },
+        )
+    }
+}
+
+/** A ref field with a "Browse…" button next to it; the path stays editable by hand (pasted or typed). */
+@Composable
+private fun RefField(label: String, value: String, onValueChange: (String) -> Unit, placeholder: String, onBrowse: () -> Unit) {
+    Column {
+        DialogField(label, value, onValueChange, placeholder = placeholder)
+        GhostButton(stringResource(Res.string.vault_browse), onClick = onBrowse, modifier = Modifier.padding(top = 8.dp))
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/KeyFileStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/KeyFileStateTest.kt
@@ -1,0 +1,141 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.SecretFileReader
+import app.skerry.shared.vault.SecretFileResult
+import app.skerry.shared.vault.SshCertificateInfo
+import app.skerry.shared.vault.SshCertificateInspector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val CERT = "ssh-ed25519-cert-v01@openssh.com AAAA"
+
+private fun info(expired: Boolean = false) = SshCertificateInfo(
+    keyTypeLabel = "ED25519",
+    keyId = "dev@corp",
+    principals = listOf("dev"),
+    serial = "1",
+    validFrom = "2026-07-01",
+    validUntil = "2026-08-01",
+    expired = expired,
+    caFingerprintSha256 = "SHA256:ca",
+)
+
+private val inspector = SshCertificateInspector { if (it == CERT) info() else null }
+
+class KeyFileStateTest {
+
+    @Test
+    fun `reports both files present and parses the certificate`() {
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/id", "/keys/id-cert.pub"),
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok("pem") else SecretFileResult.Ok(CERT) },
+            inspector = inspector,
+        )
+
+        assertTrue(state.keyReadable)
+        assertEquals("/keys/id-cert.pub", state.certificateRef)
+        assertTrue(state.certificateReadable)
+        assertEquals("ED25519", state.certificate?.keyTypeLabel)
+    }
+
+    @Test
+    fun `blank certificate ref resolves to the sibling actually on disk`() {
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/id"),
+            files = { ref -> if (ref == "/keys/id-cert.pub") SecretFileResult.Ok(CERT) else SecretFileResult.Ok("pem") },
+            inspector = inspector,
+        )
+
+        assertEquals("/keys/id-cert.pub", state.certificateRef)
+        assertTrue(state.certificateReadable)
+    }
+
+    @Test
+    fun `a missing sibling is not an error - the key authenticates on its own`() {
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/id"),
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok("pem") else SecretFileResult.NotFound },
+            inspector = inspector,
+        )
+
+        assertTrue(state.keyReadable)
+        assertNull(state.certificateRef)
+        assertFalse(state.certificateReadable)
+        assertFalse(state.certificateExpected)
+    }
+
+    @Test
+    fun `an explicitly named certificate that is missing is flagged`() {
+        // The user asked for this file by name, so its absence is a broken credential, not a fallback.
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/id", "/keys/id-cert.pub"),
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok("pem") else SecretFileResult.NotFound },
+            inspector = inspector,
+        )
+
+        assertTrue(state.certificateExpected)
+        assertFalse(state.certificateReadable)
+        assertEquals("/keys/id-cert.pub", state.certificateRef)
+    }
+
+    @Test
+    fun `an unreadable sibling is flagged, unlike an absent one`() {
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/id"),
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok("pem") else SecretFileResult.Denied },
+            inspector = inspector,
+        )
+
+        assertTrue(state.certificateExpected)
+        assertFalse(state.certificateReadable)
+        assertEquals("/keys/id-cert.pub", state.certificateRef)
+    }
+
+    @Test
+    fun `the private key is probed, never pulled into memory`() {
+        // Browsing the vault must not load key material: the list only needs to know the file is
+        // there. Only the certificate — public by definition — is actually read.
+        var keyRead = false
+        val files = object : SecretFileReader {
+            override fun read(ref: String): SecretFileResult {
+                if (ref == "/keys/id") keyRead = true
+                return SecretFileResult.Ok(if (ref == "/keys/id") "pem" else CERT)
+            }
+
+            override fun probe(ref: String): Boolean = true
+        }
+
+        val state = inspectKeyFile(CredentialSecret.KeyFile("/keys/id"), files, inspector)
+
+        assertTrue(state.keyReadable)
+        assertFalse(keyRead, "the private key file was read into memory just to render the vault")
+    }
+
+    @Test
+    fun `an unreadable key is reported as such`() {
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("/keys/gone"),
+            files = { SecretFileResult.NotFound },
+            inspector = inspector,
+        )
+
+        assertFalse(state.keyReadable)
+    }
+
+    @Test
+    fun `no sibling is probed for an opaque ref`() {
+        val probed = mutableListOf<String>()
+        val state = inspectKeyFile(
+            CredentialSecret.KeyFile("content://doc/42"),
+            files = { ref -> probed += ref; SecretFileResult.Ok("pem") },
+            inspector = inspector,
+        )
+
+        assertEquals(listOf("content://doc/42"), probed)
+        assertNull(state.certificateRef)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultPresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultPresentationTest.kt
@@ -24,6 +24,17 @@ class VaultPresentationTest {
     }
 
     @Test
+    fun `files a file-backed secret by whether it names a certificate`() {
+        val plainKey = Credential("f1", "key file", CredentialSecret.KeyFile("~/.ssh/id_ed25519"))
+        val withCert = Credential("f2", "cert file", CredentialSecret.KeyFile("~/.ssh/id_ed25519", "~/.ssh/id_ed25519-cert.pub"))
+
+        assertEquals(VaultCategoryKind.SSH_KEYS, VaultPresentation.categoryOf(plainKey))
+        assertEquals(VaultCategoryKind.CERTIFICATES, VaultPresentation.categoryOf(withCert))
+        assertEquals("key", VaultPresentation.secretIcon(plainKey.secret))
+        assertEquals("workspace_premium", VaultPresentation.secretIcon(withCert.secret))
+    }
+
+    @Test
     fun `filters credentials into keychain categories`() {
         assertEquals(listOf("k1", "k2"), VaultPresentation.credentialsIn(VaultCategoryKind.SSH_KEYS, credentials).map { it.id })
         assertEquals(listOf("p1"), VaultPresentation.credentialsIn(VaultCategoryKind.PASSWORDS, credentials).map { it.id })

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -24,6 +24,8 @@ import app.skerry.shared.ssh.ProbeHostKeyVerifier
 import app.skerry.shared.ssh.RoutingTransport
 import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.ssh.SshjTransport
+import app.skerry.shared.ssh.KeyFileResolver
+import app.skerry.shared.vault.OkioSecretFileReader
 import app.skerry.ui.connection.KeyboardInteractivePromptController
 import app.skerry.shared.ssh.TofuHostKeyVerifier
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
@@ -183,16 +185,28 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     // controller; it is shared by every transport that authenticates, so a code asked for while
     // dialing a tunnel or probing a container prompts the same way a session does.
     val keyboardInteractive = KeyboardInteractivePromptController()
+    // File-backed credentials (key/certificate kept outside the vault) are read at connect time, so
+    // every transport that authenticates gets the same resolver. `~` expands against the user's home
+    // the way an OpenSSH config would; the inspector lets an expired certificate be refused here,
+    // with its date, instead of turning into "server rejected the credentials".
+    val certificateInspector = SshjCertificateInspector()
+    val secretFiles = OkioSecretFileReader(FileSystem.SYSTEM, homeDir = System.getProperty("user.home"))
+    val keyFileResolver = KeyFileResolver(files = secretFiles, inspector = certificateInspector)
     val transport = RoutingTransport(
         ssh = SshjTransport(
             TofuHostKeyVerifier(knownHostsStore, mismatchStore) { Instant.now().toString() },
-            keyboardInteractive.responder,
+            keyFiles = keyFileResolver,
+            keyboardInteractiveResponder = keyboardInteractive.responder,
         ),
     )
     // "Test connection" from the form uses a separate transport with a read-only verifier: it
     // accepts a matching trusted key, rejects a key change on a known host, and accepts a new host
     // WITHOUT writing to known-hosts. Only a real connection (TOFU above) establishes trust.
-    val probeTransport = SshjTransport(ProbeHostKeyVerifier(knownHostsStore), keyboardInteractive.responder)
+    val probeTransport = SshjTransport(
+        ProbeHostKeyVerifier(knownHostsStore),
+        keyFiles = keyFileResolver,
+        keyboardInteractiveResponder = keyboardInteractive.responder,
+    )
     val knownHosts = KnownHostsController(knownHostsStore, mismatchStore) { Instant.now().toString() }
     // Host manager: profiles are HOST records in the vault, tree order lives in the layout record
     // ([VaultHostStore]/[WorkspaceLayout]). The vault starts locked (empty list); the controller
@@ -262,12 +276,15 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     // SSH key generation in the Vault section: BouncyCastle over the sshj format (the same one the transport reads).
     val keyGenerator = BouncyCastleSshKeyGenerator()
     // Parses imported SSH certificates (Vault -> Certificates section) via sshj over the ssh-wire format.
-    val certificateInspector = SshjCertificateInspector()
     // Global tunnels: saved forwards in tunnels.json. Activation uses a SEPARATE probe transport
     // (read-only verifier): only an already-trusted host can be enabled — a tunnel opens without a
     // terminal, so silent TOFU must not happen here. Host/secret resolution goes through the graph
     // (hosts + credentials in the unlocked vault). Scope lives for the app's lifetime.
-    val tunnelTransport = SshjTransport(ProbeHostKeyVerifier(knownHostsStore), keyboardInteractive.responder)
+    val tunnelTransport = SshjTransport(
+        ProbeHostKeyVerifier(knownHostsStore),
+        keyFiles = keyFileResolver,
+        keyboardInteractiveResponder = keyboardInteractive.responder,
+    )
     val tunnelScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     val tunnels = TunnelManager(
         store = VaultTunnelStore(vault, trash),
@@ -394,7 +411,7 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         // on a locked vault); the list rereads when a new vault is created and unlocked.
         credentials.reload()
     }
-    val deps = AppDependencies(transport = transport, hosts = hosts, vault = vault, credentials = credentials, knownHosts = knownHosts, keyGenerator = keyGenerator, certificateInspector = certificateInspector, tunnels = tunnels, snippets = snippets, runbooks = runbooks, runbookRunner = runbookRunner, sync = sync, teams = teams, localAi = localAi)
+    val deps = AppDependencies(transport = transport, hosts = hosts, vault = vault, credentials = credentials, knownHosts = knownHosts, keyGenerator = keyGenerator, certificateInspector = certificateInspector, secretFiles = secretFiles, tunnels = tunnels, snippets = snippets, runbooks = runbooks, runbookRunner = runbookRunner, sync = sync, teams = teams, localAi = localAi)
     return DesktopGraph(
         deps = deps,
         keyboardInteractive = keyboardInteractive,
@@ -528,6 +545,7 @@ fun main(args: Array<String>) {
                     knownHosts = deps.knownHosts,
                     keyGenerator = deps.keyGenerator,
                     certificateInspector = deps.certificateInspector,
+                    secretFiles = deps.secretFiles,
                     tunnels = deps.tunnels,
                     snippets = deps.snippets,
                     runbooks = deps.runbooks,

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/PickSecretFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/PickSecretFile.desktop.kt
@@ -1,0 +1,20 @@
+package app.skerry.ui.vault
+
+import java.awt.FileDialog
+import java.awt.Frame
+import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
+
+/**
+ * Desktop location picker: the native AWT [FileDialog] in LOAD mode, returning the absolute path
+ * and reading nothing. Shown on [Dispatchers.Swing] because the modal dialog runs a nested EDT
+ * event loop (same as [importTextFile]).
+ */
+actual suspend fun pickSecretFileRef(title: String): String? = withContext(Dispatchers.Swing) {
+    val dialog = FileDialog(null as Frame?, title, FileDialog.LOAD).apply { isVisible = true }
+    val dir = dialog.directory ?: return@withContext null
+    val name = dialog.file ?: return@withContext null
+    File(dir, name).absolutePath
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/KeyFileResolver.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/KeyFileResolver.kt
@@ -1,0 +1,94 @@
+package app.skerry.shared.ssh
+
+import app.skerry.shared.vault.SecretFileReader
+import app.skerry.shared.vault.SecretFileResult
+import app.skerry.shared.vault.SshCertificateInspector
+
+/**
+ * Expands [SshAuth.KeyFile] into a concrete authentication method by reading the referenced files.
+ * Runs immediately before authentication (inside the transport, on its IO dispatcher), so a
+ * certificate an external issuer rewrote a second ago is the one presented.
+ *
+ * Certificate selection follows OpenSSH: an explicit [SshAuth.KeyFile.certificateRef] is used as
+ * given, and a blank one means "look for the `<key>-cert.pub` sibling", falling back to plain
+ * public-key auth when there is none. The sibling probe only applies to path-shaped refs — a
+ * `content://` document Uri has no siblings to guess at.
+ *
+ * Failures throw [SshAuthenticationException] with the ref named: a file-backed credential breaks
+ * for pedestrian reasons (issuer not run today, key moved, Uri grant revoked), and "authentication
+ * failed" would send the user looking at the server instead of at their own disk. A ref is the
+ * user's own input — their own on another of their devices, once sync has carried the credential —
+ * never someone else's, since team sharing strips credential bindings. That is why naming it is
+ * acceptable where a host address wouldn't be; the text still stays out of any log.
+ *
+ * [inspector] is optional; when present, a certificate that *parses* and has expired is refused
+ * here instead of at the server. One that doesn't parse is passed through — an inspector that
+ * doesn't recognise a newer key type must not block a certificate the server would accept.
+ */
+class KeyFileResolver(
+    private val files: SecretFileReader,
+    private val inspector: SshCertificateInspector? = null,
+) {
+
+    /** [auth] as-is unless it is a [SshAuth.KeyFile], which is expanded by reading its files. */
+    fun resolve(auth: SshAuth): SshAuth {
+        if (auth !is SshAuth.KeyFile) return auth
+        val privateKey = require(auth.privateKeyRef, KEY)
+        val explicit = auth.certificateRef?.takeIf { it.isNotBlank() }
+        val certificate = when {
+            explicit != null -> require(explicit, CERT)
+            else -> keyFileSiblingRef(auth.privateKeyRef)?.let { sibling ->
+                // An absent sibling is the ordinary plain-key case; a sibling that is *there* but
+                // unreadable is not. Falling back silently would answer a cert-only server with the
+                // wrong method and leave nothing pointing at the file that actually broke.
+                when (val result = files.read(sibling)) {
+                    is SecretFileResult.Ok -> result.text
+                    SecretFileResult.NotFound -> null
+                    else -> require(sibling, CERT)
+                }
+            }
+        }
+        return when (certificate) {
+            null -> SshAuth.PublicKey(privateKey, auth.passphrase)
+            else -> {
+                inspector?.inspect(certificate)?.let { info ->
+                    if (info.expired) {
+                        throw SshAuthenticationException(
+                            "Certificate expired on ${info.validUntil} (${explicit ?: keyFileSiblingRef(auth.privateKeyRef)}) — issue a new one",
+                        )
+                    }
+                }
+                SshAuth.Certificate(privateKey, certificate, auth.passphrase)
+            }
+        }
+    }
+
+    /** File content at [ref], or [SshAuthenticationException] naming what went wrong with it. */
+    private fun require(ref: String, what: String): String = when (val result = files.read(ref)) {
+        is SecretFileResult.Ok -> result.text
+        SecretFileResult.NotFound -> fail("$what file not found: $ref")
+        SecretFileResult.Denied -> fail("$what file access denied: $ref")
+        SecretFileResult.TooLarge -> fail("$what file is too large to be a key: $ref")
+        SecretFileResult.Unsupported ->
+            fail("$what file was picked on another device and can't be opened here: $ref")
+        is SecretFileResult.Failed -> fail("$what file could not be read: $ref${result.detail?.let { " ($it)" }.orEmpty()}")
+    }
+
+    private fun fail(message: String): Nothing = throw SshAuthenticationException(message)
+
+    private companion object {
+        const val KEY = "Private key"
+        const val CERT = "Certificate"
+    }
+}
+
+/**
+ * The certificate OpenSSH would look for next to a key: `<ref>-cert.pub`. Null for a ref carrying a
+ * URI scheme — appending a suffix to an opaque Uri would only ask the provider for a document that
+ * cannot exist. Shared with the vault UI so the form and the connection agree on which file a blank
+ * certificate ref means.
+ */
+fun keyFileSiblingRef(ref: String): String? =
+    ref.trim().takeIf { it.isNotEmpty() && !SCHEME.containsMatchIn(it) }?.let { "$it-cert.pub" }
+
+private val SCHEME = Regex("^[a-zA-Z][a-zA-Z0-9+.\\-]*://")

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigImport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigImport.kt
@@ -1,41 +1,77 @@
 package app.skerry.shared.ssh
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
 
 /**
- * Turns entries parsed from `ssh_config` into ready-to-save [Host] profiles. Pure and
- * platform-independent so the mapping (including ProxyJump resolution and the username fallback) is
- * covered by commonTest, leaving the UI/controller layer to only pick a file and persist the result.
+ * What an `ssh_config` import will create: [hosts] and the file-backed [credentials] they reference.
+ * Both carry final ids, so the caller only persists them (credentials first — hosts point at them).
+ */
+data class SshConfigImportPlan(
+    val hosts: List<Host>,
+    val credentials: List<Credential>,
+)
+
+/**
+ * Turns entries parsed from `ssh_config` into ready-to-save profiles. Pure and platform-independent
+ * so the mapping (ProxyJump resolution, username fallback, key binding) is covered by commonTest,
+ * leaving the UI/controller layer to only pick a file and persist the result.
  *
- * v1 scope, matching the parser: SSH-only, no secrets. `IdentityFile` is not read into the vault, so
- * every profile gets [Host.credentialId] `null` (the key/password is entered at connect time).
+ * `IdentityFile` becomes a [CredentialSecret.KeyFile]: the key stays where OpenSSH keeps it and is
+ * read at connect time, which is also what makes a `CertificateFile` issued for a few hours usable.
+ * No key material is copied into the vault — only the location, so an import can't quietly duplicate
+ * a private key into a synced store.
  */
 object SshConfigImport {
 
     /**
-     * Builds a [Host] for each [selected] alias in [hosts] (order preserved), assigning ids from
-     * [newId]. [defaultUser] is the local OS user, used when the config omits `User`. ProxyJump is
-     * resolved against the ids of the hosts being imported in this same batch — a jump target that
-     * isn't selected leaves [Host.jumpHostId] `null` rather than a dangling reference.
+     * Plans the [selected] aliases in [hosts] (order preserved), assigning ids from [newId].
+     * [defaultUser] is the local OS user, used when the config omits `User`. ProxyJump is resolved
+     * against the ids of the hosts in this same batch — a jump target that isn't selected leaves
+     * [Host.jumpHostId] `null` rather than a dangling reference.
+     *
+     * Hosts naming the same (key, certificate) pair — compared literally, as OpenSSH itself compares
+     * `IdentityFile` values — share one credential. Labels are derived
+     * from the file name and made unique against each other and [existingLabels] — snippets address
+     * secrets by label (`${{vault:…}}`), so a collision would silently retarget them.
      */
     fun plan(
         hosts: List<SshConfigHost>,
         selected: Set<String>,
         defaultUser: String?,
         newId: () -> String,
-    ): List<Host> {
+        existingLabels: Set<String> = emptySet(),
+    ): SshConfigImportPlan {
         val chosen = hosts.filter { it.alias in selected }
         // Assign every id up front so ProxyJump can reference a host that appears later in the list.
         val idByAlias = LinkedHashMap<String, String>()
         for (entry in chosen) idByAlias[entry.alias] = newId()
-        return chosen.map { entry ->
+
+        val credentials = LinkedHashMap<KeyRefs, Credential>()
+        val takenLabels = existingLabels.toMutableSet()
+        for (entry in chosen) {
+            val key = entry.identityFile?.takeIf { it.isNotBlank() } ?: continue
+            val refs = KeyRefs(key, entry.certificateFile?.takeIf { it.isNotBlank() })
+            credentials.getOrPut(refs) {
+                Credential(
+                    id = newId(),
+                    label = uniqueLabel(labelFor(key), takenLabels).also { takenLabels += it },
+                    secret = CredentialSecret.KeyFile(refs.key, refs.certificate),
+                )
+            }
+        }
+
+        val planned = chosen.map { entry ->
+            val refs = entry.identityFile?.takeIf { it.isNotBlank() }
+                ?.let { KeyRefs(it, entry.certificateFile?.takeIf { c -> c.isNotBlank() }) }
             Host(
                 id = idByAlias.getValue(entry.alias),
                 label = entry.alias,
                 address = entry.hostName,
                 port = entry.port,
                 username = entry.user ?: defaultUser ?: "",
-                credentialId = null,
+                credentialId = refs?.let { credentials[it]?.id },
                 connectionType = ConnectionType.SSH,
                 // Resolve ProxyJump within the batch; drop a self-reference (an alias jumping through
                 // itself) so we never persist an obviously-broken jump. Mutual cycles that survive are
@@ -43,5 +79,21 @@ object SshConfigImport {
                 jumpHostId = entry.proxyJump?.takeIf { it != entry.alias }?.let { idByAlias[it] },
             )
         }
+        return SshConfigImportPlan(planned, credentials.values.toList())
+    }
+
+    /** Key and certificate locations together — the identity of a credential within one import. */
+    private data class KeyRefs(val key: String, val certificate: String?)
+
+    /** File name of a ref, without directories: `~/.ssh/id_ed25519` → `id_ed25519`. */
+    private fun labelFor(ref: String): String =
+        ref.trimEnd('/').substringAfterLast('/').substringAfterLast('\\').ifBlank { "key" }
+
+    /** [base], or `base (2)`, `base (3)`… until it doesn't clash with [taken]. */
+    private fun uniqueLabel(base: String, taken: Set<String>): String {
+        if (base !in taken) return base
+        var n = 2
+        while ("$base ($n)" in taken) n++
+        return "$base ($n)"
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
@@ -14,6 +14,8 @@ data class SshConfigHost(
     val user: String?,
     val proxyJump: String?,
     val identityFile: String?,
+    /** `CertificateFile` — the CA-issued certificate that goes with [identityFile]; null when absent. */
+    val certificateFile: String? = null,
 )
 
 /**
@@ -31,7 +33,7 @@ data class SshConfigParseResult(
  * supplies the file text (read via the platform file picker) so it stays testable in commonTest.
  *
  * Scope is deliberately a pragmatic subset (v1): `Host` blocks with `HostName`, `Port`, `User`,
- * `ProxyJump`, `IdentityFile`. Wildcard patterns (`*`, `?`) and negations (`!`) are honoured for
+ * `ProxyJump`, `IdentityFile`, `CertificateFile`. Wildcard patterns (`*`, `?`) and negations (`!`) are honoured for
  * option matching but never become hosts themselves. `Match` blocks and `Include` are skipped with a
  * warning — evaluating them needs a live host/connection context the importer doesn't have.
  *
@@ -153,6 +155,7 @@ object SshConfigParser {
                     user = resolve("user"),
                     proxyJump = resolve("proxyjump")?.let { firstJumpHop(it) },
                     identityFile = resolve("identityfile"),
+                    certificateFile = resolve("certificatefile"),
                 )
             )
         }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
@@ -100,6 +100,25 @@ sealed interface SshAuth {
     }
 
     /**
+     * Key and (optional) certificate to be read from where they live at connect time rather than
+     * carried in the vault — the form short-lived CA certificates take, since an external issuer
+     * rewrites the file every few hours. Comes from
+     * [app.skerry.shared.vault.CredentialSecret.KeyFile] and is expanded by [KeyFileResolver] into
+     * [PublicKey] or [Certificate] just before authentication, so the file read is as late as
+     * possible.
+     *
+     * [privateKeyRef]/[certificateRef] are locations (path or `content://` Uri), not secrets, but
+     * [passphrase] is one — `toString` redacts the lot, like its siblings.
+     */
+    data class KeyFile(
+        val privateKeyRef: String,
+        val certificateRef: String? = null,
+        val passphrase: String? = null,
+    ) : SshAuth {
+        override fun toString(): String = "KeyFile(redacted)"
+    }
+
+    /**
      * No stored secret: the server drives the exchange and the user answers it
      * ([KeyboardInteractiveResponder]) — a TOTP-only login, a push confirmation, an SMS token.
      *

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
@@ -48,6 +48,34 @@ sealed interface CredentialSecret {
     ) : CredentialSecret {
         override fun toString(): String = "Certificate(redacted)"
     }
+
+    /**
+     * Key (and optional certificate) kept *outside* the vault, referenced by location and re-read on
+     * every connection. This is what makes short-lived CA certificates usable: an external issuer
+     * (`tsh login`, `vault write ssh/sign`, `step ssh certificate`) rewrites the file every few
+     * hours and the profile keeps working — a certificate pasted into the vault as text would have
+     * to be pasted again each time.
+     *
+     * [privateKeyRef]/[certificateRef] are opaque to this model and interpreted by the platform
+     * reader ([SecretFileReader]): a filesystem path on desktop, a `content://` document Uri on
+     * Android. A null/blank [certificateRef] means "look for the OpenSSH sibling"
+     * (`<privateKeyRef>-cert.pub`) and, failing that, authenticate with the plain key.
+     *
+     * The refs are locations, not secrets, but [passphrase] is one — and so is the fact of which
+     * files a user keeps keys in, so `toString` redacts everything as the other secrets do. The
+     * refs are device-local by nature: synced to a device where that file doesn't exist, the
+     * profile fails to connect with "file not found" rather than silently authenticating as
+     * someone else.
+     */
+    @Serializable
+    @SerialName("key_file")
+    data class KeyFile(
+        val privateKeyRef: String,
+        val certificateRef: String? = null,
+        val passphrase: String? = null,
+    ) : CredentialSecret {
+        override fun toString(): String = "KeyFile(redacted)"
+    }
 }
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecretFileReader.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecretFileReader.kt
@@ -1,0 +1,120 @@
+package app.skerry.shared.vault
+
+import okio.FileSystem
+import okio.IOException
+import okio.Path.Companion.toPath
+
+/**
+ * Outcome of reading a secret file ([SecretFileReader.read]). Failures are typed rather than a bare
+ * null: a connection that can't start must say which of "you pointed at nothing", "the OS said no"
+ * and "this ref belongs to another device" happened — with only a null, all three read as a generic
+ * auth failure.
+ */
+sealed interface SecretFileResult {
+    /** File read; [text] is its content decoded as UTF-8, verbatim (trailing newline included). */
+    data class Ok(val text: String) : SecretFileResult {
+        // Private key material: never let it reach a log or a crash report through toString.
+        override fun toString(): String = "Ok(redacted)"
+    }
+
+    /** Nothing readable at the ref: no such file, or a directory in its place. */
+    data object NotFound : SecretFileResult
+
+    /** The file is there but the OS refused access (permissions, revoked Uri grant). */
+    data object Denied : SecretFileResult
+
+    /** Larger than the reader's limit — refused without reading it into memory. */
+    data object TooLarge : SecretFileResult
+
+    /** The ref means nothing to this reader (e.g. a `content://` Uri reaching the desktop). */
+    data object Unsupported : SecretFileResult
+
+    /** Read failed for another reason; [detail] is diagnostic text (no file content). */
+    data class Failed(val detail: String?) : SecretFileResult
+}
+
+/**
+ * Reads a key/certificate file referenced by a [CredentialSecret.KeyFile]. The ref is
+ * platform-shaped — a filesystem path on desktop, a `content://` document Uri on Android — so the
+ * interpretation lives in the platform implementation and callers stay ref-agnostic.
+ *
+ * Blocking on purpose (files are small and reads happen on a connect path already on an IO
+ * dispatcher); callers on the UI thread must dispatch it themselves.
+ */
+fun interface SecretFileReader {
+    fun read(ref: String): SecretFileResult
+
+    /**
+     * Whether [ref] can be read right now, *without* pulling its content into memory. The vault list
+     * uses this for private keys: rendering a row must not load key material, it only needs to know
+     * the file is still where the credential says it is. Defaults to a full read for implementations
+     * that have no cheaper way to tell.
+     */
+    fun probe(ref: String): Boolean = read(ref) is SecretFileResult.Ok
+}
+
+/**
+ * [SecretFileReader] over okio — desktop and Android alike for real filesystem paths (Android's
+ * SAF-backed refs are handled by its own reader, which delegates here for plain paths).
+ *
+ * A leading `~` expands to [homeDir] (null: no expansion, and a `~` ref simply won't resolve) so a
+ * profile can be written the way OpenSSH config writes it. Refs carrying a URI scheme are
+ * [SecretFileResult.Unsupported] rather than being resolved as relative paths — that's a ref made
+ * on another device, and "not found" would be a misleading thing to tell the user.
+ *
+ * [maxBytes] caps what may be pulled into memory: a key or certificate is a few kilobytes, and a
+ * mistyped ref pointing at a disk image must not be slurped whole.
+ */
+class OkioSecretFileReader(
+    private val fileSystem: FileSystem,
+    private val homeDir: String?,
+    private val maxBytes: Long = MAX_BYTES,
+) : SecretFileReader {
+
+    override fun read(ref: String): SecretFileResult {
+        val trimmed = ref.trim()
+        if (trimmed.isEmpty()) return SecretFileResult.NotFound
+        if (SCHEME.containsMatchIn(trimmed)) return SecretFileResult.Unsupported
+        val path = expandHome(trimmed)?.toPath() ?: return SecretFileResult.NotFound
+        val meta = try {
+            fileSystem.metadataOrNull(path) ?: return SecretFileResult.NotFound
+        } catch (e: IOException) {
+            return SecretFileResult.Failed(e.message)
+        }
+        if (!meta.isRegularFile) return SecretFileResult.NotFound
+        if ((meta.size ?: 0L) > maxBytes) return SecretFileResult.TooLarge
+        return try {
+            SecretFileResult.Ok(fileSystem.read(path) { readUtf8() })
+        } catch (e: IOException) {
+            // okio has no permission-denied type, and the OS text is localized, so matching it would
+            // only work in English. Metadata just said the file is there and readable-sized; a read
+            // that still fails is access, not absence.
+            SecretFileResult.Denied
+        }
+    }
+
+    /** Metadata only — the file is never opened, so no key material reaches memory. */
+    override fun probe(ref: String): Boolean {
+        val trimmed = ref.trim()
+        if (trimmed.isEmpty() || SCHEME.containsMatchIn(trimmed)) return false
+        val path = expandHome(trimmed)?.toPath() ?: return false
+        val meta = runCatching { fileSystem.metadataOrNull(path) }.getOrNull() ?: return false
+        return meta.isRegularFile && (meta.size ?: 0L) <= maxBytes
+    }
+
+    private fun expandHome(ref: String): String? = when {
+        !ref.startsWith("~") -> ref
+        homeDir == null -> null
+        ref == "~" -> homeDir
+        ref.startsWith("~/") -> homeDir.trimEnd('/') + ref.removePrefix("~")
+        // `~user/...` — another account's home; we don't resolve it (no passwd lookup in common code).
+        else -> null
+    }
+
+    companion object {
+        /** 256 KiB — orders of magnitude above any key or certificate, still a hard stop. */
+        const val MAX_BYTES: Long = 256L * 1024
+
+        private val SCHEME = Regex("^[a-zA-Z][a-zA-Z0-9+.\\-]*://")
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/SshCertificateInspector.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/SshCertificateInspector.kt
@@ -33,7 +33,7 @@ data class SshCertificateInfo(
  * format) is injected; the UI only depends on this contract. Coroutine-free: parsing is
  * synchronous and cheap (triggered by user action).
  */
-interface SshCertificateInspector {
+fun interface SshCertificateInspector {
     /**
      * Extract public metadata from certificate string [certificate] (`*-cert.pub`, format
      * `ssh-…-cert-v01@openssh.com <base64> [comment]`). Returns `null` if the certificate can't

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/KeyFileResolverTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/KeyFileResolverTest.kt
@@ -1,0 +1,199 @@
+package app.skerry.shared.ssh
+
+import app.skerry.shared.vault.SecretFileResult
+import app.skerry.shared.vault.SshCertificateInfo
+import app.skerry.shared.vault.SshCertificateInspector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val PEM = "-----BEGIN OPENSSH PRIVATE KEY-----\nkey\n-----END OPENSSH PRIVATE KEY-----\n"
+private const val CERT = "ssh-ed25519-cert-v01@openssh.com AAAAcert user@laptop"
+
+/** Inspector stub: certificates map to fixed metadata; anything else fails to parse (null). */
+private fun inspectorOf(vararg certs: Pair<String, SshCertificateInfo>) =
+    SshCertificateInspector { certificate -> certs.toMap()[certificate] }
+
+private fun certInfo(validUntil: String = "2027-01-01", expired: Boolean = false) = SshCertificateInfo(
+    keyTypeLabel = "ED25519",
+    keyId = "dev@corp",
+    principals = listOf("dev"),
+    serial = "7",
+    validFrom = "2026-07-27",
+    validUntil = validUntil,
+    expired = expired,
+    caFingerprintSha256 = "SHA256:ca",
+)
+
+class KeyFileResolverTest {
+
+    @Test
+    fun `explicit certificate ref resolves to certificate auth`() {
+        val resolver = KeyFileResolver(
+            files = { ref ->
+                when (ref) {
+                    "/keys/id" -> SecretFileResult.Ok(PEM)
+                    "/keys/id-cert.pub" -> SecretFileResult.Ok(CERT)
+                    else -> SecretFileResult.NotFound
+                }
+            },
+            inspector = inspectorOf(CERT to certInfo()),
+        )
+
+        val auth = resolver.resolve(SshAuth.KeyFile("/keys/id", "/keys/id-cert.pub", passphrase = "pp"))
+
+        assertEquals(SshAuth.Certificate(PEM, CERT, "pp"), auth)
+    }
+
+    @Test
+    fun `blank certificate ref picks up the OpenSSH sibling next to the key`() {
+        val resolver = KeyFileResolver(
+            files = { ref ->
+                when (ref) {
+                    "/keys/id" -> SecretFileResult.Ok(PEM)
+                    "/keys/id-cert.pub" -> SecretFileResult.Ok(CERT)
+                    else -> SecretFileResult.NotFound
+                }
+            },
+            inspector = inspectorOf(CERT to certInfo()),
+        )
+
+        val auth = resolver.resolve(SshAuth.KeyFile("/keys/id", certificateRef = null))
+
+        assertEquals(SshAuth.Certificate(PEM, CERT, null), auth)
+    }
+
+    @Test
+    fun `a sibling certificate that exists but cannot be read fails instead of silently dropping to the key`() {
+        // "No sibling" and "the sibling is unreadable" are different situations: the first is the
+        // normal plain-key case, the second means the cert-auth the user expects is quietly not
+        // happening, and the server's refusal would point at nothing.
+        val resolver = KeyFileResolver(
+            files = { ref ->
+                when (ref) {
+                    "/keys/id" -> SecretFileResult.Ok(PEM)
+                    else -> SecretFileResult.Denied
+                }
+            },
+        )
+
+        val e = assertFailsWith<SshAuthenticationException> {
+            resolver.resolve(SshAuth.KeyFile("/keys/id", certificateRef = null))
+        }
+
+        assertTrue("/keys/id-cert.pub" in e.message.orEmpty(), "message should name the sibling: ${e.message}")
+    }
+
+    @Test
+    fun `no certificate anywhere falls back to plain public-key auth`() {
+        val resolver = KeyFileResolver(
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok(PEM) else SecretFileResult.NotFound },
+        )
+
+        val auth = resolver.resolve(SshAuth.KeyFile("/keys/id", certificateRef = null, passphrase = "pp"))
+
+        assertEquals(SshAuth.PublicKey(PEM, "pp"), auth)
+    }
+
+    @Test
+    fun `missing private key fails with the ref in the message`() {
+        val resolver = KeyFileResolver(files = { SecretFileResult.NotFound })
+
+        val e = assertFailsWith<SshAuthenticationException> {
+            resolver.resolve(SshAuth.KeyFile("/keys/gone", null))
+        }
+
+        assertTrue("/keys/gone" in e.message.orEmpty(), "message should name the ref: ${e.message}")
+    }
+
+    @Test
+    fun `explicitly named certificate that is missing fails instead of falling back to the key`() {
+        // Silently degrading to publickey would answer a cert-only server with the wrong method and
+        // leave the user reading "authentication failed" with no hint that the cert file went stale.
+        val resolver = KeyFileResolver(
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok(PEM) else SecretFileResult.NotFound },
+        )
+
+        val e = assertFailsWith<SshAuthenticationException> {
+            resolver.resolve(SshAuth.KeyFile("/keys/id", "/keys/id-cert.pub"))
+        }
+
+        assertTrue("/keys/id-cert.pub" in e.message.orEmpty(), "message should name the ref: ${e.message}")
+    }
+
+    @Test
+    fun `expired certificate fails before connecting and says when it expired`() {
+        val resolver = KeyFileResolver(
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok(PEM) else SecretFileResult.Ok(CERT) },
+            inspector = inspectorOf(CERT to certInfo(validUntil = "2026-07-01", expired = true)),
+        )
+
+        val e = assertFailsWith<SshAuthenticationException> {
+            resolver.resolve(SshAuth.KeyFile("/keys/id", "/keys/id-cert.pub"))
+        }
+
+        assertTrue("2026-07-01" in e.message.orEmpty(), "message should carry the expiry date: ${e.message}")
+    }
+
+    @Test
+    fun `unparseable certificate is passed through for the server to judge`() {
+        // An inspector that doesn't know a newer key type must not block a certificate the server
+        // would have accepted; only a parsed-and-expired certificate is refused locally.
+        val resolver = KeyFileResolver(
+            files = { ref -> if (ref == "/keys/id") SecretFileResult.Ok(PEM) else SecretFileResult.Ok("garbage") },
+            inspector = inspectorOf(),
+        )
+
+        val auth = resolver.resolve(SshAuth.KeyFile("/keys/id", "/keys/id-cert.pub"))
+
+        assertEquals(SshAuth.Certificate(PEM, "garbage", null), auth)
+    }
+
+    @Test
+    fun `denied and unsupported refs are reported apart from a missing file`() {
+        val denied = KeyFileResolver(files = { SecretFileResult.Denied })
+        val foreign = KeyFileResolver(files = { SecretFileResult.Unsupported })
+
+        val deniedMessage = assertFailsWith<SshAuthenticationException> {
+            denied.resolve(SshAuth.KeyFile("/keys/id", null))
+        }.message.orEmpty()
+        val foreignMessage = assertFailsWith<SshAuthenticationException> {
+            foreign.resolve(SshAuth.KeyFile("content://doc/1", null))
+        }.message.orEmpty()
+
+        assertTrue("denied" in deniedMessage.lowercase(), deniedMessage)
+        assertTrue("device" in foreignMessage.lowercase(), foreignMessage)
+    }
+
+    @Test
+    fun `sibling probe is skipped for refs that are not paths`() {
+        // "content://doc/42-cert.pub" is not a sibling of anything — appending a suffix to an opaque
+        // Uri would query the provider for a document that never exists.
+        val probed = mutableListOf<String>()
+        val resolver = KeyFileResolver(
+            files = { ref -> probed += ref; SecretFileResult.Ok(PEM) },
+        )
+
+        resolver.resolve(SshAuth.KeyFile("content://doc/42", certificateRef = null))
+
+        assertEquals(listOf("content://doc/42"), probed)
+    }
+
+    @Test
+    fun `other auth methods pass through untouched`() {
+        val resolver = KeyFileResolver(files = { SecretFileResult.NotFound })
+
+        assertEquals(SshAuth.Interactive, resolver.resolve(SshAuth.Interactive))
+        assertEquals(SshAuth.Password("p"), resolver.resolve(SshAuth.Password("p")))
+    }
+
+    @Test
+    fun `resolution never leaks key material through toString`() {
+        val auth = KeyFileResolver(files = { SecretFileResult.Ok(PEM) })
+            .resolve(SshAuth.KeyFile("/keys/id", "/keys/id-cert.pub"))
+
+        assertNull(PEM.takeIf { it in auth.toString() }, "auth.toString() leaked the private key")
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigImportTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.ssh
 
+import app.skerry.shared.vault.CredentialSecret
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -18,7 +19,9 @@ class SshConfigImportTest {
         port: Int = 22,
         user: String? = null,
         proxyJump: String? = null,
-    ) = SshConfigHost(alias, hostName, port, user, proxyJump, identityFile = null)
+        identityFile: String? = null,
+        certificateFile: String? = null,
+    ) = SshConfigHost(alias, hostName, port, user, proxyJump, identityFile, certificateFile)
 
     @Test
     fun `maps parsed fields onto a host profile`() {
@@ -28,7 +31,7 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        val h = plan.single()
+        val h = plan.hosts.single()
         assertEquals("web", h.label)
         assertEquals("10.0.0.1", h.address)
         assertEquals(2222, h.port)
@@ -50,7 +53,7 @@ class SshConfigImportTest {
             defaultUser = "localuser",
             newId = ids(),
         )
-        assertEquals("localuser", plan.single().username)
+        assertEquals("localuser", plan.hosts.single().username)
     }
 
     @Test
@@ -61,7 +64,7 @@ class SshConfigImportTest {
             defaultUser = "localuser",
             newId = ids(),
         )
-        assertEquals("configured", plan.single().username)
+        assertEquals("configured", plan.hosts.single().username)
     }
 
     @Test
@@ -72,7 +75,7 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertEquals("", plan.single().username)
+        assertEquals("", plan.hosts.single().username)
     }
 
     @Test
@@ -83,7 +86,7 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertEquals(listOf("a", "c"), plan.map { it.label })
+        assertEquals(listOf("a", "c"), plan.hosts.map { it.label })
     }
 
     @Test
@@ -94,8 +97,8 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        val web = plan.single { it.label == "web" }
-        val bastion = plan.single { it.label == "bastion" }
+        val web = plan.hosts.single { it.label == "web" }
+        val bastion = plan.hosts.single { it.label == "bastion" }
         assertEquals(bastion.id, web.jumpHostId)
     }
 
@@ -107,7 +110,7 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertNull(plan.single().jumpHostId)
+        assertNull(plan.hosts.single().jumpHostId)
     }
 
     @Test
@@ -118,8 +121,8 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertEquals(3, plan.map { it.id }.toSet().size)
-        assertTrue(plan.all { it.id.isNotBlank() })
+        assertEquals(3, plan.hosts.map { it.id }.toSet().size)
+        assertTrue(plan.hosts.all { it.id.isNotBlank() })
     }
 
     @Test
@@ -130,7 +133,7 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertNull(plan.single().jumpHostId)
+        assertNull(plan.hosts.single().jumpHostId)
     }
 
     @Test
@@ -141,6 +144,104 @@ class SshConfigImportTest {
             defaultUser = null,
             newId = ids(),
         )
-        assertTrue(plan.isEmpty())
+        assertTrue(plan.hosts.isEmpty())
+    }
+
+    @Test
+    fun `IdentityFile becomes a file-backed credential bound to the host`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", identityFile = "~/.ssh/id_ed25519")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        val credential = plan.credentials.single()
+        assertEquals(CredentialSecret.KeyFile("~/.ssh/id_ed25519", null), credential.secret)
+        assertEquals("id_ed25519", credential.label)
+        assertEquals(credential.id, plan.hosts.single().credentialId)
+    }
+
+    @Test
+    fun `CertificateFile is carried into the credential`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", identityFile = "~/.ssh/id_ed25519", certificateFile = "~/.ssh/work-cert.pub")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        assertEquals(
+            CredentialSecret.KeyFile("~/.ssh/id_ed25519", "~/.ssh/work-cert.pub"),
+            plan.credentials.single().secret,
+        )
+    }
+
+    @Test
+    fun `hosts sharing an identity file share one credential`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", identityFile = "~/.ssh/id_ed25519"), host("db", identityFile = "~/.ssh/id_ed25519")),
+            selected = setOf("web", "db"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        assertEquals(1, plan.credentials.size)
+        assertEquals(plan.hosts[0].credentialId, plan.hosts[1].credentialId)
+    }
+
+    @Test
+    fun `same file name from different directories gets a distinct label`() {
+        // Labels are how snippets reference a secret (${{vault:label}}), so two "id_ed25519" entries
+        // pointing at different files must not collide.
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("a", identityFile = "~/.ssh/id_ed25519"), host("b", identityFile = "/work/keys/id_ed25519")),
+            selected = setOf("a", "b"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        assertEquals(2, plan.credentials.size)
+        assertEquals(2, plan.credentials.map { it.label }.toSet().size)
+    }
+
+    @Test
+    fun `a label already used in the vault is not reused`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", identityFile = "~/.ssh/id_ed25519")),
+            selected = setOf("web"),
+            defaultUser = null,
+            existingLabels = setOf("id_ed25519"),
+            newId = ids(),
+        )
+
+        assertTrue(plan.credentials.single().label != "id_ed25519", plan.credentials.single().label)
+    }
+
+    @Test
+    fun `CertificateFile without an IdentityFile creates nothing`() {
+        // Without a key there is nothing to authenticate with; inventing a credential would only
+        // produce a profile that fails at connect time.
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", certificateFile = "~/.ssh/work-cert.pub")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        assertTrue(plan.credentials.isEmpty())
+        assertNull(plan.hosts.single().credentialId)
+    }
+
+    @Test
+    fun `identity files of unselected hosts are ignored`() {
+        val plan = SshConfigImport.plan(
+            hosts = listOf(host("web", identityFile = "~/.ssh/a"), host("db", identityFile = "~/.ssh/b")),
+            selected = setOf("web"),
+            defaultUser = null,
+            newId = ids(),
+        )
+
+        assertEquals(listOf("a"), plan.credentials.map { it.label })
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
@@ -53,6 +53,34 @@ class CredentialStoreTest {
     }
 
     @Test
+    fun `key-file credential round-trips`() {
+        val store = CredentialStore(FakeVault())
+        val cred = Credential(
+            "c-5",
+            "Teleport cert",
+            CredentialSecret.KeyFile(
+                privateKeyRef = "~/.ssh/id_ed25519",
+                certificateRef = "~/.ssh/id_ed25519-cert.pub",
+                passphrase = "pp",
+            ),
+        )
+
+        store.put(cred)
+
+        assertEquals(cred, store.get("c-5"))
+    }
+
+    @Test
+    fun `key-file credential without an explicit certificate round-trips with null`() {
+        val store = CredentialStore(FakeVault())
+        val cred = Credential("c-6", "Vault-signed", CredentialSecret.KeyFile(privateKeyRef = "/keys/id_rsa"))
+
+        store.put(cred)
+
+        assertEquals(cred, store.get("c-6"))
+    }
+
+    @Test
     fun `all returns live credentials and skips tombstones`() {
         val store = CredentialStore(FakeVault())
         store.put(Credential("a", "A", CredentialSecret.Password("x")))

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/OkioSecretFileReaderTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/OkioSecretFileReaderTest.kt
@@ -1,0 +1,102 @@
+package app.skerry.shared.vault
+
+import okio.ForwardingFileSystem
+import okio.IOException
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Source
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class OkioSecretFileReaderTest {
+
+    private val fs = FakeFileSystem()
+
+    private fun reader(maxBytes: Long = 256L * 1024) =
+        OkioSecretFileReader(fs, homeDir = "/home/dev", maxBytes = maxBytes)
+
+    private fun write(path: String, content: String) {
+        val p = path.toPath()
+        p.parent?.let { fs.createDirectories(it) }
+        fs.write(p) { writeUtf8(content) }
+    }
+
+    @Test
+    fun `reads file content verbatim`() {
+        write("/keys/id_ed25519", "-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n")
+
+        val result = reader().read("/keys/id_ed25519")
+
+        assertEquals(
+            SecretFileResult.Ok("-----BEGIN OPENSSH PRIVATE KEY-----\nabc\n-----END OPENSSH PRIVATE KEY-----\n"),
+            result,
+        )
+    }
+
+    @Test
+    fun `expands a leading tilde to the home directory`() {
+        write("/home/dev/.ssh/id_ed25519-cert.pub", "ssh-ed25519-cert-v01@openssh.com AAAA")
+
+        assertEquals(
+            SecretFileResult.Ok("ssh-ed25519-cert-v01@openssh.com AAAA"),
+            reader().read("~/.ssh/id_ed25519-cert.pub"),
+        )
+    }
+
+    @Test
+    fun `missing file reports not found`() {
+        assertIs<SecretFileResult.NotFound>(reader().read("/keys/absent"))
+    }
+
+    @Test
+    fun `directory in place of a file reports not found`() {
+        fs.createDirectories("/keys/dir".toPath())
+
+        assertIs<SecretFileResult.NotFound>(reader().read("/keys/dir"))
+    }
+
+    @Test
+    fun `blank ref reports not found without touching the filesystem`() {
+        assertIs<SecretFileResult.NotFound>(reader().read("   "))
+    }
+
+    @Test
+    fun `file above the size limit is rejected without being read`() {
+        write("/keys/huge", "x".repeat(2048))
+
+        assertIs<SecretFileResult.TooLarge>(reader(maxBytes = 1024).read("/keys/huge"))
+    }
+
+    @Test
+    fun `a readable-looking file whose read fails is denied, regardless of the message locale`() {
+        // okio has no permission-denied type, and the OS message is localized ("Отказано в доступе"),
+        // so classification can't be based on its text: metadata says the file is there, the read
+        // says otherwise — that is the signal.
+        write("/keys/locked", "secret")
+        val refusing = object : ForwardingFileSystem(fs) {
+            override fun source(file: Path): Source = throw IOException("Отказано в доступе")
+        }
+
+        assertIs<SecretFileResult.Denied>(
+            OkioSecretFileReader(refusing, homeDir = null).read("/keys/locked"),
+        )
+    }
+
+    @Test
+    fun `a ref carrying a URI scheme is unsupported rather than treated as a path`() {
+        // Comes from a credential synced off Android: a content:// document Uri means nothing to
+        // the filesystem, and reporting "not found" would send the user hunting for a file.
+        assertIs<SecretFileResult.Unsupported>(reader().read("content://com.android.providers/document/42"))
+    }
+
+    @Test
+    fun `tilde stays literal when no home directory is known`() {
+        write("/work/~/key", "k")
+
+        val reader = OkioSecretFileReader(fs, homeDir = null)
+
+        assertIs<SecretFileResult.NotFound>(reader.read("~/key"))
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -32,9 +32,14 @@ import net.schmizz.sshj.userauth.password.Resource
  * [keyboardInteractiveResponder] answers the server's keyboard-interactive challenges (2FA codes and
  * the like). Null — the default — means the method isn't offered at all, so a server that insists on
  * it fails authentication exactly as it did before the responder existed.
+ *
+ * [keyFiles] expands file-backed credentials ([SshAuth.KeyFile]) at authentication time. Null means
+ * this transport can't read them and such a credential fails with a message saying so, rather than
+ * with an opaque auth error.
  */
 class SshjTransport(
     private val hostKeyVerifier: HostKeyVerifier,
+    private val keyFiles: KeyFileResolver? = null,
     private val keyboardInteractiveResponder: KeyboardInteractiveResponder? = null,
 ) : SshTransport {
 
@@ -170,7 +175,7 @@ class SshjTransport(
     private fun authenticate(
         client: SSHClient,
         username: String,
-        auth: SshAuth,
+        requested: SshAuth,
         hop: Boolean,
         host: String,
         port: Int,
@@ -178,6 +183,14 @@ class SshjTransport(
         // Held so the failure below can tell "the user waved the prompt away" apart from "the server
         // said no" — sshj reports both as the same UserAuthException.
         var prompts: ResponderChallengeProvider? = null
+        // File-backed credentials are read here rather than when the profile was resolved: the point
+        // of them is that an external issuer keeps rewriting the file, so the read has to be as late
+        // as the connection itself. Throws (with the ref named) if the file isn't there.
+        val auth = when (requested) {
+            is SshAuth.KeyFile -> keyFiles?.resolve(requested)
+                ?: throw SshAuthenticationException("File-backed credentials are not available on this platform")
+            else -> requested
+        }
         try {
             // One ordered list rather than a single call: a server configured with
             // `AuthenticationMethods publickey,keyboard-interactive` answers the first method with
@@ -226,6 +239,8 @@ class SshjTransport(
                     // Nothing to offer up front: the whole exchange is the server asking and the
                     // user answering, added below.
                     SshAuth.Interactive -> Unit
+                    // Resolved into one of the branches above before the list is built.
+                    is SshAuth.KeyFile -> Unit
                 }
                 keyboardInteractiveResponder?.let { responder ->
                     val provider = ResponderChallengeProvider(


### PR DESCRIPTION
A credential can reference a key and certificate on disk instead of storing them, so short-lived CA certificates keep working while their issuer rewrites the file.

## What it does

`CredentialSecret.KeyFile` holds a private-key ref and an optional certificate ref — a filesystem path on desktop, a persisted `content://` document Uri on Android. The files are read inside the transport immediately before authentication, so a certificate `tsh login` / `vault write ssh/sign` / `step ssh certificate` wrote a second ago is the one presented. Nothing is copied into the vault.

## Where

- **Vault → Keys / Certificates → "Link key file"** (desktop and Android): refs are typed or picked through the native picker; the Android pick takes a persistable read grant, otherwise access would die with the process.
- **Vault list**: `FILE` / `FILE MISSING` / `EXPIRED` badges plus certificate metadata read off disk; the detail panel shows both refs and whether each is readable on this device.
- **Import `~/.ssh/config`**: `IdentityFile` and `CertificateFile` now create a file-backed credential bound to the host.

## Behaviour

- Certificate selection follows OpenSSH: an explicit ref is used as given, a blank one means the `<key>-cert.pub` sibling, and with no sibling the plain key authenticates.
- A sibling that exists but cannot be read fails instead of silently downgrading to the plain key — against a cert-only server that downgrade would surface as a bare "credentials rejected".
- A certificate that parses and has expired is refused before connecting, with its date. One that doesn't parse is passed through: an inspector that doesn't recognise a newer key type must not block a certificate the server would accept.
- Refs are device-local by nature. Synced to a device where the file isn't there, the connection fails naming the file rather than authenticating as something else.
- Browsing the vault probes the private key instead of reading it; only the certificate, which is public, is actually read.

## Also in this PR

- `SshConfigImport.plan` returns hosts and credentials together, deduplicated per (key, certificate) pair, with labels made unique against the vault — snippets address secrets by label.
- `SecretFileReader` classifies failures structurally (metadata says the file is there, the read fails ⇒ access denied) rather than by matching the OS message, which is localized.
- The parser learned `CertificateFile`.

Tested against a real OpenSSH sshd configured certificate-only (`TrustedUserCAKeys`, `AuthorizedKeysFile none`): sibling pickup, explicit ref, missing key, expired certificate and an unreadable sibling all behave as described. UI interaction and the Android grant surviving an app restart still need a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)