### PR TITLE
RDP: verify the licensing MAC and the Proprietary Certificate signature

### DIFF
--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ConstantTime.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ConstantTime.kt
@@ -1,0 +1,13 @@
+package app.skerry.shared.rdp
+
+/**
+ * Compare two byte strings without leaking where they first differ. Every MAC and signature the RDP
+ * stack checks goes through this: `contentEquals` bails on the first mismatch, and that timing is
+ * what lets an attacker walk a forgery byte by byte.
+ */
+internal fun constantTimeEquals(a: ByteArray, b: ByteArray): Boolean {
+    if (a.size != b.size) return false
+    var diff = 0
+    for (i in a.indices) diff = diff or (a[i].toInt() xor b[i].toInt())
+    return diff == 0
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/LicenseExchange.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/LicenseExchange.kt
@@ -63,7 +63,8 @@ class LicenseExchange(
      * Answer a Server Platform Challenge. The challenge itself is opaque — it is decrypted only to
      * be handed back inside the response, which is what proves the client derived the same keys.
      *
-     * @throws RdpProtocolException the challenge arrived before the licence request that keys it
+     * @throws RdpProtocolException the challenge arrived before the licence request that keys it,
+     *   or its MAC does not cover the challenge that arrived with it
      */
     fun platformChallengeResponse(reader: RdpReader): ByteArray {
         if (licensingEncryptionKey.isEmpty()) {
@@ -71,9 +72,15 @@ class LicenseExchange(
         }
         reader.u32le() // ConnectFlags, reserved
         val encryptedChallenge = readBlob(reader)
-        // MACData follows; the server's own MAC is not verified — it protects against a tampered
-        // challenge, and a wrong one already fails the exchange one message later.
+        val serverMac = reader.bytes(MAC_SIZE)
         val challenge = Rc4(licensingEncryptionKey).process(encryptedChallenge)
+        // MS-RDPELE 2.2.2.4: the MAC covers the decrypted challenge. Nothing an attacker who can
+        // reach these bytes gains by flipping them — they are already inside the TLS tunnel — but a
+        // mismatch is the one signal that says the tunnel, or our own key schedule, is not what we
+        // think it is, and answering a challenge we cannot authenticate would hide it.
+        if (!constantTimeEquals(mac(challenge), serverMac)) {
+            throw RdpProtocolException("the platform challenge's MAC does not match the challenge")
+        }
 
         val responseData = RdpWriter(challenge.size + 8).apply {
             u16le(PLATFORM_CHALLENGE_VERSION)
@@ -116,17 +123,20 @@ class LicenseExchange(
         if (certificate.isEmpty()) return null
         val reader = RdpReader(certificate)
         return when (val version = reader.u32le() and CERT_CHAIN_VERSION_MASK) {
-            CERT_CHAIN_VERSION_1 -> proprietaryPublicKey(reader)
+            CERT_CHAIN_VERSION_1 -> proprietaryPublicKey(certificate, reader)
             CERT_CHAIN_VERSION_2 -> x509ChainPublicKey(reader)
             else -> throw RdpProtocolException("unknown server certificate version $version")
         }
     }
 
-    private fun proprietaryPublicKey(reader: RdpReader): RdpRsaPublicKey? {
+    private fun proprietaryPublicKey(certificate: ByteArray, reader: RdpReader): RdpRsaPublicKey? {
         reader.u32le() // dwSigAlgId
         reader.u32le() // dwKeyAlgId
         reader.u16le() // wPublicKeyBlobType
         val keyBlob = reader.slice(reader.u16le().boundedLength())
+        // Everything read so far is what the signature covers, and it is checked before the key it
+        // carries is used for anything.
+        verifyProprietarySignature(certificate.copyOfRange(0, reader.position), reader)
         if (keyBlob.u32le() != RSA1_MAGIC) return null
         val keyLength = keyBlob.u32le().boundedLength()
         keyBlob.u32le() // bitlen
@@ -138,6 +148,32 @@ class LicenseExchange(
             modulus = modulus.copyOfRange(0, (modulus.size - RSA_PADDING).coerceAtLeast(1)).reversedArray(),
             exponent = exponent.reversedArray(),
         )
+    }
+
+    /**
+     * The signature of a proprietary certificate (MS-RDPBCGR 5.3.3.1.1): MD5 over [signed], wrapped
+     * in fixed padding and RSA-signed with the Terminal Services key. Microsoft published that key's
+     * private half, so this says nothing about who the server is — it says the key blob is the one
+     * whoever wrote the certificate meant to send, which is the bit worth keeping.
+     *
+     * @throws RdpProtocolException the signature is absent, the wrong size, or over other bytes
+     */
+    private fun verifyProprietarySignature(signed: ByteArray, reader: RdpReader) {
+        reader.u16le() // wSignatureBlobType
+        val blob = reader.bytes(reader.u16le().boundedLength())
+        if (blob.size != TSSK_KEY_SIZE + RSA_PADDING || blob.copyOfRange(TSSK_KEY_SIZE, blob.size).any { it != ZERO }) {
+            throw RdpProtocolException("proprietary certificate signature of ${blob.size} bytes")
+        }
+        val value = crypto.modPow(blob.copyOfRange(0, TSSK_KEY_SIZE).reversedArray(), TSSK_EXPONENT, TSSK_MODULUS)
+            .toLittleEndianField(TSSK_KEY_SIZE)
+        // The signed value is the hash, then 0x00, then 0xFF up to a trailing 0x01 — a fixed shape
+        // that leaves an attacker who cannot produce it nowhere to hide a second hash.
+        val wellFormed = value[HASH_SIZE] == ZERO && value[SIGNATURE_TAIL] == 1.toByte() &&
+            (HASH_SIZE + 1 until SIGNATURE_TAIL).all { value[it] == 0xFF.toByte() } &&
+            constantTimeEquals(value.copyOfRange(0, HASH_SIZE), crypto.md5(signed))
+        if (!wellFormed) {
+            throw RdpProtocolException("the proprietary certificate is not signed by the Terminal Services key")
+        }
     }
 
     private fun x509ChainPublicKey(reader: RdpReader): RdpRsaPublicKey? {
@@ -154,13 +190,19 @@ class LicenseExchange(
      * reversed back into a field of the modulus' width — followed by the eight zero bytes every RDP
      * client appends.
      */
-    private fun encryptPremaster(key: RdpRsaPublicKey): ByteArray {
-        val encrypted = crypto.modPow(premasterSecret.reversedArray(), key.exponent, key.modulus)
-        val field = ByteArray(key.modulus.size)
-        // Left-pad to the modulus width (a product with leading zero bytes comes back short), then
-        // flip to little-endian.
-        encrypted.copyInto(field, (field.size - encrypted.size).coerceAtLeast(0))
-        return field.reversedArray() + ByteArray(RSA_PADDING)
+    private fun encryptPremaster(key: RdpRsaPublicKey): ByteArray =
+        crypto.modPow(premasterSecret.reversedArray(), key.exponent, key.modulus)
+            .toLittleEndianField(key.modulus.size) + ByteArray(RSA_PADDING)
+
+    /**
+     * A big-endian RSA result as the little-endian field of [width] bytes the wire carries: left-pad
+     * (a product with leading zero bytes comes back short), then flip.
+     */
+    private fun ByteArray.toLittleEndianField(width: Int): ByteArray {
+        val field = ByteArray(width)
+        val count = minOf(size, width)
+        copyInto(field, width - count, size - count, size)
+        return field.reversedArray()
     }
 
     /**
@@ -277,5 +319,31 @@ class LicenseExchange(
 
         /** Generous next to any real licensing field (a certificate chain is the largest). */
         private const val MAX_FIELD_SIZE = 16384
+
+        private const val MAC_SIZE = 16
+        private const val HASH_SIZE = 16
+        private const val ZERO = 0.toByte()
+
+        /** Width of the Terminal Services key, and so of the signature it produces. */
+        private const val TSSK_KEY_SIZE = 64
+
+        /** Where the 0x01 that closes a proprietary certificate's signature sits. */
+        private const val SIGNATURE_TAIL = 62
+
+        /**
+         * The Terminal Services signing key (MS-RDPBCGR 5.3.3.1.1), big-endian as [RdpLicenseCrypto]
+         * takes it. Its private half is published in the same section — see
+         * [verifyProprietarySignature] for what the signature is and is not worth.
+         */
+        private val TSSK_MODULUS = hex(
+            "87EA6D05 5F099320 BB61F51A 09065E6C 7D5CF63D FEBFE77C EFFE3A58 6B6563CE" +
+                "954552F2 9A6BB7D7 E2C1F5EF 8720883E CB5FBA4A 1EC1BB4D C93E4372 BD5E3A3D",
+        )
+        private val TSSK_EXPONENT = hex("C0887B5B")
+
+        private fun hex(text: String): ByteArray {
+            val digits = text.filterNot { it == ' ' }
+            return ByteArray(digits.length / 2) { digits.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/nla/NtlmSession.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/nla/NtlmSession.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.rdp.nla
 
 import app.skerry.shared.rdp.RdpProtocolException
+import app.skerry.shared.rdp.constantTimeEquals
 
 /** Which end of the exchange a session speaks as; it decides which key pair seals and which verifies. */
 enum class NtlmRole { Client, Server }
@@ -73,13 +74,6 @@ class NtlmSession(
         // With key exchange negotiated the checksum rides the same keystream as the payload.
         val sealedChecksum = seal.process(checksum)
         return byteArrayOf(1, 0, 0, 0) + sealedChecksum + sequenceBytes
-    }
-
-    private fun constantTimeEquals(a: ByteArray, b: ByteArray): Boolean {
-        if (a.size != b.size) return false
-        var diff = 0
-        for (i in a.indices) diff = diff or (a[i].toInt() xor b[i].toInt())
-        return diff == 0
     }
 
     private companion object {

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpConnectTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpConnectTest.kt
@@ -295,23 +295,18 @@ class RdpConnectTest {
             return X224.dataHeader(body.size) + body
         }
 
-        /** A Server Licence Request with a proprietary certificate wrapped around a fake RSA key. */
+        /**
+         * A Server Licence Request with an X.509 chain around a stand-in server key. The other
+         * certificate format a server may send, the proprietary one, has to carry a real Terminal
+         * Services signature, which [FakeLicenseCrypto] cannot produce — `LicenseExchangeTest`
+         * covers that form with real crypto.
+         */
         private fun licenseRequestPdu(): ByteArray {
-            val modulus = ByteArray(64) { (it + 1).toByte() }
-            val keyBlob = RdpWriter(modulus.size + 32).apply {
-                u32le(0x31415352) // "RSA1"
-                u32le(modulus.size + 8) // keylen counts the trailing padding
-                u32le(modulus.size * 8)
-                u32le(modulus.size)
-                bytes(byteArrayOf(1, 0, 1, 0)) // exponent, little-endian
-                bytes(modulus)
-                zeros(8)
-            }.toByteArray()
-            val certificate = RdpWriter(keyBlob.size + 32).apply {
-                u32le(1) // CERT_CHAIN_VERSION_1
-                u32le(0).u32le(0) // signature and key algorithm ids
-                u16le(0x0006).u16le(keyBlob.size).bytes(keyBlob)
-                u16le(0x0008).u16le(0) // empty signature blob
+            val leaf = ByteArray(48) { (it + 1).toByte() } // any bytes: the fake crypto reads a key out of them
+            val certificate = RdpWriter(leaf.size + 16).apply {
+                u32le(2) // CERT_CHAIN_VERSION_2
+                u32le(1) // one certificate in the chain: the server's own
+                u32le(leaf.size).bytes(leaf)
             }.toByteArray()
             val body = RdpWriter(certificate.size + 96).apply {
                 zeros(32) // ServerRandom

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/LicenseExchangeTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/LicenseExchangeTest.kt
@@ -9,6 +9,7 @@ import java.security.interfaces.RSAPublicKey
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
@@ -56,17 +57,10 @@ class LicenseExchangeTest {
     fun `answers a platform challenge with the decrypted challenge and a valid MAC`() {
         val exchange = LicenseExchange(crypto, logon)
         val serverRandom = ByteArray(32) { (it * 7).toByte() }
-        val request = licenseBody(exchange.newLicenseRequest(RdpReader(licenseRequest(serverRandom))), LicenseExchange.NEW_LICENSE_REQUEST)
-        request.u32le()
-        request.u32le()
-        val clientRandom = request.bytes(32)
-        val premaster = decryptPremaster(readBlob(request))
-        val keys = ServerKeys(premaster, clientRandom, serverRandom)
+        val keys = serverKeys(exchange, serverRandom)
 
         val challenge = "TEST-CHALLENGE-01".encodeToByteArray()
-        val response = exchange.platformChallengeResponse(
-            RdpReader(platformChallenge(Rc4(keys.licensingEncryptionKey).process(challenge))),
-        )
+        val response = exchange.platformChallengeResponse(RdpReader(platformChallenge(challenge, keys)))
 
         val body = licenseBody(response, LicenseExchange.PLATFORM_CHALLENGE_RESPONSE)
         val responseData = Rc4(keys.licensingEncryptionKey).process(readBlob(body))
@@ -84,6 +78,39 @@ class LicenseExchangeTest {
     }
 
     @Test
+    fun `rejects a platform challenge whose MAC does not cover the challenge`() {
+        val exchange = LicenseExchange(crypto, logon)
+        val keys = serverKeys(exchange, ByteArray(32) { (it * 5).toByte() })
+        val challenge = platformChallenge("TEST-CHALLENGE-01".encodeToByteArray(), keys)
+        challenge[challenge.size - 1] = (challenge[challenge.size - 1] + 1).toByte() // last byte of MACData
+
+        assertFailsWith<RdpProtocolException> { exchange.platformChallengeResponse(RdpReader(challenge)) }
+    }
+
+    @Test
+    fun `rejects a proprietary certificate whose public key was swapped after signing`() {
+        val exchange = LicenseExchange(crypto, logon)
+        val certificate = proprietaryCertificate()
+        // The last byte of the modulus, well inside the signed range: the swap a signature is here to catch.
+        val keyByte = certificate.size - SIGNATURE_FIELD_SIZE - 4 - 8 - 1
+        certificate[keyByte] = (certificate[keyByte] + 1).toByte()
+
+        assertFailsWith<RdpProtocolException> {
+            exchange.newLicenseRequest(RdpReader(licenseRequest(ByteArray(32), certificate)))
+        }
+    }
+
+    @Test
+    fun `rejects a proprietary certificate that carries no signature`() {
+        val exchange = LicenseExchange(crypto, logon)
+        val certificate = proprietaryCertificate(signature = { ByteArray(0) })
+
+        assertFailsWith<RdpProtocolException> {
+            exchange.newLicenseRequest(RdpReader(licenseRequest(ByteArray(32), certificate)))
+        }
+    }
+
+    @Test
     fun `the hardware id is stable across connections from the same client`() {
         // A licence server indexes issued licences by this; a random one would ask for a new licence
         // on every connect and drain the pool.
@@ -93,18 +120,25 @@ class LicenseExchangeTest {
     }
 
     private fun hardwareIdOf(exchange: LicenseExchange): ByteArray {
-        val serverRandom = ByteArray(32) { 3 }
-        val request = licenseBody(exchange.newLicenseRequest(RdpReader(licenseRequest(serverRandom))), LicenseExchange.NEW_LICENSE_REQUEST)
-        request.u32le()
-        request.u32le()
-        val clientRandom = request.bytes(32)
-        val keys = ServerKeys(decryptPremaster(readBlob(request)), clientRandom, serverRandom)
+        val keys = serverKeys(exchange, ByteArray(32) { 3 })
         val response = licenseBody(
-            exchange.platformChallengeResponse(RdpReader(platformChallenge(Rc4(keys.licensingEncryptionKey).process(ByteArray(8))))),
+            exchange.platformChallengeResponse(RdpReader(platformChallenge(ByteArray(8), keys))),
             LicenseExchange.PLATFORM_CHALLENGE_RESPONSE,
         )
         readBlob(response)
         return Rc4(keys.licensingEncryptionKey).process(readBlob(response))
+    }
+
+    /** Run the licence request past [exchange] and derive, server-side, the keys it just agreed on. */
+    private fun serverKeys(exchange: LicenseExchange, serverRandom: ByteArray): ServerKeys {
+        val request = licenseBody(
+            exchange.newLicenseRequest(RdpReader(licenseRequest(serverRandom))),
+            LicenseExchange.NEW_LICENSE_REQUEST,
+        )
+        request.u32le() // key exchange algorithm
+        request.u32le() // platform id
+        val clientRandom = request.bytes(32)
+        return ServerKeys(decryptPremaster(readBlob(request)), clientRandom, serverRandom)
     }
 
     /** The server side of MS-RDPELE 5.1.2/5.1.5, written from the specification rather than reused. */
@@ -142,8 +176,27 @@ class LicenseExchangeTest {
         }
     }
 
-    /** A Server Licence Request carrying a proprietary certificate around the test's RSA key. */
-    private fun licenseRequest(serverRandom: ByteArray): ByteArray {
+    /** A Server Licence Request carrying [certificate], by default a correctly signed proprietary one. */
+    private fun licenseRequest(serverRandom: ByteArray, certificate: ByteArray = proprietaryCertificate()): ByteArray =
+        RdpWriter(certificate.size + 128).apply {
+            bytes(serverRandom)
+            u32le(0x00040000) // ProductInfo: dwVersion
+            u32le(4)
+            bytes(byteArrayOf(1, 2, 3, 4)) // company name
+            u32le(2)
+            bytes(byteArrayOf(5, 6)) // product id
+            u16le(0x000D).u16le(4).u32le(1) // KeyExchangeList: RSA
+            u16le(0x0003).u16le(certificate.size).bytes(certificate)
+            u32le(1).u16le(0x000E).u16le(2).bytes(byteArrayOf(7, 8)) // ScopeList
+        }.toByteArray()
+
+    /**
+     * A proprietary certificate (MS-RDPBCGR 2.2.1.4.3.1.1) around the test's RSA key, signed the way
+     * a Windows server signs one. [signature] is the hook the tampering tests replace.
+     */
+    private fun proprietaryCertificate(
+        signature: (ByteArray) -> ByteArray = ::terminalServicesSignature,
+    ): ByteArray {
         val modulusLe = publicKey.modulus.toByteArray().dropSign().reversedArray()
         val exponentLe = publicKey.publicExponent.toByteArray().dropSign().reversedArray().copyOf(4)
         val keyBlob = RdpWriter(modulusLe.size + 32).apply {
@@ -155,37 +208,47 @@ class LicenseExchangeTest {
             bytes(modulusLe)
             zeros(8)
         }.toByteArray()
-        val certificate = RdpWriter(keyBlob.size + 32).apply {
+        // The signature covers everything from dwVersion to the end of the public key blob.
+        val signed = RdpWriter(keyBlob.size + 32).apply {
             u32le(1) // CERT_CHAIN_VERSION_1
-            u32le(0) // dwSigAlgId
-            u32le(0) // dwKeyAlgId
+            u32le(1) // dwSigAlgId: RSA
+            u32le(1) // dwKeyAlgId: RSA
             u16le(0x0006) // wPublicKeyBlobType
             u16le(keyBlob.size)
             bytes(keyBlob)
-            u16le(0x0008) // wSignatureBlobType
-            u16le(0)
         }.toByteArray()
-
-        return RdpWriter(certificate.size + 128).apply {
-            bytes(serverRandom)
-            u32le(0x00040000) // ProductInfo: dwVersion
-            u32le(4)
-            bytes(byteArrayOf(1, 2, 3, 4)) // company name
-            u32le(2)
-            bytes(byteArrayOf(5, 6)) // product id
-            u16le(0x000D).u16le(4).u32le(1) // KeyExchangeList: RSA
-            u16le(0x0003).u16le(certificate.size).bytes(certificate)
-            u32le(1).u16le(0x000E).u16le(2).bytes(byteArrayOf(7, 8)) // ScopeList
+        val signatureBlob = signature(signed)
+        return signed + RdpWriter(signatureBlob.size + 4).apply {
+            u16le(0x0008) // wSignatureBlobType
+            u16le(signatureBlob.size)
+            bytes(signatureBlob)
         }.toByteArray()
     }
 
-    /** A Server Platform Challenge around [encryptedChallenge] (its MAC is not checked by the client). */
-    private fun platformChallenge(encryptedChallenge: ByteArray): ByteArray =
-        RdpWriter(encryptedChallenge.size + 32).apply {
+    /**
+     * MS-RDPBCGR 5.3.3.1.1: MD5 over the certificate, then the fixed padding, then RSA with the
+     * Terminal Services private key — the one Microsoft published, which is why every client can
+     * check the signature and no client learns anything about who sent it.
+     */
+    private fun terminalServicesSignature(signed: ByteArray): ByteArray {
+        val hash = MessageDigest.getInstance("MD5").digest(signed)
+        val plain = hash + byteArrayOf(0) + ByteArray(45) { 0xFF.toByte() } + byteArrayOf(1)
+        val value = BigInteger(1, plain.reversedArray()).modPow(TSSK_PRIVATE_EXPONENT, TSSK_MODULUS)
+        val field = ByteArray(TSSK_KEY_SIZE)
+        val bigEndian = value.toByteArray().dropSign()
+        bigEndian.copyInto(field, field.size - bigEndian.size)
+        return field.reversedArray() + ByteArray(8) // the eight zero bytes an RSA field ends with
+    }
+
+    /** A Server Platform Challenge around [challenge], encrypted and MAC'd as a licence server does. */
+    private fun platformChallenge(challenge: ByteArray, keys: ServerKeys): ByteArray {
+        val encrypted = Rc4(keys.licensingEncryptionKey).process(challenge)
+        return RdpWriter(encrypted.size + 32).apply {
             u32le(0) // ConnectFlags
-            u16le(0x0009).u16le(encryptedChallenge.size).bytes(encryptedChallenge)
-            zeros(16) // MACData
+            u16le(0x0009).u16le(encrypted.size).bytes(encrypted)
+            bytes(keys.mac(challenge)) // MACData, over the decrypted challenge
         }.toByteArray()
+    }
 
     /** Strips the security header and preamble, asserting the message type. */
     private fun licenseBody(message: ByteArray, expectedType: Int): RdpReader {
@@ -212,4 +275,23 @@ class LicenseExchangeTest {
 
     private fun ByteArray.dropSign(): ByteArray =
         if (size > 1 && this[0] == 0.toByte()) copyOfRange(1, size) else this
+
+    private companion object {
+        const val TSSK_KEY_SIZE = 64
+
+        /** SignatureBlob as it appears on the wire: the 512-bit value plus its eight zero bytes. */
+        const val SIGNATURE_FIELD_SIZE = TSSK_KEY_SIZE + 8
+
+        /** The Terminal Services signing key (MS-RDPBCGR 5.3.3.1.1), private half included. */
+        val TSSK_MODULUS = BigInteger(
+            "87EA6D055F099320BB61F51A09065E6C7D5CF63DFEBFE77CEFFE3A586B6563CE" +
+                "954552F29A6BB7D7E2C1F5EF8720883ECB5FBA4A1EC1BB4DC93E4372BD5E3A3D",
+            16,
+        )
+        val TSSK_PRIVATE_EXPONENT = BigInteger(
+            "5FF33FE7130110C7B39B510B17790735DD0D7B0AB83AC79924B1DD249F129A17" +
+                "6008E89933CC92CF944967E9FAE63E24F868652516160058558711DA3219A787",
+            16,
+        )
+    }
 }


### PR DESCRIPTION
Closes #103.

Two checks the licensing exchange skipped are now performed.

**Server Platform Challenge MAC.** The MACData that follows the encrypted challenge covers the decrypted challenge (MS-RDPELE 2.2.2.4). It is recomputed and compared in constant time before the challenge is answered; a mismatch fails the connection instead of sending a response to a challenge that could not be authenticated.

**Proprietary certificate signature.** A server certificate in the legacy format (MS-RDPBCGR 2.2.1.4.3.1.1) carries an RSA signature made with the Terminal Services key. The client now verifies it — MD5 over `dwVersion` through the end of the public key blob, then the fixed padding of MS-RDPBCGR 5.3.3.1.1 — before the public key it carries is used to encrypt the premaster secret. The signature blob has to be present and 72 bytes; anything else is rejected. Microsoft published the private half of that key, so this identifies no one: it establishes that the key blob is the one whoever wrote the certificate meant to send.

The model licence server in `LicenseExchangeTest` now signs and MACs the way a real one does, so both checks are validated against an implementation written from the specification. New tests cover a public key swapped after signing, a certificate with no signature, and a challenge whose MAC does not match.

`constantTimeEquals` moves out of `NtlmSession` into `rdp/ConstantTime.kt`, shared by both call sites. The model server in `RdpConnectTest` sends an X.509 chain instead of a proprietary certificate — that form no longer exists without a real signature, which the test's stand-in crypto cannot produce, and the chain format had no coverage before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)