### PR TITLE
Session panel for remote desktops: screenshot, Ctrl+Alt+Del, clipboard, and settings that apply mid-session

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.android.kt
@@ -1,0 +1,83 @@
+package app.skerry.ui.remote
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import app.skerry.ui.sftp.SafBridge
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Puts the frame in the gallery under `Pictures/Skerry`, through MediaStore on Android 10+ (no
+ * storage permission needed, and the picture shows up in the gallery). On 8 and 9 MediaStore's
+ * relative path does not exist yet and writing to shared storage needs a permission this app never
+ * asks for, so the file goes to the app's own pictures directory instead.
+ *
+ * A write that fails — or is cancelled — takes its half-written file with it: a partial PNG under a
+ * name that says "screenshot" is worse than no file at all.
+ */
+actual suspend fun saveRemoteScreenshot(image: ImageBitmap, baseName: String): String? = withContext(Dispatchers.IO) {
+    val ctx = SafBridge.context() ?: return@withContext null
+    val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+    val name = screenshotFileName(baseName, stamp)
+    val bitmap = try {
+        image.asAndroidBitmap()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
+        return@withContext null
+    }
+
+    if (Build.VERSION.SDK_INT >= 29) {
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, name)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
+            put(MediaStore.Images.Media.RELATIVE_PATH, "${Environment.DIRECTORY_PICTURES}/Skerry")
+        }
+        val resolver = ctx.contentResolver
+        val uri = try {
+            resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, values)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            null
+        } ?: return@withContext null
+        return@withContext try {
+            resolver.openOutputStream(uri)!!.use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            "${Environment.DIRECTORY_PICTURES}/Skerry/$name"
+        } catch (e: CancellationException) {
+            deleteQuietly(ctx.contentResolver, uri)
+            throw e
+        } catch (_: Exception) {
+            deleteQuietly(ctx.contentResolver, uri)
+            null
+        }
+    }
+
+    val file = File(File(ctx.getExternalFilesDir(Environment.DIRECTORY_PICTURES), "Skerry"), name)
+    try {
+        file.parentFile?.mkdirs()
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        file.absolutePath
+    } catch (e: CancellationException) {
+        runCatching { file.delete() }
+        throw e
+    } catch (_: Exception) {
+        runCatching { file.delete() }
+        null
+    }
+}
+
+private fun deleteQuietly(resolver: android.content.ContentResolver, uri: Uri) {
+    runCatching { resolver.delete(uri, null, null) }
+}

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -24,4 +24,19 @@
     <string name="conn_subtitle_new_desktop">Добавьте удалённый рабочий стол. Пароль шифруется мастер-паролем.</string>
     <string name="nav_tab_desktops">Столы</string>
     <string name="rd_screen_title">Рабочие столы</string>
+    <string name="rd_panel_title">Сессия</string>
+    <string name="rd_panel_hide">Скрыть панель</string>
+    <string name="rd_panel_show">Показать панель</string>
+    <string name="rd_screenshot">Снимок экрана</string>
+    <string name="rd_screenshot_saved">Сохранено в %s</string>
+    <string name="rd_screenshot_failed">Не удалось записать файл</string>
+    <string name="rd_settings">Настройки</string>
+    <string name="rd_ctrl_alt_del">Отправить Ctrl+Alt+Del</string>
+    <string name="rd_clipboard">Буфер обмена</string>
+    <string name="rd_clipboard_from_remote">С удалённой машины</string>
+    <string name="rd_clipboard_empty">Пока ничего не копировали</string>
+    <string name="rd_clipboard_copy_here">Скопировать сюда</string>
+    <string name="rd_clipboard_send">Отправить свой</string>
+    <string name="rd_audio">Звук</string>
+    <string name="rd_clipboard_share">Общий буфер обмена</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -24,4 +24,19 @@
     <string name="conn_subtitle_new_desktop">添加远程桌面。其密码将使用主密码加密。</string>
     <string name="nav_tab_desktops">桌面</string>
     <string name="rd_screen_title">远程桌面</string>
+    <string name="rd_panel_title">会话</string>
+    <string name="rd_panel_hide">隐藏面板</string>
+    <string name="rd_panel_show">显示面板</string>
+    <string name="rd_screenshot">屏幕截图</string>
+    <string name="rd_screenshot_saved">已保存到 %s</string>
+    <string name="rd_screenshot_failed">无法写入文件</string>
+    <string name="rd_settings">设置</string>
+    <string name="rd_ctrl_alt_del">发送 Ctrl+Alt+Del</string>
+    <string name="rd_clipboard">剪贴板</string>
+    <string name="rd_clipboard_from_remote">来自远程主机</string>
+    <string name="rd_clipboard_empty">尚未复制任何内容</string>
+    <string name="rd_clipboard_copy_here">复制到本机</string>
+    <string name="rd_clipboard_send">发送本机内容</string>
+    <string name="rd_audio">声音</string>
+    <string name="rd_clipboard_share">共享剪贴板</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -24,4 +24,19 @@
     <string name="conn_subtitle_new_desktop">Add a remote desktop. Its password is encrypted with your master password.</string>
     <string name="nav_tab_desktops">Desktops</string>
     <string name="rd_screen_title">Remote desktops</string>
