### PR TITLE
Desktop shell: the work area follows the selected tab, the rail follows nothing

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -66,13 +66,21 @@ fun SessionView.asDesktopView(): DesktopView = when (this) {
 }
 
 /**
- * Work-area section a tab belongs to: a remote-desktop tab ([Tab.isVnc]) renders in the
- * remote-desktop section, everything else (shells, SFTP, recording player) in the terminal one.
- * Activating a tab moves the shell to its section, so the rail, the sidebar and the work area never
- * disagree about what is on screen.
+ * Section the work area renders, given the selected tab [active] and the section open in the rail
+ * ([DesktopDesignState.section]). A remote-desktop tab ([Tab.isVnc]) renders as a framebuffer,
+ * everything else (shells, SFTP, recording player) as a terminal-side view.
+ *
+ * The work area belongs to the tab, not to the rail: opening a section swaps the catalog in the
+ * sidebar and leaves the live session on screen, so walking over to the desktops catalog while a
+ * shell is running doesn't replace that shell with an empty state. It works the other way too —
+ * tabbing between sessions swaps the screen without dragging the catalog along. Only with no tab
+ * open does the rail decide the whole work area: there is nothing to keep.
  */
-fun sectionOf(tab: Tab?): HostSection =
-    if (tab?.isVnc == true) HostSection.RemoteDesktops else HostSection.Terminal
+fun workAreaSection(active: Tab?, section: HostSection): HostSection = when {
+    active == null -> section
+    active.isVnc -> HostSection.RemoteDesktops
+    else -> HostSection.Terminal
+}
 
 /** Settings panel tabs. */
 enum class SettingsTab { AI, Sync, Security, Appearance, Terminal, Keyboard, Trash, About }
@@ -488,8 +496,8 @@ class DesktopDesignState(
      * Open a work-area section from the rail (terminal / remote desktops). Clears the app overlay —
      * the click asks for the work area, which an open Vault/Teams section would otherwise hide. The
      * session sub-view ([view]) is left alone, so returning to the terminal lands on the SFTP panel
-     * if that is where the user was. Activating the section's newest tab is the caller's job (it
-     * holds the session manager), see [app.skerry.ui.desktop.openRailSection].
+     * if that is where the user was. The selected tab is left alone too — see
+     * [app.skerry.ui.desktop.openRailSection] for why the rail doesn't touch it.
      */
     fun showSection(s: HostSection) {
         appOverlay = null

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventType
@@ -1105,7 +1103,7 @@ private fun DesktopChrome(
                             stringResource(Res.string.shell_disconnect_message)
                         },
                         confirmLabel = stringResource(Res.string.shell_disconnect),
-                        onConfirm = { closeSessionTab(state, sessions, pc.id); state.dismissClose() },
+                        onConfirm = { sessions?.close(pc.id); state.dismissClose() },
                         onDismiss = state::dismissClose,
                     )
                 }
@@ -1256,8 +1254,6 @@ internal fun selectTabByIndex(index: Int, state: DesktopDesignState, sessions: S
     if (sessions != null) {
         val target = sessions.tabs.getOrNull(index) ?: return false
         sessions.activate(target.id)
-        // A tab hotkey can cross sections (Alt+3 onto a remote desktop): the work area follows.
-        followActiveTabSection(state, sessions)
         return true
     }
     if (index !in state.tabs.indices) return false
@@ -1273,7 +1269,6 @@ internal fun cycleTab(delta: Int, state: DesktopDesignState, sessions: SessionsC
         val current = list.indexOfFirst { it.id == sessions.activeId }.coerceAtLeast(0)
         val next = ((current + delta) % list.size + list.size) % list.size
         sessions.activate(list[next].id)
-        followActiveTabSection(state, sessions)
         return true
     }
     val count = state.tabs.size
@@ -1397,14 +1392,14 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
                         name = focused.tabTitle(state.showTerminalTitleOnTabs),
                         // A recording tab has no connection: its dot and accent are sunset, so it
                         // never reads as a live (or dead) session.
-                        dot = if (s.isPlayer) Skerry.colors.sunset else sessionDotColor(focused.controller.uiState),
+                        dot = if (s.isPlayer) Skerry.colors.sunset else sessionDotColor(focused.status),
                         accent = if (s.isPlayer || prodTab) Skerry.colors.sunset else Skerry.colors.cyan,
                         split = s.isSplit,
                         active = s.id == sessions.activeId,
-                        // Chips of both sections share one row, so selecting one also moves the work
-                        // area to the section that tab belongs to.
-                        onClick = { sessions.activate(s.id); followActiveTabSection(state, sessions) },
-                        onClose = { tabDrag.tabClosed(s.id); closeSessionTab(state, sessions, s.id) },
+                        // Chips of both sections share one row: selecting one swaps the work area
+                        // (workAreaSection) and leaves the rail on whatever catalog is open.
+                        onClick = { sessions.activate(s.id) },
+                        onClose = { tabDrag.tabClosed(s.id); sessions.close(s.id) },
                         dragging = tabDrag.draggingTabId == s.id,
                         modifier = Modifier
                             .tabBoundsAnchor(tabDrag, s.id)
@@ -1511,15 +1506,6 @@ internal fun SessionTabChip(
                 },
             )
             .border(1.dp, if (active) accentBorder else Skerry.colors.line, shape)
