### PR TITLE
RDP: image quality in the profile, no AI policy on remote desktops

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -165,6 +165,12 @@
     <string name="conn_clipboard_share_desc">Текст, скопированный на любой стороне, доступен на другой, пока открыта сессия.</string>
     <string name="conn_audio_output_device">Устройство вывода</string>
     <string name="conn_audio_device_default">Системное по умолчанию</string>
+    <!-- RDP image quality (profile setting: RDP settles the picture at connect time) -->
+    <string name="conn_field_image_quality">Качество изображения</string>
+    <string name="conn_image_quality_low_desc">Без обоев, тем, анимаций и эффектов курсора.</string>
+    <string name="conn_image_quality_medium_desc">Без обоев, тем и анимаций.</string>
+    <string name="conn_image_quality_high_desc">Полный рабочий стол, сглаживание шрифтов и композиция.</string>
+    <string name="conn_image_quality_note">Применяется при подключении: RDP фиксирует это на всю сессию.</string>
     <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
     <string name="conn_err_hostkey_changed">Ключ хоста изменился. Разберитесь в «Известных хостах».</string>
     <string name="conn_err_hostkey_untrusted">Ключ хоста ещё не доверенный. Подключитесь раз терминалом или добавьте его CA в «Известных хостах».</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -165,6 +165,12 @@
     <string name="conn_clipboard_share_desc">会话打开期间，任一侧复制的文本都可在另一侧使用。</string>
     <string name="conn_audio_output_device">输出设备</string>
     <string name="conn_audio_device_default">系统默认</string>
+    <!-- RDP image quality (profile setting: RDP settles the picture at connect time) -->
+    <string name="conn_field_image_quality">画质</string>
+    <string name="conn_image_quality_low_desc">无壁纸、主题、动画和光标效果。</string>
+    <string name="conn_image_quality_medium_desc">无壁纸、主题和动画。</string>
+    <string name="conn_image_quality_high_desc">完整桌面、字体平滑与桌面合成。</string>
+    <string name="conn_image_quality_note">在连接时生效，RDP 会将其固定为整个会话的设置。</string>
     <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
     <string name="conn_err_hostkey_changed">主机密钥已更改。请在「已知主机」中处理。</string>
     <string name="conn_err_hostkey_untrusted">主机密钥尚未受信任。请先用终端连接一次，或在「已知主机」中添加其 CA。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -165,6 +165,12 @@
     <string name="conn_clipboard_share_desc">Text copied on either side becomes available on the other, for as long as the session is open.</string>
     <string name="conn_audio_output_device">Output device</string>
     <string name="conn_audio_device_default">System default</string>
