### PR TITLE
Gate hooks: record a run whose output went to a file, and make the bypass reachable

### DIFF
--- a/.claude/hooks/gate-state.py
+++ b/.claude/hooks/gate-state.py
@@ -23,6 +23,11 @@ REVIEWERS = re.compile(
 )
 GATE_TASKS = re.compile(r"detektAll|allTests")
 CODE_FILE = re.compile(r"\.kts?$")
+# `> file`, `2> file`, `>> file`, `&> file` — where a gate run puts gradle's output.
+REDIRECT = re.compile(r"(?:\d?>>?|&>)\s*\"?([^\s\"|;&]+)")
+# A log older than this belongs to an earlier run: the command was rerun and this time wrote nothing.
+LOG_MAX_AGE_S = 30 * 60
+LOG_TAIL_BYTES = 64 * 1024
 
 
 def state_path() -> str:
@@ -53,6 +58,35 @@ def mark(key: str) -> None:
         pass  # a hook must never break the session
 
 
+def log_tail(path: str) -> str:
+    """The end of a log the command redirected into, or empty if there is no usable one."""
+    path = os.path.expanduser(path)
+    try:
+        if time.time() - os.path.getmtime(path) > LOG_MAX_AGE_S:
+            return ""
+        with open(path, errors="replace") as fh:
+            fh.seek(0, os.SEEK_END)
+            fh.seek(max(0, fh.tell() - LOG_TAIL_BYTES))
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def gradle_was_green(command: str, response_text: str) -> bool:
+    """
+    Whether a gate run passed. The verdict is not always in what the tool returned: `/gate` sends
+    gradle's output to a file (a pipe would mask the exit code), and then the tool answers with
+    nothing but an exit code — which used to read as "not green" and blocked the commit that a
+    fully green gate had just earned.
+    """
+    outputs = [response_text] + [log_tail(target) for target in REDIRECT.findall(command)]
+    # A failure anywhere in the run outweighs a success beside it: one command can hold several
+    # gradle invocations, and the gate is what all of them together say.
+    if any("BUILD FAILED" in text for text in outputs):
+        return False
+    return any("BUILD SUCCESSFUL" in text for text in outputs)
+
+
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -69,8 +103,8 @@ def main() -> None:
             mark("code")
     elif tool == "Bash":
         command = tool_input.get("command") or ""
-        # A green gate run: the gradle tasks that matter, and no failure in the output.
-        if GATE_TASKS.search(command) and "BUILD SUCCESSFUL" in response_text:
+        # A green gate run: the gradle tasks that matter, and no failure in what it wrote.
+        if GATE_TASKS.search(command) and gradle_was_green(command, response_text):
             mark("build")
     elif tool in ("Agent", "Task"):
         subagent = tool_input.get("subagent_type") or ""

--- a/.claude/hooks/guard-git.py
+++ b/.claude/hooks/guard-git.py
@@ -22,6 +22,9 @@ import time
 # `rtk` transparently prefixes shell commands in this environment, so match through it.
 GIT_WRITE = re.compile(r"(?:^|[;&|]|\s)(?:rtk\s+)?git\s+(?:-\S+\s+)*(commit|push)(?![\w-])")
 PR_CREATE = re.compile(r"(?:^|[;&|]|\s)(?:rtk\s+)?gh\s+pr\s+create\b")
+# A hook reads the environment of the process that spawned it, not the one the command will run in,
+# so the documented escape hatch is recognised in the command text as well.
+OVERRIDE = re.compile(r"\bSKERRY_GATE_OVERRIDE=1\b")
 
 
 def current_branch() -> str:
@@ -92,7 +95,8 @@ def main() -> None:
         )
         sys.exit(2)
 
-    if (match or PR_CREATE.search(command)) and os.environ.get("SKERRY_GATE_OVERRIDE") != "1":
+    overridden = os.environ.get("SKERRY_GATE_OVERRIDE") == "1" or OVERRIDE.search(command)
+    if (match or PR_CREATE.search(command)) and not overridden:
         stale = gate_debt()
         if stale:
             sys.stderr.write(


### PR DESCRIPTION
Two holes in the pre-PR gate hooks, both hit while landing #114.

**`gate-state.py` — a green gate left no mark.** The recorder marked `build` only when `BUILD SUCCESSFUL` appeared in what the Bash tool returned. `/gate` tells the model to send gradle's output to a file (a pipe would mask the exit code), and the tool then answers with an exit code and nothing else — so a fully green run was never recorded and the commit it had just earned was refused.

It now also reads the files the command redirected into (`>`, `2>`, `>>`, `&>`):

- a failure in any output outweighs a success beside it — one command can hold several gradle runs, and the gate is what all of them together say;
- a log older than 30 minutes belongs to an earlier run and is ignored, so a run that wrote nothing cannot inherit the last verdict;
- only the last 64 KiB of a log is read.

**`guard-git.py` — the documented bypass could not be used.** A hook reads the environment of the process that spawned it, not the one the command will run in, so `SKERRY_GATE_OVERRIDE=1 git commit …` never reached the guard. It is now recognised in the command text as well. The bypass covers gate staleness only — committing while HEAD is on `main` stays refused with it present.

## Checked

Crafted payloads fed to the hooks in throwaway repositories.

Recorder, 7 cases: output in the response; output redirected to a file; two runs where the second failed; a failure in the response beside a stale success; an hour-old log; a missing log; tasks that are not the gate's.

Guard, 6 cases: stale gate blocks `commit` and `push`; the bypass lets `commit` and `gh pr create` through; `SKERRY_GATE_OVERRIDE=0` is not mistaken for it; `main` stays protected while the bypass is present.

No Kotlin touched, so CI has nothing new to compile.