### PR TITLE
Remote desktop: watch the session close as a flow, not as snapshot state

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopController.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import app.skerry.shared.graphics.RemoteDesktopSession
 import app.skerry.ui.vnc.VncFailure
 import app.skerry.ui.vnc.vncFailureOf
@@ -14,6 +13,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
@@ -113,11 +113,11 @@ class RemoteDesktopController(
      */
     private fun watchForClose(screen: RemoteDesktopScreenState, sScope: CoroutineScope) {
         sScope.launch {
-            snapshotFlow { screen.closed }.first { it }
+            val closed = screen.close.filterNotNull().first()
             // Dispatch onto the main scope (like ConnectionController) so the transition doesn't race disconnect.
             scope.launch {
                 if (uiState is RemoteDesktopUiState.Connected) {
-                    uiState = RemoteDesktopUiState.Disconnected(screen, screen.cleanExit, screen.closeReason)
+                    uiState = RemoteDesktopUiState.Disconnected(screen, closed.cleanExit, closed.reason)
                     releaseSession()
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopScreenState.kt
@@ -18,6 +18,9 @@ import app.skerry.ui.vnc.clampPan
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -252,20 +255,19 @@ class RemoteDesktopScreenState(
         }
     }
 
-    /** True once the session has closed (server drop / EOF); the controller reacts to this. */
-    var closed by mutableStateOf(false)
-        private set
-
-    /** Whether the last close was a clean peer exit (vs a transport drop). */
-    var cleanExit: Boolean = false
-        private set
+    private val _close = MutableStateFlow<RemoteDesktopUpdate.Closed?>(null)
 
     /**
-     * The server's own explanation of the close, where it gave one ("the account may not log on
-     * remotely"). Empty when the session simply dropped.
+     * The close, once the session ended on its own (server drop / EOF); null while it is live. It
+     * carries `cleanExit` (a clean peer exit vs a transport drop) and the server's own explanation
+     * where it gave one ("the account may not log on remotely").
+     *
+     * A flow rather than snapshot state: the watcher is a coroutine on the session scope, not a
+     * composition, and snapshot reads only reach one through the process-wide apply-observer
+     * registry — delivered by whatever frame happens to run next. The terminal side watches
+     * `TerminalState` the same way.
      */
-    var closeReason: String = ""
-        private set
+    val close: StateFlow<RemoteDesktopUpdate.Closed?> = _close.asStateFlow()
 
     /** Latest clipboard text from the remote host; the view mirrors it into the system clipboard. */
     var serverClipboard: String? by mutableStateOf(null)
@@ -287,8 +289,9 @@ class RemoteDesktopScreenState(
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Exception) {
-                cleanExit = false
-                closed = true
+                // Only if nothing closed the session already: a read loop that blows up behind an
+                // orderly close must not replace the server's own words with a bare drop.
+                _close.compareAndSet(null, RemoteDesktopUpdate.Closed(cleanExit = false))
             }
         }
     }
@@ -316,11 +319,7 @@ class RemoteDesktopScreenState(
                 if (remoteResize) scheduleRemoteResize()
             }
 
-            is RemoteDesktopUpdate.Closed -> {
-                cleanExit = update.cleanExit
-                closeReason = update.reason
-                closed = true
-            }
+            is RemoteDesktopUpdate.Closed -> _close.value = update
 
             else -> onPeripheralUpdate(update)
         }
@@ -392,7 +391,7 @@ class RemoteDesktopScreenState(
      * Fire-and-forget a write to the server. Every caller is a UI event (a mouse move, a menu click)
      * racing the read loop, so the socket can already be dead when the write lands — and an exception
      * escaping a bare `launch` isn't merely lost, it reaches the default handler and takes the whole
-     * process down on Android. The dropped session surfaces through [closed] instead, which is the
+     * process down on Android. The dropped session surfaces through [close] instead, which is the
      * read loop's job; there is nothing a failed input write can tell the user that the imminent
      * "Connection lost" doesn't.
      *

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopControllerTest.kt
@@ -1,6 +1,5 @@
 package app.skerry.ui.remote
 
-import androidx.compose.runtime.snapshots.Snapshot
 import app.skerry.shared.graphics.RemoteDesktopUpdate
 import app.skerry.ui.vnc.VncFailure
 import kotlinx.coroutines.CompletableDeferred
@@ -57,10 +56,6 @@ class RemoteDesktopControllerTest {
         controller.connect { session }
         advanceUntilIdle()
         updates.emit(RemoteDesktopUpdate.Closed(cleanExit = false, reason = "the server went away"))
-        advanceUntilIdle()
-        // The watcher hangs off snapshotFlow, which a running Compose frame would notify; outside
-        // one the test has to apply the snapshot itself.
-        Snapshot.sendApplyNotifications()
         advanceUntilIdle()
 
         val state = controller.uiState

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteDesktopScreenStateTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -66,15 +67,46 @@ class RemoteDesktopScreenStateTest {
     }
 
     @Test
-    fun close_update_marks_closed() = runTest {
+    fun close_update_publishes_the_reason_the_server_gave() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val updates = MutableSharedFlow<RemoteDesktopUpdate>(extraBufferCapacity = 8)
         val session = FakeRemoteDesktop(updates = updates)
         val screen = RemoteDesktopScreenState(session, scope)
 
-        updates.emit(RemoteDesktopUpdate.Closed(cleanExit = true))
-        assertTrue(screen.closed)
-        assertTrue(screen.cleanExit)
+        assertNull(screen.close.value)
+        updates.emit(RemoteDesktopUpdate.Closed(cleanExit = true, reason = "the user logged off"))
+        assertEquals(
+            RemoteDesktopUpdate.Closed(cleanExit = true, reason = "the user logged off"),
+            screen.close.value,
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun a_throwing_update_flow_closes_the_screen_as_a_drop() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeRemoteDesktop(updates = flow { error("socket died") })
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        assertEquals(RemoteDesktopUpdate.Closed(cleanExit = false), screen.close.value)
+        scope.cancel()
+    }
+
+    @Test
+    fun the_close_the_server_explained_survives_the_read_loop_blowing_up_after_it() = runTest {
+        // Teardown throwing behind an orderly close must not replace the server's own words with a
+        // bare drop — that is the only text the tab has to explain why it ended.
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val explained = RemoteDesktopUpdate.Closed(cleanExit = true, reason = "the account may not log on remotely")
+        val session = FakeRemoteDesktop(
+            updates = flow {
+                emit(explained)
+                error("socket died")
+            },
+        )
+        val screen = RemoteDesktopScreenState(session, scope)
+
+        assertEquals(explained, screen.close.value)
         scope.cancel()
     }
 


### PR DESCRIPTION
`RemoteDesktopController` waited for a dropped session through `snapshotFlow { screen.closed }`. A snapshot read reaches a coroutine only through the process-wide Compose apply-observer registry, delivered by whatever frame runs next — so the transition to `Disconnected` depended on timing the controller does not own, and the test had to call `Snapshot.sendApplyNotifications()` itself.

`RemoteDesktopScreenState` now publishes the close as `StateFlow<RemoteDesktopUpdate.Closed?>` carrying `cleanExit` and the server's reason, and the controller collects it — the way `ConnectionController` watches `TerminalState`. A close that lands before the watcher subscribes is replayed instead of lost.

A read loop that throws behind an orderly close no longer replaces the server's own words with a bare drop (`compareAndSet(null, …)`).

Tests: the controller test no longer touches the Compose snapshot system; the screen-state test pins the full close value including the reason, the throwing-read-loop path, and that an explained close survives a later failure.

Fixes #124