+    <!-- RDP image quality (profile setting: RDP settles the picture at connect time) -->
+    <string name="conn_field_image_quality">Image quality</string>
+    <string name="conn_image_quality_low_desc">No wallpaper, themes, animations or cursor effects.</string>
+    <string name="conn_image_quality_medium_desc">No wallpaper, themes or animations.</string>
+    <string name="conn_image_quality_high_desc">Full desktop, font smoothing and composition.</string>
+    <string name="conn_image_quality_note">Applied when the session connects; RDP fixes it for the whole session.</string>
     <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
     <string name="conn_err_hostkey_changed">Host key changed. Resolve it in Known hosts.</string>
     <string name="conn_err_hostkey_untrusted">Host key not trusted yet. Connect once from a terminal, or add its CA in Known hosts.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -489,6 +489,7 @@ fun DesktopDesignApp(
                                     audioOutput = request.audioOutput,
                                     audioDeviceId = request.audioDeviceId,
                                     clipboard = request.clipboard,
+                                    imageQuality = request.imageQuality,
                                 ),
                                 app.skerry.shared.rdp.RdpCredentials(
                                     username = request.user,
@@ -723,6 +724,7 @@ private fun DesktopChrome(
                 audioOutput = host.rdp?.audioOutput == true,
                 audioDeviceId = host.rdp?.audioOutputDeviceId.orEmpty(),
                 clipboard = host.rdp?.clipboard != false,
+                imageQuality = host.rdp?.quality ?: app.skerry.shared.rdp.RdpImageQuality.DEFAULT,
             ),
             remoteResize = host.vncResizeToWindow,
             onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.container.ContainerRuntime
 import app.skerry.shared.container.ContainerSpec
 import app.skerry.shared.host.Host
 import app.skerry.shared.host.normalizeNotes
+import app.skerry.shared.rdp.RdpImageQuality
 import app.skerry.shared.rdp.RdpSpec
 import app.skerry.shared.tag.MAX_TAGS_PER_RECORD
 import app.skerry.shared.tag.normalizeTag
@@ -146,6 +147,12 @@ class NewConnectionFormState {
 
     /** Share the clipboard with the session, both ways (MS-RDPECLIP). On, as every client has it. */
     var rdpClipboard: Boolean by mutableStateOf(true)
+
+    /**
+     * How much of the remote desktop the server is asked to draw. A profile setting because RDP
+     * settles the picture at connect time (see [app.skerry.shared.rdp.RdpImageQuality]).
+     */
+    var rdpQuality: RdpImageQuality by mutableStateOf(RdpImageQuality.DEFAULT)
 
     /**
      * The farm routing token of an imported `.rdp` profile. Not editable — no user types one — but
@@ -313,6 +320,7 @@ class NewConnectionFormState {
         audioOutput = rdpAudioOutput,
         audioOutputDeviceId = if (rdpAudioOutput) rdpAudioDeviceId else "",
         clipboard = rdpClipboard,
+        quality = rdpQuality,
     )
 
     companion object {
@@ -361,6 +369,7 @@ class NewConnectionFormState {
                 rdpAudioOutput = spec.audioOutput
                 rdpAudioDeviceId = spec.audioOutputDeviceId
                 rdpClipboard = spec.clipboard
+                rdpQuality = spec.quality
             }
             host.container?.let { spec ->
                 containerRuntime = spec.runtime

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -61,6 +61,7 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isRdp
+import app.skerry.shared.ssh.hasAiPolicy
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.connection.ContainerBrowseController
@@ -104,6 +105,7 @@ import app.skerry.ui.generated.resources.conn_duplicate_name
 import app.skerry.ui.generated.resources.conn_field_ai_policy
 import app.skerry.ui.generated.resources.conn_field_audio
 import app.skerry.ui.generated.resources.conn_field_clipboard
+import app.skerry.ui.generated.resources.conn_field_image_quality
 import app.skerry.ui.generated.resources.conn_field_authentication
 import app.skerry.ui.generated.resources.conn_field_baud
 import app.skerry.ui.generated.resources.conn_field_device
@@ -367,6 +369,8 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                     // The session's sound, played on this machine (MS-RDPEA), and where to play it.
                     Field(stringResource(Res.string.conn_field_audio)) { RdpAudioSection(form) }
                     Field(stringResource(Res.string.conn_field_clipboard)) { RdpClipboardSection(form) }
+                    Spacer14()
+                    Field(stringResource(Res.string.conn_field_image_quality)) { RdpQualitySection(form) }
                 }
                 // Container profiles: which container/pod on that host to enter. Sits after auth
                 // because "Browse" dials the host with exactly these credentials.
@@ -457,9 +461,9 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                     )
                 }
                 // AI policy selection is visible when AI is actually available (live controller or feature flag).
-                // Written directly into the form -> host profile (Host.aiPolicy). Not for VNC: a remote
-                // desktop has no shell/terminal for AI to act on.
-                if (!form.connectionType.isVnc && (LocalFeatures.current.ai || LocalAi.current != null)) {
+                // Written directly into the form -> host profile (Host.aiPolicy). Not for a remote
+                // desktop: VNC and RDP have no shell/terminal for AI to act on (see [hasAiPolicy]).
+                if (form.connectionType.hasAiPolicy && (LocalFeatures.current.ai || LocalAi.current != null)) {
                     Spacer14()
                     Field(stringResource(Res.string.conn_field_ai_policy)) {
                         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/RdpQualitySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/RdpQualitySection.kt
@@ -1,0 +1,76 @@
+package app.skerry.ui.host
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.rdp.RdpImageQuality
+import app.skerry.ui.design.DropdownField
+import app.skerry.ui.design.Txt
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_image_quality_high_desc
+import app.skerry.ui.generated.resources.conn_image_quality_low_desc
+import app.skerry.ui.generated.resources.conn_image_quality_medium_desc
+import app.skerry.ui.generated.resources.conn_image_quality_note
+import app.skerry.ui.generated.resources.vnc_quality_high
+import app.skerry.ui.generated.resources.vnc_quality_low
+import app.skerry.ui.generated.resources.vnc_quality_medium
+
+/**
+ * Image quality of an RDP profile: how much of the remote desktop the server is asked to draw.
+ *
+ * A profile setting rather than a control beside the live picture — RDP settles this in the Client
+ * Info PDU and holds it for the session, so the note under the picker says when the choice lands
+ * rather than letting the user wonder why the desktop did not change.
+ *
+ * Shared by the desktop modal and the mobile sheet, like [RdpAudioSection].
+ */
+@Composable
+fun RdpQualitySection(form: NewConnectionFormState) {
+    Column(Modifier.fillMaxWidth()) {
+        DropdownField(
+            value = form.rdpQuality,
+            options = RdpImageQuality.entries,
+            label = { it.qualityLabel() },
+            onPick = { form.rdpQuality = it },
+        )
+        Txt(
+            form.rdpQuality.qualityDescription(),
+            color = Skerry.colors.dim,
+            size = 11.sp,
+            lineHeight = 15.sp,
+            modifier = Modifier.padding(top = 6.dp),
+        )
+        Txt(
+            stringResource(Res.string.conn_image_quality_note),
+            color = Skerry.colors.faint,
+            size = 11.sp,
+            lineHeight = 15.sp,
+            modifier = Modifier.padding(top = 3.dp),
+        )
+    }
+}
+
+/** The level names are the ones the VNC quality menu already uses — same three words. */
+@Composable
+private fun RdpImageQuality.qualityLabel(): String = stringResource(
+    when (this) {
+        RdpImageQuality.Low -> Res.string.vnc_quality_low
+        RdpImageQuality.Medium -> Res.string.vnc_quality_medium
+        RdpImageQuality.High -> Res.string.vnc_quality_high
+    },
+)
+
+@Composable
+private fun RdpImageQuality.qualityDescription(): String = stringResource(
+    when (this) {
+        RdpImageQuality.Low -> Res.string.conn_image_quality_low_desc
+        RdpImageQuality.Medium -> Res.string.conn_image_quality_medium_desc
+        RdpImageQuality.High -> Res.string.conn_image_quality_high_desc
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -185,6 +185,7 @@ fun MobileDesignApp(
                             audioOutput = request.audioOutput,
                             audioDeviceId = request.audioDeviceId,
                             clipboard = request.clipboard,
+                            imageQuality = request.imageQuality,
                         ),
                         app.skerry.shared.rdp.RdpCredentials(
                             username = request.user,
@@ -733,6 +734,7 @@ private fun openMobileRdp(
             audioOutput = host.rdp?.audioOutput == true,
             audioDeviceId = host.rdp?.audioOutputDeviceId.orEmpty(),
             clipboard = host.rdp?.clipboard != false,
+            imageQuality = host.rdp?.quality ?: app.skerry.shared.rdp.RdpImageQuality.DEFAULT,
         ),
         remoteResize = host.vncResizeToWindow,
         onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -52,6 +52,7 @@ import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth
+import app.skerry.shared.ssh.hasAiPolicy
 import app.skerry.shared.ssh.isRdp
 import app.skerry.shared.ssh.isVnc
 import app.skerry.ui.host.HostSection
@@ -105,6 +106,7 @@ import app.skerry.ui.generated.resources.conn_field_notes
 import app.skerry.ui.generated.resources.conn_field_tags
 import app.skerry.ui.generated.resources.conn_notes_placeholder
 import app.skerry.ui.generated.resources.conn_field_domain
+import app.skerry.ui.generated.resources.conn_field_image_quality
 import app.skerry.ui.generated.resources.conn_field_username
 import app.skerry.ui.generated.resources.conn_group_delete
 import app.skerry.ui.generated.resources.conn_group_new
@@ -356,6 +358,10 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                     app.skerry.ui.host.RdpClipboardSection(form)
                 }
                 Spacer(Modifier.height(14.dp))
+                MobileFormField(stringResource(Res.string.conn_field_image_quality)) {
+                    app.skerry.ui.host.RdpQualitySection(form)
+                }
+                Spacer(Modifier.height(14.dp))
             } else if (form.connectionType.isVnc) {
                 // VNC: a password (no username), plus the RFB port. No jump host / keep-alive.
                 MobileFormField(stringResource(Res.string.conn_field_port), Modifier.width(120.dp)) {
@@ -435,8 +441,8 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                 )
             }
 
-            // AI policy: not for VNC (a remote desktop has no shell for AI to act on).
-            if (!form.connectionType.isVnc && (LocalFeatures.current.ai || LocalAi.current != null)) {
+            // AI policy: not for a remote desktop (VNC and RDP have no shell for AI to act on).
+            if (form.connectionType.hasAiPolicy && (LocalFeatures.current.ai || LocalAi.current != null)) {
                 Spacer(Modifier.height(14.dp))
                 MobileFormField(stringResource(Res.string.conn_field_ai_policy_short)) { AiPolicyPills(form) }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RdpConnectRequest.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RdpConnectRequest.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.remote
 
+import app.skerry.shared.rdp.RdpImageQuality
+
 /**
  * What an RDP tab needs to dial, resolved from the host profile and the vault before the tab opens.
  *
@@ -24,6 +26,8 @@ data class RdpConnectRequest(
     val audioDeviceId: String = "",
     /** Share the clipboard with the session, in both directions (the profile's setting). */
     val clipboard: Boolean = true,
+    /** How much of the desktop to ask for; fixed for the session once the connection is made. */
+    val imageQuality: RdpImageQuality = RdpImageQuality.DEFAULT,
 ) {
     /** The domain half of `DOMAIN\user`, or empty when the name carries none. */
     val domain: String get() = username.substringBefore('\\', missingDelimiterValue = "")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -171,6 +171,26 @@ class NewConnectionFormStateTest {
     }
 
     @Test
+    fun rdp_image_quality_travels_into_the_draft_and_back_out_of_the_profile() {
+        val f = NewConnectionFormState().apply { name = "desk"; address = "10.0.0.9"; username = "admin" }
+        f.chooseConnectionType(app.skerry.shared.ssh.ConnectionType.RDP)
+        // The default is the picture every RDP session had before the profile could choose, so an
+        // untouched form still saves no RDP settings at all.
+        assertEquals(app.skerry.shared.rdp.RdpImageQuality.Medium, f.rdpQuality)
+        assertNull(f.toDraft().rdp)
+
+        f.rdpQuality = app.skerry.shared.rdp.RdpImageQuality.High
+        assertEquals(app.skerry.shared.rdp.RdpImageQuality.High, checkNotNull(f.toDraft().rdp).quality)
+
+        val host = Host(
+            "1", "desk", "10.0.0.9", 3389, "admin",
+            connectionType = app.skerry.shared.ssh.ConnectionType.RDP,
+            rdp = app.skerry.shared.rdp.RdpSpec(quality = app.skerry.shared.rdp.RdpImageQuality.Low),
+        )
+        assertEquals(app.skerry.shared.rdp.RdpImageQuality.Low, NewConnectionFormState.fromHost(host).rdpQuality)
+    }
+
+    @Test
     fun rdp_form_carries_the_farm_routing_token_it_was_prefilled_with() {
         // The token isn't editable (it comes from an imported .rdp file), but the form is what hands
         // the profile's RDP settings back on save — dropping it would send the next connection to an

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientInfo.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientInfo.kt
@@ -39,12 +39,6 @@ object ClientInfo {
     /** Extended info is mandatory for RDP 5+ servers; the address family says which form it takes. */
     private const val ADDRESS_FAMILY_INET = 0x0002
 
-    /** TS_EXTENDED_INFO_PACKET::performanceFlags (2.2.1.11.1.1.1). */
-    private const val PERF_DISABLE_WALLPAPER = 0x00000001
-    private const val PERF_DISABLE_FULLWINDOWDRAG = 0x00000002
-    private const val PERF_DISABLE_MENUANIMATIONS = 0x00000004
-    private const val PERF_DISABLE_THEMING = 0x00000008
-
     /** ANSI code page 0 means "use the one implied by the Unicode flag". */
     private const val CODE_PAGE_DEFAULT = 0
 
@@ -56,14 +50,14 @@ object ClientInfo {
      * render audio at all — a server that hears that flag keeps the sound channel shut whatever the
      * client asked for, which is exactly what a session nobody listens to should cost.
      *
-     * [performanceOptimizations] turns off wallpaper, drag rendering, menu animations and theming —
-     * everything that costs bandwidth without carrying information. It is on by default because the
-     * alternative is a client that feels slow on exactly the links people use RDP over.
+     * [quality] is the profile's picture: which of the desktop's decoration the server is asked to
+     * draw ([RdpImageQuality.performanceFlags]). It is settled here and nowhere else — the server
+     * holds it for the life of the session.
      */
     fun pdu(
         logon: RdpLogonInfo,
         audioPlayback: Boolean = false,
-        performanceOptimizations: Boolean = true,
+        quality: RdpImageQuality = RdpImageQuality.DEFAULT,
     ): ByteArray {
         val writer = RdpWriter(512)
         RdpSecurityHeader.write(writer, RdpSecurityHeader.SEC_INFO_PKT)
@@ -94,14 +88,7 @@ object ClientInfo {
         writer.u16le(2).u16le(0) // cbClientDir + terminator
         writeTimeZone(writer)
         writer.u32le(0) // clientSessionId, ignored by the server
-        writer.u32le(
-            if (performanceOptimizations) {
-                PERF_DISABLE_WALLPAPER or PERF_DISABLE_FULLWINDOWDRAG or
-                    PERF_DISABLE_MENUANIMATIONS or PERF_DISABLE_THEMING
-            } else {
-                0
-            },
-        )
+        writer.u32le(quality.performanceFlags)
         writer.u16le(0) // cbAutoReconnectCookie
         return writer.toByteArray()
     }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpClientSettings.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpClientSettings.kt
@@ -26,6 +26,8 @@ data class RdpClientSettings(
     val wantsGraphicsPipeline: Boolean = true,
     /** Session a redirection told us to rejoin (see [RdpTarget.redirectedSessionId]); 0 if none. */
     val redirectedSessionId: Int = 0,
+    /** How much of the desktop the server is asked to draw; goes into the Client Info PDU. */
+    val imageQuality: RdpImageQuality = RdpImageQuality.DEFAULT,
 ) {
     init {
         require(desktopWidth in MIN_DIMENSION..MAX_DIMENSION) { "desktop width out of range" }
@@ -56,3 +58,31 @@ data class RdpClientSettings(
         const val CHANNEL_AUDIO = "rdpsnd"
     }
 }
+
+/**
+ * The settings a connection to this target asks for, once the negotiation has settled
+ * [selectedProtocol] and the platform has said whether it managed to open an output device
+ * ([audioOpened]).
+ *
+ * Lives here rather than inside the transport because it is a field-by-field copy of everything the
+ * profile can decide — the one place where a forgotten line would ship a default nobody chose.
+ */
+fun RdpTarget.clientSettings(selectedProtocol: Int, audioOpened: Boolean): RdpClientSettings =
+    RdpClientSettings(
+        desktopWidth = desktopWidth,
+        desktopHeight = desktopHeight,
+        clientName = clientName,
+        selectedProtocol = selectedProtocol,
+        keyboardLayout = keyboardLayout,
+        redirectedSessionId = redirectedSessionId,
+        wantsGraphicsPipeline = graphicsPipeline,
+        imageQuality = imageQuality,
+        channels = buildList {
+            if (clipboard) add(RdpClientSettings.CHANNEL_CLIPBOARD)
+            if (audioOpened) add(RdpClientSettings.CHANNEL_AUDIO)
+            // The dynamic channel carries the graphics pipeline, the display control channel and the
+            // audio a modern host prefers to send that way; without it the server has no way to open
+            // any of them, which is the point of leaving it out.
+            if (graphicsPipeline || dynamicResize || audioOpened) add(RdpClientSettings.CHANNEL_DYNAMIC)
+        },
+    )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpConnect.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpConnect.kt
@@ -49,7 +49,11 @@ class RdpConnectionSequence(
                 serverData.ioChannelId,
                 // The sound channel being in the request is what makes audio wanted; the flag inside
                 // the Client Info PDU has to agree, or the server keeps the channel shut.
-                ClientInfo.pdu(logon, audioPlayback = settings.channels.contains(RdpClientSettings.CHANNEL_AUDIO)),
+                ClientInfo.pdu(
+                    logon,
+                    audioPlayback = settings.channels.contains(RdpClientSettings.CHANNEL_AUDIO),
+                    quality = settings.imageQuality,
+                ),
             ),
         )
         awaitLicensing(userId, serverData.ioChannelId)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpImageQuality.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpImageQuality.kt
@@ -1,0 +1,56 @@
+package app.skerry.shared.rdp
+
+import kotlinx.serialization.Serializable
+
+/**
+ * How much of the remote desktop the session asks the server to draw.
+ *
+ * RDP settles this once, in the Client Info PDU (MS-RDPBCGR 2.2.1.11.1.1.1), and the server holds it
+ * for the life of the session — which is why this belongs to the profile and not to the panel beside
+ * a live picture: a menu there could only take effect on the next connection.
+ *
+ * [Medium] is what every session sent before the profile could choose, so an existing profile keeps
+ * exactly the picture it had.
+ *
+ * Serialized by name (like [app.skerry.shared.ssh.ConnectionType]): enum order does not affect
+ * stored profiles, and a missing field reads as [Medium].
+ */
+@Serializable
+enum class RdpImageQuality {
+    /** Everything decorative off, cursor effects included — for a link where each frame is paid for. */
+    Low,
+
+    /** No wallpaper, window drag, menu animations or theming; the rest of the desktop as it is. */
+    Medium,
+
+    /** The desktop as the user set it up, with font smoothing and composition asked for explicitly. */
+    High,
+
+    ;
+
+    /** TS_EXTENDED_INFO_PACKET::performanceFlags for this level. */
+    val performanceFlags: Int
+        get() = when (this) {
+            Low -> MEDIUM_FLAGS or PERF_DISABLE_CURSOR_SHADOW or PERF_DISABLE_CURSORSETTINGS
+            Medium -> MEDIUM_FLAGS
+            High -> PERF_ENABLE_FONT_SMOOTHING or PERF_ENABLE_DESKTOP_COMPOSITION
+        }
+
+    companion object {
+        /** MS-RDPBCGR 2.2.1.11.1.1.1. */
+        private const val PERF_DISABLE_WALLPAPER = 0x00000001
+        private const val PERF_DISABLE_FULLWINDOWDRAG = 0x00000002
+        private const val PERF_DISABLE_MENUANIMATIONS = 0x00000004
+        private const val PERF_DISABLE_THEMING = 0x00000008
+        private const val PERF_DISABLE_CURSOR_SHADOW = 0x00000020
+        private const val PERF_DISABLE_CURSORSETTINGS = 0x00000040
+        private const val PERF_ENABLE_FONT_SMOOTHING = 0x00000080
+        private const val PERF_ENABLE_DESKTOP_COMPOSITION = 0x00000100
+
+        private const val MEDIUM_FLAGS = PERF_DISABLE_WALLPAPER or PERF_DISABLE_FULLWINDOWDRAG or
+            PERF_DISABLE_MENUANIMATIONS or PERF_DISABLE_THEMING
+
+        /** What a profile that never chose gets: the picture this client has always asked for. */
+        val DEFAULT = Medium
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSpec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSpec.kt
@@ -18,6 +18,10 @@ import kotlinx.serialization.Serializable
  * no use for it. [audioOutputDeviceId] names the device to play on, as
  * [app.skerry.shared.audio.AudioOutputs] lists them; empty means the system default, and so does a
  * device that has since been unplugged.
+ *
+ * [quality] is how much of the remote desktop the server is asked to draw. It lives on the profile
+ * rather than in the live session's panel because RDP settles the picture in the Client Info PDU and
+ * keeps it for the whole session (see [RdpImageQuality]).
  */
 @Serializable
 data class RdpSpec(
@@ -25,8 +29,10 @@ data class RdpSpec(
     val audioOutput: Boolean = false,
     val audioOutputDeviceId: String = "",
     val clipboard: Boolean = true,
+    val quality: RdpImageQuality = RdpImageQuality.DEFAULT,
 ) {
     /** Whether anything here is worth storing; an all-default spec is dropped to `null`. */
     val isEmpty: Boolean
-        get() = loadBalanceInfo.isBlank() && !audioOutput && audioOutputDeviceId.isBlank() && clipboard
+        get() = loadBalanceInfo.isBlank() && !audioOutput && audioOutputDeviceId.isBlank() &&
+            clipboard && quality == RdpImageQuality.DEFAULT
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpTransport.kt
@@ -56,6 +56,11 @@ data class RdpTarget(
      */
     val audioDeviceId: String = "",
     /**
+     * How much of the desktop to ask the server to draw (see [RdpSpec.quality]). Part of the target
+     * because RDP settles it during the connection sequence and never revisits it.
+     */
+    val imageQuality: RdpImageQuality = RdpImageQuality.DEFAULT,
+    /**
      * A Remote Desktop farm's routing token (see [RdpSpec.loadBalanceInfo]); empty for a plain host.
      * It goes into the X.224 Connection Request, before anything is encrypted, so the connection
      * broker can route this connection to the collection the profile came from.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
@@ -76,6 +76,14 @@ val ConnectionType.isRemoteDesktop: Boolean
     }
 
 /**
+ * Whether a per-profile AI policy applies. The assistant reads a terminal and writes commands into
+ * it; a remote desktop has neither, so both connection forms leave the policy picker out rather than
+ * store a choice that decides nothing.
+ */
+val ConnectionType.hasAiPolicy: Boolean
+    get() = !isRemoteDesktop
+
+/**
  * Whether the profile is an RDP remote desktop. Unlike VNC it authenticates with a *user name* and
  * password (and optionally a domain, written into the user name as `DOMAIN\user` rather than stored
  * as its own field — that is the form every RDP client accepts and the one users already type), so

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/ClientInfoTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/ClientInfoTest.kt
@@ -4,8 +4,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * The Client Info PDU (MS-RDPBCGR 2.2.1.11.1.1). What matters here is the audio bit: a server that
- * hears INFO_NOAUDIOPLAYBACK never opens the sound channel, however the client asked for it.
+ * The Client Info PDU (MS-RDPBCGR 2.2.1.11.1.1) settles two things for the whole session. The audio
+ * bit: a server that hears INFO_NOAUDIOPLAYBACK never opens the sound channel, however the client
+ * asked for it. And the performance flags: how much of the desktop the server bothers to draw.
  */
 class ClientInfoTest {
 
@@ -19,11 +20,51 @@ class ClientInfoTest {
         assertEquals(0, flagsOf(ClientInfo.pdu(logon, audioPlayback = true)) and INFO_NOAUDIOPLAYBACK)
     }
 
+    @Test
+    fun `the default quality is what the client has always sent`() {
+        // Medium is the behaviour every session had before the profile could choose: wallpaper,
+        // window drag, menu animations and theming off, nothing switched back on.
+        assertEquals(
+            PERF_DISABLE_WALLPAPER or PERF_DISABLE_FULLWINDOWDRAG or PERF_DISABLE_MENUANIMATIONS or
+                PERF_DISABLE_THEMING,
+            performanceFlagsOf(ClientInfo.pdu(logon)),
+        )
+        assertEquals(performanceFlagsOf(ClientInfo.pdu(logon)), performanceFlagsOf(ClientInfo.pdu(logon, quality = RdpImageQuality.Medium)))
+    }
+
+    @Test
+    fun `low quality also drops the cursor effects`() {
+        val flags = performanceFlagsOf(ClientInfo.pdu(logon, quality = RdpImageQuality.Low))
+        assertEquals(
+            PERF_DISABLE_WALLPAPER or PERF_DISABLE_FULLWINDOWDRAG or PERF_DISABLE_MENUANIMATIONS or
+                PERF_DISABLE_THEMING or PERF_DISABLE_CURSOR_SHADOW or PERF_DISABLE_CURSORSETTINGS,
+            flags,
+        )
+    }
+
+    @Test
+    fun `high quality asks for the full desktop back`() {
+        val flags = performanceFlagsOf(ClientInfo.pdu(logon, quality = RdpImageQuality.High))
+        assertEquals(PERF_ENABLE_FONT_SMOOTHING or PERF_ENABLE_DESKTOP_COMPOSITION, flags)
+    }
+
     /** TS_INFO_PACKET::flags, past the security header and the code page. */
     private fun flagsOf(pdu: ByteArray): Int = RdpReader(pdu).apply { skip(8) }.u32le()
+
+    private fun performanceFlagsOf(pdu: ByteArray): Int =
+        readPerformanceFlags(RdpReader(pdu).apply { skip(4) }) // past the security header
 
     private companion object {
         val logon = RdpLogonInfo(domain = "CORP", username = "elton")
         const val INFO_NOAUDIOPLAYBACK = 0x08000000
+
+        const val PERF_DISABLE_WALLPAPER = 0x00000001
+        const val PERF_DISABLE_FULLWINDOWDRAG = 0x00000002
+        const val PERF_DISABLE_MENUANIMATIONS = 0x00000004
+        const val PERF_DISABLE_THEMING = 0x00000008
+        const val PERF_DISABLE_CURSOR_SHADOW = 0x00000020
+        const val PERF_DISABLE_CURSORSETTINGS = 0x00000040
+        const val PERF_ENABLE_FONT_SMOOTHING = 0x00000080
+        const val PERF_ENABLE_DESKTOP_COMPOSITION = 0x00000100
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpClientSettingsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpClientSettingsTest.kt
@@ -1,0 +1,85 @@
+package app.skerry.shared.rdp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What the transport tells the server about the session it wants, derived from the profile's target.
+ *
+ * Worth a test of its own because it is a field-by-field copy: every option a profile can set passes
+ * through here on its way to the wire, and a line left behind would ship a default no one asked for
+ * with nothing to notice it.
+ */
+class RdpClientSettingsTest {
+
+    private val target = RdpTarget(
+        host = "rds.example.com",
+        desktopWidth = 1600,
+        desktopHeight = 900,
+        clientName = "SKERRY",
+        keyboardLayout = 0x419,
+        imageQuality = RdpImageQuality.High,
+        redirectedSessionId = 42,
+    )
+
+    @Test
+    fun `every option of the profile reaches the settings`() {
+        val settings = target.clientSettings(RdpSecurityProtocol.HYBRID, audioOpened = false)
+
+        assertEquals(1600, settings.desktopWidth)
+        assertEquals(900, settings.desktopHeight)
+        assertEquals("SKERRY", settings.clientName)
+        assertEquals(RdpSecurityProtocol.HYBRID, settings.selectedProtocol)
+        assertEquals(0x419, settings.keyboardLayout)
+        assertEquals(42, settings.redirectedSessionId)
+        assertEquals(RdpImageQuality.High, settings.imageQuality)
+        assertTrue(settings.wantsGraphicsPipeline)
+    }
+
+    @Test
+    fun `the protocol comes from the negotiation, not from the profile`() {
+        // The server picks it; echoing back anything else is what the server drops the connection on.
+        val settings = target.clientSettings(RdpSecurityProtocol.SSL, audioOpened = false)
+
+        assertEquals(RdpSecurityProtocol.SSL, settings.selectedProtocol)
+    }
+
+    @Test
+    fun `a channel is asked for only when something will speak on it`() {
+        val plain = target.copy(clipboard = false, graphicsPipeline = false, dynamicResize = false)
+            .clientSettings(RdpSecurityProtocol.SSL, audioOpened = false)
+        assertEquals(emptyList<String>(), plain.channels)
+
+        val full = target.clientSettings(RdpSecurityProtocol.SSL, audioOpened = true)
+        assertEquals(
+            listOf(
+                RdpClientSettings.CHANNEL_CLIPBOARD,
+                RdpClientSettings.CHANNEL_AUDIO,
+                RdpClientSettings.CHANNEL_DYNAMIC,
+            ),
+            full.channels,
+        )
+    }
+
+    @Test
+    fun `sound the device refused to play is not asked for on the wire`() {
+        // The profile wanting audio is not enough: with no device open there is nothing to render
+        // it here, and a channel the client never reads would cost bandwidth for every beep.
+        val settings = target.clientSettings(RdpSecurityProtocol.SSL, audioOpened = false)
+
+        assertFalse(RdpClientSettings.CHANNEL_AUDIO in settings.channels)
+    }
+
+    @Test
+    fun `resizing alone still opens the dynamic channel the display control rides`() {
+        val settings = target.copy(graphicsPipeline = false, dynamicResize = true)
+            .clientSettings(RdpSecurityProtocol.SSL, audioOpened = false)
+
+        assertTrue(RdpClientSettings.CHANNEL_DYNAMIC in settings.channels)
+        // A profile that turned the pipeline off must not still advertise MS-RDPEGFX in the GCC
+        // data: both sides default to true, so a dropped mapping would be invisible otherwise.
+        assertFalse(settings.wantsGraphicsPipeline)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpConnectTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpConnectTest.kt
@@ -107,6 +107,23 @@ class RdpConnectTest {
     }
 
     @Test
+    fun `the profile's image quality reaches the server in the Client Info PDU`() = runTest {
+        // The picture is settled here and nowhere else: a quality that stops at the settings object
+        // would leave the profile's choice with nothing to act on.
+        val server = ModelServer()
+
+        RdpConnectionSequence(
+            server.source,
+            server.sink,
+            settings.copy(imageQuality = RdpImageQuality.High),
+            logon,
+            FakeLicenseCrypto,
+        ).run()
+
+        assertEquals(PERF_ENABLE_FONT_SMOOTHING or PERF_ENABLE_DESKTOP_COMPOSITION, server.clientInfoPerformanceFlags)
+    }
+
+    @Test
     fun `a channel the server confirms as a different id fails the connection`() = runTest {
         val server = ModelServer(misconfirmChannel = true)
 
@@ -144,6 +161,10 @@ class RdpConnectTest {
         var confirmedShareId = 0
             private set
         var sawLicenseRequest = false
+            private set
+
+        /** What the client asked the session to look like (TS_EXTENDED_INFO_PACKET). */
+        var clientInfoPerformanceFlags = 0
             private set
 
         val source = RdpSource { dst, offset, len ->
@@ -193,6 +214,7 @@ class RdpConnectTest {
             // tell them apart, exactly as they do for the client reading the other direction.
             if (first == 0x40 || first == 0x80) {
                 body.skip(4)
+                if (first == 0x40) clientInfoPerformanceFlags = readPerformanceFlags(body)
                 if (first == 0x80) {
                     // The client's new-licence request: answer as a server with nothing to license.
                     sawLicenseRequest = true
@@ -427,6 +449,8 @@ class RdpConnectTest {
         const val LICENSE_ERROR_TYPE = 0xFF
         const val LICENSE_REQUEST_TYPE = 0x01
         const val REDIRECTED_SESSION_ID = 0x0000002A
+        const val PERF_ENABLE_FONT_SMOOTHING = 0x00000080
+        const val PERF_ENABLE_DESKTOP_COMPOSITION = 0x00000100
 
         /** The order the client joins: user channel, I/O channel, then the virtual channels. */
         val CHANNELS = intArrayOf(1007, 1003, 1004, 1005)

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpSpecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpSpecTest.kt
@@ -1,0 +1,39 @@
+package app.skerry.shared.rdp
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * What a stored RDP profile promises across versions: a record written before a field existed still
+ * loads, and the quality travels as its name rather than its position in the enum.
+ */
+class RdpSpecTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `a profile saved before the quality setting keeps the picture it had`() {
+        val stored = """{"loadBalanceInfo":"tsv://x","audioOutput":true}"""
+
+        val spec = json.decodeFromString(RdpSpec.serializer(), stored)
+
+        assertEquals(RdpImageQuality.Medium, spec.quality)
+    }
+
+    @Test
+    fun `the quality is stored by name, so reordering the enum cannot repaint a profile`() {
+        val encoded = json.encodeToString(RdpSpec.serializer(), RdpSpec(quality = RdpImageQuality.High))
+
+        assertTrue(encoded.contains("\"quality\":\"High\""), encoded)
+        assertEquals(RdpImageQuality.High, json.decodeFromString(RdpSpec.serializer(), encoded).quality)
+    }
+
+    @Test
+    fun `only a non-default quality makes a spec worth storing`() {
+        assertTrue(RdpSpec().isEmpty)
+        assertFalse(RdpSpec(quality = RdpImageQuality.Low).isEmpty)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpTestBytes.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/RdpTestBytes.kt
@@ -24,3 +24,19 @@ fun RdpReader.utf16le(byteCount: Int): String = buildString {
 /** Read [byteCount] bytes of a fixed-size ASCII field (virtual channel names) without its padding. */
 fun RdpReader.ascii(byteCount: Int): String =
     bytes(byteCount).takeWhile { it.toInt() != 0 }.toByteArray().decodeToString()
+
+/**
+ * TS_EXTENDED_INFO_PACKET::performanceFlags of a Client Info PDU, from a reader standing on the code
+ * page field — that is, right after the security header. Every field before the flags is variable
+ * length, so this walks them rather than counting a fixed offset.
+ */
+fun readPerformanceFlags(reader: RdpReader): Int {
+    reader.skip(8) // codePage, flags
+    val lengths = List(5) { reader.u16le() } // domain, username, password, shell, working directory
+    lengths.forEach { reader.skip(it + 2) } // each cb* excludes the terminator the string carries
+    reader.skip(2) // clientAddressFamily
+    repeat(2) { reader.skip(reader.u16le()) } // clientAddress, clientDir, each behind its own length
+    reader.skip(172) // TS_TIME_ZONE_INFORMATION
+    reader.skip(4) // clientSessionId
+    return reader.u32le()
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
@@ -34,6 +34,17 @@ class ConnectionTypeTest {
     }
 
     @Test
+    fun `VNC and RDP are exactly the transports without an AI policy`() {
+        // Both connection forms gate the policy picker on this; a remote desktop has no shell for
+        // the assistant to read or act on. Named rather than derived from isRemoteDesktop, so a
+        // rewrite that forgets RDP fails here instead of restating itself.
+        assertEquals(
+            setOf(ConnectionType.VNC, ConnectionType.RDP),
+            ConnectionType.entries.filterNot { it.hasAiPolicy }.toSet(),
+        )
+    }
+
+    @Test
     fun `a remote desktop never authenticates over ssh`() {
         // Remote-desktop profiles have no username/key/jump host; the forms gate on this.
         ConnectionType.entries.filter { it.isRemoteDesktop }.forEach {

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -108,26 +108,7 @@ class RdpTcpTransport(
                 val networkLevelAuth = connection.selectedProtocol == RdpSecurityProtocol.HYBRID
                 if (networkLevelAuth) authenticate(connection, target, credentials)
 
-                val settings = RdpClientSettings(
-                    desktopWidth = target.desktopWidth,
-                    desktopHeight = target.desktopHeight,
-                    clientName = target.clientName,
-                    selectedProtocol = connection.selectedProtocol,
-                    keyboardLayout = target.keyboardLayout,
-                    redirectedSessionId = target.redirectedSessionId,
-                    wantsGraphicsPipeline = target.graphicsPipeline,
-                    channels = buildList {
-                        if (target.clipboard) add(RdpClientSettings.CHANNEL_CLIPBOARD)
-                        if (audio != null) add(RdpClientSettings.CHANNEL_AUDIO)
-                        // The dynamic channel carries the graphics pipeline, the display control
-                        // channel and the audio a modern host prefers to send that way; without it
-                        // the server has no way to open any of them, which is the point of leaving
-                        // it out.
-                        if (target.graphicsPipeline || target.dynamicResize || audio != null) {
-                            add(RdpClientSettings.CHANNEL_DYNAMIC)
-                        }
-                    },
-                )
+                val settings = target.clientSettings(connection.selectedProtocol, audioOpened = audio != null)
                 // With NLA the user is already authenticated; sending the password again in the
                 // Client Info PDU would put it on a second path for no gain.
                 val logon = RdpLogonInfo(


### PR DESCRIPTION
## Image quality of an RDP profile

The connection form gains an **Image quality** field for RDP: Low / Medium / High, mapped to the performance flags of the Client Info PDU (MS-RDPBCGR 2.2.1.11.1.1.1).

| Level | What the server is asked to draw |
|---|---|
| Low | No wallpaper, themes, animations or cursor effects |
| Medium | No wallpaper, themes or animations |
| High | Full desktop, font smoothing and desktop composition |

It is a profile setting rather than a control beside the live picture: RDP settles the picture during the connection sequence and holds it for the whole session, so a menu in the session panel could only ever take effect on the next connect. The field says so under the picker.

Medium is what this client has always sent, so existing profiles keep the picture they had, and an untouched form still stores no RDP settings at all (`RdpSpec.isEmpty`). The setting travels with the profile through the vault and sync, serialized by name.

## AI policy on remote desktops

The AI policy picker was hidden for VNC only, so an RDP profile offered a choice that decides nothing — there is no shell for the assistant to read or act on. Both the desktop modal and the mobile sheet now gate on `ConnectionType.hasAiPolicy`, one place instead of two conditions that had already drifted apart.

## Transport seam

`RdpClientSettings` was assembled inline in `RdpTcpTransport` (jvmShared, no tests). It moves to `RdpTarget.clientSettings()` in `commonMain`, so every field a profile can decide — and the virtual-channel list — is covered by a test instead of riding an untested copy.

## Verification

`./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll` and `:androidApp:compileDebugKotlin` all green. Each new test was re-run with its fix reverted and fails there.

Not verified against a live Windows host; the Android build compiles but was not run on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)