### PR TITLE
RDP: restore the cursor from the pointer cache, and clean up the connection forms

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -61,7 +61,9 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth
 import app.skerry.shared.ssh.isRdp
+import app.skerry.shared.serial.SerialPortInfo
 import app.skerry.shared.ssh.hasAiPolicy
+import app.skerry.shared.ssh.hasConnectionTest
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.connection.ContainerBrowseController
@@ -224,7 +226,13 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
     // (behind the vault gate); in mock/preview tester == null and the button is disabled.
     val transport = LocalTestTransport.current
     val testScope = rememberCoroutineScope()
-    val tester = remember(transport, testScope) { transport?.let { ConnectionTestController(it, testScope) } }
+    // The probe is an SSH connect, so the controller exists only where there is one to make: a remote
+    // desktop, Telnet, Serial or a local shell has no test, and with no controller there is no status
+    // to leave stale under a button the form doesn't draw.
+    val showsTest = form.connectionType.hasConnectionTest
+    val tester = remember(transport, testScope, showsTest) {
+        if (showsTest) transport?.let { ConnectionTestController(it, testScope) } else null
+    }
     // On transport change (new tester) or modal close, cancel the old tester's in-flight check,
     // otherwise an orphaned connection probe would keep the network busy until its own timeout.
     DisposableEffect(tester) { onDispose { tester?.reset() } }
@@ -241,9 +249,9 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
         // Testable: the probe connects and answers whatever the server asks, same as a real session.
         AuthMode.INTERACTIVE -> true
     }
-    // "Test connection" needs the SSH auth path (Telnet/Serial have no auth/cipher probe).
-    // For Mosh it probes the SSH hop — the UDP leg is only exercised by a real connect.
-    val canTest = tester != null && form.connectionType.usesSshAuth && hasTestSecret &&
+    // Whether the button can fire: the form still has to name a host, a user and a secret. For Mosh
+    // the probe rides the SSH hop — the UDP leg is only exercised by a real connect.
+    val canTest = tester != null && hasTestSecret &&
         form.address.isNotBlank() && form.username.isNotBlank() && form.portOrNull != null
     // Editing connection/auth fields invalidates the previous test result, it's no longer relevant.
     // A listing belongs to one host/runtime/namespace too — the same edits make it stale.
@@ -325,19 +333,16 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                 val serial = form.connectionType == ConnectionType.SERIAL
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                     Field(if (serial) stringResource(Res.string.conn_field_device) else stringResource(Res.string.conn_field_host_address), Modifier.weight(1f)) {
-                        ModalTextField(
-                            form.address, { form.address = it },
-                            if (serial) "/dev/ttyUSB0 or COM3" else "192.168.1.45 or example.com",
-                            icon = if (serial) "usb" else "dns",
-                        )
+                        if (serial) {
+                            SerialDeviceField(form)
+                        } else {
+                            ModalTextField(form.address, { form.address = it }, "192.168.1.45 or example.com", icon = "dns")
+                        }
                     }
                     Field(if (serial) stringResource(Res.string.conn_field_baud) else stringResource(Res.string.conn_field_port), Modifier.width(110.dp)) {
                         ModalTextField(form.port, { form.port = it }, if (serial) "9600" else "22", keyboardType = KeyboardType.Number)
                     }
                 }
-                // Picker of discovered ports (desktop: jSerialComm, Android: USB-OTG): tapping fills
-                // the Device field. Empty (no adapter / no USB Host) means no chips, manual input remains.
-                if (serial) SerialPortPicker(form)
                 // Auth follows the SSH path (SSH and Mosh): Telnet enters login/password in the
                 // terminal itself, Serial has no auth at all.
                 if (form.connectionType.usesSshAuth) {
@@ -491,26 +496,28 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                     }
                 }
                 CancelButton(stringResource(Res.string.conn_cancel), onClick = state::closeModal)
-                GhostButton(
-                    stringResource(Res.string.conn_test),
-                    onClick = {
-                        // Secret is materialized here (only for the connect's duration), target from form fields.
-                        val auth = formSshAuth(form, credentials)
-                        if (canTest && auth != null) {
-                            when (testJump) {
-                                is JumpChainResolution.Unavailable -> tester.fail(ConnectionTestProblem.Jump(testJump.problem))
-                                is JumpChainResolution.Resolved ->
-                                    tester.test(SshTarget(form.address.trim(), form.portOrNull ?: 22, form.username.trim(), jump = testJump.jump), auth)
+                if (showsTest) {
+                    GhostButton(
+                        stringResource(Res.string.conn_test),
+                        onClick = {
+                            // Secret is materialized here (only for the connect's duration), target from form fields.
+                            val auth = formSshAuth(form, credentials)
+                            if (canTest && auth != null) {
+                                when (testJump) {
+                                    is JumpChainResolution.Unavailable -> tester.fail(ConnectionTestProblem.Jump(testJump.problem))
+                                    is JumpChainResolution.Resolved ->
+                                        tester.test(SshTarget(form.address.trim(), form.portOrNull ?: 22, form.username.trim(), jump = testJump.jump), auth)
+                                }
+                            } else {
+                                // Form isn't ready to dial (missing host/username/credentials): report it as a
+                                // failure so the click isn't a silent no-op.
+                                tester?.fail(ConnectionTestProblem.IncompleteForm)
                             }
-                        } else {
-                            // Form isn't ready to dial (missing host/username/credentials): report it as a
-                            // failure so the click isn't a silent no-op.
-                            tester?.fail(ConnectionTestProblem.IncompleteForm)
-                        }
-                    },
-                    fg = if (canTest) Skerry.colors.text else Skerry.colors.faint,
-                    border = if (canTest) Skerry.colors.lineStrong else Skerry.colors.line,
-                )
+                        },
+                        fg = if (canTest) Skerry.colors.text else Skerry.colors.faint,
+                        border = if (canTest) Skerry.colors.lineStrong else Skerry.colors.line,
+                    )
+                }
                 PrimaryButton(
                     if (editHost != null) stringResource(Res.string.conn_save_changes) else stringResource(Res.string.conn_save),
                     onClick = {
@@ -575,6 +582,8 @@ private fun ModalTextField(
     singleLine: Boolean = true,
     mono: Boolean = false,
     minHeightDp: Int? = null,
+    /** Drawn at the right edge, inside the border — the serial device field hangs its menu arrow here. */
+    trailing: (@Composable () -> Unit)? = null,
 ) {
     val fonts = LocalFonts.current
     val family = if (mono) fonts.mono else fonts.ui
@@ -608,44 +617,72 @@ private fun ModalTextField(
                     if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = fontSize, font = if (mono) fonts.mono else null)
                     inner()
                 }
+                trailing?.invoke()
             }
         },
     )
 }
 
 /**
- * Segmented transport picker (SSH / Telnet / Serial): writes [NewConnectionFormState.connectionType]
- * via [NewConnectionFormState.chooseConnectionType] (which substitutes the default port/speed). Changing
- * the type rebuilds the form (hides auth, changes the address/port labels).
+ * The Serial "Device" field: the port path, typed by hand or picked from the ports discovered on this
+ * machine (desktop: jSerialComm, Android: USB-OTG). Both, rather than either — a port that appeared
+ * after the form opened has to be typeable, and a path nobody remembers has to be pickable. Writes
+ * [NewConnectionFormState.address]; with no ports discovered it is an ordinary text field.
  */
 @Composable
