### PR TITLE
Terminal: a still autocomplete ghost, a clear that clears, and no jump on focus

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -806,7 +806,10 @@ private fun MobileKeybar(
     val plain = { seq: String -> terminal.sendUserInput(seq); onCtrlArmedChange(false) }
     val char = { c: String ->
         if (ctrlArmed && c.length == 1) {
-            terminal.sendUserInput(controlByte(c[0]))
+            // typeInput for the same reason as below: the ctrl forms of these keys edit or run the
+            // shell line (ctrl + "-" is CR, ctrl + "/" is accept-line-and-down-history), so they owe
+            // the engine and the production guard the same visibility as anything else typed here.
+            terminal.typeInput(controlByte(c[0]))
             onCtrlArmedChange(false)
         } else {
             // typeInput, not sendUserInput: a character from the panel is typing, and it has to reach
@@ -843,10 +846,12 @@ private fun MobileKeybar(
         KeyCap("esc") { plain(ESC) }
         // Tab with an autocomplete suggestion — accept it; otherwise a normal tab to the PTY.
         KeyCap("tab") {
-            if (terminal.suggestionTail != null) { terminal.acceptSuggestion(); onCtrlArmedChange(false) } else plain("\t")
+            if (terminal.hasSuggestion) { terminal.acceptSuggestion(); onCtrlArmedChange(false) } else plain("\t")
         }
-        // With a suggestion shown — cycle alternatives (like Shift+Tab on desktop).
-        if (terminal.suggestionTail != null) {
+        // With a suggestion available — cycle alternatives (like Shift+Tab on desktop). Keyed on the
+        // engine, not on the drawn ghost: the ghost blinks off for the echo round trip, and the row
+        // would reflow under the finger on every keystroke.
+        if (terminal.hasSuggestion) {
             KeyCapIcon("autorenew") { terminal.cycleSuggestion() }
         }
         // Reverse history search (Ctrl-R): open the search overlay (query typed on the soft keyboard).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -785,22 +785,17 @@ fun TerminalScreen(
               }
           }
       }
-      Text(
-        text = structural,
-        style = structuralStyle,
-        modifier = Modifier
-            .fillMaxSize()
-            .verticalScroll(scroll)
-            // bottom += bottomSlack — an empty gap below the content so the live grid sticks to the
-            // viewport top rather than leaving a peeked scrollback row above (see bottomSlack).
-            .padding(start = PADDING_DP.dp, top = PADDING_DP.dp, end = PADDING_DP.dp, bottom = PADDING_DP.dp + bottomSlack)
-            // Scroll height is set explicitly (contentHeight) from cellHeight, not the Text font metrics.
-            .height(contentHeight)
-            .fillMaxWidth()
-            .focusRequester(focusRequester)
-            // Focus reporting (DEC 1004): vim/tmux get ESC[I/ESC[O on terminal window focus.
-            .onFocusChanged { state.notifyFocus(it.isFocused) }
-            .onPreviewKeyEvent { event ->
+      // Keyboard focus sits on this wrapper rather than on the scrolling text inside it: a focusable
+      // node within its own verticalScroll makes Compose scroll that container to "reveal" the node
+      // when it takes focus, and clicking the pane back into focus slid the whole screen up by a
+      // couple of rows. Nothing scrollable wraps this Box, so taking focus moves nothing.
+      Box(
+          Modifier
+              .fillMaxSize()
+              .focusRequester(focusRequester)
+              // Focus reporting (DEC 1004): vim/tmux get ESC[I/ESC[O on terminal window focus.
+              .onFocusChanged { state.notifyFocus(it.isFocused) }
+              .onPreviewKeyEvent { event ->
                 // Toggle the link (hand) cursor as Ctrl is pressed/released without moving the mouse.
                 // Runs before the KeyDown guard so a Ctrl KeyUp also clears it. Never consumes the event.
                 hoverPos?.let { updateHoverAffordance(it, event.isCtrlPressed) }
@@ -883,8 +878,21 @@ fun TerminalScreen(
                 } else {
                     false
                 }
-            }
-            .focusable()
+              }
+              .focusable()
+      ) {
+      Text(
+        text = structural,
+        style = structuralStyle,
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(scroll)
+            // bottom += bottomSlack — an empty gap below the content so the live grid sticks to the
+            // viewport top rather than leaving a peeked scrollback row above (see bottomSlack).
+            .padding(start = PADDING_DP.dp, top = PADDING_DP.dp, end = PADDING_DP.dp, bottom = PADDING_DP.dp + bottomSlack)
+            // Scroll height is set explicitly (contentHeight) from cellHeight, not the Text font metrics.
+            .height(contentHeight)
+            .fillMaxWidth()
             .onGloballyPositioned { layoutCoords = it }
             // Mouse wheel: when the app listens for the mouse — send a wheel report; in alt-screen without
             // mouse tracking (less/man) — arrows (3 rows per "tick"), since there's no own scrollback.
@@ -1148,6 +1156,7 @@ fun TerminalScreen(
                 }
             },
       )
+      }
 
       // Cursor overlay over the text per the DECSCUSR shape. Block — fill the cell + redraw the char in
       // a contrasting color; Underline — a bar at the bottom; Bar — a vertical line on the left. Geometry

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -836,8 +836,11 @@ fun TerminalScreen(
                     state.openReverseSearch()
                     return@onPreviewKeyEvent true
                 }
-                // Shift+Tab — cycle autocomplete suggestion alternatives (only if one exists).
-                if (event.isShiftPressed && event.key == Key.Tab && state.suggestionTail != null) {
+                // Shift+Tab — cycle autocomplete suggestion alternatives. Swallowed whenever a ghost
+                // is on screen, even one that cannot be accepted yet: letting it through sends ESC[Z,
+                // which the engine reads as navigation and drops the line it is tracking.
+                val ghostOnScreen = state.hasSuggestion || state.suggestionTail != null
+                if (event.isShiftPressed && event.key == Key.Tab && ghostOnScreen) {
                     state.cycleSuggestion()
                     return@onPreviewKeyEvent true
                 }
@@ -871,7 +874,7 @@ fun TerminalScreen(
                     textToolbar.hide()
                     // Tab with an autocomplete suggestion — accept it (fish-style), don't send to the shell.
                     // Without a suggestion Tab goes to the PTY as usual (server-side completion isn't broken).
-                    if (bytes == "\t" && state.suggestionTail != null) {
+                    if (bytes == "\t" && state.hasSuggestion) {
                         state.acceptSuggestion()
                     } else {
                         state.typeInput(bytes)
@@ -1177,13 +1180,18 @@ fun TerminalScreen(
       }
 
       // Autocomplete "ghost": draw the suggestion tail in gray from the cursor position (fish/zsh-style).
-      // Same monospace geometry as the cursor; Tab (desktop) / chip (mobile) accept it. In alt-screen
-      // (vim/htop) there's no suggestion — [suggestionTail] is already cleared there.
-      val ghost = state.suggestionTail
-      if (ghost != null && !closed && screen.isNotEmpty()) {
+      // Same monospace geometry as the cursor; Tab (desktop) and the `tab` keycap (mobile) accept it.
+      // It continues what the cursor row shows, so text and ghost always read as one command. In
+      // alt-screen (vim/htop) there's no suggestion — [suggestionTail] is already cleared there.
+      if (!closed && screen.isNotEmpty()) {
           Canvas(Modifier.fillMaxSize().padding(PADDING_DP.dp).clipToBounds()) {
-              val x = cursorCol * metrics.cellWidth
-              val y = cursorRow * metrics.cellHeight - scroll.value.toFloat()
+              // Tail and cursor are read here, in the draw phase, rather than in composition: the tail
+              // changes on each published snapshot and on Shift+Tab, and reading it above would
+              // recompose the whole terminal to repaint one overlay. Reading the cursor alongside it
+              // keeps both from the same snapshot even if one lands between composition and draw.
+              val ghost = state.suggestionTail ?: return@Canvas
+              val x = state.cursorCol * metrics.cellWidth
+              val y = state.cursorRow * metrics.cellHeight - scroll.value.toFloat()
               drawGlyphText(measurer, ghost, Offset(x, y), ghostStyle)
           }
       }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -398,8 +398,10 @@ class TerminalScreenState(
         bracketedPaste = emulator.bracketedPaste
         focusReporting = emulator.focusReporting
         altScreen = emulator.altScreen
-        // Entering a fullscreen TUI (vim/htop) clears the autocomplete suggestion — no "line" there.
-        if (altScreen && suggestionTail != null) suggestionTail = null
+        // The echo of what was typed arrives here, and the ghost continues what this snapshot shows —
+        // so this is where it is recomputed. Also clears it on entering a fullscreen TUI (vim/htop):
+        // there is no "line" there.
+        refreshSuggestion()
         title = emulator.title
         palette = emulator.paletteSnapshot()
         // The buffer changed under an open search panel: rebuild the match list (throttled — see
@@ -493,8 +495,25 @@ class TerminalScreenState(
         CommandHistory().apply { if (initialHistory.isNotEmpty()) preload(initialHistory) },
     )
 
-    /** Tail of the current autocomplete suggestion (shown grayed after typed text) or `null`. */
+    /**
+     * What to draw in gray at the cursor of the published snapshot: the rest of the suggested command
+     * after the part the host has echoed back. `null` when there is nothing to continue there — the
+     * echo has not started, the line wrapped onto the next row, or the shell redrew it. The
+     * suggestion may exist anyway; [hasSuggestion] is what decides whether Tab has something to
+     * accept, and it always accepts the command this tail belongs to.
+     */
     var suggestionTail: String? by mutableStateOf(null)
+        private set
+
+    /**
+     * Whether there is a suggestion to accept, drawable or not. Tab (accept), Shift+Tab (cycle) and
+     * the mobile keycaps key off this: the completion exists the moment the key is typed, and gating
+     * them on [suggestionTail] would send a raw Tab to the shell — or, on Shift+Tab, an ESC[Z that
+     * the engine reads as navigation and drops the tracked line — while the echo is in flight. False
+     * once the screen and the tracked line have genuinely diverged (a wrapped or shell-redrawn line),
+     * where completing would edit a line the user is no longer on.
+     */
+    var hasSuggestion: Boolean by mutableStateOf(false)
         private set
 
     /**
@@ -533,7 +552,7 @@ class TerminalScreenState(
         // and parking it in a confirmation dialog would put it on screen in clear text.
         if (awaitingSecret) {
             autocomplete.reset()
-            if (suggestionTail != null) suggestionTail = null
+            refreshSuggestion()
             send(text)
             // A secret is mirrored like anything else typed: entering one sudo password across
             // synchronized panes is the case people turn the toggle on for. Each pane decides on its
@@ -549,7 +568,7 @@ class TerminalScreenState(
 
     private fun deliverTypedInput(text: String, mirror: Boolean = true) {
         val committed = autocomplete.onUserInput(text.encodeToByteArray())
-        refreshSuggestion()
+        refreshSuggestion(lineChanged = true)
         send(text)
         // Mirrored from here, not from typeInput: input held by the production guard must reach the
         // other panes only once it is confirmed (this runs again on confirm), never on the hold.
@@ -566,6 +585,10 @@ class TerminalScreenState(
     // The hold/confirm/dismiss rules live in [ProductionGuardHold]; what belongs here is only what
     // is terminal-specific — which candidates a path offers, and how a held block is replayed.
     private val guard = ProductionGuardHold()
+
+    // What can make the shell run the line it is holding: Enter in both forms, plus readline's
+    // accept-line-and-down-history (Ctrl-O), which the mobile keybar reaches as ctrl + "/".
+    private val runLineControls = charArrayOf('\r', '\n', '\u000F')
 
     /**
      * What the production guard asks about in this session (host tag, root login, the
@@ -592,7 +615,7 @@ class TerminalScreenState(
      */
     private fun holdForProductionGuard(text: String): Boolean {
         if (altScreen) return false
-        if (text.none { it == '\r' || it == '\n' }) return false
+        if (text.none { it in runLineControls }) return false
         return guard.hold(text, HeldInputSource.Typed) {
             // The first line continues whatever is already on the shell line; the rest of the block
             // stands on its own. A soft-keyboard delta or an IME clipboard insert arrives whole, so
@@ -665,11 +688,16 @@ class TerminalScreenState(
     /**
      * Accept the current autocomplete suggestion: sends its tail to the PTY (the shell echoes it).
      * Returns `true` if there was something to accept, else `false`.
+     *
+     * The tail comes from the tracked line, while the ghost is drawn from what the screen has echoed
+     * ([refreshSuggestion]) — so while the echo lags, what is sent completes what was typed, not the
+     * older line the ghost is still continuing. Completing the visible line instead would drop the
+     * characters already in flight.
      */
     fun acceptSuggestion(): Boolean {
         if (altScreen) return false
         val tail = autocomplete.acceptSuggestion() ?: return false
-        refreshSuggestion()
+        refreshSuggestion(lineChanged = true)
         sendBytes(tail)
         return true
     }
@@ -681,7 +709,7 @@ class TerminalScreenState(
     fun cycleSuggestion() {
         if (altScreen) return
         autocomplete.cycleSuggestion()
-        suggestionTail = autocomplete.suggestionTail()
+        refreshSuggestion()
     }
 
     // --- Reverse search (Ctrl-R): overlay state lives here so desktop keys and the mobile
@@ -782,8 +810,64 @@ class TerminalScreenState(
         typeInput(command)
     }
 
-    private fun refreshSuggestion() {
-        suggestionTail = if (altScreen) null else autocomplete.suggestionTail()
+    /**
+     * Recomputes what the ghost shows and whether Tab has anything to accept.
+     *
+     * The ghost is drawn at the cursor of the published snapshot, so its text must continue what that
+     * snapshot shows — [echoedLine], the part of the tracked line the host has echoed back. Deriving
+     * it from the tracked line instead makes it jump a cell per keystroke (the cursor has not moved
+     * yet); hiding it until the echo lands makes it blink off for the round trip instead. Following
+     * the screen does neither: the completed command stands still while the typed part grows into it.
+     *
+     * [lineChanged] only opens the window in which Tab still works while the echo is in flight. What
+     * leaves an already-drawn ghost alone is a line that just got SHORTER: the erased characters are
+     * still on screen, so the ghost of the longer line is what belongs there — and nothing may be
+     * accepted in that window either, or Tab would insert a command other than the visible one.
+     */
+    private fun refreshSuggestion(lineChanged: Boolean = false) {
+        val line = autocomplete.currentLine
+        val echoed = echoedLine(line)
+        val caughtUp = line.isNotEmpty() && echoed == line
+        // A local edit opens the window Tab must survive; a snapshot closes it once the screen either
+        // confirms the whole line or shows none of it. A snapshot confirming just a prefix means the
+        // echo is still arriving, so the window stays open.
+        echoPending = if (lineChanged) true else echoed.isNotEmpty() && !caughtUp
+        val shrank = line.length < trackedLength
+        trackedLength = line.length
+        // One candidate for both jobs: what Tab inserts is what the ghost shows, so the key never does
+        // something other than what is on screen. It is chosen for the tracked line — the line Tab
+        // completes — and only its rendering is cut back to the echoed prefix below.
+        val chosen = if (altScreen) null else autocomplete.suggestion()
+        hasSuggestion = chosen != null && !shrank && (echoPending || caughtUp)
+        if (chosen == null) {
+            suggestionTail = null
+            return
+        }
+        if (shrank) return
+        suggestionTail = if (echoed.isNotEmpty() && chosen.startsWith(echoed)) chosen.substring(echoed.length) else null
+    }
+
+    // Whether the tracked line moved since the last published snapshot, i.e. the screen has not seen
+    // the latest keystroke/paste yet.
+    private var echoPending = false
+
+    // Tracked line length at the last refresh, to tell a local erase from anything else.
+    private var trackedLength = 0
+
+    /**
+     * The longest prefix of the tracked line the screen confirms — the cursor row up to the cursor
+     * ends with it, so it is exactly what a ghost drawn at the cursor continues. Empty when nothing
+     * of the line is on screen: the echo has not started, the line wrapped onto the next row, or the
+     * shell redrew it (Ctrl-W, its own Tab completion) — in all three there is nothing to continue.
+     */
+    private fun echoedLine(line: String): String {
+        if (line.isEmpty()) return ""
+        val onScreen = screenLineToCursor()
+        // Compared in place: this runs on every published snapshot, and a substring per candidate
+        // length would allocate through the whole line on each batch of output.
+        var length = minOf(onScreen.length, line.length)
+        while (length > 0 && !onScreen.regionMatches(onScreen.length - length, line, 0, length)) length--
+        return line.substring(0, length)
     }
 
     // --- Output search (find in scrollback): the panel's whole state lives here so desktop keys and
@@ -1112,7 +1196,7 @@ class TerminalScreenState(
         // multi-line paste commits, same as if they had been typed.
         if (!awaitingSecret) {
             autocomplete.onUserInput(text.encodeToByteArray())
-            refreshSuggestion()
+            refreshSuggestion(lineChanged = true) // the paste moved the line; the screen has not seen it yet
         }
         send(bracketedPasteWrap(text, bracketedPaste))
         // Mirrored as a paste, not as typing: each pane wraps it for its own bracketed-paste mode,

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -278,12 +278,298 @@ class TerminalScreenStateTest {
     @Test
     fun `preloaded history feeds autosuggestion`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
         val state = TerminalScreenState(
-            FakeTerminalSession(), scope,
+            session, scope,
             initialHistory = listOf("git push origin main"),
         )
+        session.emit("$ ".encodeToByteArray())
         state.typeInput("git pu")
+        session.emit("git pu".encodeToByteArray())
+
         assertEquals("sh origin main", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the ghost follows the echoed text and never blinks off while typing`() = runTest {
+        // The ghost is drawn at the cursor of the published snapshot, so its text has to be the
+        // continuation of what that snapshot shows — not of the locally tracked line, which runs
+        // ahead of the echo. Recomputing it on every keystroke made it disappear for the round trip
+        // (a visible blink per character); deriving it from the screen keeps the completed command
+        // standing still while the typed part grows into it.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("git push origin main"),
+        )
+        session.emit("$ ".encodeToByteArray())
+
+        state.typeInput("git")
+        assertEquals(null, state.suggestionTail) // nothing echoed yet, so there is no place to draw
+        session.emit("git".encodeToByteArray())
+        assertEquals(" push origin main", state.suggestionTail)
+
+        // Typing ahead of the echo leaves the ghost where it is: the screen still reads "git".
+        state.typeInput(" pu")
+        assertEquals(" push origin main", state.suggestionTail)
+
+        // The echo arrives and the ghost shortens by exactly the characters that became text — its
+        // right edge does not move.
+        session.emit(" pu".encodeToByteArray())
+        assertEquals("sh origin main", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `an accepted suggestion stays on screen until its echo turns it into text`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("git push origin main", "git push origin main --force-with-lease"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("git pu")
+        session.emit("git pu".encodeToByteArray())
+        assertEquals("sh origin main", state.suggestionTail)
+
+        assertTrue(state.acceptSuggestion())
+        // Still anchored to what the screen shows ("git pu"), now continuing the accepted command.
+        assertEquals("sh origin main --force-with-lease", state.suggestionTail)
+
+        session.emit("sh origin main".encodeToByteArray())
+        assertEquals(" --force-with-lease", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `Tab accepts a suggestion that is not drawable yet`() = runTest {
+        // Nothing is echoed yet, so there is no ghost — but the completion exists. Tab and the mobile
+        // chip key off [hasSuggestion], or a Tab pressed on a slow link would fall through to the
+        // shell as a raw HT and Shift+Tab would reach the PTY as ESC[Z, clearing the tracked line.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("git push origin main"),
+        )
+        session.emit("$ ".encodeToByteArray())
+
+        state.typeInput("git pu")
+        assertEquals(null, state.suggestionTail)
+        assertTrue(state.hasSuggestion)
+        assertTrue(state.acceptSuggestion())
+        assertEquals("sh origin main", session.sent.last().decodeToString())
+        scope.cancel()
+    }
+
+    @Test
+    fun `backspace does not blink the ghost either`() = runTest {
+        // The erase is local first: until the shell echoes it the screen still reads "ll", and the
+        // ghost that belongs to "ll" is the correct thing to keep drawing there.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("lsof -i", "ll -h"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("ll")
+        session.emit("ll".encodeToByteArray())
+        assertEquals(" -h", state.suggestionTail)
+
+        state.typeInput("\b")
+        assertEquals(" -h", state.suggestionTail)
+
+        session.emit("\b \b".encodeToByteArray()) // how a shell erases a character
+        assertEquals("sof -i", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the guard holds a line run by accept-line-and-down-history`() = runTest {
+        // Ctrl-O runs the current line just like Enter does; the mobile keybar reaches it as ctrl + "/".
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+        state.typeInput("rm -rf /srv")
+
+        state.typeInput("${15.toChar()}") // Ctrl-O
+
+        assertNotNull(state.pendingGuarded)
+        assertEquals(false, session.sent.any { it.decodeToString() == "${15.toChar()}" })
+        scope.cancel()
+    }
+
+    @Test
+    fun `Tab inside the backspace window offers nothing`() = runTest {
+        // The ghost still shows the longer line's completion until the erase echoes, so accepting in
+        // that window would insert a command other than the one on screen.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("less /var/log/syslog", "ll -h"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("ll")
+        session.emit("ll".encodeToByteArray())
+        assertEquals(" -h", state.suggestionTail)
+
+        state.typeInput("\b")
+        assertEquals(" -h", state.suggestionTail) // unchanged: the screen still reads "ll"
+        assertEquals(false, state.hasSuggestion)
+
+        session.emit("\b \b".encodeToByteArray())
+        assertTrue(state.hasSuggestion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a paste gets its ghost when the echo lands`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("systemctl restart nginx"),
+        )
+        session.emit("$ ".encodeToByteArray())
+
+        state.paste("systemctl")
+        assertEquals(null, state.suggestionTail)
+
+        session.emit("systemctl".encodeToByteArray())
+        assertEquals(" restart nginx", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the ghost shows the command Tab will insert, not the one the screen alone suggests`() = runTest {
+        // Two sources of truth: the ghost continues the echoed prefix, Tab completes the tracked line.
+        // Picking the candidate from the echoed prefix draws "docker ps" while Tab would insert
+        // "docker logs " — the key does something other than what the user is looking at.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("docker")
+        session.emit("docker".encodeToByteArray())
+        assertEquals(" ps", state.suggestionTail)
+
+        state.typeInput(" l") // typed ahead of the echo
+        assertEquals(" logs ", state.suggestionTail)
+
+        assertTrue(state.acceptSuggestion())
+        assertEquals("ogs ", session.sent.last().decodeToString())
+        scope.cancel()
+    }
+
+    @Test
+    fun `cycling while the echo lags draws the alternative that Tab will insert`() = runTest {
+        // The ghost is drawn from the echoed prefix and the accepted text from the tracked line, so
+        // both must name the SAME candidate. Picking it by index in two different candidate lists
+        // ("back" matches three commands, "backu" only two) draws one alternative and inserts another.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("backupdb", "backupfiles", "backends"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("back")
+        session.emit("back".encodeToByteArray())
+
+        state.typeInput("u") // typed ahead of the echo: screen still reads "back"
+        state.cycleSuggestion()
+        state.cycleSuggestion() // past the end of the "backu" candidates — wraps to the first
+
+        assertEquals("updb", state.suggestionTail)
+        assertTrue(state.acceptSuggestion())
+        assertEquals("pdb", session.sent.last().decodeToString())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a ghost after a non-BMP character keeps its place`() = runTest {
+        // The echoed prefix is found by comparing UTF-16 code units, and an emoji is a surrogate
+        // pair: a probe landing between the halves must not corrupt the tail or throw.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("echo 😀 done"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("echo 😀")
+        session.emit("echo 😀".encodeToByteArray())
+
+        assertEquals(" done", state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a line the shell redrew offers nothing to accept`() = runTest {
+        // Ctrl-W kills a word on the host but is a control byte the engine ignores, so its line keeps
+        // the word. Neither the ghost nor Tab may act on a line that no longer exists on screen.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("git push origin main"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("git pu")
+        session.emit("git pu".encodeToByteArray())
+        assertTrue(state.hasSuggestion)
+
+        state.typeInput("${23.toChar()}") // Ctrl-W
+        session.emit("\r$ git ${27.toChar()}[K".encodeToByteArray()) // the shell redraws the line
+
+        assertEquals(false, state.hasSuggestion)
+        assertEquals(null, state.suggestionTail)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a wrapped line gets no ghost`() = runTest {
+        // The ghost is drawn as one unwrapped run from the cursor, so on a line that already wrapped
+        // it would run off the right edge. Nothing is drawn there at all.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("uptime --pretty"),
+        )
+        state.resize(PtySize(cols = 6, rows = 4))
+        state.typeInput("uptime -")
+        session.emit("uptime -".encodeToByteArray())
+
+        assertEquals(null, state.suggestionTail)
+        // And nothing to accept either: Tab would insert a completion the user never saw.
+        assertEquals(false, state.hasSuggestion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `entering alt-screen clears a visible ghost`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(
+            session, scope,
+            initialHistory = listOf("vimdiff a b"),
+        )
+        session.emit("$ ".encodeToByteArray())
+        state.typeInput("vim")
+        session.emit("vim".encodeToByteArray())
+        assertEquals("diff a b", state.suggestionTail)
+
+        session.emit("${27.toChar()}[?1049h".encodeToByteArray())
+        assertEquals(true, state.altScreen)
+        assertEquals(null, state.suggestionTail)
+        assertEquals(false, state.hasSuggestion)
         scope.cancel()
     }
 
@@ -303,11 +589,15 @@ class TerminalScreenStateTest {
     @Test
     fun `cycle suggestion advances the ghost tail`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
         val state = TerminalScreenState(
-            FakeTerminalSession(), scope,
+            session, scope,
             initialHistory = listOf("backupdb", "backupfiles"),
         )
+        session.emit("$ ".encodeToByteArray())
         state.typeInput("back")
+        session.emit("back".encodeToByteArray())
+
         assertEquals("updb", state.suggestionTail)
         state.cycleSuggestion()
         assertEquals("upfiles", state.suggestionTail)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
@@ -27,6 +27,15 @@ class AutocompleteEngine(
     /** Current typed line (for tests/diagnostics). */
     val currentLine: String get() = line.toString()
 
+    /**
+     * Whether the tracked line may no longer match the host's. Set when input carried a control byte
+     * this engine ignores but a shell acts on (Ctrl-W erases a word, Ctrl-T transposes): from there
+     * the line here and the line on screen have diverged, and anything built on it — a suggestion, a
+     * completion to insert — would complete a line the user is not on. Cleared when the line is.
+     */
+    var lineSuspect: Boolean = false
+        private set
+
     /** Command history (for reverse-search from the UI). */
     val commandHistory: CommandHistory get() = history
 
@@ -37,6 +46,7 @@ class AutocompleteEngine(
     fun reset() {
         line.clear()
         cycleIndex = 0
+        lineSuspect = false
     }
 
     /**
@@ -53,16 +63,21 @@ class AutocompleteEngine(
             when {
                 b == CR || b == LF -> {
                     val cmd = line.toString().trim()
-                    if (cmd.isNotEmpty()) {
+                    if (cmd.isNotEmpty() && !lineSuspect) {
                         history.record(cmd)
                         committed = cmd
                     }
                     line.clear()
+                    lineSuspect = false
                 }
                 b == BS || b == DEL -> if (line.isNotEmpty()) line.deleteAt(line.length - 1)
-                b == CTRL_U || b == CTRL_C -> line.clear()
-                b == ESC -> { line.clear(); i = skipEscapeSequence(data, i) } // arrows/navigation — reset
+                b == CTRL_U || b == CTRL_C -> { line.clear(); lineSuspect = false }
+                b == ESC -> { line.clear(); lineSuspect = false; i = skipEscapeSequence(data, i) } // arrows/navigation — reset
                 b == TAB -> { /* accept — handled by the UI via acceptSuggestion */ }
+                // A control byte that edits the line on the shell side (Ctrl-W kills a word, Ctrl-K
+                // the rest of it) leaves the two lines disagreeing — mark the line, nothing is offered
+                // for it. Cursor moves and screen redraws (Ctrl-A/E, Ctrl-L) keep the line as it is.
+                b in LINE_EDITING_CONTROLS -> lineSuspect = true
                 b < 0x20 -> { /* other control bytes — ignored, line untouched */ }
                 else -> {
                     // Printable character: decoded as UTF-8 (multi-byte sequences taken whole).
@@ -83,8 +98,9 @@ class AutocompleteEngine(
      * path/tokens seen in this session's history. Duplicates collapsed, first-seen order kept.
      * Empty if there's nothing to suggest (empty line / ends with a space).
      */
-    fun candidates(): List<String> {
-        val prefix = line.toString()
+    fun candidates(): List<String> = candidatesFor(line.toString())
+
+    private fun candidatesFor(prefix: String): List<String> {
         if (prefix.isBlank() || prefix.endsWith(' ')) return emptyList()
         val out = LinkedHashSet<String>()
         history.matches(prefix).forEach { out.add(it) }
@@ -96,18 +112,21 @@ class AutocompleteEngine(
         return out.filter { it.length > prefix.length && it.startsWith(prefix) }.toList()
     }
 
-    /** Full suggestion for the current line — the candidate under the cycle cursor, or `null`. */
-    fun suggestion(): String? {
-        val c = candidates()
+    /**
+     * Full suggestion for the current line — the candidate under the cycle cursor, or `null`. Also
+     * `null` for a line a control byte may have edited ([lineSuspect]): completing it would rewrite a
+     * line the user is no longer on.
+     */
+    fun suggestion(): String? = if (lineSuspect) null else suggestionFor(line.toString())
+
+    private fun suggestionFor(prefix: String): String? {
+        val c = candidatesFor(prefix)
         if (c.isEmpty()) return null
         return c[cycleIndex.mod(c.size)]
     }
 
     /** Suggestion tail — what to render in gray after the typed text, or `null`. */
-    fun suggestionTail(): String? {
-        val full = suggestion() ?: return null
-        return full.substring(line.length)
-    }
+    fun suggestionTail(): String? = suggestion()?.substring(line.length)
 
     /**
      * Switches to the next suggestion alternative (Shift+Tab). Cycles through [candidates] with
@@ -210,6 +229,15 @@ class AutocompleteEngine(
         const val CTRL_U = 21
         const val ESC = 27
         const val TAB = 9
+
+        /**
+         * Control bytes a shell acts on by rewriting the current line, which this engine cannot
+         * follow: Ctrl-D (delete forward), Ctrl-K (kill to end), Ctrl-N/Ctrl-P (history recall,
+         * which replaces the line wholesale), Ctrl-O (run it and recall the next), Ctrl-T
+         * (transpose), Ctrl-W (kill word), Ctrl-Y (yank), Ctrl-_ (undo). Ctrl-U and Ctrl-C clear the
+         * line outright and are handled above; cursor moves and redraws (Ctrl-A/B/E/F/L) leave it be.
+         */
+        val LINE_EDITING_CONTROLS = setOf(4, 11, 14, 15, 16, 20, 23, 25, 31)
     }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
@@ -944,11 +944,13 @@ class TerminalEmulator(
         when (mode) {
             0 -> { eraseLine(0); for (r in cy + 1 until rows) blankLine(r) }
             1 -> { for (r in 0 until cy) blankLine(r); eraseLine(1) }
-            // ED 2/3 clear the whole screen. On the primary buffer the old screen goes to scrollback so
-            // `clear`/`Ctrl+L` leave output scrollable (like gnome-terminal/VTE) rather than lost. ED 3
-            // ("erase saved lines") deliberately does not wipe history — clear sends it right after ED 2,
-            // by which point the screen is already empty, so no extra rows reach history.
-            2, 3 -> clearScreenToScrollback()
+            // ED 2 clears the screen; on the primary buffer the old screen goes to scrollback, so
+            // Ctrl+L (which sends ED 2 alone) pushes output out of sight but keeps it scrollable.
+            2 -> clearScreenToScrollback()
+            // ED 3 is "erase saved lines" — history goes. `clear` sends it right after ED 2, which is
+            // what makes that command drop the output instead of only paging past it. Not from the alt
+            // screen: a TUI resetting its display would take history it never owned with it.
+            3 -> if (!altScreen) scrollback.clear()
         }
     }
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
@@ -206,4 +206,67 @@ class AutocompleteEngineTest {
         assertEquals("vim /etc/nginx/nginx.conf", e.suggestion())
         assertEquals("inx/nginx.conf", e.suggestionTail())
     }
+
+    @Test
+    fun `a screen-only control byte leaves the line trustworthy`() {
+        // Ctrl-L redraws the prompt; the line itself is untouched, so the command it ends up running
+        // still belongs in history.
+        val e = AutocompleteEngine()
+        e.onUserInput("systemctl restart nginx".encodeToByteArray())
+        e.onUserInput(byteArrayOf(12)) // Ctrl-L
+        assertEquals(false, e.lineSuspect)
+
+        e.onUserInput("\r".encodeToByteArray())
+        assertEquals(listOf("systemctl restart nginx"), e.commandHistory.commands)
+    }
+
+    @Test
+    fun `history recall on the host makes the line suspect`() {
+        // Ctrl-P replaces the whole line with a recalled command; recording what this engine still
+        // holds would file a command that never ran and offer it back next session.
+        val e = AutocompleteEngine()
+        e.onUserInput("git s".encodeToByteArray())
+        e.onUserInput(byteArrayOf(16)) // Ctrl-P
+        assertEquals(true, e.lineSuspect)
+
+        e.onUserInput("\r".encodeToByteArray())
+        assertTrue(e.commandHistory.commands.isEmpty())
+    }
+
+    @Test
+    fun `a yank into an empty line makes it suspect too`() {
+        // Ctrl-Y pastes the kill ring: the host's line grows while this one stays empty.
+        val e = AutocompleteEngine()
+        e.onUserInput(byteArrayOf(25)) // Ctrl-Y on a fresh prompt
+        e.onUserInput(" --now\r".encodeToByteArray())
+
+        assertTrue(e.commandHistory.commands.isEmpty())
+    }
+
+    @Test
+    fun `a suspect line is not completed either`() {
+        val e = AutocompleteEngine(CommandHistory().apply { record("git push origin main") })
+        e.onUserInput("git pu".encodeToByteArray())
+        e.onUserInput(byteArrayOf(23)) // Ctrl-W
+
+        assertEquals(null, e.suggestion())
+        assertEquals(null, e.acceptSuggestion())
+    }
+
+    @Test
+    fun `a line a control byte may have edited is neither suggested nor recorded`() {
+        // Ctrl-W kills a word on the host; this engine does not track that, so from there its line
+        // and the host's can disagree — offering a completion for it, or filing it as a command that
+        // ran, would both be wrong.
+        val e = AutocompleteEngine(CommandHistory().apply { record("git push origin main") })
+        e.onUserInput("git pu".encodeToByteArray())
+        assertEquals(false, e.lineSuspect)
+
+        e.onUserInput(byteArrayOf(23)) // Ctrl-W
+        assertEquals(true, e.lineSuspect)
+
+        e.onUserInput("\r".encodeToByteArray())
+        assertEquals(false, e.lineSuspect) // a fresh line is trustworthy again
+        assertEquals(listOf("git push origin main"), e.commandHistory.commands)
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
@@ -489,55 +489,70 @@ class TerminalEmulatorTest {
     }
 
     @Test
-    fun `erase display 3 keeps scrollback so clear preserves history`() {
+    fun `erase display 3 wipes the scrollback`() {
         val emu = emulate(cols = 10, rows = 2, chunks = arrayOf("a\r\nb\r\nc\r\nd"))
-        val before = emu.lines.size
-        assertTrue(before > 2) // scrollback accumulated
+        assertTrue(emu.lines.size > 2) // scrollback accumulated
+
         emu.feed("$esc[3J".encodeToByteArray())
-        // ED 3 ("erase saved lines") does not wipe history — it stays scrollable.
-        assertTrue(emu.lines.size >= before, "scrollback preserved")
+
+        // ED 3 is "erase saved lines": history is gone, only the visible grid is left.
+        assertEquals(2, emu.lines.size)
     }
 
     @Test
-    fun `clear sequence blanks the screen yet keeps prior output scrollable`() {
-        // Exactly what the `clear` command sends: home, erase screen, erase saved lines.
+    fun `erase display 3 from the alternate screen keeps the primary scrollback`() {
+        // A TUI resetting its own display must not destroy the history it never owned.
+        val emu = emulate(cols = 10, rows = 2, chunks = arrayOf("keep me\r\nand me\r\nx"))
+        val before = emu.lines.size
+
+        emu.feed("$esc[?1049h".encodeToByteArray())
+        emu.feed("$esc[3J".encodeToByteArray())
+        emu.feed("$esc[?1049l".encodeToByteArray())
+
+        assertEquals(before, emu.lines.size)
+    }
+
+    @Test
+    fun `clear leaves nothing to scroll back to`() {
+        // Exactly what the `clear` command sends: home, erase screen, erase saved lines. Unlike Ctrl+L
+        // (ED 2 alone), it is meant to drop the output, not just push it out of sight.
         val emu = emulate(cols = 10, rows = 3, chunks = arrayOf("alpha\r\nbeta\r\ngamma", "$esc[H$esc[2J$esc[3J"))
-        // Prior output is available in history...
+
         val text = emu.lines.joinToString("\n") { row -> row.joinToString("") { it.text }.trimEnd() }
-        assertTrue("alpha" in text && "beta" in text && "gamma" in text, "history preserved")
-        // ...while the visible grid (bottom 3 rows) is blank and the cursor is at its start (home).
-        assertTrue(emu.lines.takeLast(3).all { row -> row.all { it.text == " " } }, "screen cleared")
-        assertEquals(3, emu.cursorRow)
+        assertTrue("alpha" !in text && "beta" !in text && "gamma" !in text, "history dropped")
+        assertEquals(3, emu.lines.size) // the visible grid and nothing else
+        assertTrue(emu.lines.all { row -> row.all { it.text == " " } }, "screen cleared")
+        assertEquals(0, emu.cursorRow)
         assertEquals(0, emu.cursorCol)
     }
 
     @Test
-    fun `clear keeps a background-colored blank row in history`() {
-        // A row of spaces with a colored background (BCE) is content, not emptiness: on clear it must go
-        // to scrollback, not be trimmed as a trailing blank.
+    fun `ctrl-L keeps a background-colored blank row in history`() {
+        // A row of spaces with a colored background (BCE) is content, not emptiness: pushing the screen
+        // to scrollback must move it, not trim it as a trailing blank.
         val emu = emulate(cols = 4, rows = 3, chunks = arrayOf("ab\r\n", "$esc[41m    $esc[m"))
-        emu.feed("$esc[H$esc[2J$esc[3J".encodeToByteArray())
+        emu.feed("$esc[H$esc[2J".encodeToByteArray())
         assertEquals(5, emu.lines.size) // "ab" + the colored row in scrollback + 3 blank on-screen
         assertEquals(TermColor.Red, emu.lines[1][0].style.bg)
     }
 
     @Test
-    fun `repeated clear does not flood scrollback with blank lines`() {
+    fun `repeated ctrl-L does not flood scrollback with blank lines`() {
         val emu = emulate(cols = 10, rows = 3, chunks = arrayOf("x\r\ny"))
-        emu.feed("$esc[H$esc[2J$esc[3J".encodeToByteArray())
+        emu.feed("$esc[H$esc[2J".encodeToByteArray())
         val afterFirst = emu.lines.size
-        emu.feed("$esc[H$esc[2J$esc[3J".encodeToByteArray()) // clearing an already-empty screen
+        emu.feed("$esc[H$esc[2J".encodeToByteArray()) // clearing an already-empty screen
         assertEquals(afterFirst, emu.lines.size, "a repeated clear doesn't spawn empty rows in history")
     }
 
     @Test
-    fun `resize after clear keeps the screen empty and history scrolled back`() {
-        // After `clear`, prior output sits in scrollback and the visible screen is empty (a single fresh
+    fun `resize after ctrl-L keeps the screen empty and history scrolled back`() {
+        // After Ctrl+L, prior output sits in scrollback and the visible screen is empty (a single fresh
         // prompt at the top). A resize — e.g. opening a split that narrows the terminal — must not pull
         // history back onto the visible screen: the empty space below the cursor is screen content, not
         // an "insignificant tail", and reflow must preserve it.
         val emu = emulate(cols = 10, rows = 4, chunks = arrayOf("line1\r\nline2\r\nline3"))
-        emu.feed("$esc[H$esc[2J$esc[3J".encodeToByteArray()) // clear: history → scrollback, screen empty
+        emu.feed("$esc[H$esc[2J".encodeToByteArray())        // Ctrl+L: screen → scrollback, screen empty
         emu.feed("$ ".encodeToByteArray())                   // fresh prompt in the top screen row
         emu.resize(6, 4)                                     // narrow the terminal (like opening a split)
 
@@ -559,7 +574,7 @@ class TerminalEmulatorTest {
         // When a resize also reduces height, the nr-1 cap on the preserved space below the cursor must
         // keep the cursor within the new screen (not push it past the top boundary).
         val emu = emulate(cols = 10, rows = 4, chunks = arrayOf("line1\r\nline2\r\nline3"))
-        emu.feed("$esc[H$esc[2J$esc[3J".encodeToByteArray()) // clear
+        emu.feed("$esc[H$esc[2J".encodeToByteArray()) // clear
         emu.feed("$ ".encodeToByteArray())                   // prompt at the top of the screen
         emu.resize(6, 2)                                     // narrower AND shorter
 


### PR DESCRIPTION
Three terminal fixes.

## The autocomplete ghost stays still while typing

The inline suggestion was drawn at the cursor of the published snapshot but built from the locally tracked line, so between a keystroke and its echo it sat in the column the typed character was about to take and jumped a cell when the echo landed.

The ghost now continues the part of the line the host has echoed back, and the command it shows is the one Tab inserts — text and ghost always read as one command, and the key never does something other than what is on screen. Local edits no longer recompute it, so it does not blink off for the round trip either.

Tab, Shift+Tab and the mobile keycaps key off a separate `hasSuggestion`: completing works while the echo is in flight and stops once the screen and the tracked line have genuinely diverged — a wrapped line, a line the shell redrew, or one edited by a control byte the engine cannot follow (Ctrl-W, Ctrl-K, history recall). Such a line is no longer filed into history either.

Two paths that reach the shell line are covered along the way: the mobile keybar's ctrl forms now go through the engine and the production guard like anything else typed, and the guard holds a line about to run through readline's accept-line-and-down-history, not only through Enter.

## `clear` drops the output

ED 3 ("erase saved lines") was treated like ED 2 and moved the screen into scrollback, so `clear` left everything one scroll away. It now wipes the scrollback, which is what makes the command drop the output the way a normal terminal does, while Ctrl+L (ED 2 alone) still pushes the screen into history and keeps it scrollable. Not from the alternate screen: a TUI resetting its display would take history it never owned with it.

## Clicking a pane no longer slides the screen

The focusable node sat in the same modifier chain as the terminal's own `verticalScroll`, so taking focus made Compose scroll that container to bring a child taller than the viewport into view — an animated slide of about two rows, one pixel per frame. Focus now lives on a wrapper around the scrolling text, with nothing scrollable above it; the scroll, the padding and the gesture handlers stay where they were, so pointer coordinates are unchanged.

## Verification

`./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll` and `:androidApp:compileDebugKotlin` are green. The autocomplete and `clear` behaviour is covered by tests that fail when each mechanism is reverted. The focus fix was verified against the running desktop app — an offscreen scene does not reproduce the bring-into-view, and a semantics-level test would need a test dependency the project does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)