### PR TITLE
RDP: cover the platform audio sinks, and the state machine they shared

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -10,6 +10,14 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     // FragmentActivity — host of the biometric prompt (androidx.biometric)
     implementation(libs.androidx.fragment)
+    // Host tests for the Android side of :shared. They live here rather than in :shared because that
+    // module's androidHostTest would inherit commonTest, whose vault suite needs libsodium's natives
+    // — absent on a host JVM. What runs here is the pure Android mapping (see AndroidAudioMapping):
+    // an AudioTrack or an AudioDeviceInfo cannot be built off a device at all.
+    // -junit5 spelled out: the Kotlin plugin picks kotlin("test")'s backend from the Test task only
+    // for its own JVM targets, and an AGP unit-test task is not one — a bare kotlin("test") here
+    // resolves to the JUnit 4 variant and `kotlin.test.Test` does not compile.
+    testImplementation(kotlin("test-junit5"))
 }
 
 android {
@@ -65,6 +73,10 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_21
         targetCompatibility = JavaVersion.VERSION_21
+    }
+    testOptions {
+        // The same JUnit 5 backend the multiplatform modules run kotlin("test") on.
+        unitTests.all { it.useJUnitPlatform() }
     }
 }
 

--- a/androidApp/src/test/kotlin/app/skerry/android/audio/AndroidAudioMappingTest.kt
+++ b/androidApp/src/test/kotlin/app/skerry/android/audio/AndroidAudioMappingTest.kt
@@ -1,0 +1,83 @@
+package app.skerry.android.audio
+
+import android.media.AudioDeviceInfo
+import android.media.AudioFormat
+import app.skerry.shared.audio.AndroidAudioMapping
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The Android side of RDP audio, as far as a host JVM can reach it: an `AudioTrack` needs a real
+ * device, so what is pinned here is the mapping around it — the depths a track can be opened for,
+ * how channels are routed, and the id a profile stores for an output.
+ */
+class AndroidAudioMappingTest {
+
+    @Test
+    fun `PCM is opened at the two depths a track has an encoding for`() {
+        assertEquals(AudioFormat.ENCODING_PCM_8BIT, AndroidAudioMapping.encoding(8))
+        assertEquals(AudioFormat.ENCODING_PCM_16BIT, AndroidAudioMapping.encoding(16))
+    }
+
+    /** Nothing else is ever negotiated (see AudioChannel), and an unknown depth must not be guessed. */
+    @Test
+    fun `a depth the platform cannot play opens no track`() {
+        assertNull(AndroidAudioMapping.encoding(24))
+        assertNull(AndroidAudioMapping.encoding(32))
+        assertNull(AndroidAudioMapping.encoding(0))
+    }
+
+    @Test
+    fun `one channel is mono and two are stereo`() {
+        assertEquals(AudioFormat.CHANNEL_OUT_MONO, AndroidAudioMapping.channelMask(1))
+        assertEquals(AudioFormat.CHANNEL_OUT_STEREO, AndroidAudioMapping.channelMask(2))
+    }
+
+    @Test
+    fun `anything wider than stereo is still played as stereo`() {
+        assertEquals(AudioFormat.CHANNEL_OUT_STEREO, AndroidAudioMapping.channelMask(6))
+    }
+
+    /**
+     * The id survives a reconnect — an [AudioDeviceInfo.id] does not, and a profile that stored one
+     * would silently fall back to the speaker the next time the headset is plugged in.
+     */
+    @Test
+    fun `an output is identified by its type and product`() {
+        assertEquals(
+            "${AudioDeviceInfo.TYPE_BLUETOOTH_A2DP}:WH-1000XM4",
+            AndroidAudioMapping.outputId(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, "WH-1000XM4"),
+        )
+    }
+
+    @Test
+    fun `an output with no product name still has an id`() {
+        assertEquals(
+            "${AudioDeviceInfo.TYPE_BUILTIN_SPEAKER}:",
+            AndroidAudioMapping.outputId(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, null),
+        )
+    }
+
+    @Test
+    fun `a sink is named after its kind and its product`() {
+        assertEquals(
+            "USB — Scarlett 2i2",
+            AndroidAudioMapping.outputLabel(AudioDeviceInfo.TYPE_USB_HEADSET, "  Scarlett 2i2  "),
+        )
+    }
+
+    @Test
+    fun `a sink whose product says nothing new is named once`() {
+        assertEquals("Speaker", AndroidAudioMapping.outputLabel(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, "Speaker"))
+        assertEquals("Speaker", AndroidAudioMapping.outputLabel(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, null))
+    }
+
+    @Test
+    fun `a sink of a kind we have no name for is still offered`() {
+        assertEquals(
+            "Audio output — Dock",
+            AndroidAudioMapping.outputLabel(AudioDeviceInfo.TYPE_DOCK, "Dock"),
+        )
+    }
+}

