### PR TITLE
RDP: skip drawing orders instead of ending the session

### DIFF
--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientCapabilities.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientCapabilities.kt
@@ -6,7 +6,8 @@ package app.skerry.shared.rdp
  *
  * - No drawing orders are claimed (`orderSupport` is all zeros). This client paints from bitmap
  *   updates and surface commands, and a server told otherwise would send GDI primitives nothing
- *   here can execute — a blank screen rather than a slow one.
+ *   here can execute. One that sends them regardless has its orders skipped and the desktop
+ *   repainted (see `FastPathDecoder` and `RdpSessionCodec.repaintDropped`).
  * - Surface commands plus RemoteFX are claimed, which is what makes a modern server stream tiles
  *   instead of legacy bitmaps.
  * - Fast-path input and output are claimed in both directions: it is the low-latency framing, and

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
@@ -15,6 +15,11 @@ class FastPathDecoder(
      * copies would decode half the bitmaps against a stale table and simply show wrong colours.
      */
     private val palette: SessionPalette,
+    /**
+     * Where updates this client cannot draw are recorded. Shared with the session codec, which turns
+     * a raised flag into a repaint request; a decoder used on its own simply drops them.
+     */
+    private val dropped: DroppedGraphics = DroppedGraphics(),
 ) {
     private var fragmentType = -1
     private val fragments = mutableListOf<ByteArray>()
@@ -135,11 +140,14 @@ class FastPathDecoder(
             // cache beyond the minimum, so the honest answer is to leave the cursor as it is.
             UPDATETYPE_CACHED_POINTER -> emptyList()
             UPDATETYPE_SYNCHRONIZE -> emptyList()
-            UPDATETYPE_ORDERS ->
-                // Orders were never claimed in the capability exchange; a server sending them anyway
-                // is drawing something this client cannot execute, and silently dropping them would
-                // leave a screen that is wrong rather than merely stale.
-                throw RdpProtocolException("server sent drawing orders, which this client does not support")
+            // Orders were never claimed in the capability exchange (MS-RDPEGDI), so a server sending
+            // them anyway is drawing something nothing here can execute. Skipping the one update
+            // costs the pixels it drew, which the session codec then asks the server to repaint —
+            // the same trade as a bitmap rectangle that fails to decode.
+            UPDATETYPE_ORDERS -> {
+                dropped.record()
+                emptyList()
+            }
 
             else -> emptyList()
         }
@@ -306,4 +314,21 @@ object BitmapUpdate {
  */
 class SessionPalette {
     var colors: IntArray? = null
+}
+
+/**
+ * Graphics that arrived but were not drawn, because the client cannot execute what they describe.
+ * A holder for the same reason as [SessionPalette]: either decode path can meet them, and one of
+ * the two lives in [FastPathDecoder] while the repaint is asked for from the session codec.
+ */
+class DroppedGraphics {
+    private var pending = false
+
+    /** Note that an update was received and not drawn. */
+    fun record() {
+        pending = true
+    }
+
+    /** Whether anything was dropped since the last call; reading clears the flag. */
+    fun take(): Boolean = pending.also { pending = false }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
@@ -16,10 +16,11 @@ class FastPathDecoder(
      */
     private val palette: SessionPalette,
     /**
-     * Where updates this client cannot draw are recorded. Shared with the session codec, which turns
-     * a raised flag into a repaint request; a decoder used on its own simply drops them.
+     * Where graphics that did not reach the framebuffer are recorded. Shared with the session codec,
+     * which is the half that can ask the server to repaint them — no default, because a decoder
+     * wired to a holder nobody reads would drop pixels and never get them back.
      */
-    private val dropped: DroppedGraphics = DroppedGraphics(),
+    private val dropped: DroppedGraphics,
 ) {
     private var fragmentType = -1
     private val fragments = mutableListOf<ByteArray>()
@@ -120,7 +121,7 @@ class FastPathDecoder(
         when (updateCode) {
             UPDATETYPE_BITMAP -> {
                 reader.u16le() // updateType, repeated inside the payload
-                listOf(BitmapUpdate.apply(reader, framebuffer, palette.colors))
+                listOf(BitmapUpdate.apply(reader, framebuffer, palette.colors, dropped))
             }
 
             UPDATETYPE_PALETTE -> {
@@ -185,7 +186,12 @@ object BitmapUpdate {
     private const val NO_BITMAP_COMPRESSION_HDR = 0x0400
 
     /** Apply a bitmap update to [framebuffer] and report the rectangles it changed. */
-    fun apply(reader: RdpReader, framebuffer: RemoteFramebuffer, palette: IntArray?): RdpUpdate.Region {
+    fun apply(
+        reader: RdpReader,
+        framebuffer: RemoteFramebuffer,
+        palette: IntArray?,
+        dropped: DroppedGraphics,
+    ): RdpUpdate.Region {
         val count = reader.u16le()
         val rects = mutableListOf<RdpRect>()
         repeat(count) {
@@ -215,8 +221,9 @@ object BitmapUpdate {
                 decodeBitmap(data, width, height, bitsPerPixel, bytesPerPixel, flags, palette)
             } catch (e: RdpProtocolException) {
                 // One rectangle this client cannot read is not worth the whole session: the pixels
-                // under it stay as they were and the server repaints them on the next refresh,
-                // which is a scarred screen instead of a dropped connection.
+                // under it stay as they were until the repaint the recorded drop asks for, which is
+                // a briefly scarred screen instead of a dropped connection.
+                dropped.record()
                 return@repeat
             }
             blit(framebuffer, pixels, left, top, width, height)
@@ -317,9 +324,10 @@ class SessionPalette {
 }
 
 /**
- * Graphics that arrived but were not drawn, because the client cannot execute what they describe.
- * A holder for the same reason as [SessionPalette]: either decode path can meet them, and one of
- * the two lives in [FastPathDecoder] while the repaint is asked for from the session codec.
+ * Graphics that arrived but never reached the framebuffer — orders this client cannot execute, a
+ * rectangle it cannot decode. A holder for the same reason as [SessionPalette]: either decode path
+ * can meet them, one of the two lives in [FastPathDecoder], and the repaint that brings the pixels
+ * back is asked for from the session codec.
  */
 class DroppedGraphics {
     private var pending = false

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
@@ -1,6 +1,9 @@
 package app.skerry.shared.rdp
 
 import app.skerry.shared.graphics.RemoteFramebuffer
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /**
  * The live session's protocol loop: reads server PDUs (fast-path updates and slow-path share PDUs),
@@ -19,14 +22,16 @@ class RdpSessionCodec(
     private val settings: RdpClientSettings,
     private val logon: RdpLogonInfo,
     remoteFx: RemoteFxDecoder? = null,
+    /** Injected so a test can hold the clock still while it drives [readMessage]. */
+    private val timeSource: TimeSource = TimeSource.Monotonic,
 ) {
     private val palette = SessionPalette()
     private val dropped = DroppedGraphics()
     private val fastPath = FastPathDecoder(framebuffer, palette, dropped)
     private val surfaces = SurfaceDecoder(RdpCodecs(remoteFx))
 
-    /** Whether a repaint asked for after dropped graphics is still unanswered; see [repaintDropped]. */
-    private var repaintPending = false
+    /** When the last repaint was asked for, or null if none has been; see [repaintDropped]. */
+    private var lastRepaint: TimeMark? = null
 
     /** The desktop size the server is currently serving. */
     val desktopWidth: Int get() = state.capabilities.desktopWidth
@@ -46,21 +51,24 @@ class RdpSessionCodec(
         // Acknowledge completed frames before returning: the server paces itself on these.
         for (update in updates) {
             if (update is RdpUpdate.Frame && !update.begin) acknowledgeFrame(update.frameId)
-            // Pixels landed, so a repaint that was asked for has been answered.
-            if (update is RdpUpdate.Region && update.rects.isNotEmpty()) repaintPending = false
         }
         if (dropped.take()) repaintDropped()
         return updates
     }
 
     /**
-     * Ask the server to send, as bitmaps, what it drew with an update this client had to skip.
-     * One repaint is asked for at a time: a server that ignores the negotiation once tends to do it
-     * every frame, and a full-screen repaint per dropped update is a traffic storm rather than a fix.
+     * Ask the server to send, as bitmaps, what it drew with something this client had to skip.
+     *
+     * Rate-limited rather than sent per dropped update: whatever makes a server drop graphics on us
+     * — orders we never claimed, a rectangle in a codec we misread — tends to repeat every frame,
+     * and a full-desktop repaint per occurrence is a traffic storm rather than a fix. The interval
+     * is measured from the request, not from an answer, because a Refresh Rect PDU is not
+     * acknowledged: its bitmaps are indistinguishable from the ones the server would have sent anyway.
      */
     private suspend fun repaintDropped() {
-        if (repaintPending) return
-        repaintPending = true
+        if (!state.capabilities.refreshRectSupported) return
+        if (lastRepaint?.elapsedNow()?.let { it < MIN_REPAINT_INTERVAL } == true) return
+        lastRepaint = timeSource.markNow()
         requestRefresh(listOf(RdpRect(0, 0, desktopWidth, desktopHeight)))
     }
 
@@ -106,7 +114,7 @@ class RdpSessionCodec(
 
     /** Slow-path graphics: the same payloads as fast-path, wrapped in a share data PDU. */
     private fun slowPathUpdate(reader: RdpReader): List<RdpUpdate> = when (reader.u16le()) {
-        UPDATETYPE_BITMAP -> listOf(BitmapUpdate.apply(reader, framebuffer, palette.colors))
+        UPDATETYPE_BITMAP -> listOf(BitmapUpdate.apply(reader, framebuffer, palette.colors, dropped))
         UPDATETYPE_PALETTE -> {
             palette.colors = BitmapUpdate.readPalette(reader)
             emptyList()
@@ -291,6 +299,9 @@ class RdpSessionCodec(
         const val SYSPTR_NULL = 0x00000000
 
         const val COMPRESSION_USED = 0x20
+
+        /** How rarely a repaint of the whole desktop may be asked for; see [repaintDropped]. */
+        val MIN_REPAINT_INTERVAL = 1.seconds
 
         const val CHANNEL_FLAG_FIRST = 0x00000001
         const val CHANNEL_FLAG_LAST = 0x00000002

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
@@ -21,8 +21,12 @@ class RdpSessionCodec(
     remoteFx: RemoteFxDecoder? = null,
 ) {
     private val palette = SessionPalette()
-    private val fastPath = FastPathDecoder(framebuffer, palette)
+    private val dropped = DroppedGraphics()
+    private val fastPath = FastPathDecoder(framebuffer, palette, dropped)
     private val surfaces = SurfaceDecoder(RdpCodecs(remoteFx))
+
+    /** Whether a repaint asked for after dropped graphics is still unanswered; see [repaintDropped]. */
+    private var repaintPending = false
 
     /** The desktop size the server is currently serving. */
     val desktopWidth: Int get() = state.capabilities.desktopWidth
@@ -42,8 +46,22 @@ class RdpSessionCodec(
         // Acknowledge completed frames before returning: the server paces itself on these.
         for (update in updates) {
             if (update is RdpUpdate.Frame && !update.begin) acknowledgeFrame(update.frameId)
+            // Pixels landed, so a repaint that was asked for has been answered.
+            if (update is RdpUpdate.Region && update.rects.isNotEmpty()) repaintPending = false
         }
+        if (dropped.take()) repaintDropped()
         return updates
+    }
+
+    /**
+     * Ask the server to send, as bitmaps, what it drew with an update this client had to skip.
+     * One repaint is asked for at a time: a server that ignores the negotiation once tends to do it
+     * every frame, and a full-screen repaint per dropped update is a traffic storm rather than a fix.
+     */
+    private suspend fun repaintDropped() {
+        if (repaintPending) return
+        repaintPending = true
+        requestRefresh(listOf(RdpRect(0, 0, desktopWidth, desktopHeight)))
     }
 
     private suspend fun slowPath(packet: ByteArray): List<RdpUpdate> {
@@ -94,8 +112,11 @@ class RdpSessionCodec(
             emptyList()
         }
 
-        UPDATETYPE_ORDERS ->
-            throw RdpProtocolException("server sent drawing orders, which this client does not support")
+        // Skipped and repainted rather than fatal, for the reason spelled out in [FastPathDecoder].
+        UPDATETYPE_ORDERS -> {
+            dropped.record()
+            emptyList()
+        }
 
         else -> emptyList()
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 private const val WHITE = 0xFFFFFFFF.toInt()
@@ -230,12 +231,44 @@ class GraphicsTest {
     }
 
     @Test
-    fun `drawing orders are refused because none were ever claimed`() {
-        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette())
+    fun `drawing orders are skipped rather than ending the session`() {
+        val dropped = DroppedGraphics()
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), dropped)
 
-        assertFailsWith<RdpProtocolException> {
+        val updates =
             decoder.decode(fastPathPacket(updateCode = 0, fragmentation = 0, body = byteArrayOf(1)), SurfaceDecoder())
-        }
+
+        assertTrue(updates.isEmpty())
+        assertTrue(dropped.take(), "the skipped orders have to be reported so the pixels can be asked for again")
+        assertFalse(dropped.take(), "taking the flag clears it")
+    }
+
+    @Test
+    fun `an update after skipped orders in the same packet still paints`() {
+        val framebuffer = RemoteFramebuffer(4, 4)
+        val decoder = FastPathDecoder(framebuffer, SessionPalette())
+        val bitmap = RdpWriter(64).apply {
+            u16le(0x0001) // updateType, repeated inside the payload
+            u16le(1) // one rectangle
+            u16le(0).u16le(0).u16le(1).u16le(1)
+            u16le(2).u16le(2)
+            u16le(16) // bitsPerPixel
+            u16le(0) // flags: uncompressed
+            u16le(8)
+            u16le(0xF800).u16le(0xF800)
+            u16le(0xFFFF).u16le(0xFFFF)
+        }.toByteArray()
+
+        val updates = decoder.decode(
+            fastPathPacket(
+                fastPathUpdate(updateCode = 0, fragmentation = 0, body = byteArrayOf(1)),
+                fastPathUpdate(updateCode = 1, fragmentation = 0, body = bitmap),
+            ),
+            SurfaceDecoder(),
+        )
+
+        assertTrue(updates.single() is RdpUpdate.Region)
+        assertEquals(WHITE, framebuffer.pixels[0])
     }
 
     @Test
@@ -294,17 +327,23 @@ class GraphicsTest {
     }
 
     /** Wrap [body] in a fast-path output packet with one update of [updateCode]. */
-    private fun fastPathPacket(updateCode: Int, fragmentation: Int, body: ByteArray): ByteArray {
-        val payload = RdpWriter(body.size + 8).apply {
+    private fun fastPathPacket(updateCode: Int, fragmentation: Int, body: ByteArray): ByteArray =
+        fastPathPacket(fastPathUpdate(updateCode, fragmentation, body))
+
+    /** One update record: the header a fast-path packet carries a run of. */
+    private fun fastPathUpdate(updateCode: Int, fragmentation: Int, body: ByteArray): ByteArray =
+        RdpWriter(body.size + 8).apply {
             u8(updateCode or (fragmentation shl 4))
             u16le(body.size)
             bytes(body)
         }.toByteArray()
-        val total = payload.size + 3
+
+    private fun fastPathPacket(vararg updates: ByteArray): ByteArray {
+        val total = updates.sumOf { it.size } + 3
         return RdpWriter(total).apply {
             u8(0) // action = fast-path output, no flags
             u16be(total or 0x8000) // two-byte length form
-            bytes(payload)
+            for (update in updates) bytes(update)
         }.toByteArray()
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
@@ -101,7 +101,7 @@ class GraphicsTest {
             u16le(0xFFFF).u16le(0xFFFF)
         }.toByteArray()
 
-        val update = BitmapUpdate.apply(RdpReader(body), framebuffer, null) as RdpUpdate.Region
+        val update = BitmapUpdate.apply(RdpReader(body), framebuffer, null, DroppedGraphics()) as RdpUpdate.Region
 
         assertEquals(1, update.rects.size)
         assertEquals(WHITE, framebuffer.pixels[0]) // top row of the image
@@ -122,9 +122,11 @@ class GraphicsTest {
             u16le(0) // bitmapLength
         }.toByteArray()
 
-        val update = BitmapUpdate.apply(RdpReader(body), framebuffer, null) as RdpUpdate.Region
+        val dropped = DroppedGraphics()
+        val update = BitmapUpdate.apply(RdpReader(body), framebuffer, null, dropped) as RdpUpdate.Region
 
         assertEquals(emptyList(), update.rects, "an impossible rectangle reached the framebuffer")
+        assertTrue(dropped.take(), "a rectangle that never reached the screen has to be repainted")
     }
 
     @Test
@@ -197,7 +199,7 @@ class GraphicsTest {
     @Test
     fun `fast-path reassembles an update split across packets`() {
         val framebuffer = RemoteFramebuffer(4, 4)
-        val decoder = FastPathDecoder(framebuffer, SessionPalette())
+        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics())
         val bitmap = RdpWriter(64).apply {
             u16le(0x0001) // updateType inside the payload
             u16le(1)
@@ -222,7 +224,7 @@ class GraphicsTest {
 
     @Test
     fun `a fragment run of the wrong type is refused`() {
-        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette())
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics())
         decoder.decode(fastPathPacket(updateCode = 1, fragmentation = 2, body = byteArrayOf(0, 0)), SurfaceDecoder())
 
         assertFailsWith<RdpProtocolException> {
@@ -246,7 +248,7 @@ class GraphicsTest {
     @Test
     fun `an update after skipped orders in the same packet still paints`() {
         val framebuffer = RemoteFramebuffer(4, 4)
-        val decoder = FastPathDecoder(framebuffer, SessionPalette())
+        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics())
         val bitmap = RdpWriter(64).apply {
             u16le(0x0001) // updateType, repeated inside the payload
             u16le(1) // one rectangle

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/OptionalClientPdusTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/OptionalClientPdusTest.kt
@@ -28,19 +28,45 @@ class OptionalClientPdusTest {
         supportedCodecs = emptyList(),
     )
 
-    private fun codec(caps: ServerCapabilities, written: MutableList<ByteArray>) = RdpSessionCodec(
-        source = { _, _, _ -> error("no reads in this test") },
-        sink = { bytes -> written += bytes },
-        framebuffer = RemoteFramebuffer(caps.desktopWidth, caps.desktopHeight),
-        state = RdpSessionState(userId = 1007, ioChannelId = 1003, channels = emptyMap(), capabilities = caps),
-        settings = RdpClientSettings(
-            desktopWidth = caps.desktopWidth,
-            desktopHeight = caps.desktopHeight,
-            clientName = "Skerry",
-            selectedProtocol = 1,
-        ),
-        logon = RdpLogonInfo(domain = "", username = "u"),
-    )
+    private fun codec(
+        caps: ServerCapabilities,
+        written: MutableList<ByteArray>,
+        incoming: ByteArray = ByteArray(0),
+    ): RdpSessionCodec {
+        var offset = 0
+        return RdpSessionCodec(
+            source = { dst, dstOffset, len ->
+                if (offset + len > incoming.size) error("the test fixture ran out of bytes")
+                incoming.copyInto(dst, dstOffset, offset, offset + len)
+                offset += len
+            },
+            sink = { bytes -> written += bytes },
+            framebuffer = RemoteFramebuffer(caps.desktopWidth, caps.desktopHeight),
+            state = RdpSessionState(userId = 1007, ioChannelId = 1003, channels = emptyMap(), capabilities = caps),
+            settings = RdpClientSettings(
+                desktopWidth = caps.desktopWidth,
+                desktopHeight = caps.desktopHeight,
+                clientName = "Skerry",
+                selectedProtocol = 1,
+            ),
+            logon = RdpLogonInfo(domain = "", username = "u"),
+        )
+    }
+
+    /** A fast-path packet carrying one drawing-orders update, which this client cannot execute. */
+    private fun ordersPacket(): ByteArray {
+        val update = RdpWriter(8).apply {
+            u8(0) // updateCode 0 = orders, single fragment, uncompressed
+            u16le(1)
+            u8(1) // numberOrders, and nothing this client reads past it
+        }.toByteArray()
+        val total = update.size + 3
+        return RdpWriter(total).apply {
+            u8(0) // action = fast-path output
+            u16be(total or 0x8000)
+            bytes(update)
+        }.toByteArray()
+    }
 
     @Test
     fun a_refresh_declares_the_length_of_the_whole_packet() = runTest {
@@ -76,6 +102,36 @@ class OptionalClientPdusTest {
         val written = mutableListOf<ByteArray>()
         codec(capabilities(refreshRect = true, suppressOutput = true), written)
             .requestRefresh(listOf(RdpRect(0, 0, 1024, 768)))
+
+        assertEquals(1, written.size)
+    }
+
+    @Test
+    fun drawing_orders_are_skipped_and_the_screen_asked_for_again() = runTest {
+        val written = mutableListOf<ByteArray>()
+        val session = codec(capabilities(refreshRect = true, suppressOutput = true), written, ordersPacket())
+
+        assertTrue(session.readMessage().isEmpty(), "orders carry nothing the UI can act on")
+        assertEquals(1, written.size, "the pixels the orders drew have to be asked for as bitmaps")
+        // The refresh covers the whole desktop, as inclusive right/bottom coordinates.
+        val pdu = written.single()
+        val rect = RdpReader(pdu, pdu.size - 8)
+        assertEquals(listOf(0, 0, 1023, 767), listOf(rect.u16le(), rect.u16le(), rect.u16le(), rect.u16le()))
+    }
+
+    @Test
+    fun a_second_orders_update_does_not_pile_up_another_repaint() = runTest {
+        // A server that ignores the negotiation once will do it every frame; one full-screen repaint
+        // may be outstanding at a time, or the answer to a broken server is a traffic storm.
+        val written = mutableListOf<ByteArray>()
+        val session = codec(
+            capabilities(refreshRect = true, suppressOutput = true),
+            written,
+            ordersPacket() + ordersPacket(),
+        )
+
+        session.readMessage()
+        session.readMessage()
 
         assertEquals(1, written.size)
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/OptionalClientPdusTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/OptionalClientPdusTest.kt
@@ -5,6 +5,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+import kotlin.time.TimeSource
 
 /**
  * Client PDUs the server has to opt into (MS-RDPBCGR 2.2.11.2 / 2.2.11.3): sending one that was not
@@ -32,6 +35,7 @@ class OptionalClientPdusTest {
         caps: ServerCapabilities,
         written: MutableList<ByteArray>,
         incoming: ByteArray = ByteArray(0),
+        timeSource: TimeSource = TimeSource.Monotonic,
     ): RdpSessionCodec {
         var offset = 0
         return RdpSessionCodec(
@@ -50,6 +54,7 @@ class OptionalClientPdusTest {
                 selectedProtocol = 1,
             ),
             logon = RdpLogonInfo(domain = "", username = "u"),
+            timeSource = timeSource,
         )
     }
 
@@ -66,6 +71,13 @@ class OptionalClientPdusTest {
             u16be(total or 0x8000)
             bytes(update)
         }.toByteArray()
+    }
+
+    /** The same orders update on the slow path: a Share Data PDU inside an MCS domain PDU. */
+    private fun slowPathOrdersPacket(caps: ServerCapabilities): ByteArray {
+        val body = RdpWriter(4).u16le(0).u8(1).toByteArray() // updateType 0 = orders, numberOrders
+        val share = RdpShare.dataPdu(caps.shareId, userId = 1002, pduType2 = RdpShare.PDUTYPE2_UPDATE, body = body)
+        return Mcs.sendDataRequest(userId = 1002, channelId = 1003, payload = share)
     }
 
     @Test
@@ -120,12 +132,45 @@ class OptionalClientPdusTest {
     }
 
     @Test
-    fun a_second_orders_update_does_not_pile_up_another_repaint() = runTest {
-        // A server that ignores the negotiation once will do it every frame; one full-screen repaint
-        // may be outstanding at a time, or the answer to a broken server is a traffic storm.
+    fun slow_path_orders_are_skipped_the_same_way() = runTest {
+        val caps = capabilities(refreshRect = true, suppressOutput = true)
         val written = mutableListOf<ByteArray>()
+        val session = codec(caps, written, slowPathOrdersPacket(caps))
+
+        assertTrue(session.readMessage().isEmpty())
+        assertEquals(1, written.size, "the slow path drops orders too, and owes the same repaint")
+    }
+
+    @Test
+    fun repaints_after_dropped_graphics_are_rate_limited() = runTest {
+        // A server that ignores the negotiation once will do it every frame, and a full-desktop
+        // repaint per dropped update is a traffic storm rather than a fix.
+        val written = mutableListOf<ByteArray>()
+        val clock = TestTimeSource()
         val session = codec(
             capabilities(refreshRect = true, suppressOutput = true),
+            written,
+            ordersPacket() + ordersPacket() + ordersPacket(),
+            timeSource = clock,
+        )
+
+        session.readMessage()
+        session.readMessage()
+        assertEquals(1, written.size, "a second drop in the same second repaints again")
+
+        clock += 2.seconds
+        session.readMessage()
+        assertEquals(2, written.size, "a drop after the interval is worth another repaint")
+    }
+
+    @Test
+    fun no_repaint_is_asked_of_a_server_that_cannot_refresh() = runTest {
+        // The capability is checked before the rate limiter records a request, so a request that
+        // never went out cannot mute a later one. Nothing reaches the wire either way; this pins
+        // the half that is observable.
+        val written = mutableListOf<ByteArray>()
+        val session = codec(
+            capabilities(refreshRect = false, suppressOutput = true),
             written,
             ordersPacket() + ordersPacket(),
         )
@@ -133,7 +178,7 @@ class OptionalClientPdusTest {
         session.readMessage()
         session.readMessage()
 
-        assertEquals(1, written.size)
+        assertTrue(written.isEmpty())
     }
 
     @Test


### PR DESCRIPTION
An RDP server that sends drawing orders (`UPDATETYPE_ORDERS`, MS-RDPEGDI) used to end the session with a protocol error. It is now skipped, and the session asks the server to repaint the desktop so the pixels come back as bitmaps.

The client never claims orders — the Order capability set goes out with `orderSupport` all zeros, and the session paints from bitmap updates and surface commands. Implementing MS-RDPEGDI would mean primary, secondary and alternate-secondary orders plus the bitmap, glyph, brush and offscreen caches, to serve a server that ignores what was negotiated. Dropping the session for one unexpected update type is the other extreme, so the update is skipped on both the fast and the slow path.

Skipping alone would leave the screen wrong where the orders drew. Anything that fails to reach the framebuffer — orders, and now also a bitmap rectangle whose codec cannot be read — is recorded, and the session codec sends a Refresh Rect PDU for the whole desktop.

Repaints are rate-limited to one per second rather than one per dropped update: a server that ignores the negotiation once tends to do it every frame, and a full-desktop repaint each time would be a traffic storm. The interval is measured from the request, because a Refresh Rect PDU is not acknowledged — its bitmaps are indistinguishable from the ones the server would have sent anyway. Servers that never advertised Refresh Rect are left alone.

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)