### PR TITLE
fix(sync): fall back to login when a closed instance refuses registration with 403

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -115,6 +115,7 @@
     <string name="sync_fail_too_many_requests">Сервер ограничивает частоту запросов — подождите и попробуйте снова</string>
     <string name="sync_fail_server_error">Сервер отвечает с ошибкой — попробуйте позже</string>
     <string name="sync_fail_rejected">Сервер отклонил запрос — обратитесь к его администратору</string>
+    <string name="sync_fail_registration_refused_signin">Сервер отклонил регистрацию и вход — проверьте пароль</string>
 
     <!-- issue #28: подключение к существующему аккаунту с другим паролём меняет пароль этого устройства -->
     <string name="sync_password_replace_title">Использовать пароль аккаунта?</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -115,6 +115,7 @@
     <string name="sync_fail_too_many_requests">服务器正在限制请求频率，请稍候重试</string>
     <string name="sync_fail_server_error">服务器响应异常，请稍后重试</string>
     <string name="sync_fail_rejected">服务器拒绝了该请求 — 请联系服务器管理员</string>
+    <string name="sync_fail_registration_refused_signin">服务器拒绝了注册和登录 — 请检查密码</string>
 
     <!-- issue #28: 连接到使用其他密码的现有账户会将本设备改用该密码 -->
     <string name="sync_password_replace_title">使用账户密码？</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -115,6 +115,7 @@
     <string name="sync_fail_too_many_requests">The server is throttling requests — wait a moment and try again</string>
     <string name="sync_fail_server_error">The server isn't responding correctly — try again later</string>
     <string name="sync_fail_rejected">The server refused this request — ask its administrator</string>
+    <string name="sync_fail_registration_refused_signin">The server refused registration and sign-in — check the password</string>
 
     <!-- issue #28: joining an existing account whose password differs re-keys this device to it -->
     <string name="sync_password_replace_title">Use your account password?</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -173,6 +173,11 @@ enum class SyncFailureReason {
     SyncFailed,            // sync cycle failure (detail: cause)
     RevokeFailed,          // device revoke failed (detail: cause)
     Rejected,              // the server refused on purpose (closed registration, blocked account id) — detail: its message
+    // The instance refuses new accounts AND didn't accept the sign-in: either there is no such
+    // account, or its password was rotated elsewhere and this vault still holds the old one. The two
+    // are indistinguishable by design (see the anti-enumeration login), so both are named — detail:
+    // the server's registration refusal.
+    RegistrationRefusedSignInFailed,
     TooManyRequests,       // the server's rate limiter turned the request away — retrying later works
     ServerError,           // the server (or the proxy in front of it) is broken or restarting
 }