--- a/androidApp/src/test/kotlin/app/skerry/android/audio/AndroidTrackSinkTest.kt
+++ b/androidApp/src/test/kotlin/app/skerry/android/audio/AndroidTrackSinkTest.kt
@@ -1,0 +1,108 @@
+package app.skerry.android.audio
+
+import app.skerry.shared.audio.AndroidPlaybackTrack
+import app.skerry.shared.audio.AndroidTrackSink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the session does to an Android track. The track itself needs a real device, so the sequences
+ * that matter — the one that drops a stream mid-session and the one that gives the output back —
+ * are exercised against a fake, the way the desktop sink is against a fake line.
+ */
+class AndroidTrackSinkTest {
+
+    @Test
+    fun `the track takes the whole block`() {
+        val track = FakeTrack()
+
+        AndroidTrackSink(track).write(ByteArray(320))
+
+        assertEquals(listOf("write 320"), track.events)
+    }
+
+    /** The track has to be paused before its buffer can be dropped; it resumes on the next write. */
+    @Test
+    fun `flush pauses the track, drops the buffer and plays on`() {
+        val track = FakeTrack()
+
+        AndroidTrackSink(track).flush()
+
+        assertEquals(listOf("pause", "flush", "play"), track.events)
+    }
+
+    /**
+     * A track left paused takes every block the session hands it and plays none, and nothing
+     * reopens it until the server changes format — so play() runs even when the steps before it did
+     * not.
+     */
+    @Test
+    fun `a track that will not pause is played on anyway`() {
+        val track = FakeTrack(failPause = true)
+
+        AndroidTrackSink(track).flush()
+
+        assertTrue("play" in track.events, "a session whose sound went silent for good")
+    }
+
+    /**
+     * pause() comes first: it unblocks a write parked on a full buffer, which is what ends the
+     * playback loop instead of leaving it stuck on a track nobody listens to.
+     */
+    @Test
+    fun `the track is paused before it is given back`() {
+        val track = FakeTrack()
+
+        AndroidTrackSink(track).close()
+
+        assertEquals(listOf("pause", "flush", "stop", "release"), track.events)
+    }
+
+    @Test
+    fun `a track that throws on the way out is still released`() {
+        val track = FakeTrack(failPause = true, failStop = true)
+
+        AndroidTrackSink(track).close()
+
+        assertTrue(track.released, "a track left unreleased holds the output for the rest of the process")
+    }
+}
+
+/** An [AndroidPlaybackTrack] that records what was asked of it. */
+private class FakeTrack(
+    private val failPause: Boolean = false,
+    private val failStop: Boolean = false,
+) : AndroidPlaybackTrack {
+
+    val events = mutableListOf<String>()
+    var released = false
+        private set
+
+    override fun write(pcm: ByteArray) {
+        events += "write ${pcm.size}"
+    }
+
+    override fun pause() {
+        events += "pause"
+        if (failPause) error("the track is gone")
+    }
+
+    override fun flush() {
+        events += "flush"
+    }
+
+    override fun play() {
+        events += "play"
+    }
+
+    override fun stop() {
+        events += "stop"
+        if (failStop) error("the track is gone")
+    }
+
+    override fun release() {
+        events += "release"
+        released = true
+    }
+}

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -31,6 +31,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Remote-desktop session as the UI sees it (pixels, updates, input) | `graphics/RemoteDesktopSession`, `RemoteDesktopUpdate`, `RemoteKeyEvent`, `RemoteDesktopQuality`, `RemoteDesktopCapabilities` — RDP and VNC adapters both implement this, protocol types stay behind it |
 | ARGB pixel buffer (resize/blit/fill/copyRect) | `graphics/RemoteFramebuffer` |
 | PCM playback and output-device enumeration | `audio/RemoteAudio`: `AudioOutputs`, `RemoteAudioPlayerFactory`, `RemoteAudioFormat` |
+| Open/reopen/teardown of a playback device | `audio/PcmPlayer`: `PcmPlayer` over `PcmSink` + `PcmSinkOpener` — a platform sink answers for the device only, never for when to open it |
 | Reading/writing a protocol PDU with bounds checks | `rdp/RdpIo`: `RdpReader`, `RdpWriter`, `RdpSource`, `RdpSink`; malformed input → `rdp/RdpProtocolException` |
 | RDP connection entry point and live session | `rdp/RdpTransport`: `RdpTransport`, `RdpSession`, `RdpUpdate` |
 | MS-RDPEDYC dynamic channel (clipboard/display/audio/graphics) | `rdp/egfx/DynamicChannelHandler` |

--- a/shared/src/androidMain/kotlin/app/skerry/shared/audio/AndroidAudio.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/audio/AndroidAudio.kt
@@ -27,85 +27,30 @@ class AndroidAudioOutputs(context: Context) : AudioOutputs {
     }
 }
 
-/** Opens [AndroidAudioTrackPlayer]s on the device an RDP profile named. */
+/** Opens the Android players on the device an RDP profile named. */
 class AndroidAudioPlayers(context: Context) : RemoteAudioPlayerFactory {
 
     private val appContext = context.applicationContext
 
-    override fun open(deviceId: String): RemoteAudioPlayer = AndroidAudioTrackPlayer(appContext, deviceId)
+    override fun open(deviceId: String): RemoteAudioPlayer =
+        PcmPlayer(AndroidTrackSinks(appContext, deviceId), trace = audioTrace)
 }
 
 /**
- * Plays PCM through an [AudioTrack] routed to [deviceId] (the system's own routing when it is blank
- * or the device is gone).
- *
- * Like the desktop player, the track is built on the first block — the server picks the format — and
- * rebuilt when the format changes. Writes are blocking, so the session keeps this off its read loop.
+ * Opens an [AudioTrack] routed to [deviceId] (the system's own routing when it is blank or the
+ * device is gone). When to open one, and what a refusal costs, is [PcmPlayer]'s.
  */
