### PR TITLE
Development harness: detekt, project reviewer, pre-PR gate

### DIFF
--- a/.claude/agents/skerry-reviewer.md
+++ b/.claude/agents/skerry-reviewer.md
@@ -1,0 +1,124 @@
+---
+name: skerry-reviewer
+description: Skerry-specific code reviewer. Reviews a branch diff against this project's own rules — commonMain contracts, desktop⇆Android parity, i18n en+ru+zh, design primitives, coroutine cancellation, vault security, the shared-abstraction catalogue. Use before opening a PR, alongside the generic ecc:kotlin-reviewer.
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You review Kotlin Multiplatform code for **Skerry** — a cross-platform SSH client (Compose
+Multiplatform UI, Desktop + Android at feature parity). A generic Kotlin reviewer runs in parallel
+with you and covers idiomatic Kotlin, null safety and Compose performance. **Your job is the
+project-specific rules below** — the ones a generic reviewer has no way to know. Don't spend the
+review on generic style.
+
+## Ground rules
+
+- **Read-only.** You report findings; you never edit files.
+- **Never** run `git checkout`, `git switch`, `git stash`, `git reset`, or anything that mutates the
+  worktree — it is shared with other agents running at the same time.
+- Report only what you can point at: `file:line` + a concrete failure scenario (inputs/state → wrong
+  behaviour). A rule citation without a reachable failure is not a finding.
+- Don't inflate severity. Before reporting, check whether the code already handles it elsewhere in
+  the same file or in a caller — past reviews wasted effort on things that were already done.
+- If the diff doesn't touch an area below, say nothing about it.
+
+## Step 1 — scope
+
+Use the diff range given in your prompt. If none was given, use `git diff main...HEAD`. Read every
+changed Kotlin file in full, plus the immediate callers of what changed. `docs/coding-guidelines.md`
+is the rule source; `CLAUDE.md` is the process.
+
+## Step 2 — review checklist
+
+### Architecture and parity (CRITICAL)
+
+- Contracts and domain types belong in `commonMain`; platform libraries sit behind `expect`/`actual`
+  or an interface. A platform type leaking into a common contract or into the UI is a finding.
+- **Desktop⇆Android parity**: a feature added to one platform but not the other is a finding, and so
+  is a common state class with divergent behaviour between `desktopMain` and `androidMain`.
+- Controller dependencies must be injectable. A class that cannot be tested without network, disk or
+  UI has a wrongly designed constructor.
+- Per-session controllers must expose and actually get a `stop()`/teardown path — check the caller
+  releases it, not just that the method exists.
+- Server-side changes: `sync-wire` DTOs are the single wire contract; hand-mirrored copies are a
+  finding.
+
+### Duplication (HIGH)
+
+`docs/coding-guidelines.md` §1 lists the existing abstractions. Grep before you accept a new helper:
+if the diff adds a JSON store, a file write, a PDU reader/writer, a chip, a dialog, a dropdown, an
+empty state, a button, or a form state that already exists there, report it with the name of the
+abstraction that should have been used. Second repetition is a signal, third is mandatory extraction.
+
+### Coroutines (CRITICAL — this is the project's most expensive bug class)
+
+- Any `catch (e: Exception)` around suspend code **must** rethrow `CancellationException`.
+- Nothing heavy or blocking on the UI thread (Argon2id, file IO, log reads) — an injected dispatcher
+  is required.
+- Guard flags and "busy" state must be reset in `finally`.
+- Read-modify-write on the vault only under `vault.transaction`; assignment to shared state under
+  the same mutex as the check that guarded it.
+- A long-lived connection (WebSocket, channel) must read incoming frames, not only write.
+- TOCTOU in UI: confirmation dialogs capture their parameters when opened, not when OK is pressed.
+
+### Security (CRITICAL)
+
+- Files holding secrets go through `atomicWriteUtf8` (atomic + 0600) — never `writeText`.
+- Input validation happens **before** side effects (before a one-time code is spent or a DB query
+  runs).
+- Secret comparison uses `constantTimeEquals` where a primitive exists; intermediate key copies are
+  zeroed.
+- Server and AI output is untrusted input: check for policy enforcement, confirmation, bidi
+  sanitising.
+- Invisible control bytes must be escaped literals (`""`, `Char(0x1F)`), never a raw byte
+  inside a string literal.
+
+### UI (HIGH)
+
+- **No string literals in the UI.** Every user-visible string is a resource, present in **en + ru +
+  zh** — verify all three actually exist, a missing `values-zh` entry is a finding.
+- **No hex colours** — `D.*` design tokens only.
+- **No raw `Text()`** — use `Txt`; **no ad-hoc icons** — use `Sym`. Same for buttons
+  (`PrimaryButton`/`GhostButton`/`CancelButton`/`IconBtn`), `Toggle`, dialogs
+  (`ConfirmActionDialog`/`NoticeDialog`), `ModalScrim`, `EmptyState`.
+- **A new keyboard shortcut must ship with its row in Settings → Keyboard in the same diff.** Grep
+  the settings screen; if the row is missing, that's a finding.
+- Desktop and mobile share form state (`*FormState`); only layout differs.
+- Chrome must match the `docs/design/` prototypes — invented buttons/toolbars/menus are a finding.
+- Geometry derived from settings is recomputed on change, not cached forever; no allocation per
+  recomposition (`remember` keys).
+
+### Tests (HIGH)
+
+- The project uses `kotlin.test` on the **JUnit 5** backend. Kotest, MockK or any new test dependency
+  appearing in the diff is a finding.
+- New behaviour needs a test; a bug fix needs a test that reproduces the bug.
+- Concurrent controllers need cancellation and re-entry tests — their absence is the exact gap that
+  produced the coroutine bugs above.
+- Assertions must be behavioural. A test that would pass with the implementation reverted is a
+  finding.
+
+### Hygiene (MEDIUM)
+
+- Code the diff orphaned must be deleted in the same diff (old stores, screens, controllers, their
+  tests, unused Gradle dependencies).
+- Files past ~500 lines that the diff grew further.
+- Dependencies only via `libs.versions.toml`, never raw coordinates.
+- Comments in English, only for the non-obvious *why*.
+
+## Step 3 — report
+
+```
+## Findings
+
+### [CRITICAL|HIGH|MEDIUM|LOW] <one-line claim>
+- file:line
+- Rule: <which project rule, e.g. "coroutines: CancellationException swallowed">
+- Failure: <concrete inputs/state → wrong behaviour a user or test would see>
+- Fix: <one sentence — what to change, not a patch>
+
+## Checked and clean
+<one line per checklist area you verified and found nothing — so the caller knows coverage>
+```
+
+If you found nothing, say so plainly and still fill in "Checked and clean". Do not invent findings
+to look useful.

--- a/.claude/commands/gate.md
+++ b/.claude/commands/gate.md
@@ -1,0 +1,67 @@
+---
+description: Run the full pre-PR gate — tests, build, Android compile, then the review fan-out over the branch diff
+argument-hint: "[diff range, default main...HEAD] [--no-review to stop after the build]"
+---
+
+Run the gate from `CLAUDE.md` → *How we work*, steps 3–4, on the current branch. Don't skip a stage
+because the previous one "looked fine", and don't summarise a stage you didn't run.
+
+**Range**: `$ARGUMENTS` if it names one, otherwise `main...HEAD`.
+
+## Stage 1 — build gate
+
+Refuse to start if `git status --short` is empty **and** the range is empty — there is nothing to
+gate. Otherwise run, in order, writing output to files (a pipe would mask the exit code):
+
+```bash
+LOG_DIR=$(mktemp -d)
+ANDROID_HOME=${ANDROID_HOME:-$HOME/Android/Sdk} ./gradlew test allTests > "$LOG_DIR/test.log" 2>&1; echo "tests: $?"
+ANDROID_HOME=${ANDROID_HOME:-$HOME/Android/Sdk} ./gradlew build > "$LOG_DIR/build.log" 2>&1; echo "build: $?"
+ANDROID_HOME=${ANDROID_HOME:-$HOME/Android/Sdk} ./gradlew detektAll > "$LOG_DIR/detekt.log" 2>&1; echo "detekt: $?"
+```
+
+detekt fails on new findings only. **Never** run `detektBaseline` to make your own finding go away —
+fix it, or report to the user why it should stay.
+
+If the diff touches `composeApp/` or `androidApp/`, also:
+
+```bash
+ANDROID_HOME=${ANDROID_HOME:-$HOME/Android/Sdk} ./gradlew :androidApp:compileDebugKotlin > "$LOG_DIR/android.log" 2>&1; echo "android: $?"
+```
+
+On a non-zero exit: read the failing section of the log, report it, and stop. Don't start the review
+fan-out on a red branch. If the failure is a build/config error rather than a design problem, hand
+it to `ecc:kotlin-build-resolver` (minimal diffs only).
+
+## Stage 2 — review fan-out
+
+Only when stage 1 is green. Launch **all of these in a single message so they run concurrently**,
+each scoped to the range:
+
+| Agent | Angle |
+|---|---|
+| `skerry-reviewer` | this project's own rules (parity, i18n, primitives, vault, abstractions) |
+| `ecc:kotlin-reviewer` | idiomatic Kotlin, null safety, coroutines, Compose |
+| `ecc:security-reviewer` | secrets, crypto, injection, untrusted input |
+| `ecc:silent-failure-hunter` | swallowed exceptions, bad fallbacks, errors that vanish |
+| `ecc:pr-test-analyzer` | whether the tests cover the behaviour, not just the lines |
+
+Add by judgement: `ecc:performance-optimizer` (terminal/rendering hot paths),
+`ecc:type-design-analyzer` (new domain types), `ecc:a11y-architect` (new UI surface),
+`ecc:java-reviewer` or `ecc:database-reviewer` (server changes).
+
+Every reviewer prompt must state: the exact range, "read-only, report `file:line` + concrete failure
+scenario", and "never run `git checkout`/`switch`/`stash`/`reset` — the worktree is shared".
+
+Skip this stage entirely if `$ARGUMENTS` contains `--no-review`.
+
+## Stage 3 — triage
+
+Reviewers are fallible — **verify each finding against the actual code before acting on it**. Past
+runs produced inflated severities and findings that were already implemented.
+
+Then report to the user as a single table: finding → `file:line` → verdict (fix / reject + reason).
+Nothing gets silently dropped. Apply the fixes that survive triage; any fix that changes behaviour
+goes back through the TDD loop (failing test first). Re-run stage 1 after applying fixes.
+
+Finish by stating plainly what is still unverified — live device, live server, another OS.