@@ -502,8 +507,32 @@ class SyncCoordinator(
                 try {
                     syncClient.register(accountId, ak, crypto.wrapDataKey(mk, dataKey), device)
                 } catch (e: SyncException) {
-                    if (e.kind != SyncException.Kind.CONFLICT) throw e
-                    val s = syncClient.login(accountId, ak, device)
+                    // CONFLICT: the account is already there. FORBIDDEN: the instance refuses NEW accounts
+                    // (closed registration, or the account cap) and answers before it ever looks at the id,
+                    // so an existing account gets the same 403. Both mean the account, if it exists, is
+                    // reachable only through login.
+                    if (e.kind != SyncException.Kind.CONFLICT && e.kind != SyncException.Kind.FORBIDDEN) throw e
+                    val s = try {
+                        syncClient.login(accountId, ak, device)
+                    } catch (failure: SyncException) {
+                        // A 401/404 after a 403 is ambiguous, and the server keeps it that way on purpose
+                        // (it hides "no such account" behind the wrong-password shape): either there is no
+                        // account on an instance that won't create one, or the account password was rotated
+                        // from another device and this vault still holds the old one. Reporting only the 403
+                        // would misname the second case — the refusal may be "registration limit reached",
+                        // which says nothing about a password — so the failure names both and carries the
+                        // server's own sentence as its detail. Every other login failure (throttled,
+                        // network, 5xx) is a fact of its own and survives untouched, as does the CONFLICT
+                        // path, where a 401 is an ordinary wrong password.
+                        if (e.kind == SyncException.Kind.FORBIDDEN &&
+                            (failure.kind == SyncException.Kind.UNAUTHORIZED || failure.kind == SyncException.Kind.NOT_FOUND)
+                        ) {
+                            runCatching { syncClient.close() }
+                            _status.value = SyncStatus.Failed(SyncFailureReason.RegistrationRefusedSignInFailed, e.message)
+                            return
+                        }
+                        throw failure
+                    }
                     reactivated = s.reactivated
                     // Same password on both sides: nothing to re-wrap, only a possible key change.
                     adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf()) == KeyAdoption.Adopted

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
@@ -12,6 +12,7 @@ import app.skerry.ui.generated.resources.sync_fail_network
 import app.skerry.ui.generated.resources.sync_fail_pairing
 import app.skerry.ui.generated.resources.sync_fail_pairing_expired
 import app.skerry.ui.generated.resources.sync_fail_protocol
+import app.skerry.ui.generated.resources.sync_fail_registration_refused_signin
 import app.skerry.ui.generated.resources.sync_fail_rejected
 import app.skerry.ui.generated.resources.stail_sync_fail_detail
 import app.skerry.ui.generated.resources.stail_sync_fail_key_adopt
@@ -63,4 +64,5 @@ internal fun syncFailureResource(reason: SyncFailureReason): StringResource =
         SyncFailureReason.TooManyRequests -> Res.string.sync_fail_too_many_requests
         SyncFailureReason.ServerError -> Res.string.sync_fail_server_error
         SyncFailureReason.Rejected -> Res.string.sync_fail_rejected
+        SyncFailureReason.RegistrationRefusedSignInFailed -> Res.string.sync_fail_registration_refused_signin
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
@@ -26,6 +26,7 @@ import okio.Path.Companion.toPath
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * A throttled or broken server must be named as such. Both are reachable states of a self-hosted
@@ -40,19 +41,47 @@ class SyncCoordinatorServerFailureTest {
     private val account = "maya"
     private val password = "vault-A"
 
-    /** Server that rejects registration with [kind] — the first call any connect makes. */
-    private class RejectingClient(private val kind: SyncException.Kind) : SyncClient {
+    /**
+     * Server that rejects registration with [kind] — the first call any connect makes. What the
+     * login fallback (CONFLICT/FORBIDDEN → login) then does is [loginSession] on success or
+     * [loginFailure] on refusal; with neither set, login is unreachable for that test.
+     * [loginCalls] is what proves the fallback ran at all — the status alone can't tell a
+     * rethrown 403 from one that never reached login.
+     */
+    private class RejectingClient(
+        private val kind: SyncException.Kind,
+        private val loginSession: SyncSession? = null,
+        private val loginFailure: SyncException? = null,
+    ) : SyncClient {
+        @Volatile
+        var loginCalls = 0
+            private set
+
+        @Volatile
+        var closeCalls = 0
+            private set
+
         override suspend fun ping(): Boolean = true
 
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
             throw SyncException(kind, "rejected")
 
         override fun changes(session: SyncSession): Flow<SyncSignal> = flow { awaitCancellation() }
-        override suspend fun close() {}
+        override suspend fun close() {
+            closeCalls++
+        }
         override suspend fun refresh(session: SyncSession): SyncSession = nope()
-        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession = nope()
+        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
+            loginCalls++
+            loginFailure?.let { throw it }
+            return loginSession ?: nope()
+        }
         override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = nope()
+        // An empty wrap can't be unwrapped, so adoptAccountDataKey returns Undecryptable — which the
+        // matchesVault branch treats as "key not ours to adopt" and connects anyway. That is the only
+        // reason this stub reaches Online; the tests here are about the register/login handshake, not
+        // about key adoption.
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ByteArray(0)
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
@@ -70,12 +99,12 @@ class SyncCoordinatorServerFailureTest {
     }
 
     private fun reasonForRejectedConnect(kind: SyncException.Kind): SyncFailureReason =
-        failedConnect(kind).reason
+        failedConnect(RejectingClient(kind)).reason
 
-    private fun failedConnect(kind: SyncException.Kind): SyncStatus.Failed = runBlocking {
+    private fun failedConnect(client: RejectingClient): SyncStatus.Failed = runBlocking {
         initializeVaultCrypto()
         val sut = SyncCoordinator(
-            clientFactory = { RejectingClient(kind) },
+            clientFactory = { client },
             crypto = crypto,
             vault = localVault(),
             engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
@@ -104,15 +133,98 @@ class SyncCoordinatorServerFailureTest {
     }
 
     /**
-     * A refusal the server chose (closed registration, a blocked account id) is neither the user's
-     * fault nor a retryable failure: it is named, so the server's own explanation can be shown
-     * instead of "protocol error".
+     * register → 403, login → 401. Two causes are indistinguishable here (the server hides "no such
+     * account" behind the wrong-password shape): no account on an instance that won't create one, or
+     * an account whose password was rotated from another device while this vault kept the old one.
+     * Naming only the 403 would misreport the second case — "registration limit reached" has nothing
+     * to do with a stale password — so the failure names both, and keeps the server's own sentence
+     * as the detail.
      */
     @Test
-    fun `a refused registration is reported as a rejection, with the server's own words`() {
-        val failed = failedConnect(SyncException.Kind.FORBIDDEN)
-        assertEquals(SyncFailureReason.Rejected, failed.reason)
-        // Without the detail the user only learns "rejected" — never by whom or what to do about it.
+    fun `a refused registration whose login also fails names both causes, with the server's own words`() {
+        val client = RejectingClient(
+            SyncException.Kind.FORBIDDEN,
+            loginFailure = SyncException(SyncException.Kind.UNAUTHORIZED, "no such account"),
+        )
+        val failed = failedConnect(client)
+        // The fallback must have been tried before the refusal is reported — otherwise this asserts
+        // nothing the pre-fix "rethrow the 403 immediately" code didn't already satisfy.
+        assertEquals(1, client.loginCalls, "the 403 must be probed with a login before it is reported")
+        // The client is opened by this connect and nothing downstream adopts it — leaving it behind
+        // leaks a Ktor pool per failed attempt, and a closed instance fails on every reconnect.
+        assertEquals(1, client.closeCalls, "the client must be closed on the way out")
+        assertEquals(SyncFailureReason.RegistrationRefusedSignInFailed, failed.reason)
+        // Without the detail the user never learns which refusal the server chose.
         assertEquals("rejected", failed.detail)
+    }
+
+    /** The server answers 404 rather than 401 for the same "no account" case: same conclusion. */
+    @Test
+    fun `a refused registration whose login answers not found lands on the same failure`() {
+        val failed = failedConnect(
+            RejectingClient(
+                SyncException.Kind.FORBIDDEN,
+                loginFailure = SyncException(SyncException.Kind.NOT_FOUND, "no such account"),
+            ),
+        )
+        assertEquals(SyncFailureReason.RegistrationRefusedSignInFailed, failed.reason)
+    }
+
+    /**
+     * The 403 is only substituted for a login failure that says "this account can't be signed into".
+     * A throttled fallback is a different, retryable fact and must survive as itself — otherwise the
+     * user is told to go ask an administrator about a limiter that clears in a minute.
+     */
+    @Test
+    fun `a throttled login fallback keeps the throttling, not the registration refusal`() {
+        val failed = failedConnect(
+            RejectingClient(
+                SyncException.Kind.FORBIDDEN,
+                loginFailure = SyncException(SyncException.Kind.TOO_MANY_REQUESTS, "slow down"),
+            ),
+        )
+        assertEquals(SyncFailureReason.TooManyRequests, failed.reason)
+    }
+
+    /**
+     * The CONFLICT path shares the fallback but not the substitution: on an open instance a 401 after
+     * a 409 is an ordinary wrong password, and pinning that here keeps a future edit of the branch
+     * condition from silently widening the FORBIDDEN behaviour over it.
+     */
+    @Test
+    fun `an existing account with a wrong password still reports as unauthorized`() {
+        val failed = failedConnect(
+            RejectingClient(
+                SyncException.Kind.CONFLICT,
+                loginFailure = SyncException(SyncException.Kind.UNAUTHORIZED, "authentication failed"),
+            ),
+        )
+        assertEquals(SyncFailureReason.Unauthorized, failed.reason)
+    }
+
+    /**
+     * Regression test for the closed-registration edge: a closed instance answers /auth/register
+     * with 403 for every account (it never looks at the id), so an existing account must fall back
+     * to login — not be locked out. register → 403, login → OK: connect succeeds.
+     */
+    @Test
+    fun `a closed instance still lets existing accounts log in via the login fallback`() {
+        val result = runBlocking {
+            initializeVaultCrypto()
+            val session = SyncSession(accountId = account, accessToken = "at", refreshToken = "rt")
+            val sut = SyncCoordinator(
+                clientFactory = { RejectingClient(SyncException.Kind.FORBIDDEN, loginSession = session) },
+                crypto = crypto,
+                vault = localVault(),
+                engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
+            )
+            try {
+                sut.connect(serverUrl, account, password.toCharArray())
+                withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            } finally {
+                sut.close()
+            }
+        }
+        assertTrue(result !is SyncStatus.Failed, "expected connect to succeed, got $result")
     }
 }

--- a/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AuthRoutes.kt
@@ -43,8 +43,10 @@ fun Route.authRoutes(services: Services) {
     rateLimit(RateLimits.REGISTER) {
         post("/auth/register") {
             // Registration policy is checked before any work: a closed instance (Vaultwarden's
-            // SIGNUPS_ALLOWED=false) rejects new accounts outright; existing accounts still log in
-            // and pair new devices (those paths don't hit /auth/register).
+            // SIGNUPS_ALLOWED=false) rejects new accounts outright. The check runs before the id is
+            // even read, so an EXISTING account gets this same 403 — a connect under the device's own
+            // vault password probes register first. The client treats 403 like the 409 it gets on an
+            // open instance and falls back to login, which is how existing accounts still get in here.
             if (!services.config.registrationOpen) {
                 services.metrics.registrationRejected(RegistrationRejection.CLOSED)
                 services.metrics.authAttempt(AuthKind.REGISTER, AuthOutcome.DENIED)


### PR DESCRIPTION
Fixes #129.

**Problem.** A closed instance (registration disabled, or the account cap) answers `/auth/register` with **403** for every account — it checks registration policy before it ever looks at the id. An existing account therefore gets the same 403 as a brand-new one. The client only fell back to login on `CONFLICT`, so existing users were locked out of their own accounts on closed instances.

**Fix.** In `SyncCoordinator.doConnect`'s `matchesVault` branch, treat `FORBIDDEN` like `CONFLICT` — fall back to login. If that login then fails with 401/404, rethrow the **original 403**: the password here is this vault's own, so a 401 means "no such account on an instance that won't create one", and the user should see the registration refusal rather than a wrong-password error.

This also covers the account-cap 403, which has the same shape.

**Also in this PR.** The comment at `AuthRoutes.kt:44-46` claimed existing accounts "don't hit `/auth/register`" — they do, on every connect. Corrected to describe the probe-then-fallback flow.

**Tests.** Added next to `SyncCoordinatorServerFailureTest.kt`:
- `register → 403, login → OK`: connect succeeds and establishes a session (regression test — fails without this fix).
- `register → 403, login → 401`: reports `SyncStatus.Failed(Rejected, "registration is closed")` — the original refusal, not the 401.

The existing `a refused registration is reported as a rejection...` test now reaches `login()`, so its `RejectingClient` fake throws `SyncException(UNAUTHORIZED)` there, per the rethrow above; the assertions are unchanged.

All 6 tests in the class pass locally; detekt clean. Maintainer edits enabled.