-            // Accent strip on the active tab's top edge (editor tab style). drawBehind renders over the
-            // background/border but under content; doesn't inflate the chip's width.
-            .then(
-                if (active) {
-                    Modifier.drawBehind { drawRect(accent, size = Size(size.width, 2.dp.toPx())) }
-                } else {
-                    Modifier
-                },
-            )
             .clickable(interactionSource = interaction, indication = null, onClick = onClick)
             // Middle-click closes the tab (browser-tab convention), active or not: armed on the
             // tertiary press, committed on its release while still over the chip — moving off
@@ -1575,7 +1561,6 @@ private fun TabInsertLine() {
 
 @Composable
 private fun IconRail(state: DesktopDesignState) {
-    val sessions = LocalSessions.current
     Column(
         Modifier
             .width(52.dp)
@@ -1596,8 +1581,9 @@ private fun IconRail(state: DesktopDesignState) {
                     when (val target = item.target) {
                         // App-level (Vault/Known/Teams/Tunnels/Snippets) → overlay over the tabs.
                         is RailTarget.View -> state.showView(target.view)
-                        // Work-area section: switch the shell and land on that section's newest tab.
-                        is RailTarget.Section -> openRailSection(state, sessions, target.section)
+                        // Work-area section: swaps the sidebar catalog; a running session stays on
+                        // screen (openRailSection).
+                        is RailTarget.Section -> openRailSection(state, target.section)
                     }
                 },
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Rail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Rail.kt
@@ -2,9 +2,7 @@ package app.skerry.ui.desktop
 
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
-import app.skerry.ui.app.sectionOf
 import app.skerry.ui.host.HostSection
-import app.skerry.ui.session.SessionsController
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.rail_desktops
 import app.skerry.ui.generated.resources.rail_hosts
@@ -54,33 +52,16 @@ fun railItemActive(item: RailItem, state: DesktopDesignState): Boolean = when (v
 }
 
 /**
- * Open a work-area section from the rail: switch the shell to it and activate that section's newest
- * tab, so returning to a section lands back on its live session instead of an empty work area. With
- * no tab of that section the active tab is left alone — the work area shows the section's empty
- * state, and the other section's tab stays selected for when the user switches back.
+ * Open a work-area section from the rail: swap the sidebar catalog, leave the running session on
+ * screen. Walking the rail is navigation, not a session switch — the tab the user is working in
+ * keeps its chip selected and keeps rendering ([app.skerry.ui.app.workAreaSection]), and the
+ * catalog that just opened is how the next session starts. Only with no tab open does the section
+ * take over the whole work area.
  */
-fun openRailSection(state: DesktopDesignState, sessions: SessionsController?, section: HostSection) {
+fun openRailSection(state: DesktopDesignState, section: HostSection) {
     state.showSection(section)
-    sessions?.lastSessionIn(remoteDesktop = section == HostSection.RemoteDesktops)
-        ?.let { sessions.activate(it.id) }
 }
 
-/**
- * Follow a tab selection (chip click, tab hotkey, a session opening): the work area moves to the
- * section the now-active tab belongs to, so clicking a remote-desktop chip shows the framebuffer
- * rather than leaving the terminal on screen.
- */
-fun followActiveTabSection(state: DesktopDesignState, sessions: SessionsController?) {
-    state.showSection(sectionOf(sessions?.active))
-}
-
-/**
- * Close tab [id] and follow whatever tab becomes active. Every close path goes through here (chip
- * "×", the disconnect confirmation): closing hands the selection to a neighbour, which may belong
- * to the other section, and a close that forgot to follow would leave the rail, the tab row and
- * the work area pointing at three different things.
- */
-fun closeSessionTab(state: DesktopDesignState, sessions: SessionsController?, id: String) {
-    sessions?.close(id)
-    followActiveTabSection(state, sessions)
-}
+// Selecting, cycling or closing a tab deliberately has no rail counterpart: the work area follows
+// the selection on its own ([app.skerry.ui.app.workAreaSection]), and the catalog stays the one the
+// user opened. The rail moves on a rail click and on a connect (which lands in that host's section).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/Viewport.kt
@@ -17,13 +17,18 @@ import app.skerry.ui.tunnel.TunnelsView
 import app.skerry.ui.vault.VaultView
 import app.skerry.ui.vnc.RemoteDesktopsView
 import app.skerry.ui.app.asSessionView
+import app.skerry.ui.app.workAreaSection
 
 /**
  * Switches the main content area. App-level views (Vault/Known/Teams/Snippets) render over
- * everything per [DesktopDesignState.appOverlay]; otherwise the selected work-area section
- * ([DesktopDesignState.section]) decides: remote desktops render their own catalog + framebuffer,
- * the terminal section renders the active terminal tab's subview
- * ([app.skerry.ui.session.Session.view]), falling back to [state.view] with no live sessions.
+ * everything per [DesktopDesignState.appOverlay]; otherwise the selected tab decides
+ * ([workAreaSection]): a remote-desktop tab renders the framebuffer, any other one renders its
+ * subview ([app.skerry.ui.session.Session.view]). Only with no tab open does the section chosen in
+ * the rail decide, on its empty state — with no live sessions at all (design preview) it also
+ * supplies the subview via [state.view].
+ *
+ * The sidebar beside the work area is the rail's, not the tab's: it always lists
+ * [DesktopDesignState.section]'s catalog.
  */
 @Composable
 fun Viewport(state: DesktopDesignState) {
@@ -34,20 +39,21 @@ fun Viewport(state: DesktopDesignState) {
         DesktopView.Vault -> VaultView()
         DesktopView.Known -> KnownHostsView()
         DesktopView.Teams -> TeamsView()
-        // overlay == null: renders the selected section (showView only stores app-level values in appOverlay).
-        else -> when (state.section) {
-            HostSection.RemoteDesktops -> RemoteDesktopsView(state)
-            HostSection.Terminal -> {
-                val sessions = LocalSessions.current
-                // activeTerminal, not active: a remote-desktop tab may still be the selected one
-                // (its section has no tab to fall back to), and it is not this section's to render.
-                val view = sessions?.activeTerminal?.view ?: state.view.asSessionView()
-                when (view) {
-                    SessionView.Terminal -> TerminalView(state)
-                    SessionView.Sftp -> SftpView()
-                    // A remote desktop never renders here (see activeTerminal); keep the branch total.
-                    SessionView.Vnc -> TerminalView(state)
-                    SessionView.Player -> CastPlayerView()
+        // overlay == null: renders the work area (showView only stores app-level values in appOverlay).
+        else -> {
+            val sessions = LocalSessions.current
+            when (workAreaSection(sessions?.active, state.section)) {
+                HostSection.RemoteDesktops -> RemoteDesktopsView(state)
+                HostSection.Terminal -> {
+                    // activeTerminal, not active: a remote-desktop tab renders in the branch above.
+                    val view = sessions?.activeTerminal?.view ?: state.view.asSessionView()
+                    when (view) {
+                        SessionView.Terminal -> TerminalView(state)
+                        SessionView.Sftp -> SftpView()
+                        // A remote desktop never renders here (see activeTerminal); keep the branch total.
+                        SessionView.Vnc -> TerminalView(state)
+                        SessionView.Player -> CastPlayerView()
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -77,6 +77,7 @@ import app.skerry.ui.host.folderRangeAnchor
 import app.skerry.ui.host.hostBoundsAnchor
 import app.skerry.ui.host.hostChipLabel
 import app.skerry.ui.host.icon
+import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
 import app.skerry.ui.host.draggableFolderHeader
 import app.skerry.ui.host.draggableHostRow
@@ -461,13 +462,13 @@ private fun MobileFolderHeader(
  * Host row: icon tile + name + monospace `user@address` + status dot. The tile carries the
  * profile's protocol ([app.skerry.ui.host.icon], same symbol as the desktop sidebar and the
  * connection form); the dot color is live, taken from the host's latest session status
- * ([SessionsController.statusFor]) via the desktop-shared [sessionDotColor] (connected → green,
+ * ([SessionsController.sessionStatusFor]) via the desktop-shared [sessionDotColor] (live → green,
  * connecting → amber, error/dropped → sunset, no session → dim). Reading uiState inside the
  * composition subscribes the row to status changes so the dot updates on connect.
  */
 @Composable
 private fun MobileHostRow(host: Host, onClick: () -> Unit) {
-    val dotColor = sessionDotColor(LocalSessions.current?.statusFor(host.id))
+    val dotColor = sessionDotColor(LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle)
     val prod = isProdHost(host)
     Row(
         Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -67,6 +67,7 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_accept
@@ -699,7 +700,7 @@ internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>, section: HostSec
  */
 @Composable
 private fun MobileTeamHostRow(host: Host, mono: androidx.compose.ui.text.font.FontFamily, onClick: () -> Unit) {
-    val dotColor = sessionDotColor(LocalSessions.current?.statusFor(host.id))
+    val dotColor = sessionDotColor(LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle)
     Row(
         Modifier
             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionStatus.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionStatus.kt
@@ -1,0 +1,37 @@
+package app.skerry.ui.session
+
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.remote.RemoteDesktopUiState
+
+/**
+ * Status a session reports to the chrome around it (tab chip, host row) — one scale for both kinds
+ * of session. A remote desktop keeps its state in [Session.vncController] while its
+ * [Session.controller] stays an idle placeholder, so reading the terminal controller alone reports
+ * a live desktop as idle.
+ */
+enum class SessionStatus { Live, Connecting, Failed, Idle }
+
+/** Status of a terminal session's connection. */
+fun ConnectionUiState?.asSessionStatus(): SessionStatus = when (this) {
+    is ConnectionUiState.Connected -> SessionStatus.Live
+    ConnectionUiState.Connecting -> SessionStatus.Connecting
+    is ConnectionUiState.Error -> SessionStatus.Failed
+    // A clean shell exit is not a failure; a retrying reconnect reads like connecting; exhausted
+    // retries mean no session, same as an error.
+    is ConnectionUiState.Disconnected -> when {
+        cleanExit -> SessionStatus.Idle
+        reconnecting -> SessionStatus.Connecting
+        else -> SessionStatus.Failed
+    }
+    else -> SessionStatus.Idle
+}
+
+/** Status of a remote-desktop session — the framebuffer sibling of the mapping above. */
+fun RemoteDesktopUiState?.asSessionStatus(): SessionStatus = when (this) {
+    is RemoteDesktopUiState.Connected -> SessionStatus.Live
+    RemoteDesktopUiState.Connecting -> SessionStatus.Connecting
+    is RemoteDesktopUiState.Error -> SessionStatus.Failed
+    // No auto-reconnect on this side: a closed session is either a clean end or a drop.
+    is RemoteDesktopUiState.Disconnected -> if (cleanExit) SessionStatus.Idle else SessionStatus.Failed
+    null -> SessionStatus.Idle
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionVisuals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionVisuals.kt
@@ -7,22 +7,19 @@ import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.theme.Skerry
 
 /**
- * Session status-dot color (titlebar tab, sidebar host row) by connection state: connected -
- * green, connecting - amber, error - sunset, otherwise (form/no session) - faint. Palette from
- * [D] design tokens.
+ * Session status-dot color (titlebar tab, sidebar host row): live - green, connecting - amber,
+ * failed - sunset, idle (form/clean exit/no session) - faint. Palette from [D] design tokens.
  */
 @Composable
 @ReadOnlyComposable
-fun sessionDotColor(state: ConnectionUiState?): Color = when (state) {
-    is ConnectionUiState.Connected -> Skerry.colors.moss
-    ConnectionUiState.Connecting -> Skerry.colors.amber
-    is ConnectionUiState.Error -> Skerry.colors.sunset
-    // Clean shell exit is faint (not an error); auto-reconnect in progress is amber (like
-    // Connecting); exhausted retries are sunset, same as an error (no live session).
-    is ConnectionUiState.Disconnected -> when {
-        state.cleanExit -> Skerry.colors.faint
-        state.reconnecting -> Skerry.colors.amber
-        else -> Skerry.colors.sunset
-    }
-    else -> Skerry.colors.faint
+fun sessionDotColor(status: SessionStatus): Color = when (status) {
+    SessionStatus.Live -> Skerry.colors.moss
+    SessionStatus.Connecting -> Skerry.colors.amber
+    SessionStatus.Failed -> Skerry.colors.sunset
+    SessionStatus.Idle -> Skerry.colors.faint
 }
+
+/** Same dot for a terminal connection read straight off its controller (panes, info panel). */
+@Composable
+@ReadOnlyComposable
+fun sessionDotColor(state: ConnectionUiState?): Color = sessionDotColor(state.asSessionStatus())

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -70,6 +70,14 @@ class Session(
         private set
 
     /**
+     * Status for the chrome around this session (tab chip, host row). Reads whichever controller
+     * actually holds the connection: a remote desktop's terminal [controller] is a placeholder that
+     * never leaves its idle state, so going through it alone would paint a live desktop grey.
+     */
+    val status: SessionStatus
+        get() = if (isVnc) vncController?.uiState.asSessionStatus() else controller.uiState.asSessionStatus()
+
+    /**
      * A blank pane with no session: no host selected and no connection started yet (controller in
      * [ConnectionUiState.Form]). A pane with a host already bound does not become blank again after
      * [ConnectionController.disconnect].
@@ -295,12 +303,6 @@ class SessionsController(
 
     /** The active tab as seen by the remote-desktop section, `null` when a terminal tab is active. */
     val activeDesktop: Tab? get() = active?.takeIf { it.isVnc }
-
-    /**
-     * Newest tab of a section, or `null` if it has none. Switching sections from the rail activates
-     * this one, so returning to a section lands back on a live session instead of an empty area.
-     */
-    fun lastSessionIn(remoteDesktop: Boolean): Tab? = tabs.lastOrNull { it.isVnc == remoteDesktop }
 
     /**
      * Put [session] in a tab of its own, append it to the bar and make it active.
@@ -629,9 +631,12 @@ class SessionsController(
         tabs = remaining
     }
 
-    /** State of the most recent session for host [hostId] (for the sidebar status dot), or null. */
-    fun statusFor(hostId: String): ConnectionUiState? =
-        allSessions.lastOrNull { it.hostId == hostId }?.controller?.uiState
+    /**
+     * Status of the most recent session for host [hostId] — what the catalog's status dot reads.
+     * Remote desktops included: their state lives in their own controller (see [Session.status]).
+     */
+    fun sessionStatusFor(hostId: String): SessionStatus =
+        allSessions.lastOrNull { it.hostId == hostId }?.status ?: SessionStatus.Idle
 
     /** Close all sessions (panes included) — call on screen teardown to avoid leaking sockets. */
     fun disconnectAll() {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebar.kt
@@ -139,6 +139,7 @@ import app.skerry.ui.host.hostChipLabel
 import app.skerry.ui.host.hostTagChips
 import app.skerry.ui.host.icon
 import app.skerry.ui.session.SessionsController
+import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -835,7 +836,7 @@ private fun HostRow(
             // Selection highlight: marks the row clicked in double-click mode (and the most recently
             // connected one in single-click mode). Distinct from the live-connection status dot.
             selected = host.id == selectedHostId,
-            dot = sessionDotColor(sessions?.statusFor(host.id)),
+            dot = sessionDotColor(sessions?.sessionStatusFor(host.id) ?: SessionStatus.Idle),
             badge = null,
             onClick = onClick,
             onSelect = onSelect,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -439,7 +439,11 @@ fun TerminalView(state: DesktopDesignState) {
             visible = !state.sidebarHidden,
             enter = expandHorizontally(expandFrom = Alignment.End),
             exit = shrinkHorizontally(shrinkTowards = Alignment.End),
-        ) { HostsSidebar(state) }
+        ) {
+            // The catalog belongs to the rail, not to what's on screen: a shell keeps running while
+            // the user browses the desktops list beside it (see workAreaSection).
+            HostsSidebar(state, state.section)
+        }
         // Reopen handle: a slim strip at the terminal's left edge, shown only while the sidebar is
         // collapsed (its collapse chevron lives in the panel header, which is gone when hidden).
         AnimatedVisibility(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -80,7 +80,6 @@ import app.skerry.ui.generated.resources.vnc_resize_to_window
 import app.skerry.ui.generated.resources.vnc_session_closed
 import app.skerry.ui.generated.resources.vnc_view_only
 import app.skerry.ui.design.EmptyState
-import app.skerry.ui.host.HostSection
 import app.skerry.ui.terminal.HostsSidebar
 import app.skerry.ui.terminal.SidebarReopenHandle
 import app.skerry.ui.terminal.plainTextClipEntry
@@ -103,7 +102,11 @@ fun RemoteDesktopsView(state: DesktopDesignState) {
             visible = !state.sidebarHidden,
             enter = expandHorizontally(expandFrom = Alignment.End),
             exit = shrinkHorizontally(shrinkTowards = Alignment.End),
-        ) { HostsSidebar(state, HostSection.RemoteDesktops) }
+        ) {
+            // Same as the terminal side: the catalog follows the rail, the framebuffer follows the
+            // selected tab (see workAreaSection).
+            HostsSidebar(state, state.section)
+        }
         AnimatedVisibility(
             visible = state.sidebarHidden,
             enter = fadeIn() + expandHorizontally(expandFrom = Alignment.Start),

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionStatusTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionStatusTest.kt
@@ -1,0 +1,82 @@
+package app.skerry.ui.session
+
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.remote.FakeRemoteDesktop
+import app.skerry.ui.remote.RemoteDesktopScreenState
+import app.skerry.ui.remote.RemoteDesktopUiState
+import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.vnc.VncFailure
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The two mappings onto [SessionStatus] decide the color of every status dot (tab chip, host row).
+ * An inverted `cleanExit` or a swapped `reconnecting` branch compiles and shows a dropped session
+ * as idle, so every branch is pinned here.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionStatusTest {
+
+    @Test
+    fun `a terminal connection maps every state onto its status`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val terminal = TerminalScreenState(FakeSession(), scope)
+
+        assertEquals(SessionStatus.Idle, (null as ConnectionUiState?).asSessionStatus())
+        assertEquals(SessionStatus.Idle, ConnectionUiState.Form.asSessionStatus())
+        assertEquals(SessionStatus.Connecting, ConnectionUiState.Connecting.asSessionStatus())
+        assertEquals(SessionStatus.Live, ConnectionUiState.Connected(terminal).asSessionStatus())
+        assertEquals(SessionStatus.Failed, ConnectionUiState.Error("boom").asSessionStatus())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a dropped shell is a failure until it exits cleanly or starts retrying`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val terminal = TerminalScreenState(FakeSession(), scope)
+        fun dropped(reconnecting: Boolean, cleanExit: Boolean) =
+            ConnectionUiState.Disconnected(terminal, reconnecting, attempt = 1, cleanExit = cleanExit)
+
+        assertEquals(SessionStatus.Idle, dropped(reconnecting = false, cleanExit = true).asSessionStatus())
+        assertEquals(SessionStatus.Connecting, dropped(reconnecting = true, cleanExit = false).asSessionStatus())
+        // Retries exhausted: the session is gone and says so, rather than fading to idle.
+        assertEquals(SessionStatus.Failed, dropped(reconnecting = false, cleanExit = false).asSessionStatus())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a remote desktop maps every state onto its status`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(), scope)
+
+        assertEquals(SessionStatus.Idle, (null as RemoteDesktopUiState?).asSessionStatus())
+        assertEquals(SessionStatus.Connecting, RemoteDesktopUiState.Connecting.asSessionStatus())
+        assertEquals(SessionStatus.Live, RemoteDesktopUiState.Connected(screen).asSessionStatus())
+        assertEquals(SessionStatus.Failed, RemoteDesktopUiState.Error(VncFailure.Auth).asSessionStatus())
+        // No auto-reconnect on this side: a close is either the user's own exit or a drop.
+        assertEquals(SessionStatus.Idle, RemoteDesktopUiState.Disconnected(screen, cleanExit = true).asSessionStatus())
+        assertEquals(SessionStatus.Failed, RemoteDesktopUiState.Disconnected(screen, cleanExit = false).asSessionStatus())
+        scope.cancel()
+    }
+}
+
+/** A terminal session that never emits: the states above only need a screen to carry. */
+private class FakeSession : TerminalSession {
+    override val state: StateFlow<TerminalState> = MutableStateFlow(TerminalState.Open)
+    override val output: Flow<ByteArray> = emptyFlow()
+    override suspend fun send(data: ByteArray) {}
+    override suspend fun resize(size: PtySize) {}
+    override suspend fun close() {}
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -28,13 +28,14 @@ import app.skerry.shared.graphics.RemoteDesktopUpdate
 import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.session.SessionStatus
+import app.skerry.ui.session.asSessionStatus
 import app.skerry.ui.terminal.MirroredInput
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
+import app.skerry.ui.app.workAreaSection
 import app.skerry.ui.desktop.RAIL
 import app.skerry.ui.desktop.RailTarget
-import app.skerry.ui.desktop.closeSessionTab
-import app.skerry.ui.desktop.followActiveTabSection
 import app.skerry.ui.desktop.openRailSection
 import app.skerry.ui.desktop.railItemActive
 import app.skerry.ui.host.HostSection
@@ -196,14 +197,14 @@ class SessionsControllerTest {
     }
 
     @Test
-    fun `statusFor reports the state of the newest session for a host, else null`() = runTest {
+    fun `sessionStatusFor reports the newest session of a host, idle for an unopened one`() = runTest {
         val (sessions, scope) = sessionsWith(FakeTransport())
-        assertNull(sessions.statusFor("host-a"))
+        assertEquals(SessionStatus.Idle, sessions.sessionStatusFor("host-a"))
 
         sessions.open(hostId = "host-a")
 
-        assertIs<ConnectionUiState.Connected>(sessions.statusFor("host-a"))
-        assertNull(sessions.statusFor("host-b"))
+        assertEquals(SessionStatus.Live, sessions.sessionStatusFor("host-a"))
+        assertEquals(SessionStatus.Idle, sessions.sessionStatusFor("host-b"))
         scope.cancel()
     }
 
@@ -437,13 +438,13 @@ class SessionsControllerTest {
     }
 
     @Test
-    fun `statusFor sees a host connected in a pane, not just in a tab of its own`() = runTest {
+    fun `sessionStatusFor sees a host connected in a pane, not just in a tab of its own`() = runTest {
         val (sessions, scope) = sessionsWith(FakeTransport())
         val a = sessions.open(hostId = "host-a")
         val pane = sessions.addPane()!!
         sessions.connectPane(tabId = a, paneId = pane, hostId = "host-b")
 
-        assertIs<ConnectionUiState.Connected>(sessions.statusFor("host-b"))
+        assertEquals(SessionStatus.Live, sessions.sessionStatusFor("host-b"))
         scope.cancel()
     }
 
@@ -1046,6 +1047,40 @@ class SessionsControllerTest {
         scope.cancel()
     }
 
+    @Test
+    fun `a connected remote desktop reports a live status, not the placeholder controller's`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+
+        val desktop = sessions.openVnc(hostId = "screen")!!
+
+        val session = sessions.tab(desktop)!!.focusedPane
+        assertEquals(SessionStatus.Live, session.status)
+        // The terminal controller beside it never connects — reading it alone reports Idle.
+        assertEquals(SessionStatus.Idle, session.controller.uiState.asSessionStatus())
+        scope.cancel()
+    }
+
+    @Test
+    fun `the catalog dot sees a connected desktop, and nothing for an unopened host`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+
+        sessions.openVnc(hostId = "screen")
+
+        assertEquals(SessionStatus.Live, sessions.sessionStatusFor("screen"))
+        assertEquals(SessionStatus.Idle, sessions.sessionStatusFor("host-b"))
+        scope.cancel()
+    }
+
+    @Test
+    fun `a connected shell reports a live status`() = runTest {
+        val (sessions, scope) = sessionsWith(FakeTransport())
+
+        val id = sessions.open(hostId = "host-a")
+
+        assertEquals(SessionStatus.Live, sessions.tab(id)!!.focusedPane.status)
+        scope.cancel()
+    }
+
     // Section-scoped active tab (terminal shell vs remote desktop)
 
     @Test
@@ -1071,28 +1106,6 @@ class SessionsControllerTest {
         assertEquals(id, sessions.activeTerminal?.id)
         assertNull(sessions.activeDesktop)
         sessions.close(id)
-        scope.cancel()
-    }
-
-    @Test
-    fun `lastSessionIn finds the newest tab of a section`() = runTest {
-        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
-        val shellA = sessions.open(hostId = "a")
-        val desktop = sessions.openVnc(hostId = "screen")!!
-        val shellB = sessions.open(hostId = "b")
-
-        assertEquals(shellB, sessions.lastSessionIn(remoteDesktop = false)?.id)
-        assertEquals(desktop, sessions.lastSessionIn(remoteDesktop = true)?.id)
-        assertTrue(shellA != shellB)
-        scope.cancel()
-    }
-
-    @Test
-    fun `lastSessionIn reports nothing when the section has no tabs`() = runTest {
-        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
-        sessions.open(hostId = "a")
-
-        assertNull(sessions.lastSessionIn(remoteDesktop = true))
         scope.cancel()
     }
 
@@ -1262,50 +1275,65 @@ class DesktopSectionNavigationTest {
     }
 
     @Test
-    fun `opening a section activates its newest tab`() = runTest {
+    fun `opening a section keeps the running session on screen`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+
+        openRailSection(state, HostSection.RemoteDesktops)
+
+        // The rail moved the catalog to the desktops, but the shell is what the user was working
+        // in: it stays selected and stays on screen. The desktops catalog is how a desktop opens.
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(shell, sessions.activeId)
+        assertEquals(HostSection.Terminal, workAreaSection(sessions.active, state.section))
+        scope.cancel()
+    }
+
+    @Test
+    fun `opening a section with no tabs switches the whole work area`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+
+        openRailSection(state, HostSection.RemoteDesktops)
+
+        // Nothing to keep on screen, so the rail decides: the desktops empty state.
+        assertEquals(HostSection.RemoteDesktops, workAreaSection(sessions.active, state.section))
+        scope.cancel()
+    }
+
+    @Test
+    fun `a desktop session stays on screen while the terminal catalog is open`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+
+        openRailSection(state, HostSection.Terminal)
+
+        // Symmetric to the shell case: the framebuffer keeps rendering while the hosts catalog is
+        // the one in the sidebar.
+        assertEquals(HostSection.Terminal, state.section)
+        assertEquals(HostSection.RemoteDesktops, workAreaSection(sessions.active, state.section))
+        scope.cancel()
+    }
+
+    @Test
+    fun `selecting a tab moves the work area, never the rail`() = runTest {
         val (sessions, scope) = sessions()
         val state = DesktopDesignState()
         val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
         val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+        openRailSection(state, HostSection.Terminal)
 
-        openRailSection(state, sessions, HostSection.Terminal)
+        // Chip clicks and tab hotkeys swap what's on screen and nothing else: the catalog stays the
+        // one the user opened, so tabbing through sessions doesn't shuffle the sidebar under them.
+        sessions.activate(desktop)
         assertEquals(HostSection.Terminal, state.section)
-        assertEquals(shell, sessions.activeId)
-
-        openRailSection(state, sessions, HostSection.RemoteDesktops)
-        assertEquals(HostSection.RemoteDesktops, state.section)
-        assertEquals(desktop, sessions.activeId)
-        scope.cancel()
-    }
-
-    @Test
-    fun `opening a section with no tabs still switches the work area`() = runTest {
-        val (sessions, scope) = sessions()
-        val state = DesktopDesignState()
-        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
-
-        openRailSection(state, sessions, HostSection.RemoteDesktops)
-
-        // The section opens on its empty state; the shell tab stays selected for the way back.
-        assertEquals(HostSection.RemoteDesktops, state.section)
-        assertEquals(shell, sessions.activeId)
-        assertNull(sessions.activeDesktop)
-        scope.cancel()
-    }
-
-    @Test
-    fun `selecting a tab moves the work area to its section`() = runTest {
-        val (sessions, scope) = sessions()
-        val state = DesktopDesignState()
-        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
-        sessions.openVnc("screen", "screen", "", target, VncAuth.None)
-
-        followActiveTabSection(state, sessions)
-        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(HostSection.RemoteDesktops, workAreaSection(sessions.active, state.section))
 
         sessions.activate(shell)
-        followActiveTabSection(state, sessions)
         assertEquals(HostSection.Terminal, state.section)
+        assertEquals(HostSection.Terminal, workAreaSection(sessions.active, state.section))
         scope.cancel()
     }
 
@@ -1329,36 +1357,71 @@ class DesktopSectionNavigationTest {
     }
 
     @Test
-    fun `closing a tab hands the work area to the tab that becomes active`() = runTest {
+    fun `closing the last tab keeps the open catalog and shows its empty state`() = runTest {
         val (sessions, scope) = sessions()
         val state = DesktopDesignState()
-        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
-        sessions.openVnc("screen", "screen", "", target, VncAuth.None)
-        sessions.activate(shell)
-        followActiveTabSection(state, sessions)
-        assertEquals(HostSection.Terminal, state.section)
-
-        // Closing the active shell promotes its right neighbour — a remote desktop.
-        closeSessionTab(state, sessions, shell)
-
+        val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+        openRailSection(state, HostSection.RemoteDesktops)
         assertEquals(HostSection.RemoteDesktops, state.section)
-        assertEquals(sessions.activeId, sessions.activeDesktop?.id)
+
+        sessions.close(desktop)
+
+        assertTrue(sessions.tabs.isEmpty())
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(HostSection.RemoteDesktops, workAreaSection(sessions.active, state.section))
         scope.cancel()
     }
 
     @Test
-    fun `closing the last tab of a section falls back to the other one`() = runTest {
+    fun `closing the active tab hands the screen to the neighbour, catalog unchanged`() = runTest {
         val (sessions, scope) = sessions()
         val state = DesktopDesignState()
-        sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
         val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
-        followActiveTabSection(state, sessions)
+        openRailSection(state, HostSection.RemoteDesktops)
+        assertEquals(HostSection.RemoteDesktops, state.section)
 
         sessions.close(desktop)
-        followActiveTabSection(state, sessions)
 
-        // The shell tab became active, so the shell section is what the work area shows.
+        // The shell takes over the screen; the rail and the sidebar stay on the desktops catalog.
+        assertEquals(shell, sessions.activeId)
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        assertEquals(HostSection.Terminal, workAreaSection(sessions.active, state.section))
+        scope.cancel()
+    }
+
+    @Test
+    fun `closing an inactive tab never moves the selection`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val first = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        val second = sessions.open("b", "b", "", target, SshAuth.Password("pw"))
+        sessions.openVnc("screen", "screen", "", target, VncAuth.None)
+        sessions.activate(second)
+        // Working in a shell while browsing the desktop catalog — the rail leaves the selection be.
+        openRailSection(state, HostSection.RemoteDesktops)
+
+        sessions.close(first)
+
+        assertEquals(second, sessions.activeId)
+        assertEquals(HostSection.RemoteDesktops, state.section)
+        scope.cancel()
+    }
+
+    @Test
+    fun `closing a tab of the other section leaves the open one alone`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        val shell = sessions.open("a", "a", "", target, SshAuth.Password("pw"))
+        val desktop = sessions.openVnc("screen", "screen", "", target, VncAuth.None)!!
+        sessions.activate(shell)
+        openRailSection(state, HostSection.Terminal)
+
+        // The "×" of a remote-desktop chip is reachable from the terminal section — one tab row.
+        sessions.close(desktop)
+
         assertEquals(HostSection.Terminal, state.section)
+        assertEquals(shell, sessions.activeId)
         scope.cancel()
     }
 }


### PR DESCRIPTION
## What this does

**The work area belongs to the selected tab, the sidebar catalog to the rail.**

Opening the remote-desktops section used to replace a running shell with an empty state, and every tab action dragged the rail along: selecting a chip, cycling with the tab hotkeys, and closing the last tab of a section, which dropped the user back on the terminal section.

Now:

| Surface | Follows |
|---|---|
| Work area | the selected tab (`workAreaSection`); the rail section only when no tab is open |
| Sidebar catalog, rail highlight | a rail click, or a connect (which lands in that host's section) |

Walking the rail swaps the catalog and leaves the live session on screen — a shell keeps running while the desktops catalog is open beside it, and a framebuffer keeps rendering while the hosts catalog is. Selecting or closing a tab moves nothing but the screen.

**Status dot on remote desktops.** The tab chip read the session's terminal controller, which for a remote desktop is an idle placeholder beside the real one, so a connected desktop always showed a grey dot. `SessionStatus` reports a session's status from whichever controller holds the connection. The host catalog dots — desktop sidebar, mobile hosts and teams rows — read it too, where the same bug was visible.

**Tab chip.** The active chip no longer draws the accent strip on its top edge; the accent background and border still mark it.

## Removed

`followActiveTabSection`, `closeSessionTab`, `sectionOf`, `SessionsController.lastSessionIn` and `statusFor` lost their callers with the rework and are gone.

## Tests

`SessionStatusTest` pins every branch of both status mappings, including each `Disconnected` sub-case. `DesktopSectionNavigationTest` covers the navigation split in both directions and four close scenarios; `SessionsControllerTest` covers the desktop session reporting a live status rather than its placeholder controller's.

## Verification

Desktop, live: open an SSH session, click **Remote desktops** in the rail — the terminal stays on screen with the desktops catalog beside it. Open a desktop from that catalog, then click **Terminal** — the framebuffer stays, the hosts catalog appears. `Ctrl+Tab` between them: only the screen changes. Close the last tab: the catalog you opened stays open on its empty state. The connected desktop's chip dot is green.

Android compiles; the mobile catalog dots were switched to the same status source but were not checked on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)