### PR TITLE
Say why a connection was refused: host key reasons, dead audio devices, stuck runbook steps

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -165,4 +165,10 @@
     <string name="conn_clipboard_share_desc">Текст, скопированный на любой стороне, доступен на другой, пока открыта сессия.</string>
     <string name="conn_audio_output_device">Устройство вывода</string>
     <string name="conn_audio_device_default">Системное по умолчанию</string>
+    <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
+    <string name="conn_err_hostkey_changed">Ключ хоста изменился. Разберитесь в «Известных хостах».</string>
+    <string name="conn_err_hostkey_untrusted">Ключ хоста ещё не доверенный. Подключитесь раз терминалом или добавьте его CA в «Известных хостах».</string>
+    <string name="conn_err_hostkey_locked">Хранилище заблокировано: доверие к ключу не прочитать. Разблокируйте и повторите.</string>
+    <string name="conn_err_hostkey_cert">Хост обязан предъявить сертификат доверенного CA; предъявленное отклонено.</string>
+    <string name="conn_err_hostkey_jump">Промежуточный хост — %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
@@ -37,6 +37,7 @@
 
     <!-- Run panel -->
     <string name="runbook_panel_running">Выполняется</string>
+    <string name="runbook_panel_stalled">Ни вывода, ни статуса — оболочка может ждать ввода. Посмотрите в терминал.</string>
     <string name="runbook_panel_waiting">Ждёт вас</string>
     <string name="runbook_panel_done">Завершён</string>
     <string name="runbook_panel_done_with_failures">Завершён с ошибками</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -38,5 +38,6 @@
     <string name="rd_clipboard_copy_here">Скопировать сюда</string>
     <string name="rd_clipboard_send">Отправить свой</string>
     <string name="rd_audio">Звук</string>
+    <string name="rd_audio_device_lost">Аудиоустройство перестало принимать звук. Выберите другой вывод в профиле и переподключитесь.</string>
     <string name="rd_clipboard_share">Общий буфер обмена</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -165,4 +165,10 @@
     <string name="conn_clipboard_share_desc">会话打开期间，任一侧复制的文本都可在另一侧使用。</string>
     <string name="conn_audio_output_device">输出设备</string>
     <string name="conn_audio_device_default">系统默认</string>
+    <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
+    <string name="conn_err_hostkey_changed">主机密钥已更改。请在「已知主机」中处理。</string>
+    <string name="conn_err_hostkey_untrusted">主机密钥尚未受信任。请先用终端连接一次，或在「已知主机」中添加其 CA。</string>
+    <string name="conn_err_hostkey_locked">保管库已锁定：无法读取主机密钥信任。请解锁后重试。</string>
+    <string name="conn_err_hostkey_cert">该主机必须出示受信任 CA 签发的证书；它出示的已被拒绝。</string>
+    <string name="conn_err_hostkey_jump">跳板主机 — %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
@@ -37,6 +37,7 @@
 
     <!-- Run panel -->
     <string name="runbook_panel_running">执行中</string>
+    <string name="runbook_panel_stalled">既无输出也无状态——外壳可能在等待输入。请查看终端。</string>
     <string name="runbook_panel_waiting">等待确认</string>
     <string name="runbook_panel_done">已完成</string>
     <string name="runbook_panel_done_with_failures">完成，但有失败</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -38,5 +38,6 @@
     <string name="rd_clipboard_copy_here">复制到本机</string>
     <string name="rd_clipboard_send">发送本机内容</string>
     <string name="rd_audio">声音</string>
+    <string name="rd_audio_device_lost">音频设备已停止接收声音。请在配置中改选输出设备后重新连接。</string>
     <string name="rd_clipboard_share">共享剪贴板</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -165,4 +165,10 @@
     <string name="conn_clipboard_share_desc">Text copied on either side becomes available on the other, for as long as the session is open.</string>
     <string name="conn_audio_output_device">Output device</string>
     <string name="conn_audio_device_default">System default</string>
+    <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
+    <string name="conn_err_hostkey_changed">Host key changed. Resolve it in Known hosts.</string>
+    <string name="conn_err_hostkey_untrusted">Host key not trusted yet. Connect once from a terminal, or add its CA in Known hosts.</string>
+    <string name="conn_err_hostkey_locked">Vault locked: host key trust can\'t be read. Unlock and retry.</string>
+    <string name="conn_err_hostkey_cert">This host must present a certificate from a trusted CA; what it offered was refused.</string>
+    <string name="conn_err_hostkey_jump">Jump host — %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
@@ -37,6 +37,7 @@
 
     <!-- Run panel -->
     <string name="runbook_panel_running">Running</string>
+    <string name="runbook_panel_stalled">No output and no status yet — the shell may be waiting for input. Check the terminal.</string>
     <string name="runbook_panel_waiting">Waiting for you</string>
     <string name="runbook_panel_done">Finished</string>
     <string name="runbook_panel_done_with_failures">Finished with failures</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -38,5 +38,6 @@
     <string name="rd_clipboard_copy_here">Copy here</string>
     <string name="rd_clipboard_send">Send mine</string>
     <string name="rd_audio">Sound</string>
+    <string name="rd_audio_device_lost">The audio device stopped taking sound. Pick another output in the profile, then reconnect.</string>
     <string name="rd_clipboard_share">Share the clipboard</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -12,8 +12,10 @@ import app.skerry.shared.serial.SerialUnavailableException
 import app.skerry.shared.mosh.MoshSetupException
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.carriedBySsh
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshHostKeyRejectedException
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.ShellChannel
 import app.skerry.shared.ssh.SshTransport
@@ -59,11 +61,12 @@ sealed interface ConnectionUiState {
     data class Connected(val terminal: TerminalScreenState) : ConnectionUiState
 
     /**
-     * Connect failed; [message] is shown to the user. [moshReason]/[moshDetail] and
-     * [serialProblem]/[serialDetail] are set when the failure is a typed Mosh setup or serial port
-     * problem — the view then renders a localized explanation (missing server package, locale,
-     * blocked UDP; port missing, permission denied) instead of the raw English [message]
-     * (see `connectionErrorText`); building the text here would bake in one language
+     * Connect failed; [message] is shown to the user. [moshReason]/[moshDetail],
+     * [serialProblem]/[serialDetail] and [hostKeyRefusal] are set when the failure is a typed Mosh
+     * setup, serial port or host key problem — the view then renders a localized explanation
+     * (missing server package, locale, blocked UDP; port missing, permission denied; key changed,
+     * host not trusted yet) instead of the raw English [message] (see `connectionErrorText`);
+     * building the text here would bake in one language
      * (same rule as [app.skerry.shared.sync.SyncFailureReason]).
      */
     data class Error(
@@ -72,6 +75,8 @@ sealed interface ConnectionUiState {
         val moshDetail: String? = null,
         val serialProblem: SerialProblem? = null,
         val serialDetail: String? = null,
+        val hostKeyRefusal: HostKeyRefusal? = null,
+        val hostKeyRefusalOnHop: Boolean = false,
     ) : ConnectionUiState
 
     /**
@@ -257,6 +262,8 @@ class ConnectionController(
                     moshDetail = (e as? MoshSetupException)?.detail,
                     serialProblem = serial?.problem,
                     serialDetail = serial?.detail,
+                    hostKeyRefusal = (e as? SshHostKeyRejectedException)?.refusal,
+                    hostKeyRefusalOnHop = (e as? SshHostKeyRejectedException)?.hop == true,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTest.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnectionException
@@ -25,8 +26,8 @@ sealed interface ConnectionTestProblem {
     /** The server rejected the supplied credentials. */
     data object AuthenticationFailed : ConnectionTestProblem
 
-    /** The host presented a key that doesn't match the pinned one. */
-    data object HostKeyRejected : ConnectionTestProblem
+    /** The host key was not trusted; [refusal] is why, where the transport reported it. */
+    data class HostKeyRejected(val refusal: HostKeyRefusal? = null) : ConnectionTestProblem
 
     /** Anything else on the wire. Deliberately coarse: transport text would leak library/host detail. */
     data object ConnectionFailed : ConnectionTestProblem
@@ -88,7 +89,7 @@ suspend fun runConnectionTest(
 } catch (e: SshAuthenticationException) {
     ConnectionTestStatus.Failure(ConnectionTestProblem.AuthenticationFailed)
 } catch (e: SshHostKeyRejectedException) {
-    ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected)
+    ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected(e.refusal))
 } catch (e: SshConnectionException) {
     ConnectionTestStatus.Failure(ConnectionTestProblem.ConnectionFailed)
 } catch (e: CancellationException) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTestFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionTestFailureText.kt