-class AndroidAudioTrackPlayer(
+internal class AndroidTrackSinks(
     private val context: Context,
     private val deviceId: String,
-) : RemoteAudioPlayer {
+) : PcmSinkOpener {
 
-    @Volatile
-    private var track: AudioTrack? = null
-
-    @Volatile
-    private var current: RemoteAudioFormat? = null
-
-    @Volatile
-    private var closed = false
-
-    override fun play(format: RemoteAudioFormat, pcm: ByteArray) {
-        if (closed) return
-        if (format != current) reopen(format)
-        val open = track ?: return
-        runCatching { open.write(pcm, 0, pcm.size) }
-    }
-
-    override fun flush() {
-        // The track has to be paused before its buffer can be dropped; it resumes on the next write.
-        runCatching {
-            track?.let { open ->
-                open.pause()
-                open.flush()
-                open.play()
-            }
-        }
-    }
-
-    override fun close() {
-        closed = true
-        release()
-    }
-
-    private fun release() {
-        val open = track ?: return
-        track = null
-        current = null
-        // pause() first: it unblocks a write parked on a full buffer, which is what ends the
-        // playback loop instead of leaving it stuck on a track nobody listens to.
-        runCatching {
-            open.pause()
-            open.flush()
-            open.stop()
-        }
-        runCatching { open.release() }
-    }
-
-    private fun reopen(format: RemoteAudioFormat) {
-        release()
-        if (closed) return
-        val encoding = when (format.bitsPerSample) {
-            8 -> AudioFormat.ENCODING_PCM_8BIT
-            16 -> AudioFormat.ENCODING_PCM_16BIT
-            else -> return
-        }
-        val channelMask =
-            if (format.channels >= 2) AudioFormat.CHANNEL_OUT_STEREO else AudioFormat.CHANNEL_OUT_MONO
+    override fun open(format: RemoteAudioFormat): PcmSink? {
+        val encoding = AndroidAudioMapping.encoding(format.bitsPerSample) ?: return null
+        val channelMask = AndroidAudioMapping.channelMask(format.channels)
         val built = runCatching {
             val minimum = AudioTrack.getMinBufferSize(format.sampleRate, channelMask, encoding)
-                .coerceAtLeast(format.sampleRate * format.channels * (format.bitsPerSample / 8) / 5)
+                .coerceAtLeast(format.bufferBytes())
             AudioTrack.Builder()
                 .setAudioAttributes(
                     AudioAttributes.Builder()
@@ -123,14 +68,18 @@ class AndroidAudioTrackPlayer(
                 .setBufferSizeInBytes(minimum)
                 .setTransferMode(AudioTrack.MODE_STREAM)
                 .build()
-        }.getOrNull() ?: return
-        built.preferredDevice = preferredDevice()
-        runCatching { built.play() }.onFailure {
+        }.getOrNull() ?: return null
+        return runCatching {
+            // The setter shares play()'s guard: the sink the profile named can go stale between the
+            // lookup and the assignment (a Bluetooth headset dropping), and a track built but never
+            // released holds the output for the rest of the process.
+            built.preferredDevice = preferredDevice()
+            built.play()
+            AndroidTrackSink(AudioTrackHandle(built))
+        }.getOrElse {
             runCatching { built.release() }
-            return
+            null
         }
-        track = built
-        current = format
     }
 
     private fun preferredDevice(): AudioDeviceInfo? {
@@ -141,12 +90,100 @@ class AndroidAudioTrackPlayer(
     }
 }
 
-/** Type plus product name: the same headset gets the same id across reconnects. */
-private val AudioDeviceInfo.stableId: String get() = "$type:${productName ?: ""}"
+/**
+ * The calls a sink makes on an [AudioTrack], as an interface.
+ *
+ * A track cannot be built off a real device, so without this seam the teardown sequence below —
+ * which is what a session's sound hangs on when it ends — could only be read, never run. Public for
+ * the same reason as [AndroidAudioMapping]: its tests live in `:androidApp`.
+ */
+interface AndroidPlaybackTrack {
+    fun write(pcm: ByteArray)
+    fun pause()
+    fun flush()
+    fun play()
+    fun stop()
+    fun release()
+}
 
-private val AudioDeviceInfo.label: String
-    get() {
-        val product = productName?.toString()?.trim().orEmpty()
+/** One playing track. Writes block while it drains, which is the back-pressure [PcmPlayer] relies on. */
+class AndroidTrackSink(private val track: AndroidPlaybackTrack) : PcmSink {
+
+    override fun write(pcm: ByteArray) {
+        track.write(pcm)
+    }
+
+    /**
+     * The track has to be paused before its buffer can be dropped; it resumes on the next write.
+     * Each step stands alone, and play() runs whatever happened before it: a track left paused takes
+     * every block the session hands it and plays none, and nothing reopens it until the server
+     * changes format.
+     */
+    override fun flush() {
+        runCatching { track.pause() }
+        runCatching { track.flush() }
+        runCatching { track.play() }
+    }
+
+    /**
+     * Give the device back. pause() comes first: it unblocks a write parked on a full buffer, which
+     * is what ends the playback loop instead of leaving it stuck on a track nobody listens to. Each
+     * step stands alone — a track that fails to stop still has to be released.
+     */
+    override fun close() {
+        runCatching { track.pause() }
+        runCatching { track.flush() }
+        runCatching { track.stop() }
+        runCatching { track.release() }
+    }
+}
+
+/** The real thing behind [AndroidPlaybackTrack]; nothing here has a decision of its own. */
+private class AudioTrackHandle(private val track: AudioTrack) : AndroidPlaybackTrack {
+
+    override fun write(pcm: ByteArray) {
+        track.write(pcm, 0, pcm.size)
+    }
+
+    override fun pause() = track.pause()
+
+    override fun flush() = track.flush()
+
+    override fun play() = track.play()
+
+    override fun stop() = track.stop()
+
+    override fun release() = track.release()
+}
+
+/**
+ * How an RDP format and a platform output are read into `android.media`.
+ *
+ * Separate from the sinks it serves, and public rather than internal, because this is the part of
+ * the Android audio path a test can hold: an [AudioTrack] or an [AudioDeviceInfo] cannot be built
+ * off a real device, while the mapping decides what a profile stores and what the server is told
+ * this client can play. Its tests live in `:androidApp` — the only module here with an Android host
+ * test source set (see that module's build file).
+ */
+object AndroidAudioMapping {
+
+    /** `null` for a depth `AudioTrack` has no encoding for, which is a device that will not open. */
+    fun encoding(bitsPerSample: Int): Int? = when (bitsPerSample) {
+        8 -> AudioFormat.ENCODING_PCM_8BIT
+        16 -> AudioFormat.ENCODING_PCM_16BIT
+        else -> null
+    }
+
+    /** Anything the server calls multi-channel is played as stereo — the track takes no more. */
+    fun channelMask(channels: Int): Int =
+        if (channels >= 2) AudioFormat.CHANNEL_OUT_STEREO else AudioFormat.CHANNEL_OUT_MONO
+
+    /** Type plus product name: the same headset gets the same id across reconnects. */
+    fun outputId(type: Int, productName: String?): String = "$type:${productName.orEmpty()}"
+
+    /** What the device picker shows: the kind of sink, named after its product when it has one. */
+    fun outputLabel(type: Int, productName: String?): String {
+        val product = productName?.trim().orEmpty()
         val kind = when (type) {
             AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "Speaker"
             AudioDeviceInfo.TYPE_WIRED_HEADSET, AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Wired headset"
@@ -157,3 +194,10 @@ private val AudioDeviceInfo.label: String
         }
         return if (product.isEmpty() || product == kind) kind else "$kind — $product"
     }
+}
+
+private val AudioDeviceInfo.stableId: String
+    get() = AndroidAudioMapping.outputId(type, productName?.toString())
+
+private val AudioDeviceInfo.label: String
+    get() = AndroidAudioMapping.outputLabel(type, productName?.toString())

--- a/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
@@ -1,0 +1,147 @@
+package app.skerry.shared.audio
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * One opened playback device, at its narrowest: bytes in, and the two ways a session gives it back.
+ *
+ * [write] blocks while the device drains, which is the back-pressure that paces the stream (see
+ * [RemoteAudioPlayer]). Everything above it — when to open, when to reopen, what a dead device costs
+ * — is [PcmPlayer]'s, so that a platform only has to answer for the device itself.
+ */
+interface PcmSink {
+    /** Hand the whole block to the device, blocking until it has taken it. */
+    fun write(pcm: ByteArray)
+
+    /** Drop what has not been played yet, keeping the device open. */
+    fun flush()
+
+    /** Give the device back. Called once. */
+    fun close()
+}
+
+/**
+ * Opens a device for exactly one format; `null` when the platform has none it can play this on —
+ * which is not fatal, the next block asks again.
+ */
+fun interface PcmSinkOpener {
+    fun open(format: RemoteAudioFormat): PcmSink?
+}
+
+/**
+ * The playback half of [RemoteAudioPlayer], as both platforms run it.
+ *
+ * The device is opened on the first block rather than at connect time: the format is the server's to
+ * choose, and a device opened for the wrong one would have to be torn down again. A format change
+ * reopens it — a remote session switches from a 22 kHz notification sound to 44 kHz media without
+ * asking.
+ *
+ * Nothing here throws at the caller. A device that will not open costs the block it was given and is
+ * asked for again on the next one. A device that dies mid-stream is not replaced: it keeps taking
+ * blocks nobody hears until the server changes format, which is the trade both platform sinks made
+ * before this class existed — rebuilding a device on every failed write would rebuild it fifty times
+ * a second, and a write fails for reasons that outlive the retry.
+ */
+class PcmPlayer(
+    private val sinks: PcmSinkOpener,
+    /**
+     * Where a line about the device goes. Silent by default; the session turns it on from an
+     * environment variable. A device that never opens looks exactly like a server that stopped
+     * sending, and only these lines tell the two apart.
+     */
+    private val trace: (String) -> Unit = {},
+) : RemoteAudioPlayer {
+
+    /**
+     * Guards the fields below, and nothing slow: opening a device, writing to it and closing it all
+     * happen outside it. [play] blocks inside the device for as long as it takes to drain and
+     * [flush] runs on the session's read loop — a lock held across either would stall the picture
+     * along with the sound.
+     */
+    private val lock = SynchronizedObject()
+
+    private var sink: PcmSink? = null
+
+    private var current: RemoteAudioFormat? = null
+
+    private var closed = false
+
+    /** Traced once per spell of silence: every block retries, and a line each would be a flood. */
+    private var refused = false
+
+    private var writesFailing = false
+
+    /** Formats already announced to the trace; a session alternates between two or three of them. */
+    private val traced = mutableSetOf<RemoteAudioFormat>()
+
+    override fun play(format: RemoteAudioFormat, pcm: ByteArray) {
+        val open = device(format) ?: return
+        // A device that fails mid-block was unplugged or reclaimed; there is nothing to retry, and
+        // the block it swallowed is 20 ms of a stream that keeps arriving.
+        runCatching { open.write(pcm) }.onFailure { failure ->
+            if (!writesFailing) trace("the device stopped taking blocks: $failure")
+            writesFailing = true
+        }
+    }
+
+    override fun flush() {
+        val open = synchronized(lock) { sink } ?: return
+        runCatching { open.flush() }
+    }
+
+    override fun close() {
+        val open = synchronized(lock) {
+            closed = true
+            take()
+        }
+        runCatching { open?.close() }
+    }
+
+    /**
+     * The device to play [format] on, opened here when the last block was in another one. Only the
+     * playback path calls this, one block at a time; [close] is the only other writer of the fields.
+     */
+    private fun device(format: RemoteAudioFormat): PcmSink? {
+        val previous = synchronized(lock) {
+            if (closed) return null
+            if (format == current) return sink
+            take()
+        }
+        runCatching { previous?.close() }
+        val opened = runCatching { sinks.open(format) }.getOrNull()
+        if (opened == null) {
+            if (!refused) trace("no device would open for $format")
+            refused = true
+            return null
+        }
+        val published = synchronized(lock) {
+            // close() may have run through the open above, on the thread that tore the session down
+            // or from the opener itself. It found nothing to give back, and this device would stay
+            // open for the rest of the process.
+            if (closed) {
+                false
+            } else {
+                refused = false
+                writesFailing = false
+                sink = opened
+                current = format
+                true
+            }
+        }
+        if (!published) {
+            runCatching { opened.close() }
+            return null
+        }
+        if (traced.add(format)) trace("a device took $format")
+        return opened
+    }
+
+    /** The device, out of the player and into the caller's hands. Call under [lock]. */
+    private fun take(): PcmSink? {
+        val open = sink ?: return null
+        sink = null
+        current = null
+        return open
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/audio/RemoteAudio.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/audio/RemoteAudio.kt
@@ -11,6 +11,15 @@ data class RemoteAudioFormat(
 )
 
 /**
+ * What a platform device should hold: a fifth of a second of this format. Enough that a scheduling
+ * hiccup does not become an audible gap, short enough that the sound stays with the picture.
+ */
+internal fun RemoteAudioFormat.bufferBytes(): Int =
+    sampleRate * channels * (bitsPerSample / 8) / BUFFER_FRACTION
+
+private const val BUFFER_FRACTION = 5
+
+/**
  * A playback device the platform offers. [id] is what a host profile stores, so it has to survive a
  * reboot and a reconnected device; [name] is what the user picks from.
  */

--- a/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
@@ -1,0 +1,264 @@
+package app.skerry.shared.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The playback state machine both platform sinks run on: when a device is opened, when it is torn
+ * down and reopened, and what a device that refuses to open or dies mid-stream costs the session.
+ *
+ * The device itself (a `SourceDataLine` on the desktop, an `AudioTrack` on Android) cannot be opened
+ * off a real machine, so the rules that used to live inside each of them are exercised here against
+ * a recording sink instead.
+ */
+class PcmPlayerTest {
+
+    private val stereo = RemoteAudioFormat(sampleRate = 44100, channels = 2, bitsPerSample = 16)
+    private val notification = RemoteAudioFormat(sampleRate = 22050, channels = 1, bitsPerSample = 8)
+
+    @Test
+    fun `no device is opened until the first block arrives`() {
+        val devices = FakeSinks()
+        PcmPlayer(devices)
+
+        assertEquals(emptyList(), devices.events)
+    }
+
+    @Test
+    fun `the first block opens a device and reaches it whole`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320"), devices.events)
+    }
+
+    @Test
+    fun `blocks in the same format keep the device that is already open`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        player.play(stereo, ByteArray(160))
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "write#1 160"), devices.events)
+    }
+
+    /** A session that switches from a 22 kHz notification sound to 44 kHz media, mid-stream. */
+    @Test
+    fun `a format change releases the old device before opening the new one`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(notification, ByteArray(64))
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(
+            listOf("open#1 $notification", "write#1 64", "close#1", "open#2 $stereo", "write#2 320"),
+            devices.events,
+        )
+    }
+
+    @Test
+    fun `a device that will not open drops the block, and the next one tries again`() {
+        val devices = FakeSinks(refuse = { it == stereo })
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        devices.refuse = { false }
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(listOf("refused $stereo", "open#1 $stereo", "write#1 320"), devices.events)
+    }
+
+    @Test
+    fun `an opener that throws is a device that is not there`() {
+        val devices = FakeSinks(refuse = { error("no mixer") })
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(emptyList(), devices.events)
+    }
+
+    /**
+     * A format the device refuses must not leave the previous one playing: the samples that follow
+     * are in the new format, and a line still open on the old one would turn them into noise.
+     */
+    @Test
+    fun `a refused format leaves no device behind`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        devices.refuse = { it == notification }
+        player.play(notification, ByteArray(64))
+        devices.refuse = { false }
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(
+            listOf(
+                "open#1 $stereo", "write#1 320",
+                "close#1", "refused $notification",
+                "open#2 $stereo", "write#2 320",
+            ),
+            devices.events,
+        )
+    }
+
+    @Test
+    fun `an opener that throws on a format change leaves no device behind`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        devices.refuse = { error("the mixer went away") }
+        player.play(notification, ByteArray(64))
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "close#1"), devices.events)
+    }
+
+    /**
+     * The session is torn down while a device is still opening: [close] finds nothing to give back,
+     * and without a second look the device that arrives a moment later is held for the rest of the
+     * process.
+     */
+    @Test
+    fun `a device that opens into a closed player is given back at once`() {
+        val devices = FakeSinks()
+        lateinit var player: PcmPlayer
+        devices.onOpen = { player.close() }
+        player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(listOf("open#1 $stereo", "close#1"), devices.events)
+    }
+
+    /** A device unplugged mid-session throws on write; the stream must not die with it. */
+    @Test
+    fun `a write that throws is not the session's problem`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        devices.failWrite = true
+        player.play(stereo, ByteArray(320))
+        devices.failWrite = false
+        player.play(stereo, ByteArray(160))
+
+        assertEquals(
+            listOf("open#1 $stereo", "write#1 320", "write#1 320", "write#1 160"),
+            devices.events,
+        )
+    }
+
+    @Test
+    fun `flush drops what the device has not played yet`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        player.flush()
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "flush#1"), devices.events)
+    }
+
+    @Test
+    fun `flushing before anything played touches no device`() {
+        val devices = FakeSinks()
+
+        PcmPlayer(devices).flush()
+
+        assertEquals(emptyList(), devices.events)
+    }
+
+    @Test
+    fun `close releases the device, and later blocks reach nothing`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        player.close()
+        player.play(stereo, ByteArray(320))
+        player.flush()
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "close#1"), devices.events)
+    }
+
+    @Test
+    fun `close is idempotent`() {
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        player.close()
+        player.close()
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "close#1"), devices.events)
+    }
+
+    @Test
+    fun `closing a player that never played releases nothing`() {
+        val devices = FakeSinks()
+
+        PcmPlayer(devices).close()
+
+        assertTrue(devices.events.isEmpty())
+    }
+
+    /** Teardown races playback: the device may be gone by the time the session gives it back. */
+    @Test
+    fun `a device that throws on close does not stop the session from closing`() {
+        val devices = FakeSinks(failClose = true)
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+        player.close()
+        player.play(stereo, ByteArray(320))
+
+        assertEquals(listOf("open#1 $stereo", "write#1 320", "close#1"), devices.events)
+    }
+}
+
+/** Records what the player asks of a device, in the order it asks. */
+private class FakeSinks(
+    var refuse: (RemoteAudioFormat) -> Boolean = { false },
+    private val failClose: Boolean = false,
+) : PcmSinkOpener {
+
+    val events = mutableListOf<String>()
+    var failWrite = false
+
+    /** Runs while the device is opening — where a teardown from another thread lands. */
+    var onOpen: () -> Unit = {}
+
+    private var opened = 0
+
+    override fun open(format: RemoteAudioFormat): PcmSink? {
+        if (refuse(format)) {
+            events += "refused $format"
+            return null
+        }
+        val no = ++opened
+        events += "open#$no $format"
+        onOpen()
+        return object : PcmSink {
+            override fun write(pcm: ByteArray) {
+                events += "write#$no ${pcm.size}"
+                if (failWrite) error("the device is gone")
+            }
+
+            override fun flush() {
+                events += "flush#$no"
+            }
+
+            override fun close() {
+                events += "close#$no"
+                if (failClose) error("the device is gone")
+            }
+        }
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/audio/RemoteAudioFormatTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/audio/RemoteAudioFormatTest.kt
@@ -1,0 +1,17 @@
+package app.skerry.shared.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RemoteAudioFormatTest {
+
+    /**
+     * A fifth of a second: enough that a scheduling hiccup does not become an audible gap, short
+     * enough that the sound stays with the picture.
+     */
+    @Test
+    fun `a device buffer holds a fifth of a second`() {
+        assertEquals(35280, RemoteAudioFormat(sampleRate = 44100, channels = 2, bitsPerSample = 16).bufferBytes())
+        assertEquals(1600, RemoteAudioFormat(sampleRate = 8000, channels = 1, bitsPerSample = 8).bufferBytes())
+    }
+}

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/audio/JavaSoundAudio.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/audio/JavaSoundAudio.kt
@@ -43,94 +43,33 @@ class JavaSoundOutputs : AudioOutputs {
     }
 }
 
-/** Opens [JavaSoundPlayer]s; the device is resolved per session, when the sound actually starts. */
+/** Opens the desktop's players; the device is resolved per session, when the sound actually starts. */
 class JavaSoundPlayers : RemoteAudioPlayerFactory {
-    override fun open(deviceId: String): RemoteAudioPlayer = JavaSoundPlayer(deviceId)
+    override fun open(deviceId: String): RemoteAudioPlayer =
+        PcmPlayer(JavaSoundSinks(deviceId), trace = audioTrace)
 }
 
 /**
- * Plays PCM through a [SourceDataLine] on the mixer named [deviceId] (the system default when it is
- * blank or no longer there).
- *
- * The line is opened on the first block rather than at connect time: the format is the server's to
- * choose, and a line opened for the wrong one would have to be torn down again. A format change
- * reopens it, which is what happens when the remote session switches from a 22 kHz notification
- * sound to 44 kHz media.
+ * Opens a [SourceDataLine] on the mixer named [deviceId] — the system default when it is blank or no
+ * longer there, since an unplugged headset must not cost the sound. When to open one, and what a
+ * refusal costs, is [PcmPlayer]'s.
  */
-class JavaSoundPlayer(private val deviceId: String) : RemoteAudioPlayer {
+internal class JavaSoundSinks(private val deviceId: String) : PcmSinkOpener {
 
-    /**
-     * Written by the playback thread, read by whoever closes the session. Volatile rather than
-     * synchronized: [play] blocks inside the line for as long as the device takes to drain, and a
-     * lock around it would make [close] wait exactly when it is trying to cut the sound short.
-     */
-    @Volatile
-    private var line: SourceDataLine? = null
-
-    @Volatile
-    private var current: RemoteAudioFormat? = null
-
-    @Volatile
-    private var closed = false
-
-    override fun play(format: RemoteAudioFormat, pcm: ByteArray) {
-        if (closed) return
-        if (format != current) reopen(format)
-        val open = line ?: return
-        // A short write is what the line reports when it was stopped mid-block; there is nothing to
-        // retry, since whoever stopped it wanted the rest dropped.
-        runCatching { open.write(pcm, 0, pcm.size) }
-    }
-
-    override fun flush() {
-        runCatching { line?.flush() }
-    }
-
-    override fun close() {
-        closed = true
-        release()
-    }
-
-    /**
-     * Give the device back. stop() comes before close(): it releases a write parked on a full
-     * buffer, which is what lets the playback loop finish instead of holding the session open.
-     */
-    private fun release() {
-        val open = line ?: return
-        line = null
-        current = null
-        runCatching {
-            open.stop()
-            open.flush()
-            open.close()
-        }
-    }
-
-    private fun reopen(format: RemoteAudioFormat) {
-        release()
-        if (closed) return
-        val audioFormat = AudioFormat(
-            format.sampleRate.toFloat(),
-            format.bitsPerSample,
-            format.channels,
-            // 8-bit PCM is unsigned and everything wider is signed — that is what WAVE_FORMAT_PCM means.
-            format.bitsPerSample > 8,
-            false, // little-endian, as RDP sends it
-        )
+    override fun open(format: RemoteAudioFormat): PcmSink? {
+        val audioFormat = lineFormat(format)
         val info = DataLine.Info(SourceDataLine::class.java, audioFormat)
-        val opened = mixerLine(info) ?: runCatching { AudioSystem.getLine(info) as SourceDataLine }.getOrNull()
-        line = opened?.also { target ->
-            runCatching {
-                // A buffer of a fifth of a second: enough that a scheduling hiccup does not become an
-                // audible gap, short enough that the sound stays with the picture.
-                target.open(audioFormat, bufferBytes(format))
-                target.start()
-            }.onFailure {
-                runCatching { target.close() }
-                line = null
-            }
+        val line = mixerLine(info)
+            ?: runCatching { AudioSystem.getLine(info) as SourceDataLine }.getOrNull()
+            ?: return null
+        return runCatching {
+            line.open(audioFormat, format.bufferBytes())
+            line.start()
+            JavaSoundSink(line)
+        }.getOrElse {
+            runCatching { line.close() }
+            null
         }
-        current = if (line != null) format else null
     }
 
     /** The line on the profile's chosen mixer, or null when it is gone or cannot take this format. */
@@ -140,10 +79,45 @@ class JavaSoundPlayer(private val deviceId: String) : RemoteAudioPlayer {
             ?.firstOrNull { it.name.trim() == deviceId } ?: return null
         return runCatching { AudioSystem.getMixer(mixerInfo).getLine(info) as SourceDataLine }.getOrNull()
     }
-
-    private fun bufferBytes(format: RemoteAudioFormat): Int =
-        format.sampleRate * format.channels * (format.bitsPerSample / 8) / 5
 }
+
+/** One open line. Writes block while it drains, which is the back-pressure [PcmPlayer] relies on. */
+internal class JavaSoundSink(private val line: SourceDataLine) : PcmSink {
+
+    // A short write is what the line reports when it was stopped mid-block; there is nothing to
+    // retry, since whoever stopped it wanted the rest dropped.
+    override fun write(pcm: ByteArray) {
+        line.write(pcm, 0, pcm.size)
+    }
+
+    override fun flush() {
+        line.flush()
+    }
+
+    /**
+     * Give the device back. stop() comes before close(): it releases a write parked on a full
+     * buffer, which is what lets the playback loop finish instead of holding the session open. Each
+     * step stands alone — a line that fails to stop still has to be closed, or it holds the device
+     * for the rest of the process.
+     */
+    override fun close() {
+        runCatching { line.stop() }
+        runCatching { line.flush() }
+        runCatching { line.close() }
+    }
+}
+
+/**
+ * The RDP format as `javax.sound.sampled` takes it. 8-bit PCM is unsigned and everything wider is
+ * signed — that is what `WAVE_FORMAT_PCM` means — and the samples arrive little-endian.
+ */
+internal fun lineFormat(format: RemoteAudioFormat): AudioFormat = AudioFormat(
+    format.sampleRate.toFloat(),
+    format.bitsPerSample,
+    format.channels,
+    format.bitsPerSample > 8,
+    false,
+)
 
 private val Mixer.supportsPlayback: Boolean
     get() = isLineSupported(Line.Info(SourceDataLine::class.java))

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/audio/JavaSoundSinkTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/audio/JavaSoundSinkTest.kt
@@ -1,0 +1,136 @@
+package app.skerry.shared.audio
+
+import javax.sound.sampled.AudioFormat
+import javax.sound.sampled.Control
+import javax.sound.sampled.Line
+import javax.sound.sampled.LineListener
+import javax.sound.sampled.SourceDataLine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The desktop sink: how an RDP format becomes a `javax.sound.sampled` line, and what the session
+ * does to that line. A real mixer is not part of it — the tests that need a device are the ones no
+ * CI runner can run, and the rules that used to hide behind one are exercised against a fake line.
+ */
+class JavaSoundSinkTest {
+
+    private val stereo = RemoteAudioFormat(sampleRate = 44100, channels = 2, bitsPerSample = 16)
+    private val notification = RemoteAudioFormat(sampleRate = 22050, channels = 1, bitsPerSample = 8)
+
+    @Test
+    fun `16-bit PCM opens a signed little-endian line`() {
+        val format = lineFormat(stereo)
+
+        assertEquals(AudioFormat.Encoding.PCM_SIGNED, format.encoding)
+        assertEquals(44100f, format.sampleRate)
+        assertEquals(16, format.sampleSizeInBits)
+        assertEquals(2, format.channels)
+        assertEquals(4, format.frameSize)
+        assertFalse(format.isBigEndian, "RDP sends PCM little-endian")
+    }
+
+    /** 8-bit PCM is unsigned and everything wider is signed — that is what `WAVE_FORMAT_PCM` means. */
+    @Test
+    fun `8-bit PCM opens an unsigned line`() {
+        val format = lineFormat(notification)
+
+        assertEquals(AudioFormat.Encoding.PCM_UNSIGNED, format.encoding)
+        assertEquals(1, format.frameSize)
+    }
+
+    @Test
+    fun `the line takes the whole block`() {
+        val line = FakeLine()
+
+        JavaSoundSink(line).write(ByteArray(320))
+
+        assertEquals(listOf("write 0..320"), line.events)
+    }
+
+    @Test
+    fun `flush drops the buffer and keeps the line`() {
+        val line = FakeLine()
+
+        JavaSoundSink(line).flush()
+
+        assertEquals(listOf("flush"), line.events)
+        assertFalse(line.closed)
+    }
+
+    /**
+     * stop() comes before close(): it releases a write parked on a full buffer, which is what lets
+     * the playback loop finish instead of holding the session open.
+     */
+    @Test
+    fun `the line is stopped before it is given back`() {
+        val line = FakeLine()
+
+        JavaSoundSink(line).close()
+
+        assertEquals(listOf("stop", "flush", "close"), line.events)
+    }
+
+    @Test
+    fun `a line that throws on the way out is still closed`() {
+        val line = FakeLine(failStop = true)
+
+        JavaSoundSink(line).close()
+
+        assertTrue(line.closed, "a line left open holds the device for the rest of the process")
+    }
+}
+
+/** A [SourceDataLine] that records what was asked of it; everything else is dead weight. */
+private class FakeLine(private val failStop: Boolean = false) : SourceDataLine {
+
+    val events = mutableListOf<String>()
+    var closed = false
+        private set
+
+    override fun write(b: ByteArray, off: Int, len: Int): Int {
+        events += "write $off..$len"
+        return len
+    }
+
+    override fun flush() {
+        events += "flush"
+    }
+
+    override fun start() {
+        events += "start"
+    }
+
+    override fun stop() {
+        events += "stop"
+        if (failStop) error("the line is gone")
+    }
+
+    override fun close() {
+        events += "close"
+        closed = true
+    }
+
+    override fun open(format: AudioFormat, bufferSize: Int) = Unit
+    override fun open(format: AudioFormat) = Unit
+    override fun open() = Unit
+    override fun drain() = Unit
+    override fun isRunning() = false
+    override fun isActive() = false
+    override fun isOpen() = !closed
+    override fun getFormat(): AudioFormat = AudioFormat(44100f, 16, 2, true, false)
+    override fun getBufferSize() = 0
+    override fun available() = 0
+    override fun getFramePosition() = 0
+    override fun getLongFramePosition() = 0L
+    override fun getMicrosecondPosition() = 0L
+    override fun getLevel() = 0f
+    override fun getLineInfo(): Line.Info = Line.Info(SourceDataLine::class.java)
+    override fun getControls(): Array<Control> = emptyArray()
+    override fun isControlSupported(control: Control.Type) = false
+    override fun getControl(control: Control.Type): Control = throw IllegalArgumentException("no controls")
+    override fun addLineListener(listener: LineListener) = Unit
+    override fun removeLineListener(listener: LineListener) = Unit
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/audio/PcmPlayerThreadingTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/audio/PcmPlayerThreadingTest.kt
@@ -1,0 +1,94 @@
+package app.skerry.shared.audio
+
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The two waits [PcmPlayer] must never make anyone else do. Playback and teardown are on different
+ * threads by design — [app.skerry.shared.rdp.AudioChannel] drains its queue on the IO dispatcher
+ * while the session closes the player from wherever the session ends — and keeping the device calls
+ * outside the lock is what stops either of these from hanging.
+ *
+ * On the JVM because it takes real threads; the class under test is common.
+ */
+class PcmPlayerThreadingTest {
+
+    private val stereo = RemoteAudioFormat(sampleRate = 44100, channels = 2, bitsPerSample = 16)
+
+    @Test
+    fun `close gives the device back while a write is parked on it`() {
+        val events = Collections.synchronizedList(mutableListOf<String>())
+        val writing = CountDownLatch(1)
+        val unpark = CountDownLatch(1)
+        val sink = object : PcmSink {
+            override fun write(pcm: ByteArray) {
+                events += "write"
+                writing.countDown()
+                unpark.await()
+            }
+
+            override fun flush() = Unit
+
+            override fun close() {
+                events += "close"
+                // A real device unparks the write from here; this one is unparked by the test.
+                unpark.countDown()
+            }
+        }
+        val player = PcmPlayer(PcmSinkOpener { sink })
+
+        val playback = thread { player.play(stereo, ByteArray(320)) }
+        assertTrue(writing.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), "the write never started")
+        val teardown = thread { player.close() }
+        teardown.join(TIMEOUT_MILLIS)
+
+        assertFalse(teardown.isAlive, "close waited for a device buffer to drain")
+        assertEquals(listOf("write", "close"), events)
+        unpark.countDown()
+        playback.join(TIMEOUT_MILLIS)
+    }
+
+    /**
+     * `SNDC_CLOSE` arrives on the session's read loop and ends in [PcmPlayer.flush]. Opening a
+     * device is a mixer lookup or a binder call, and a read loop parked on one freezes the picture,
+     * the clipboard and the graphics channel with it.
+     */
+    @Test
+    fun `flush does not wait for a device that is still opening`() {
+        val opening = CountDownLatch(1)
+        val unpark = CountDownLatch(1)
+        val sink = object : PcmSink {
+            override fun write(pcm: ByteArray) = Unit
+            override fun flush() = Unit
+            override fun close() = Unit
+        }
+        val player = PcmPlayer(
+            PcmSinkOpener {
+                opening.countDown()
+                unpark.await()
+                sink
+            },
+        )
+
+        val playback = thread { player.play(stereo, ByteArray(320)) }
+        assertTrue(opening.await(TIMEOUT_SECONDS, TimeUnit.SECONDS), "the device never started opening")
+        val reader = thread { player.flush() }
+        reader.join(TIMEOUT_MILLIS)
+
+        assertFalse(reader.isAlive, "the read loop was left waiting for a device to open")
+        unpark.countDown()
+        playback.join(TIMEOUT_MILLIS)
+    }
+
+    private companion object {
+        /** Long enough that a loaded CI runner does not fail a passing implementation. */
+        const val TIMEOUT_SECONDS = 5L
+        const val TIMEOUT_MILLIS = 5_000L
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/audio/AudioTrace.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/audio/AudioTrace.kt
@@ -1,0 +1,21 @@
+package app.skerry.shared.audio
+
+/**
+ * Diagnostics for the audio path, from what the connection asked for to the blocks that reach the
+ * device: `SKERRY_RDP_AUDIO_TRACE=1` writes it to stderr.
+ *
+ * A session with no sound has to be diagnosed on the machine where it happens, against the server
+ * that does it, and the interesting part is what the *server* does — whether it opens an audio
+ * channel at all. Note that `./gradlew run` starts the app in a process that inherits the Gradle
+ * daemon's environment rather than the shell's, so the run task forwards the variable as the system
+ * property this also reads (see composeApp/build.gradle.kts); a packaged build reads the variable
+ * itself.
+ *
+ * It lives with the players rather than with the RDP session that reads the variable's name: the
+ * platform sinks trace through it too, and `rdp` already depends on `audio` — the other direction
+ * would close a cycle.
+ */
+private val audioTracing = System.getenv("SKERRY_RDP_AUDIO_TRACE") == "1" ||
+    System.getProperty("skerry.rdp.audioTrace") == "1"
+
+internal val audioTrace: (String) -> Unit = { line -> if (audioTracing) System.err.println("rdp audio: $line") }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.rdp
 
 import app.skerry.shared.audio.RemoteAudioPlayer
+import app.skerry.shared.audio.audioTrace
 import app.skerry.shared.audio.RemoteAudioPlayerFactory
 import app.skerry.shared.graphics.RemoteFramebuffer
 import app.skerry.shared.rdp.egfx.ClearCodec
@@ -81,7 +82,7 @@ class RdpTcpTransport(
             // the session bandwidth for every sound the server sends.
             val audio: RemoteAudioPlayer? =
                 if (target.audioOutput) audioPlayers?.open(target.audioDeviceId) else null
-            rdpAudioTrace(
+            audioTrace(
                 "connect: audioOutput=${target.audioOutput} device='${target.audioDeviceId}' " +
                     "factory=${audioPlayers != null} player=${audio != null}",
             )
@@ -125,7 +126,7 @@ class RdpTcpTransport(
                     username = credentials.username,
                     password = if (networkLevelAuth) "" else credentials.password,
                 )
-                rdpAudioTrace(
+                audioTrace(
                     "connect: requesting static channels ${settings.channels}, " +
                         "client info says audio playback is wanted=" +
                         settings.channels.contains(RdpClientSettings.CHANNEL_AUDIO),
@@ -181,22 +182,6 @@ class RdpTcpTransport(
 }
 
 /**
- * Diagnostics for the audio path, from what the connection asked for to the blocks that reach the
- * device: `SKERRY_RDP_AUDIO_TRACE=1` writes it to stderr.
- *
- * A session with no sound has to be diagnosed on the machine where it happens, against the server
- * that does it, and the interesting part is what the *server* does — whether it opens an audio
- * channel at all. Note that `./gradlew run` starts the app in a process that inherits the Gradle
- * daemon's environment rather than the shell's, so the run task forwards the variable as the system
- * property this also reads (see composeApp/build.gradle.kts); a packaged build reads the variable
- * itself.
- */
-private val audioTracing = System.getenv("SKERRY_RDP_AUDIO_TRACE") == "1" ||
-    System.getProperty("skerry.rdp.audioTrace") == "1"
-
-internal val rdpAudioTrace: (String) -> Unit = { line -> if (audioTracing) System.err.println("rdp audio: $line") }
-
-/**
  * A live session over a connected [connection].
  *
  * Cancellation follows the VNC session's pattern: the blocking socket read does not respond to
@@ -236,7 +221,7 @@ class RdpSocketSession(
 
     private val dynamicChannels = DynamicChannels(
         send = { data -> codec.sendChannelData(RdpClientSettings.CHANNEL_DYNAMIC, data) },
-        trace = rdpAudioTrace,
+        trace = audioTrace,
     )
 
     /**
@@ -245,7 +230,7 @@ class RdpSocketSession(
      * because the connection request named them, so a channel with nowhere to play would receive
      * audio and drop it.
      */
-    private val audio = audioPlayer?.let { player -> AudioChannel(player, trace = rdpAudioTrace) }
+    private val audio = audioPlayer?.let { player -> AudioChannel(player, trace = audioTrace) }
 
     /**
      * Playback runs on a thread of its own: writing into the device blocks until it has room, and on
@@ -293,10 +278,10 @@ class RdpSocketSession(
                 }
                 // Nothing else should arrive on a static channel this session asked for; if it
                 // does, the audio was routed past its handler rather than never sent.
-                else -> rdpAudioTrace("channel data on $channelId (${data.size} bytes), no handler")
+                else -> audioTrace("channel data on $channelId (${data.size} bytes), no handler")
             }
         }
-        rdpAudioTrace("session: channels granted by the server ${state.channels}, audio=${audio != null}")
+        audioTrace("session: channels granted by the server ${state.channels}, audio=${audio != null}")
         audio?.let { channel ->
             // Both transports of MS-RDPEA, because the server picks: a Windows host with drdynvc
             // open sends the sound over the dynamic channel and leaves the static one silent.


### PR DESCRIPTION
The desktop and Android players each carried their own copy of the same untested playback logic: open on the first block, reopen on a format change, keep the session alive when the device refuses. It is now one class in `commonMain` — `PcmPlayer` over `PcmSink` and `PcmSinkOpener` — and a platform answers for the device only: `JavaSoundSink` around a `SourceDataLine`, `AndroidTrackSink` around an `AudioTrack`.

### Defects this uncovered, each pinned by a test

- A teardown step that threw skipped the ones after it, leaving the device open for the rest of the process — on both platforms.
- `AndroidTrackSink.flush()` left the track paused for good when `pause()` threw: every later block is written to a track that plays nothing, and nothing reopens it until the server changes format.
- A session closed while a device was still opening never got that device back: `close()` found nothing to release, and the device was published a moment later.
- An `AudioTrack` whose preferred device went stale between the lookup and the assignment was leaked instead of released.

### Threading

The device fields are swapped under a lock, while opening a device, writing to it and closing it all happen outside it: a write parked on a full buffer must not delay the teardown that unparks it, and `SNDC_CLOSE` reaches `flush()` on the session's read loop, which would otherwise stall the picture behind a mixer lookup. Two tests drive that with real threads.

### Diagnostics

`PcmPlayer` traces through the audio trace as `AudioChannel` already does — a device that never opens looks exactly like a server that stopped sending, and nothing in the log told the two apart. `SKERRY_RDP_AUDIO_TRACE=1` now also prints the format a device took and the first block it refused. The flag moved from the `rdp` package into `audio`, which `rdp` already depends on.

### Tests

| Where | What |
|---|---|
| `commonTest` | 16 cases on the state machine against a recording sink, plus the device-buffer size |
| `desktopTest` | 6 on the line format and the `SourceDataLine` sequences, 2 on the threading |
| `androidApp/src/test` | 9 on the `android.media` mapping, 5 on the `AudioTrack` sequences |

The Android host tests live in `:androidApp` because `:shared` cannot have them: its `androidHostTest` would inherit `commonTest`, whose vault suite needs libsodium natives a host JVM has not got. `kotlin("test-junit5")` + `useJUnitPlatform()` keeps them on the project's own test stack.

Not covered, and not coverable off a device: `JavaSoundSinks.open` (a real mixer) and `AndroidTrackSinks.open` (a real `AudioTrack` and audio HAL).

Part of #105 — the other half of that issue, a live run on an Android device, is still open.