+    <string name="rd_panel_title">Session</string>
+    <string name="rd_panel_hide">Hide the panel</string>
+    <string name="rd_panel_show">Show the panel</string>
+    <string name="rd_screenshot">Screenshot</string>
+    <string name="rd_screenshot_saved">Saved to %s</string>
+    <string name="rd_screenshot_failed">Could not write the file</string>
+    <string name="rd_settings">Settings</string>
+    <string name="rd_ctrl_alt_del">Send Ctrl+Alt+Del</string>
+    <string name="rd_clipboard">Clipboard</string>
+    <string name="rd_clipboard_from_remote">From the remote machine</string>
+    <string name="rd_clipboard_empty">Nothing copied yet</string>
+    <string name="rd_clipboard_copy_here">Copy here</string>
+    <string name="rd_clipboard_send">Send mine</string>
+    <string name="rd_audio">Sound</string>
+    <string name="rd_clipboard_share">Share the clipboard</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -285,6 +285,9 @@ class DesktopDesignState(
     /** Whether the terminal's left host sidebar is hidden (toggled from the icon rail). */
     var sidebarHidden: Boolean by mutableStateOf(false); private set
 
+    /** Whether the session panel beside a live remote desktop is hidden. */
+    var remotePanelHidden: Boolean by mutableStateOf(false); private set
+
     /**
      * Which catalog the work area is showing: terminal-style connections or remote desktops (the
      * rail's two session-level items). Each section has its own host sidebar, its own "New
@@ -569,6 +572,8 @@ class DesktopDesignState(
     fun showSettingsTab(t: SettingsTab) { settingsTab = t }
     fun toggleSplit() { split = !split }
     fun toggleSidebar() { sidebarHidden = !sidebarHidden }
+
+    fun toggleRemotePanel() { remotePanelHidden = !remotePanelHidden }
     fun toggleInfo() { infoPanel = !infoPanel; onInfoPanelChange(infoPanel) }
 
     // Signal to focus the AI bar's input (hotkey Cmd// Ctrl+Shift+/). SharedFlow rather than a counter

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -1,10 +1,13 @@
 package app.skerry.ui.mobile
 
 import app.skerry.ui.remote.remoteKeyEvent
+import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopUiState
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -84,9 +87,9 @@ fun MobileVncScreen(state: MobileDesignState) {
     var keyboardOn by remember { mutableStateOf(false) }
     // The bar starts visible so the screen still explains itself on arrival, then gets out of the way.
     var barVisible by remember { mutableStateOf(true) }
-    // The graphics menu hangs off the bar, so the bar has to outlive it — auto-hiding underneath would
-    // take the open menu down with it mid-choice.
-    var menuOpen by remember { mutableStateOf(false) }
+    // The session panel is opened from the bar, so the bar has to outlive it — auto-hiding underneath
+    // would take the panel's own way back with it.
+    var panelOpen by remember { mutableStateOf(false) }
     // Bumped by every reveal, and part of the auto-hide effect's key: re-setting an already-true
     // `barVisible` is not a state change and would leave the running timer to expire on its old
     // schedule — a swipe would then be answered by the bar vanishing a moment later.
@@ -96,8 +99,8 @@ fun MobileVncScreen(state: MobileDesignState) {
 
     // Auto-hide, restarted by every reveal. Held open while the keyboard is up: the button that puts
     // it away lives on the bar, and hiding the bar under the user's hands would strand them.
-    LaunchedEffect(barVisible, keyboardOn, menuOpen, revealNonce) {
-        if (barVisible && !keyboardOn && !menuOpen) {
+    LaunchedEffect(barVisible, keyboardOn, panelOpen, revealNonce) {
+        if (barVisible && !keyboardOn && !panelOpen) {
             delay(BAR_AUTO_HIDE_MS)
             barVisible = false
         }
@@ -143,8 +146,8 @@ fun MobileVncScreen(state: MobileDesignState) {
                 screen = (vnc?.uiState as? RemoteDesktopUiState.Connected)?.screen,
                 title = sessions?.activeSession?.title ?: "VNC",
                 keyboardOn = keyboardOn,
-                menuOpen = menuOpen,
-                onMenuOpenChange = { menuOpen = it },
+                panelOpen = panelOpen,
+                onPanelOpenChange = { panelOpen = it },
                 onToggleKeyboard = { keyboardOn = !keyboardOn },
                 onClose = {
                     sessions?.active?.let { sessions.close(it.id) }
@@ -154,6 +157,29 @@ fun MobileVncScreen(state: MobileDesignState) {
         }
 
         val connected = (vnc?.uiState as? RemoteDesktopUiState.Connected)?.screen
+        // Kept across the frame the session drops on: the exit animation still has to draw the panel
+        // it is sliding away, and a content lambda reading `connected` would compose nothing there —
+        // the panel would vanish rather than leave.
+        var lastScreen by remember { mutableStateOf(connected) }
+        if (connected != null) lastScreen = connected
+        // The panel slides over the picture rather than beside it: on a phone a column of its width
+        // would leave the desktop a strip.
+        AnimatedVisibility(
+            visible = panelOpen && connected != null,
+            modifier = Modifier.align(Alignment.CenterEnd),
+            enter = slideInHorizontally { it },
+            exit = slideOutHorizontally { it },
+        ) {
+            lastScreen?.let {
+                RemoteDesktopPanel(
+                    it,
+                    onHide = { panelOpen = false },
+                    modifier = Modifier.hiddenSystemBarsPadding(),
+                    // Pinch-zoom is real here, so the fit can be off and worth resetting.
+                    showResetZoom = true,
+                )
+            }
+        }
         if (keyboardOn && connected != null) VncImeField(connected) { keyboardOn = false }
     }
 }
@@ -165,8 +191,8 @@ private fun MobileVncBar(
     screen: RemoteDesktopScreenState?,
     title: String,
     keyboardOn: Boolean,
-    menuOpen: Boolean,
-    onMenuOpenChange: (Boolean) -> Unit,
+    panelOpen: Boolean,
+    onPanelOpenChange: (Boolean) -> Unit,
     onToggleKeyboard: () -> Unit,
     onClose: () -> Unit,
 ) {
@@ -186,7 +212,7 @@ private fun MobileVncBar(
             screen?.serverName ?: title,
             color = Skerry.colors.text, size = 13.sp, modifier = Modifier.weight(1f).padding(start = 4.dp),
         )
-        if (screen != null) MobileVncGraphics(screen, menuOpen, onMenuOpenChange)
+        if (screen != null) MobileVncIcon("tune") { onPanelOpenChange(!panelOpen) }
         MobileVncIcon(if (keyboardOn) "keyboard_hide" else "keyboard", onClick = onToggleKeyboard)
         MobileVncIcon("close", onClick = onClose)
     }
@@ -242,50 +268,6 @@ private fun VncImeField(screen: RemoteDesktopScreenState, onClosed: () -> Unit) 
 private fun CenterText(text: String, color: Color) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Txt(text, color = color, size = 13.sp)
-    }
-}
-
-/** Graphics settings dropdown for the mobile VNC bar: quality, view-only, reset zoom. */
-@Composable
-private fun MobileVncGraphics(screen: RemoteDesktopScreenState, open: Boolean, onOpenChange: (Boolean) -> Unit) {
-    AnchoredDropdown(
-        expanded = open,
-        onDismiss = { onOpenChange(false) },
-        // Must not steal focus: with the IME field open, a focusable popup would drop the keyboard.
-        focusable = false,
-        trigger = { MobileVncIcon("tune") { onOpenChange(!open) } },
-        menu = { width ->
-            Column(
-                Modifier.width(width.coerceAtLeast(200.dp)).clip(RoundedCornerShape(11.dp))
-                    .background(Skerry.colors.surfaceDeep).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(11.dp)).padding(vertical = 4.dp),
-            ) {
-                Txt(stringResource(Res.string.vnc_quality), color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.padding(start = 14.dp, top = 6.dp, bottom = 2.dp))
-                RemoteDesktopQuality.entries.forEach { q ->
-                    MobileVncMenuRow(q.label(), selected = screen.quality == q) { screen.applyQuality(q) }
-                }
-                HLine(modifier = Modifier.padding(vertical = 4.dp))
-                MobileVncMenuRow(stringResource(Res.string.vnc_view_only), selected = screen.viewOnly, icon = if (screen.viewOnly) "check_box" else "check_box_outline_blank") { screen.toggleViewOnly() }
-                // Only offered once the server has said it accepts SetDesktopSize.
-                if (screen.canResizeRemote) {
-                    MobileVncMenuRow(stringResource(Res.string.vnc_resize_to_window), selected = screen.remoteResize, icon = if (screen.remoteResize) "check_box" else "check_box_outline_blank") { screen.toggleRemoteResize() }
-                }
-                MobileVncMenuRow(stringResource(Res.string.vnc_reset_zoom), selected = false, icon = "fit_screen") { screen.resetZoom(); onOpenChange(false) }
-            }
-        },
-    )
-}
-
-@Composable
-private fun MobileVncMenuRow(label: String, selected: Boolean, icon: String? = null, onClick: () -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent).clickable(onClick = onClick)
-            .padding(horizontal = 14.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        if (icon != null) Sym(icon, size = 17.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim)
-        Txt(label, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text, size = 14.sp, modifier = Modifier.weight(1f))
-        if (selected && icon == null) Sym("check", size = 16.sp, color = Skerry.colors.cyanBright)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/PopupToggleGuard.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/PopupToggleGuard.kt
@@ -1,0 +1,38 @@
+package app.skerry.ui.remote
+
+import androidx.compose.runtime.Stable
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * Keeps a popup's own button from reopening what the same press just closed.
+ *
+ * A press on the button of an open menu is two events: the popup sees a click outside itself and
+ * dismisses, and then the click reaches the button, which toggles the menu back open. The user sees
+ * a menu that will not close. The dismissal is what marks the guard, and the click that follows it
+ * within [WINDOW] is swallowed — only that one, so a user pressing the button again straight away
+ * still gets the menu.
+ */
+@Stable
+class PopupToggleGuard(private val source: TimeSource = TimeSource.Monotonic) {
+    private var dismissedAt: TimeMark? = null
+
+    /** Called from the popup's own dismiss handler. */
+    fun onDismissed() {
+        dismissedAt = source.markNow()
+    }
+
+    /** Whether a click on the trigger should act, or belongs to the dismissal that just happened. */
+    fun opensOnClick(): Boolean {
+        val justDismissed = dismissedAt?.let { it.elapsedNow() < WINDOW } == true
+        dismissedAt = null
+        return !justDismissed
+    }
+
+    private companion object {
+        // Long enough for the dismissal and the click to be the same press, short enough that a
+        // deliberate second press is never mistaken for one.
+        val WINDOW = 200.milliseconds
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
@@ -1,0 +1,415 @@
+package app.skerry.ui.remote
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import app.skerry.shared.graphics.RemoteDesktopQuality
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.HoverTooltip
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_audio
+import app.skerry.ui.generated.resources.rd_clipboard
+import app.skerry.ui.generated.resources.rd_clipboard_copy_here
+import app.skerry.ui.generated.resources.rd_clipboard_empty
+import app.skerry.ui.generated.resources.rd_clipboard_from_remote
+import app.skerry.ui.generated.resources.rd_clipboard_send
+import app.skerry.ui.generated.resources.rd_clipboard_share
+import app.skerry.ui.generated.resources.rd_ctrl_alt_del
+import app.skerry.ui.generated.resources.rd_panel_hide
+import app.skerry.ui.generated.resources.rd_screenshot
+import app.skerry.ui.generated.resources.rd_screenshot_failed
+import app.skerry.ui.generated.resources.rd_screenshot_saved
+import app.skerry.ui.generated.resources.rd_settings
+import app.skerry.ui.generated.resources.vnc_quality
+import app.skerry.ui.generated.resources.vnc_reset_zoom
+import app.skerry.ui.generated.resources.vnc_resize_to_window
+import app.skerry.ui.generated.resources.vnc_view_only
+import app.skerry.ui.terminal.fetchSystemClipboardText
+import app.skerry.ui.terminal.plainTextClipEntry
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.vnc.label
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+
+/** Width of the session panel: a strip of icons, the same figure on both platforms. */
+val REMOTE_PANEL_WIDTH: Dp = 44.dp
+
+/**
+ * The session panel beside a live remote desktop: the actions that belong to the session rather than
+ * to the picture — a screenshot, the secure attention sequence, the clipboard, and the settings that
+ * used to sit in the floating gear.
+ *
+ * Icons only, each naming itself on hover (desktop) or on a long press (touch). A column of labels
+ * would cost the desktop a fifth of its width for text the user reads once.
+ *
+ * [showResetZoom] is for the touch platform only: pinch-zoom is real on a phone, while the desktop
+ * wheel scrolls the remote desktop instead, so there the control would be a no-op.
+ */
+@Composable
+fun RemoteDesktopPanel(
+    screen: RemoteDesktopScreenState,
+    onHide: () -> Unit,
+    modifier: Modifier = Modifier,
+    showResetZoom: Boolean = false,
+) {
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboard.current
+    var settingsOpen by remember { mutableStateOf(false) }
+    var clipboardOpen by remember { mutableStateOf(false) }
+    // Where the last screenshot went. Shown as a tooltip on its own button and cleared on a timer:
+    // the strip has no room for a line of text, and the answer is only interesting for a moment.
+    var shotPath by remember { mutableStateOf<String?>(null) }
+    var shotFailed by remember { mutableStateOf(false) }
+    LaunchedEffect(shotPath, shotFailed) {
+        if (shotPath != null || shotFailed) {
+            delay(SHOT_NOTE_MS)
+            shotPath = null
+            shotFailed = false
+        }
+    }
+    val shotNote = when {
+        shotFailed -> stringResource(Res.string.rd_screenshot_failed)
+        else -> shotPath?.let { stringResource(Res.string.rd_screenshot_saved, it) }
+    }
+
+    Column(
+        modifier.width(REMOTE_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2)
+            .verticalScroll(rememberScrollState()),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        PanelIcon("chevron_right", stringResource(Res.string.rd_panel_hide), onClick = onHide)
+        HLine(modifier = Modifier.padding(vertical = 2.dp))
+
+        PanelIcon("photo_camera", stringResource(Res.string.rd_screenshot), forcedTooltip = shotNote) {
+            scope.launch {
+                val saved = saveRemoteScreenshot(screen.imageBitmap, screen.serverName)
+                shotPath = saved
+                shotFailed = saved == null
+            }
+        }
+
+        // The keyboard cannot produce this one: the local OS takes Ctrl+Alt+Del before any app sees it.
+        PanelIcon("keyboard", stringResource(Res.string.rd_ctrl_alt_del), enabled = !screen.viewOnly) {
+            screen.sendCtrlAltDel()
+        }
+
+        if (screen.capabilities.clipboard) {
+            if (!screen.clipboardShared) clipboardOpen = false
+            PanelPopup(
+                expanded = clipboardOpen,
+                onDismiss = { clipboardOpen = false },
+                onToggle = { clipboardOpen = !clipboardOpen },
+                trigger = { toggle ->
+                    PanelIcon(
+                        "content_paste",
+                        stringResource(Res.string.rd_clipboard),
+                        // Nothing here works while sharing is off, and a button that answers a press
+                        // with silence reads as a broken one.
+                        enabled = screen.clipboardShared,
+                        active = clipboardOpen,
+                        onClick = toggle,
+                    )
+                },
+            ) {
+                ClipboardMenu(
+                    screen,
+                    onCopyHere = { text -> scope.launch { clipboard.setClipEntry(plainTextClipEntry(text)) } },
+                    onSendMine = {
+                        scope.launch { fetchSystemClipboardText(clipboard)?.let(screen::onLocalClipboard) }
+                    },
+                )
+            }
+        }
+
+        PanelPopup(
+            expanded = settingsOpen,
+            onDismiss = { settingsOpen = false },
+            onToggle = { settingsOpen = !settingsOpen },
+            trigger = { toggle ->
+                PanelIcon("tune", stringResource(Res.string.rd_settings), active = settingsOpen, onClick = toggle)
+            },
+        ) {
+            SettingsMenu(screen, showResetZoom)
+        }
+    }
+}
+
+/**
+ * Slim strip at the right edge while the session panel is collapsed, painted in the panel's own
+ * surface so it reads as the panel peeking out. The mirror image of the hosts sidebar's handle.
+ */
+@Composable
+fun PanelReopenHandle(onClick: () -> Unit) {
+    Box(
+        Modifier.width(16.dp).fillMaxHeight().background(Skerry.colors.surface2).clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym("chevron_left", size = 16.sp, color = Skerry.colors.faint)
+    }
+}
+
+/**
+ * One button of the strip. [forcedTooltip] shows a message the user did not ask to hover — the
+ * screenshot's answer — and takes precedence over [tooltip] while it lasts.
+ */
+@Composable
+private fun PanelIcon(
+    icon: String,
+    tooltip: String,
+    enabled: Boolean = true,
+    active: Boolean = false,
+    forcedTooltip: String? = null,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    // Touch has no hover: a long press is how a phone asks what a button is.
+    var pressedLong by remember { mutableStateOf(false) }
+    LaunchedEffect(pressedLong) {
+        if (pressedLong) {
+            delay(SHOT_NOTE_MS)
+            pressedLong = false
+        }
+    }
+
+    Box(
+        Modifier.size(PANEL_ICON_BOX).clip(RoundedCornerShape(7.dp))
+            .background(
+                when {
+                    active -> Skerry.colors.cyan10
+                    hovered -> Skerry.colors.hover
+                    else -> Color.Transparent
+                },
+            )
+            .hoverable(interaction, enabled = enabled)
+            .pointerInput(enabled) {
+                detectTapGestures(
+                    onLongPress = { pressedLong = true },
+                    onTap = { if (enabled) onClick() },
+                )
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym(
+            icon,
+            size = 18.sp,
+            color = when {
+                !enabled -> Skerry.colors.faint
+                active -> Skerry.colors.cyanBright
+                else -> Skerry.colors.dim
+            },
+        )
+        val shown = forcedTooltip ?: tooltip.takeIf { hovered || pressedLong }
+        if (shown != null) HoverTooltip(shown)
+    }
+}
+
+/**
+ * A menu hung off a button of the strip, opening to its left. The shared [app.skerry.ui.design.AnchoredDropdown]
+ * drops straight down from the anchor's left edge, which against the right screen edge would put the
+ * menu off-screen.
+ */
+@Composable
+private fun PanelPopup(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onToggle: () -> Unit,
+    trigger: @Composable (toggle: () -> Unit) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    // A press on the button of an open menu dismisses the popup and then reaches the button, which
+    // would open it straight back up. See [PopupToggleGuard].
+    val guard = remember { PopupToggleGuard() }
+    val gap = with(LocalDensity.current) { 6.dp.roundToPx() }
+    val position = remember(gap) {
+        object : PopupPositionProvider {
+            override fun calculatePosition(
+                anchorBounds: IntRect,
+                windowSize: IntSize,
+                layoutDirection: LayoutDirection,
+                popupContentSize: IntSize,
+            ): IntOffset {
+                val left = anchorBounds.left - popupContentSize.width - gap
+                return IntOffset(
+                    // Falls back to the right of the anchor on a window too narrow for either side,
+                    // where a negative x would clip the menu against the window edge.
+                    x = if (left >= 0) left else (anchorBounds.right + gap).coerceAtMost(
+                        (windowSize.width - popupContentSize.width).coerceAtLeast(0),
+                    ),
+                    y = anchorBounds.top.coerceAtMost(
+                        (windowSize.height - popupContentSize.height).coerceAtLeast(0),
+                    ),
+                )
+            }
+        }
+    }
+    Box {
+        trigger { if (guard.opensOnClick()) onToggle() }
+        if (expanded) {
+            Popup(
+                popupPositionProvider = position,
+                onDismissRequest = {
+                    guard.onDismissed()
+                    onDismiss()
+                },
+                // Focusable would take the keyboard off the remote surface, and remote typing would
+                // die until the user clicked the picture again.
+                properties = PopupProperties(focusable = false),
+            ) {
+                Box(
+                    Modifier.width(MENU_WIDTH).clip(RoundedCornerShape(9.dp)).background(Skerry.colors.surfaceDeep)
+                        .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(9.dp)).padding(vertical = 4.dp),
+                ) { content() }
+            }
+        }
+    }
+}
+
+/** The settings that used to live in the floating gear, now behind the strip's gear. */
+@Composable
+private fun SettingsMenu(screen: RemoteDesktopScreenState, showResetZoom: Boolean) {
+    Column(Modifier.fillMaxWidth()) {
+        if (screen.capabilities.adjustableQuality) {
+            Txt(
+                stringResource(Res.string.vnc_quality),
+                color = Skerry.colors.faint,
+                size = 10.5.sp,
+                modifier = Modifier.padding(start = 12.dp, top = 6.dp, bottom = 2.dp),
+            )
+            RemoteDesktopQuality.entries.forEach { q ->
+                MenuRow(q.label(), selected = screen.quality == q) { screen.applyQuality(q) }
+            }
+            HLine(modifier = Modifier.padding(vertical = 4.dp))
+        }
+        CheckRow(stringResource(Res.string.vnc_view_only), screen.viewOnly, screen::toggleViewOnly)
+        // Only offered once the server has said it accepts a resize request.
+        if (screen.canResizeRemote) {
+            CheckRow(stringResource(Res.string.vnc_resize_to_window), screen.remoteResize, screen::toggleRemoteResize)
+        }
+        if (screen.capabilities.audio) {
+            CheckRow(stringResource(Res.string.rd_audio), !screen.audioMuted, screen::toggleAudioMuted)
+        }
+        if (screen.capabilities.clipboard) {
+            CheckRow(stringResource(Res.string.rd_clipboard_share), screen.clipboardShared, screen::toggleClipboardShared)
+        }
+        if (showResetZoom) {
+            MenuRow(stringResource(Res.string.vnc_reset_zoom), selected = false) { screen.resetZoom() }
+        }
+    }
+}
+
+/** What the remote machine last put on its clipboard, and the two ways to move text across. */
+@Composable
+private fun ClipboardMenu(
+    screen: RemoteDesktopScreenState,
+    onCopyHere: (String) -> Unit,
+    onSendMine: () -> Unit,
+) {
+    val remote = screen.serverClipboard
+    Column(
+        Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Txt(stringResource(Res.string.rd_clipboard_from_remote), color = Skerry.colors.faint, size = 10.sp)
+        Txt(
+            remote?.take(CLIPBOARD_PREVIEW) ?: stringResource(Res.string.rd_clipboard_empty),
+            color = if (remote == null) Skerry.colors.dim else Skerry.colors.text,
+            size = 11.5.sp,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+            if (remote != null) SmallButton(stringResource(Res.string.rd_clipboard_copy_here)) { onCopyHere(remote) }
+            SmallButton(stringResource(Res.string.rd_clipboard_send), onClick = onSendMine)
+        }
+    }
+}
+
+@Composable
+private fun SmallButton(label: String, onClick: () -> Unit) {
+    Box(
+        Modifier.clip(RoundedCornerShape(6.dp)).background(Skerry.colors.surfaceDeep)
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick).padding(horizontal = 8.dp, vertical = 5.dp),
+    ) {
+        Txt(label, color = Skerry.colors.cyanBright, size = 11.sp)
+    }
+}
+
+@Composable
+private fun MenuRow(label: String, selected: Boolean, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
+            .clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(label, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
+        if (selected) Sym("check", size = 14.sp, color = Skerry.colors.cyanBright)
+    }
+}
+
+@Composable
+private fun CheckRow(label: String, checked: Boolean, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Sym(
+            if (checked) "check_box" else "check_box_outline_blank",
+            size = 15.sp,
+            color = if (checked) Skerry.colors.cyanBright else Skerry.colors.dim,
+        )
+        Txt(label, color = if (checked) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
+    }
+}
+
+private val PANEL_ICON_BOX = 34.dp
+private val MENU_WIDTH = 220.dp
+private const val CLIPBOARD_PREVIEW = 400
+private const val SHOT_NOTE_MS = 2500L

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.unit.IntSize
 import app.skerry.shared.graphics.RemoteDesktopQuality
 import app.skerry.shared.graphics.RemoteDesktopSession
@@ -168,6 +169,44 @@ class RemoteDesktopScreenState(
         }
     }
 
+    /** Sound from the remote machine is silenced locally; the channel itself stays open. */
+    var audioMuted by mutableStateOf(false)
+        private set
+
+    fun toggleAudioMuted() {
+        audioMuted = !audioMuted
+        send { session.setAudioMuted(audioMuted) }
+    }
+
+    /**
+     * Whether the clipboard travels at all. Enforced here rather than on the channel: both protocols
+     * settle their clipboard at connect time, so this is the only place a running session can stop
+     * text from crossing — in either direction, since the risk is symmetric.
+     */
+    var clipboardShared by mutableStateOf(true)
+        private set
+
+    fun toggleClipboardShared() {
+        clipboardShared = !clipboardShared
+        // Text that crossed while sharing was on is retracted with the switch: leaving it on screen
+        // would keep offering the remote machine's clipboard after the user said it should stay there.
+        if (!clipboardShared) serverClipboard = null
+    }
+
+    /**
+     * The secure attention sequence. It cannot be typed: the local OS takes Ctrl+Alt+Del for itself
+     * before any application sees it, which is the entire point of the sequence — so on the remote
+     * machine it can only arrive as keys the client synthesizes.
+     */
+    fun sendCtrlAltDel() {
+        if (viewOnly) return
+        val keys = CTRL_ALT_DEL.mapNotNull { remoteKeyEvent(it, 0) }
+        send {
+            keys.forEach { session.sendKey(it, down = true) }
+            keys.asReversed().forEach { session.sendKey(it, down = false) }
+        }
+    }
+
     /** True once the session has closed (server drop / EOF); the controller reacts to this. */
     var closed by mutableStateOf(false)
         private set
@@ -238,7 +277,7 @@ class RemoteDesktopScreenState(
             // server to its own screen, which is what the user sees.
             is RemoteDesktopUpdate.CursorPosition -> Unit
             is RemoteDesktopUpdate.CursorVisible -> if (!update.visible) cursor = null
-            is RemoteDesktopUpdate.ClipboardText -> {
+            is RemoteDesktopUpdate.ClipboardText -> if (clipboardShared) {
                 serverClipboard = update.text
                 onClipboard(update.text)
             }
@@ -266,6 +305,7 @@ class RemoteDesktopScreenState(
 
     /** Send local clipboard text to the server. */
     fun onLocalClipboard(text: String) {
+        if (!clipboardShared) return
         send { session.sendClipboardText(text) }
     }
 
@@ -290,5 +330,7 @@ class RemoteDesktopScreenState(
 
     private companion object {
         const val RESIZE_DEBOUNCE_MS = 400L
+
+        val CTRL_ALT_DEL = listOf(Key.CtrlLeft, Key.AltLeft, Key.Delete)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.kt
@@ -1,0 +1,28 @@
+package app.skerry.ui.remote
+
+import androidx.compose.ui.graphics.ImageBitmap
+
+/**
+ * Writes the current remote frame to a PNG the user can find outside the app: the pictures folder on
+ * desktop, the gallery on Android. [baseName] names the file and is sanitized by the implementation.
+ *
+ * Returns where it landed, for the confirmation the panel shows, or null when it could not be
+ * written — a full disk or a revoked media permission is not worth an error dialog over a screenshot.
+ */
+expect suspend fun saveRemoteScreenshot(image: ImageBitmap, baseName: String): String?
+
+/** A file name that is safe on every platform: a host name can carry anything a URL can. */
+internal fun screenshotFileName(baseName: String, stamp: String): String {
+    // Dots are kept — a host name is mostly dots — but never two in a row, which is the one spelling
+    // that means a directory above this one.
+    val safe = baseName.map { if (it.isLetterOrDigit() || it == '-' || it == '_' || it == '.') it else '-' }
+        .joinToString("")
+        .replace("..", "-")
+        .replace(Regex("-+"), "-")
+        .trim('-', '.')
+        .take(48)
+        // Trimmed again: the cut can land on a separator and leave one dangling before the stamp.
+        .trim('-', '.')
+        .ifEmpty { "desktop" }
+    return "skerry-$safe-$stamp.png"
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -1,6 +1,8 @@
 package app.skerry.ui.vnc
 
 import app.skerry.ui.remote.remoteKeyEvent
+import app.skerry.ui.remote.PanelReopenHandle
+import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopController
 import app.skerry.ui.remote.RemoteDesktopUiState
@@ -133,9 +135,18 @@ fun VncView(state: DesktopDesignState) {
     Box(Modifier.fillMaxSize()) {
         when (val ui = vnc.uiState) {
             is RemoteDesktopUiState.Connecting -> CenterNotice("hourglass_empty", stringResource(Res.string.vnc_connecting))
-            is RemoteDesktopUiState.Connected -> Box(Modifier.fillMaxSize()) {
-                VncSurface(ui.screen)
-                Box(Modifier.align(Alignment.TopEnd)) { VncGraphicsBar(ui.screen) }
+            is RemoteDesktopUiState.Connected -> Row(Modifier.fillMaxSize()) {
+                Box(Modifier.weight(1f).fillMaxHeight()) { VncSurface(ui.screen) }
+                AnimatedVisibility(
+                    visible = !state.remotePanelHidden,
+                    enter = expandHorizontally(expandFrom = Alignment.Start),
+                    exit = shrinkHorizontally(shrinkTowards = Alignment.Start),
+                ) { RemoteDesktopPanel(ui.screen, onHide = state::toggleRemotePanel) }
+                AnimatedVisibility(
+                    visible = state.remotePanelHidden,
+                    enter = fadeIn() + expandHorizontally(expandFrom = Alignment.End),
+                    exit = fadeOut() + shrinkHorizontally(shrinkTowards = Alignment.End),
+                ) { PanelReopenHandle(onClick = state::toggleRemotePanel) }
             }
             is RemoteDesktopUiState.Error -> CenterNotice(
                 "error",
@@ -336,50 +347,6 @@ private fun DrawScope.drawCursor(screen: RemoteDesktopScreenState, sprite: VncCu
     )
 }
 
-/**
- * Compact graphics-settings control in the corner of a live VNC tab: a gear that opens a menu for
- * image quality (Auto/Low/Medium/High → [RemoteDesktopScreenState.setQuality]), view-only, and reset zoom.
- */
-@Composable
-private fun VncGraphicsBar(screen: RemoteDesktopScreenState) {
-    var open by remember { mutableStateOf(false) }
-    Box(Modifier.padding(8.dp)) {
-        AnchoredDropdown(
-            expanded = open,
-            onDismiss = { open = false },
-            // The menu must not steal the keyboard from the VNC surface — remote typing would die
-            // until the user clicks the picture again.
-            focusable = false,
-            trigger = {
-                Box(
-                    Modifier.clip(RoundedCornerShape(8.dp)).background(Color.Black.copy(alpha = 0.45f))
-                        .clickable { open = !open }.padding(7.dp),
-                ) { Sym("tune", size = 18.sp, color = Skerry.colors.text) }
-            },
-            menu = { width ->
-                Column(
-                    Modifier.width(width.coerceAtLeast(180.dp)).clip(RoundedCornerShape(9.dp))
-                        .background(Skerry.colors.surfaceDeep).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(9.dp)).padding(vertical = 4.dp),
-                ) {
-                    Txt(stringResource(Res.string.vnc_quality), color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.padding(start = 12.dp, top = 6.dp, bottom = 2.dp))
-                    RemoteDesktopQuality.entries.forEach { q ->
-                        VncMenuRow(q.label(), selected = screen.quality == q) { screen.applyQuality(q) }
-                    }
-                    HLine(modifier = Modifier.padding(vertical = 4.dp))
-                    // No "Reset zoom" here: desktop has no local zoom (the wheel scrolls the remote
-                    // desktop instead), so the fit is always 1:1 and the control would be a no-op.
-                    // Mobile keeps it — pinch-zoom is real there.
-                    VncMenuRow(stringResource(Res.string.vnc_view_only), selected = screen.viewOnly, icon = if (screen.viewOnly) "check_box" else "check_box_outline_blank") { screen.toggleViewOnly() }
-                    // Only offered once the server has said it accepts SetDesktopSize.
-                    if (screen.canResizeRemote) {
-                        VncMenuRow(stringResource(Res.string.vnc_resize_to_window), selected = screen.remoteResize, icon = if (screen.remoteResize) "check_box" else "check_box_outline_blank") { screen.toggleRemoteResize() }
-                    }
-                }
-            },
-        )
-    }
-}
-
 /** Localized label for a quality level in the graphics menu (shared with the mobile VNC screen). */
 @Composable
 internal fun RemoteDesktopQuality.label(): String = stringResource(
@@ -390,20 +357,6 @@ internal fun RemoteDesktopQuality.label(): String = stringResource(
         RemoteDesktopQuality.High -> Res.string.vnc_quality_high
     },
 )
-
-@Composable
-private fun VncMenuRow(label: String, selected: Boolean, icon: String? = null, onClick: () -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent).clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        if (icon != null) Sym(icon, size = 15.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim)
-        Txt(label, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
-        if (selected && icon == null) Sym("check", size = 14.sp, color = Skerry.colors.cyanBright)
-    }
-}
 
 @Composable
 private fun CenterNotice(icon: String, message: String, color: Color = Skerry.colors.dim) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
@@ -692,4 +692,16 @@ class DesktopDesignStateTest {
         s.dismissGroupDialog()
         assertEquals(null, s.groupDialog)
     }
+    @Test
+    fun the_remote_desktop_panel_hides_and_comes_back() {
+        val s = DesktopDesignState()
+
+        assertFalse(s.remotePanelHidden)
+        s.toggleRemotePanel()
+        assertTrue(s.remotePanelHidden)
+        // Independent of the hosts sidebar: they are different edges of the same screen.
+        assertFalse(s.sidebarHidden)
+        s.toggleRemotePanel()
+        assertFalse(s.remotePanelHidden)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/FakeRemoteDesktop.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/FakeRemoteDesktop.kt
@@ -24,11 +24,19 @@ open class FakeRemoteDesktop(
     val visibility = mutableListOf<Boolean>()
     var closed = false
 
+    val audioMutes = mutableListOf<Boolean>()
+
     override val capabilities = RemoteDesktopCapabilities(
         adjustableQuality = true,
         remoteResize = true,
         cursorHandover = true,
+        audio = true,
+        clipboard = true,
     )
+
+    override suspend fun setAudioMuted(muted: Boolean) {
+        audioMutes += muted
+    }
 
     override suspend fun sendPointer(x: Int, y: Int, buttonMask: Int) {
         pointers += Triple(x, y, buttonMask)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/PopupToggleGuardTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/PopupToggleGuardTest.kt
@@ -1,0 +1,52 @@
+package app.skerry.ui.remote
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TestTimeSource
+
+class PopupToggleGuardTest {
+
+    @Test
+    fun the_click_that_dismissed_the_popup_does_not_reopen_it() {
+        val time = TestTimeSource()
+        val guard = PopupToggleGuard(time)
+
+        // What one press on an open menu's button really is: the popup takes the click as an outside
+        // click and dismisses, then the same click lands on the button.
+        guard.onDismissed()
+        time += 5.milliseconds
+
+        assertFalse(guard.opensOnClick())
+    }
+
+    @Test
+    fun a_later_click_opens_the_popup_again() {
+        val time = TestTimeSource()
+        val guard = PopupToggleGuard(time)
+
+        guard.onDismissed()
+        time += 500.milliseconds
+
+        assertTrue(guard.opensOnClick())
+    }
+
+    @Test
+    fun a_click_with_no_dismissal_behind_it_always_opens() {
+        val guard = PopupToggleGuard(TestTimeSource())
+
+        assertTrue(guard.opensOnClick())
+    }
+
+    @Test
+    fun the_guard_only_swallows_one_click() {
+        val time = TestTimeSource()
+        val guard = PopupToggleGuard(time)
+
+        guard.onDismissed()
+        assertFalse(guard.opensOnClick())
+        // The next press is the user asking for the menu again, however fast they were.
+        assertTrue(guard.opensOnClick())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
@@ -77,6 +77,108 @@ class RemoteDesktopScreenStateTest {
     }
 
     @Test
+    fun muting_the_session_reaches_the_protocol() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop()
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        assertFalse(screen.audioMuted)
+        screen.toggleAudioMuted()
+        assertTrue(screen.audioMuted)
+        screen.toggleAudioMuted()
+
+        assertEquals(listOf(true, false), session.audioMutes)
+        scope.cancel()
+    }
+
+    @Test
+    fun unshared_clipboard_moves_in_neither_direction() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val session = FakeRemoteDesktop(updates = updates)
+        val pasted = mutableListOf<String>()
+        val screen = RemoteDesktopScreenState(session, scope, onClipboard = { pasted += it })
+
+        screen.toggleClipboardShared()
+        screen.onLocalClipboard("secret")
+        updates.emit(RemoteDesktopUpdate.ClipboardText("from the server"))
+
+        assertTrue(session.clipboard.isEmpty())
+        assertTrue(pasted.isEmpty())
+        // Nothing of the remote clipboard is kept either — the panel would otherwise show text the
+        // user has just said should not leave the remote machine.
+        assertNull(screen.serverClipboard)
+        scope.cancel()
+    }
+
+    @Test
+    fun ctrl_alt_del_presses_all_three_and_releases_them_in_reverse() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop()
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.sendCtrlAltDel()
+
+        assertEquals(6, session.keys.size)
+        assertEquals(listOf(true, true, true, false, false, false), session.keys.map { it.second })
+        val down = session.keys.take(3).map { it.first.scancode }
+        assertEquals(down, session.keys.drop(3).map { it.first.scancode }.reversed())
+        // The delete key is the extended one on the keypad-less block; without the flag the remote
+        // driver reads it as the keypad's period and the secure attention sequence never fires.
+        assertTrue(session.keys.first { it.first.scancode == DELETE_SCANCODE }.first.extended)
+        scope.cancel()
+    }
+
+    @Test
+    fun view_only_swallows_ctrl_alt_del() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop()
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.toggleViewOnly()
+        screen.sendCtrlAltDel()
+
+        assertTrue(session.keys.isEmpty())
+        scope.cancel()
+    }
+
+    @Test
+    fun sharing_the_clipboard_again_lets_text_cross_once_more() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val session = FakeRemoteDesktop(updates = updates)
+        val pasted = mutableListOf<String>()
+        val screen = RemoteDesktopScreenState(session, scope, onClipboard = { pasted += it })
+
+        screen.toggleClipboardShared()
+        screen.toggleClipboardShared()
+        screen.onLocalClipboard("mine")
+        updates.emit(RemoteDesktopUpdate.ClipboardText("theirs"))
+
+        assertEquals("mine", session.clipboard.single())
+        assertEquals("theirs", pasted.single())
+        assertEquals("theirs", screen.serverClipboard)
+        scope.cancel()
+    }
+
+    @Test
+    fun turning_sharing_off_retracts_the_text_that_already_crossed() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(updates = updates), scope)
+
+        updates.emit(RemoteDesktopUpdate.ClipboardText("from the server"))
+        assertEquals("from the server", screen.serverClipboard)
+
+        screen.toggleClipboardShared()
+
+        // Otherwise the panel keeps offering the remote machine's clipboard after the user said it
+        // should stay there.
+        assertNull(screen.serverClipboard)
+        scope.cancel()
+    }
+
+    @Test
     fun cursor_shape_becomes_a_sprite_and_an_empty_one_clears_it() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
@@ -262,5 +364,9 @@ class RemoteDesktopScreenStateTest {
         updates.emit(RemoteDesktopUpdate.ClipboardText("copied"))
         assertEquals("copied", received.single())
         scope.cancel()
+    }
+
+    private companion object {
+        const val DELETE_SCANCODE = 0x53
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteScreenshotNameTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteScreenshotNameTest.kt
@@ -1,0 +1,34 @@
+package app.skerry.ui.remote
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RemoteScreenshotNameTest {
+
+    @Test
+    fun a_host_name_becomes_a_file_name() {
+        assertEquals("skerry-web-01.lan-20260729-101500.png", screenshotFileName("web-01.lan", "20260729-101500"))
+    }
+
+    @Test
+    fun path_separators_and_spaces_cannot_escape_the_name() {
+        val name = screenshotFileName("../../etc/passwd desktop", "1")
+        assertTrue('/' !in name && ' ' !in name, name)
+        assertEquals("skerry-etc-passwd-desktop-1.png", name)
+    }
+
+    @Test
+    fun a_long_name_is_cut_without_leaving_a_dangling_separator() {
+        // The cut lands on the dash this name is padded with; a name ending in one would read as
+        // "skerry-host--20260729-101500.png".
+        val name = screenshotFileName("host" + "-x".repeat(40), "1")
+        assertTrue(name.length <= "skerry-".length + 48 + "-1.png".length, name)
+        assertTrue("--" !in name && "-." !in name, name)
+    }
+
+    @Test
+    fun a_nameless_desktop_still_gets_a_file() {
+        assertEquals("skerry-desktop-1.png", screenshotFileName("///", "1"))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.desktop.kt
@@ -1,0 +1,53 @@
+package app.skerry.ui.remote
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asSkiaBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.skia.EncodedImageFormat
+import org.jetbrains.skia.Image
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * Writes the frame into the user's pictures folder under `Skerry/`, falling back to the home
+ * directory on a system that has no such folder (a headless Linux box has none).
+ */
+actual suspend fun saveRemoteScreenshot(image: ImageBitmap, baseName: String): String? = withContext(Dispatchers.IO) {
+    val png = try {
+        Image.makeFromBitmap(image.asSkiaBitmap()).encodeToData(EncodedImageFormat.PNG)?.bytes
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
+        null
+    } ?: return@withContext null
+
+    val stamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+    val file = pictureDir().resolve(screenshotFileName(baseName, stamp))
+    try {
+        Files.createDirectories(file.parent)
+        Files.write(file, png)
+        file.toString()
+    } catch (e: CancellationException) {
+        // A write cut short leaves however many bytes reached the disk; a half-written PNG under a
+        // name that says "screenshot" is worse than no file at all.
+        deleteQuietly(file)
+        throw e
+    } catch (_: Exception) {
+        deleteQuietly(file)
+        null
+    }
+}
+
+private fun deleteQuietly(file: Path) {
+    runCatching { Files.deleteIfExists(file) }
+}
+
+private fun pictureDir(): Path {
+    val home = Path.of(System.getProperty("user.home").orEmpty().ifEmpty { "." })
+    val pictures = home.resolve("Pictures")
+    return if (Files.isDirectory(pictures)) pictures.resolve("Skerry") else home.resolve("Skerry")
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/RemoteScreenshotDesktopTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/RemoteScreenshotDesktopTest.kt
@@ -1,0 +1,71 @@
+package app.skerry.ui.remote
+
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.test.runTest
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.readBytes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** The desktop half of the screenshot button: a real PNG under the user's pictures folder. */
+class RemoteScreenshotDesktopTest {
+
+    @Test
+    fun the_frame_lands_in_the_pictures_folder_as_a_png() = runTest {
+        withHome { home ->
+            home.resolve("Pictures").createDirectories()
+
+            val path = saveRemoteScreenshot(ImageBitmap(4, 3), "win-01.lan")
+
+            assertTrue(path != null && path.endsWith(".png"), "no file was written: $path")
+            val file = Path.of(path!!)
+            assertTrue(file.startsWith(home.resolve("Pictures").resolve("Skerry")), path)
+            // Written, not just named: the first eight bytes are the PNG signature.
+            assertEquals(PNG_MAGIC.toList(), file.readBytes().take(PNG_MAGIC.size).toList())
+        }
+    }
+
+    @Test
+    fun a_home_without_a_pictures_folder_still_gets_the_file() = runTest {
+        withHome { home ->
+            val path = saveRemoteScreenshot(ImageBitmap(2, 2), "desk")
+
+            assertTrue(path != null && Path.of(path).startsWith(home.resolve("Skerry")), "$path")
+        }
+    }
+
+    @Test
+    fun an_unwritable_target_answers_null_instead_of_throwing() = runTest {
+        withHome { home ->
+            // A regular file where the Skerry directory should go: createDirectories fails, and a
+            // screenshot is not worth an exception escaping into the UI.
+            Files.createFile(home.resolve("Skerry"))
+
+            assertNull(saveRemoteScreenshot(ImageBitmap(2, 2), "desk"))
+            // And nothing half-written is left behind under it.
+            assertTrue(home.listDirectoryEntries().none { it.fileName.toString().startsWith("skerry-") })
+        }
+    }
+
+    private inline fun withHome(body: (Path) -> Unit) {
+        val previous = System.getProperty("user.home")
+        val home = Files.createTempDirectory("skerry-shot")
+        System.setProperty("user.home", home.toString())
+        try {
+            body(home)
+        } finally {
+            if (previous != null) System.setProperty("user.home", previous) else System.clearProperty("user.home")
+            home.toFile().deleteRecursively()
+        }
+    }
+
+    private companion object {
+        val PNG_MAGIC = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
@@ -55,6 +55,9 @@ interface RemoteDesktopSession {
     /** Tell the server whether anyone is looking; a hidden window need not be rendered. */
     suspend fun setOutputVisible(visible: Boolean)
 
+    /** Silence the sound coming from the remote machine, or let it through; no-op without audio. */
+    suspend fun setAudioMuted(muted: Boolean)
+
     /** Close the session. Idempotent. */
     suspend fun close()
 }
@@ -70,6 +73,10 @@ data class RemoteDesktopCapabilities(
     val remoteResize: Boolean,
     /** The cursor can be handed back and forth between client and server. */
     val cursorHandover: Boolean,
+    /** The session carries sound, so muting it means something (RDP with a device; never RFB). */
+    val audio: Boolean = false,
+    /** The session carries a clipboard, so sharing it can be turned off mid-session. */
+    val clipboard: Boolean = true,
 )
 
 /** Quality preference, where the protocol has one. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/AudioChannel.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/AudioChannel.kt
@@ -104,6 +104,18 @@ class AudioChannel(
         for (block in queue) player.play(block.format, block.pcm)
     }
 
+    /**
+     * Silence the session's sound without touching the channel: blocks keep being parsed and
+     * confirmed, they just never reach the device. Dropping the channel instead would be a one-way
+     * door — the server opens `rdpsnd` from the connection request, so a session that closed it
+     * could not get its sound back without reconnecting.
+     */
+    fun setMuted(value: Boolean) {
+        muted = value
+        // What is already queued was recorded before the mute and would play after it.
+        if (value) stop()
+    }
+
     /** Stop playback and release the device; [play] returns. Idempotent. */
     fun close() {
         queue.close()
@@ -213,6 +225,7 @@ class AudioChannel(
     }
 
     private fun enqueue(format: RemoteAudioFormat?, pcm: ByteArray) {
+        if (muted) return
         if (format == null || pcm.isEmpty()) {
             trace("dropped a block of ${pcm.size} bytes in an unknown format")
             return
@@ -222,6 +235,10 @@ class AudioChannel(
     }
 
     private var blocksQueued = 0
+
+    // Set from the UI thread, read on the read loop.
+    @kotlin.concurrent.Volatile
+    private var muted = false
 
     /** The server closed the stream: what is still queued belongs to sound nobody will hear. */
     private fun stop() {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
@@ -41,6 +41,10 @@ class RdpRemoteDesktop(
         adjustableQuality = false,
         remoteResize = true,
         cursorHandover = false,
+        // Both were settled by the connection request: a session that did not ask for sound has no
+        // device to mute, and one that did not ask for the clipboard has no channel to share.
+        audio = session.audioAvailable,
+        clipboard = session.clipboardAvailable,
     )
 
     override val updates: Flow<RemoteDesktopUpdate> = session.updates.map { update ->
@@ -126,6 +130,8 @@ class RdpRemoteDesktop(
     override suspend fun setLocalCursor(enabled: Boolean) = Unit
 
     override suspend fun setOutputVisible(visible: Boolean) = session.setOutputVisible(visible)
+
+    override suspend fun setAudioMuted(muted: Boolean) = session.setAudioMuted(muted)
 
     override suspend fun close() = session.close()
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
@@ -137,6 +137,18 @@ interface RdpSession {
     /** Send text to the remote clipboard. */
     suspend fun sendClipboardText(text: String)
 
+    /** Whether this session has sound at all: false when no device was opened for it. */
+    val audioAvailable: Boolean
+
+    /** Whether the clipboard channel was asked for at connect time. */
+    val clipboardAvailable: Boolean
+
+    /**
+     * Silence the session's sound, or let it through again. The channel stays open either way — the
+     * server opens it from the connection request, so closing it could not be undone mid-session.
+     */
+    fun setAudioMuted(muted: Boolean)
+
     /** Close the connection. Idempotent. */
     suspend fun close()
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vnc/VncRemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vnc/VncRemoteDesktop.kt
@@ -25,6 +25,9 @@ class VncRemoteDesktop(private val session: VncSession) : RemoteDesktopSession {
         adjustableQuality = true,
         remoteResize = true,
         cursorHandover = true,
+        // RFB carries no sound.
+        audio = false,
+        clipboard = true,
     )
 
     override val updates: Flow<RemoteDesktopUpdate> = session.updates.map { update ->
@@ -75,6 +78,9 @@ class VncRemoteDesktop(private val session: VncSession) : RemoteDesktopSession {
 
     /** RFB has no way to say "nobody is looking"; an idle client simply stops asking for updates. */
     override suspend fun setOutputVisible(visible: Boolean) = Unit
+
+    /** RFB has no audio channel; there is nothing to silence. */
+    override suspend fun setAudioMuted(muted: Boolean) = Unit
 
     override suspend fun close() = session.close()
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/AudioChannelTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/AudioChannelTest.kt
@@ -162,6 +162,53 @@ class AudioChannelTest {
         assertEquals(PCM_44_STEREO, player.played.single().first)
     }
 
+    @Test
+    fun `muted sound never reaches the device, and what was queued is dropped`() = runTest {
+        negotiate()
+        val playback = launch { channel.play() }
+
+        channel.setMuted(true)
+        channel.receive(wave2(timestamp = 3, formatNo = 0, blockNo = 1, samples = ByteArray(8) { 1 }))
+        advanceUntilIdle()
+        playback.cancel()
+
+        assertTrue(player.played.isEmpty())
+        assertEquals(1, player.flushes)
+        // The server allows only a few unconfirmed blocks: a muted client that stopped confirming
+        // would be a client the server stops sending to, and unmuting would then stay silent.
+        assertEquals(SNDC_WAVECONFIRM, typeOf(sent.single()))
+    }
+
+    @Test
+    fun `unmuting lets the next block through`() = runTest {
+        negotiate()
+        val playback = launch { channel.play() }
+
+        channel.setMuted(true)
+        channel.receive(wave2(timestamp = 3, formatNo = 0, blockNo = 1, samples = ByteArray(8) { 1 }))
+        channel.setMuted(false)
+        channel.receive(wave2(timestamp = 4, formatNo = 0, blockNo = 2, samples = ByteArray(8) { 2 }))
+        advanceUntilIdle()
+        playback.cancel()
+
+        assertContentEquals(ByteArray(8) { 2 }, player.played.single().second)
+    }
+
+    @Test
+    fun `muting drops what was already queued, or the mute would play out first`() = runTest {
+        negotiate()
+
+        // Queued while unmuted and not yet handed to the device: playback starts after the mute.
+        channel.receive(wave2(timestamp = 1, formatNo = 0, blockNo = 1, samples = ByteArray(8) { 1 }))
+        channel.setMuted(true)
+        val playback = launch { channel.play() }
+        advanceUntilIdle()
+        playback.cancel()
+
+        assertTrue(player.played.isEmpty())
+        assertEquals(1, player.flushes)
+    }
+
     /** Settle on the two formats the wave tests index into. */
     private suspend fun negotiate() {
         channel.receive(serverFormats(version = 6, formats = listOf(PCM_44_STEREO, PCM_22_MONO_8BIT)))

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -396,6 +396,18 @@ class RdpSocketSession(
     override suspend fun sendClipboardText(text: String) =
         withContext(Dispatchers.IO) { clipboard.offerText(text) }
 
+    // Both halves have to hold: a device opened here, and a channel the server granted. Either one
+    // alone leaves a switch with nothing behind it.
+    override val audioAvailable: Boolean = audioPlayer != null && state.channels[RdpClientSettings.CHANNEL_AUDIO] != null
+
+    // What the server actually granted, not what was asked for: a host that refused the channel
+    // leaves a toggle that could only ever report "off".
+    override val clipboardAvailable: Boolean = state.channels[RdpClientSettings.CHANNEL_CLIPBOARD] != null
+
+    override fun setAudioMuted(muted: Boolean) {
+        audio?.setMuted(muted)
+    }
+
     override suspend fun close() = withContext(Dispatchers.IO) {
         // Ask the server to end the session before dropping the socket, so it tears the session
         // down instead of leaving it disconnected-but-alive for the next logon to inherit.


### PR DESCRIPTION
A live VNC or RDP session gets a panel of its own at the right edge, in place of the gear that floated over the picture. It hides and reopens like the hosts sidebar, and is a strip of icons — each names itself on hover, or on a long press on a touch screen.

**Screenshot** — the current frame as a PNG. Desktop writes it to `~/Pictures/Skerry`; Android 10+ puts it in the gallery under `Pictures/Skerry` through MediaStore, and 8–9 into the app's own pictures directory, where no storage permission is needed. The file name comes from the desktop's name, which the server supplies, so it is sanitized to what is safe on both platforms. Where it landed is shown on the button and fades.

**Ctrl+Alt+Del** — synthesized by the client. The local OS takes the sequence before any application sees it, so on the remote machine it can only arrive as keys sent deliberately. Not offered in view-only mode.

**Clipboard** — what the remote machine last copied, with a button to take it here and one to send the local clipboard across.

**Settings that apply to the running session.** Quality, view-only and resize-to-window moved into a menu behind the panel's gear, joined by two that could previously only be chosen before connecting:

- *Sound* is silenced locally. The `rdpsnd` channel stays open and keeps confirming blocks — a server allows only a few unconfirmed ones and stops sending to a client that goes quiet, and the channel is opened from the connection request, so closing it could not be undone mid-session. Blocks already queued are dropped, or the mute would play itself out first.
- *Share the clipboard* stops text in both directions and retracts what already crossed.

Both are offered only where the protocol carries them and the server granted the channel; on VNC there is no sound to mute, and an RDP host that refused `cliprdr` gets no clipboard button.

The two menus open to the left of the strip, and the press that dismisses one no longer reopens it on the way back to the button.

## Tests

Audio mute (dropped but confirmed, unmute resumes, a queued block is dropped by the mute), the clipboard gate in both directions including re-enabling and retraction, Ctrl+Alt+Del ordering and the extended flag on Delete, view-only swallowing it, screenshot name sanitizing, the desktop screenshot writing a real PNG (and answering null rather than throwing on an unwritable path), the reopen guard on a test time source, and the panel's hide toggle.