@@ -12,7 +12,9 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun connectionTestFailureText(problem: ConnectionTestProblem): String = when (problem) {
     ConnectionTestProblem.AuthenticationFailed -> stringResource(Res.string.conn_test_err_auth)
-    ConnectionTestProblem.HostKeyRejected -> stringResource(Res.string.conn_test_err_host_key)
+    is ConnectionTestProblem.HostKeyRejected ->
+        problem.refusal?.let { stringResource(hostKeyRefusalText(it)) }
+            ?: stringResource(Res.string.conn_test_err_host_key)
     ConnectionTestProblem.ConnectionFailed -> stringResource(Res.string.conn_test_err_connection)
     ConnectionTestProblem.IncompleteForm -> stringResource(Res.string.conn_test_incomplete)
     is ConnectionTestProblem.Jump -> jumpProblemText(problem.problem)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ContainerBrowse.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ContainerBrowse.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.container.ContainerSpec
 import app.skerry.shared.container.containerListCommandLine
 import app.skerry.shared.container.parseContainerList
 import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnectionException
@@ -25,15 +26,26 @@ import kotlinx.coroutines.withContext
 /**
  * Why "Browse containers" came back empty-handed. Typed, not a message string, so the view renders
  * localized text (`containerBrowseFailureText`) — same rule as [ConnectionTestProblem].
- * [COMMAND_FAILED] covers the runtime side: no `docker`/`kubectl` on the host, no permission on the
- * socket, no cluster context — all indistinguishable from here and all fixed on the host.
  */
-enum class ContainerBrowseProblem {
-    AUTHENTICATION_FAILED,
-    HOST_KEY_REJECTED,
-    CONNECTION_FAILED,
-    INCOMPLETE_FORM,
-    COMMAND_FAILED,
+sealed interface ContainerBrowseProblem {
+    data object AuthenticationFailed : ContainerBrowseProblem
+
+    /**
+     * The host key was not trusted; [refusal] is why, where the transport reported it. The probe
+     * dials a host the user usually already has an open session with, so the reasons it can really
+     * hit — the key changed since, the vault locked in between — have different fixes.
+     */
+    data class HostKeyRejected(val refusal: HostKeyRefusal? = null) : ContainerBrowseProblem
+
+    data object ConnectionFailed : ContainerBrowseProblem
+
+    data object IncompleteForm : ContainerBrowseProblem
+
+    /**
+     * The runtime side: no `docker`/`kubectl` on the host, no permission on the socket, no cluster
+     * context — all indistinguishable from here and all fixed on the host.
+     */
+    data object CommandFailed : ContainerBrowseProblem
 }
 
 /**
@@ -73,7 +85,7 @@ suspend fun listContainers(
         // A non-zero exit means the CLI itself refused (missing binary, denied socket, no context):
         // the stdout we might have is not a listing.
         if (result.exitCode != null && result.exitCode != 0) {
-            ContainerBrowseStatus.Failure(ContainerBrowseProblem.COMMAND_FAILED)
+            ContainerBrowseStatus.Failure(ContainerBrowseProblem.CommandFailed)
         } else {
             ContainerBrowseStatus.Loaded(parseContainerList(spec.runtime, result.stdout))
         }
@@ -87,15 +99,15 @@ suspend fun listContainers(
         }
     }
 } catch (e: SshAuthenticationException) {
-    ContainerBrowseStatus.Failure(ContainerBrowseProblem.AUTHENTICATION_FAILED)
+    ContainerBrowseStatus.Failure(ContainerBrowseProblem.AuthenticationFailed)
 } catch (e: SshHostKeyRejectedException) {
-    ContainerBrowseStatus.Failure(ContainerBrowseProblem.HOST_KEY_REJECTED)
+    ContainerBrowseStatus.Failure(ContainerBrowseProblem.HostKeyRejected(e.refusal))
 } catch (e: SshConnectionException) {
-    ContainerBrowseStatus.Failure(ContainerBrowseProblem.CONNECTION_FAILED)
+    ContainerBrowseStatus.Failure(ContainerBrowseProblem.ConnectionFailed)
 } catch (e: CancellationException) {
     throw e
 } catch (e: Exception) {
-    ContainerBrowseStatus.Failure(ContainerBrowseProblem.CONNECTION_FAILED)
+    ContainerBrowseStatus.Failure(ContainerBrowseProblem.ConnectionFailed)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ContainerBrowseFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ContainerBrowseFailureText.kt
@@ -12,9 +12,11 @@ import org.jetbrains.compose.resources.stringResource
 /** Localized reason a container listing failed (shown under the container field). */
 @Composable
 fun containerBrowseFailureText(problem: ContainerBrowseProblem): String = when (problem) {
-    ContainerBrowseProblem.AUTHENTICATION_FAILED -> stringResource(Res.string.conn_container_err_auth)
-    ContainerBrowseProblem.HOST_KEY_REJECTED -> stringResource(Res.string.conn_container_err_host_key)
-    ContainerBrowseProblem.CONNECTION_FAILED -> stringResource(Res.string.conn_container_err_connection)
-    ContainerBrowseProblem.INCOMPLETE_FORM -> stringResource(Res.string.conn_container_incomplete)
-    ContainerBrowseProblem.COMMAND_FAILED -> stringResource(Res.string.conn_container_err_command)
+    ContainerBrowseProblem.AuthenticationFailed -> stringResource(Res.string.conn_container_err_auth)
+    is ContainerBrowseProblem.HostKeyRejected ->
+        problem.refusal?.let { hostKeyRefusalLine(it, hop = false) }
+            ?: stringResource(Res.string.conn_container_err_host_key)
+    ContainerBrowseProblem.ConnectionFailed -> stringResource(Res.string.conn_container_err_connection)
+    ContainerBrowseProblem.IncompleteForm -> stringResource(Res.string.conn_container_incomplete)
+    ContainerBrowseProblem.CommandFailed -> stringResource(Res.string.conn_container_err_command)
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostKeyRefusalText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostKeyRefusalText.kt
@@ -1,0 +1,47 @@
+package app.skerry.ui.connection
+
+import androidx.compose.runtime.Composable
+import app.skerry.shared.ssh.HostKeyRefusal
+import app.skerry.shared.ssh.SshHostKeyRejectedException
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_err_hostkey_cert
+import app.skerry.ui.generated.resources.conn_err_hostkey_changed
+import app.skerry.ui.generated.resources.conn_err_hostkey_jump
+import app.skerry.ui.generated.resources.conn_err_hostkey_locked
+import app.skerry.ui.generated.resources.conn_err_hostkey_untrusted
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getString
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The line shown for a refused host key. A resource rather than a string: the two call sites read
+ * it differently — the terminal notice from a composition, the tunnel list from a coroutine — and
+ * both must say the same thing.
+ *
+ * Every reason ends in the move that resolves it; a refusal the user can't act on is the failure
+ * this mapping exists to avoid.
+ */
+internal fun hostKeyRefusalText(refusal: HostKeyRefusal): StringResource = when (refusal) {
+    HostKeyRefusal.KeyChanged -> Res.string.conn_err_hostkey_changed
+    HostKeyRefusal.NotTrustedYet -> Res.string.conn_err_hostkey_untrusted
+    HostKeyRefusal.TrustStoreUnreadable -> Res.string.conn_err_hostkey_locked
+    HostKeyRefusal.CertificateRejected -> Res.string.conn_err_hostkey_cert
+}
+
+/**
+ * The line as shown, with [hop] marking a key that belonged to a ProxyJump hop rather than to the
+ * host being dialed. Without the mark the advice sends the user to the wrong machine: a bastion that
+ * rotated its key reads as "the host you asked for changed its key", and the target's entry is
+ * intact.
+ */
+@Composable
+internal fun hostKeyRefusalLine(refusal: HostKeyRefusal, hop: Boolean): String {
+    val line = stringResource(hostKeyRefusalText(refusal))
+    return if (hop) stringResource(Res.string.conn_err_hostkey_jump, line) else line
+}
+
+/** [hostKeyRefusalLine] for a caller outside a composition; null when the refusal carried no reason. */
+internal suspend fun hostKeyRefusalLine(e: SshHostKeyRejectedException): String? {
+    val line = getString(hostKeyRefusalText(e.refusal ?: return null))
+    return if (e.hop) getString(Res.string.conn_err_hostkey_jump, line) else line
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/MoshFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/MoshFailureText.kt
@@ -13,14 +13,16 @@ import app.skerry.ui.generated.resources.mosh_err_udp
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * User-facing text for a connect error, localized for typed Mosh and serial failures. Mosh problems
- * are almost always server-side and fixable — Skerry ships only the client, so the message must
- * say what to do on the server (install the package, generate a locale, open UDP) instead of
- * leaking a raw exception string; serial problems say what to do with the device. Everything else
- * keeps the transport's message as before.
+ * User-facing text for a connect error, localized for typed Mosh, serial and host key failures.
+ * Mosh problems are almost always server-side and fixable — Skerry ships only the client, so the
+ * message must say what to do on the server (install the package, generate a locale, open UDP)
+ * instead of leaking a raw exception string; serial problems say what to do with the device, and a
+ * refused host key what to do about the trust. Everything else keeps the transport's message as
+ * before.
  */
 @Composable
 fun connectionErrorText(error: ConnectionUiState.Error): String {
+    error.hostKeyRefusal?.let { return hostKeyRefusalLine(it, error.hostKeyRefusalOnHop) }
     error.serialProblem?.let { return serialProblemText(it, error.serialDetail) }
     val reason = error.moshReason ?: return error.message.takeIf { it.isNotBlank() }
         ?.let { stringResource(Res.string.conn_error_failed_detail, it) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -379,11 +379,11 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                             val jump = (testJump as? JumpChainResolution.Resolved)?.jump
                             when {
                                 auth == null || form.address.isBlank() || form.username.isBlank() || form.portOrNull == null ->
-                                    browser?.fail(ContainerBrowseProblem.INCOMPLETE_FORM)
+                                    browser?.fail(ContainerBrowseProblem.IncompleteForm)
                                 // An unresolvable jump chain can't be probed through; the precise
                                 // reason is what "Test connection" is for.
                                 testJump is JumpChainResolution.Unavailable ->
-                                    browser?.fail(ContainerBrowseProblem.CONNECTION_FAILED)
+                                    browser?.fail(ContainerBrowseProblem.ConnectionFailed)
                                 else -> browser?.load(
                                     SshTarget(form.address.trim(), form.portOrNull ?: 22, form.username.trim(), jump = jump),
                                     auth,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -385,9 +385,9 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                         )
                         when {
                             auth == null || form.address.isBlank() || form.username.isBlank() || form.portOrNull == null ->
-                                browser?.fail(ContainerBrowseProblem.INCOMPLETE_FORM)
+                                browser?.fail(ContainerBrowseProblem.IncompleteForm)
                             jump is JumpChainResolution.Unavailable ->
-                                browser?.fail(ContainerBrowseProblem.CONNECTION_FAILED)
+                                browser?.fail(ContainerBrowseProblem.ConnectionFailed)
                             else -> browser?.load(
                                 SshTarget(
                                     form.address.trim(), form.portOrNull ?: 22, form.username.trim(),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
@@ -336,7 +336,10 @@ private fun SettingsMenu(screen: RemoteDesktopScreenState, showResetZoom: Boolea
             CheckRow(stringResource(Res.string.rd_audio), !screen.audioMuted, screen::toggleAudioMuted)
             // The switch says sound is on while nothing comes out: without this line the only
             // witness to a device that died mid-session is a trace nobody has turned on.
-            if (screen.audioFailed) {
+            // Hidden while muted: muting stops the writes, so the player can never see a device
+            // take blocks again, and the line would sit under an off switch for the rest of the
+            // session telling the user to reconnect.
+            if (screen.audioFailed && !screen.audioMuted) {
                 Txt(
                     stringResource(Res.string.rd_audio_device_lost),
                     color = Skerry.colors.sunset,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
@@ -51,6 +51,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.rd_audio
+import app.skerry.ui.generated.resources.rd_audio_device_lost
 import app.skerry.ui.generated.resources.rd_clipboard
 import app.skerry.ui.generated.resources.rd_clipboard_copy_here
 import app.skerry.ui.generated.resources.rd_clipboard_empty
@@ -333,6 +334,16 @@ private fun SettingsMenu(screen: RemoteDesktopScreenState, showResetZoom: Boolea
         }
         if (screen.capabilities.audio) {
             CheckRow(stringResource(Res.string.rd_audio), !screen.audioMuted, screen::toggleAudioMuted)
+            // The switch says sound is on while nothing comes out: without this line the only
+            // witness to a device that died mid-session is a trace nobody has turned on.
+            if (screen.audioFailed) {
+                Txt(
+                    stringResource(Res.string.rd_audio_device_lost),
+                    color = Skerry.colors.sunset,
+                    size = 10.5.sp,
+                    modifier = Modifier.padding(start = 34.dp, end = 12.dp, bottom = 4.dp),
+                )
+            }
         }
         if (screen.capabilities.clipboard) {
             CheckRow(stringResource(Res.string.rd_clipboard_share), screen.clipboardShared, screen::toggleClipboardShared)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -208,6 +208,14 @@ class RemoteDesktopScreenState(
     }
 
     /**
+     * The local device stopped taking sound: the session is mute for a reason that has nothing to do
+     * with [audioMuted] and that nothing else on screen would show. Cleared by the same report when
+     * a device takes blocks again.
+     */
+    var audioFailed by mutableStateOf(false)
+        private set
+
+    /**
      * Whether the clipboard travels at all. Enforced here rather than on the channel: both protocols
      * settle their clipboard at connect time, so this is the only place a running session can stop
      * text from crossing — in either direction, since the risk is symmetric.
@@ -300,6 +308,19 @@ class RemoteDesktopScreenState(
                 if (remoteResize) scheduleRemoteResize()
             }
 
+            is RemoteDesktopUpdate.Closed -> {
+                cleanExit = update.cleanExit
+                closeReason = update.reason
+                closed = true
+            }
+
+            else -> onPeripheralUpdate(update)
+        }
+    }
+
+    /** Everything that touches neither the picture nor the session's life: cursor, clipboard, sound. */
+    private fun onPeripheralUpdate(update: RemoteDesktopUpdate) {
+        when (update) {
             is RemoteDesktopUpdate.CursorShape -> cursor = VncCursorImage.of(update)
             // The pointer the server warps is not ours to move: the sprite tracks the local pointer,
             // and jumping it would desynchronise the two. The position is still applied by the
@@ -311,12 +332,9 @@ class RemoteDesktopScreenState(
                 onClipboard(update.text)
             }
 
+            is RemoteDesktopUpdate.AudioPlaybackFailing -> audioFailed = update.failing
             is RemoteDesktopUpdate.Bell -> {}
-            is RemoteDesktopUpdate.Closed -> {
-                cleanExit = update.cleanExit
-                closeReason = update.reason
-                closed = true
-            }
+            else -> Unit // handled by the caller
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -318,7 +318,15 @@ class RemoteDesktopScreenState(
         }
     }
 
-    /** Everything that touches neither the picture nor the session's life: cursor, clipboard, sound. */
+    /**
+     * Everything that touches neither the picture nor the session's life: cursor, clipboard, sound.
+     *
+     * Exhaustive on purpose — the members [onUpdate] handles are listed here as no-ops rather than
+     * swept up by an `else`. The compiler refusing to build until a new [RemoteDesktopUpdate] is
+     * handled somewhere is the only thing that kept every update reaching the screen; an `else` in
+     * both halves would have let the next one be dropped in silence, which is exactly the bug this
+     * split was made to accommodate.
+     */
     private fun onPeripheralUpdate(update: RemoteDesktopUpdate) {
         when (update) {
             is RemoteDesktopUpdate.CursorShape -> cursor = VncCursorImage.of(update)
@@ -334,7 +342,13 @@ class RemoteDesktopScreenState(
 
             is RemoteDesktopUpdate.AudioPlaybackFailing -> audioFailed = update.failing
             is RemoteDesktopUpdate.Bell -> {}
-            else -> Unit // handled by the caller
+
+            // Handled by the caller; named so this `when` stays exhaustive.
+            is RemoteDesktopUpdate.Region,
+            is RemoteDesktopUpdate.Resize,
+            is RemoteDesktopUpdate.RemoteResizeSupported,
+            is RemoteDesktopUpdate.Closed,
+            -> Unit
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
@@ -38,6 +38,7 @@ import app.skerry.ui.generated.resources.runbook_panel_failed
 import app.skerry.ui.generated.resources.runbook_panel_progress
 import app.skerry.ui.generated.resources.runbook_panel_run_step
 import app.skerry.ui.generated.resources.runbook_panel_running
+import app.skerry.ui.generated.resources.runbook_panel_stalled
 import app.skerry.ui.generated.resources.runbook_panel_skip_step
 import app.skerry.ui.generated.resources.runbook_panel_stop
 import app.skerry.ui.generated.resources.runbook_panel_stopped
@@ -134,6 +135,14 @@ private fun StepRow(state: RunbookStepState, mono: androidx.compose.ui.text.font
                 Txt(
                     stripUnsafeFormatChars(state.step.command), color = Skerry.colors.faint, size = 10.5.sp,
                     font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+            }
+            // The step is not ended on this — it may be a legitimate `sleep` — but a run that will
+            // never finish looks exactly like one still working, and only the terminal can tell.
+            if (state.stalled) {
+                Txt(
+                    stringResource(Res.string.runbook_panel_stalled),
+                    color = Skerry.colors.amber, size = 10.5.sp,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
@@ -244,16 +244,19 @@ class RunbookRunner(
      */
     fun stop() {
         if (!active) return
+        // The step's own state is settled inside the same critical section as the generation bump:
+        // markStalled re-reads the generation under this lock, so a poll racing Stop is refused
+        // rather than allowed to re-flag a step this call has just finished with.
         synchronized(lock) {
             generation++
             watchJob?.cancel()
             watchJob = null
-        }
-        steps.getOrNull(currentIndex)?.let {
-            if (it.status == RunbookStepStatus.RUNNING || it.status == RunbookStepStatus.AWAITING_CONFIRM) {
-                it.status = RunbookStepStatus.STOPPED
+            steps.getOrNull(currentIndex)?.let {
+                if (it.status == RunbookStepStatus.RUNNING || it.status == RunbookStepStatus.AWAITING_CONFIRM) {
+                    it.status = RunbookStepStatus.STOPPED
+                }
+                it.stalled = false // the run is over; nothing is waiting on this step any more
             }
-            it.stalled = false // the run is over; nothing is waiting on this step any more
         }
         phase = RunbookPhase.STOPPED
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
@@ -75,6 +75,18 @@ class RunbookStepState internal constructor(val index: Int, val step: RunbookSte
     /** Exit code the shell reported, once it has; `null` while the step hasn't finished. */
     var exitCode: Int? by mutableStateOf(null)
         internal set
+
+    /**
+     * The step has printed nothing for a long while and still hasn't reported a status — the shape
+     * a step takes when nothing will ever print its marker: an unterminated here-doc or quote leaves
+     * the shell at its continuation prompt, `exec` replaces the shell that would have printed it, a
+     * non-POSIX shell never had `$?` to print.
+     *
+     * A guess, deliberately: `sleep 3600` and a silent migration look identical from here. So it
+     * only marks the step, never ends it — see [RunbookRunner.watch].
+     */
+    var stalled: Boolean by mutableStateOf(false)
+        internal set
 }
 
 /**
@@ -104,6 +116,12 @@ class RunbookRunner(
      * quick step doesn't feel stalled, large enough that scanning the tail is free in comparison.
      */
     private val pollIntervalMillis: Long = 120L,
+    /**
+     * How long a running step may print nothing before it is marked as possibly stuck
+     * ([RunbookStepState.stalled]). Long enough that an ordinary quiet stretch — a package download,
+     * a `sleep`, a compile that only speaks at the end — passes unremarked.
+     */
+    private val stallAfterMillis: Long = 120_000L,
 ) {
     var runbook: Runbook? by mutableStateOf(null)
         private set
@@ -235,6 +253,7 @@ class RunbookRunner(
             if (it.status == RunbookStepStatus.RUNNING || it.status == RunbookStepStatus.AWAITING_CONFIRM) {
                 it.status = RunbookStepStatus.STOPPED
             }
+            it.stalled = false // the run is over; nothing is waiting on this step any more
         }
         phase = RunbookPhase.STOPPED
     }
@@ -299,11 +318,16 @@ class RunbookRunner(
      * There is deliberately no per-step timeout — a migration or a package build legitimately takes
      * an hour, and killing the procedure on a guess would be worse than waiting. A step that can
      * never report (a shell without `$?`, a command still waiting on stdin) is ended by the user
-     * with [stop].
+     * with [stop] — so the run says when a step looks like that one
+     * ([RunbookStepState.stalled]) instead of waiting silently forever: no output for
+     * [stallAfterMillis] and no marker. Only the terminal's size and hash are kept between polls,
+     * never its text — a step's resolved line can carry a `${'$'}{{vault}}` secret and the run stores none.
      */
     private fun watch(index: Int, token: String, target: RunbookTarget) {
         val generationAtStart = synchronized(lock) { generation }
         val job = scope.launch {
+            var lastPrint: Pair<Int, Int>? = null
+            var quietMillis = 0L
             while (true) {
                 delay(pollIntervalMillis)
                 if (stale(generationAtStart)) return@launch
@@ -311,7 +335,15 @@ class RunbookRunner(
                     stop()
                     return@launch
                 }
-                val code = RunbookMarker.exitCodeIn(target.readOutput(), token) ?: continue
+                val text = target.readOutput()
+                val print = text.length to text.hashCode()
+                if (print == lastPrint) quietMillis += pollIntervalMillis else quietMillis = 0
+                lastPrint = print
+                val code = RunbookMarker.exitCodeIn(text, token)
+                if (code == null) {
+                    markStalled(index, generationAtStart, quietMillis >= stallAfterMillis)
+                    continue
+                }
                 // Check-then-act under the lock: without it a Stop landing between the check and
                 // finishStep would still let the run advance and send the next command.
                 synchronized(lock) {
@@ -330,9 +362,21 @@ class RunbookRunner(
 
     private fun stale(generationAtStart: Int): Boolean = synchronized(lock) { generationAtStart != generation }
 
+    /**
+     * Marks (or unmarks) step [index] as possibly stuck, under the same generation guard as
+     * [finishStep]: a poll landing just after Stop must not put a warning on a run that is over.
+     */
+    private fun markStalled(index: Int, generationAtStart: Int, stalled: Boolean) = synchronized(lock) {
+        if (generationAtStart != generation) return@synchronized
+        val state = steps.getOrNull(index) ?: return@synchronized
+        if (state.stalled != stalled) state.stalled = stalled
+    }
+
     private fun finishStep(index: Int, exitCode: Int) {
         val state = steps.getOrNull(index) ?: return
         state.exitCode = exitCode
+        // It reported after all: whatever the warning said, the step was only slow.
+        state.stalled = false
         if (exitCode == 0) {
             state.status = RunbookStepStatus.SUCCEEDED
             advance(index + 1)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
@@ -4,6 +4,7 @@ import app.skerry.shared.ssh.PortForwardException
 import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnectionException
 import app.skerry.shared.ssh.SshHostKeyRejectedException
+import app.skerry.ui.connection.hostKeyRefusalLine
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ptail_err_auth_failed
 import app.skerry.ui.generated.resources.ptail_err_connection_failed
@@ -15,10 +16,13 @@ import org.jetbrains.compose.resources.getString
  * Friendly message for a failure while dialling a host on the tunnel path (raising a forward or
  * scanning for services). Raw exception text (addresses, sshj internals) is never shown in the UI,
  * only generic messages, as in runConnectionTest. Host key rejection is called out separately:
- * tunnels use the probe verifier, so this is the expected outcome for a not-yet-trusted host.
+ * tunnels dial with `UnknownHost.Refuse`, so a host nobody has opened a terminal to is refused by
+ * design — and the message has to say so, since the tunnel form never mentioned host keys. The
+ * generic line stays for a rejection that arrived without a reason.
  */
 internal suspend fun friendlyTunnelError(e: Throwable): String = when (e) {
-    is SshHostKeyRejectedException -> getString(Res.string.ptail_err_host_not_trusted)
+    is SshHostKeyRejectedException ->
+        hostKeyRefusalLine(e) ?: getString(Res.string.ptail_err_host_not_trusted)
     is SshAuthenticationException -> getString(Res.string.ptail_err_auth_failed)
     is PortForwardException -> getString(Res.string.ptail_err_forward_failed)
     is SshConnectionException -> getString(Res.string.ptail_err_connection_failed)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.sftp.SftpProgress
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.ExecResult
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.LocalForwardSpec
 import app.skerry.shared.ssh.PortForward
 import app.skerry.shared.ssh.PtySize
@@ -17,6 +18,7 @@ import app.skerry.shared.ssh.ShellChannel
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshHostKeyRejectedException
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
 import kotlinx.coroutines.CompletableDeferred
@@ -152,6 +154,23 @@ class ConnectionControllerTest {
         val state = controller.uiState
         assertIs<ConnectionUiState.Error>(state)
         assertEquals(MoshSetupException.Reason.SERVER_NOT_INSTALLED, state.moshReason)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a rejected host key carries its reason into Error`() = runTest {
+        // The English transport text is diagnostics; what the view needs to explain the refusal in
+        // the user's language is the typed reason, same rule as the Mosh case above.
+        val transport = FakeSshTransport(
+            error = SshHostKeyRejectedException("Host key rejected by verifier", HostKeyRefusal.KeyChanged),
+        )
+        val (controller, scope) = controllerWith(transport)
+
+        controller.connect(target, SshAuth.Password("pw"))
+
+        val state = controller.uiState
+        assertIs<ConnectionUiState.Error>(state)
+        assertEquals(HostKeyRefusal.KeyChanged, state.hostKeyRefusal)
         scope.cancel()
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.connection
 
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.ExecResult
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.LocalForwardSpec
 import app.skerry.shared.ssh.PortForward
 import app.skerry.shared.ssh.PtySize
@@ -64,7 +65,19 @@ class ConnectionTestTest {
     @Test
     fun `host key rejection maps to a typed reason`() = runTest {
         val status = runConnectionTest(ProbeTransport(error = SshHostKeyRejectedException("bad key")), target, auth)
-        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected), status)
+        assertEquals(ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected()), status)
+    }
+
+    @Test
+    fun `host key rejection keeps why it was refused`() = runTest {
+        // "Test connection" dials with UnknownHost.Accept, so what lands here is a key that changed,
+        // a certificate that didn't hold up, or a locked vault — three different fixes.
+        val error = SshHostKeyRejectedException("bad key", HostKeyRefusal.CertificateRejected)
+        val status = runConnectionTest(ProbeTransport(error = error), target, auth)
+        assertEquals(
+            ConnectionTestStatus.Failure(ConnectionTestProblem.HostKeyRejected(HostKeyRefusal.CertificateRejected)),
+            status,
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ContainerBrowseTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ContainerBrowseTest.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshConnectionException
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.SshHostKeyRejectedException
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
@@ -77,7 +78,7 @@ class ContainerBrowseTest {
             FakeConnection(stdout = "", stderr = "docker: command not found", exitCode = 127),
         )
         val result = listContainers(transport, target, auth, ContainerSpec())
-        assertEquals(ContainerBrowseStatus.Failure(ContainerBrowseProblem.COMMAND_FAILED), result)
+        assertEquals(ContainerBrowseStatus.Failure(ContainerBrowseProblem.CommandFailed), result)
         assertTrue(transport.connection.disconnected)
     }
 
@@ -93,10 +94,23 @@ class ContainerBrowseTest {
             val status = listContainers(FailingTransport(error), target, auth, ContainerSpec())
             return (status as ContainerBrowseStatus.Failure).problem
         }
-        assertEquals(ContainerBrowseProblem.AUTHENTICATION_FAILED, problemFor(SshAuthenticationException("no")))
-        assertEquals(ContainerBrowseProblem.HOST_KEY_REJECTED, problemFor(SshHostKeyRejectedException("no")))
-        assertEquals(ContainerBrowseProblem.CONNECTION_FAILED, problemFor(SshConnectionException("no")))
-        assertEquals(ContainerBrowseProblem.CONNECTION_FAILED, problemFor(IllegalStateException("boom")))
+        assertEquals(ContainerBrowseProblem.AuthenticationFailed, problemFor(SshAuthenticationException("no")))
+        assertEquals(ContainerBrowseProblem.HostKeyRejected(), problemFor(SshHostKeyRejectedException("no")))
+        assertEquals(ContainerBrowseProblem.ConnectionFailed, problemFor(SshConnectionException("no")))
+        assertEquals(ContainerBrowseProblem.ConnectionFailed, problemFor(IllegalStateException("boom")))
+    }
+
+    @Test
+    fun a_rejected_host_key_keeps_why_it_was_refused() = runTest {
+        // The probe reconnects to a host the user already has a trusted session with, so the two
+        // reasons it can really hit — the key changed since, or the vault locked in between — have
+        // different fixes and must not collapse into one line.
+        val error = SshHostKeyRejectedException("no", HostKeyRefusal.KeyChanged)
+        val status = listContainers(FailingTransport(error), target, auth, ContainerSpec())
+        assertEquals(
+            ContainerBrowseStatus.Failure(ContainerBrowseProblem.HostKeyRejected(HostKeyRefusal.KeyChanged)),
+            status,
+        )
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostKeyRefusalTextTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostKeyRefusalTextTest.kt
@@ -1,0 +1,51 @@
+package app.skerry.ui.connection
+
+import app.skerry.shared.ssh.HostKeyRefusal
+import app.skerry.shared.ssh.SshHostKeyRejectedException
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_err_hostkey_cert
+import app.skerry.ui.generated.resources.conn_err_hostkey_changed
+import app.skerry.ui.generated.resources.conn_err_hostkey_locked
+import app.skerry.ui.generated.resources.conn_err_hostkey_untrusted
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.getString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HostKeyRefusalTextTest {
+
+    @Test
+    fun `each reason gets its own line`() = runTest {
+        // The mapping is the whole feature: swapping two branches compiles, passes every verifier
+        // test, and tells a user with a locked vault that their certificate was rejected.
+        assertEquals(Res.string.conn_err_hostkey_changed, hostKeyRefusalText(HostKeyRefusal.KeyChanged))
+        assertEquals(Res.string.conn_err_hostkey_untrusted, hostKeyRefusalText(HostKeyRefusal.NotTrustedYet))
+        assertEquals(Res.string.conn_err_hostkey_locked, hostKeyRefusalText(HostKeyRefusal.TrustStoreUnreadable))
+        assertEquals(Res.string.conn_err_hostkey_cert, hostKeyRefusalText(HostKeyRefusal.CertificateRejected))
+    }
+
+    @Test
+    fun `no two reasons read the same`() = runTest {
+        val lines = HostKeyRefusal.entries.map { getString(hostKeyRefusalText(it)) }
+
+        assertEquals(lines.size, lines.toSet().size, "two reasons share a line: $lines")
+        assertTrue(lines.none { it.isBlank() })
+    }
+
+    @Test
+    fun `a hop's refusal says the jump host, not the target`() = runTest {
+        val target = hostKeyRefusalLine(SshHostKeyRejectedException("x", HostKeyRefusal.KeyChanged))
+        val hop = hostKeyRefusalLine(SshHostKeyRejectedException("x", HostKeyRefusal.KeyChanged, hop = true))
+
+        assertEquals(getString(Res.string.conn_err_hostkey_changed), target)
+        assertTrue(hop != null && hop != target, "a hop rejection must not read like the target's")
+        assertTrue(hop.contains(getString(Res.string.conn_err_hostkey_changed)), "the reason itself is kept")
+    }
+
+    @Test
+    fun `a rejection with no reason has no line of its own`() = runTest {
+        assertNull(hostKeyRefusalLine(SshHostKeyRejectedException("x")))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
@@ -22,6 +22,24 @@ import kotlin.test.assertTrue
 class RemoteDesktopScreenStateTest {
 
     @Test
+    fun a_dead_audio_device_is_visible_on_the_screen_state() = runTest {
+        // The mute switch stays on while nothing comes out: only this flag separates "you silenced
+        // it" from "the device died", and the panel has nothing else to show.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(updates = updates), scope)
+
+        assertFalse(screen.audioFailed)
+        updates.emit(RemoteDesktopUpdate.AudioPlaybackFailing(failing = true))
+        assertTrue(screen.audioFailed)
+        assertFalse(screen.audioMuted) // the user never touched the switch
+
+        updates.emit(RemoteDesktopUpdate.AudioPlaybackFailing(failing = false))
+        assertFalse(screen.audioFailed)
+        scope.cancel()
+    }
+
+    @Test
     fun region_update_bumps_the_frame_counter() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertTrue
 class RunbookRunnerTest {
 
     private val poll = 100L
+    private val stallAfter = 5_000L
 
     private class FakeTerminal {
         val sent = mutableListOf<String>()
@@ -72,6 +73,7 @@ class RunbookRunnerTest {
             newId = { RUN_ID },
             environment = ::environment,
             pollIntervalMillis = poll,
+            stallAfterMillis = stallAfter,
         )
         try {
             body(runner, term)
@@ -87,6 +89,61 @@ class RunbookRunnerTest {
         target: RunbookTarget,
         contextValue: (SnippetSegment.Variable) -> String,
     ): Boolean = requestStart(runbook, target) && confirmStart(contextValue)
+
+    @Test
+    fun a_step_that_goes_quiet_without_reporting_is_flagged() = runnerTest { r, term ->
+        // An unterminated here-doc (or quote, or a shell that replaced itself with `exec`) leaves
+        // nothing that will ever print the marker. The run cannot know that, but it can see that the
+        // step has printed nothing for a long time and has not reported a status.
+        r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
+        assertFalse(r.steps[0].stalled)
+
+        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+
+        assertTrue(r.steps[0].stalled)
+        // Not killed: `sleep 3600` and a silent migration look exactly the same from here, so the
+        // decision stays the user's.
+        assertEquals(RunbookStepStatus.RUNNING, r.steps[0].status)
+        assertEquals(RunbookPhase.RUNNING, r.phase)
+    }
+
+    @Test
+    fun a_step_that_keeps_printing_is_never_flagged() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "apt upgrade")), term.target()) { "" }
+
+        repeat(6) {
+            testScheduler.advanceTimeBy(stallAfter / 2); testScheduler.runCurrent()
+            term.buffer += "Unpacking package $it\n"
+        }
+        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+
+        assertFalse(r.steps[0].stalled, "a long step that talks is not a stuck one")
+    }
+
+    @Test
+    fun output_after_a_quiet_spell_clears_the_flag() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "./migrate.sh")), term.target()) { "" }
+        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        assertTrue(r.steps[0].stalled)
+
+        term.buffer += "migrating 1/400\n"
+        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+
+        assertFalse(r.steps[0].stalled)
+    }
+
+    @Test
+    fun a_step_that_reports_after_a_quiet_spell_does_not_stay_flagged() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "sleep 300")), term.target()) { "" }
+        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        assertTrue(r.steps[0].stalled)
+
+        term.complete(0, 0)
+        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+
+        assertEquals(RunbookStepStatus.SUCCEEDED, r.steps[0].status)
+        assertFalse(r.steps[0].stalled)
+    }
 
     @Test
     fun sends_the_command_with_the_exit_code_probe() = runnerTest { r, term ->

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
@@ -146,6 +146,33 @@ class RunbookRunnerTest {
     }
 
     @Test
+    fun stopping_a_flagged_step_clears_the_flag_and_a_late_poll_cannot_bring_it_back() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
+        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        assertTrue(r.steps[0].stalled)
+
+        r.stop()
+        // A poll that passed its staleness check just before Stop must not re-flag a run that is
+        // over — the same race the generation guard exists for, now on this flag too.
+        testScheduler.advanceTimeBy(stallAfter * 2); testScheduler.runCurrent()
+
+        assertEquals(RunbookStepStatus.STOPPED, r.steps[0].status)
+        assertFalse(r.steps[0].stalled)
+    }
+
+    @Test
+    fun a_new_run_after_a_stalled_one_starts_unflagged() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
+        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        assertTrue(r.steps[0].stalled)
+        r.stop()
+
+        r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
+
+        assertFalse(r.steps[0].stalled)
+    }
+
+    @Test
     fun sends_the_command_with_the_exit_code_probe() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "systemctl restart nginx")), term.target()) { "" }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
@@ -1,9 +1,12 @@
 package app.skerry.ui.tunnel
 
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_err_hostkey_changed
+import app.skerry.ui.generated.resources.conn_err_hostkey_untrusted
 import app.skerry.ui.generated.resources.ptail_err_host_not_trusted
 import org.jetbrains.compose.resources.getString
 import app.skerry.shared.sftp.SftpClient
+import app.skerry.shared.ssh.HostKeyRefusal
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.ExecResult
 import app.skerry.shared.ssh.LocalForwardSpec
@@ -168,6 +171,37 @@ class TunnelManagerTest {
         // doesn't depend on the machine locale.
         assertEquals(getString(Res.string.ptail_err_host_not_trusted), status.message)
         assertTrue(conn.disconnected) // connection not leaked
+    }
+
+    @Test
+    fun `a host with no known key tells the user how to make it known`() = runTest {
+        // The refusal a tunnel actually hits: it dials with UnknownHost.Refuse, so a host nobody
+        // has ever opened a terminal to is turned away. Without the hint the failure is unreadable —
+        // the tunnel form never asked about host keys.
+        val conn = FakeTunnelConnection(
+            localError = SshHostKeyRejectedException("no", HostKeyRefusal.NotTrustedYet),
+        )
+        val manager = managerWith(FakeTunnelTransport(conn))
+        val id = manager.save(localDraft())
+
+        manager.activate(id)
+
+        val status = assertIs<TunnelStatus.Failed>(manager.tunnels.single().status)
+        assertEquals(getString(Res.string.conn_err_hostkey_untrusted), status.message)
+    }
+
+    @Test
+    fun `a changed host key is not reported as an untrusted one`() = runTest {
+        val conn = FakeTunnelConnection(
+            localError = SshHostKeyRejectedException("changed", HostKeyRefusal.KeyChanged),
+        )
+        val manager = managerWith(FakeTunnelTransport(conn))
+        val id = manager.save(localDraft())
+
+        manager.activate(id)
+
+        val status = assertIs<TunnelStatus.Failed>(manager.tunnels.single().status)
+        assertEquals(getString(Res.string.conn_err_hostkey_changed), status.message)
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
@@ -77,8 +77,10 @@ class PcmPlayer(
      * change reopens the device. Read from outside so the session can say so — a device that dies
      * mid-stream is otherwise indistinguishable from a server that went quiet.
      *
-     * False while no device would open at all: nothing was playing, every block retries, and calling
-     * that a dead device would raise the alarm on the first block of a session that has none.
+     * False while no device would open *at all*: nothing was playing, every block retries, and
+     * calling that a dead device would raise the alarm on the first block of a session that has
+     * none. A device that was playing and then would not reopen for a new format is a different
+     * story and does count — see [device].
      */
     override val playbackFailed: Boolean
         get() = synchronized(lock) { writesFailing }
@@ -124,6 +126,10 @@ class PcmPlayer(
         if (opened == null) {
             if (!refused) trace("no device would open for $format")
             refused = true
+            // A reopen that fails is a device that was playing and now isn't — the same silence as a
+            // write that stops being taken, one step earlier in the state machine. Only a session
+            // that never had a device at all ([previous] null) is left unreported.
+            if (previous != null) synchronized(lock) { writesFailing = true }
             return null
         }
         val published = synchronized(lock) {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/audio/PcmPlayer.kt
@@ -72,6 +72,17 @@ class PcmPlayer(
 
     private var writesFailing = false
 
+    /**
+     * A device took blocks and then stopped: the session is mute and stays that way until a format
+     * change reopens the device. Read from outside so the session can say so — a device that dies
+     * mid-stream is otherwise indistinguishable from a server that went quiet.
+     *
+     * False while no device would open at all: nothing was playing, every block retries, and calling
+     * that a dead device would raise the alarm on the first block of a session that has none.
+     */
+    override val playbackFailed: Boolean
+        get() = synchronized(lock) { writesFailing }
+
     /** Formats already announced to the trace; a session alternates between two or three of them. */
     private val traced = mutableSetOf<RemoteAudioFormat>()
 
@@ -80,8 +91,8 @@ class PcmPlayer(
         // A device that fails mid-block was unplugged or reclaimed; there is nothing to retry, and
         // the block it swallowed is 20 ms of a stream that keeps arriving.
         runCatching { open.write(pcm) }.onFailure { failure ->
-            if (!writesFailing) trace("the device stopped taking blocks: $failure")
-            writesFailing = true
+            val first = synchronized(lock) { (!writesFailing).also { writesFailing = true } }
+            if (first) trace("the device stopped taking blocks: $failure")
         }
     }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/audio/RemoteAudio.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/audio/RemoteAudio.kt
@@ -54,6 +54,12 @@ interface RemoteAudioPlayer {
     /** Drop whatever has not been played yet (the server closed the stream). */
     fun flush()
 
+    /**
+     * Whether the device this player opened has stopped taking blocks. Default false: a player that
+     * cannot tell reports nothing rather than a permanent alarm.
+     */
+    val playbackFailed: Boolean get() = false
+
     /** Release the device. Idempotent. */
     fun close()
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
@@ -139,6 +139,12 @@ sealed interface RemoteDesktopUpdate {
     data object Bell : RemoteDesktopUpdate
 
     /**
+     * The local device playing the session's sound stopped taking blocks ([failing] true), or
+     * started again. Only protocols that carry audio ever emit it.
+     */
+    data class AudioPlaybackFailing(val failing: Boolean) : RemoteDesktopUpdate
+
+    /**
      * The session ended. [cleanExit] true = the peer closed it in an orderly way; [reason] carries
      * the server's own explanation where it gave one (a refused logon, an idle timeout).
      */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/AudioChannel.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/AudioChannel.kt
@@ -104,6 +104,22 @@ class AudioChannel(
         for (block in queue) player.play(block.format, block.pcm)
     }
 
+    /** What was last reported, so a state that hasn't moved produces no update. */
+    private var reportedFailure = false
+
+    /**
+     * The playback state, if it changed since the last call: true = the device stopped taking
+     * blocks, false = it is taking them again, null = no news. Drained by the session's read loop
+     * the way incoming clipboard text is — playback runs on its own thread and has no way to reach
+     * the update stream itself.
+     */
+    fun drainPlaybackChange(): Boolean? {
+        val failing = player.playbackFailed
+        if (failing == reportedFailure) return null
+        reportedFailure = failing
+        return failing
+    }
+
     /**
      * Silence the session's sound without touching the channel: blocks keep being parsed and
      * confirmed, they just never reach the device. Dropping the channel instead would be a one-way

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpRemoteDesktop.kt
@@ -66,6 +66,7 @@ class RdpRemoteDesktop(
             is RdpUpdate.PointerPosition -> RemoteDesktopUpdate.CursorPosition(update.x, update.y)
             is RdpUpdate.PointerVisible -> RemoteDesktopUpdate.CursorVisible(update.visible)
             is RdpUpdate.ClipboardText -> RemoteDesktopUpdate.ClipboardText(update.text)
+            is RdpUpdate.AudioPlayback -> RemoteDesktopUpdate.AudioPlaybackFailing(update.failing)
             is RdpUpdate.Bell -> RemoteDesktopUpdate.Bell
             is RdpUpdate.Closed -> RemoteDesktopUpdate.Closed(update.cleanExit, update.reason)
             // Frame markers pace the protocol and are acknowledged inside the codec; the screen has

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpUpdate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpUpdate.kt
@@ -12,6 +12,13 @@ sealed interface RdpUpdate {
     data class Resize(val width: Int, val height: Int) : RdpUpdate
 
     /**
+     * The device playing the session's sound stopped taking blocks ([failing] true), or started
+     * again. Not a session failure: the picture and the input are unaffected, only the sound is
+     * gone, so it is reported rather than thrown.
+     */
+    data class AudioPlayback(val failing: Boolean) : RdpUpdate
+
+    /**
      * The server opened the display control channel and stated its limits, so resolution requests
      * are worth making (MS-RDPEDISP). A server without that channel never emits this, and the
      * session keeps the size it connected with.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/HostCertificates.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/HostCertificates.kt
@@ -106,41 +106,46 @@ class HostCertificateVerifier(
     private val nowEpochSeconds: () -> Long,
 ) : HostKeyVerifier {
 
-    override fun verify(offer: HostKeyOffer): Boolean {
+    override fun check(offer: HostKeyOffer): HostKeyRefusal? {
         // Read before anything else: deciding a bare key needs the trusted set too, now that a CA
         // claiming the host is what makes that key inadmissible.
-        val trusted = cas.allOrNull() ?: return false
+        val trusted = cas.allOrNull() ?: return HostKeyRefusal.TrustStoreUnreadable
         val claiming = trusted.filter { HostPattern.matches(it.hostPattern, offer.host, offer.port) }
         val certificate = offer.certificate
-            ?: return if (claiming.isEmpty()) fallback.verify(offer) else false
+            ?: return if (claiming.isEmpty()) fallback.check(offer) else HostKeyRefusal.CertificateRejected
         // A blank fingerprint means the CA key didn't parse; it must not match a stored entry whose
         // own fingerprint is blank (a corrupt or hand-edited synced record).
         if (certificate.caFingerprint.isBlank()) return unclaimedFallback(claiming, offer)
         if (claiming.none { it.fingerprint == certificate.caFingerprint }) return unclaimedFallback(claiming, offer)
 
-        if (!certificate.caSignatureVerified) return false
-        if (!certificate.hostCertificate) return false
-        if (certificate.criticalOptions.isNotEmpty()) return false
+        // One reason for every failed check below, on purpose: which one it was is a hint to whoever
+        // offered the certificate, and the user's move — inspect what the host serves — is the same.
+        if (!certificate.caSignatureVerified) return HostKeyRefusal.CertificateRejected
+        if (!certificate.hostCertificate) return HostKeyRefusal.CertificateRejected
+        if (certificate.criticalOptions.isNotEmpty()) return HostKeyRefusal.CertificateRejected
         val now = nowEpochSeconds()
-        if (now < certificate.validAfterEpochSeconds || now >= certificate.validBeforeEpochSeconds) return false
+        if (now < certificate.validAfterEpochSeconds || now >= certificate.validBeforeEpochSeconds) {
+            return HostKeyRefusal.CertificateRejected
+        }
         // Bound the work a hostile server can ask for: an offered certificate can list any number
         // of principals, each matched against the host.
         if (certificate.principals.isNotEmpty() &&
             certificate.principals.asSequence().take(MAX_PRINCIPALS).none { principalMatches(it, offer.host) }
         ) {
-            return false
+            return HostKeyRefusal.CertificateRejected
         }
         // Deliberately no store write: see the class doc — certificates rotate, trust is in the CA.
-        return true
+        return null
     }
 
     /**
      * A certificate this class cannot use: TOFU decides only if no CA claims the host, and then on
      * the key inside the certificate rather than the certificate itself, whose fingerprint changes
-     * on every re-issue.
+     * on every re-issue. TOFU's own reason is passed through — the host it refused is not a
+     * certificate host, and saying so would send the user after the wrong thing.
      */
-    private fun unclaimedFallback(claiming: List<TrustedCa>, offer: HostKeyOffer): Boolean =
-        if (claiming.isEmpty()) fallback.verify(offer.bareKey()) else false
+    private fun unclaimedFallback(claiming: List<TrustedCa>, offer: HostKeyOffer): HostKeyRefusal? =
+        if (claiming.isEmpty()) fallback.check(offer.bareKey()) else HostKeyRefusal.CertificateRejected
 
     private fun principalMatches(principal: String, host: String): Boolean =
         principal.length <= HostPattern.MAX_PATTERN_LENGTH && globMatches(principal.lowercase(), host.lowercase())

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/KnownHosts.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/KnownHosts.kt
@@ -104,30 +104,27 @@ class TofuHostKeyVerifier(
     private val mismatches: HostKeyMismatchStore = NoopHostKeyMismatchStore,
     private val now: () -> String = { "" },
 ) : HostKeyVerifier {
-    override fun verify(offer: HostKeyOffer): Boolean {
+    override fun check(offer: HostKeyOffer): HostKeyRefusal? {
         // A certificate is remembered by the key inside it: the certificate blob is re-issued on a
         // schedule, so trusting its fingerprint would report "host key changed" on every rotation.
         // Done here rather than only in [HostCertificateVerifier] so the rule holds even where this
         // verifier is wired up on its own.
         val (host, port, keyType, fingerprint, _) = offer.bareKey()
-        val known = store.allOrNull() ?: return false
+        val known = store.allOrNull() ?: return HostKeyRefusal.TrustStoreUnreadable
         val existing = known.firstOrNull {
             it.host == host && it.port == port && it.keyType == keyType
         }
-        return when (existing) {
-            null -> {
+        return when {
+            existing == null -> {
                 store.add(KnownHost(host, port, keyType, fingerprint, now()))
-                true
+                null
             }
+            existing.fingerprint == fingerprint -> null
             else -> {
-                if (existing.fingerprint == fingerprint) {
-                    true
-                } else {
-                    mismatches.record(
-                        HostKeyMismatch(host, port, keyType, existing.fingerprint, fingerprint, now()),
-                    )
-                    false
-                }
+                mismatches.record(
+                    HostKeyMismatch(host, port, keyType, existing.fingerprint, fingerprint, now()),
+                )
+                HostKeyRefusal.KeyChanged
             }
         }
     }
@@ -170,13 +167,17 @@ class ReadOnlyHostKeyVerifier(
     private val store: KnownHostsStore,
     private val unknownHost: UnknownHost,
 ) : HostKeyVerifier {
-    override fun verify(offer: HostKeyOffer): Boolean {
+    override fun check(offer: HostKeyOffer): HostKeyRefusal? {
         // Compared by the key inside a certificate, for the same reason as in [TofuHostKeyVerifier].
         val bare = offer.bareKey()
-        val known = store.allOrNull() ?: return false
+        val known = store.allOrNull() ?: return HostKeyRefusal.TrustStoreUnreadable
         val existing = known.firstOrNull {
             it.host == bare.host && it.port == bare.port && it.keyType == bare.keyType
         }
-        return if (existing == null) unknownHost == UnknownHost.Accept else existing.fingerprint == bare.fingerprint
+        return when {
+            existing == null -> HostKeyRefusal.NotTrustedYet.takeIf { unknownHost == UnknownHost.Refuse }
+            existing.fingerprint == bare.fingerprint -> null
+            else -> HostKeyRefusal.KeyChanged
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshTransport.kt
@@ -180,14 +180,49 @@ data class OfferedHostCertificate(
     val criticalOptions: List<String> = emptyList(),
 )
 
+/**
+ * Why a host key was refused. Four situations that a yes/no verdict collapses into one
+ * "host key rejected", though what the user has to do about them could not differ more: resolve a
+ * key change, connect once from a terminal, unlock the vault, or fix the certificate.
+ *
+ * Coarse on purpose — this crosses into the UI, and a reason exists only where it changes the
+ * advice given. [CertificateRejected] covers every way a certificate can fail for that reason:
+ * naming them (expired / wrong principal / unknown CA) would tell an on-path server which lie
+ * came closest.
+ */
+enum class HostKeyRefusal {
+    /** A key is trusted for this host and the server offered a different one — the MITM signal. */
+    KeyChanged,
+
+    /**
+     * No key is trusted for this host yet, and this connection is not allowed to establish trust
+     * (see [UnknownHost.Refuse]) — a tunnel activating with nobody watching.
+     */
+    NotTrustedYet,
+
+    /** The trusted set could not be read (locked vault): fail closed, decide nothing. */
+    TrustStoreUnreadable,
+
+    /** A trusted CA claims this host, and what the server offered is not a certificate that holds up. */
+    CertificateRejected,
+}
+
 /** Trust decision for a host key. See [HostKeyOffer]. */
 fun interface HostKeyVerifier {
-    fun verify(offer: HostKeyOffer): Boolean
+    /** @return `null` when the key may be used, otherwise why it was refused. */
+    fun check(offer: HostKeyOffer): HostKeyRefusal?
+
+    /** [check] as a yes/no, for call sites that only branch on the outcome. */
+    fun verify(offer: HostKeyOffer): Boolean = check(offer) == null
 }
 
 /** Trust decision for a plain (non-certificate) host key — the shorthand used by tests and probes. */
 fun HostKeyVerifier.verify(host: String, port: Int, keyType: String, fingerprint: String): Boolean =
     verify(HostKeyOffer(host, port, keyType, fingerprint))
+
+/** [check] for a plain (non-certificate) host key. */
+fun HostKeyVerifier.check(host: String, port: Int, keyType: String, fingerprint: String): HostKeyRefusal? =
+    check(HostKeyOffer(host, port, keyType, fingerprint))
 
 /**
  * One prompt of a keyboard-interactive exchange (RFC 4256). [text] is the server's wording verbatim
@@ -395,6 +430,21 @@ open class SshException(message: String, cause: Throwable? = null) : Exception(m
 
 class SshConnectionException(message: String, cause: Throwable? = null) : SshException(message, cause)
 
-class SshHostKeyRejectedException(message: String, cause: Throwable? = null) : SshException(message, cause)
+/**
+ * The host key was not trusted. [refusal] is why, when the transport could tell — the UI turns it
+ * into advice the user can act on; null where the rejection came from somewhere without a reason to
+ * report. [message] stays English diagnostics, as everywhere in the transport.
+ */
+class SshHostKeyRejectedException(
+    message: String,
+    val refusal: HostKeyRefusal? = null,
+    /**
+     * The key belonged to a ProxyJump hop, not to the host being dialed. Kept apart from [refusal]
+     * because the advice is useless without it: told only "host key changed", the user inspects the
+     * target's fingerprint and finds it untouched while the bastion is the one that rotated.
+     */
+    val hop: Boolean = false,
+    cause: Throwable? = null,
+) : SshException(message, cause)
 
 class SshAuthenticationException(message: String, cause: Throwable? = null) : SshException(message, cause)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
@@ -2,6 +2,7 @@ package app.skerry.shared.audio
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -153,6 +154,38 @@ class PcmPlayerTest {
             listOf("open#1 $stereo", "write#1 320", "write#1 320", "write#1 160"),
             devices.events,
         )
+    }
+
+    @Test
+    fun `a device that stopped taking blocks says so, and stops saying it once one is open again`() {
+        // The session goes mute with nothing on screen to explain it: the block is swallowed, the
+        // server keeps sending, and the trace that used to be the only witness is off by default.
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+        player.play(stereo, ByteArray(320))
+        assertFalse(player.playbackFailed)
+
+        devices.failWrite = true
+        player.play(stereo, ByteArray(320))
+        assertTrue(player.playbackFailed)
+
+        // A format change is the one thing that reopens the device (see the class doc), so it is
+        // also the only way back to sound.
+        devices.failWrite = false
+        player.play(notification, ByteArray(160))
+        assertFalse(player.playbackFailed)
+    }
+
+    @Test
+    fun `a device that will not open is not a playback failure`() {
+        // Nothing was ever taking blocks, so there is no device that stopped: the player retries on
+        // every block, and reporting it as a dead device would be a false alarm on the first one.
+        val devices = FakeSinks(refuse = { true })
+        val player = PcmPlayer(devices)
+
+        player.play(stereo, ByteArray(320))
+
+        assertFalse(player.playbackFailed)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/audio/PcmPlayerTest.kt
@@ -177,6 +177,22 @@ class PcmPlayerTest {
     }
 
     @Test
+    fun `a device that was playing and will not reopen is a playback failure`() {
+        // The same silence as a write that stops being taken, reached through the other door: sound
+        // was working, the server switched format, and the device is gone by the time we ask for it
+        // again. Reporting this as healthy would leave a mute session with nothing on screen.
+        val devices = FakeSinks()
+        val player = PcmPlayer(devices)
+        player.play(stereo, ByteArray(320))
+        assertFalse(player.playbackFailed)
+
+        devices.refuse = { true }
+        player.play(notification, ByteArray(160))
+
+        assertTrue(player.playbackFailed)
+    }
+
+    @Test
     fun `a device that will not open is not a playback failure`() {
         // Nothing was ever taking blocks, so there is no device that stopped: the player retries on
         // every block, and reporting it as a dead device would be a false alarm on the first one.

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/AudioChannelTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/AudioChannelTest.kt
@@ -5,6 +5,7 @@ import app.skerry.shared.audio.RemoteAudioPlayer
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -288,9 +289,26 @@ class AudioChannelTest {
         }
     }
 
+    @Test
+    fun `a device that stops taking blocks is reported once, and so is its recovery`() {
+        // The read loop drains this on every pass, so a state that hasn't moved must produce no
+        // update — otherwise the session would report the same dead device sixty times a second.
+        val channel = AudioChannel(player)
+        assertNull(channel.drainPlaybackChange())
+
+        player.playbackFailed = true
+        assertEquals(true, channel.drainPlaybackChange())
+        assertNull(channel.drainPlaybackChange())
+
+        player.playbackFailed = false
+        assertEquals(false, channel.drainPlaybackChange())
+        assertNull(channel.drainPlaybackChange())
+    }
+
     private class RecordingPlayer : RemoteAudioPlayer {
         val played = mutableListOf<Pair<RemoteAudioFormat, ByteArray>>()
         var flushes = 0
+        override var playbackFailed = false
 
         override fun play(format: RemoteAudioFormat, pcm: ByteArray) {
             played.add(format to pcm)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpRemoteDesktopTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpRemoteDesktopTest.kt
@@ -1,11 +1,38 @@
 package app.skerry.shared.rdp
 
+import app.skerry.shared.graphics.RemoteDesktopUpdate
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /** The adapter between the RDP session and what the UI sees ([RdpRemoteDesktop]). */
 class RdpRemoteDesktopTest {
+
+    @Test
+    fun a_dead_audio_device_reaches_the_ui_as_a_playback_failure() = runTest {
+        // The one hop between the RDP session and what the screen state sees. Drop the arm and the
+        // player, the channel and the screen state all still pass their own tests while the UI never
+        // hears about a device that died.
+        val stream = MutableSharedFlow<RdpUpdate>(extraBufferCapacity = 4)
+        val seen = mutableListOf<RemoteDesktopUpdate>()
+        val desktop = RdpRemoteDesktop(FakeRdpSession(updates = stream))
+        val collector = launch { desktop.updates.collect { update -> seen.add(update) } }
+        runCurrent()
+
+        stream.emit(RdpUpdate.AudioPlayback(failing = true))
+        stream.emit(RdpUpdate.AudioPlayback(failing = false))
+        runCurrent()
+        collector.cancel()
+
+        val expected: List<RemoteDesktopUpdate> = listOf(
+            RemoteDesktopUpdate.AudioPlaybackFailing(failing = true),
+            RemoteDesktopUpdate.AudioPlaybackFailing(failing = false),
+        )
+        assertEquals(expected, seen)
+    }
 
     @Test
     fun a_hidden_window_is_reported_and_nothing_is_asked_for() = runTest {

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/HostCertificateVerifierTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/HostCertificateVerifierTest.kt
@@ -301,6 +301,56 @@ class HostCertificateVerifierTest {
     }
 
     @Test
+    fun `every way a claimed host fails its certificate reports the same reason`() {
+        // Deliberately one reason for all of them: naming which check failed would tell an on-path
+        // server how close its forgery came. The user's move is the same in every case — look at
+        // the certificate the host serves.
+        val cas = { InMemoryTrustedCaStore(listOf(trustedCa())) }
+        val refused = listOf(
+            "bare key" to offer(cert = null),
+            "another CA" to offer(certificate(caFingerprint = OTHER_CA_FP)),
+            "signature unchecked" to offer(certificate(caSignatureVerified = false)),
+            "user certificate" to offer(certificate(hostCertificate = false)),
+            "critical option" to offer(certificate(criticalOptions = listOf("force-command"))),
+            "expired" to offer(certificate(validBefore = NOW - 1)),
+            "wrong principal" to offer(certificate(principals = listOf("db-01.prod.example.com"))),
+        )
+
+        for ((case, refusedOffer) in refused) {
+            val verifier = HostCertificateVerifier(cas(), RecordingVerifier()) { NOW }
+            assertEquals(HostKeyRefusal.CertificateRejected, verifier.check(refusedOffer), case)
+        }
+    }
+
+    @Test
+    fun `an unreadable CA store is named as such, not as a certificate problem`() {
+        // The vault locked mid-handshake: nothing about the certificate is known yet, and the fix
+        // is to unlock and retry.
+        val cas = InMemoryTrustedCaStore(listOf(trustedCa())).apply { readable = false }
+        val verifier = HostCertificateVerifier(cas, RecordingVerifier()) { NOW }
+
+        assertEquals(HostKeyRefusal.TrustStoreUnreadable, verifier.check(offer()))
+    }
+
+    @Test
+    fun `the fallback's reason is passed through for a host no CA claims`() {
+        // TOFU decided, so its verdict — "this host's key changed" — is what the user must see,
+        // not a certificate story about a host that has nothing to do with certificates.
+        val fallback = RecordingVerifier(answer = false, refusal = HostKeyRefusal.KeyChanged)
+        val cas = InMemoryTrustedCaStore(listOf(trustedCa(pattern = "*.staging.example.com")))
+        val verifier = HostCertificateVerifier(cas, fallback) { NOW }
+
+        assertEquals(HostKeyRefusal.KeyChanged, verifier.check(offer(cert = null)))
+    }
+
+    @Test
+    fun `an accepted certificate has no refusal`() {
+        val verifier = HostCertificateVerifier(InMemoryTrustedCaStore(listOf(trustedCa())), RecordingVerifier()) { NOW }
+
+        assertNull(verifier.check(offer()))
+    }
+
+    @Test
     fun `picks the CA that covers the host among several`() {
         val fallback = RecordingVerifier(answer = true)
         val cas = InMemoryTrustedCaStore(
@@ -316,12 +366,15 @@ class HostCertificateVerifierTest {
     }
 }
 
-/** Records what it was asked about; answers [answer]. */
-private class RecordingVerifier(private val answer: Boolean = true) : HostKeyVerifier {
+/** Records what it was asked about; accepts when [answer], otherwise refuses with [refusal]. */
+private class RecordingVerifier(
+    private val answer: Boolean = true,
+    private val refusal: HostKeyRefusal = HostKeyRefusal.KeyChanged,
+) : HostKeyVerifier {
     val seen = mutableListOf<HostKeyOffer>()
-    override fun verify(offer: HostKeyOffer): Boolean {
+    override fun check(offer: HostKeyOffer): HostKeyRefusal? {
         seen += offer
-        return answer
+        return if (answer) null else refusal
     }
 }
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ReadOnlyHostKeyVerifierTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ReadOnlyHostKeyVerifierTest.kt
@@ -80,6 +80,40 @@ class ReadOnlyHostKeyVerifierTest {
     }
 
     @Test
+    fun `Refuse says the host is merely untrusted, not that its key changed`() {
+        // This is the one refusal the user can fix themselves — open a terminal session once, or
+        // add a CA — and the message can only say so if the reason survives the trip to the UI.
+        val store = RecordingKnownHostsStore()
+        val verifier = ReadOnlyHostKeyVerifier(store, UnknownHost.Refuse)
+
+        assertEquals(HostKeyRefusal.NotTrustedYet, verifier.check("example.com", 22, ed25519, fpA))
+    }
+
+    @Test
+    fun `a changed key is named as such under either policy`() {
+        bothPolicies { policy, store ->
+            store.seed(KnownHost("example.com", 22, ed25519, fpA))
+            val verifier = ReadOnlyHostKeyVerifier(store, policy)
+
+            assertEquals(HostKeyRefusal.KeyChanged, verifier.check("example.com", 22, ed25519, fpB), "$policy")
+        }
+    }
+
+    @Test
+    fun `an unreadable store is named as such under either policy`() {
+        bothPolicies { policy, store ->
+            store.readable = false
+            val verifier = ReadOnlyHostKeyVerifier(store, policy)
+
+            assertEquals(
+                HostKeyRefusal.TrustStoreUnreadable,
+                verifier.check("example.com", 22, ed25519, fpA),
+                "$policy",
+            )
+        }
+    }
+
+    @Test
     fun `a new key type for a known host counts as an unknown host`() {
         // ed25519 is stored, the server offers rsa: a different (host, port, keyType) triple, so there
         // is no key to compare against and the policy decides.

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/TofuHostKeyVerifierTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/TofuHostKeyVerifierTest.kt
@@ -3,6 +3,7 @@ package app.skerry.shared.ssh
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class TofuHostKeyVerifierTest {
@@ -109,6 +110,32 @@ class TofuHostKeyVerifierTest {
 
         assertFalse(verifier.verify("example.com", 22, ed25519, fpA))
         assertEquals(emptyList(), store.all())
+    }
+
+    @Test
+    fun `names a changed key as such, so the UI can point at the known-hosts manager`() {
+        val store = InMemoryKnownHostsStore()
+        val verifier = TofuHostKeyVerifier(store)
+        verifier.verify("example.com", 22, ed25519, fpA)
+
+        assertEquals(HostKeyRefusal.KeyChanged, verifier.check("example.com", 22, ed25519, fpB))
+    }
+
+    @Test
+    fun `an unreadable store is not reported as a changed key`() {
+        // "Unlock the vault and retry" and "the host's key changed" are opposite conclusions; a
+        // locked vault must not read as the MITM signal.
+        val store = InMemoryKnownHostsStore().apply { readable = false }
+        val verifier = TofuHostKeyVerifier(store)
+
+        assertEquals(HostKeyRefusal.TrustStoreUnreadable, verifier.check("example.com", 22, ed25519, fpA))
+    }
+
+    @Test
+    fun `an accepted key has no refusal`() {
+        val verifier = TofuHostKeyVerifier(InMemoryKnownHostsStore())
+
+        assertNull(verifier.check("example.com", 22, ed25519, fpA))
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
@@ -29,7 +29,7 @@ private const val USER = "skerry"
 private const val PASSWORD = "correct horse battery staple"
 private const val README_BODY = "hello sftp\n"
 
-private val acceptAllKeys = HostKeyVerifier { true }
+private val acceptAllKeys = HostKeyVerifier { null }
 
 /**
  * Integration tests for [SshjSftpClient] against an embedded Apache MINA SSHD with an SFTP subsystem.

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellChannelTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellChannelTest.kt
@@ -49,7 +49,7 @@ class ShellChannelTest {
     }
 
     private suspend fun connect(): SshConnection =
-        SshjTransport(HostKeyVerifier { true }).connect(
+        SshjTransport(HostKeyVerifier { null }).connect(
             SshTarget(host = "127.0.0.1", port = server.port, username = USER),
             SshAuth.Password(PASSWORD),
         )

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellCommandChannelTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/ShellCommandChannelTest.kt
@@ -60,7 +60,7 @@ class ShellCommandChannelTest {
     }
 
     private suspend fun connect(target: SshTarget): SshConnection =
-        SshjTransport(HostKeyVerifier { true }).connect(target, SshAuth.Password(PASSWORD))
+        SshjTransport(HostKeyVerifier { null }).connect(target, SshAuth.Password(PASSWORD))
 
     private fun target(command: List<String>? = null) = SshTarget(
         host = "127.0.0.1",
@@ -101,7 +101,7 @@ class ShellCommandChannelTest {
 
     @Test
     fun `a container profile execs into the container over ssh`() = runBlocking {
-        val transport = ContainerTransport(SshjTransport(HostKeyVerifier { true }))
+        val transport = ContainerTransport(SshjTransport(HostKeyVerifier { null }))
         val connection = transport.connect(
             SshTarget(
                 host = "127.0.0.1",

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjCertificateAuthTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjCertificateAuthTest.kt
@@ -15,7 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
-private val acceptAllHostKeys = HostKeyVerifier { true }
+private val acceptAllHostKeys = HostKeyVerifier { null }
 
 /**
  * Integration tests for SSH certificate auth ([SshAuth.Certificate]) against an embedded

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjHostCertificateTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjHostCertificateTest.kt
@@ -146,10 +146,13 @@ class SshjHostCertificateTest {
     fun `rejects a certificate issued for a different host`() = runTest {
         startServer(hostCertificate(principals = listOf("other.example.com")))
 
-        assertFailsWith<SshHostKeyRejectedException> {
+        val rejection = assertFailsWith<SshHostKeyRejectedException> {
             SshjTransport(verifier(listOf(trustedCa()), RecordingKnownHosts()))
                 .connect(target(), SshAuth.Password(CERT_PASSWORD))
         }
+        // sshj fails the certificate during KEX, so our verifier never runs and the reason is the
+        // transport's own — the one path no unit test on the verifiers can reach.
+        assertEquals(HostKeyRefusal.CertificateRejected, rejection.refusal)
     }
 
     @Test
@@ -161,10 +164,11 @@ class SshjHostCertificateTest {
             ),
         )
 
-        assertFailsWith<SshHostKeyRejectedException> {
+        val rejection = assertFailsWith<SshHostKeyRejectedException> {
             SshjTransport(verifier(listOf(trustedCa()), RecordingKnownHosts()))
                 .connect(target(), SshAuth.Password(CERT_PASSWORD))
         }
+        assertEquals(HostKeyRefusal.CertificateRejected, rejection.refusal)
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjJumpTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjJumpTest.kt
@@ -10,6 +10,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 private const val USER = "skerry"
@@ -55,7 +56,7 @@ class SshjJumpTest {
     private fun target(jump: SshJump?) =
         SshTarget(host = "127.0.0.1", port = targetServer.port, username = USER, jump = jump)
 
-    private val acceptAll = HostKeyVerifier { true }
+    private val acceptAll = HostKeyVerifier { null }
 
     @Test
     fun `connects through the jump host and executes a command`() = runTest {
@@ -85,7 +86,7 @@ class SshjJumpTest {
         val seen = mutableListOf<Pair<String, Int>>()
         val recording = HostKeyVerifier { offer ->
             synchronized(seen) { seen += offer.host to offer.port }
-            true
+            null
         }
         val connection = SshjTransport(recording).connect(target(jumpHop()), SshAuth.Password(PASSWORD))
         connection.disconnect()
@@ -95,23 +96,31 @@ class SshjJumpTest {
 
     @Test
     fun `rejected jump host key fails the connect and names the hop`() = runTest {
-        val rejectJump = HostKeyVerifier { it.port != jumpServer.port }
+        val rejectJump = HostKeyVerifier { offer ->
+            if (offer.port == jumpServer.port) HostKeyRefusal.NotTrustedYet else null
+        }
         val e = assertFailsWith<SshHostKeyRejectedException> {
             SshjTransport(rejectJump).connect(target(jumpHop()), SshAuth.Password(PASSWORD))
         }
         // The user must be able to tell WHOSE key was rejected — a changed bastion key would
         // otherwise send them investigating the target's fingerprint (and vice versa).
         assertEquals("Jump host key rejected by verifier", e.message)
+        assertEquals(HostKeyRefusal.NotTrustedYet, e.refusal) // the reason survives the IO thread
+        assertTrue(e.hop, "the refusal must say it was the hop, not the target")
         awaitNoSessions(jumpServer)
     }
 
     @Test
     fun `rejected target host key names the target, not the hop`() = runTest {
-        val rejectTarget = HostKeyVerifier { it.port != targetServer.port }
+        val rejectTarget = HostKeyVerifier { offer ->
+            if (offer.port == targetServer.port) HostKeyRefusal.NotTrustedYet else null
+        }
         val e = assertFailsWith<SshHostKeyRejectedException> {
             SshjTransport(rejectTarget).connect(target(jumpHop()), SshAuth.Password(PASSWORD))
         }
         assertEquals("Host key rejected by verifier", e.message)
+        assertEquals(HostKeyRefusal.NotTrustedYet, e.refusal)
+        assertFalse(e.hop)
         awaitNoSessions(jumpServer)
     }
 

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjKeyboardInteractiveTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjKeyboardInteractiveTest.kt
@@ -28,7 +28,7 @@ private const val PROMPT = "Verification code:"
 private const val NAME = "Two-factor authentication"
 private const val INSTRUCTION = "Enter the code from your authenticator app"
 
-private val trustAll = HostKeyVerifier { true }
+private val trustAll = HostKeyVerifier { null }
 
 /**
  * Integration tests for keyboard-interactive authentication against an embedded Apache MINA SSHD:

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjPortForwardTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjPortForwardTest.kt
@@ -20,7 +20,7 @@ import kotlin.test.assertTrue
 private const val USER = "skerry"
 private const val PASSWORD = "correct horse battery staple"
 
-private val acceptAllKeys = HostKeyVerifier { true }
+private val acceptAllKeys = HostKeyVerifier { null }
 
 /**
  * Integration tests for port forwarding against an embedded Apache MINA SSHD. The tunnel

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 private const val USER = "skerry"
 private const val PASSWORD = "correct horse battery staple"
 
-private val acceptAllKeys = HostKeyVerifier { true }
+private val acceptAllKeys = HostKeyVerifier { null }
 
 /** Integration tests for SshjTransport against an embedded Apache MINA SSHD. */
 class SshjTransportTest {
@@ -167,12 +167,15 @@ class SshjTransportTest {
         val rejecting = HostKeyVerifier { offer ->
             seenKeyType = offer.keyType
             seenFingerprint = offer.fingerprint
-            false
+            HostKeyRefusal.KeyChanged
         }
 
-        assertFailsWith<SshHostKeyRejectedException> {
+        val rejection = assertFailsWith<SshHostKeyRejectedException> {
             SshjTransport(rejecting).connect(target(), SshAuth.Password(PASSWORD))
         }
+        // The verifier runs on sshj's IO thread and the reason is read back here: without this the
+        // transport could drop it and every other assertion would still hold.
+        assertEquals(HostKeyRefusal.KeyChanged, rejection.refusal)
         assertTrue(!seenKeyType.isNullOrBlank(), "verifier should receive the key type")
         assertTrue(
             seenFingerprint.orEmpty().startsWith("SHA256:"),

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -336,6 +336,8 @@ class RdpSocketSession(
             for (update in display.drainUpdates()) emit(update)
             if (batch.any { it is RdpUpdate.Closed }) break
             for (text in clipboard.drainIncoming()) emit(RdpUpdate.ClipboardText(text))
+            // Playback runs on its own scope and cannot emit; the read loop asks it instead.
+            audio?.drainPlaybackChange()?.let { emit(RdpUpdate.AudioPlayback(it)) }
         }
     }.flowOn(Dispatchers.IO)
         // Runs on the collector side, so it fires even while the read loop is parked in a blocking

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -6,7 +6,6 @@ import java.security.PrivateKey
 import java.security.PublicKey
 import java.security.Security
 import java.util.Base64
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import kotlinx.coroutines.Dispatchers
@@ -123,7 +122,7 @@ class SshjTransport(
         // harmless there.
         client.connectTimeout = CONNECT_TIMEOUT_MILLIS
         configure(client)
-        val hostKeyRejected = installHostKeyVerifier(client)
+        val hostKeyRefused = installHostKeyVerifier(client)
         opened += client
         try {
             if (upstream == null) {
@@ -135,9 +134,11 @@ class SshjTransport(
             // Don't put the host address in the message text (logs/crash reporters): connect
             // metadata is sensitive in a zero-knowledge client. Diagnostic detail stays in the
             // cause (e).
-            if (hostKeyRejected.get()) {
+            hostKeyRefused.get()?.let { refusal ->
                 throw SshHostKeyRejectedException(
                     if (hop) "Jump host key rejected by verifier" else "Host key rejected by verifier",
+                    refusal,
+                    hop,
                 )
             }
             // sshj checks a host certificate (CA signature, principals, validity) during KEX and
@@ -150,6 +151,8 @@ class SshjTransport(
                     } else {
                         "Host certificate rejected: not valid for this host, or expired"
                     },
+                    HostKeyRefusal.CertificateRejected,
+                    hop,
                     e,
                 )
             }
@@ -159,15 +162,15 @@ class SshjTransport(
     }
 
     /**
-     * Attach an adapter for our [hostKeyVerifier] to [client]. The returned flag is set on
-     * rejection: verify() is called from sshj's IO thread, while the flag is read from the
-     * coroutine after connect() — needs thread-safe visibility, hence AtomicBoolean.
+     * Attach an adapter for our [hostKeyVerifier] to [client]. The returned holder carries the
+     * refusal: check() is called from sshj's IO thread, while the reason is read from the
+     * coroutine after connect() — needs thread-safe visibility, hence AtomicReference.
      */
-    private fun installHostKeyVerifier(client: SSHClient): AtomicBoolean {
-        val hostKeyRejected = AtomicBoolean(false)
+    private fun installHostKeyVerifier(client: SSHClient): AtomicReference<HostKeyRefusal?> {
+        val hostKeyRefusal = AtomicReference<HostKeyRefusal?>(null)
         client.addHostKeyVerifier(object : net.schmizz.sshj.transport.verification.HostKeyVerifier {
             override fun verify(hostname: String, port: Int, key: PublicKey): Boolean {
-                val trusted = hostKeyVerifier.verify(
+                val refusal = hostKeyVerifier.check(
                     HostKeyOffer(
                         host = hostname,
                         port = port,
@@ -176,13 +179,13 @@ class SshjTransport(
                         certificate = (key as? Certificate<*>)?.let { offeredCertificate(it, hostname) },
                     ),
                 )
-                if (!trusted) hostKeyRejected.set(true)
-                return trusted
+                if (refusal != null) hostKeyRefusal.set(refusal)
+                return refusal == null
             }
 
             override fun findExistingAlgorithms(hostname: String, port: Int): List<String> = emptyList()
         })
-        return hostKeyRejected
+        return hostKeyRefusal
     }
 
     /**


### PR DESCRIPTION
Three failures that the app could detect but never told anyone about. Rebased onto `main` after #117 merged; replaces #118, which GitHub closed when its base branch was deleted.

## Host key refusals carry a reason

`HostKeyVerifier` answers with a reason instead of a yes/no: `check(offer)` returns `null` when the key may be used, otherwise one of

| Reason | What the user does |
|---|---|
| `KeyChanged` | resolve it in Known hosts |
| `NotTrustedYet` | connect once from a terminal, or add the host's CA |
| `TrustStoreUnreadable` | unlock the vault and retry |
| `CertificateRejected` | look at the certificate the host serves |

The reason travels in `SshHostKeyRejectedException` with a flag saying the key belonged to a ProxyJump hop rather than to the host being dialed — without it a bastion that rotated its key reads as "the host you asked for changed its key" and sends the user to inspect an untouched entry. One resource mapping renders the pair for the terminal notice, the tunnel list, the "Test connection" footer and the container picker.

Every certificate failure — wrong CA, unverified signature, user certificate, critical option, expired, wrong principal, no certificate at all — reports the same reason on purpose: naming the one that failed would tell an on-path server how close its forgery came, and the user's move is the same in each case.

Activating a tunnel to a host with no `known_hosts` entry is refused by design (the forward comes up with nobody watching). It now says so, and says what makes the host known.

## A dead audio device is visible

`PcmPlayer` noticed a device that died mid-stream, but the only witness was a trace behind a system property that is off by default: the session went mute while the switch still read "Sound: on". The state now reaches the session panel, which says the device stopped and what to do. A device that was playing and then will not reopen for a new format counts too; a device that never opened at all does not — nothing was playing, every block retries, and an alarm on the first block of a session with no output device would be a false one.

Reported as a state, so a device that takes blocks again clears the line instead of leaving a stale warning.

## A runbook step that can never report says so

A step whose marker will never arrive — an unterminated here-doc or quote leaves the shell at its continuation prompt, `exec` replaces the shell that would print it, a non-POSIX shell never had `$?` — looks exactly like a step still working, and the run waits on it until someone notices.

The watcher now also tracks whether the terminal is printing. No new output for two minutes and no marker marks the step in the panel with what it means and where to look. It never ends the step: `sleep 3600` and a silent migration are indistinguishable from here, so the decision stays the user's, and the mark clears the moment output resumes or the step reports. Only the tail's length and hash are carried between polls, never its text — a resolved step line can hold a vault secret and the run stores none.

## Verification

`./gradlew test allTests`, `./gradlew build` with lint, `./gradlew detektAll` and `:androidApp:compileDebugKotlin` all green. New UI strings in en, ru and zh.

Not verified live: none of the three was reproduced against a real host. To see them, refuse a tunnel to a host missing from `known_hosts`; pull the audio device during an RDP session with sound; run a runbook step of `cat <<EOF` with no terminator and wait two minutes.