--- a/.claude/hooks/gate-state.py
+++ b/.claude/hooks/gate-state.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""PostToolUse recorder for the pre-PR gate.
+
+Tracks three timestamps in .git/skerry-gate-state.json:
+  code   — last edit to a .kt/.kts file
+  build  — last green `gradlew` run that included the test and detekt tasks
+  review — last run of a reviewer subagent
+
+guard-git.py refuses a commit or a PR when `code` is newer than `build` or `review`, i.e. when the
+code changed after it was last gated. Documentation-only changes never set `code`, so they commit
+freely.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+REVIEWERS = re.compile(
+    r"skerry-reviewer|kotlin-reviewer|security-reviewer|silent-failure-hunter|pr-test-analyzer"
+)
+GATE_TASKS = re.compile(r"detektAll|allTests")
+CODE_FILE = re.compile(r"\.kts?$")
+
+
+def state_path() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--git-dir"], capture_output=True, text=True, timeout=5
+        )
+        git_dir = out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return os.path.join(git_dir, "skerry-gate-state.json") if git_dir else ""
+
+
+def mark(key: str) -> None:
+    path = state_path()
+    if not path:
+        return
+    try:
+        with open(path) as fh:
+            state = json.load(fh)
+    except (OSError, ValueError):
+        state = {}
+    state[key] = time.time()
+    try:
+        with open(path, "w") as fh:
+            json.dump(state, fh)
+    except OSError:
+        pass  # a hook must never break the session
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+
+    tool = payload.get("tool_name") or ""
+    tool_input = payload.get("tool_input") or {}
+    response = payload.get("tool_response")
+    response_text = response if isinstance(response, str) else json.dumps(response or "")
+
+    if tool in ("Edit", "Write", "MultiEdit", "NotebookEdit"):
+        if CODE_FILE.search(tool_input.get("file_path") or ""):
+            mark("code")
+    elif tool == "Bash":
+        command = tool_input.get("command") or ""
+        # A green gate run: the gradle tasks that matter, and no failure in the output.
+        if GATE_TASKS.search(command) and "BUILD SUCCESSFUL" in response_text:
+            mark("build")
+    elif tool in ("Agent", "Task"):
+        subagent = tool_input.get("subagent_type") or ""
+        if REVIEWERS.search(subagent):
+            mark("review")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/guard-git.py
+++ b/.claude/hooks/guard-git.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for Bash commands in the Skerry repo.
+
+Three rules, all from CLAUDE.md -> How we work:
+  * `main` is protected: committing or pushing while HEAD is on main is blocked outright.
+  * Code that changed after the last gate run cannot be committed or pushed: the build/detekt run
+    and the reviewer fan-out must both post-date the last .kt/.kts edit (state written by
+    gate-state.py). Set SKERRY_GATE_OVERRIDE=1 to bypass deliberately.
+  * `gh pr create` asks for confirmation on top of that.
+
+Exit 2 blocks the call and hands stderr to the model; a JSON body on stdout with exit 0
+downgrades the call to an explicit confirmation.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+
+# `rtk` transparently prefixes shell commands in this environment, so match through it.
+GIT_WRITE = re.compile(r"(?:^|[;&|]|\s)(?:rtk\s+)?git\s+(?:-\S+\s+)*(commit|push)(?![\w-])")
+PR_CREATE = re.compile(r"(?:^|[;&|]|\s)(?:rtk\s+)?gh\s+pr\s+create\b")
+
+
+def current_branch() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+        return out.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def gate_debt() -> list:
+    """Which gate stages are stale relative to the last code edit."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--git-dir"], capture_output=True, text=True, timeout=5
+        )
+        path = os.path.join(out.stdout.strip(), "skerry-gate-state.json")
+        with open(path) as fh:
+            state = json.load(fh)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return []  # no state yet — nothing was tracked, so nothing to claim
+
+    code = state.get("code")
+    if not code:
+        return []
+    stale = []
+    if code > state.get("build", 0):
+        stale.append("build + tests + detekt")
+    if code > state.get("review", 0):
+        stale.append("reviewer fan-out")
+    if stale:
+        age = int(time.time() - code)
+        stale.append(f"(last code edit {age}s ago)")
+    return stale
+
+
+def ask(reason: str) -> None:
+    json.dump({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }, sys.stdout)
+    sys.exit(0)
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)  # never break the session on a malformed payload
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    if not command:
+        sys.exit(0)
+
+    match = GIT_WRITE.search(command)
+    if match and current_branch() == "main":
+        verb = match.group(1)
+        sys.stderr.write(
+            f"Blocked: `git {verb}` while HEAD is on main. This repo is PR-only — "
+            "create a feature branch (`git checkout -b <type>/<slug>`) and open a PR. "
+            "Carry the working tree over with the branch; do not stash or reset it.\n"
+        )
+        sys.exit(2)
+
+    if (match or PR_CREATE.search(command)) and os.environ.get("SKERRY_GATE_OVERRIDE") != "1":
+        stale = gate_debt()
+        if stale:
+            sys.stderr.write(
+                "Blocked: code changed after the last gate run — stale: "
+                + ", ".join(stale)
+                + ". Run /gate (build + tests + detekt, then the reviewer fan-out) and triage the "
+                "findings first. If this is deliberate, re-run with SKERRY_GATE_OVERRIDE=1 and say "
+                "why in the message to the user.\n"
+            )
+            sys.exit(2)
+
+    if PR_CREATE.search(command):
+        ask(
+            "Opening a PR. Confirm the pre-PR gate actually ran on this branch: "
+            "tests + build + Android compile green, and the review fan-out "
+            "(skerry-reviewer, ecc:kotlin-reviewer, ecc:security-reviewer, "
+            "ecc:silent-failure-hunter) triaged. Run /gate if it did not."
+        )
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-git.py"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit|Bash|Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/gate-state.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,12 @@ jobs:
         # inside a coroutine and surfaces as a test that never reaches its final state.
         run: xvfb-run --auto-servernum ./gradlew test allTests --stacktrace
 
+      # Static analysis. Runs after the tests so a red suite is reported first — detekt findings are
+      # cheaper to read once the behaviour is known good. Existing findings sit in
+      # gradle/detekt-baseline-*.xml; this step fails only on NEW ones.
+      - name: Detekt
+        run: ./gradlew detektAll --stacktrace
+
       # Gradle prints only the assertion's file and line; the values it compared live in the report.
       - name: Upload test reports
         if: failure()
@@ -64,4 +70,5 @@ jobs:
           path: |
             **/build/reports/tests/
             **/build/test-results/
+            **/build/reports/detekt/
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,12 @@ server/.env
 *.db-journal
 .tokensave
 
+# Claude Code: the shared harness (agents, /gate, hooks, settings.json) IS committed; per-machine
+# state is not.
+.claude/settings.local.json
+.claude/worktrees/
+.claude/*.lock
+
 # Flatpak build outputs (the committed inputs are the manifest + flatpak-sources.json)
 composeApp/flatpak/.build/
 composeApp/flatpak/*.flatpak

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,24 @@ Requires **JDK 21** (`foojay-resolver` fetches one if needed); Android needs `AN
 ./gradlew :composeApp:packageDistributionForCurrentOS       # .deb / .rpm / .msi / .dmg
 ANDROID_HOME=$HOME/Android/Sdk ./gradlew :androidApp:installDebug
 ./gradlew test allTests                                     # JUnit 5; `test` alone skips shared/composeApp
+./gradlew :androidApp:compileDebugKotlin                    # Android side of a UI change
+./gradlew build                                             # full gate, lint included
+./gradlew detektAll                                         # static analysis; detektBaseline to re-baseline
+./gradlew koverHtmlReport                                   # coverage report
 docker compose up -d --build                                # sync server; set SKERRY_JWT_SECRET
 ./gradlew :server:run -PserverOnly                          # server-only build, no Android SDK
 ```
 
+Test stack is `kotlin("test")` on the **JUnit 5** backend. There is no Kotest, no MockK, and no
+detekt/ktlint in this repo — don't introduce them because a generic Kotlin skill suggests them.
+Fakes are hand-written; the lint gate is Android lint inside `./gradlew build`.
+
 ## Repository layout
 
 ```
-shared/       # KMP core: ssh/, sftp/, vault/, sync/, team/, terminal/, ai/ (+ai/local),
-              # telnet/, serial/, tunnel/, snippet/, host/, files/
+shared/       # KMP core: ssh/, sftp/, vault/, sync/, team/, share/, terminal/, ai/ (+ai/local),
+              # telnet/, serial/, mosh/, rdp/, vnc/, graphics/, audio/, tunnel/, container/,
+              # snippet/, runbook/, host/, tag/, files/, guard/, update/
               # commonMain + jvmSharedMain (shared JVM for desktop+Android) + desktopMain + androidMain
 composeApp/   # UI (Compose Multiplatform): commonMain + androidMain + desktopMain
 androidApp/   # Android app (MainActivity, manifest); applicationId app.skerry
@@ -30,21 +39,123 @@ sync-wire/    # wire contract shared by client and server (needed by server-only
 docs/         # HTML prototypes (source of truth for UX) and design documents
 ```
 
+## How we work
+
+Every change follows the same loop. Steps 1–4 are not optional, and step 4 runs **before** the PR is
+merged, not after.
+
+### 0. Orient before writing code
+
+- **Read `docs/coding-guidelines.md`** — it encodes bugs we already paid for. Division of labour:
+  this file owns the *process*, `coding-guidelines.md` owns *what the code must look like*
+  (abstraction catalogue, decomposition, coroutine and security patterns, self-review checklist).
+  A rule belongs in exactly one of the two.
+- **Search for an existing abstraction before creating one** (guidelines §1). Second repetition is a
+  signal, third makes extraction mandatory.
+- For a non-trivial feature, map the ground first with `ecc:code-explorer` (how the existing
+  subsystem works) and/or `ecc:code-architect` (where the new pieces belong). Skip for small fixes.
+- Work happens on a feature branch. `main` is protected — every change lands through a PR.
+
+### 1. RED — the failing test comes first
+
+- Write the test before the implementation, in `commonMain` test sources unless the behaviour is
+  genuinely platform-specific.
+- Run it and **confirm it fails for the intended reason**, not on a compile error or a typo.
+- For a bug fix, the test must reproduce the bug.
+- For controllers touching coroutines, cover cancellation and re-entry — that's the bug class
+  guidelines §3 exists for.
+- `ecc:tdd-guide` and the `ecc:kotlin-testing` skill are the reference for test shape; ignore their
+  Kotest/MockK examples and use `kotlin.test` (see above).
+
+### 2. GREEN — minimal implementation, then refactor
+
+- Contracts and domain types in `commonMain`; platform libraries behind `expect`/`actual` or an
+  interface. UI sees common contracts only.
+- Desktop⇆Android parity: a feature isn't done until it works on both.
+- Delete the code the change orphaned, in the same commit.
+
+### 3. Build gate
+
+- `./gradlew test allTests`, then `./gradlew build` (lint on), then `./gradlew detektAll`, and
+  `:androidApp:compileDebugKotlin` for anything that touches UI. `/gate` runs the whole sequence
+  plus the review fan-out.
+- detekt fails on **new** findings only; the existing ones sit in `gradle/detekt-baseline-*.xml`.
+  Re-baselining (`./gradlew detektBaseline`) to silence your own finding is not allowed — fix it,
+  or say out loud why it stays.
+- Run builds **without `| tail` / `| grep`** — the pipe masks the exit code. Redirect to a file and
+  check `echo $?`.
+- If the build breaks in a way that isn't obviously yours, hand it to `ecc:kotlin-build-resolver`
+  (minimal diffs, no architectural edits) instead of reshaping the design around the error.
+- New test added? Re-run it with the fix reverted to prove it actually catches the regression.
+
+### 4. Review gate — ECC fan-out before the PR
+
+Once the branch is green, launch the reviewers **in parallel, in a single message**, scoped to
+`git diff main...HEAD`:
+
+| Agent | Looks for |
+|---|---|
+| `ecc:kotlin-reviewer` | idiomatic Kotlin, null safety, coroutine/structured-concurrency safety, Compose pitfalls |
+| `ecc:security-reviewer` | secrets, unsafe crypto, injection, untrusted input crossing a boundary |
+| `ecc:silent-failure-hunter` | swallowed exceptions, bad fallbacks, errors that never propagate |
+| `ecc:pr-test-analyzer` | whether the tests actually cover the behaviour, not just the lines |
+
+Add when the diff calls for it: `ecc:performance-optimizer` (hot paths, terminal rendering),
+`ecc:type-design-analyzer` (new domain types), `ecc:comment-analyzer` (comment rot),
+`ecc:a11y-architect` (new UI surfaces), `ecc:database-reviewer` / `ecc:java-reviewer` (server side).
+
+Rules for the fan-out:
+
+- Reviewers are **read-only**. They report; the fixes are mine, in the working tree.
+- Subagents must never run `git checkout`, switch branches, or stash — they share the worktree.
+- Every finding gets one of two outcomes: fixed, or explicitly rejected to the user with the reason.
+  Silent dismissal is not an option.
+- A fix that changes behaviour goes back through step 1 (test first).
+- Reviewers are fallible: verify each finding against the actual code before acting on it.
+
+`/ecc:kotlin-review`, `/ecc:code-review` and `/ecc:review-pr` are the command shortcuts for the same
+agents when a single-angle pass is enough.
+
+**This stage is enforced, not advisory.** A local hook records every `.kt`/`.kts` edit, every green
+`allTests`/`detektAll` run and every reviewer subagent; `git commit`, `git push` and `gh pr create`
+are refused while the code is newer than either. Documentation-only changes are unaffected. The
+deliberate bypass is `SKERRY_GATE_OVERRIDE=1`, and using it means saying out loud why.
+
+### 5. Hand-off
+
+- Commit messages in English. Commit and push **only when asked**.
+- PR description in English: what the feature does, no development history, no "why we tried X".
+- Tell the user how to verify the result with their own eyes — screen, scenario, keystrokes.
+- State plainly what was *not* verified (live device, live server, other OS).
+
 ## Conventions
 
-- **TDD**: write the failing test first, then the implementation.
-- **Contracts live in `commonMain`**; platform libraries sit behind `expect`/`actual` or an
-  interface. Keep desktop⇆Android parity — a feature isn't done until it works on both.
-- **Read `docs/coding-guidelines.md` before writing code** — abstractions, decomposition, coroutine
-  and security patterns, self-review checklist.
-- **Build UI 1:1 from the prototype** in `docs/design/Skerry Tablet.html` (`Skerry Logo.html`
-  is the brand-mark source). Don't invent chrome. Design tokens come from its `:root` block,
-  mirrored in the Compose theme.
-- Commit messages in English; commit and push only when asked.
+Code-level rules — reusable abstractions, file size, coroutines, security, design tokens, i18n —
+live in `docs/coding-guidelines.md` and are not repeated here. What's left is project-wide:
+
+- **UI 1:1 from the prototype** in `docs/design/Skerry Tablet.html` (`Skerry Logo.html` is the
+  brand-mark source). Don't invent chrome; design tokens come from its `:root` block, mirrored in
+  the Compose theme.
+- A new keyboard shortcut ships with its row in Settings → Keyboard in the same commit.
+- UI copy is technical and short; no reassuring second sentence.
+- **Reporting to the user follows the same register as UI copy.** This is systems software, not a
+  blog: fact, number, conclusion. A table or a short list beats paragraphs. Don't restate what was
+  just done at length, don't enumerate options you won't take, don't ask about the obvious. Spell
+  something out only when it hides a real gotcha or a decision that changes the work.
+- Code comments in English, and only for the non-obvious *why*.
+
+## Tooling
+
+The ECC plugin (`ecc@ecc`) supplies the agents above plus skills worth loading in context:
+`kotlin-testing`, `kotlin-coroutines-flows`, `compose-multiplatform-patterns`, `kotlin-patterns`,
+`tdd-workflow`, `security-review`, `git-workflow`. Contributors without the plugin can read this
+section as a checklist — the requirements (tests first, review before merge) are the point; the
+agents are just how we execute them here.
 
 ## Warnings
 
 - **ProGuard/minification is disabled on purpose** for the desktop release — it broke the crypto
   stack (JNA/libsodium, okio, BouncyCastle's signed jar). See the comment in
   `composeApp/build.gradle.kts` before re-enabling.
+- CI runs `xvfb-run --auto-servernum ./gradlew test allTests`; UI tests need the virtual display.
 - Licenses: GPL-3.0 for the clients, AGPL-3.0 for `server/`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ hood, Compose Multiplatform UI on top. One core codebase and one UI across
 |---|---|---|---|---|
 | **Open source** | ✅ GPL-3.0 · AGPL-3.0 | ❌ | ✅ MIT | ✅ MIT |
 | **Platforms** | Linux · Windows · macOS · Android | Windows · macOS · Linux · iOS · Android | Windows · Unix | Windows · macOS · Linux |
-| **First release** | 2026 (v0.1.x) | 2011 | 1999 | 2017 |
+| **First release** | 2026 (v0.2.x) | 2011 | 1999 | 2017 |
 | **Price** | free | free tier · paid from $10/mo | free | free |
 | **Works without an account** | ✅ | ⚠️ local only <sup>1</sup> | ✅ | ✅ |
 | **Encrypted vault** | ✅ always on <sup>2</sup> | ✅ | ❌ | ⚠️ opt-in |
@@ -33,7 +33,8 @@ hood, Compose Multiplatform UI on top. One core codebase and one UI across
 | **Port forwarding** | ✅ local · remote · dynamic | ✅ | ✅ | ✅ |
 | **Serial / Telnet** | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
 | **Mosh** | ✅ | ✅ | ❌ | ❌ |
-| **VNC remote desktop** | ✅ built-in | ❌ | ❌ | ❌ |
+| **VNC / RDP remote desktop** | ✅ built-in, both | ❌ | ❌ | ❌ |
+| **Live session sharing** | ✅ end-to-end encrypted | ⚠️ paid tier | ❌ | ❌ |
 | **AI assistant** | ✅ local or BYOK cloud <sup>4</sup> | ⚠️ cloud, account required | ❌ | ❌ |
 
 **Legend:** ✅ yes · ⚠️ partial / with caveats · ❌ no
@@ -49,7 +50,7 @@ Spotted an error? Please open a PR.*
 ## Status
 
 Actively developed for **Linux**, **Windows**, **macOS**, and **Android**. **iOS/iPadOS** is
-planned.
+deferred — there are no iOS targets in the build.
 
 ## Install
 
@@ -97,15 +98,25 @@ Building it yourself is also easy — see [Building from source](#building-from-
 
 ## Features
 
-- **Connections** — SSH with jump hosts (ProxyJump) and SSH certificates; Mosh; SFTP
-  (dual-pane commander with a built-in file viewer/editor); port forwarding: local, remote,
-  dynamic/SOCKS, plus discovery of listening services with one-tap forwarding; VNC remote
-  desktop; Docker and Kubernetes exec (pick a container/pod on the host and drop into its
-  shell); Telnet; serial (desktop and Android USB-OTG).
+- **Connections** — SSH with jump hosts (ProxyJump), SSH certificates (loaded from the vault or
+  read from disk on every connection), host-key certificates signed by a CA, and
+  keyboard-interactive 2FA challenges; Mosh; SFTP (dual-pane commander with a built-in file
+  viewer/editor, sortable columns and a quick name filter); port forwarding: local, remote,
+  dynamic/SOCKS, plus discovery of listening services with one-tap forwarding; Docker and
+  Kubernetes exec (pick a container/pod on the host and drop into its shell); Telnet; serial
+  (desktop and Android USB-OTG); a local shell in a tab, without any connection at all.
+  Existing hosts can be imported from `~/.ssh/config`.
+- **Remote desktops** — VNC and RDP in a section of their own, both on a client stack written
+  for this project. A session panel carries screenshots, Ctrl+Alt+Del, clipboard exchange and
+  settings that apply mid-session.
 - **Terminal** — custom grid emulation, session tabs with up to four tiled panes and
   synchronized input, SSH auto-reconnect, scrollback search, live host metrics, a command
-  palette over the history, broadcast input to several sessions, and session recording
-  (asciinema v2) with in-app playback.
+  palette over the history, broadcast input to several sessions, file paths from the output
+  opened straight in the SFTP panel, and session recording (asciinema v2) with in-app playback.
+- **Session sharing** — stream a live terminal to a teammate end-to-end encrypted, read-only or
+  with the keyboard handed over.
+- **Production guard** — hosts tagged `prod` score every command for risk and stop the dangerous
+  ones behind an explicit confirmation.
 - **Themes** — dark and light app themes with a card-based catalog; the terminal follows
   the app theme, and the System mode tracks the OS live.
 - **Vault** — always-on encryption (Argon2id + XChaCha20-Poly1305) for keys, passwords,
@@ -113,7 +124,8 @@ Building it yourself is also easy — see [Building from source](#building-from-
   and tunnels stay restorable in the trash for 30 days, on every synced device.
 - **Sync** — optional and self-hosted, zero-knowledge, live push over WebSocket, device
   pairing via QR. See [Sync server](#sync-server).
-- **Teams** — end-to-end encrypted sharing of hosts and snippets within a team.
+- **Teams** — end-to-end encrypted sharing of hosts and snippets within a team, with access
+  scopes per member and an activity feed of who changed which host and who opened a session.
 - **Snippets & AI** — command library with type-ahead in the terminal; dynamic `${{…}}`
   variables (date/time, uuid, random, clipboard, vault secrets, prompted parameters) resolved
   at run time behind a confirmation preview; AI assistant with
@@ -149,20 +161,23 @@ only coexist under explicit rules:
 
 ## Tech stack
 
-- **Language/UI**: Kotlin 2.x, Compose Multiplatform 1.11.1
-- **Build**: Gradle 9.3.1, Android Gradle Plugin 9.0.1
+- **Language/UI**: Kotlin 2.4.10, Compose Multiplatform 1.9.3
+- **Build**: Gradle 9.6.1, Android Gradle Plugin 9.1.1
 - **JVM target**: JDK 21 (`jvmToolchain(21)` in all modules, `JVM_21`)
-- **Android**: minSdk 26 (Android 8.0), compileSdk/targetSdk 36
-- **Core**: sshj 0.40.0, BouncyCastle 1.80.2, libsodium (ionspin KMP), okio, atomicfu
-- **Serial**: jSerialComm 2.11.0 (desktop), usb-serial-for-android 3.9.0 (Android, jitpack)
-- **Sync**: Ktor 3.4.3 (client+server), Exposed 0.58.0, SQLite/PostgreSQL, HikariCP,
+- **Android**: minSdk 26 (Android 8.0), compileSdk 37, targetSdk 36
+- **Core**: sshj 0.40.0, BouncyCastle 1.85, libsodium (ionspin KMP), okio 3.18.0, atomicfu
+- **Remote desktop**: VNC (RFB) and RDP stacks written for this project, no third-party client
+- **Serial**: jSerialComm 2.11.4 (desktop), usb-serial-for-android (Android, jitpack)
+- **Sync**: Ktor 3.5.1 (client+server), Exposed 1.3.1, SQLite/PostgreSQL, HikariCP,
   Nimbus SRP-6a
+- **Quality**: JUnit 5, Kover coverage, detekt static analysis
 
 ## Repository layout
 
 ```
-shared/       # KMP core: ssh/, sftp/, vault/, sync/, team/, terminal/, ai/ (+ai/local),
-              # telnet/, serial/, tunnel/, snippet/, host/, files/
+shared/       # KMP core: ssh/, sftp/, vault/, sync/, team/, share/, terminal/, ai/ (+ai/local),
+              # telnet/, serial/, mosh/, rdp/, vnc/, graphics/, audio/, tunnel/, container/,
+              # snippet/, runbook/, host/, tag/, files/, guard/, update/
 composeApp/   # UI (Compose Multiplatform): commonMain + androidMain + desktopMain
 androidApp/   # Android app (MainActivity, manifest); applicationId app.skerry
 server/       # self-hosted sync server (Ktor, AGPL-3.0)
@@ -198,10 +213,11 @@ Android:
 ANDROID_HOME=$HOME/Android/Sdk ./gradlew :androidApp:installDebug
 ```
 
-Tests (JUnit 5):
+Tests (JUnit 5) and static analysis:
 
 ```bash
-./gradlew test
+./gradlew test allTests    # `test` alone skips the multiplatform modules
+./gradlew detektAll        # detekt; existing findings sit in gradle/detekt-baseline-*.xml
 ```
 
 ## Sync server

--- a/README.ru.md
+++ b/README.ru.md
@@ -23,7 +23,7 @@ macOS)** и **Android**, паритет фич между платформами
 |---|---|---|---|---|
 | **Open source** | ✅ GPL-3.0 · AGPL-3.0 | ❌ | ✅ MIT | ✅ MIT |
 | **Платформы** | Linux · Windows · macOS · Android | Windows · macOS · Linux · iOS · Android | Windows · Unix | Windows · macOS · Linux |
-| **Первый релиз** | 2026 (v0.1.x) | 2011 | 1999 | 2017 |
+| **Первый релиз** | 2026 (v0.2.x) | 2011 | 1999 | 2017 |
 | **Цена** | бесплатно | free-тариф · платно от $10/мес | бесплатно | бесплатно |
 | **Работает без аккаунта** | ✅ | ⚠️ только локально <sup>1</sup> | ✅ | ✅ |
 | **Шифрованный vault** | ✅ всегда включён <sup>2</sup> | ✅ | ❌ | ⚠️ по желанию |
@@ -33,7 +33,8 @@ macOS)** и **Android**, паритет фич между платформами
 | **Port forwarding** | ✅ local · remote · dynamic | ✅ | ✅ | ✅ |
 | **Serial / Telnet** | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ | ✅ / ✅ |
 | **Mosh** | ✅ | ✅ | ❌ | ❌ |
-| **Удалённый рабочий стол VNC** | ✅ встроенный | ❌ | ❌ | ❌ |
+| **Удалённый рабочий стол VNC / RDP** | ✅ встроенные оба | ❌ | ❌ | ❌ |
+| **Совместные сессии** | ✅ end-to-end | ⚠️ платный тариф | ❌ | ❌ |
 | **AI-ассистент** | ✅ локальный или BYOK-облако <sup>4</sup> | ⚠️ облако, нужен аккаунт | ❌ | ❌ |
 
 **Обозначения:** ✅ есть · ⚠️ частично / с оговорками · ❌ нет
@@ -49,7 +50,7 @@ macOS)** и **Android**, паритет фич между платформами
 ## Статус
 
 В активной разработке под **Linux**, **Windows**, **macOS** и **Android**. **iOS/iPadOS**
-— в планах.
+отложены — таргетов iOS в сборке нет.
 
 ## Установка
 
@@ -97,15 +98,25 @@ macOS)** и **Android**, паритет фич между платформами
 
 ## Возможности
 
-- **Подключения** — SSH с jump-хостами (ProxyJump) и SSH-сертификатами; Mosh; SFTP
-  (двухпанельный commander со встроенным просмотром/редактированием файлов); port
-  forwarding: local, remote, dynamic/SOCKS, плюс обнаружение слушающих сервисов с пробросом
-  в один тап; удалённый рабочий стол VNC; exec в Docker и Kubernetes (выбор контейнера или
-  пода на хосте и вход в его shell); Telnet; serial (desktop и Android USB-OTG).
+- **Подключения** — SSH с jump-хостами (ProxyJump), SSH-сертификатами (из vault или прямо с
+  диска — файл перечитывается при каждом подключении), сертификатами хост-ключей от CA и
+  ответами на keyboard-interactive 2FA; Mosh; SFTP (двухпанельный commander со встроенным
+  просмотром/редактированием файлов, настраиваемыми колонками и быстрым фильтром по имени);
+  port forwarding: local, remote, dynamic/SOCKS, плюс обнаружение слушающих сервисов с
+  пробросом в один тап; exec в Docker и Kubernetes (выбор контейнера или пода на хосте и вход
+  в его shell); Telnet; serial (desktop и Android USB-OTG); локальный shell во вкладке — вообще
+  без подключения. Хосты можно импортировать из `~/.ssh/config`.
+- **Удалённые рабочие столы** — VNC и RDP в отдельном разделе, оба на собственном клиентском
+  стеке. Панель сессии даёт скриншот, Ctrl+Alt+Del, обмен буфером обмена и настройки,
+  применяемые прямо посреди сессии.
 - **Терминал** — своя grid-эмуляция, вкладки с тайловой раскладкой до четырёх панелей и
   синхронным вводом, авто-реконнект SSH, поиск по scrollback, живые метрики хоста, палитра
-  команд по истории, трансляция ввода в несколько сессий и запись сессий (asciinema v2)
-  со встроенным проигрывателем.
+  команд по истории, трансляция ввода в несколько сессий, открытие файловых путей из вывода
+  сразу в панели SFTP и запись сессий (asciinema v2) со встроенным проигрывателем.
+- **Совместные сессии** — трансляция живого терминала коллеге по E2E-шифрованному каналу:
+  только просмотр или с передачей клавиатуры.
+- **Production guard** — на хостах с тегом `prod` каждая команда оценивается по риску, опасные
+  требуют явного подтверждения.
 - **Темы** — тёмные и светлые темы приложения с каталогом-карточками; терминал следует теме
   приложения, режим «Системная» отслеживает ОС на лету.
 - **Vault** — всегда включённое шифрование (Argon2id + XChaCha20-Poly1305) для ключей,
@@ -114,7 +125,8 @@ macOS)** и **Android**, паритет фич между платформами
   синхронизированном устройстве.
 - **Sync** — опциональная и self-hosted, zero-knowledge, live push через WebSocket, паринг
   устройств по QR. См. [Sync-сервер](#sync-сервер).
-- **Teams** — E2E-шифрованный шаринг хостов и сниппетов внутри команды.
+- **Teams** — E2E-шифрованный шаринг хостов и сниппетов внутри команды, с областями доступа для
+  каждого участника и лентой активности: кто менял какой хост и кто открывал сессию.
 - **Сниппеты и AI** — библиотека команд с type-ahead в терминале; динамические переменные
   `${{…}}` (дата/время, uuid, random, буфер обмена, секреты хранилища, запрашиваемые
   параметры), разворачиваемые при запуске за диалогом подтверждения; AI-ассистент с per-host
@@ -151,20 +163,23 @@ macOS)** и **Android**, паритет фич между платформами
 
 ## Технологии
 
-- **Язык/UI**: Kotlin 2.x, Compose Multiplatform 1.11.1
-- **Сборка**: Gradle 9.3.1, Android Gradle Plugin 9.0.1
+- **Язык/UI**: Kotlin 2.4.10, Compose Multiplatform 1.9.3
+- **Сборка**: Gradle 9.6.1, Android Gradle Plugin 9.1.1
 - **JVM-таргет**: JDK 21 (`jvmToolchain(21)` во всех модулях, `JVM_21`)
-- **Android**: minSdk 26 (Android 8.0), compileSdk/targetSdk 36
-- **Ядро**: sshj 0.40.0, BouncyCastle 1.80.2, libsodium (ionspin KMP), okio, atomicfu
-- **Serial**: jSerialComm 2.11.0 (desktop), usb-serial-for-android 3.9.0 (Android, jitpack)
-- **Sync**: Ktor 3.4.3 (клиент+сервер), Exposed 0.58.0, SQLite/PostgreSQL, HikariCP,
+- **Android**: minSdk 26 (Android 8.0), compileSdk 37, targetSdk 36
+- **Ядро**: sshj 0.40.0, BouncyCastle 1.85, libsodium (ionspin KMP), okio 3.18.0, atomicfu
+- **Удалённый рабочий стол**: собственные стеки VNC (RFB) и RDP, без сторонних клиентов
+- **Serial**: jSerialComm 2.11.4 (desktop), usb-serial-for-android (Android, jitpack)
+- **Sync**: Ktor 3.5.1 (клиент+сервер), Exposed 1.3.1, SQLite/PostgreSQL, HikariCP,
   Nimbus SRP-6a
+- **Качество**: JUnit 5, покрытие Kover, статанализ detekt
 
 ## Структура репозитория
 
 ```
-shared/       # ядро KMP: ssh/, sftp/, vault/, sync/, team/, terminal/, ai/ (+ai/local),
-              # telnet/, serial/, tunnel/, snippet/, host/, files/
+shared/       # ядро KMP: ssh/, sftp/, vault/, sync/, team/, share/, terminal/, ai/ (+ai/local),
+              # telnet/, serial/, mosh/, rdp/, vnc/, graphics/, audio/, tunnel/, container/,
+              # snippet/, runbook/, host/, tag/, files/, guard/, update/
 composeApp/   # UI (Compose Multiplatform): commonMain + androidMain + desktopMain
 androidApp/   # Android-приложение (MainActivity, манифест); applicationId app.skerry
 server/       # self-hosted sync-сервер (Ktor, AGPL-3.0)
@@ -200,10 +215,11 @@ Android:
 ANDROID_HOME=$HOME/Android/Sdk ./gradlew :androidApp:installDebug
 ```
 
-Тесты (JUnit 5):
+Тесты (JUnit 5) и статанализ:
 
 ```bash
-./gradlew test
+./gradlew test allTests    # один `test` пропускает мультиплатформенные модули
+./gradlew detektAll        # detekt; накопленные замечания лежат в gradle/detekt-baseline-*.xml
 ```
 
 ## Sync-сервер

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@ buildscript {
             // Compose Hot Reload (dev-only live reload) rides the same online-only gate as Kover: a
             // plugins {} entry would be resolved even with `apply false` and break the offline build.
             classpath("org.jetbrains.compose.hot-reload:hot-reload-gradle-plugin:" + libs.versions.composeHotReload.get())
+            // detekt (static analysis) rides the same online-only gate for the same reason.
+            classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:" + libs.versions.detekt.get())
         }
     }
 }
@@ -42,4 +44,6 @@ plugins {
 // script header. buildscript{} above already gates the classpath the same way.
 if (System.getProperty("skerry.offlineRepo") == null) {
     apply(from = rootProject.file("gradle/kover.gradle.kts"))
+    // Static analysis, wired the same way and for the same offline reason. Run: ./gradlew detekt
+    apply(from = rootProject.file("gradle/detekt.gradle.kts"))
 }

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -1,130 +1,160 @@
-# Skerry — правила написания кода
+# Skerry — coding guidelines
 
-Документ для ассистента (и людей): **читать перед написанием любого кода**. Каждое правило
-здесь — не теория, а класс проблем, который реально пришлось массово исправлять в предрелизном
-ревью 2026-07-02 и глобальном рефакторинге 2026-07-03/04 (~115 файлов, −7646 строк). Цель —
-писать сразу так, чтобы третий такой проход не понадобился.
+Rules for the code itself. `CLAUDE.md` owns the *process* (TDD loop, build gate, review fan-out,
+hand-off); this file owns *what the code must look like once you're writing it*. Read it before
+writing code — every rule here is a class of defect we already paid for in the 2026-07-02
+pre-release review and the 2026-07-03/04 refactor (~115 files, −7646 lines). The goal is to write it
+right the first time so a third such pass isn't needed.
 
-## 1. Сначала поиск, потом код
+## 1. Search before you write
 
-Перед тем как писать новый класс/функцию/паттерн — **найти существующее**. Девять копий
-vault-backed JSON store и девять копий admin-token guard появились потому, что каждая новая фича
-писалась «с нуля рядом». Грепать по ключевым словам задачи; если похожий код есть в двух местах —
-значит, нужна общая абстракция, а не третья копия.
+Before adding a class, function, or pattern — **look for the existing one**. Nine copies of a
+vault-backed JSON store and nine copies of an admin-token guard exist because every new feature was
+written "from scratch, next to the old one". Grep for the keywords of the task; if similar code
+already lives in two places, the answer is a shared abstraction, not a third copy.
 
-Готовые абстракции (использовать, не переизобретать):
+Duplication rule: **the second repetition is already a signal**, at the third extraction is
+mandatory. Tests included (see `RoutesTestSupport` on the server).
 
-| Задача | Абстракция |
+### Core (`shared/`)
+
+| Task | Abstraction |
 |---|---|
-| Vault-backed JSON-стор (список записей) | `shared/vault/VaultRecordCodec` |
-| Атомарная запись файла с правами 0600 | `shared/vault/atomicWriteUtf8` (vault/log/bio) |
-| Состояние port-forward | `shared/ssh/ForwardState` |
-| Транспорт «просто поток» (telnet/serial) | `shared/ssh/StreamOnlyConnection` (jvmShared) |
-| Стриминг AI-ответа / парсинг реплики | `ui/ai/AiStreamRunner`, `AiReplyParser` |
-| Sealed-токен sync, health-мониторинг | `ui/sync/SealedTokenCodec`, `ServerHealthMonitor` |
-| Модальные подложки, дропдауны, чипы, лейблы | `ui/design`: `ModalScrim`, `DropdownField`, `ChipButton`, `FieldLabel` |
-| Мобильный хром | `MobilePushHeader`, `MobileScreenTitle`, `MobileFabButton`, `MobileTagsEditor` |
-| Состояние форм туннелей/сниппетов (desktop и mobile) | `TunnelFormState`, `SnippetFormState` |
-| Отображение секретов | `VaultPresentation.secretStyle` |
-| Блокирующий read-цикл shell-канала (ssh/telnet/serial) | `shared/ssh/StreamShellChannel` |
-| Wire-DTO клиент⇆сервер sync | модуль `:sync-wire` (`app.skerry.sync.wire`) — НЕ зеркалить вручную |
-| Разбор/применение SGR, метрики символов, reflow | `shared/terminal`: `SgrParser`, `CharMetrics`, `TerminalReflow` |
-| Constant-time сравнение секретов | `shared/vault/constantTimeEquals` |
-| Мобильные поля форм (лейбл-капс + текстовое поле) | `ui/mobile/MobileForm.kt`: `MobileFormField`/`MobileFormInput` |
-| Причина сбоя sync → локализованный текст | `SyncFailureReason` + `ui/sync/syncFailureText` (строки не строить в контроллере) |
-| Server: guard админ-токена | route-scoped plugin (один, в Routes) — не инлайнить проверку в каждый маршрут |
-| Server: rate-limit, path-id, лимиты параметров | хелперы `requiredPathId`/`limitParam`/rate-limit-helper |
+| Vault-backed JSON store (list of records) | `vault/VaultRecordCodec` |
+| Atomic file write with 0600 permissions | `vault/atomicWriteUtf8` (vault / log / bio) |
+| Constant-time secret comparison | `vault/constantTimeEquals` |
+| Port-forward state | `ssh/ForwardState` |
+| "Just a stream" transport (telnet/serial) | `ssh/StreamOnlyConnection` (jvmShared) |
+| Blocking read loop of a shell channel (ssh/telnet/serial) | `ssh/StreamShellChannel` |
+| SGR parsing, glyph metrics, reflow | `terminal/SgrParser`, `CharMetrics`, `TerminalReflow` |
+| Sync client⇆server wire DTO | module `:sync-wire` (`app.skerry.sync.wire`) — never mirror by hand |
+| Remote-desktop session as the UI sees it (pixels, updates, input) | `graphics/RemoteDesktopSession`, `RemoteDesktopUpdate`, `RemoteKeyEvent`, `RemoteDesktopQuality`, `RemoteDesktopCapabilities` — RDP and VNC adapters both implement this, protocol types stay behind it |
+| ARGB pixel buffer (resize/blit/fill/copyRect) | `graphics/RemoteFramebuffer` |
+| PCM playback and output-device enumeration | `audio/RemoteAudio`: `AudioOutputs`, `RemoteAudioPlayerFactory`, `RemoteAudioFormat` |
+| Reading/writing a protocol PDU with bounds checks | `rdp/RdpIo`: `RdpReader`, `RdpWriter`, `RdpSource`, `RdpSink`; malformed input → `rdp/RdpProtocolException` |
+| RDP connection entry point and live session | `rdp/RdpTransport`: `RdpTransport`, `RdpSession`, `RdpUpdate` |
+| MS-RDPEDYC dynamic channel (clipboard/display/audio/graphics) | `rdp/egfx/DynamicChannelHandler` |
+| Platform crypto injected into RDP (NLA, licensing) | `rdp/nla/NtlmCrypto`, `rdp/LicenseCrypto/RdpLicenseCrypto` |
+| Server-certificate trust decision (TOFU by fingerprint) | `rdp/RdpCertificate/RdpCertificateVerifier` |
+| VNC connection entry point, session, auth | `vnc/VncTransport`: `VncTransport`, `VncSession`, `VncUpdate`, `VncAuth` |
+| Platform codecs injected into VNC (zlib, JPEG, DES challenge) | `vnc/VncCodecPorts`: `InflaterFactory`, `VncImageDecoder`, `VncChallengeResponder` |
+| Shared-session wire protocol and its encryption | `share/SessionShareFrame` (`ShareFrame`, `ShareDirection`), `share/SessionShareCodec`, `share/ShareChannel` |
+| Shared-session orchestration | `share/SessionShareHost` (host), `share/SharedSessionViewer` (viewer) |
+| Runbook model, text format, storage | `runbook/Runbook`, `RunbookScript`, `RunbookMarker`, `RunbookStore` (+ `VaultRunbookStore`) |
+| docker/k8s exec target and command building | `container/ContainerSpec`, `ContainerCommands`, `ContainerListing`; tunnelling a session through it — `container/ContainerTransport` |
+| Mosh session key, framing, timing, wire messages | `mosh/MoshKey`, `MoshFragment`, `MoshTiming`, `MoshSync`, `MoshWire` (codec in jvmShared) |
+| Host tag normalisation and prod-first ordering | `tag/Tags`: `normalizeTag`, `orderTagsProdFirst` |
+| Risk scoring of a production command | `guard/ProductionGuard` + `ProductionGuardPolicy` |
+| App version compare, release lookup, update settings | `update/UpdateVersion`, `ReleaseInfo`, `UpdateChecker`, `UpdateSettings` |
+| Server: admin-token guard | route-scoped plugin (one, in Routes) — don't inline the check per route |
+| Server: rate limit, path id, parameter limits | helpers `requiredPathId` / `limitParam` / the rate-limit helper |
 
-Правило дублирования: **второй повтор — уже сигнал**, при третьем экстракция обязательна.
-Это касается и тестов (см. `RoutesTestSupport` на сервере).
+### UI (`composeApp/`)
 
-## 2. Размер и декомпозиция — при создании, не потом
+| Task | Abstraction |
+|---|---|
+| Any text on screen | `ui/design/DesignPrimitives.Txt` — never a raw `Text()` |
+| Any icon | `ui/design/Sym` (Material Symbols glyph) + `DesignFonts` |
+| Fonts | `ui/design/DesignFoundation`: `rememberUiFont`, `rememberMono`, `rememberMaterialSymbols` |
+| Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` |
+| Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` |
+| Chips | `Chip` (label, active/inactive) vs `ChipButton` (action chip: colour, outline/filled, enabled) — pick one, don't add a third |
+| Rules and separators | `HLine`, `VLine` |
+| Dropdowns and modals | `AnchoredDropdown`, `DropdownField`, `ModalScrim` |
+| Confirming a destructive action / informing | `ui/design/ConfirmActionDialog`, `NoticeDialog` |
+| Sidebar and section chrome | `ui/design/SectionChrome`: `SidebarSectionTitle`, `SectionHeader`, `EmptyState`, `SidebarSearchField` |
+| Field labels, caps, avatars | `FieldLabel`, `LabelCase.labelUppercase`, `InitialsAvatar` |
+| Mobile chrome | `MobilePushHeader`, `MobileScreenTitle`, `MobileFabButton`, `MobileTagsEditor` |
+| Mobile form fields (label caps + input) | `ui/mobile/MobileForm.kt`: `MobileFormField` / `MobileFormInput` |
+| Tunnel/snippet form state (desktop and mobile) | `TunnelFormState`, `SnippetFormState` |
+| Secret display | `VaultPresentation.secretStyle` |
+| Terminal screen state (incl. scrollback search) | `ui/terminal/TerminalScreenState` |
+| Tiled session panes (split/resize/navigate) | `ui/session/PaneLayout` |
+| Remote-desktop screen | `ui/remote/RemoteDesktopController`, `RemoteDesktopScreenState`, `RemoteDesktopPanel` |
+| Streaming an AI reply / parsing it | `ui/ai/AiStreamRunner`, `AiReplyParser` |
+| Sealed sync token, health monitoring | `ui/sync/SealedTokenCodec`, `ServerHealthMonitor` |
+| Sync failure reason → localised text | `SyncFailureReason` + `ui/sync/syncFailureText` (don't build strings in the controller) |
 
-`TerminalView` дорос до 1587 строк, `SettingsPanel` до 1465, `SshjTransport` до 719 — каждый
-пришлось резать отдельным заходом.
+## 2. Size and decomposition — when you create it, not later
 
-- **Файл, приближающийся к ~400–500 строк, делить сразу**: по секциям экрана, по подсистемам
-  (connection / channel / forwards), по вкладкам настроек. Новую секцию/фичу — в новый файл
-  своего пакета, а не «допишу в конец существующего».
-- Один Compose-файл = один экран или один переиспользуемый блок. Панели/диалоги/сайдбары экрана —
-  отдельными файлами рядом.
-- Логика (парсинг, стейт-машины, протоколы) — **не внутри composable и не внутри контроллера UI**,
-  а отдельным классом в `shared/` или рядом с UI, но чистым и тестируемым напрямую
-  (образец: `AiStreamRunner`/`AiReplyParser` с прямыми security-тестами).
+`TerminalView` grew to 1587 lines, `SettingsPanel` to 1465, `SshjTransport` to 719 — each had to be
+cut apart in its own pass.
 
-## 3. Корутины и конкурентность
+- **A file approaching ~400–500 lines gets split right away**: by screen section, by subsystem
+  (connection / channel / forwards), by settings tab. A new section or feature goes into a new file
+  in its own package, not appended to the end of an existing one.
+- One Compose file = one screen or one reusable block. A screen's panels, dialogs and sidebars go
+  into their own files next to it.
+- Logic (parsing, state machines, protocols) does **not** live inside a composable or a UI
+  controller. It belongs in a separate class in `shared/`, or next to the UI but pure and directly
+  testable (the model: `AiStreamRunner` / `AiReplyParser` with direct security tests).
 
-Самый дорогой класс багов рефакторинга. Правила без исключений:
+## 3. Coroutines and concurrency
 
-- **`CancellationException` не глотать никогда.** Любой `catch (e: Exception)` вокруг
-  suspend-кода обязан пробрасывать её (`if (e is CancellationException) throw e`) — иначе отмена
-  маскируется под сетевую ошибку (грабли: serial/telnet каналы, `KtorSyncClient`,
-  `SecretCopyAuthorizer`).
-- **Тяжёлое/блокирующее — не на UI-потоке.** Argon2id (64 MiB), файловый IO, чтение логов —
-  через инжектированный dispatcher (`kdfDispatcher`-паттерн из `VaultGateController`). На Android
-  это ANR, на desktop — фриз.
-- **Guard-флаги и «занято»-состояния сбрасывать в `finally`**, иначе отменённая корутина
-  заклинивает фичу навсегда (грабли: биометрия в `SecretCopyAuthorizer`, `syncNow` в Busy).
-- **Read-modify-write по vault — только под `vault.transaction`** (грабли: `VaultHostStore`
-  vs фоновый merge). Общее правило: присваивание разделяемого состояния — под тем же mutex,
-  что и проверка (грабли: двойной connect в `SyncCoordinator` тёк Ktor-клиентом).
-- **Долгоживущее соединение обязано читать входящие фреймы** — WebSocket-хендлер, который только
-  пишет, не заметит Close и повиснет до следующего publish.
-- **TOCTOU в UI**: параметры операции захватывать в момент открытия подтверждающего диалога, а не
-  перечитывать при нажатии OK (грабли: SFTP overwrite перенаправлялся навигацией панели).
+The most expensive defect class of the refactor. No exceptions to these:
 
-## 4. Безопасность — по умолчанию, не «допилим потом»
+- **Never swallow `CancellationException`.** Any `catch (e: Exception)` around suspend code must
+  rethrow it (`if (e is CancellationException) throw e`) — otherwise cancellation masquerades as a
+  network error (bitten by: serial/telnet channels, `KtorSyncClient`, `SecretCopyAuthorizer`).
+- **Nothing heavy or blocking on the UI thread.** Argon2id (64 MiB), file IO, log reading — through
+  an injected dispatcher (the `kdfDispatcher` pattern from `VaultGateController`). On Android that's
+  an ANR, on desktop a freeze.
+- **Reset guard flags and "busy" state in `finally`**, or a cancelled coroutine wedges the feature
+  forever (bitten by: biometrics in `SecretCopyAuthorizer`, `syncNow` stuck in Busy).
+- **Read-modify-write on the vault only under `vault.transaction`** (bitten by: `VaultHostStore` vs
+  the background merge). General form: assignment to shared state happens under the same mutex as
+  the check that guarded it (bitten by: a double connect in `SyncCoordinator` leaking a Ktor client).
+- **A long-lived connection must read incoming frames** — a WebSocket handler that only writes will
+  miss Close and hang until the next publish.
+- **TOCTOU in the UI**: capture the operation's parameters when the confirmation dialog opens, don't
+  re-read them when OK is pressed (bitten by: SFTP overwrite being redirected by panel navigation).
 
-- Секретосодержащие файлы: **только `atomicWriteUtf8`** (атомарность + 0600). Обычный
-  `writeText` ломал TOFU known_hosts и оставлял world-readable vault-файлы.
-- **Валидация входа — до побочных эффектов**: длину/формат `deviceId`, кодов, id проверять до
-  того, как потрачен одноразовый код или сделан запрос в БД (400, а не 500 + сожжённый код).
-- Промежуточные копии ключей зануляются; сравнение секретов — constant-time, где есть примитив.
-- Невидимые управляющие байты в коде — только escaped-литералами (`""`, `Char(0x1F)`),
-  никогда сырым байтом в строке: он не виден в Read/grep и молча теряется при правках.
-- Вывод сервера/AI — недоверенный источник (политики, подтверждение, редактирование bidi).
+## 4. Security by default, not "we'll harden it later"
 
-## 5. UI: токены, ресурсы, паритет
+- Files holding secrets: **`atomicWriteUtf8` only** (atomic + 0600). A plain `writeText` broke TOFU
+  `known_hosts` and left world-readable vault files.
+- **Validate input before side effects**: check the length and format of `deviceId`, codes and ids
+  *before* a one-time code is spent or a DB query is made (400, not 500 plus a burned code).
+- Intermediate key copies are zeroed; secret comparison is constant-time where a primitive exists.
+- Invisible control bytes in source: escaped literals only (`""`, `Char(0x1F)`), never a raw
+  byte inside a string — it is invisible in Read/grep and silently lost on edit.
+- Server and AI output is an untrusted source (policies, confirmation, bidi sanitising).
 
-- **Никаких hex-цветов в экранах** — только токены `D.*` (в рефакторинге заменили ~70 захардкоженных
-  цветов; понадобился новый оттенок — добавить токен, сверив с `:root` прототипа).
-- **Никаких строк-литералов в UI** — всё через ресурсы (en+ru сразу).
-- Desktop и mobile **делят state и логику форм** (`*FormState`), расходится только layout.
-  Новая форма = сначала общий state-класс, потом два тонких view.
-- Хром — строго 1:1 по прототипам `docs/design/` (см. память template-fidelity): не изобретать
-  кнопок/тулбаров/меню, которых нет в моке.
-- Геометрия, зависящая от настроек (размер шрифта → hit-testing мыши), пересчитывается при смене
-  настройки, а не кэшируется навсегда; объекты не аллоцируются на каждую рекомпозицию
-  (`remember` с правильными ключами).
+## 5. UI: tokens, resources, parity
 
-## 6. Архитектура и тестируемость
+- **No hex colours in screens** — `D.*` tokens only (the refactor replaced ~70 hardcoded colours).
+  Need a new shade? Add a token, checked against the prototype's `:root` block.
+- **No string literals in the UI** — everything through resources, en + ru + zh at once.
+- **No raw Compose Material components** where a design primitive exists (§1, UI table). `Txt` and
+  `Sym` are used by 100+ and 70+ files respectively; a raw `Text()` or a stray icon is a bug.
+- Desktop and mobile **share form state and logic** (`*FormState`); only the layout differs. A new
+  form starts as a shared state class, then two thin views.
+- Chrome follows the `docs/design/` prototypes 1:1 — don't invent buttons, toolbars or menus that
+  aren't in the mock.
+- Geometry derived from settings (font size → mouse hit-testing) is recomputed when the setting
+  changes rather than cached forever; objects are not allocated on every recomposition (`remember`
+  with correct keys).
 
-- Контракты и доменные типы — в `commonMain`; платформенные библиотеки — за `expect/actual`.
-  UI видит только common-контракты (см. память tdd-and-architecture).
-- **Зависимости контроллеров инжектируются** (пример: `SyncEngine` в `SyncCoordinator`) — если
-  класс нельзя протестировать без сети/диска/UI, конструктор спроектирован неправильно.
-- TDD обязателен: тест → красный → реализация → зелёный. Для конкурентных контроллеров — тесты на
-  отмену и повторный вход (именно их не хватало для багов из §3).
-- **Мёртвый код удалять в том же коммите**, который его осиротил: старые сторы, экраны,
-  контроллеры и их тесты, неиспользуемые gradle-зависимости. «Пусть полежит» = будущий рефакторинг.
-- Зависимости — только через version catalog (`libs.versions.toml`), не сырыми координатами.
+## 6. Architecture and testability
 
-## 7. Проверка перед сдачей шага
+- Contracts and domain types live in `commonMain`; platform libraries sit behind `expect`/`actual`.
+  The UI sees common contracts only.
+- **Controller dependencies are injected** (example: `SyncEngine` into `SyncCoordinator`). If a
+  class can't be tested without network, disk or UI, its constructor is designed wrong.
+- Concurrent controllers need tests for cancellation and re-entry — exactly what was missing for the
+  bugs in §3. The TDD loop itself is in `CLAUDE.md` → *How we work*.
+- **Delete dead code in the same commit that orphaned it**: old stores, screens, controllers and
+  their tests, unused Gradle dependencies. "Leave it for now" is a future refactor.
+- Dependencies only through the version catalog (`libs.versions.toml`), never raw coordinates.
 
-- Сборку гонять **без `| tail`/`| grep`** (пайп маскирует exit-код) — вывод в файл + `echo $?`.
-- Полный гейт — `./gradlew build` **с включённым lint** (Android lint/NewApi ловит API-мины вроде
-  `Path.of`); Android-компиляция UI — `:androidApp:compileDebugKotlin`.
-- Остальные платформенные грабли (рендер терминала, локаль, ProGuard off, od для control-байтов) —
-  в памяти platform-gotchas: **выглядящие «поправимыми» странности кода намеренны**, не откатывать.
-- В конце шага сказать пользователю, как проверить результат глазами (экран/сценарий).
+## Self-review checklist before finishing a task
 
-## Чек-лист самопроверки перед завершением задачи
-
-1. Не создал ли я копию существующего паттерна? (грепнуть похожее)
-2. Нет ли файла, переросшего ~500 строк из-за моих правок?
-3. Все `catch` вокруг suspend пробрасывают `CancellationException`? Guard-флаги — в `finally`?
-4. Ничего блокирующего на UI-потоке? Разделяемое состояние — под mutex/transaction?
-5. Цвета — токенами, строки — ресурсами (en+ru), формы — через общий state?
-6. Файлы с секретами — через `atomicWriteUtf8`? Валидация — до побочных эффектов?
-7. Новый код покрыт тестами (включая отмену/гонки), мёртвый — удалён?
-8. Сборка прогнана без пайпа, с lint, на обоих таргетах?
+1. Did I create a copy of an existing pattern? (grep for something similar)
+2. Did any file grow past ~500 lines because of my edits?
+3. Does every `catch` around suspend code rethrow `CancellationException`? Guard flags in `finally`?
+4. Nothing blocking on the UI thread? Shared state under a mutex/transaction?
+5. Colours via tokens, strings via resources (en + ru + zh), text via `Txt`, icons via `Sym`,
+   forms via shared state?
+6. Secret-bearing files through `atomicWriteUtf8`? Validation before side effects?
+7. Is the new code covered by tests (cancellation and races included), and is the dead code gone?
+8. Build, test and review gates from `CLAUDE.md` → *How we work* all run?

--- a/gradle/detekt-baseline-androidApp.xml
+++ b/gradle/detekt-baseline-androidApp.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LongMethod:MainActivity.kt$MainActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
+    <ID>LongMethod:MainActivity.kt$MainActivity$private fun buildDependencies(): AppDependencies</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/detekt-baseline-composeApp.xml
+++ b/gradle/detekt-baseline-composeApp.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:AiReplyParser.kt$AiReplyParser$firstTok.isNotEmpty() &amp;&amp; firstTok.none { it.isWhitespace() } &amp;&amp; firstTok.all { it.isLetterOrDigit() || it == '-' }</ID>
+    <ID>ComplexCondition:DesktopDesignApp.kt$state.appOverlay != null || state.modalOpen || state.settingsOpen || state.sshImportOpen || state.rdpImportOpen || state.commandPaletteOpen || state.broadcastOpen || state.castRecording != null || // The snippet-variable confirmation dialog is modal too: a hotkey firing over it // would type into the terminal under the dialog or race the pending run. snippets?.pendingRun != null || // Same for both production-guard dialogs. This handler runs on the root's // preview pass, above the focus their scrim takes, so a snippet chord would // otherwise reach the production shell while the user is reading the question. prodConnect != null || prodGuardDialogOpen(sessions?.active)</ID>
+    <ID>ComplexCondition:DesktopShortcuts.kt$alt &amp;&amp; !ctrl &amp;&amp; !meta &amp;&amp; !shift</ID>
+    <ID>ComplexCondition:DesktopShortcuts.kt$ctrl &amp;&amp; !alt &amp;&amp; !meta &amp;&amp; key == Key.Tab</ID>
+    <ID>ComplexCondition:FramebufferImage.desktop.kt$FramebufferImage$srcOff &gt;= 0 &amp;&amp; dstOff &gt;= 0 &amp;&amp; dstOff + r.width &lt;= pixels.size &amp;&amp; srcOff + r.width &lt;= src.size</ID>
+    <ID>ComplexCondition:HostsSidebar.kt$e.type != PointerEventType.Press || !e.buttons.isPrimaryPressed || e.buttons.isSecondaryPressed || e.buttons.isTertiaryPressed</ID>
+    <ID>ComplexCondition:HostsSidebar.kt$folders.isEmpty() &amp;&amp; section == HostSection.RemoteDesktops &amp;&amp; query.isBlank() &amp;&amp; effectiveChip == ALL_HOSTS_CHIP</ID>
+    <ID>ComplexCondition:HostsSidebar.kt$noteVisible &amp;&amp; !note.isNullOrBlank() &amp;&amp; !menuOpen &amp;&amp; !snippetPickerOpen</ID>
+    <ID>ComplexCondition:MobileTeamsView.kt$!invited &amp;&amp; team.hasKey &amp;&amp; (scopeId.isEmpty() || activeScope?.hasKey == true)</ID>
+    <ID>ComplexCondition:RemoteScreenshot.kt$it.isLetterOrDigit() || it == '-' || it == '_' || it == '.'</ID>
+    <ID>ComplexCondition:RunbookPalette.kt$open &amp;&amp; enabled &amp;&amp; terminal != null &amp;&amp; active != null</ID>
+    <ID>ComplexCondition:TeamsView.kt$!invited &amp;&amp; team.hasKey &amp;&amp; (scopeId.isEmpty() || activeScope?.hasKey == true)</ID>
+    <ID>ComplexCondition:TerminalGeometry.kt$cols &lt;= 0 || rows &lt;= 0 || metrics.cellWidth &lt;= 0f || metrics.cellHeight &lt;= 0f</ID>
+    <ID>ComplexCondition:TerminalScreen.kt$focused &amp;&amp; !closed &amp;&amp; !imeInput &amp;&amp; modalsOpen == 0 &amp;&amp; !searchOpen</ID>
+    <ID>ComplexCondition:TerminalScreen.kt$g &lt; row.size &amp;&amp; row[g].width == CellWidth.Single &amp;&amp; row[g].style == st &amp;&amp; row[g].isPlainAscii()</ID>
+    <ID>ComplexCondition:TerminalScreenState.kt$TerminalScreenState$guardPolicy.production &amp;&amp; !awaitingSecret &amp;&amp; text.any { it == '\n' || it == '\r' }</ID>
+    <ID>ComplexCondition:TerminalSearchRenderTest.kt$TerminalSearchRenderTest$close(p shr 16 and 0xFF, argb shr 16 and 0xFF) &amp;&amp; close(p shr 8 and 0xFF, argb shr 8 and 0xFF) &amp;&amp; close(p and 0xFF, argb and 0xFF) &amp;&amp; (p ushr 24) == 0xFF</ID>
+    <ID>ComplexCondition:TerminalView.kt$sessions == null || !state.openFilePathsInSftp || controller == null || !controller.supportsSftp</ID>
+    <ID>ComplexCondition:VaultGateScreen.kt$event == Lifecycle.Event.ON_STOP &amp;&amp; controller.state == VaultGateState.Unlocked &amp;&amp; !controller.biometricInFlight &amp;&amp; deviceMandatesAutoLock()</ID>
+    <ID>ComplexCondition:VncCoordinates.kt$FitGeometry$fx &lt; 0f || fy &lt; 0f || fx &gt;= fbWidth || fy &gt;= fbHeight</ID>
+    <ID>ComplexCondition:VncCoordinates.kt$canvas.width &lt;= 0 || canvas.height &lt;= 0 || fbWidth &lt;= 0 || fbHeight &lt;= 0</ID>
+    <ID>ComplexCondition:VncCoordinates.kt$fbWidth &lt;= 0 || fbHeight &lt;= 0 || canvasWidth &lt;= 0f || canvasHeight &lt;= 0f</ID>
+    <ID>CyclomaticComplexMethod:DesktopDesignApp.kt$private fun runDesktopShortcut( shortcut: DesktopShortcut, state: DesktopDesignState, sessions: SessionsController?, onLock: () -&gt; Unit, ): Boolean</ID>
+    <ID>CyclomaticComplexMethod:DesktopShortcuts.kt$fun matchDesktopShortcut(ctrl: Boolean, shift: Boolean, alt: Boolean, meta: Boolean, key: Key): DesktopShortcut?</ID>
+    <ID>CyclomaticComplexMethod:HostSidebarDnd.kt$internal suspend fun PointerInputScope.detectDeadZoneDragGestures( onStart: (Offset) -&gt; Unit, onMove: (PointerInputChange, Offset) -&gt; Unit, onEnd: () -&gt; Unit, onCancel: () -&gt; Unit, )</ID>
+    <ID>CyclomaticComplexMethod:KeyboardInteractiveDialog.kt$internal fun sanitizeServerText(text: String, maxChars: Int): String</ID>
+    <ID>CyclomaticComplexMethod:RemoteScreenshot.android.kt$actual suspend fun saveRemoteScreenshot(image: ImageBitmap, baseName: String): String?</ID>
+    <ID>CyclomaticComplexMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) fun main()</ID>
+    <ID>CyclomaticComplexMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) private fun renderMobile(out: String, viewName: String, overlay: String, live: Boolean)</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun runSyncLocked(c: SyncClient, s: SyncSession)</ID>
+    <ID>CyclomaticComplexMethod:SyncFailureText.kt$internal fun syncFailureResource(reason: SyncFailureReason): StringResource</ID>
+    <ID>CyclomaticComplexMethod:TeamActivityFeedView.kt$private fun rowIcon(kind: TeamActivityKind): String</ID>
+    <ID>CyclomaticComplexMethod:TeamSpaces.kt$TeamSpaces$suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, identity: AccountIdentity?): List&lt;TeamScopeUi&gt;</ID>
+    <ID>CyclomaticComplexMethod:TeamsCoordinator.kt$TeamsCoordinator$private suspend fun adoptRotatedKeys(s: SyncSession, c: TeamClient, remote: List&lt;TeamSummary&gt;, identity: AccountIdentity)</ID>
+    <ID>CyclomaticComplexMethod:TerminalFilePaths.kt$internal fun detectFilePaths(text: String): List&lt;TextLinkSpan&gt;</ID>
+    <ID>CyclomaticComplexMethod:TerminalFilePaths.kt$private fun cutLineSuffix(token: String): String</ID>
+    <ID>CyclomaticComplexMethod:TerminalInput.kt$private fun keypadSequence(key: Key): String?</ID>
+    <ID>CyclomaticComplexMethod:TerminalInput.kt$private fun letterIndex(key: Key): Int?</ID>
+    <ID>CyclomaticComplexMethod:TerminalInput.kt$private fun navKeySequence(key: Key, applicationCursor: Boolean, shift: Boolean, alt: Boolean, ctrl: Boolean): String?</ID>
+    <ID>CyclomaticComplexMethod:VncTouchSurface.kt$private suspend fun androidx.compose.ui.input.pointer.PointerInputScope.vncTouchGestures( screen: RemoteDesktopScreenState, pad: VncTrackpad, canvasSize: () -&gt; IntSize, )</ID>
+    <ID>EmptyFunctionBlock:PlatformBackHandler.desktop.kt${ }</ID>
+    <ID>EmptyFunctionBlock:QrScanner.desktop.kt${ }</ID>
+    <ID>EmptyFunctionBlock:Screenshot.kt$&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:Screenshot.kt$FakeChannel${}</ID>
+    <ID>EmptyFunctionBlock:Screenshot.kt$FakeConnection${}</ID>
+    <ID>EmptyFunctionBlock:SecureScreen.desktop.kt${}</ID>
+    <ID>ExceptionRaisedInUnexpectedLocation:FilePicker.android.kt$SafDownloadTarget$override suspend fun finalize(): Unit</ID>
+    <ID>ExceptionRaisedInUnexpectedLocation:TransferCoordinatorTest.kt$TransferCoordinatorTest.FakeDownloadTarget$override suspend fun finalize()</ID>
+    <ID>LargeClass:FilePaneControllerTest.kt$FilePaneControllerTest</ID>
+    <ID>LargeClass:SessionsControllerTest.kt$SessionsControllerTest</ID>
+    <ID>LargeClass:SyncCoordinator.kt$SyncCoordinator</ID>
+    <ID>LargeClass:TerminalScreenStateTest.kt$TerminalScreenStateTest</ID>
+    <ID>LongMethod:FullAppThemeSwitchRenderTest.kt$FullAppThemeSwitchRenderTest$@Test fun themeSwitchRepaintsLiveTerminalInFullApp()</ID>
+    <ID>LongMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) fun main()</ID>
+    <ID>LongMethod:SessionShareController.kt$SessionShareController$fun share(teamId: String, teamName: String, paneId: String, label: String, source: ShareSource, readOnlyOnly: Boolean)</ID>
+    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
+    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
+    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>LongMethod:TerminalThemeTest.kt$TerminalThemeTest$@Test fun every_theme_matches_its_golden_palette()</ID>
+    <ID>LongMethod:VncTouchSurface.kt$private suspend fun androidx.compose.ui.input.pointer.PointerInputScope.vncTouchGestures( screen: RemoteDesktopScreenState, pad: VncTrackpad, canvasSize: () -&gt; IntSize, )</ID>
+    <ID>LongMethod:main.kt$fun main(args: Array&lt;String&gt;)</ID>
+    <ID>LongMethod:main.kt$private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph</ID>
+    <ID>LongParameterList:AiStreamRunner.kt$AiStreamRunner$( endpoint: AiEndpoint, messages: List&lt;AiMessage&gt;, onDelta: (String) -&gt; Unit, onComplete: (String) -&gt; Unit, onError: (AiFailure) -&gt; Unit, onFinally: () -&gt; Unit, // null uses the provider default; the terminal bar requests a low value (command, not creative). temperature: Double? = null, )</ID>
+    <ID>LongParameterList:DesktopDesignApp.kt$( sessions: SessionsController?, state: DesktopDesignState, tabId: String?, paneId: String, host: Host, auth: SshAuth, jump: SshJump? = null, )</ID>
+    <ID>LongParameterList:MobileDesignApp.kt$( sessions: SessionsController?, state: MobileDesignState, host: Host, auth: SshAuth, jump: SshJump?, dest: MobileConnectDest, )</ID>
+    <ID>LongParameterList:SessionShareController.kt$SessionShareController$(teamId: String, teamName: String, paneId: String, label: String, source: ShareSource, readOnlyOnly: Boolean)</ID>
+    <ID>LongParameterList:SessionsController.kt$SessionsController$( tabId: String, paneId: String, hostId: String?, title: String, subtitle: String, target: SshTarget, auth: SshAuth, )</ID>
+    <ID>LongParameterList:SharedSessionsList.kt$( sessions: SessionsController?, title: String, subtitle: String, viewer: TerminalSession, onPaneOpened: (String) -&gt; Unit, showTerminal: () -&gt; Unit, )</ID>
+    <ID>LongParameterList:TeamSpaces.kt$TeamSpaces$( private val keyStore: TeamKeyStore, private val teamVaults: TeamVaults, private val crypto: VaultCrypto, private val inviteCodec: TeamInviteCodec, private val accountVaultUnlocked: () -&gt; Boolean, private val markError: (TeamsFailure) -&gt; Unit, private val syncSpace: suspend (TeamScopeRef) -&gt; Unit, )</ID>
+    <ID>LongParameterList:TeamSpaces.kt$TeamSpaces$( recipientPublicKey: ByteArray, identity: AccountIdentity, senderId: String, recipientId: String, teamId: String, scopeId: String, key: DataKey, name: String, epoch: Int, )</ID>
+    <ID>LongParameterList:TeamSpaces.kt$TeamSpaces$(s: SyncSession, c: TeamClient, teamId: String, scopeId: String, accountId: String, identity: AccountIdentity)</ID>
+    <ID>LongParameterList:TeamSpaces.kt$TeamSpaces$(s: SyncSession, c: TeamClient, teamId: String, scopeId: String, name: String, identity: AccountIdentity)</ID>
+    <ID>LongParameterList:TeamsCoordinator.kt$TeamsCoordinator$( private val session: () -&gt; SyncSession?, private val client: () -&gt; TeamClient?, private val vault: Vault, private val crypto: VaultCrypto, private val teamVaults: TeamVaults, private val teamState: SyncStateStore, /** Generator of client-side ids (teams and scopes) — a UUID in production. */ private val newId: () -&gt; String, private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default), private val onTeamsChanged: () -&gt; Unit = {}, )</ID>
+    <ID>LongParameterList:TerminalGeometry.kt$( viewportWidthPx: Float, viewportHeightPx: Float, paddingPx: Float, metrics: TerminalMetrics, cols: Int, rows: Int, )</ID>
+    <ID>LongParameterList:TerminalScreen.kt$(style: TermStyle, left: Float, top: Float, width: Float, chh: Float, palette: Palette, effects: UnderlineEffects, theme: TerminalTheme)</ID>
+    <ID>LongParameterList:TransferCoordinator.kt$TransferCoordinator$( name: String, localPath: String, type: FileItemType, size: Long, remoteDir: String, plan: UploadPlan, )</ID>
+    <ID>LongParameterList:TransferCoordinator.kt$TransferCoordinator$( name: String, remotePath: String, type: FileItemType, size: Long, localDir: String, plan: DownloadPlan, )</ID>
+    <ID>LongParameterList:TunnelForm.kt$( id: String?, label: String, hostId: String?, direction: TunnelDirection, bindHost: String, bindPort: String, destHost: String, destPort: String, )</ID>
+    <ID>LongParameterList:WindowResize.kt$( start: Rectangle, edge: ResizeEdge, deltaX: Int, deltaY: Int, minWidth: Int, minHeight: Int, )</ID>
+    <ID>LongParameterList:main.kt$DesktopGraph$( val deps: AppDependencies, val keyboardInteractive: KeyboardInteractivePromptController, val securityLog: FileSecurityLog, val probeTransport: SshTransport, val vncTransport: app.skerry.shared.vnc.VncTransport, val rdpTransport: app.skerry.shared.rdp.RdpTransport, val workspaceLayout: WorkspaceLayoutStore, val ai: AiAssistantController, val updates: app.skerry.ui.update.UpdateNoticeController, val onVaultUnlocked: () -&gt; Unit, val onVaultReset: (ResetScope) -&gt; Unit, )</ID>
+    <ID>NestedBlockDepth:AndroidSecretFileReader.kt$AndroidSecretFileReader$override fun read(ref: String): SecretFileResult</ID>
+    <ID>NestedBlockDepth:HostMenuWidthTest.kt$HostMenuWidthTest$@Test fun `the row menu never renders narrower than its floor`()</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun runSyncLocked(c: SyncClient, s: SyncSession)</ID>
+    <ID>NestedBlockDepth:TerminalScreen.kt$private fun DrawScope.drawCellUnderline(style: TermStyle, left: Float, top: Float, width: Float, chh: Float, palette: Palette, effects: UnderlineEffects, theme: TerminalTheme)</ID>
+    <ID>SpreadOperator:KeyboardInteractiveDialog.kt$(*Array(challenge.prompts.size) { "" })</ID>
+    <ID>SwallowedException:AndroidSecretFileReader.kt$AndroidSecretFileReader$e: FileNotFoundException</ID>
+    <ID>SwallowedException:AndroidSecretFileReader.kt$AndroidSecretFileReader$e: SecurityException</ID>
+    <ID>SwallowedException:ConnectionController.kt$ConnectionController$e: Exception</ID>
+    <ID>SwallowedException:ConnectionTest.kt$e: Exception</ID>
+    <ID>SwallowedException:ConnectionTest.kt$e: SshAuthenticationException</ID>
+    <ID>SwallowedException:ConnectionTest.kt$e: SshConnectionException</ID>
+    <ID>SwallowedException:ConnectionTest.kt$e: SshHostKeyRejectedException</ID>
+    <ID>SwallowedException:ContainerBrowse.kt$e: Exception</ID>
+    <ID>SwallowedException:ContainerBrowse.kt$e: SshAuthenticationException</ID>
+    <ID>SwallowedException:ContainerBrowse.kt$e: SshConnectionException</ID>
+    <ID>SwallowedException:ContainerBrowse.kt$e: SshHostKeyRejectedException</ID>
+    <ID>SwallowedException:FilePicker.android.kt$e: Exception</ID>
+    <ID>SwallowedException:QrScanner.android.kt$e: Exception</ID>
+    <ID>SwallowedException:SecretCopyAuthorizer.kt$SecretCopyAuthorizer$e: Exception</ID>
+    <ID>SwallowedException:ServerHealthMonitor.kt$ServerHealthMonitor$e: Exception</ID>
+    <ID>SwallowedException:ServiceScanController.kt$ServiceScanController$e: UnsupportedOperationException</ID>
+    <ID>SwallowedException:SyncCoordinator.kt$SyncCoordinator$e: Exception</ID>
+    <ID>SwallowedException:TeamsCoordinator.kt$TeamsCoordinator$e: Exception</ID>
+    <ID>TooGenericExceptionThrown:HostMetricsControllerTest.kt$HostMetricsControllerTest$throw RuntimeException("boom")</ID>
+    <ID>TooGenericExceptionThrown:HostMetricsMonitorControllerTest.kt$HostMetricsMonitorControllerTest$throw RuntimeException("channel dropped")</ID>
+    <ID>TooGenericExceptionThrown:PingControllerTest.kt$PingControllerTest$throw RuntimeException("boom")</ID>
+    <ID>TooGenericExceptionThrown:TransferCoordinatorTest.kt$TransferCoordinatorTest.FakeDownloadTarget$throw RuntimeException(it)</ID>
+    <ID>UnusedParameter:MobileFilesView.kt$mono: FontFamily</ID>
+    <ID>UnusedParameter:MobileSnippetsView.kt$mono: FontFamily</ID>
+    <ID>UnusedPrivateMember:DesktopDesignApp.kt$@Composable private fun SidebarToggle(hidden: Boolean, onToggle: () -&gt; Unit)</ID>
+    <ID>UnusedPrivateMember:MobileDesignApp.kt$@Composable private fun MobileRoutePlaceholder(state: MobileDesignState, title: String)</ID>
+    <ID>UnusedPrivateProperty:Screenshot.kt$FakeConnection$val tick = polls++</ID>
+    <ID>UseCheckOrError:RemoteDesktopScreenStateTest.kt$RemoteDesktopScreenStateTest.&lt;no name provided&gt;$throw IllegalStateException("Socket closed")</ID>
+    <ID>UseCheckOrError:SyncCoordinatorNetworkRecoveryTest.kt$SyncCoordinatorNetworkRecoveryTest$throw IllegalStateException("vault is locked")</ID>
+    <ID>VariableNaming:AttachedSessionTest.kt$AttachedSessionTest.WatchedSession$val _state = MutableStateFlow&lt;TerminalState&gt;(TerminalState.Open)</ID>
+    <ID>VariableNaming:HostMenuWidthTest.kt$HostMenuWidthTest$/** The trailing "⋮" IconBtn's box size in HostEntryRow, at density 1. */ private val MENU_BUTTON_BOX = 22f</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/detekt-baseline-server.xml
+++ b/gradle/detekt-baseline-server.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:AuthRoutes.kt$decoded == null || deviceId == null || accountId == null || services.devices.isRevoked(accountId, deviceId)</ID>
+    <ID>CyclomaticComplexMethod:AdminCliParser.kt$fun parseCli(args: List&lt;String&gt;, env: Map&lt;String, String&gt; = System.getenv()): ParsedCli</ID>
+    <ID>CyclomaticComplexMethod:AdminCliRunner.kt$private suspend fun execute( command: AdminCommand, options: CliOptions, token: String?, out: Appendable, err: Appendable, now: Long, clientFactory: (CliOptions) -&gt; HttpClient, ): Int</ID>
+    <ID>CyclomaticComplexMethod:AdminRoutes.kt$fun Route.adminRoutes(services: Services)</ID>
+    <ID>CyclomaticComplexMethod:AuthRoutes.kt$fun Route.authRoutes(services: Services)</ID>
+    <ID>CyclomaticComplexMethod:Plugins.kt$fun Application.configureServer(services: Services)</ID>
+    <ID>CyclomaticComplexMethod:TeamRecordRepository.kt$TeamRecordRepository$suspend fun upsert(teamId: String, scopeId: String, incoming: List&lt;IncomingRecord&gt;): TeamUpsertResult</ID>
+    <ID>CyclomaticComplexMethod:TeamRoutes.kt$fun Route.teamRoutes(services: Services)</ID>
+    <ID>CyclomaticComplexMethod:TeamScopeRoutes.kt$fun Route.teamScopeRoutes(services: Services)</ID>
+    <ID>EmptyForBlock:SyncWebSocket.kt${ }</ID>
+    <ID>LongMethod:AdminCliParser.kt$fun parseCli(args: List&lt;String&gt;, env: Map&lt;String, String&gt; = System.getenv()): ParsedCli</ID>
+    <ID>LongMethod:AdminCliRunner.kt$private suspend fun execute( command: AdminCommand, options: CliOptions, token: String?, out: Appendable, err: Appendable, now: Long, clientFactory: (CliOptions) -&gt; HttpClient, ): Int</ID>
+    <ID>LongMethod:AdminRoutes.kt$fun Route.adminRoutes(services: Services)</ID>
+    <ID>LongMethod:AuthRoutes.kt$fun Route.authRoutes(services: Services)</ID>
+    <ID>LongMethod:Plugins.kt$fun Application.configureServer(services: Services)</ID>
+    <ID>LongMethod:SyncWebSocket.kt$fun Route.syncWebSocket(services: Services)</ID>
+    <ID>LongMethod:TeamRoutes.kt$fun Route.teamRoutes(services: Services)</ID>
+    <ID>LongMethod:TeamScopeRoutes.kt$fun Route.teamScopeRoutes(services: Services)</ID>
+    <ID>LongParameterList:ActivityRepository.kt$ActivityRepository$( accountId: String, teamId: String, event: String, recordId: String, recordType: String?, scopeId: String, durationSec: Long?, now: Long = System.currentTimeMillis(), )</ID>
+    <ID>LongParameterList:AdminCliRunner.kt$( command: AdminCommand, options: CliOptions, token: String?, out: Appendable, err: Appendable, now: Long, clientFactory: (CliOptions) -&gt; HttpClient, )</ID>
+    <ID>LongParameterList:AdminCliRunner.kt$AdminApi$( out: Appendable, err: Appendable, json: Boolean, path: String, done: String, missing: String, )</ID>
+    <ID>LongParameterList:RecordRepository.kt$IncomingRecord$( val id: String, val type: String, val version: Long, val updatedAt: String, val deviceId: String, val deleted: Boolean, val blob: ByteArray, )</ID>
+    <ID>LongParameterList:ShareRelay.kt$HostShareSession$( private val relay: ShareRelay, val teamId: String, val shareId: String, val hostAccountId: String, val meta: String, val startedAt: Long, private val replayBytes: Int, private val maxGuests: Int, private val guestQueueFrames: Int, )</ID>
+    <ID>LongParameterList:TeamRepository.kt$TeamRepository$(teamId: String, accountId: String, role: String, envelope: ByteArray, invitedBy: String, now: Long)</ID>
+    <ID>SpreadOperator:ServerMetrics.kt$ServerMetrics.HistogramBuckets$( *doubleArrayOf(1.0, 10.0, 60.0, 300.0, 1_800.0, 7_200.0) .map { it * 1_000_000_000 }.toDoubleArray(), )</ID>
+    <ID>SpreadOperator:ServerMetrics.kt$ServerMetrics.HistogramBuckets$(*SLO_SECONDS.map { it * 1_000_000_000 }.toDoubleArray())</ID>
+    <ID>TooGenericExceptionCaught:SyncWebSocket.kt$error: Throwable</ID>
+    <ID>UnusedPrivateProperty:SyncWebSocket.kt$frame</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/detekt-baseline-shared.xml
+++ b/gradle/detekt-baseline-shared.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>ComplexCondition:CharMetrics.kt$CharMetrics$cp in 0x1100..0x115F || // Hangul Jamo cp in 0x2E80..0x303E || // CJK radicals, Kangxi, punctuation cp in 0x3041..0x33FF || // Hiragana/Katakana, CJK symbols cp in 0x3400..0x4DBF || // CJK Ext A cp in 0x4E00..0x9FFF || // CJK Unified cp in 0xA000..0xA4CF || // Yi cp in 0xAC00..0xD7A3 || // Hangul syllables cp in 0xF900..0xFAFF || // CJK compatibility cp in 0xFE10..0xFE19 || // vertical forms cp in 0xFE30..0xFE6F || // CJK compat forms cp in 0xFF00..0xFF60 || // fullwidth forms cp in 0xFFE0..0xFFE6 || // fullwidth signs cp in 0x1F300..0x1FAFF || // emoji, symbols, pictographs cp in 0x20000..0x3FFFD</ID>
+    <ID>ComplexCondition:Der.kt$Der$(lead == 0x00 &amp;&amp; !nextHasHighBit) || (lead == 0xFF &amp;&amp; nextHasHighBit)</ID>
+    <ID>ComplexCondition:MoshSync.kt$MoshOutgoing$!forceAck &amp;&amp; !freshDue &amp;&amp; !retransmitDue &amp;&amp; !heartbeatDue</ID>
+    <ID>ComplexCondition:NsCodec.kt$NsCodec$lumaByteCount &lt; 0 || orangeByteCount &lt; 0 || greenByteCount &lt; 0 || alphaByteCount &lt; 0</ID>
+    <ID>ComplexCondition:Progressive.kt$Progressive.SurfaceTiles$xIdx &lt; 0 || yIdx &lt; 0 || xIdx &gt;= gridWidth || yIdx &gt;= gridHeight</ID>
+    <ID>ComplexCondition:RdpImageBounds.kt$RdpImageBounds$width &lt;= 0 || height &lt;= 0 || width &gt; MAX_DIMENSION || height &gt; MAX_DIMENSION || width.toLong() * height &gt; MAX_PIXELS</ID>
+    <ID>ComplexCondition:RemoteFramebuffer.kt$RemoteFramebuffer$x &lt; 0 || y &lt; 0 || x &gt;= width || y &gt;= height</ID>
+    <ID>ComplexCondition:TerminalEmulator.kt$TerminalEmulator$last &gt;= 0 &amp;&amp; grid[last].all { it.text == " " &amp;&amp; it.style.bg == TermColor.Default &amp;&amp; !it.style.inverse }</ID>
+    <ID>CyclomaticComplexMethod:AutocompleteEngine.kt$AutocompleteEngine$fun onUserInput(data: ByteArray): String?</ID>
+    <ID>CyclomaticComplexMethod:CharMetrics.kt$CharMetrics$fun charWidth(cp: Int): Int</ID>
+    <ID>CyclomaticComplexMethod:CharMetrics.kt$CharMetrics$fun isCombining(cp: Int): Boolean</ID>
+    <ID>CyclomaticComplexMethod:ClearCodec.kt$ClearCodec$private fun subcodecs(reader: RdpReader, image: IntArray, width: Int, height: Int)</ID>
+    <ID>CyclomaticComplexMethod:CommandRisk.kt$CommandRiskClassifier$fun assess(command: String): CommandAssessment</ID>
+    <ID>CyclomaticComplexMethod:GraphicsChannel.kt$GraphicsChannel$private suspend fun handle(commandId: Int, body: RdpReader)</ID>
+    <ID>CyclomaticComplexMethod:HostPattern.kt$HostPattern$fun matches(patterns: String, host: String, port: Int): Boolean</ID>
+    <ID>CyclomaticComplexMethod:InterleavedRle.kt$InterleavedRle.Decoder$private fun operation(code: Int)</ID>
+    <ID>CyclomaticComplexMethod:ModelDownloader.kt$ModelDownloader$fun download(model: LocalModel): Flow&lt;ModelDownloadEvent&gt;</ID>
+    <ID>CyclomaticComplexMethod:MoshShellChannel.kt$MoshShellChannel$private suspend fun processDatagram(datagram: ByteArray): ByteArray?</ID>
+    <ID>CyclomaticComplexMethod:MoshWire.kt$fun decodeHostMessage(payload: ByteArray): List&lt;MoshHostUpdate&gt;</ID>
+    <ID>CyclomaticComplexMethod:RdpConnect.kt$RdpConnectionSequence$private suspend fun awaitLicensing(userId: Int, ioChannelId: Int)</ID>
+    <ID>CyclomaticComplexMethod:RdpConnect.kt$RdpConnectionSequence$private suspend fun finalize(userId: Int, ioChannelId: Int, shareId: Int)</ID>
+    <ID>CyclomaticComplexMethod:RdpFile.kt$RdpFileParser$fun parse(text: String): RdpFileParseResult</ID>
+    <ID>CyclomaticComplexMethod:RfbEncodings.kt$internal suspend fun decodeTight( source: VncSource, fb: RemoteFramebuffer, rect: VncRect, getStream: (Int) -&gt; Inflater, resetStream: (Int) -&gt; Unit, imageDecoder: VncImageDecoder?, )</ID>
+    <ID>CyclomaticComplexMethod:RfbEncodings.kt$private fun decodeZrleTile(c: ByteCursor, fb: RemoteFramebuffer, tileX: Int, tileY: Int, tw: Int, th: Int)</ID>
+    <ID>CyclomaticComplexMethod:SessionShareFrame.kt$internal fun decodeShareFrame(plaintext: ByteArray): ShareFrame?</ID>
+    <ID>CyclomaticComplexMethod:SessionShareHost.kt$SessionShareHost$private suspend fun readFromViewers()</ID>
+    <ID>CyclomaticComplexMethod:SgrParser.kt$SgrParser$fun apply(params: List&lt;IntArray&gt;, start: TermStyle): TermStyle</ID>
+    <ID>CyclomaticComplexMethod:SshConfigParser.kt$SshConfigParser$fun parse(text: String): SshConfigParseResult</ID>
+    <ID>CyclomaticComplexMethod:SshjTransport.kt$SshjTransport$private fun authenticate( client: SSHClient, username: String, requested: SshAuth, hop: Boolean, host: String, port: Int, )</ID>
+    <ID>CyclomaticComplexMethod:TelnetCodec.kt$TelnetCodec$fun consume(input: ByteArray): Decoded</ID>
+    <ID>CyclomaticComplexMethod:TelnetCodec.kt$TelnetCodec$private fun negotiate(cmd: Int, option: Int, reply: ArrayList&lt;Byte&gt;)</ID>
+    <ID>CyclomaticComplexMethod:TerminalEmulator.kt$TerminalEmulator$private fun dispatchCsi(final: Char)</ID>
+    <ID>CyclomaticComplexMethod:TerminalEmulator.kt$TerminalEmulator$private fun esc(b: Int)</ID>
+    <ID>CyclomaticComplexMethod:TerminalEmulator.kt$TerminalEmulator$private fun ground(b: Int)</ID>
+    <ID>CyclomaticComplexMethod:TerminalEmulator.kt$TerminalEmulator$private fun privateMode(final: Char, codes: List&lt;Int&gt;)</ID>
+    <ID>CyclomaticComplexMethod:TerminalEmulator.kt$TerminalEmulator$private fun privateModeSet(code: Int): Boolean?</ID>
+    <ID>CyclomaticComplexMethod:TerminalMouse.kt$fun encodeMouseReport( tracking: MouseTracking, sgr: Boolean, button: MouseButton, type: MouseEventType, col: Int, row: Int, shift: Boolean = false, alt: Boolean = false, ctrl: Boolean = false, pixels: Boolean = false, pixelX: Int = 0, pixelY: Int = 0, ): ByteArray?</ID>
+    <ID>CyclomaticComplexMethod:TerminalReflow.kt$TerminalReflow$fun reflow( src: List&lt;TermRow&gt;, nc: Int, nr: Int, maxScrollback: Int, cursorAbs: Int, cursorCol: Int, rowsBelowCursor: Int, trackCursor: Boolean, ): Result</ID>
+    <ID>CyclomaticComplexMethod:TerminalSearch.kt$fun searchTerminal( screen: List&lt;List&lt;TermCell&gt;&gt;, query: String, caseSensitive: Boolean = false, regex: Boolean = false, limit: Int = DEFAULT_SEARCH_MATCH_LIMIT, stepBudget: Int = DEFAULT_REGEX_STEP_BUDGET, fromRow: Int = 0, toRow: Int = screen.size, cancelled: () -&gt; Boolean = { false }, ): TerminalSearchResult</ID>
+    <ID>CyclomaticComplexMethod:TerminalSearch.kt$private fun findSubstringInCells( row: List&lt;TermCell&gt;, rowIndex: Int, query: String, caseSensitive: Boolean, remaining: Int, ): List&lt;TerminalMatch&gt;?</ID>
+    <ID>CyclomaticComplexMethod:TerminalSearch.kt$private fun rowText(row: List&lt;TermCell&gt;): RowText?</ID>
+    <ID>CyclomaticComplexMethod:Zgfx.kt$Zgfx$private fun decompressSegment(data: ByteArray): ByteArray</ID>
+    <ID>DestructuringDeclarationWithTooManyEntries:KnownHosts.kt$ProbeHostKeyVerifier$val (host, port, keyType, fingerprint, _) = offer.bareKey()</ID>
+    <ID>DestructuringDeclarationWithTooManyEntries:KnownHosts.kt$TofuHostKeyVerifier$val (host, port, keyType, fingerprint, _) = offer.bareKey()</ID>
+    <ID>EmptyElseBlock:RfbEncodings.kt$if (n &gt; 0) source.readFully(b, 0, n)</ID>
+    <ID>EmptyElseBlock:TelnetCodec.kt$TelnetCodec$if (reply.size &lt; MAX_REPLY_BYTES) handleSubnegotiation(subneg, reply)</ID>
+    <ID>EmptyElseBlock:TerminalEmulator.kt$TerminalEmulator$if (cx &gt; 0) cx--</ID>
+    <ID>EmptyFunctionBlock:KnownHosts.kt$NoopHostKeyMismatchStore${}</ID>
+    <ID>EmptyFunctionBlock:LlamatikRuntime.kt$LlamatikRuntime.&lt;no name provided&gt;${}</ID>
+    <ID>EmptyFunctionBlock:LocalAiProvider.kt$LocalAiProvider${}</ID>
+    <ID>ExceptionRaisedInUnexpectedLocation:RdpConnect.kt$RdpConnectionSequence$private suspend fun finalize(userId: Int, ioChannelId: Int, shareId: Int)</ID>
+    <ID>InstanceOfCheckForException:UpdateChecker.kt$UpdateChecker$e is CancellationException</ID>
+    <ID>LargeClass:FileVaultTest.kt$FileVaultTest</ID>
+    <ID>LargeClass:TerminalEmulator.kt$TerminalEmulator</ID>
+    <ID>LargeClass:TerminalEmulatorTest.kt$TerminalEmulatorTest</ID>
+    <ID>LongMethod:Capabilities.kt$Capabilities$fun parseDemandActive(reader: RdpReader): ServerCapabilities</ID>
+    <ID>LongMethod:CommandRisk.kt$CommandRiskClassifier$fun assess(command: String): CommandAssessment</ID>
+    <ID>LongMethod:RdpTcpTransport.kt$RdpTcpTransport$private suspend fun connectOnce(target: RdpTarget, credentials: RdpCredentials): RdpSession</ID>
+    <ID>LongMethod:RfbEncodings.kt$internal suspend fun decodeTight( source: VncSource, fb: RemoteFramebuffer, rect: VncRect, getStream: (Int) -&gt; Inflater, resetStream: (Int) -&gt; Unit, imageDecoder: VncImageDecoder?, )</ID>
+    <ID>LongMethod:RfbEncodings.kt$private fun decodeZrleTile(c: ByteCursor, fb: RemoteFramebuffer, tileX: Int, tileY: Int, tw: Int, th: Int)</ID>
+    <ID>LongMethod:SessionShareE2eTest.kt$SessionShareE2eTest$@Test fun `a viewer watches the host's terminal and types back into it`()</ID>
+    <ID>LongMethod:SshConfigParser.kt$SshConfigParser$fun parse(text: String): SshConfigParseResult</ID>
+    <ID>LongMethod:TerminalReflow.kt$TerminalReflow$fun reflow( src: List&lt;TermRow&gt;, nc: Int, nr: Int, maxScrollback: Int, cursorAbs: Int, cursorCol: Int, rowsBelowCursor: Int, trackCursor: Boolean, ): Result</ID>
+    <ID>LongParameterList:ClearCodecTest.kt$ClearCodecTest$( xStart: Int, xEnd: Int, yStart: Int, yEnd: Int, bkg: Int, vBars: List&lt;ByteArray&gt;, )</ID>
+    <ID>LongParameterList:ClearCodecTest.kt$ClearCodecTest$( xStart: Int, yStart: Int, width: Int, height: Int, subCodecId: Int, data: ByteArray, )</ID>
+    <ID>LongParameterList:DynamicChannels.kt$DynamicChannels$( command: Int, channelId: Int, idWidth: Int, payload: ByteArray, offset: Int, length: Int, )</ID>
+    <ID>LongParameterList:FastPath.kt$BitmapUpdate$( data: ByteArray, width: Int, height: Int, bitsPerPixel: Int, bytesPerPixel: Int, flags: Int, palette: IntArray?, )</ID>
+    <ID>LongParameterList:FastPath.kt$BitmapUpdate$(framebuffer: RemoteFramebuffer, pixels: IntArray, x: Int, y: Int, width: Int, height: Int)</ID>
+    <ID>LongParameterList:FileVault.kt$( id: String, type: RecordType, version: Long, deviceId: String, deleted: Boolean, updatedAt: String, )</ID>
+    <ID>LongParameterList:McsConnect.kt$McsConnect$( maxChannelIds: Int, maxUserIds: Int, maxTokenIds: Int, numPriorities: Int, minThroughput: Int, maxHeight: Int, maxMcsPduSize: Int, protocolVersion: Int, )</ID>
+    <ID>LongParameterList:Progressive.kt$Progressive$( block: RdpReader, region: Region, tiles: SurfaceTiles, surface: GraphicsSurface, destination: RdpRect, damaged: MutableList&lt;RdpRect&gt;, )</ID>
+    <ID>LongParameterList:Progressive.kt$Progressive$( block: RdpReader, simple: Boolean, region: Region, tiles: SurfaceTiles, surface: GraphicsSurface, destination: RdpRect, damaged: MutableList&lt;RdpRect&gt;, )</ID>
+    <ID>LongParameterList:Progressive.kt$Progressive$( components: Array&lt;IntArray&gt;, state: TileState, surface: GraphicsSurface, region: Region, destination: RdpRect, xIdx: Int, yIdx: Int, damaged: MutableList&lt;RdpRect&gt;, )</ID>
+    <ID>LongParameterList:Progressive.kt$Progressive$( state: UpgradeState, current: ShortArray, sign: ShortArray, band: Band, shift: Int, numBits: Int, )</ID>
+    <ID>LongParameterList:Progressive.kt$Progressive$( tile: TileState, component: Int, numBits: IntArray, shift: IntArray, srlData: ByteArray, rawData: ByteArray, )</ID>
+    <ID>LongParameterList:ProgressiveDwt.kt$ProgressiveDwt$( lowBuffer: IntArray, lowOffset: Int, lowStride: Int, highBuffer: IntArray, highOffset: Int, highStride: Int, out: IntArray, outOffset: Int, outStride: Int, lowCount: Int, highCount: Int, )</ID>
+    <ID>LongParameterList:RemoteFramebuffer.kt$RemoteFramebuffer$(srcX: Int, srcY: Int, dstX: Int, dstY: Int, w: Int, h: Int)</ID>
+    <ID>LongParameterList:RemoteFx.kt$RemoteFx$( reader: RdpReader, quants: Array&lt;ByteArray&gt;, mode: Rlgr.Mode, out: IntArray, width: Int, height: Int, )</ID>
+    <ID>LongParameterList:RfbEncodings.kt$( source: VncSource, fb: RemoteFramebuffer, rect: VncRect, getStream: (Int) -&gt; Inflater, resetStream: (Int) -&gt; Unit, imageDecoder: VncImageDecoder?, )</ID>
+    <ID>LongParameterList:RfbEncodings.kt$(c: ByteCursor, fb: RemoteFramebuffer, tileX: Int, tileY: Int, tw: Int, th: Int)</ID>
+    <ID>LongParameterList:RfxDwt.kt$RfxDwt$( lowBuffer: IntArray, lowOffset: Int, highBuffer: IntArray, highOffset: Int, sourceStride: Int, out: IntArray, outOffset: Int, outStride: Int, side: Int, )</ID>
+    <ID>LongParameterList:RfxForwardTransform.kt$RfxForwardTransform$( source: IntArray, sourceOffset: Int, out: IntArray, highOffset: Int, lowOffset: Int, side: Int, )</ID>
+    <ID>LongParameterList:SessionShareHost.kt$SessionShareHost$( private val codec: SessionShareCodec, private val teamKey: DataKey, private val channel: ShareChannel, private val output: Flow&lt;ByteArray&gt;, private val toShell: suspend (ByteArray) -&gt; Unit, private val geometry: () -&gt; ShareFrame.Resize, private val allowInput: () -&gt; Boolean, /** Called with who is watching, whenever that changes (empty list = nobody). */ private val onViewers: (List&lt;String&gt;) -&gt; Unit, /** A viewer typed into this session; the account it named itself with, for the "typing" hint. */ private val onTyping: (String) -&gt; Unit = {}, /** A viewer asked to be allowed to type; the host answers with [announceControl]. */ private val onControlRequest: (String) -&gt; Unit = {}, )</ID>
+    <ID>LongParameterList:SshjTransport.kt$SshjTransport$( client: SSHClient, username: String, requested: SshAuth, hop: Boolean, host: String, port: Int, )</ID>
+    <ID>LongParameterList:TeamClient.kt$TeamSummary$( val id: String, val ownerAccountId: String, val role: TeamRole, val status: TeamMemberStatus, val createdAt: Long, val memberCount: Int, val envelope: ByteArray?, /** Current teamKey generation; a rotation bumps it (see [TeamKeyEntry.epoch]). */ val keyEpoch: Long = 0, /** Signed sealed current-epoch key from a rotation; the client adopts it when its epoch is newer. */ val keyEnvelope: ByteArray? = null, )</ID>
+    <ID>LongParameterList:TeamInvite.kt$TeamInviteCodec$( recipientPublicKey: ByteArray, inviter: SigningKeyPair, inviterId: String, inviteeId: String, teamId: String, teamKey: DataKey, teamName: String, epoch: Int, scopeId: String = "", )</ID>
+    <ID>LongParameterList:TeamInvite.kt$TeamInviteCodec$( teamId: String, inviterId: String, inviteeId: String, teamKey: DataKey, teamName: String, epoch: Int, scopeId: String, )</ID>
+    <ID>LongParameterList:TeamInvite.kt$TeamInvitePayload$( val teamKey: DataKey, val teamName: String, val teamId: String, val inviterAccountId: String, val inviteeAccountId: String, val epoch: Int, /** Scope this key belongs to; empty for the team-wide key. See [TeamInviteCodec] on why it's signed. */ val scopeId: String = "", /** Detached signature over the canonical binding; checked by [TeamInviteCodec.verify]. */ internal val signature: ByteArray, )</ID>
+    <ID>LongParameterList:TerminalMouse.kt$( tracking: MouseTracking, sgr: Boolean, button: MouseButton, type: MouseEventType, col: Int, row: Int, shift: Boolean = false, alt: Boolean = false, ctrl: Boolean = false, pixels: Boolean = false, pixelX: Int = 0, pixelY: Int = 0, )</ID>
+    <ID>LongParameterList:TerminalReflow.kt$TerminalReflow$( src: List&lt;TermRow&gt;, nc: Int, nr: Int, maxScrollback: Int, cursorAbs: Int, cursorCol: Int, rowsBelowCursor: Int, trackCursor: Boolean, )</ID>
+    <ID>NestedBlockDepth:ClearCodec.kt$ClearCodec$private fun bands(reader: RdpReader, image: IntArray, width: Int, height: Int)</ID>
+    <ID>NestedBlockDepth:ClearCodec.kt$ClearCodec$private fun subcodecs(reader: RdpReader, image: IntArray, width: Int, height: Int)</ID>
+    <ID>NestedBlockDepth:MoshCompression.kt$fun moshInflate(data: ByteArray, maxSize: Int = 8 * 1024 * 1024): ByteArray?</ID>
+    <ID>NestedBlockDepth:MoshShellChannel.kt$MoshShellChannel$suspend fun handshake()</ID>
+    <ID>NestedBlockDepth:MoshWire.kt$fun decodeHostMessage(payload: ByteArray): List&lt;MoshHostUpdate&gt;</ID>
+    <ID>NestedBlockDepth:RfbEncodings.kt$internal suspend fun decodeHextile(source: VncSource, fb: RemoteFramebuffer, rect: VncRect)</ID>
+    <ID>NestedBlockDepth:RfbEncodings.kt$internal suspend fun decodeTight( source: VncSource, fb: RemoteFramebuffer, rect: VncRect, getStream: (Int) -&gt; Inflater, resetStream: (Int) -&gt; Unit, imageDecoder: VncImageDecoder?, )</ID>
+    <ID>NestedBlockDepth:RfbEncodings.kt$private fun decodeZrleTile(c: ByteCursor, fb: RemoteFramebuffer, tileX: Int, tileY: Int, tw: Int, th: Int)</ID>
+    <ID>NestedBlockDepth:SessionShareHost.kt$SessionShareHost$private suspend fun readFromViewers()</ID>
+    <ID>NestedBlockDepth:SshConfigParser.kt$SshConfigParser$fun parse(text: String): SshConfigParseResult</ID>
+    <ID>NestedBlockDepth:TelnetCodec.kt$TelnetCodec$fun consume(input: ByteArray): Decoded</ID>
+    <ID>NestedBlockDepth:TelnetCodec.kt$TelnetCodec$private fun negotiate(cmd: Int, option: Int, reply: ArrayList&lt;Byte&gt;)</ID>
+    <ID>NestedBlockDepth:TerminalReflow.kt$TerminalReflow$fun reflow( src: List&lt;TermRow&gt;, nc: Int, nr: Int, maxScrollback: Int, cursorAbs: Int, cursorCol: Int, rowsBelowCursor: Int, trackCursor: Boolean, ): Result</ID>
+    <ID>NestedBlockDepth:TerminalSearch.kt$fun searchTerminal( screen: List&lt;List&lt;TermCell&gt;&gt;, query: String, caseSensitive: Boolean = false, regex: Boolean = false, limit: Int = DEFAULT_SEARCH_MATCH_LIMIT, stepBudget: Int = DEFAULT_REGEX_STEP_BUDGET, fromRow: Int = 0, toRow: Int = screen.size, cancelled: () -&gt; Boolean = { false }, ): TerminalSearchResult</ID>
+    <ID>SwallowedException:AndroidBiometricKeyStore.kt$AndroidBiometricKeyStore$e: AEADBadTagException</ID>
+    <ID>SwallowedException:AndroidBiometricKeyStore.kt$AndroidBiometricKeyStore$e: Exception</ID>
+    <ID>SwallowedException:AndroidBiometricKeyStore.kt$AndroidBiometricKeyStore$e: KeyPermanentlyInvalidatedException</ID>
+    <ID>SwallowedException:AndroidBiometricKeyStore.kt$AndroidBiometricKeyStore$e: StrongBoxUnavailableException</ID>
+    <ID>SwallowedException:CredSsp.kt$CredSspClient$e: RdpProtocolException</ID>
+    <ID>SwallowedException:FastPath.kt$BitmapUpdate$e: RdpProtocolException</ID>
+    <ID>SwallowedException:IonspinVaultCrypto.kt$IonspinVaultCrypto$e: BoxCorruptedOrTamperedDataException</ID>
+    <ID>SwallowedException:IonspinVaultCrypto.kt$IonspinVaultCrypto$e: InvalidSignatureException</ID>
+    <ID>SwallowedException:KtorSyncClient.kt$KtorSyncClient$e: Exception</ID>
+    <ID>SwallowedException:MoshSync.kt$MoshIncoming$e: MoshWireException</ID>
+    <ID>SwallowedException:SecretFileReader.kt$OkioSecretFileReader$e: IOException</ID>
+    <ID>SwallowedException:SshjConnection.kt$SshjConnection$e: ConnectionException</ID>
+    <ID>SwallowedException:SshjConnection.kt$SshjConnection$e: TransportException</ID>
+    <ID>SwallowedException:SshjForwards.kt$AcceptingForward$e: IOException</ID>
+    <ID>SwallowedException:SshjForwards.kt$SshjDynamicForward$e: Exception</ID>
+    <ID>SwallowedException:SshjForwards.kt$SshjDynamicForward$e: IOException</ID>
+    <ID>SwallowedException:SshjForwards.kt$SshjLocalForward$e: Exception</ID>
+    <ID>SwallowedException:SshjForwards.kt$SshjRemoteForward$e: Exception</ID>
+    <ID>SwallowedException:SshjForwards.kt$SshjRemoteForward$e: IOException</ID>
+    <ID>SwallowedException:TeamInvite.kt$TeamInviteCodec$e: kotlinx.serialization.SerializationException</ID>
+    <ID>SwallowedException:TeamShare.kt$e: IllegalArgumentException</ID>
+    <ID>SwallowedException:TeamShare.kt$e: SerializationException</ID>
+    <ID>SwallowedException:TeamStores.kt$TeamIdentityStore$e: IllegalArgumentException</ID>
+    <ID>SwallowedException:VncTcpTransport.kt$VncSocketSession$e: EOFException</ID>
+    <ID>SwallowedException:VncTcpTransport.kt$VncSocketSession$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:AtomicWrite.kt$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:FileVault.kt$FileVault$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:MoshTransport.kt$MoshConnection$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PrivateConfig.kt$PrivateConfig$t: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ProcessLlmHostLauncher.kt$ProcessLlmHostLauncher$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:RdpTcpConnector.kt$RdpTcpConnector$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:RdpTcpTransport.kt$RdpTcpTransport$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ServiceLlmHostLauncher.kt$ServiceLlmHostLauncher$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:VaultBiometrics.kt$VaultBiometrics$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:VncTcpTransport.kt$VncTcpTransport$e: Throwable</ID>
+    <ID>TooGenericExceptionThrown:UpdateCheckerTest.kt$UpdateCheckerTest$throw RuntimeException("offline")</ID>
+    <ID>UnusedParameter:FastPath.kt$BitmapUpdate$bitsPerPixel: Int</ID>
+    <ID>UnusedPrivateProperty:ClientInfo.kt$ClientInfo$/** ANSI code page 0 means "use the one implied by the Unicode flag". */ private const val CODE_PAGE_DEFAULT = 0</ID>
+    <ID>UnusedPrivateProperty:FastPath.kt$BitmapUpdate$val bottom = reader.u16le()</ID>
+    <ID>UnusedPrivateProperty:FastPath.kt$BitmapUpdate$val right = reader.u16le()</ID>
+    <ID>UnusedPrivateProperty:TelnetCodecTest.kt$private const val DONT = 254</ID>
+    <ID>UseCheckOrError:FileVault.kt$FileVault$throw IllegalStateException("vault is locked")</ID>
+    <ID>VariableNaming:ProductionGuardTest.kt$ProductionGuardTest$// A production session with warnings on, so these tests exercise classification rather than the // threshold — the threshold has its own tests in [ProductionGuardPolicyTest]. private val GUARDING = ProductionGuardPolicy(production = true, confirmWarnings = true)</ID>
+    <ID>VariableNaming:TelnetCodecTest.kt$TelnetCodecTest$val NOP = 241</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/detekt.gradle.kts
+++ b/gradle/detekt.gradle.kts
@@ -1,0 +1,74 @@
+// Root detekt (static analysis) wiring, applied from build.gradle.kts ONLY for non-offline builds.
+// Same reasoning as gradle/kover.gradle.kts: it lives in its own script so the main build file never
+// references detekt types directly — the hermetic offline Flatpak build (-Dskerry.offlineRepo) has
+// no detekt on its buildscript classpath, and a direct reference in build.gradle.kts would fail to
+// COMPILE there, not merely skip at runtime.
+//
+// This script carries its own buildscript classpath: an applied script does NOT inherit the parent's
+// buildscript classpath for compilation.
+buildscript {
+    repositories { gradlePluginPortal() }
+    // Keep in sync with `detekt` in gradle/libs.versions.toml (catalog accessors aren't available
+    // in an applied script plugin, so the version is spelled out here — as with Kover).
+    dependencies { classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.8") }
+}
+
+// The DetektPlugin is deliberately NOT applied. Its KMP integration resolves
+// KotlinMultiplatformExtension, which lives in the Kotlin Gradle plugin's class loader — a different
+// one from this script's isolated buildscript classpath — so applying it dies with
+// NoClassDefFoundError on :shared and :composeApp. Registering the task type directly needs no KGP
+// at all: detekt-cli just parses the files we point it at.
+val detektVersion = "1.23.8"
+
+subprojects {
+    val detektCli = configurations.detachedConfiguration(
+        dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$detektVersion"),
+    )
+
+    tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detekt") {
+        group = "verification"
+        description = "Runs detekt over every source set of this module."
+        detektClasspath.setFrom(detektCli)
+        // KMP layout: detekt's default source set (src/main/kotlin) doesn't exist here. Point it at
+        // the whole module so commonMain/jvmSharedMain/desktopMain/androidMain are all covered.
+        setSource(files("src"))
+        include("**/*.kt", "**/*.kts")
+        // Compose resource accessors are ~43k generated lines (the i18n string table) — the same
+        // exclusion Kover carries, for the same reason.
+        exclude("**/generated/**", "**/build/**")
+        config.setFrom(rootProject.file("gradle/detekt.yml"))
+        buildUponDefaultConfig = true
+        // One baseline per module: a shared file would be overwritten by whichever module ran
+        // `detektBaseline` last, silently dropping the other modules' entries.
+        val baselineFile = rootProject.file("gradle/detekt-baseline-${project.name}.xml")
+        if (baselineFile.exists()) baseline.set(baselineFile)
+        reports {
+            html.required.set(true)
+            xml.required.set(false)
+            txt.required.set(false)
+            sarif.required.set(false)
+            md.required.set(false)
+        }
+    }
+
+    // Generates/refreshes gradle/detekt-baseline.xml. Run once per module after adding a rule:
+    // ./gradlew detektBaseline
+    tasks.register<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>("detektBaseline") {
+        group = "verification"
+        description = "Rewrites this module's detekt baseline from its current findings."
+        detektClasspath.setFrom(detektCli)
+        setSource(files("src"))
+        include("**/*.kt", "**/*.kts")
+        exclude("**/generated/**", "**/build/**")
+        config.setFrom(rootProject.file("gradle/detekt.yml"))
+        buildUponDefaultConfig = true
+        baseline.set(rootProject.file("gradle/detekt-baseline-${project.name}.xml"))
+    }
+}
+
+// Aggregate entry point: ./gradlew detektAll
+tasks.register("detektAll") {
+    group = "verification"
+    description = "Runs detekt in every module."
+    dependsOn(subprojects.map { "${it.path}:detekt" })
+}

--- a/gradle/detekt.yml
+++ b/gradle/detekt.yml
@@ -1,0 +1,118 @@
+# detekt overrides on top of the shipped defaults (buildUponDefaultConfig = true in
+# gradle/detekt.gradle.kts). Only deviations live here; everything unmentioned keeps detekt's default.
+#
+# Two goals: catch the defect classes docs/coding-guidelines.md was written for (swallowed
+# exceptions, generic catches, dead code), and stay quiet about idioms that are correct here
+# (backtick test names, capitalised @Composable functions, injected-dependency constructors).
+#
+# LIMIT — no type resolution. The detekt tasks run over source files without a compile classpath
+# (see gradle/detekt.gradle.kts: the Gradle plugin's KMP integration can't be used here), so every
+# rule that needs type information silently finds nothing. Verified: a fresh `input!!` is NOT
+# reported, while a swallowed exception in the same file IS. The rules below marked
+# "needs type resolution" are kept for the day that changes; don't rely on them today —
+# `!!`, unsafe casts and blocking calls are caught by review (skerry-reviewer), not by detekt.
+
+build:
+  maxIssues: 0
+
+comments:
+  UndocumentedPublicClass:
+    active: false
+  UndocumentedPublicFunction:
+    active: false
+  UndocumentedPublicProperty:
+    active: false
+
+# KMP test source sets. detekt's built-in test excludes assume src/test/**, which doesn't exist
+# here, so every rule that only makes sense for production code repeats this list.
+# (YAML anchors aren't supported by detekt's config loader — hence the repetition.)
+
+complexity:
+  LongMethod:
+    ignoreAnnotated: ['Composable']
+  LongParameterList:
+    ignoreAnnotated: ['Composable']
+    # Controllers take their dependencies through the constructor with test defaults — that is
+    # guidelines §6, not a smell. Only parameters without a default count here.
+    ignoreDefaultParameters: true
+  CyclomaticComplexMethod:
+    ignoreAnnotated: ['Composable']
+  TooManyFunctions:
+    # A Compose screen file legitimately holds many small composables; §2 of the coding guidelines
+    # governs file size instead, by line count and by cohesion.
+    active: false
+  LargeClass:
+    threshold: 600
+
+exceptions:
+  # The core of coding-guidelines §3: a swallowed exception is how CancellationException gets
+  # masked as a network error. These stay loud.
+  SwallowedException:
+    active: true
+    ignoredExceptionTypes:
+      - 'InterruptedException'
+      - 'NumberFormatException'
+      - 'ParseException'
+  TooGenericExceptionCaught:
+    active: true
+    exceptionNames:
+      - 'Error'
+      - 'Throwable'
+  ThrowingExceptionInMain:
+    active: true
+  PrintStackTrace:
+    active: true
+
+naming:
+  FunctionNaming:
+    ignoreAnnotated: ['Composable']
+    # Test names are backtick sentences on purpose — that's the project's test style, not a defect.
+    excludes: ['**/commonTest/**', '**/jvmTest/**', '**/desktopTest/**', '**/androidTest/**', '**/androidUnitTest/**', '**/test/**']
+  TopLevelPropertyNaming:
+    constantPattern: '[A-Z][_A-Za-z0-9]*'
+  MatchingDeclarationName:
+    # A Compose file holds a screen plus its private composables; the guidelines govern file
+    # cohesion (§2) instead of forcing one declaration per file name.
+    active: false
+
+style:
+  MagicNumber:
+    # Protocol code (RDP/VNC/mosh PDU offsets, SGR codes) is nothing but numeric literals; naming
+    # each one would hurt readability more than it helps.
+    active: false
+  ReturnCount:
+    active: false
+  UnusedPrivateMember:
+    active: true
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Unfinished work must not reach main.'
+        value: 'FIXME:'
+  MaxLineLength:
+    # Off deliberately. There is no formatter in this repo (no ktlint), the settled style runs long
+    # in protocol and Compose code, and every threshold tried (120/140/160) produced hundreds of
+    # baseline entries and zero defects. Line length is a review comment, not a build failure.
+    active: false
+  UnnecessaryAbstractClass:
+    active: false
+  LoopWithTooManyJumpStatements:
+    # Protocol decoders (RDP/VNC/mosh) are loops full of early continue/break by nature.
+    active: false
+  ThrowsCount:
+    active: false
+
+empty-blocks:
+  EmptyFunctionBlock:
+    # Hand-written fakes legitimately implement an interface method as a no-op.
+    excludes: ['**/commonTest/**', '**/jvmTest/**', '**/desktopTest/**', '**/androidTest/**', '**/androidUnitTest/**', '**/test/**']
+
+potential-bugs:
+  UnsafeCallOnNullableType:
+    active: true # needs type resolution — inert today, see the header
+  UnsafeCast:
+    active: true # needs type resolution — inert today, see the header
+  IgnoredReturnValue:
+    active: true # needs type resolution — inert today, see the header
+  ExplicitGarbageCollectionCall:
+    active: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,10 @@ jna = "5.19.1"
 # 0.9.8+ is required: earlier releases can't handle the com.android.kotlin.multiplatform.library
 # target used by :shared and :composeApp (they demand a legacy `android` extension). See kover #747/#772.
 kover = "0.9.8"
+# detekt — static analysis for Kotlin. Rides the same online-only buildscript gate as Kover: a
+# plugins {} entry would be resolved even with `apply false` and break the hermetic offline Flatpak
+# build (-Dskerry.offlineRepo). 1.23.8 is the last stable line (2.0.x is still alpha).
+detekt = "1.23.8"
 # Compose Hot Reload — dev-only live UI reload (./gradlew :composeApp:hotRunJvm). Like Kover it is
 # loaded via the root buildscript classpath and applied by id only in online builds, so the hermetic
 # offline Flatpak build (-Dskerry.offlineRepo) never resolves it. Pinned to 1.1.1: it is the last


### PR DESCRIPTION
Splits the project docs into a process file and a rules file, adds static analysis, and makes the pre-PR gate enforceable instead of advisory.

## Documentation

`CLAUDE.md` describes the development loop — orient, failing test, implementation, build gate, review fan-out, hand-off — and the commands, layout and warnings around it. `docs/coding-guidelines.md` keeps the code-level rules and is now in English. Its abstraction catalogue was extended to the subsystems added since it was written (remote desktop, audio, shared sessions, runbooks, containers, mosh, guard, update) and to the UI design primitives, split into a core table and a UI table. Rules that appeared in both files were removed from one of them.

## Static analysis

detekt 1.23.8, reachable as `./gradlew detektAll`, with `detektBaseline` to re-baseline.

Wiring follows the Kover precedent: the plugin sits on the root buildscript classpath behind the `skerry.offlineRepo` gate, because a `plugins {}` entry is resolved even with `apply false` and would break the hermetic offline Flatpak build. The detekt Gradle plugin itself is deliberately not applied — its KMP integration resolves `KotlinMultiplatformExtension`, which lives in a different class loader than an applied script, and fails on `:shared` and `:composeApp`. The `Detekt` and `DetektCreateBaselineTask` types are registered directly against `detekt-cli` instead, which needs no Kotlin plugin. The trade-off is that rules requiring type resolution find nothing; this is stated in `gradle/detekt.yml` and those rules are marked inert.

The ruleset is tuned to this codebase: `MaxLineLength` off (no formatter in the repo, every threshold produced hundreds of entries and no defects), `FunctionNaming` and `EmptyFunctionBlock` excluding the KMP test source sets (backtick test names, no-op fakes), `LongParameterList` ignoring defaulted parameters (constructor injection is a project rule), `MagicNumber` off for protocol code. Baselines are per module — a shared file would be overwritten by whichever module re-baselined last. Current debt: 300 findings, including 43 `SwallowedException` that are worth a separate pass.

CI gains a `Detekt` step after the tests and uploads detekt reports alongside the test reports on failure.

## Harness

- `.claude/agents/skerry-reviewer.md` — reviewer carrying this project's rules: commonMain contracts, desktop⇆Android parity, en+ru+zh resources, design primitives, cancellation handling, vault security, the abstraction catalogue.
- `.claude/commands/gate.md` — `/gate` runs tests, build, detekt and the Android compile, then the reviewer fan-out over the branch diff, then triage.
- `.claude/hooks/guard-git.py` — refuses `git commit`/`push` while HEAD is on main and asks for confirmation on `gh pr create`.
- `.claude/hooks/gate-state.py` — records code edits, green gate runs and reviewer runs; the commit guard refuses while the code is newer than its last gate run. Documentation-only changes are unaffected. `SKERRY_GATE_OVERRIDE=1` bypasses deliberately.

`.claude/settings.local.json` and per-machine state stay ignored.

## Verification

`./gradlew build` green (1m50s), `./gradlew detektAll` green, offline configuration (`-Dskerry.offlineRepo`) still resolves nothing detekt-related. detekt was verified to fail on a freshly introduced swallowed exception and to pass again once removed. Both hooks were exercised across branch, gate-state and override scenarios. The CI `Detekt` step has not run on a real runner yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)