### PR TITLE
RDP: tell the server when nobody is looking

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -4,6 +4,7 @@ import app.skerry.ui.remote.remoteKeyEvent
 import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopUiState
+import app.skerry.ui.remote.ReportOutputVisibility
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideInVertically
@@ -108,7 +109,11 @@ fun MobileVncScreen(state: MobileDesignState) {
 
     Box(Modifier.fillMaxSize().background(Color.Black)) {
         when (val ui = vnc?.uiState) {
-            is RemoteDesktopUiState.Connected -> VncTouchSurface(ui.screen)
+            is RemoteDesktopUiState.Connected -> {
+                // The app going to the background stops the server drawing a desktop nobody sees.
+                ReportOutputVisibility(ui.screen)
+                VncTouchSurface(ui.screen)
+            }
             is RemoteDesktopUiState.Error -> CenterText(vncFailureText(ui.failure), Skerry.colors.sunset)
             is RemoteDesktopUiState.Disconnected -> Box(Modifier.fillMaxSize()) {
                 VncTouchSurface(ui.screen, interactive = false)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -169,6 +169,35 @@ class RemoteDesktopScreenState(
         }
     }
 
+    // What the server was last told about whether anyone is looking. A session starts as visible
+    // because that is the state a server begins in, so the first report worth sending is the one
+    // that changes it — see [setVisible].
+    private var outputVisible = true
+    private var visibilityJob: Job? = null
+
+    /**
+     * Report whether this session is on screen at all. Off screen the server is asked to stop
+     * rendering and streaming a desktop nobody is looking at (RDP's Suppress Output; a no-op where
+     * the protocol has no such PDU), and the picture is asked for again on the way back.
+     *
+     * Unlike the other writes here these have to reach the server in the order they were made:
+     * minimise-and-restore fires two of them, and a "back on screen" that overtakes the "hidden"
+     * would leave the server suppressed while this side has already recorded the session as
+     * visible — with that record then swallowing every later report. So each one waits for the
+     * previous one instead of racing it.
+     *
+     * Called from the platform's window/app lifecycle — see [ReportOutputVisibility].
+     */
+    fun setVisible(visible: Boolean) {
+        if (visible == outputVisible) return
+        outputVisible = visible
+        val previous = visibilityJob
+        visibilityJob = send {
+            previous?.join()
+            session.setOutputVisible(visible)
+        }
+    }
+
     /** Sound from the remote machine is silenced locally; the channel itself stays open. */
     var audioMuted by mutableStateOf(false)
         private set
@@ -316,15 +345,16 @@ class RemoteDesktopScreenState(
      * process down on Android. The dropped session surfaces through [closed] instead, which is the
      * read loop's job; there is nothing a failed input write can tell the user that the imminent
      * "Connection lost" doesn't.
+     *
+     * The job is returned for the one caller that has to order its writes ([setVisible]); the rest
+     * drop it.
      */
-    private fun send(block: suspend () -> Unit) {
-        scope.launch {
-            try {
-                block()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (_: Exception) {
-            }
+    private fun send(block: suspend () -> Unit): Job = scope.launch {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopVisibility.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopVisibility.kt
@@ -1,0 +1,50 @@
+package app.skerry.ui.remote
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/**
+ * Keeps [screen] told whether anyone can see it, so a server need not render and stream a desktop
+ * that is off screen (RDP's Suppress Output, MS-RDPBCGR 2.2.11.3).
+ *
+ * Two things hide a session, and both are covered here. The window itself: an Android activity sent
+ * to the background and a minimised desktop window both leave the started state, which is what
+ * [windowVisibleAt] reads. And the composition: only the session on screen is composed, so the
+ * effect leaving takes the picture with it — another tab was selected, or the session is being torn
+ * down. Coming back re-adds the observer, which replays the current state and un-suppresses the
+ * server.
+ */
+@Composable
+fun ReportOutputVisibility(screen: RemoteDesktopScreenState) {
+    val owner = LocalLifecycleOwner.current
+    DisposableEffect(owner, screen) { onDispose(observeWindowVisibility(owner.lifecycle, screen::setVisible)) }
+}
+
+/**
+ * Watch [lifecycle] and hand every change of "the window is on screen" to [report]; the returned
+ * action stops watching and reports the session hidden, which is what a session leaving the screen
+ * means. Attaching reports the current state on its own — that replay is what un-suppresses a
+ * session on the way back, since by then the window has long been up and no further event is coming.
+ */
+internal fun observeWindowVisibility(lifecycle: Lifecycle, report: (Boolean) -> Unit): () -> Unit {
+    val observer = LifecycleEventObserver { _, event -> windowVisibleAt(event)?.let(report) }
+    lifecycle.addObserver(observer)
+    return {
+        lifecycle.removeObserver(observer)
+        report(false)
+    }
+}
+
+/**
+ * Whether [event] means the window is on screen, or `null` where it says nothing about that. Only
+ * the started state carries the answer: focus changes (`ON_PAUSE`/`ON_RESUME`) fire whenever a
+ * desktop window is clicked away from, and the remote desktop is still in plain sight there.
+ */
+internal fun windowVisibleAt(event: Lifecycle.Event): Boolean? = when (event) {
+    Lifecycle.Event.ON_START -> true
+    Lifecycle.Event.ON_STOP -> false
+    else -> null
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -6,6 +6,7 @@ import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopController
 import app.skerry.ui.remote.RemoteDesktopUiState
+import app.skerry.ui.remote.ReportOutputVisibility
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
@@ -136,6 +137,8 @@ fun VncView(state: DesktopDesignState) {
         when (val ui = vnc.uiState) {
             is RemoteDesktopUiState.Connecting -> CenterNotice("hourglass_empty", stringResource(Res.string.vnc_connecting))
             is RemoteDesktopUiState.Connected -> Row(Modifier.fillMaxSize()) {
+                // A minimised window, or another tab taking the screen, stops the server drawing.
+                ReportOutputVisibility(ui.screen)
                 Box(Modifier.weight(1f).fillMaxHeight()) { VncSurface(ui.screen) }
                 AnimatedVisibility(
                     visible = !state.remotePanelHidden,

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
@@ -8,6 +8,7 @@ import app.skerry.shared.graphics.RemoteRect
 import app.skerry.shared.graphics.RemoteDesktopUpdate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -350,6 +351,77 @@ class RemoteDesktopScreenStateTest {
         screen.toggleRemoteResize() // off again before the debounce fires
         advanceUntilIdle()
         assertTrue(session.desktopSizes.isEmpty())
+        scope.cancel()
+    }
+
+    @Test
+    fun a_window_going_off_screen_is_reported_to_the_session() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop()
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.setVisible(false)
+        screen.setVisible(true)
+
+        assertEquals(listOf(false, true), session.visibility)
+        scope.cancel()
+    }
+
+    @Test
+    fun a_session_starts_visible_and_says_so_only_once_it_changes() = runTest {
+        // The state is the client's half of the protocol: the server was told nothing yet and is
+        // drawing, so repeating "visible" is a PDU that buys nothing — and a hidden window reported
+        // twice (window minimised, then the tab left the screen) must not un-suppress anything.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop()
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.setVisible(true)
+        assertTrue(session.visibility.isEmpty(), "a session that was never hidden has nothing to report")
+
+        screen.setVisible(false)
+        screen.setVisible(false)
+        assertEquals(listOf(false), session.visibility)
+        scope.cancel()
+    }
+
+    @Test
+    fun visibility_reports_reach_the_session_in_the_order_they_were_made() = runTest {
+        // Minimise and restore in quick succession and the two writes race: each is its own
+        // coroutine on a multi-threaded scope. If "back on screen" overtakes "hidden", the server
+        // ends up suppressed while the client has already recorded the session as visible — and the
+        // record is what stops any later report from putting it right.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = object : FakeRemoteDesktop() {
+            override suspend fun setOutputVisible(visible: Boolean) {
+                // A slow first write is what gives the second one the chance to overtake it.
+                if (!visible) delay(50)
+                super.setOutputVisible(visible)
+            }
+        }
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.setVisible(false)
+        screen.setVisible(true)
+        advanceUntilIdle()
+
+        assertEquals(listOf(false, true), session.visibility)
+        scope.cancel()
+    }
+
+    @Test
+    fun a_visibility_report_to_a_dead_session_does_not_escape_the_launch() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = object : FakeRemoteDesktop() {
+            override suspend fun setOutputVisible(visible: Boolean): Unit = throw IllegalStateException("Socket closed")
+        }
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        screen.setVisible(false)
+
+        // Reaching here at all is the assertion: the window is minimised on a session whose socket
+        // has already gone, and an exception out of the bare launch kills the process on Android.
+        assertTrue(session.visibility.isEmpty())
         scope.cancel()
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopVisibilityTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopVisibilityTest.kt
@@ -1,0 +1,84 @@
+package app.skerry.ui.remote
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The lifecycle event a remote desktop reads as "someone can see this". Both platforms put the same
+ * meaning on the started state — an Android activity that is on screen, a desktop window that is not
+ * minimised — while focus (`ON_PAUSE`/`ON_RESUME`) says nothing about whether the picture is visible.
+ */
+class RemoteDesktopVisibilityTest {
+
+    @Test
+    fun the_started_state_is_what_being_on_screen_means() {
+        assertEquals(true, windowVisibleAt(Lifecycle.Event.ON_START))
+        assertEquals(false, windowVisibleAt(Lifecycle.Event.ON_STOP))
+    }
+
+    @Test
+    fun losing_focus_does_not_hide_a_window() {
+        // A desktop window drops to PAUSED whenever another application is clicked, and the remote
+        // desktop is still there — suppressing output on it would blank the picture the user is
+        // looking at while typing in a window next to it.
+        assertNull(windowVisibleAt(Lifecycle.Event.ON_PAUSE))
+        assertNull(windowVisibleAt(Lifecycle.Event.ON_RESUME))
+        assertNull(windowVisibleAt(Lifecycle.Event.ON_CREATE))
+    }
+
+    @Test
+    fun watching_a_window_that_is_already_up_reports_it_visible_at_once() {
+        // What un-suppresses a session on the way back: the session that left the screen was told it
+        // was hidden, and nothing else will say otherwise — the lifecycle is already started by the
+        // time the picture is composed again, so only the state replayed on attach can put it right.
+        val window = FakeWindow()
+        window.registry.currentState = Lifecycle.State.RESUMED
+        val reported = mutableListOf<Boolean>()
+
+        observeWindowVisibility(window.lifecycle) { reported += it }
+
+        assertEquals(listOf(true), reported)
+    }
+
+    @Test
+    fun a_window_going_down_and_the_watch_ending_both_report_hidden() {
+        val window = FakeWindow()
+        window.registry.currentState = Lifecycle.State.RESUMED
+        val reported = mutableListOf<Boolean>()
+        val stopWatching = observeWindowVisibility(window.lifecycle) { reported += it }
+
+        window.registry.currentState = Lifecycle.State.CREATED // minimised, or sent to the background
+        assertEquals(listOf(true, false), reported)
+
+        window.registry.currentState = Lifecycle.State.RESUMED
+        stopWatching()
+        // Leaving the composition is the other way a session goes off screen: another tab took the
+        // window. Reporting it hidden is what stops the server drawing for nobody.
+        assertEquals(listOf(true, false, true, false), reported)
+    }
+
+    @Test
+    fun nothing_is_reported_once_the_watch_has_ended() {
+        val window = FakeWindow()
+        window.registry.currentState = Lifecycle.State.RESUMED
+        val reported = mutableListOf<Boolean>()
+        val stopWatching = observeWindowVisibility(window.lifecycle) { reported += it }
+        stopWatching()
+
+        window.registry.currentState = Lifecycle.State.CREATED
+        window.registry.currentState = Lifecycle.State.RESUMED
+
+        // A session that is no longer on screen must not be un-suppressed by the window it left.
+        assertEquals(listOf(true, false), reported)
+    }
+
+    /** A window whose lifecycle the test drives; `createUnsafe` skips the main-thread check. */
+    private class FakeWindow : LifecycleOwner {
+        val registry = LifecycleRegistry.createUnsafe(this)
+        override val lifecycle: Lifecycle get() = registry
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
@@ -129,7 +129,19 @@ class RdpRemoteDesktop(
     /** The RDP cursor is always the client's to draw; there is nothing to hand over. */
     override suspend fun setLocalCursor(enabled: Boolean) = Unit
 
-    override suspend fun setOutputVisible(visible: Boolean) = session.setOutputVisible(visible)
+    /**
+     * A suppressed server draws nothing, so while the window was away its screen and the last frame
+     * held here drifted apart — the picture comes back only if the whole of it is asked for. The
+     * server is under no obligation to volunteer that repaint (MS-RDPBCGR 2.2.11.3 says what stops,
+     * not what resumes), and an incremental update would leave the stale pixels around whatever
+     * happened to change. Which is why a server that cannot be asked for the repaint is not asked
+     * to stop either — see [RdpSession.outputSuppressionSupported].
+     */
+    override suspend fun setOutputVisible(visible: Boolean) {
+        if (!session.outputSuppressionSupported) return
+        session.setOutputVisible(visible)
+        if (visible) requestFullUpdate()
+    }
 
     override suspend fun setAudioMuted(muted: Boolean) = session.setAudioMuted(muted)
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
@@ -129,6 +129,15 @@ interface RdpSession {
     suspend fun setOutputVisible(visible: Boolean)
 
     /**
+     * Whether suppressing output is worth asking for at all. It takes both optional capabilities:
+     * the one that stops the drawing (MS-RDPBCGR 2.2.11.3) and the one that asks for it back
+     * (2.2.11.2). They are separate bits, and a server that grants only the first would hold the
+     * last frame on screen for the rest of the session — a picture nobody can repair is worse than
+     * the bandwidth suppression saves.
+     */
+    val outputSuppressionSupported: Boolean
+
+    /**
      * Ask the server to serve [width]×[height] from now on (MS-RDPEDISP). Dropped when the server
      * did not open the display control channel, which is how a host that cannot resize says so.
      */

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/FakeRdpSession.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/FakeRdpSession.kt
@@ -1,0 +1,76 @@
+package app.skerry.shared.rdp
+
+import app.skerry.shared.graphics.RemoteFramebuffer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+/** An RDP session that records what was written to it, for the tests of [RdpRemoteDesktop]. */
+open class FakeRdpSession(
+    override val connectedHost: String = "fake-host",
+    override val desktopWidth: Int = 1024,
+    override val desktopHeight: Int = 768,
+    override val outputSuppressionSupported: Boolean = true,
+    override val updates: Flow<RdpUpdate> = MutableSharedFlow(),
+) : RdpSession {
+
+    /** Every write, in the order it was made — the sequence matters as much as the values. */
+    val calls = mutableListOf<String>()
+
+    val refreshed = mutableListOf<List<RdpRect>>()
+    val visibility = mutableListOf<Boolean>()
+
+    override val framebuffer = RemoteFramebuffer(desktopWidth, desktopHeight)
+
+    override val audioAvailable = true
+    override val clipboardAvailable = true
+
+    override suspend fun sendKey(scancode: Int, down: Boolean, extended: Boolean) {
+        calls += "key($scancode,$down,$extended)"
+    }
+
+    override suspend fun sendUnicode(code: Int, down: Boolean) {
+        calls += "unicode($code,$down)"
+    }
+
+    override suspend fun sendPointerMove(x: Int, y: Int) {
+        calls += "move($x,$y)"
+    }
+
+    override suspend fun sendPointerButton(button: RdpMouseButton, down: Boolean, x: Int, y: Int) {
+        calls += "button($button,$down,$x,$y)"
+    }
+
+    override suspend fun sendWheel(clicks: Int, axis: RdpWheelAxis, x: Int, y: Int) {
+        calls += "wheel($clicks,$axis,$x,$y)"
+    }
+
+    override suspend fun sendLockKeys(scroll: Boolean, num: Boolean, caps: Boolean) {
+        calls += "lock($scroll,$num,$caps)"
+    }
+
+    override suspend fun requestRefresh(rects: List<RdpRect>) {
+        refreshed += rects
+        calls += "refresh"
+    }
+
+    override suspend fun setOutputVisible(visible: Boolean) {
+        visibility += visible
+        calls += "visible($visible)"
+    }
+
+    override suspend fun setDesktopSize(width: Int, height: Int) {
+        calls += "size($width,$height)"
+    }
+
+    override suspend fun sendClipboardText(text: String) {
+        calls += "clipboard($text)"
+    }
+
+    override fun setAudioMuted(muted: Boolean) {
+        calls += "mute($muted)"
+    }
+
+    override suspend fun close() {
+        calls += "close"
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpRemoteDesktopTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpRemoteDesktopTest.kt
@@ -1,0 +1,49 @@
+package app.skerry.shared.rdp
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** The adapter between the RDP session and what the UI sees ([RdpRemoteDesktop]). */
+class RdpRemoteDesktopTest {
+
+    @Test
+    fun a_hidden_window_is_reported_and_nothing_is_asked_for() = runTest {
+        val session = FakeRdpSession()
+
+        RdpRemoteDesktop(session).setOutputVisible(false)
+
+        assertEquals(listOf(false), session.visibility)
+        // Asking for pixels from a server that was just told to stop drawing them is the one thing
+        // this must not do.
+        assertEquals(listOf("visible(false)"), session.calls)
+    }
+
+    @Test
+    fun coming_back_into_view_asks_for_the_whole_screen() = runTest {
+        // Nothing was painted while output was suppressed, so the server's screen and the last frame
+        // drawn here have drifted apart; the next incremental update would leave stale pixels behind.
+        val session = FakeRdpSession(desktopWidth = 800, desktopHeight = 600)
+
+        RdpRemoteDesktop(session).setOutputVisible(true)
+
+        assertEquals(listOf("visible(true)", "refresh"), session.calls, "the repaint follows the report")
+        assertEquals(listOf(RdpRect(0, 0, 800, 600)), session.refreshed.single())
+    }
+
+    @Test
+    fun a_session_that_cannot_be_repainted_is_never_suppressed() = runTest {
+        // Suppress Output and Refresh Rect are separate capability bits, and a server can grant one
+        // without the other. Stopping the drawing on a server that will not take a repaint request
+        // leaves the last frame on screen for the rest of the session; not suppressing at all costs
+        // bandwidth and keeps the picture. The mirror case matters too: without the suppression the
+        // repaint has nothing to repair, and every window restore would retransmit the whole desktop.
+        val session = FakeRdpSession(outputSuppressionSupported = false)
+        val desktop = RdpRemoteDesktop(session)
+
+        desktop.setOutputVisible(false)
+        desktop.setOutputVisible(true)
+
+        assertEquals(emptyList(), session.calls)
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -374,6 +374,10 @@ class RdpSocketSession(
     override suspend fun setOutputVisible(visible: Boolean) =
         withContext(Dispatchers.IO) { codec.setOutputVisible(visible) }
 
+    // Both bits, for the reason in the interface: the repaint is what ends a suppression.
+    override val outputSuppressionSupported: Boolean =
+        state.capabilities.suppressOutputSupported && state.capabilities.refreshRectSupported
+
     override suspend fun setDesktopSize(width: Int, height: Int) {
         withContext(Dispatchers.IO) { display.requestResolution(width, height) }
     }


### PR DESCRIPTION
Closes #102.

`RdpSession.setOutputVisible` built the Suppress Output PDU (MS-RDPBCGR 2.2.11.3) and had tests, but nothing called it. The UI now reports whether a session is on screen, so a server stops rendering and streaming a desktop nobody is looking at.

## What it does

A session counts as on screen while its surface is in the composition and the window is up.

- **The window.** An Android activity sent to the background and a minimised desktop window both leave the started state (Compose Multiplatform maps a minimised window to `CREATED`), so one lifecycle signal serves both platforms — no `expect`/`actual`. Losing focus is not going off screen: a desktop window behind another one is still in plain sight, and suppressing there would blank the picture the user is looking at.
- **The composition.** Only the session on screen is composed, so a tab that takes the window suppresses the one it replaced; coming back replays the lifecycle state and un-suppresses. Without that half, minimising while a terminal tab is active would report nothing.

Returning asks for the whole desktop again. A suppressed server drew nothing, so its screen and the last frame held here have drifted apart, and an incremental update would leave stale pixels around whatever changed; the server owes no repaint of its own accord.

Suppress Output and Refresh Rect are separate capability bits. A server that grants only the first would hold the last frame for the rest of the session, so suppression is used only when the repaint that ends it can also be asked for (`RdpSession.outputSuppressionSupported`); the mirror case would otherwise spend a full-desktop retransmit on every tab switch with nothing suppressed.

The two reports of a minimise-and-restore are ordered against each other rather than racing: a "back on screen" that overtook the "hidden" would leave the server suppressed while the client had already recorded the session as visible, and that record would then swallow every later report.

VNC is unaffected — RFB has no such PDU, and its `setOutputVisible` stays a no-op.

## Tests

- `RdpRemoteDesktopTest` against a new `FakeRdpSession`: suppression asks for no pixels, the return asks for the whole screen in one refresh, a session that cannot be repainted is never suppressed.
- `RemoteDesktopScreenStateTest`: the report reaches the session, repeats are dropped, ordering holds when the first write is slow, a write to a dead session does not escape its launch.
- `RemoteDesktopVisibilityTest` against a `LifecycleRegistry`: state replayed on attach, both the window going down and the watch ending report hidden, nothing reported after the watch ends.

`test allTests`, `build`, `detektAll` and `:androidApp:compileDebugKotlin` are green. Not verified against a live Windows host or on an Android device.