### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
+++ b/composeApp/flatpak/app.skerry.Skerry.metainfo.xml
@@ -78,6 +78,19 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="0.2.1" date="2026-07-30">
+      <description>
+        <p>Feature and fix release:</p>
+        <ul>
+          <li>RDP: H.264 in the graphics pipeline, picture quality in the connection profile</li>
+          <li>Remote desktops: a session panel with screenshot, Ctrl+Alt+Del, clipboard and live sound</li>
+          <li>Terminal: a steady autocomplete ghost, clear that drops the output, no jump on focus</li>
+          <li>Connections state why they were refused: host key reasons, dead audio devices, stalled runbook steps</li>
+          <li>Serial: pick the port from a list of discovered devices</li>
+          <li>Security fixes in host key trust, RDP licensing and CredSSP</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.2.0" date="2026-07-29">
       <description>
         <p>Feature release:</p>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.2.0
-skerry.versionCode=7
+skerry.versionName=0.2.1
+skerry.versionCode=8

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.2.0"
+version = "0.2.1"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.2.0"
+version = "0.2.1"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Release 0.2.1 for the clients and the sync server.