-private fun SerialPortPicker(form: NewConnectionFormState) {
-    // Enumerated once when the form opens (cheap, no permission needed). Empty means nothing rendered.
-    val ports = remember { listSerialPorts() }
-    if (ports.isEmpty()) return
-    FlowRow(
-        Modifier.fillMaxWidth().padding(top = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(6.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        ports.forEach { port ->
-            key(port.systemName) {
-                val selected = form.address == port.systemName
-                Row(
-                    Modifier
-                        .clip(RoundedCornerShape(7.dp))
-                        .background(if (selected) Skerry.colors.cyan14 else Skerry.colors.bg)
-                        .border(1.dp, if (selected) Skerry.colors.cyan else Skerry.colors.cyan14, RoundedCornerShape(7.dp))
-                        .clickable { form.address = port.systemName }
-                        .padding(horizontal = 10.dp, vertical = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(6.dp),
-                ) {
-                    Sym("usb", size = 14.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.faint)
-                    Txt(port.description, color = if (selected) Skerry.colors.text else Skerry.colors.dim, size = 12.sp)
+private fun SerialDeviceField(form: NewConnectionFormState) {
+    // Enumerated once when the form opens (cheap, no permission needed). A machine with no ports —
+    // or a platform without serial support — gets a plain text field, with no arrow to open.
+    val ports = remember { serialPortOptions(listSerialPorts()) }
+    var menuOpen by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = menuOpen && ports.isNotEmpty(),
+        onDismiss = { menuOpen = false },
+        // Focusable so a click anywhere else closes the list: unlike the tag picker this menu is not
+        // typed into, and a non-focusable Popup never gets onDismissRequest — it would hang over the
+        // form while the user moved on to the baud rate. Passed explicitly, not left to the default.
+        focusable = true,
+        trigger = {
+            ModalTextField(
+                form.address, { form.address = it }, "/dev/ttyUSB0 or COM3", icon = "usb",
+                trailing = if (ports.isEmpty()) {
+                    null
+                } else {
+                    {
+                        Sym(
+                            if (menuOpen) "expand_less" else "expand_more",
+                            size = 16.sp,
+                            color = Skerry.colors.faint,
+                            modifier = Modifier.clip(RoundedCornerShape(4.dp)).clickable { menuOpen = !menuOpen },
+                        )
+                    }
+                },
+            )
+        },
+        menu = { width ->
+            SuggestionMenu(width) {
+                ports.forEach { port ->
+                    key(port.systemName) {
+                        SerialPortRow(port, selected = form.address == port.systemName) {
+                            form.address = port.systemName
+                            menuOpen = false
+                        }
+                    }
                 }
             }
-        }
+        },
+    )
+}
+
+/** One row of the device menu: the port path, with the driver's description under it. */
+@Composable
+private fun SerialPortRow(port: SerialPortInfo, selected: Boolean, onClick: () -> Unit) {
+    Column(
+        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
+            .clickable(onClick = onClick).padding(horizontal = 11.dp, vertical = 7.dp),
+    ) {
+        Txt(port.systemName, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp)
+        Txt(port.description, color = Skerry.colors.faint, size = 11.sp)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SerialPorts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SerialPorts.kt
@@ -9,3 +9,24 @@ import app.skerry.shared.serial.SerialPortInfo
  * Empty list means no ports / platform unsupported, the form stays with a plain Device text field.
  */
 expect fun listSerialPorts(): List<SerialPortInfo>
+
+/**
+ * The discovered ports in the order the device menu offers them: adapters first, then the legacy
+ * 8250 UARTs (`/dev/ttyS0`…`ttyS31`) the Linux kernel enumerates whether or not anything is wired to
+ * them. They are kept rather than hidden — a real RS-232 header lives there on server boards — but a
+ * plugged-in adapter must not sit below three dozen identical rows to reach. Duplicates are dropped
+ * by port name, and the legacy ones sort by index so ttyS2 comes before ttyS10.
+ */
+fun serialPortOptions(ports: List<SerialPortInfo>): List<SerialPortInfo> =
+    ports.distinctBy { it.systemName }
+        .sortedWith(compareBy({ isLegacyUart(it.systemName) }, { portStem(it.systemName) }, { portIndex(it.systemName) }))
+
+/** A legacy `/dev/ttyS<n>` UART — the ones the Linux kernel lists whether or not they exist. */
+private fun isLegacyUart(systemName: String): Boolean =
+    systemName.startsWith("/dev/ttyS") && portIndex(systemName) != null
+
+/** The name without its trailing number, so ttyUSB and ttyACM stay apart while their indices sort. */
+private fun portStem(systemName: String): String = systemName.dropLastWhile { it.isDigit() }
+
+/** The trailing number of a port name, or null when it has none — COM10 must not sort before COM2. */
+private fun portIndex(systemName: String): Int? = systemName.takeLastWhile { it.isDigit() }.toIntOrNull()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -161,6 +161,7 @@ import app.skerry.ui.host.groupSuggestions
 import app.skerry.ui.host.keepAliveLabel
 import app.skerry.ui.i18n.label
 import app.skerry.ui.host.listSerialPorts
+import app.skerry.ui.host.serialPortOptions
 import app.skerry.ui.host.tagSuggestions
 import app.skerry.ui.host.pickerIcon
 import app.skerry.ui.host.pickerTypeLabel
@@ -476,7 +477,8 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
  */
 @Composable
 private fun MobileSerialPortPicker(form: NewConnectionFormState) {
-    val ports = remember { listSerialPorts() }
+    // Same order as the desktop form: adapters first, the kernel's legacy UARTs last, no duplicates.
+    val ports = remember { serialPortOptions(listSerialPorts()) }
     if (ports.isEmpty()) return
     FlowRow(
         Modifier.fillMaxWidth().padding(top = 8.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -149,6 +149,14 @@ class RemoteDesktopScreenState(
     var cursor: VncCursorImage? by mutableStateOf(null)
         private set
 
+    /**
+     * The server asked for the ordinary system pointer instead of a shape of its own (RDP's
+     * SYSPTR_DEFAULT). There is nothing to draw, so the local pointer is shown rather than hidden —
+     * distinct from a hidden cursor, where neither is drawn.
+     */
+    var systemCursor by mutableStateOf(false)
+        private set
+
     /** View-only: when true, pointer/key input is not forwarded (look, don't touch). */
     var viewOnly by mutableStateOf(false)
         private set
@@ -329,12 +337,22 @@ class RemoteDesktopScreenState(
      */
     private fun onPeripheralUpdate(update: RemoteDesktopUpdate) {
         when (update) {
-            is RemoteDesktopUpdate.CursorShape -> cursor = VncCursorImage.of(update)
+            is RemoteDesktopUpdate.CursorShape -> {
+                cursor = VncCursorImage.of(update)
+                systemCursor = false
+            }
+
             // The pointer the server warps is not ours to move: the sprite tracks the local pointer,
             // and jumping it would desynchronise the two. The position is still applied by the
             // server to its own screen, which is what the user sees.
             is RemoteDesktopUpdate.CursorPosition -> Unit
-            is RemoteDesktopUpdate.CursorVisible -> if (!update.visible) cursor = null
+            // "Visible" here is the server asking for its default pointer, not for the shape it sent
+            // last: the sprite goes, and the local pointer takes over. Hidden drops both.
+            is RemoteDesktopUpdate.CursorVisible -> {
+                cursor = null
+                systemCursor = update.visible
+            }
+
             is RemoteDesktopUpdate.ClipboardText -> if (clipboardShared) {
                 serverClipboard = update.text
                 onClipboard(update.text)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncCursor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncCursor.kt
@@ -42,15 +42,21 @@ class VncCursorImage private constructor(
  * cursor; the same is true of a server that ignores the encoding and paints the cursor into the
  * framebuffer instead. Either way something already tracks the mouse, so ours goes away.
  *
- * Only where a remote cursor actually exists, hence all three conditions:
+ * Only where a remote cursor actually exists, hence all four conditions:
  * - [pointerOverImage]: the fitted image, NOT the whole tab. Over the letterbox around it (or a tab
  *   with no frame yet) nothing tracks the mouse, so hiding ours would leave no pointer at all.
  * - not [viewOnly]: there we send no pointer events, so nothing follows the mouse — the server paints
  *   the cursor wherever it really is instead, and our own pointer is just our own pointer.
  * - [interactive]: a frozen last frame after a drop tracks nothing either.
+ * - not [systemCursor]: the server asked for the default system pointer (RDP's SYSPTR_DEFAULT), which
+ *   is a shape it never sends — ours is the one that stands in for it.
  */
-fun shouldHideLocalCursor(interactive: Boolean, viewOnly: Boolean, pointerOverImage: Boolean): Boolean =
-    interactive && !viewOnly && pointerOverImage
+fun shouldHideLocalCursor(
+    interactive: Boolean,
+    viewOnly: Boolean,
+    pointerOverImage: Boolean,
+    systemCursor: Boolean,
+): Boolean = interactive && !viewOnly && pointerOverImage && !systemCursor
 
 /**
  * Where to draw the cursor sprite's top-left corner, in canvas coordinates, for a pointer at

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -193,7 +193,14 @@ fun VncSurface(screen: RemoteDesktopScreenState, interactive: Boolean = true) {
     }
     // Something remote already tracks the mouse — our sprite, or a cursor the server painted into the
     // framebuffer — so the OS pointer on top would be a second one. See [shouldHideLocalCursor].
-    if (shouldHideLocalCursor(interactive, screen.viewOnly, pointerOverImage)) {
+    if (
+        shouldHideLocalCursor(
+            interactive = interactive,
+            viewOnly = screen.viewOnly,
+            pointerOverImage = pointerOverImage,
+            systemCursor = screen.systemCursor,
+        )
+    ) {
         hiddenPointerIcon()?.let { mod = mod.pointerHoverIcon(it) }
     }
     if (interactive) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/SerialPortOptionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/SerialPortOptionsTest.kt
@@ -1,0 +1,75 @@
+package app.skerry.ui.host
+
+import app.skerry.shared.serial.SerialPortInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SerialPortOptionsTest {
+
+    @Test
+    fun adapters_come_before_the_legacy_uarts_the_kernel_always_lists() {
+        // Linux enumerates /dev/ttyS0..31 from the 8250 driver whether or not anything is wired to
+        // them, and they all describe themselves the same way. The adapter the user actually plugged
+        // in has to be the first thing in the menu, not the 33rd.
+        val ports = listOf(
+            SerialPortInfo("/dev/ttyS4", "Serial Device (serial_8250)"),
+            SerialPortInfo("/dev/ttyUSB0", "FT232R USB UART"),
+            SerialPortInfo("/dev/ttyS0", "Serial Device (serial_8250)"),
+            SerialPortInfo("/dev/ttyACM0", "STM32 Virtual ComPort"),
+        )
+
+        assertEquals(
+            listOf("/dev/ttyACM0", "/dev/ttyUSB0", "/dev/ttyS0", "/dev/ttyS4"),
+            serialPortOptions(ports).map { it.systemName },
+        )
+    }
+
+    @Test
+    fun legacy_uarts_are_ordered_by_number_not_by_text() {
+        // ttyS10 sorts before ttyS2 as text, which reads as a shuffled list.
+        val ports = listOf(
+            SerialPortInfo("/dev/ttyS10", "Serial Device (serial_8250)"),
+            SerialPortInfo("/dev/ttyS2", "Serial Device (serial_8250)"),
+        )
+
+        assertEquals(listOf("/dev/ttyS2", "/dev/ttyS10"), serialPortOptions(ports).map { it.systemName })
+    }
+
+    @Test
+    fun a_port_listed_twice_appears_once() {
+        val ports = listOf(
+            SerialPortInfo("/dev/ttyUSB0", "FT232R USB UART"),
+            SerialPortInfo("/dev/ttyUSB0", "FT232R USB UART"),
+        )
+
+        assertEquals(1, serialPortOptions(ports).size)
+    }
+
+    @Test
+    fun windows_ports_sort_by_number_inside_the_adapter_group() {
+        // COM ports carry no 8250 marker, so they stay in the group the user cares about — and a hub
+        // of virtual ports must not read COM1, COM10, COM11, COM2.
+        val ports = listOf(
+            SerialPortInfo("COM3", "USB Serial Port"),
+            SerialPortInfo("COM10", "USB Serial Port"),
+            SerialPortInfo("COM1", "Communications Port"),
+        )
+
+        assertEquals(listOf("COM1", "COM3", "COM10"), serialPortOptions(ports).map { it.systemName })
+    }
+
+    @Test
+    fun adapter_families_stay_together() {
+        // ttyACM and ttyUSB are different devices; sorting by index alone would interleave them.
+        val ports = listOf(
+            SerialPortInfo("/dev/ttyUSB1", "FT232R USB UART"),
+            SerialPortInfo("/dev/ttyACM0", "STM32 Virtual ComPort"),
+            SerialPortInfo("/dev/ttyUSB0", "FT232R USB UART"),
+        )
+
+        assertEquals(
+            listOf("/dev/ttyACM0", "/dev/ttyUSB0", "/dev/ttyUSB1"),
+            serialPortOptions(ports).map { it.systemName },
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
@@ -214,6 +214,40 @@ class RemoteDesktopScreenStateTest {
     }
 
     @Test
+    fun the_default_system_pointer_drops_the_sprite_and_gives_the_local_one_back() = runTest {
+        // RDP's System Pointer Update (SYSPTR_DEFAULT) means "back to the ordinary arrow". Keeping the
+        // last sprite there is how an I-beam gets stuck on screen after leaving a text field.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(updates = updates), scope)
+
+        updates.emit(RemoteDesktopUpdate.CursorShape(IntArray(4) { 0xFFFFFFFF.toInt() }, 2, 2, 1, 1))
+        updates.emit(RemoteDesktopUpdate.CursorVisible(true))
+
+        assertNull(screen.cursor)
+        assertTrue(screen.systemCursor, "the OS pointer stands in for the shape we no longer have")
+
+        // A shape of its own takes the job back.
+        updates.emit(RemoteDesktopUpdate.CursorShape(IntArray(4) { 0xFFFFFFFF.toInt() }, 2, 2, 1, 1))
+        assertFalse(screen.systemCursor)
+        scope.cancel()
+    }
+
+    @Test
+    fun a_hidden_cursor_shows_neither_sprite_nor_local_pointer() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(updates = updates), scope)
+
+        updates.emit(RemoteDesktopUpdate.CursorVisible(true))
+        updates.emit(RemoteDesktopUpdate.CursorVisible(false))
+
+        assertNull(screen.cursor)
+        assertFalse(screen.systemCursor, "the server asked for no cursor at all, not for ours")
+        scope.cancel()
+    }
+
+    @Test
     fun view_only_hands_the_cursor_back_to_the_server_and_repaints() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeRemoteDesktop()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vnc/VncCursorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vnc/VncCursorTest.kt
@@ -14,27 +14,41 @@ class VncCursorTest {
     @Test
     fun hides_the_local_pointer_over_a_live_framebuffer() {
         // We draw the remote cursor ourselves there; the OS pointer on top would be a duplicate.
-        assertTrue(shouldHideLocalCursor(interactive = true, viewOnly = false, pointerOverImage = true))
+        assertTrue(shouldHideLocalCursor(interactive = true, viewOnly = false, pointerOverImage = true, systemCursor = false))
     }
 
     @Test
     fun keeps_the_local_pointer_over_the_letterbox() {
         // Outside the fitted image (black bars, or a tab with no frame yet) there is no remote cursor
         // to stand in for ours — hiding it would leave the area with no pointer at all.
-        assertFalse(shouldHideLocalCursor(interactive = true, viewOnly = false, pointerOverImage = false))
+        assertFalse(shouldHideLocalCursor(interactive = true, viewOnly = false, pointerOverImage = false, systemCursor = false))
     }
 
     @Test
     fun keeps_the_local_pointer_in_view_only() {
         // View-only sends no pointer events, so the remote cursor doesn't follow the mouse; there the
         // server paints it into the framebuffer instead (see RemoteDesktopScreenState.toggleViewOnly).
-        assertFalse(shouldHideLocalCursor(interactive = true, viewOnly = true, pointerOverImage = true))
+        assertFalse(shouldHideLocalCursor(interactive = true, viewOnly = true, pointerOverImage = true, systemCursor = false))
+    }
+
+    @Test
+    fun keeps_the_local_pointer_when_the_server_asked_for_the_default_one() {
+        // RDP's SYSPTR_DEFAULT: there is no sprite to draw, so hiding the OS pointer as well would
+        // leave the session with no cursor at all.
+        assertFalse(
+            shouldHideLocalCursor(
+                interactive = true,
+                viewOnly = false,
+                pointerOverImage = true,
+                systemCursor = true,
+            ),
+        )
     }
 
     @Test
     fun keeps_the_local_pointer_on_a_frozen_frame() {
         // A disconnected tab still renders its last frame, but nothing tracks the mouse there.
-        assertFalse(shouldHideLocalCursor(interactive = false, viewOnly = false, pointerOverImage = true))
+        assertFalse(shouldHideLocalCursor(interactive = false, viewOnly = false, pointerOverImage = true, systemCursor = false))
     }
 
     // --- sprite placement ---

--- a/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/graphics/RemoteDesktop.kt
@@ -130,7 +130,11 @@ sealed interface RemoteDesktopUpdate {
     /** The server moved the pointer itself. */
     data class CursorPosition(val x: Int, val y: Int) : RemoteDesktopUpdate
 
-    /** Whether the remote cursor is shown at all. */
+    /**
+     * Whether the remote cursor is drawn at all. False hides it; true is the server asking for the
+     * ordinary system pointer rather than a shape of its own (RDP's SYSPTR_DEFAULT), which leaves
+     * the client's own pointer to stand in — it is not a request to redraw the last shape.
+     */
     data class CursorVisible(val visible: Boolean) : RemoteDesktopUpdate
 
     /** The remote clipboard's new text. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientCapabilities.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/ClientCapabilities.kt
@@ -181,8 +181,8 @@ object ClientCapabilities {
 
     private fun pointerCapabilities(): ByteArray = RdpWriter(6).apply {
         u16le(1) // colorPointerFlag
-        u16le(25) // colorPointerCacheSize
-        u16le(25) // pointerCacheSize
+        u16le(PointerCache.CAPACITY) // colorPointerCacheSize
+        u16le(PointerCache.CAPACITY) // pointerCacheSize
     }.toByteArray()
 
     private fun inputCapabilities(): ByteArray = RdpWriter(84).apply {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/FastPath.kt
@@ -21,6 +21,11 @@ class FastPathDecoder(
      * wired to a holder nobody reads would drop pixels and never get them back.
      */
     private val dropped: DroppedGraphics,
+    /**
+     * The session's pointer cache, owned by the caller for the same reason as [palette]: a shape can
+     * arrive on this path and be recalled by a Cached Pointer Update on the other.
+     */
+    private val pointerCache: PointerCache,
 ) {
     private var fragmentType = -1
     private val fragments = mutableListOf<ByteArray>()
@@ -134,12 +139,10 @@ class FastPathDecoder(
             UPDATETYPE_PTR_NULL -> listOf(RdpUpdate.PointerVisible(false))
             UPDATETYPE_PTR_DEFAULT -> listOf(RdpUpdate.PointerVisible(true))
             UPDATETYPE_PTR_POSITION -> listOf(RdpUpdate.PointerPosition(reader.u16le(), reader.u16le()))
-            UPDATETYPE_COLOR_POINTER -> listOf(PointerUpdate.colorPointer(reader))
-            UPDATETYPE_POINTER -> listOf(PointerUpdate.newPointer(reader))
-            UPDATETYPE_LARGE_POINTER -> listOf(PointerUpdate.largePointer(reader))
-            // Cached pointers reference a slot this client never fills: it does not claim a pointer
-            // cache beyond the minimum, so the honest answer is to leave the cursor as it is.
-            UPDATETYPE_CACHED_POINTER -> emptyList()
+            UPDATETYPE_COLOR_POINTER -> listOf(PointerUpdate.colorPointer(reader, pointerCache))
+            UPDATETYPE_POINTER -> listOf(PointerUpdate.newPointer(reader, pointerCache))
+            UPDATETYPE_LARGE_POINTER -> listOf(PointerUpdate.largePointer(reader, pointerCache))
+            UPDATETYPE_CACHED_POINTER -> PointerUpdate.cachedPointer(reader, pointerCache)
             UPDATETYPE_SYNCHRONIZE -> emptyList()
             // Orders were never claimed in the capability exchange (MS-RDPEGDI), so a server sending
             // them anyway is drawing something nothing here can execute. Skipping the one update

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/PointerCache.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/PointerCache.kt
@@ -1,0 +1,29 @@
+package app.skerry.shared.rdp
+
+/**
+ * The cursor shapes the server parked in the pointer cache (MS-RDPBCGR 2.2.9.1.1.4.6).
+ *
+ * Every shape update carries the slot the server filed it under; once a shape is in a slot, the
+ * server switches back to it with a Cached Pointer Update that carries nothing but the index. That
+ * is how the cursor goes back to the arrow after an I-beam — without the cache the client has no
+ * shape to restore and the last explicit one stays on screen.
+ *
+ * Owned by the session and shared by both decoders, like [SessionPalette]: a shape can arrive
+ * fast-path and be recalled slow-path.
+ */
+class PointerCache {
+    private val slots = arrayOfNulls<RdpUpdate.PointerShape>(CAPACITY)
+
+    /** File [shape] under [index]. Indices past the cache we advertised are dropped, not stored. */
+    fun put(index: Int, shape: RdpUpdate.PointerShape) {
+        if (index in slots.indices) slots[index] = shape
+    }
+
+    /** The shape in [index], or null for a slot the server never filled. */
+    fun get(index: Int): RdpUpdate.PointerShape? = slots.getOrNull(index)
+
+    companion object {
+        /** Slots, and the number advertised as colorPointerCacheSize/pointerCacheSize. */
+        const val CAPACITY = 25
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/PointerUpdate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/PointerUpdate.kt
@@ -14,22 +14,31 @@ object PointerUpdate {
     /** Largest cursor accepted; the large-pointer capability caps shapes at 384×384. */
     private const val MAX_DIMENSION = 384
 
-    fun colorPointer(reader: RdpReader): RdpUpdate.PointerShape = shape(reader, xorBitsPerPixel = 24, wide = false)
+    fun colorPointer(reader: RdpReader, cache: PointerCache): RdpUpdate.PointerShape =
+        shape(reader, xorBitsPerPixel = 24, wide = false, cache)
 
     /** A new-style pointer: the same structure with an explicit colour depth in front. */
-    fun newPointer(reader: RdpReader): RdpUpdate.PointerShape {
+    fun newPointer(reader: RdpReader, cache: PointerCache): RdpUpdate.PointerShape {
         val xorBpp = reader.u16le()
-        return shape(reader, xorBpp, wide = false)
+        return shape(reader, xorBpp, wide = false, cache)
     }
 
     /** A large pointer: same again, with 16-bit dimensions and 32-bit mask lengths. */
-    fun largePointer(reader: RdpReader): RdpUpdate.PointerShape {
+    fun largePointer(reader: RdpReader, cache: PointerCache): RdpUpdate.PointerShape {
         val xorBpp = reader.u16le()
-        return shape(reader, xorBpp, wide = true)
+        return shape(reader, xorBpp, wide = true, cache)
     }
 
-    private fun shape(reader: RdpReader, xorBitsPerPixel: Int, wide: Boolean): RdpUpdate.PointerShape {
-        reader.u16le() // cacheIndex
+    /**
+     * A Cached Pointer Update (MS-RDPBCGR 2.2.9.1.1.4.6): a slot index, and the shape to show is the
+     * one filed there. An empty slot is the one case with nothing to draw — the server named a shape
+     * it never sent us — and the cursor stays as it is rather than being cleared.
+     */
+    fun cachedPointer(reader: RdpReader, cache: PointerCache): List<RdpUpdate> =
+        cache.get(reader.u16le())?.let { listOf(it) } ?: emptyList()
+
+    private fun shape(reader: RdpReader, xorBitsPerPixel: Int, wide: Boolean, cache: PointerCache): RdpUpdate.PointerShape {
+        val cacheIndex = reader.u16le()
         val hotspotX = reader.u16le()
         val hotspotY = reader.u16le()
         val width = reader.u16le()
@@ -64,7 +73,11 @@ object PointerUpdate {
                 }
             }
         }
-        return RdpUpdate.PointerShape(argb, width, height, hotspotX.coerceIn(0, width - 1), hotspotY.coerceIn(0, height - 1))
+        val pointer =
+            RdpUpdate.PointerShape(argb, width, height, hotspotX.coerceIn(0, width - 1), hotspotY.coerceIn(0, height - 1))
+        // Filed before it is returned: the server switches back to this shape by index alone.
+        cache.put(cacheIndex, pointer)
+        return pointer
     }
 
     private fun maskBit(mask: ByteArray, rowOffset: Int, column: Int): Boolean {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpSessionCodec.kt
@@ -27,7 +27,8 @@ class RdpSessionCodec(
 ) {
     private val palette = SessionPalette()
     private val dropped = DroppedGraphics()
-    private val fastPath = FastPathDecoder(framebuffer, palette, dropped)
+    private val pointerCache = PointerCache()
+    private val fastPath = FastPathDecoder(framebuffer, palette, dropped, pointerCache)
     private val surfaces = SurfaceDecoder(RdpCodecs(remoteFx))
 
     /** When the last repaint was asked for, or null if none has been; see [repaintDropped]. */
@@ -135,9 +136,10 @@ class RdpSessionCodec(
         return when (messageType) {
             PTR_MSGTYPE_SYSTEM -> listOf(RdpUpdate.PointerVisible(reader.u32le() != SYSPTR_NULL))
             PTR_MSGTYPE_POSITION -> listOf(RdpUpdate.PointerPosition(reader.u16le(), reader.u16le()))
-            PTR_MSGTYPE_COLOR -> listOf(PointerUpdate.colorPointer(reader))
-            PTR_MSGTYPE_POINTER -> listOf(PointerUpdate.newPointer(reader))
-            PTR_MSGTYPE_LARGE_POINTER -> listOf(PointerUpdate.largePointer(reader))
+            PTR_MSGTYPE_COLOR -> listOf(PointerUpdate.colorPointer(reader, pointerCache))
+            PTR_MSGTYPE_CACHED -> PointerUpdate.cachedPointer(reader, pointerCache)
+            PTR_MSGTYPE_POINTER -> listOf(PointerUpdate.newPointer(reader, pointerCache))
+            PTR_MSGTYPE_LARGE_POINTER -> listOf(PointerUpdate.largePointer(reader, pointerCache))
             else -> emptyList()
         }
     }
@@ -294,6 +296,7 @@ class RdpSessionCodec(
         const val PTR_MSGTYPE_SYSTEM = 0x0001
         const val PTR_MSGTYPE_POSITION = 0x0003
         const val PTR_MSGTYPE_COLOR = 0x0006
+        const val PTR_MSGTYPE_CACHED = 0x0007
         const val PTR_MSGTYPE_POINTER = 0x0008
         const val PTR_MSGTYPE_LARGE_POINTER = 0x0009
         const val SYSPTR_NULL = 0x00000000

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpUpdate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpUpdate.kt
@@ -47,7 +47,10 @@ sealed interface RdpUpdate {
     /** The server moved the pointer itself (a program warped it, not the user). */
     data class PointerPosition(val x: Int, val y: Int) : RdpUpdate
 
-    /** Whether the remote cursor is drawn at all; false is the "hidden pointer" state. */
+    /**
+     * A System Pointer Update: false is SYSPTR_NULL, the hidden pointer; true is SYSPTR_DEFAULT, the
+     * ordinary arrow — a shape the server never sends, so the client's own pointer stands in for it.
+     */
     data class PointerVisible(val visible: Boolean) : RdpUpdate
 
     /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/ConnectionType.kt
@@ -84,6 +84,15 @@ val ConnectionType.hasAiPolicy: Boolean
     get() = !isRemoteDesktop
 
 /**
+ * Whether the connection form offers "Test connection". The test is an SSH probe — it dials the
+ * profile's SSH auth path and reports a round-trip — so it only means something where [usesSshAuth]
+ * holds. Everywhere else (remote desktops, Telnet, Serial, a local shell) there is nothing for it to
+ * try, and the form leaves the button out instead of showing one stuck disabled.
+ */
+val ConnectionType.hasConnectionTest: Boolean
+    get() = usesSshAuth
+
+/**
  * Whether the profile is an RDP remote desktop. Unlike VNC it authenticates with a *user name* and
  * password (and optionally a domain, written into the user name as `DOMAIN\user` rather than stored
  * as its own field — that is the form every RDP client accepts and the one users already type), so

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/GraphicsTest.kt
@@ -176,7 +176,7 @@ class GraphicsTest {
             u8(0x7F).u8(0x00)
         }.toByteArray()
 
-        val shape = PointerUpdate.colorPointer(RdpReader(body))
+        val shape = PointerUpdate.colorPointer(RdpReader(body), PointerCache())
 
         assertEquals(2, shape.width)
         assertEquals(RED, shape.argb[0]) // opaque red where the AND bit is clear
@@ -193,13 +193,13 @@ class GraphicsTest {
             u16le(0).u16le(0)
         }.toByteArray()
 
-        assertFailsWith<RdpProtocolException> { PointerUpdate.colorPointer(RdpReader(body)) }
+        assertFailsWith<RdpProtocolException> { PointerUpdate.colorPointer(RdpReader(body), PointerCache()) }
     }
 
     @Test
     fun `fast-path reassembles an update split across packets`() {
         val framebuffer = RemoteFramebuffer(4, 4)
-        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics())
+        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics(), PointerCache())
         val bitmap = RdpWriter(64).apply {
             u16le(0x0001) // updateType inside the payload
             u16le(1)
@@ -224,7 +224,7 @@ class GraphicsTest {
 
     @Test
     fun `a fragment run of the wrong type is refused`() {
-        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics())
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics(), PointerCache())
         decoder.decode(fastPathPacket(updateCode = 1, fragmentation = 2, body = byteArrayOf(0, 0)), SurfaceDecoder())
 
         assertFailsWith<RdpProtocolException> {
@@ -235,7 +235,7 @@ class GraphicsTest {
     @Test
     fun `drawing orders are skipped rather than ending the session`() {
         val dropped = DroppedGraphics()
-        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), dropped)
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), dropped, PointerCache())
 
         val updates =
             decoder.decode(fastPathPacket(updateCode = 0, fragmentation = 0, body = byteArrayOf(1)), SurfaceDecoder())
@@ -248,7 +248,7 @@ class GraphicsTest {
     @Test
     fun `an update after skipped orders in the same packet still paints`() {
         val framebuffer = RemoteFramebuffer(4, 4)
-        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics())
+        val decoder = FastPathDecoder(framebuffer, SessionPalette(), DroppedGraphics(), PointerCache())
         val bitmap = RdpWriter(64).apply {
             u16le(0x0001) // updateType, repeated inside the payload
             u16le(1) // one rectangle

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/PointerCacheTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/PointerCacheTest.kt
@@ -1,0 +1,214 @@
+package app.skerry.shared.rdp
+
+import app.skerry.shared.graphics.RemoteFramebuffer
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The pointer cache (MS-RDPBCGR 2.2.9.1.1.4.6). A server that has already sent a shape switches back
+ * to it with a Cached Pointer Update carrying nothing but a slot index — which is how the cursor
+ * returns to the arrow after an I-beam. Ignoring those updates leaves the last explicit shape on
+ * screen forever.
+ */
+class PointerCacheTest {
+
+    @Test
+    fun a_cached_pointer_replays_the_shape_parked_in_that_slot() {
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics(), PointerCache())
+        val surfaces = SurfaceDecoder(RdpCodecs(null))
+
+        val shape = decoder.decode(fastPathPacket(UPDATETYPE_COLOR_POINTER, colorPointer(slot = 3)), surfaces)
+            .single() as RdpUpdate.PointerShape
+
+        val replayed = decoder.decode(fastPathPacket(UPDATETYPE_CACHED_POINTER, cachedPointer(3)), surfaces)
+
+        assertEquals(listOf<RdpUpdate>(shape), replayed, "the cached slot has to produce the shape again")
+    }
+
+    @Test
+    fun a_cached_pointer_for_an_empty_slot_leaves_the_cursor_alone() {
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics(), PointerCache())
+
+        val updates = decoder.decode(fastPathPacket(UPDATETYPE_CACHED_POINTER, cachedPointer(7)), SurfaceDecoder(RdpCodecs(null)))
+
+        assertTrue(updates.isEmpty(), "a slot the server never filled is the one case with nothing to draw")
+    }
+
+    @Test
+    fun a_slot_past_the_advertised_cache_is_not_fatal() {
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics(), PointerCache())
+        val surfaces = SurfaceDecoder(RdpCodecs(null))
+
+        decoder.decode(fastPathPacket(UPDATETYPE_COLOR_POINTER, colorPointer(slot = PointerCache.CAPACITY + 1)), surfaces)
+        val updates = decoder.decode(
+            fastPathPacket(UPDATETYPE_CACHED_POINTER, cachedPointer(PointerCache.CAPACITY + 1)),
+            surfaces,
+        )
+
+        assertTrue(updates.isEmpty())
+    }
+
+    @Test
+    fun both_paths_share_one_cache() = runTest {
+        // A shape can arrive fast-path and be recalled slow-path, exactly like the session palette.
+        val written = mutableListOf<ByteArray>()
+        val incoming = fastPathPacket(UPDATETYPE_COLOR_POINTER, colorPointer(slot = 1)) +
+            slowPathPointerPdu(PTR_MSGTYPE_CACHED, RdpWriter(2).u16le(1).toByteArray())
+        val session = codec(written, incoming)
+
+        val shape = session.readMessage().single() as RdpUpdate.PointerShape
+        val replayed = session.readMessage()
+
+        assertEquals(listOf<RdpUpdate>(shape), replayed)
+    }
+
+    @Test
+    fun a_shape_filed_on_the_slow_path_is_recalled_on_the_fast_one() = runTest {
+        // The mirror of the test above: the two paths are one cache in both directions, so a server
+        // that sends shapes as share PDUs and switches with fast-path updates works the same.
+        val incoming = slowPathPointerPdu(PTR_MSGTYPE_COLOR, colorPointer(slot = 2)) +
+            fastPathPacket(UPDATETYPE_CACHED_POINTER, cachedPointer(2))
+        val session = codec(mutableListOf(), incoming)
+
+        val shape = session.readMessage().single() as RdpUpdate.PointerShape
+
+        assertEquals(listOf<RdpUpdate>(shape), session.readMessage())
+    }
+
+    @Test
+    fun a_slot_filled_twice_replays_the_newer_shape() {
+        // Windows reuses slots: the cursor that comes back must be the one filed last, not the first
+        // shape that ever landed there.
+        val decoder = FastPathDecoder(RemoteFramebuffer(4, 4), SessionPalette(), DroppedGraphics(), PointerCache())
+        val surfaces = SurfaceDecoder(RdpCodecs(null))
+
+        decoder.decode(fastPathPacket(UPDATETYPE_COLOR_POINTER, colorPointer(slot = 5)), surfaces)
+        val newer = decoder.decode(fastPathPacket(UPDATETYPE_COLOR_POINTER, colorPointer(slot = 5, hotspotX = 0)), surfaces)
+            .single() as RdpUpdate.PointerShape
+
+        val replayed = decoder.decode(fastPathPacket(UPDATETYPE_CACHED_POINTER, cachedPointer(5)), surfaces)
+
+        assertEquals(listOf<RdpUpdate>(newer), replayed)
+        assertEquals(0, (replayed.single() as RdpUpdate.PointerShape).hotspotX)
+    }
+
+    @Test
+    fun the_advertised_cache_size_matches_the_one_we_keep() {
+        // colorPointerCacheSize / pointerCacheSize in the Pointer capability set: a server is free to
+        // use every slot it was promised, and a smaller cache here would drop the ones past the end.
+        val body = ClientCapabilities.confirmActive(shareId = 1, userId = 2, width = 800, height = 600, remoteFx = false)
+        val pointerSet = capabilitySet(body, CapabilitySetType.POINTER)
+
+        val reader = RdpReader(pointerSet)
+        reader.u16le() // colorPointerFlag
+        assertEquals(PointerCache.CAPACITY, reader.u16le(), "colorPointerCacheSize")
+        assertEquals(PointerCache.CAPACITY, reader.u16le(), "pointerCacheSize")
+    }
+
+    /** A 2×2 opaque-red-corner sprite (the shape [GraphicsTest] pins), parked in [slot]. */
+    private fun colorPointer(slot: Int, hotspotX: Int = 1): ByteArray = RdpWriter(64).apply {
+        u16le(slot) // cacheIndex
+        u16le(hotspotX).u16le(1) // hotspot
+        u16le(2).u16le(2) // width, height
+        u16le(4) // lengthAndMask
+        u16le(12) // lengthXorMask
+        u8(0).u8(0).u8(0)
+        u8(0).u8(0).u8(0)
+        u8(0).u8(0).u8(0xFF) // BGR red at the top-left
+        u8(0).u8(0).u8(0)
+        u8(0xFF).u8(0x00)
+        u8(0x7F).u8(0x00)
+    }.toByteArray()
+
+    private fun cachedPointer(slot: Int): ByteArray = RdpWriter(2).u16le(slot).toByteArray()
+
+    /** One fast-path update of [updateCode], single fragment, uncompressed. */
+    private fun fastPathPacket(updateCode: Int, body: ByteArray): ByteArray {
+        val update = RdpWriter(body.size + 3).apply {
+            u8(updateCode)
+            u16le(body.size)
+            bytes(body)
+        }.toByteArray()
+        val total = update.size + 3
+        return RdpWriter(total).apply {
+            u8(0) // action = fast-path output
+            u16be(total or 0x8000)
+            bytes(update)
+        }.toByteArray()
+    }
+
+    private fun slowPathPointerPdu(messageType: Int, attribute: ByteArray): ByteArray {
+        val body = RdpWriter(attribute.size + 4).apply {
+            u16le(messageType)
+            u16le(0) // pad2Octets
+            bytes(attribute)
+        }.toByteArray()
+        val share = RdpShare.dataPdu(SHARE_ID, userId = 1002, pduType2 = RdpShare.PDUTYPE2_POINTER, body = body)
+        return Mcs.sendDataRequest(userId = 1002, channelId = 1003, payload = share)
+    }
+
+    private fun codec(written: MutableList<ByteArray>, incoming: ByteArray): RdpSessionCodec {
+        var offset = 0
+        val caps = ServerCapabilities(
+            shareId = SHARE_ID,
+            desktopWidth = 640,
+            desktopHeight = 480,
+            preferredBitsPerPixel = 32,
+            desktopResizeSupported = false,
+            refreshRectSupported = false,
+            suppressOutputSupported = false,
+            fastPathOutputSupported = true,
+            noBitmapCompressionHeader = false,
+            surfaceCommandsSupported = false,
+            frameAcknowledgeSupported = false,
+            maxRequestSize = 65535,
+            supportedCodecs = emptyList(),
+        )
+        return RdpSessionCodec(
+            source = { dst, dstOffset, len ->
+                if (offset + len > incoming.size) error("the test fixture ran out of bytes")
+                incoming.copyInto(dst, dstOffset, offset, offset + len)
+                offset += len
+            },
+            sink = { bytes -> written += bytes },
+            framebuffer = RemoteFramebuffer(caps.desktopWidth, caps.desktopHeight),
+            state = RdpSessionState(userId = 1007, ioChannelId = 1003, channels = emptyMap(), capabilities = caps),
+            settings = RdpClientSettings(
+                desktopWidth = caps.desktopWidth,
+                desktopHeight = caps.desktopHeight,
+                clientName = "Skerry",
+                selectedProtocol = 1,
+            ),
+            logon = RdpLogonInfo(domain = "", username = "u"),
+        )
+    }
+
+    /** The body of capability set [type] inside a Confirm Active PDU, header stripped. */
+    private fun capabilitySet(pdu: ByteArray, type: Int): ByteArray {
+        val reader = RdpReader(pdu, RdpShare.CONTROL_HEADER_SIZE)
+        reader.skip(4) // shareId
+        reader.skip(2) // originatorId
+        val descriptorLength = reader.u16le()
+        reader.skip(2) // lengthCombinedCapabilities
+        reader.skip(descriptorLength)
+        val count = reader.u16le()
+        reader.skip(2) // pad2Octets
+        repeat(count) {
+            val setType = reader.u16le()
+            val length = reader.u16le()
+            val body = reader.bytes(length - 4)
+            if (setType == type) return body
+        }
+        error("capability set $type is not in the Confirm Active PDU")
+    }
+
+    private companion object {
+        const val SHARE_ID = 0x10001
+        const val UPDATETYPE_COLOR_POINTER = 0x9
+        const val UPDATETYPE_CACHED_POINTER = 0xA
+        const val PTR_MSGTYPE_CACHED = 0x0007
+        const val PTR_MSGTYPE_COLOR = 0x0006
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/ConnectionTypeTest.kt
@@ -45,6 +45,17 @@ class ConnectionTypeTest {
     }
 
     @Test
+    fun `only the SSH-authenticated transports offer a connection test`() {
+        // The test is an SSH probe: it dials the SSH auth path and reports a round-trip. Named one by
+        // one rather than derived from usesSshAuth, so a transport that changes its auth story has to
+        // face this list instead of silently gaining or losing the button.
+        assertEquals(
+            setOf(ConnectionType.SSH, ConnectionType.MOSH, ConnectionType.CONTAINER),
+            ConnectionType.entries.filter { it.hasConnectionTest }.toSet(),
+        )
+    }
+
+    @Test
     fun `a remote desktop never authenticates over ssh`() {
         // Remote-desktop profiles have no username/key/jump host; the forms gate on this.
         ConnectionType.entries.filter { it.isRemoteDesktop }.forEach {


### PR DESCRIPTION
## Remote cursor stuck on the last shape

The RDP cursor never went back to the arrow after an I-beam. Every shape the server sends carries the cache slot it files the shape under; to switch back to a shape it already sent, the server sends a Cached Pointer Update that names nothing but the slot. Those updates were dropped while the client kept advertising a 25-slot pointer cache, so the last shape sent in full stayed on screen for the rest of the session.

Shapes are now filed by slot and replayed from it, on the fast path and the slow path, through one cache the session owns — the same shape can arrive on either path and be recalled from the other. `SYSPTR_DEFAULT` also stops being a no-op: it drops the sprite and lets the local system pointer stand in, instead of leaving the previous shape up.

## Test connection where there is nothing to test

The button runs an SSH probe. It is now offered only for the transports that authenticate over SSH; remote desktops, Telnet, Serial and a local shell no longer show a button that can never leave its disabled state. The controller behind it is not created for them either, so no stale result can outlive a change of protocol.

## Serial device field

The device is now one control: type the port path, or pick it from a dropdown of the ports discovered on this machine. Discovered ports are ordered adapters first and the kernel's legacy `/dev/ttyS*` UARTs last, both by number rather than by text (`COM2` before `COM10`), with duplicates dropped — the adapter someone plugged in is the first row instead of the thirty-third. The phone sheet shares the same ordering.

## Verification

`./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll` and `:androidApp:compileDebugKotlin` all pass. The cursor fix was confirmed against a live Windows host: the pointer now returns to the arrow when leaving a text field. The serial dropdown and the Android side were not exercised on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)