### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
+++ b/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
@@ -78,6 +78,23 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.2.0" date="2026-07-29">
+      <description>
+        <p>Feature release:</p>
+        <ul>
+          <li>RDP: connect to a Windows desktop with a built-in client — clipboard, audio, dynamic resize</li>
+          <li>Split panes: up to four tiled sessions in one tab, with synchronized input</li>
+          <li>Session sharing: stream a live terminal to a teammate and hand over the keyboard</li>
+          <li>Runbooks: ordered checklists of commands with confirmation pauses and exit-code checks</li>
+          <li>Docker and Kubernetes exec as a connection type; local shell in a tab</li>
+          <li>Keyboard-interactive (2FA) authentication, certificates from file, host-key certificates</li>
+          <li>Import hosts from ~/.ssh/config; notes on a connection profile; production guard for prod hosts</li>
+          <li>Terminal: scrollback search, open file paths from output in the SFTP panel</li>
+          <li>SFTP: modified/permissions columns and a quick name filter</li>
+          <li>Vault trash with 30-day restore; Teams access scopes and an activity feed</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.1.4" date="2026-07-23">
       <description>
         <p>Feature release:</p>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.1.4
-skerry.versionCode=6
+skerry.versionName=0.2.0
+skerry.versionCode=7

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.4"
+version = "0.2.0"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.1.4"
+version = "0.2.0"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Version bump for the 0.2.0 release.

- `gradle.properties`: versionName 0.2.0, versionCode 7
- `server/build.gradle.kts`, `sync-wire/build.gradle.kts`: 0.2.0 (wire contract changed since server-v0.1.4 — share and team DTOs)
- `composeApp/flatpak/app.skerry.Skerry.metainfo.xml`: new `<release>` entry