### PR TITLE
Tunnels: a table that reports itself, and forwards that come up on their own

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -643,6 +643,9 @@ class MainActivity : FragmentActivity() {
             snippets.reload()
             runbooks.reload()
             tunnels.reload()
+            // Tunnels flagged for autostart come up here and only here: the other reload sites run
+            // on every synced change, and raising there would fight the user's own toggles.
+            tunnels.startAutostart()
             knownHosts.refresh()
             // Trash retention is applied on unlock too (desktop parity): waiting for the user to
             // open the Trash screen would keep an expired secret in the vault indefinitely.

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ports.xml
@@ -2,8 +2,6 @@
     <string name="ports_port_forwarding">Проброс портов</string>
     <string name="ports_saved_tunnels_subtitle">Сохранённые туннели — локальные, обратные и динамические (SOCKS) пробросы.</string>
     <string name="ports_new_tunnel">Новый туннель</string>
-    <string name="ports_active_tunnel_one">%1$d активный туннель</string>
-    <string name="ports_active_tunnels_other">Активных туннелей: %1$d</string>
     <string name="ports_no_tunnels_yet">Пока нет туннелей</string>
     <string name="ports_add_tunnel_right">Добавьте туннель справа →</string>
     <string name="ports_add_tunnel_below">Добавьте туннель ниже</string>
@@ -37,9 +35,9 @@
     <string name="ports_remove_confirm_title">Удалить «%1$s»?</string>
     <string name="ports_remove_active_message">Туннель активен. Он будет отключён и удалён — отменить нельзя.</string>
     <string name="ports_remove_inactive_message">Сохранённый туннель будет удалён. Отменить нельзя.</string>
-    <string name="ports_type_local">LOCAL</string>
-    <string name="ports_type_remote">REMOTE</string>
-    <string name="ports_type_socks">SOCKS</string>
+    <string name="ports_type_local">local</string>
+    <string name="ports_type_remote">remote</string>
+    <string name="ports_type_socks">SOCKS5</string>
     <string name="ports_type_local_display">Локальный проброс (-L)</string>
     <string name="ports_type_remote_display">Обратный проброс (-R)</string>
     <string name="ports_type_socks_display">Динамический SOCKS (-D)</string>
@@ -56,4 +54,60 @@
     <string name="ports_pick_host_to_scan">Выберите хост для сканирования</string>
     <string name="ports_open_in_browser">Открыть в браузере</string>
     <string name="ports_close">Закрыть</string>
+    <string name="ports_tunnels">Туннели</string>
+    <string name="ports_col_name">ИМЯ</string>
+    <string name="ports_col_listen">СЛУШАЕТ</string>
+    <string name="ports_col_target">НАЗНАЧЕНИЕ</string>
+    <string name="ports_col_host">ХОСТ</string>
+    <string name="ports_col_traffic">ТРАФИК</string>
+    <string name="ports_col_status">СТАТУС</string>
+    <string name="ports_status_active">активен</string>
+    <string name="ports_status_connecting">подключение</string>
+    <string name="ports_status_failed">ошибка</string>
+    <string name="ports_status_stopped">остановлен</string>
+    <string name="ports_autostart">Автостарт</string>
+    <string name="ports_autostart_hint">Эти туннели поднимаются сами после разблокировки хранилища.</string>
+    <string name="ports_autostart_none">Ни один туннель не поднимается сам</string>
+    <string name="ports_field_autostart">Поднимать после разблокировки</string>
+    <string name="ports_card_throughput">Пропускная способность</string>
+    <string name="ports_rate_out">исх.</string>
+    <string name="ports_rate_in">вх.</string>
+    <string name="ports_card_errors">Последние ошибки</string>
+    <string name="ports_errors_none">Ошибок не было</string>
+    <string name="ports_errors_updated">Обновлено</string>
+    <string name="ports_ago_seconds">%1$d с назад</string>
+    <string name="ports_ago_minutes">%1$d мин назад</string>
+    <string name="ports_event_recovered">восстановлен</string>
+    <string name="ports_fail_host_key">ключ хоста</string>
+    <string name="ports_fail_auth">аутентификация</string>
+    <string name="ports_fail_forward">проброс</string>
+    <string name="ports_fail_connection">отказ</string>
+    <string name="ports_fail_unavailable">недоступен</string>
+    <plurals name="ports_tunnel_count">
+        <item quantity="one">%1$d туннель</item>
+        <item quantity="few">%1$d туннеля</item>
+        <item quantity="many">%1$d туннелей</item>
+        <item quantity="other">%1$d туннеля</item>
+    </plurals>
+    <string name="ports_autostart_hint_one">Этот туннель поднимается сам после разблокировки хранилища.</string>
+    <plurals name="ports_count_active">
+        <item quantity="one">%1$d активный</item>
+        <item quantity="few">%1$d активных</item>
+        <item quantity="many">%1$d активных</item>
+        <item quantity="other">%1$d активных</item>
+    </plurals>
+    <plurals name="ports_count_stopped">
+        <item quantity="one">%1$d остановленный</item>
+        <item quantity="few">%1$d остановленных</item>
+        <item quantity="many">%1$d остановленных</item>
+        <item quantity="other">%1$d остановленных</item>
+    </plurals>
+    <string name="ports_bind_beyond_loopback">Слушает не только loopback — доступен из сети.</string>
+    <string name="ports_dismiss">Скрыть</string>
+    <plurals name="ports_autostart_failed">
+        <item quantity="one">%1$d туннель автостарта не поднялся</item>
+        <item quantity="few">%1$d туннеля автостарта не поднялись</item>
+        <item quantity="many">%1$d туннелей автостарта не поднялись</item>
+        <item quantity="other">%1$d туннеля автостарта не поднялись</item>
+    </plurals>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
@@ -2,8 +2,6 @@
     <string name="ports_port_forwarding">端口转发</string>
     <string name="ports_saved_tunnels_subtitle">已保存的隧道 — 本地、远程和动态 (SOCKS) 转发。</string>
     <string name="ports_new_tunnel">新建隧道</string>
-    <string name="ports_active_tunnel_one">%1$d 个活动隧道</string>
-    <string name="ports_active_tunnels_other">%1$d 个活动隧道</string>
     <string name="ports_no_tunnels_yet">暂无隧道</string>
     <string name="ports_add_tunnel_right">在右侧添加隧道 →</string>
     <string name="ports_add_tunnel_below">在下方添加隧道</string>
@@ -37,9 +35,9 @@
     <string name="ports_remove_confirm_title">移除 \"%1$s\"?</string>
     <string name="ports_remove_active_message">隧道处于活动状态，将断开并删除，无法撤销。</string>
     <string name="ports_remove_inactive_message">此已保存隧道将被删除。无法撤销。</string>
-    <string name="ports_type_local">本地转发</string>
-    <string name="ports_type_remote">远程转发</string>
-    <string name="ports_type_socks">SOCKS</string>
+    <string name="ports_type_local">本地</string>
+    <string name="ports_type_remote">远程</string>
+    <string name="ports_type_socks">SOCKS5</string>
     <string name="ports_type_local_display">本地转发 (-L)</string>
     <string name="ports_type_remote_display">远程转发 (-R)</string>
     <string name="ports_type_socks_display">动态 SOCKS (-D)</string>
@@ -56,4 +54,48 @@
     <string name="ports_pick_host_to_scan">选择要扫描的主机</string>
     <string name="ports_open_in_browser">在浏览器中打开</string>
     <string name="ports_close">关闭</string>
+    <string name="ports_tunnels">隧道</string>
+    <string name="ports_col_name">名称</string>
+    <string name="ports_col_listen">监听</string>
+    <string name="ports_col_target">目标</string>
+    <string name="ports_col_host">主机</string>
+    <string name="ports_col_traffic">流量</string>
+    <string name="ports_col_status">状态</string>
+    <string name="ports_status_active">活动</string>
+    <string name="ports_status_connecting">连接中</string>
+    <string name="ports_status_failed">失败</string>
+    <string name="ports_status_stopped">已停止</string>
+    <string name="ports_autostart">自动启动</string>
+    <string name="ports_autostart_hint">这些隧道会在保险库解锁后自动建立。</string>
+    <string name="ports_autostart_none">没有隧道会自动启动</string>
+    <string name="ports_field_autostart">解锁后自动启动</string>
+    <string name="ports_card_throughput">吞吐量</string>
+    <string name="ports_rate_out">出</string>
+    <string name="ports_rate_in">入</string>
+    <string name="ports_card_errors">最近的错误</string>
+    <string name="ports_errors_none">没有记录到故障</string>
+    <string name="ports_errors_updated">更新于</string>
+    <string name="ports_ago_seconds">%1$d 秒前</string>
+    <string name="ports_ago_minutes">%1$d 分钟前</string>
+    <string name="ports_event_recovered">已恢复</string>
+    <string name="ports_fail_host_key">主机密钥</string>
+    <string name="ports_fail_auth">认证</string>
+    <string name="ports_fail_forward">转发</string>
+    <string name="ports_fail_connection">拒绝</string>
+    <string name="ports_fail_unavailable">不可用</string>
+    <plurals name="ports_tunnel_count">
+        <item quantity="other">%1$d 个隧道</item>
+    </plurals>
+    <string name="ports_autostart_hint_one">该隧道会在保险库解锁后自动建立。</string>
+    <plurals name="ports_count_active">
+        <item quantity="other">%1$d 个活动</item>
+    </plurals>
+    <plurals name="ports_count_stopped">
+        <item quantity="other">%1$d 个已停止</item>
+    </plurals>
+    <string name="ports_bind_beyond_loopback">监听范围超出回环地址 — 可从网络访问。</string>
+    <string name="ports_dismiss">忽略</string>
+    <plurals name="ports_autostart_failed">
+        <item quantity="other">%1$d 个自动启动隧道未能建立</item>
+    </plurals>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ports.xml
@@ -2,8 +2,6 @@
     <string name="ports_port_forwarding">Port forwarding</string>
     <string name="ports_saved_tunnels_subtitle">Saved tunnels — local, remote and dynamic (SOCKS) forwards.</string>
     <string name="ports_new_tunnel">New tunnel</string>
-    <string name="ports_active_tunnel_one">%1$d active tunnel</string>
-    <string name="ports_active_tunnels_other">%1$d active tunnels</string>
     <string name="ports_no_tunnels_yet">No tunnels yet</string>
     <string name="ports_add_tunnel_right">Add a tunnel on the right →</string>
     <string name="ports_add_tunnel_below">Add a tunnel below</string>
@@ -37,9 +35,9 @@
     <string name="ports_remove_confirm_title">Remove \"%1$s\"?</string>
     <string name="ports_remove_active_message">Active tunnel. It will be disconnected and deleted — can't be undone.</string>
     <string name="ports_remove_inactive_message">This saved tunnel is deleted. This can't be undone.</string>
-    <string name="ports_type_local">LOCAL</string>
-    <string name="ports_type_remote">REMOTE</string>
-    <string name="ports_type_socks">SOCKS</string>
+    <string name="ports_type_local">local</string>
+    <string name="ports_type_remote">remote</string>
+    <string name="ports_type_socks">SOCKS5</string>
     <string name="ports_type_local_display">Local forward (-L)</string>
     <string name="ports_type_remote_display">Remote forward (-R)</string>
     <string name="ports_type_socks_display">Dynamic SOCKS (-D)</string>
@@ -56,4 +54,50 @@
     <string name="ports_pick_host_to_scan">Pick a host to scan</string>
     <string name="ports_open_in_browser">Open in browser</string>
     <string name="ports_close">Close</string>
+    <string name="ports_tunnels">Tunnels</string>
+    <string name="ports_col_name">NAME</string>
+    <string name="ports_col_listen">LISTEN</string>
+    <string name="ports_col_target">TARGET</string>
+    <string name="ports_col_host">HOST</string>
+    <string name="ports_col_traffic">TRAFFIC</string>
+    <string name="ports_col_status">STATUS</string>
+    <string name="ports_status_active">active</string>
+    <string name="ports_status_connecting">connecting</string>
+    <string name="ports_status_failed">failed</string>
+    <string name="ports_status_stopped">stopped</string>
+    <string name="ports_autostart">Autostart</string>
+    <string name="ports_autostart_hint">These tunnels come up on their own once the vault is unlocked.</string>
+    <string name="ports_autostart_none">No tunnels start on their own</string>
+    <string name="ports_field_autostart">Start on unlock</string>
+    <string name="ports_card_throughput">Throughput</string>
+    <string name="ports_rate_out">out</string>
+    <string name="ports_rate_in">in</string>
+    <string name="ports_card_errors">Recent errors</string>
+    <string name="ports_errors_none">No failures recorded</string>
+    <string name="ports_errors_updated">Updated</string>
+    <string name="ports_ago_seconds">%1$d s ago</string>
+    <string name="ports_ago_minutes">%1$d min ago</string>
+    <string name="ports_event_recovered">recovered</string>
+    <string name="ports_fail_host_key">host key</string>
+    <string name="ports_fail_auth">auth</string>
+    <string name="ports_fail_forward">forward</string>
+    <string name="ports_fail_connection">refused</string>
+    <string name="ports_fail_unavailable">unavailable</string>
+    <plurals name="ports_tunnel_count">
+        <item quantity="one">%1$d tunnel</item>
+        <item quantity="other">%1$d tunnels</item>
+    </plurals>
+    <string name="ports_autostart_hint_one">This tunnel comes up on its own once the vault is unlocked.</string>
+    <plurals name="ports_count_active">
+        <item quantity="other">%1$d active</item>
+    </plurals>
+    <plurals name="ports_count_stopped">
+        <item quantity="other">%1$d stopped</item>
+    </plurals>
+    <string name="ports_bind_beyond_loopback">Listens beyond loopback — reachable from the network.</string>
+    <string name="ports_dismiss">Dismiss</string>
+    <plurals name="ports_autostart_failed">
+        <item quantity="one">%1$d autostart tunnel didn't come up</item>
+        <item quantity="other">%1$d autostart tunnels didn't come up</item>
+    </plurals>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ToggleRow.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/ToggleRow.kt
@@ -1,0 +1,48 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.theme.Skerry
+
+/**
+ * A setting expressed as a switch: label (with an optional explanatory line) on the leading edge,
+ * [Toggle] on the trailing one. Shared because desktop panels, editor forms and mobile sheets all
+ * need the same row and had started drawing it three slightly different ways.
+ *
+ * [labelSize] exists for the mobile type scale; everything else is fixed so the rows stay
+ * recognisably the same control across platforms.
+ */
+@Composable
+fun ToggleRow(
+    label: String,
+    on: Boolean,
+    onToggle: () -> Unit,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    subtitleColor: Color = Skerry.colors.faint,
+    labelSize: TextUnit = 12.5.sp,
+) {
+    Row(
+        modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(Modifier.weight(1f).padding(end = 10.dp)) {
+            Txt(label, color = Skerry.colors.text, size = labelSize)
+            if (subtitle != null) {
+                Txt(subtitle, color = subtitleColor, size = 11.sp, lineHeight = 15.sp)
+            }
+        }
+        Toggle(on = on, onToggle = onToggle)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -46,6 +46,9 @@ import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.forward.rateFraction
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.sftp.humanSize
+import app.skerry.ui.tunnel.AutostartFailureBanner
+import app.skerry.ui.tunnel.BindExposureWarning
 import app.skerry.ui.tunnel.ListeningService
 import app.skerry.ui.tunnel.ServiceScanState
 import app.skerry.ui.tunnel.TunnelEntry
@@ -64,9 +67,11 @@ import app.skerry.ui.tunnel.displayLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ports_add_tunnel_below
 import app.skerry.ui.generated.resources.ports_already_forwarded
+import app.skerry.ui.generated.resources.ports_autostart_hint_one
 import app.skerry.ui.generated.resources.ports_changes_apply_after_restart
 import app.skerry.ui.generated.resources.ports_edit
 import app.skerry.ui.generated.resources.ports_edit_tunnel
+import app.skerry.ui.generated.resources.ports_field_autostart
 import app.skerry.ui.generated.resources.ports_field_bind_address
 import app.skerry.ui.generated.resources.ports_field_destination
 import app.skerry.ui.generated.resources.ports_field_live_throughput
@@ -106,6 +111,7 @@ import app.skerry.ui.design.MeterBar
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Toggle
+import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
 
@@ -180,6 +186,7 @@ private fun LiveMobilePortsBody(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
+        AutostartFailureBanner(manager)
         if (tunnels.isEmpty()) {
             MobileEmptyTunnels()
         } else {
@@ -245,7 +252,7 @@ private fun LiveTunnelCard(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Badge(t.direction.badgeLabel(), bg = bg, fg = fg, radius = 4, size = 9.5.sp)
-            Txt(stringResource(Res.string.ports_via, via), color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.weight(1f))
+            Txt(t.label, color = Skerry.colors.textBright, size = 13.sp, weight = FontWeight.Medium, modifier = Modifier.weight(1f))
             // Only a live local forward has something to open; -R listens on the server, -D is SOCKS.
             tunnelBrowserUrl(entry)?.let { url ->
                 val uriHandler = LocalUriHandler.current
@@ -267,6 +274,13 @@ private fun LiveTunnelCard(
             Txt("${t.bindHost}:$port", color = if (dim) Skerry.colors.dim else Skerry.colors.text, size = 12.5.sp, font = mono)
             Sym(mobileTunnelArrow(t.direction), size = 16.sp, color = Skerry.colors.faint)
             Txt(mobileTunnelDest(t), color = if (dim) Skerry.colors.faint else Skerry.colors.textBright, size = 12.5.sp, font = mono)
+        }
+        Spacer(Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Txt(stringResource(Res.string.ports_via, via), color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.weight(1f))
+            // Counters reset on every raise, so a tunnel that has carried nothing shows nothing.
+            val total = entry.bytesUp + entry.bytesDown
+            if (total > 0) Txt(humanSize(total), color = Skerry.colors.faint, size = 11.sp, font = mono)
         }
         (entry.status as? TunnelStatus.Failed)?.let {
             Spacer(Modifier.height(6.dp))
@@ -368,6 +382,7 @@ private fun MobileTunnelEditorSheet(
                 MobileFormField(stringResource(Res.string.ports_field_bind_address), Modifier.weight(1f)) { PortInput(form.bindHost, { form.bindHost = it }, "127.0.0.1", mono) }
                 MobileFormField(stringResource(Res.string.ports_field_port), Modifier.width(96.dp)) { PortInput(form.bindPort, { form.bindPort = it }, "8080", mono, KeyboardType.Number) }
             }
+            BindExposureWarning(form.bindHost)
             if (!form.isDynamic) {
                 Spacer(Modifier.height(14.dp))
                 Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -383,6 +398,15 @@ private fun MobileTunnelEditorSheet(
                     lineHeight = 17.sp,
                 )
             }
+            Spacer(Modifier.height(16.dp))
+            ToggleRow(
+                label = stringResource(Res.string.ports_field_autostart),
+                on = form.autostart,
+                onToggle = { form.autostart = !form.autostart },
+                // Singular copy: the desktop panel's hint speaks about a list, this sheet edits one.
+                subtitle = stringResource(Res.string.ports_autostart_hint_one),
+                labelSize = 14.sp,
+            )
             if (existing != null && existing.status is TunnelStatus.Active) {
                 Spacer(Modifier.height(16.dp))
                 MobileFormField(stringResource(Res.string.ports_field_live_throughput)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -155,6 +155,7 @@ import app.skerry.ui.app.SftpPrefs
 import app.skerry.ui.design.MeterBar
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.theme.Skerry
@@ -627,21 +628,9 @@ private fun ColumnsMenu(prefs: SftpPrefs) {
                 weight = FontWeight.SemiBold,
                 letterSpacing = 0.5.sp,
             )
-            ColumnToggleRow(stringResource(Res.string.sftp_col_modified), prefs.showModified) { prefs.setShowModified(it) }
-            ColumnToggleRow(stringResource(Res.string.sftp_col_permissions), prefs.showPermissions) { prefs.setShowPermissions(it) }
+            ToggleRow(stringResource(Res.string.sftp_col_modified), prefs.showModified, onToggle = { prefs.setShowModified(!prefs.showModified) })
+            ToggleRow(stringResource(Res.string.sftp_col_permissions), prefs.showPermissions, onToggle = { prefs.setShowPermissions(!prefs.showPermissions) })
         }
-    }
-}
-
-@Composable
-private fun ColumnToggleRow(label: String, on: Boolean, onToggle: (Boolean) -> Unit) {
-    Row(
-        Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Txt(label, color = Skerry.colors.text, size = 12.5.sp)
-        Toggle(on = on, onToggle = { onToggle(!on) })
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelDashboard.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelDashboard.kt
@@ -1,0 +1,177 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.Sparkline
+import app.skerry.ui.design.Txt
+import app.skerry.ui.forward.humanRate
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_autostart
+import app.skerry.ui.generated.resources.ports_autostart_none
+import app.skerry.ui.generated.resources.ports_card_errors
+import app.skerry.ui.generated.resources.ports_card_throughput
+import app.skerry.ui.generated.resources.ports_errors_none
+import app.skerry.ui.generated.resources.ports_errors_updated
+import app.skerry.ui.generated.resources.ports_rate_in
+import app.skerry.ui.generated.resources.ports_rate_out
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+import kotlin.math.max
+
+/**
+ * Sparkline scale floor (64 KiB/s), as in the host monitor: without it an idle section would
+ * auto-scale a trickle of keepalive traffic into a dramatic mountain range.
+ */
+private const val RATE_SCALE_FLOOR = 64L * 1024
+
+/** Room above the window's peak, so a steady load draws a line rather than a filled rectangle. */
+private const val SCALE_HEADROOM = 1.25f
+
+/**
+ * The three cards under the tunnel table: what is flowing right now, what comes up on its own, and
+ * what recently broke. Read-only — every one of them is a view over [TunnelManager] state, and none
+ * of them is a control.
+ */
+@Composable
+internal fun TunnelDashboard(
+    manager: TunnelManager,
+    hostLabel: (String) -> String,
+    mono: FontFamily,
+    modifier: Modifier = Modifier,
+) {
+    // IntrinsicSize.Min plus fillMaxHeight on each card: the three read as one strip, instead of
+    // three boxes whose bottom edge depends on how much each happens to have to say.
+    Row(
+        modifier.fillMaxWidth().height(IntrinsicSize.Min),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        ThroughputCard(manager.telemetry, mono, Modifier.weight(1.3f).fillMaxHeight())
+        AutostartCard(manager.tunnels, hostLabel, Modifier.weight(1f).fillMaxHeight())
+        ErrorsCard(manager.telemetry, Modifier.weight(1f).fillMaxHeight())
+    }
+}
+
+@Composable
+private fun ThroughputCard(telemetry: TunnelTelemetry, mono: FontFamily, modifier: Modifier) {
+    val history = telemetry.history
+    val latest = history.lastOrNull()
+    // Both directions share one scale so the line means "total load", not "whichever is bigger".
+    // The headroom keeps a steady load off the top edge, where a full-height fill reads as a solid
+    // block rather than a chart.
+    val peak = history.maxOfOrNull { it.up + it.down } ?: 0L
+    val scale = max(peak, RATE_SCALE_FLOOR) * SCALE_HEADROOM
+
+    DashCard(stringResource(Res.string.ports_card_throughput), modifier) {
+        Sparkline(
+            values = history.map { (it.up + it.down) / scale },
+            color = Skerry.colors.cyan,
+            modifier = Modifier.padding(top = 8.dp),
+            height = 34.dp,
+            capacity = TunnelTelemetry.HISTORY_CAPACITY,
+        )
+        Row(
+            Modifier.padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+            verticalAlignment = Alignment.Bottom,
+        ) {
+            RateStat(humanRate(latest?.up ?: 0), stringResource(Res.string.ports_rate_out), mono)
+            RateStat(humanRate(latest?.down ?: 0), stringResource(Res.string.ports_rate_in), mono)
+        }
+    }
+}
+
+@Composable
+private fun RowScope.RateStat(value: String, caption: String, mono: FontFamily) {
+    Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+        Txt(value, color = Skerry.colors.textBright, size = 15.sp, weight = FontWeight.SemiBold, font = mono)
+        Txt(caption, color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.padding(bottom = 1.dp))
+    }
+}
+
+@Composable
+private fun AutostartCard(entries: List<TunnelEntry>, hostLabel: (String) -> String, modifier: Modifier) {
+    val grouped = autostartByHost(entries)
+    DashCard(stringResource(Res.string.ports_autostart), modifier) {
+        if (grouped.isEmpty()) {
+            CardNote(stringResource(Res.string.ports_autostart_none))
+        } else {
+            grouped.forEach { (hostId, count) ->
+                CardRow(hostLabel(hostId), tunnelCountText(count), Skerry.colors.text)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorsCard(telemetry: TunnelTelemetry, modifier: Modifier) {
+    val events = telemetry.events
+    DashCard(stringResource(Res.string.ports_card_errors), modifier) {
+        if (events.isEmpty()) {
+            CardNote(stringResource(Res.string.ports_errors_none))
+        } else {
+            events.forEach { event ->
+                CardRow("${event.label} · ${event.port}", event.kind.label(), event.kind.color())
+            }
+            CardRow(
+                stringResource(Res.string.ports_errors_updated),
+                eventAgeText(telemetry.secondsSince(events.first())),
+                Skerry.colors.dim,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DashCard(title: String, modifier: Modifier, content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(Skerry.colors.surface2)
+            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(10.dp))
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+    ) {
+        Txt(title, color = Skerry.colors.text, size = 12.sp, weight = FontWeight.SemiBold)
+        content()
+    }
+}
+
+/** Label on the left, value on the right — the shape every dashboard card row shares. */
+@Composable
+private fun CardRow(label: String, value: String, valueColor: Color) {
+    Row(
+        Modifier.fillMaxWidth().padding(top = 7.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(label, color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.padding(end = 8.dp))
+        Txt(value, color = valueColor, size = 11.5.sp, weight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun CardNote(text: String) {
+    Box(Modifier.padding(top = 8.dp)) {
+        Txt(text, color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelErrors.kt
@@ -28,3 +28,14 @@ internal suspend fun friendlyTunnelError(e: Throwable): String = when (e) {
     is SshConnectionException -> getString(Res.string.ptail_err_connection_failed)
     else -> getString(Res.string.ptail_err_connection_failed)
 }
+
+/**
+ * Same classification as [friendlyTunnelError], reduced to the one-word cause the events card
+ * shows. Split out so the card never has to parse the localized sentence back into a category.
+ */
+fun tunnelFailureKind(e: Throwable): TunnelFailureKind = when (e) {
+    is SshHostKeyRejectedException -> TunnelFailureKind.HostKey
+    is SshAuthenticationException -> TunnelFailureKind.Auth
+    is PortForwardException -> TunnelFailureKind.Forward
+    else -> TunnelFailureKind.Connection
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFields.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFields.kt
@@ -1,0 +1,174 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.tunnel.TunnelDirection
+import app.skerry.ui.design.AnchoredDropdown
+import app.skerry.ui.design.MeterBar
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_no_saved_hosts
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+// Form controls of the tunnel side panels (editor, service scan, autostart). Shared so the panels
+// stay a layout each, and a change to how a field looks lands in one place.
+
+/** Editable tunnel form field: boxed input with a placeholder. */
+@Composable
+internal fun EditField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    mono: FontFamily,
+    keyboardType: KeyboardType = KeyboardType.Text,
+) {
+    val textColor = Skerry.colors.text
+    val textStyle = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 12.5.sp, fontFamily = mono) }
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle = textStyle,
+        cursorBrush = SolidColor(Skerry.colors.cyan),
+        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+        modifier = Modifier.fillMaxWidth(),
+        decorationBox = { inner ->
+            Box(fieldBox()) {
+                if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, font = mono)
+                inner()
+            }
+        },
+    )
+}
+
+/** Tunnel-type dropdown (-L/-R/-D) over the form. */
+@Composable
+internal fun TypePicker(current: TunnelDirection, onPick: (TunnelDirection) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { PickerTrigger(current.displayLabel()) { open = !open } },
+        menu = { width ->
+            MenuSurface(width) {
+                listOf(TunnelDirection.Local, TunnelDirection.Remote, TunnelDirection.Dynamic).forEach { option ->
+                    MenuItem(option.displayLabel(), active = option == current) { onPick(option); open = false }
+                }
+            }
+        },
+    )
+}
+
+/** Host dropdown over the form; empty shows a hint to add a host. */
+@Composable
+internal fun HostPicker(current: String, options: List<Pair<String, String>>, onPick: (String) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { PickerTrigger(current) { open = !open } },
+        menu = { width ->
+            MenuSurface(width, scrollable = true) {
+                if (options.isEmpty()) {
+                    Txt(stringResource(Res.string.ports_no_saved_hosts), color = Skerry.colors.faint, size = 12.sp, modifier = Modifier.padding(12.dp))
+                } else {
+                    options.forEach { (id, name) ->
+                        MenuItem(name, active = false) { onPick(id); open = false }
+                    }
+                }
+            }
+        },
+    )
+}
+
+/** Up/down throughput meter of a live tunnel. */
+@Composable
+internal fun ThroughputRow(icon: String, color: Color, fraction: Float, value: String, mono: FontFamily) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Sym(icon, size = 14.sp, color = color)
+        MeterBar(fraction, color, Modifier.weight(1f))
+        Box(Modifier.width(64.dp), contentAlignment = Alignment.CenterEnd) {
+            Txt(value, color = Skerry.colors.dim, size = 11.sp, font = mono)
+        }
+    }
+}
+
+@Composable
+private fun PickerTrigger(value: String, onClick: () -> Unit) {
+    Row(
+        fieldBox(onClick),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Txt(value, color = Skerry.colors.text, size = 12.5.sp)
+        Sym("expand_more", size = 16.sp, color = Skerry.colors.faint)
+    }
+}
+
+@Composable
+private fun MenuSurface(width: Dp, scrollable: Boolean = false, content: @Composable () -> Unit) {
+    Column(
+        Modifier.width(width)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Skerry.colors.surface2)
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp))
+            .then(if (scrollable) Modifier.heightIn(max = 240.dp).verticalScroll(rememberScrollState()) else Modifier),
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun MenuItem(label: String, active: Boolean, onClick: () -> Unit) {
+    Txt(
+        label,
+        color = if (active) Skerry.colors.cyanBright else Skerry.colors.text,
+        size = 12.5.sp,
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 9.dp),
+    )
+}
+
+/**
+ * The boxed look every field and picker trigger shares. [onClick] lands before the padding, so the
+ * whole box reacts rather than only the text inside it.
+ */
+@Composable
+private fun fieldBox(onClick: (() -> Unit)? = null): Modifier {
+    val clipped = Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
+    return (if (onClick != null) clipped.clickable(onClick = onClick) else clipped)
+        .background(Skerry.colors.bg)
+        .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp))
+        .padding(horizontal = 10.dp, vertical = 8.dp)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelForm.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.tunnel
 
 import app.skerry.shared.host.Host
+import app.skerry.shared.tunnel.Tunnel
 import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.connection.JumpChainResolution
 import app.skerry.ui.connection.resolveJumpChain
@@ -47,6 +48,22 @@ fun buildTunnelDraft(
         }
     }
 }
+
+/**
+ * A saved tunnel back as an editable draft, for changing one field without going through the form
+ * (the autostart list toggles the flag in place).
+ */
+fun Tunnel.toDraft(): TunnelDraft = TunnelDraft(
+    id = id,
+    label = label,
+    hostId = hostId,
+    direction = direction,
+    bindHost = bindHost,
+    bindPort = bindPort,
+    destHost = destHost,
+    destPort = destPort,
+    autostart = autostart,
+)
 
 /**
  * Resolves a host to connection parameters (for the [TunnelManager] production lambda). The host is

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFormState.kt
@@ -26,13 +26,19 @@ class TunnelFormState private constructor(private val editingId: String?) {
     var bindPort: String by mutableStateOf("")
     var destHost: String by mutableStateOf("")
     var destPort: String by mutableStateOf("")
+    var autostart: Boolean by mutableStateOf(false)
 
     /** SOCKS (`-D`) has no destination; the form hides the destination fields. */
     val isDynamic: Boolean get() = direction == TunnelDirection.Dynamic
 
-    /** Valid draft for [TunnelManager.save], or `null` while input is incomplete (see [buildTunnelDraft]). */
+    /**
+     * Valid draft for [TunnelManager.save], or `null` while input is incomplete (see
+     * [buildTunnelDraft]). Autostart is attached afterwards — it is a flag, with nothing about it
+     * for the address validation to reject.
+     */
     val draft: TunnelDraft?
         get() = buildTunnelDraft(editingId, label, hostId, direction, bindHost, bindPort, destHost, destPort)
+            ?.copy(autostart = autostart)
 
     companion object {
         /**
@@ -50,6 +56,7 @@ class TunnelFormState private constructor(private val editingId: String?) {
                     bindPort = seed.bindPort.toString()
                     destHost = seed.destHost ?: ""
                     destPort = seed.destPort?.toString() ?: ""
+                    autostart = seed.autostart
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
@@ -38,6 +38,7 @@ data class TunnelDraft(
     val bindPort: Int,
     val destHost: String? = null,
     val destPort: Int? = null,
+    val autostart: Boolean = false,
 )
 
 /**
@@ -155,6 +156,30 @@ class TunnelManager(
     /** Discovery of listening services on a host, for forwarding one of them in a tap. */
     val services: ServiceScanController = ServiceScanController(scanTransport, resolve, scope)
 
+    /** Aggregate throughput window and the failure journal behind the section's dashboard. */
+    val telemetry: TunnelTelemetry = TunnelTelemetry(pollIntervalMillis)
+
+    // Autostart is a one-shot per unlock: reloadManagers runs on every synced change, and re-running
+    // it there would raise tunnels the user had just switched off. Rearmed by closeAll (the lock).
+    private var autostarted = false
+
+    // Ids raised by the last autostart run, so the section can say how many of them are down.
+    // Snapshot state: dismissing the report has to reach the banner.
+    private var autostartIds: Set<String> by mutableStateOf(emptySet())
+
+    /**
+     * Autostart tunnels that are currently failed. Derived rather than latched at the end of the
+     * run: the raises settle asynchronously, and a tunnel the user retries by hand should leave the
+     * report on its own.
+     */
+    val autostartFailures: List<TunnelEntry>
+        get() = tunnels.filter { it.id in autostartIds && it.status is TunnelStatus.Failed }
+
+    /** Drops the report without touching the tunnels — the rows keep saying what happened. */
+    fun dismissAutostartReport() {
+        autostartIds = emptySet()
+    }
+
     init {
         // Polls telemetry for active tunnels: samples counters and computes rate from the delta.
         scope.launch {
@@ -179,6 +204,19 @@ class TunnelManager(
     fun find(id: String): TunnelEntry? = tunnels.firstOrNull { it.id == id }
 
     /**
+     * Raises every tunnel flagged [Tunnel.autostart]. Called once the vault is open — a tunnel
+     * needs its host's secret, so there is nothing to raise before that. Idempotent within one
+     * unlock, so wiring it into `reloadManagers` doesn't fight the user's own toggles.
+     */
+    fun startAutostart() {
+        if (autostarted) return
+        autostarted = true
+        val flagged = tunnels.filter { it.tunnel.autostart }
+        autostartIds = flagged.map { it.id }.toSet()
+        flagged.forEach { activate(it.id) }
+    }
+
+    /**
      * Creates (when [TunnelDraft.id] is null) or updates a tunnel and writes it to the store.
      * Returns the assigned id. Editing an active tunnel's config updates the row in place but
      * does not restart the forward; new parameters take effect on the next activation.
@@ -194,6 +232,7 @@ class TunnelManager(
             bindPort = draft.bindPort,
             destHost = draft.destHost,
             destPort = draft.destPort,
+            autostart = draft.autostart,
         )
         store.put(tunnel)
         val existing = find(id)
@@ -206,6 +245,7 @@ class TunnelManager(
         deactivate(id)
         store.remove(id)
         tunnels = tunnels.filterNot { it.id == id }
+        telemetry.forget(id)
     }
 
     /** Activates a tunnel: opens the host connection and raises the forward. Idempotent for an active tunnel. */
@@ -219,7 +259,10 @@ class TunnelManager(
         entry.connectingJob = scope.launch {
             try {
                 when (val resolution = resolve(entry.tunnel.hostId)) {
-                    is TunnelResolution.Unavailable -> entry.status = TunnelStatus.Failed(reason = resolution.reason)
+                    is TunnelResolution.Unavailable -> {
+                        entry.status = TunnelStatus.Failed(reason = resolution.reason)
+                        noteFailure(entry, TunnelFailureKind.Unavailable)
+                    }
                     is TunnelResolution.Ready -> openForward(entry, resolution)
                 }
             } finally {
@@ -242,13 +285,22 @@ class TunnelManager(
             entry.handle = forward
             entry.resetCounters()
             entry.status = TunnelStatus.Active(forward.boundPort)
+            telemetry.active(entry.id, entry.tunnel.label, forward.boundPort)
+            // Once it has come up, the autostart run is answered for it. A failure hours later,
+            // after the user toggled it by hand, is not something autostart did.
+            autostartIds = autostartIds - entry.id
         } catch (e: CancellationException) {
             closeQuietly(conn)
             throw e
         } catch (e: Exception) {
             closeQuietly(conn)
             entry.status = TunnelStatus.Failed(friendlyTunnelError(e))
+            noteFailure(entry, tunnelFailureKind(e))
         }
+    }
+
+    private fun noteFailure(entry: TunnelEntry, kind: TunnelFailureKind) {
+        telemetry.failed(entry.id, entry.tunnel.label, entry.tunnel.bindPort, kind)
     }
 
     private suspend fun raise(conn: SshConnection, tunnel: Tunnel): PortForward = when (tunnel.direction) {
@@ -295,20 +347,30 @@ class TunnelManager(
     fun closeAll() {
         tunnels.forEach { deactivate(it.id) }
         services.reset()
+        // The window and the journal describe connections that no longer exist, and behind a lock
+        // screen they would still name hosts and ports. Autostart rearms for the next unlock.
+        telemetry.reset()
+        autostarted = false
+        autostartIds = emptySet()
     }
 
     internal fun pollTelemetry() {
+        var up = 0L
+        var down = 0L
         tunnels.forEach { entry ->
             val handle = entry.handle ?: return@forEach
-            val up = handle.bytesUp
-            val down = handle.bytesDown
-            entry.upRate = ((up - entry.prevUp) * 1000 / pollIntervalMillis).coerceAtLeast(0)
-            entry.downRate = ((down - entry.prevDown) * 1000 / pollIntervalMillis).coerceAtLeast(0)
-            entry.prevUp = up
-            entry.prevDown = down
-            entry.bytesUp = up
-            entry.bytesDown = down
+            val entryUp = handle.bytesUp
+            val entryDown = handle.bytesDown
+            entry.upRate = ((entryUp - entry.prevUp) * 1000 / pollIntervalMillis).coerceAtLeast(0)
+            entry.downRate = ((entryDown - entry.prevDown) * 1000 / pollIntervalMillis).coerceAtLeast(0)
+            entry.prevUp = entryUp
+            entry.prevDown = entryDown
+            entry.bytesUp = entryUp
+            entry.bytesDown = entryDown
+            up += entry.upRate
+            down += entry.downRate
         }
+        telemetry.sample(up, down)
     }
 
     private fun closeQuietly(conn: SshConnection?) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelNotices.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelNotices.kt
@@ -1,0 +1,83 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_autostart_failed
+import app.skerry.ui.generated.resources.ports_bind_beyond_loopback
+import app.skerry.ui.generated.resources.ports_dismiss
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.pluralStringResource
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Aggregate report of the last autostart run. The rows already carry each failure, but nothing
+ * otherwise distinguishes "the vault unlocked" from "everything the user asked to come up did":
+ * the tunnels that dial themselves are exactly the ones nobody is watching. Renders nothing when
+ * they all came up, or once dismissed. Shared by the desktop section and the mobile screen.
+ */
+@Composable
+internal fun AutostartFailureBanner(manager: TunnelManager, modifier: Modifier = Modifier) {
+    val failures = manager.autostartFailures
+    if (failures.isEmpty()) return
+    Row(
+        modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Skerry.colors.amberSoft)
+            .border(1.dp, Skerry.colors.amber.copy(alpha = 0.3f), RoundedCornerShape(8.dp))
+            .padding(horizontal = 12.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(9.dp),
+    ) {
+        Sym("bolt", size = 15.sp, color = Skerry.colors.amber)
+        Txt(
+            pluralStringResource(Res.plurals.ports_autostart_failed, failures.size, failures.size),
+            color = Skerry.colors.amber,
+            size = 12.sp,
+            modifier = Modifier.weight(1f),
+        )
+        // A button, not a tappable label: the banner is shared with the phone, where 11 sp of text
+        // is not something a thumb can hit.
+        IconBtn(
+            "close",
+            onClick = { manager.dismissAutostartReport() },
+            box = 34,
+            icon = 16.sp,
+            tint = Skerry.colors.amber,
+            tooltip = stringResource(Res.string.ports_dismiss),
+        )
+    }
+}
+
+/** Warning under the bind address: this listener is reachable from outside this machine. */
+@Composable
+internal fun BindExposureWarning(bindHost: String, modifier: Modifier = Modifier) {
+    if (!bindsBeyondLoopback(bindHost)) return
+    Row(
+        modifier.fillMaxWidth().padding(top = 6.dp),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Sym("warning", size = 13.sp, color = Skerry.colors.amber)
+        Txt(
+            stringResource(Res.string.ports_bind_beyond_loopback),
+            color = Skerry.colors.amber,
+            size = 11.sp,
+            lineHeight = 15.sp,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
@@ -1,0 +1,385 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.ssh.usesSshAuth
+import app.skerry.ui.design.Badge
+import app.skerry.ui.design.FieldLabel
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.ToggleRow
+import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.design.Txt
+import app.skerry.ui.forward.humanRate
+import app.skerry.ui.forward.rateFraction
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_already_forwarded
+import app.skerry.ui.generated.resources.ports_autostart
+import app.skerry.ui.generated.resources.ports_autostart_hint
+import app.skerry.ui.generated.resources.ports_changes_apply_after_restart
+import app.skerry.ui.generated.resources.ports_field_autostart
+import app.skerry.ui.generated.resources.ports_field_bind_address
+import app.skerry.ui.generated.resources.ports_field_destination
+import app.skerry.ui.generated.resources.ports_field_live_throughput
+import app.skerry.ui.generated.resources.ports_field_name
+import app.skerry.ui.generated.resources.ports_field_port
+import app.skerry.ui.generated.resources.ports_field_type
+import app.skerry.ui.generated.resources.ports_field_via_host
+import app.skerry.ui.generated.resources.ports_forward
+import app.skerry.ui.generated.resources.ports_new_tunnel
+import app.skerry.ui.generated.resources.ports_no_services
+import app.skerry.ui.generated.resources.ports_no_tunnels_yet
+import app.skerry.ui.generated.resources.ports_open_in_browser
+import app.skerry.ui.generated.resources.ports_ph_web_tunnel
+import app.skerry.ui.generated.resources.ports_pick_host_to_scan
+import app.skerry.ui.generated.resources.ports_remove
+import app.skerry.ui.generated.resources.ports_save
+import app.skerry.ui.generated.resources.ports_scan
+import app.skerry.ui.generated.resources.ports_scanning
+import app.skerry.ui.generated.resources.ports_select_host
+import app.skerry.ui.generated.resources.ports_service_port
+import app.skerry.ui.generated.resources.ports_services_hint
+import app.skerry.ui.generated.resources.ports_services_title
+import app.skerry.ui.generated.resources.ports_services_unsupported
+import app.skerry.ui.generated.resources.ports_socks_hint
+import app.skerry.ui.generated.resources.ports_tunnel_detail
+import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The three things the right-hand column of the tunnel section can hold: the create/edit form,
+ * service discovery, and the autostart list. They are alternatives, never shown together — the
+ * column is one slot (see `TunnelsView`).
+ */
+
+private val PANEL_WIDTH = 308.dp
+
+/**
+ * Tunnel editor (create/edit): name, type, via-host, bind and destination, plus the autostart
+ * switch. Save builds [TunnelFormState.draft] and writes it via [TunnelManager]; for an existing
+ * tunnel it also shows Remove and live throughput. Fields reset when [existing] changes.
+ */
+@Composable
+internal fun TunnelEditor(
+    manager: TunnelManager,
+    hosts: HostManagerController?,
+    mono: FontFamily,
+    existing: TunnelEntry?,
+    onSaved: (String) -> Unit,
+    onRequestRemove: () -> Unit,
+    onClose: () -> Unit,
+) {
+    val editingId = existing?.id
+    // Keyed by editingId: the form is an isolated edit buffer, populated once per selected
+    // tunnel. Mutations to entry.tunnel from elsewhere (save for the same id) intentionally
+    // don't propagate here — unfinished user edits take priority.
+    val form = remember(editingId) { TunnelFormState.fromEntry(existing) }
+
+    val draft = form.draft
+    val (badgeBg, badgeFg) = form.direction.badgeColors()
+    // The tunnel dials this host over SSH, so remote desktops are not candidates.
+    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
+    val hostLabel = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
+
+    SidePanel {
+        PanelHeader(
+            title = if (existing == null) stringResource(Res.string.ports_new_tunnel) else stringResource(Res.string.ports_tunnel_detail),
+            onClose = onClose,
+            leading = { Badge(form.direction.badgeLabel(), bg = badgeBg, fg = badgeFg, radius = 4, size = 10.sp) },
+        )
+        Box(Modifier.padding(bottom = 10.dp))
+        FieldLabel(labelUppercase(stringResource(Res.string.ports_field_name)), top = 0.dp)
+        EditField(form.label, { form.label = it }, stringResource(Res.string.ports_ph_web_tunnel), mono)
+        Box(Modifier.padding(bottom = 12.dp))
+        FieldLabel(labelUppercase(stringResource(Res.string.ports_field_type)), top = 0.dp)
+        TypePicker(form.direction, onPick = { form.direction = it })
+        Box(Modifier.padding(bottom = 12.dp))
+        FieldLabel(labelUppercase(stringResource(Res.string.ports_field_via_host)), top = 0.dp)
+        HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { form.hostId = it })
+        Box(Modifier.padding(bottom = 12.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(Modifier.weight(1f)) {
+                FieldLabel(labelUppercase(stringResource(Res.string.ports_field_bind_address)), top = 0.dp)
+                EditField(form.bindHost, { form.bindHost = it }, "127.0.0.1", mono)
+            }
+            Column(Modifier.width(70.dp)) {
+                FieldLabel(labelUppercase(stringResource(Res.string.ports_field_port)), top = 0.dp)
+                EditField(form.bindPort, { form.bindPort = it }, "0", mono, KeyboardType.Number)
+            }
+        }
+        BindExposureWarning(form.bindHost)
+        if (!form.isDynamic) {
+            Box(Modifier.padding(bottom = 12.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Column(Modifier.weight(1f)) {
+                    FieldLabel(labelUppercase(stringResource(Res.string.ports_field_destination)), top = 0.dp)
+                    EditField(form.destHost, { form.destHost = it }, "10.0.0.5", mono)
+                }
+                Column(Modifier.width(70.dp)) {
+                    FieldLabel(labelUppercase(stringResource(Res.string.ports_field_port)), top = 0.dp)
+                    EditField(form.destPort, { form.destPort = it }, "80", mono, KeyboardType.Number)
+                }
+            }
+        } else {
+            Box(Modifier.padding(bottom = 4.dp))
+            Txt(stringResource(Res.string.ports_socks_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
+        }
+        Box(Modifier.padding(bottom = 14.dp))
+        ToggleRow(
+            label = stringResource(Res.string.ports_field_autostart),
+            on = form.autostart,
+            onToggle = { form.autostart = !form.autostart },
+        )
+        if (existing != null && existing.status is TunnelStatus.Active) {
+            tunnelBrowserUrl(existing)?.let { url ->
+                val uriHandler = LocalUriHandler.current
+                Box(Modifier.padding(bottom = 14.dp))
+                GhostButton(
+                    stringResource(Res.string.ports_open_in_browser),
+                    onClick = { runCatching { uriHandler.openUri(url) } },
+                    icon = "open_in_new",
+                    fg = Skerry.colors.cyanBright,
+                    border = Skerry.colors.cyan20,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+            Box(Modifier.padding(bottom = 16.dp))
+            FieldLabel(labelUppercase(stringResource(Res.string.ports_field_live_throughput)), top = 0.dp)
+            ThroughputRow("arrow_upward", Skerry.colors.cyanBright, rateFraction(existing.upRate), humanRate(existing.upRate), mono)
+            Box(Modifier.padding(bottom = 8.dp))
+            ThroughputRow("arrow_downward", Skerry.colors.moss, rateFraction(existing.downRate), humanRate(existing.downRate), mono)
+            Box(Modifier.padding(bottom = 10.dp))
+            // Editing an active tunnel saves fine, but the forward is already up — new
+            // parameters take effect on the next activation (save doesn't restart the connection).
+            Txt(stringResource(Res.string.ports_changes_apply_after_restart), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
+        }
+        Box(Modifier.padding(bottom = 18.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            PrimaryButton(
+                label = stringResource(Res.string.ports_save),
+                onClick = { draft?.let { onSaved(manager.save(it)) } },
+                modifier = Modifier.weight(1f),
+                enabled = draft != null,
+            )
+            if (existing != null) {
+                GhostButton(
+                    stringResource(Res.string.ports_remove),
+                    onClick = onRequestRemove,
+                    fg = Skerry.colors.sunset,
+                    border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Autostart list: every saved tunnel with the switch that decides whether it comes up on its own
+ * after unlock. A per-tunnel field also lives in the editor; this panel exists because the flag is
+ * a property of the set — the question "what starts by itself" is not answerable one form at a time.
+ */
+@Composable
+internal fun AutostartPanel(manager: TunnelManager, hostLabel: (String) -> String, onClose: () -> Unit) {
+    SidePanel {
+        PanelHeader(
+            title = stringResource(Res.string.ports_autostart),
+            onClose = onClose,
+            leading = { Sym("bolt", size = 16.sp, color = Skerry.colors.cyanBright) },
+        )
+        Txt(
+            stringResource(Res.string.ports_autostart_hint),
+            color = Skerry.colors.faint,
+            size = 11.sp,
+            lineHeight = 15.sp,
+            modifier = Modifier.padding(bottom = 14.dp),
+        )
+        if (manager.tunnels.isEmpty()) {
+            Txt(stringResource(Res.string.ports_no_tunnels_yet), color = Skerry.colors.faint, size = 11.5.sp)
+            return@SidePanel
+        }
+        Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            manager.tunnels.forEach { entry ->
+                // Stabilized by id, as the table rows are: the panel sits next to a list that
+                // repaints on every telemetry tick.
+                val onToggle = remember(entry.id, manager) {
+                    { manager.save(entry.tunnel.toDraft().copy(autostart = !entry.tunnel.autostart)); Unit }
+                }
+                // The row names the listener it arms, and says so in amber when that listener is
+                // reachable from the network: this switch, not the editor, is what makes the
+                // forward come up unattended.
+                val exposed = bindsBeyondLoopback(entry.tunnel.bindHost)
+                ToggleRow(
+                    label = entry.tunnel.label,
+                    on = entry.tunnel.autostart,
+                    onToggle = onToggle,
+                    modifier = boxedRow(),
+                    subtitle = "${hostLabel(entry.tunnel.hostId)} · ${entry.tunnel.bindHost}:${entry.tunnel.bindPort}",
+                    subtitleColor = if (exposed) Skerry.colors.amber else Skerry.colors.faint,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Service discovery panel: pick a saved host, scan it for listening TCP ports, and forward one in a
+ * tap (a local forward is created and activated right away).
+ */
+@Composable
+internal fun ServicesPanel(
+    manager: TunnelManager,
+    hosts: HostManagerController?,
+    mono: FontFamily,
+    onClose: () -> Unit,
+) {
+    val scan = manager.services
+    // Only SSH-authenticated hosts can be scanned: the scan is an SSH exec round-trip, so Telnet/
+    // Serial/VNC profiles (no command channel) are excluded from the picker rather than offered and
+    // then rejected as Unsupported. MOSH qualifies — it dials the same SSH hop.
+    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
+    var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
+    val hostLabel = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
+        ?: stringResource(Res.string.ports_select_host)
+
+    SidePanel {
+        PanelHeader(
+            title = stringResource(Res.string.ports_services_title),
+            onClose = onClose,
+            leading = { Sym("radar", size = 16.sp, color = Skerry.colors.cyanBright) },
+        )
+        Txt(stringResource(Res.string.ports_services_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(bottom = 14.dp))
+        FieldLabel(labelUppercase(stringResource(Res.string.ports_field_via_host)), top = 0.dp)
+        HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { hostId = it })
+        Box(Modifier.padding(bottom = 12.dp))
+        PrimaryButton(
+            label = stringResource(Res.string.ports_scan),
+            onClick = { hostId?.let { scan.scan(it) } },
+            modifier = Modifier.fillMaxWidth(),
+            icon = "radar",
+            enabled = hostId != null,
+        )
+        Box(Modifier.padding(bottom = 14.dp))
+        when (val state = scan.state) {
+            ServiceScanState.Idle -> ScanNote(stringResource(Res.string.ports_pick_host_to_scan), Skerry.colors.faint)
+            ServiceScanState.Scanning -> ScanNote(stringResource(Res.string.ports_scanning), Skerry.colors.amber)
+            ServiceScanState.Unsupported -> ScanNote(stringResource(Res.string.ports_services_unsupported), Skerry.colors.dim)
+            is ServiceScanState.Failed -> ScanNote(serviceScanFailureText(state), Skerry.colors.sunset)
+            is ServiceScanState.Ready -> {
+                val scanned = scan.scannedHostId
+                if (state.services.isEmpty() || scanned == null) {
+                    ScanNote(stringResource(Res.string.ports_no_services), Skerry.colors.faint)
+                } else {
+                    val taken = forwardedPorts(manager.tunnels.map { it.tunnel }, scanned)
+                    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        state.services.forEach { service ->
+                            ServiceRow(
+                                service = service,
+                                mono = mono,
+                                forwarded = service.port in taken,
+                                // Saved and raised in one go — the point of the panel is not to
+                                // land in the editor with fields pre-filled.
+                                onForward = { label -> manager.activate(manager.save(serviceTunnelDraft(service, scanned, label))) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ScanNote(text: String, color: Color) {
+    Txt(text, color = color, size = 11.5.sp, lineHeight = 16.sp)
+}
+
+/** One discovered service: port, owning process, and the one-tap forward action. */
+@Composable
+private fun ServiceRow(service: ListeningService, mono: FontFamily, forwarded: Boolean, onForward: (String) -> Unit) {
+    // Name for the tunnel when the host didn't disclose the process; localized here, since the
+    // draft is built outside the composition.
+    val fallback = stringResource(Res.string.ports_service_port, service.port)
+    Row(boxedRow(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Txt("${service.port}", color = Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.width(46.dp))
+        Txt(serviceLabel(service), color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.weight(1f))
+        if (forwarded) {
+            Txt(stringResource(Res.string.ports_already_forwarded), color = Skerry.colors.moss, size = 10.5.sp)
+        } else {
+            Txt(
+                stringResource(Res.string.ports_forward),
+                color = Skerry.colors.cyanBright,
+                size = 10.5.sp,
+                weight = FontWeight.SemiBold,
+                modifier = Modifier.clickable { onForward(fallback) }.padding(horizontal = 4.dp, vertical = 2.dp),
+            )
+        }
+    }
+}
+
+/** The scrolling column every side panel lives in. */
+@Composable
+private fun SidePanel(content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        Modifier.width(PANEL_WIDTH)
+            .fillMaxHeight()
+            .background(Skerry.colors.surface2)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 18.dp),
+        content = content,
+    )
+}
+
+/** Panel title with its leading mark and the close affordance. */
+@Composable
+private fun PanelHeader(title: String, onClose: () -> Unit, leading: @Composable () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(bottom = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            leading()
+            Txt(title, color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
+        }
+        Sym("close", size = 16.sp, color = Skerry.colors.faint, modifier = Modifier.clickable(onClick = onClose))
+    }
+}
+
+/** Outlined row used for list items inside a panel. */
+@Composable
+private fun boxedRow(): Modifier = Modifier.fillMaxWidth()
+    .clip(RoundedCornerShape(7.dp))
+    .background(Skerry.colors.bg)
+    .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(7.dp))
+    .padding(horizontal = 10.dp, vertical = 8.dp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPresentation.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPresentation.kt
@@ -11,6 +11,22 @@ import app.skerry.ui.generated.resources.ports_type_remote
 import app.skerry.ui.generated.resources.ports_type_remote_display
 import app.skerry.ui.generated.resources.ports_type_socks
 import app.skerry.ui.generated.resources.ports_type_socks_display
+import app.skerry.ui.generated.resources.ports_ago_minutes
+import app.skerry.ui.generated.resources.ports_ago_seconds
+import app.skerry.ui.generated.resources.ports_event_recovered
+import app.skerry.ui.generated.resources.ports_fail_auth
+import app.skerry.ui.generated.resources.ports_fail_connection
+import app.skerry.ui.generated.resources.ports_fail_forward
+import app.skerry.ui.generated.resources.ports_fail_host_key
+import app.skerry.ui.generated.resources.ports_fail_unavailable
+import app.skerry.ui.generated.resources.ports_status_active
+import app.skerry.ui.generated.resources.ports_status_connecting
+import app.skerry.ui.generated.resources.ports_status_failed
+import app.skerry.ui.generated.resources.ports_count_active
+import app.skerry.ui.generated.resources.ports_count_stopped
+import app.skerry.ui.generated.resources.ports_status_stopped
+import app.skerry.ui.generated.resources.ports_tunnel_count
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
@@ -42,4 +58,149 @@ fun TunnelDirection.badgeColors(): Pair<Color, Color> = when (this) {
     TunnelDirection.Local -> Skerry.colors.cyan.copy(alpha = 0.12f) to Skerry.colors.cyanBright
     TunnelDirection.Remote -> Skerry.colors.amber.copy(alpha = 0.14f) to Skerry.colors.amber
     TunnelDirection.Dynamic -> Skerry.colors.moss.copy(alpha = 0.14f) to Skerry.colors.moss
+}
+
+/** Which way traffic crosses the tunnel — the arrow between the LISTEN and TARGET columns. */
+enum class TunnelFlow { Outbound, Inbound }
+
+/**
+ * `-L`/`-D` listen here and reach out to the target; `-R` listens on the server and traffic arrives
+ * from there, so the arrow points back at the local target.
+ */
+fun TunnelDirection.flow(): TunnelFlow =
+    if (this == TunnelDirection.Remote) TunnelFlow.Inbound else TunnelFlow.Outbound
+
+/**
+ * Whether a listener on [bindHost] is reachable from outside this machine. Drives the editor's
+ * warning: a forward bound to a wildcard or a LAN address hands whatever is on the other end to
+ * anyone who can reach the interface, and autostart can now raise such a forward with no click.
+ *
+ * An empty value is quiet — the form substitutes loopback for it. A name we cannot resolve is
+ * treated as reachable: the warning must not fall silent exactly where we are unsure.
+ */
+fun bindsBeyondLoopback(bindHost: String): Boolean {
+    val host = bindHost.trim().removeSurrounding("[", "]").lowercase()
+    return when {
+        host.isEmpty() -> false
+        host == "localhost" || host == "::1" -> false
+        else -> !isLoopbackIpv4(host)
+    }
+}
+
+/**
+ * True only for a clean dotted quad inside `127.0.0.0/8`. Deliberately not a prefix test: a DNS
+ * label may begin with "127." and resolve anywhere its owner chooses, and an octet with a leading
+ * zero is read as octal by some resolvers — neither is something we can call loopback.
+ */
+private fun isLoopbackIpv4(host: String): Boolean {
+    val octets = host.split(".")
+    if (octets.size != 4) return false
+    if (octets.any { it.isEmpty() || it.length > 3 || !it.all(Char::isDigit) }) return false
+    if (octets.any { it.length > 1 && it[0] == '0' }) return false
+    val numbers = octets.map { it.toInt() }
+    return numbers.all { it in 0..255 } && numbers[0] == 127
+}
+
+/** STATUS column states. Connecting and Failed are their own — "not active" isn't the whole story. */
+enum class TunnelStatusBadge { Active, Connecting, Failed, Stopped }
+
+fun TunnelStatus.badge(): TunnelStatusBadge = when (this) {
+    is TunnelStatus.Active -> TunnelStatusBadge.Active
+    TunnelStatus.Connecting -> TunnelStatusBadge.Connecting
+    is TunnelStatus.Failed -> TunnelStatusBadge.Failed
+    TunnelStatus.Inactive -> TunnelStatusBadge.Stopped
+}
+
+/** Header tally: carrying traffic vs everything else (off, dialling, or failed). */
+data class TunnelCounts(val active: Int, val stopped: Int)
+
+fun tunnelCounts(entries: List<TunnelEntry>): TunnelCounts {
+    val active = entries.count { it.status is TunnelStatus.Active }
+    return TunnelCounts(active = active, stopped = entries.size - active)
+}
+
+/**
+ * Hosts with autostart tunnels and how many each has, in first-seen order — the dashboard card
+ * answering "what comes up on its own after unlock". Hosts without one are absent, not zero.
+ */
+fun autostartByHost(entries: List<TunnelEntry>): List<Pair<String, Int>> =
+    entries.filter { it.tunnel.autostart }
+        .groupBy { it.tunnel.hostId }
+        .map { (hostId, tunnels) -> hostId to tunnels.size }
+
+/** STATUS cell text. */
+@Composable
+fun TunnelStatusBadge.label(): String = stringResource(
+    when (this) {
+        TunnelStatusBadge.Active -> Res.string.ports_status_active
+        TunnelStatusBadge.Connecting -> Res.string.ports_status_connecting
+        TunnelStatusBadge.Failed -> Res.string.ports_status_failed
+        TunnelStatusBadge.Stopped -> Res.string.ports_status_stopped
+    },
+)
+
+/** STATUS cell colors: background (translucent accent) plus text. */
+@Composable
+@ReadOnlyComposable
+fun TunnelStatusBadge.colors(): Pair<Color, Color> = when (this) {
+    TunnelStatusBadge.Active -> Skerry.colors.moss.copy(alpha = 0.14f) to Skerry.colors.moss
+    TunnelStatusBadge.Connecting -> Skerry.colors.amber.copy(alpha = 0.14f) to Skerry.colors.amber
+    TunnelStatusBadge.Failed -> Skerry.colors.sunset.copy(alpha = 0.14f) to Skerry.colors.sunset
+    TunnelStatusBadge.Stopped -> Skerry.colors.overlayMed to Skerry.colors.dim
+}
+
+/** One-word cause in the events card. */
+@Composable
+fun TunnelFailureKind.label(): String = stringResource(
+    when (this) {
+        TunnelFailureKind.HostKey -> Res.string.ports_fail_host_key
+        TunnelFailureKind.Auth -> Res.string.ports_fail_auth
+        TunnelFailureKind.Forward -> Res.string.ports_fail_forward
+        TunnelFailureKind.Connection -> Res.string.ports_fail_connection
+        TunnelFailureKind.Unavailable -> Res.string.ports_fail_unavailable
+    },
+)
+
+/** Right-hand word of an events-card row. */
+@Composable
+fun TunnelEventKind.label(): String = when (this) {
+    is TunnelEventKind.Failed -> kind.label()
+    TunnelEventKind.Recovered -> stringResource(Res.string.ports_event_recovered)
+}
+
+/** Recovered reads as good news, a failure as bad; the host-key case is the loudest of them. */
+@Composable
+@ReadOnlyComposable
+fun TunnelEventKind.color(): Color = when (this) {
+    TunnelEventKind.Recovered -> Skerry.colors.moss
+    is TunnelEventKind.Failed -> when (kind) {
+        TunnelFailureKind.Forward, TunnelFailureKind.Unavailable -> Skerry.colors.amber
+        else -> Skerry.colors.sunset
+    }
+}
+
+/** Age of an event: seconds under a minute, whole minutes above it. */
+@Composable
+fun eventAgeText(seconds: Long): String =
+    if (seconds < 60) stringResource(Res.string.ports_ago_seconds, seconds)
+    else stringResource(Res.string.ports_ago_minutes, seconds / 60)
+
+/**
+ * Tunnel count for the autostart card. A hand-rolled one/other split is only right in English —
+ * Russian needs a third form for 2–4 ("3 туннеля", not "3 туннелей"), so the choice belongs to the
+ * resource's plural rules, not to this function.
+ */
+@Composable
+fun tunnelCountText(count: Int): String = pluralStringResource(Res.plurals.ports_tunnel_count, count, count)
+
+/**
+ * Section header tally. Both halves are plurals for the same reason as [tunnelCountText] — "1
+ * активных" is what a single non-plural template produces, and English hides it because the
+ * adjective doesn't inflect. The two are joined by a separator, not by grammar.
+ */
+@Composable
+fun tunnelCountsSubtitle(counts: TunnelCounts): String {
+    val active = pluralStringResource(Res.plurals.ports_count_active, counts.active, counts.active)
+    val stopped = pluralStringResource(Res.plurals.ports_count_stopped, counts.stopped, counts.stopped)
+    return "$active · $stopped"
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTable.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTable.kt
@@ -1,0 +1,216 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.tunnel.TunnelDirection
+import app.skerry.ui.design.Badge
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Toggle
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_col_host
+import app.skerry.ui.generated.resources.ports_col_listen
+import app.skerry.ui.generated.resources.ports_col_name
+import app.skerry.ui.generated.resources.ports_col_status
+import app.skerry.ui.generated.resources.ports_col_target
+import app.skerry.ui.generated.resources.ports_col_traffic
+import app.skerry.ui.generated.resources.ports_col_type
+import app.skerry.ui.generated.resources.ports_dynamic_proxy
+import app.skerry.ui.sftp.humanSize
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Placeholder in a numeric cell with nothing to show yet (a tunnel that has carried no bytes). */
+private const val NO_VALUE = "—"
+
+private val TYPE_WIDTH = 76.dp
+private val ARROW_WIDTH = 18.dp
+private val HOST_WIDTH = 100.dp
+private val TRAFFIC_WIDTH = 72.dp
+private val STATUS_WIDTH = 86.dp
+private val ACTIONS_WIDTH = 62.dp
+
+/**
+ * Column header of the tunnel table. Kept next to the row that fills it — the two share the width
+ * constants above, and a column added to one without the other silently skews the grid.
+ */
+@Composable
+internal fun TunnelHeaderRow() {
+    TunnelGridRow(Modifier.background(Skerry.colors.overlayFaint).padding(vertical = 10.dp)) {
+        HeaderCell(stringResource(Res.string.ports_col_name), Modifier.weight(1f))
+        HeaderCell(stringResource(Res.string.ports_col_type), Modifier.width(TYPE_WIDTH))
+        HeaderCell(stringResource(Res.string.ports_col_listen), Modifier.weight(1.1f))
+        Box(Modifier.width(ARROW_WIDTH))
+        HeaderCell(stringResource(Res.string.ports_col_target), Modifier.weight(1.1f))
+        HeaderCell(stringResource(Res.string.ports_col_host), Modifier.width(HOST_WIDTH))
+        HeaderCell(stringResource(Res.string.ports_col_traffic), Modifier.width(TRAFFIC_WIDTH), end = true)
+        HeaderCell(stringResource(Res.string.ports_col_status), Modifier.width(STATUS_WIDTH))
+        Box(Modifier.width(ACTIONS_WIDTH))
+    }
+}
+
+/**
+ * One saved tunnel: name, type, both endpoints with the arrow showing which way traffic goes,
+ * host, bytes carried since it came up, status, and the on/off switch. A failed tunnel spells the
+ * reason out under the row — the STATUS badge only says that something went wrong.
+ */
+@Composable
+internal fun TunnelRow(
+    entry: TunnelEntry,
+    via: String,
+    mono: FontFamily,
+    selected: Boolean,
+    onSelect: () -> Unit,
+    onToggle: () -> Unit,
+) {
+    val t = entry.tunnel
+    val (typeBg, typeFg) = t.direction.badgeColors()
+    val badge = entry.status.badge()
+    val (statusBg, statusFg) = badge.colors()
+    val dim = entry.status !is TunnelStatus.Active
+    val addressColor = if (dim) Skerry.colors.dim else Skerry.colors.textBright
+
+    Column(
+        Modifier.fillMaxWidth()
+            .clickable(onClick = onSelect)
+            .background(if (selected) Skerry.colors.cyan08 else Color.Transparent),
+    ) {
+        TunnelGridRow(Modifier.padding(vertical = 12.dp)) {
+            Txt(
+                t.label,
+                color = if (dim) Skerry.colors.text else Skerry.colors.textBright,
+                size = 12.5.sp,
+                weight = FontWeight.Medium,
+                modifier = Modifier.weight(1f),
+            )
+            Box(Modifier.width(TYPE_WIDTH)) {
+                Badge(t.direction.badgeLabel(), bg = typeBg, fg = typeFg, radius = 4, size = 10.sp)
+            }
+            Txt(listenText(entry), color = addressColor, size = 12.5.sp, font = mono, modifier = Modifier.weight(1.1f))
+            Box(Modifier.width(ARROW_WIDTH)) {
+                Sym(flowIcon(t.direction), size = 15.sp, color = Skerry.colors.faint)
+            }
+            Txt(
+                targetText(t.destHost, t.destPort),
+                color = if (t.destHost == null) Skerry.colors.dim else addressColor,
+                size = 12.5.sp,
+                font = mono,
+                modifier = Modifier.weight(1.1f),
+            )
+            Txt(via, color = Skerry.colors.dim, size = 11.5.sp, font = mono, modifier = Modifier.width(HOST_WIDTH))
+            EndCell(Modifier.width(TRAFFIC_WIDTH)) {
+                Txt(trafficText(entry), color = Skerry.colors.dim, size = 11.5.sp, font = mono)
+            }
+            Box(Modifier.width(STATUS_WIDTH)) {
+                Badge(badge.label(), bg = statusBg, fg = statusFg, radius = 4, size = 10.sp)
+            }
+            Row(
+                Modifier.width(ACTIONS_WIDTH),
+                horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OpenInBrowserAction(entry)
+                TunnelSwitch(entry, onToggle)
+            }
+        }
+        (entry.status as? TunnelStatus.Failed)?.let {
+            Txt(
+                tunnelFailureText(it),
+                color = Skerry.colors.sunset,
+                size = 11.sp,
+                font = mono,
+                modifier = Modifier.padding(start = 16.dp, bottom = 10.dp),
+            )
+        }
+    }
+}
+
+/** Shared geometry of the header and the rows — one place decides padding and column spacing. */
+@Composable
+private fun TunnelGridRow(modifier: Modifier = Modifier, content: @Composable RowScope.() -> Unit) {
+    Row(
+        modifier.fillMaxWidth().padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        content = content,
+    )
+}
+
+@Composable
+private fun HeaderCell(text: String, modifier: Modifier = Modifier, end: Boolean = false) {
+    Box(modifier, contentAlignment = if (end) Alignment.CenterEnd else Alignment.CenterStart) {
+        Txt(text, color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
+    }
+}
+
+@Composable
+private fun EndCell(modifier: Modifier, content: @Composable BoxScope.() -> Unit) {
+    Box(modifier, contentAlignment = Alignment.CenterEnd, content = content)
+}
+
+/** Listener side: bind address with the port actually bound once up, the requested one before that. */
+@Composable
+private fun listenText(entry: TunnelEntry): String {
+    val port = (entry.status as? TunnelStatus.Active)?.boundPort ?: entry.tunnel.bindPort
+    return "${entry.tunnel.bindHost}:$port"
+}
+
+/** Destination side; SOCKS has none — the client picks one per connection. */
+@Composable
+private fun targetText(destHost: String?, destPort: Int?): String =
+    if (destHost == null || destPort == null) stringResource(Res.string.ports_dynamic_proxy) else "$destHost:$destPort"
+
+/** Bytes carried since the tunnel came up; counters reset on every raise, so a stopped one shows nothing. */
+@Composable
+private fun trafficText(entry: TunnelEntry): String {
+    val total = entry.bytesUp + entry.bytesDown
+    return if (total == 0L) NO_VALUE else humanSize(total)
+}
+
+private fun flowIcon(direction: TunnelDirection): String =
+    if (direction.flow() == TunnelFlow.Inbound) "arrow_back" else "arrow_forward"
+
+/**
+ * Opens a live local forward in the browser. Only shown when there is something to open: `-R`
+ * listens on the server and `-D` is a SOCKS proxy, so neither gets a link.
+ */
+@Composable
+private fun OpenInBrowserAction(entry: TunnelEntry) {
+    val url = tunnelBrowserUrl(entry) ?: return
+    val uriHandler = LocalUriHandler.current
+    Sym(
+        "open_in_new",
+        size = 15.sp,
+        color = Skerry.colors.cyanBright,
+        // A failing system handler must not throw into the composition (see AboutSection).
+        modifier = Modifier.clickable { runCatching { uriHandler.openUri(url) } },
+    )
+}
+
+/** On/off switch; an hourglass stands in while the tunnel is still dialling. */
+@Composable
+private fun TunnelSwitch(entry: TunnelEntry, onToggle: () -> Unit) {
+    when (entry.status) {
+        is TunnelStatus.Active -> Toggle(on = true, onToggle = onToggle)
+        TunnelStatus.Connecting -> Sym("hourglass_top", size = 16.sp, color = Skerry.colors.amber)
+        else -> Toggle(on = false, onToggle = onToggle)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTelemetry.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTelemetry.kt
@@ -1,0 +1,109 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/** Aggregate throughput of every active tunnel at one poll tick, in bytes per second. */
+data class ThroughputSample(val up: Long, val down: Long)
+
+/**
+ * One-word cause of a tunnel failure, for the recent-events card. Typed at the point the exception
+ * is caught rather than derived from [friendlyTunnelError]'s text, which is localized and written
+ * for a human.
+ */
+enum class TunnelFailureKind { HostKey, Auth, Forward, Connection, Unavailable }
+
+/** What happened to a tunnel, as the events card reports it. */
+sealed interface TunnelEventKind {
+    data class Failed(val kind: TunnelFailureKind) : TunnelEventKind
+    data object Recovered : TunnelEventKind
+}
+
+/**
+ * A tunnel changing between working and not. [tick] is the telemetry poll counter at the moment it
+ * happened — the age shown in the card is derived from it, so the section needs no wall clock.
+ */
+data class TunnelEvent(
+    val tunnelId: String,
+    val label: String,
+    val port: Int,
+    val kind: TunnelEventKind,
+    val tick: Long,
+)
+
+/**
+ * Section-wide telemetry behind the tunnel dashboard: a bounded window of aggregate throughput for
+ * the sparkline, and a bounded journal of failures and recoveries. Kept apart from [TunnelManager]
+ * — the manager answers for connections, this only records what happened to them, and being a plain
+ * object it is directly testable.
+ *
+ * Failures are deduplicated: a tunnel is either in the failing set or not, so a retry loop against
+ * a host that is down writes one entry, not one per attempt.
+ */
+@Stable
+class TunnelTelemetry(private val pollIntervalMillis: Long) {
+
+    /** Oldest first — the sparkline draws left to right. */
+    var history: List<ThroughputSample> by mutableStateOf(emptyList())
+        private set
+
+    /** Newest first — the card shows the most recent failures. */
+    var events: List<TunnelEvent> by mutableStateOf(emptyList())
+        private set
+
+    // Snapshot-backed: the events card renders the age of its newest entry, and `events` alone
+    // stops changing the moment a failure is recorded. A plain field would freeze the card at
+    // "0 s ago" forever, because nothing it observes would ever invalidate again.
+    private var tick: Long by mutableStateOf(0)
+
+    // Cause per failing tunnel, not a bare set: a retry that fails for a *different* reason is news,
+    // and deduplicating on the id alone would leave the card asserting a cause that no longer holds.
+    private val failing = mutableMapOf<String, TunnelFailureKind>()
+
+    /** Records one poll tick of aggregate throughput and advances the clock the events age against. */
+    fun sample(up: Long, down: Long) {
+        tick++
+        history = (history + ThroughputSample(up, down)).takeLast(HISTORY_CAPACITY)
+    }
+
+    /** A tunnel stopped working. A repeat of the cause already recorded for it is ignored. */
+    fun failed(tunnelId: String, label: String, port: Int, kind: TunnelFailureKind) {
+        if (failing.put(tunnelId, kind) == kind) return
+        record(TunnelEvent(tunnelId, label, port, TunnelEventKind.Failed(kind), tick))
+    }
+
+    /** A tunnel came up. Only newsworthy if it was previously failing. */
+    fun active(tunnelId: String, label: String, port: Int) {
+        failing.remove(tunnelId) ?: return
+        record(TunnelEvent(tunnelId, label, port, TunnelEventKind.Recovered, tick))
+    }
+
+    /** Drops a deleted tunnel from the failing set so a recreated one reports its failure again. */
+    fun forget(tunnelId: String) {
+        failing.remove(tunnelId)
+    }
+
+    /** Whole seconds between [event] and the latest poll. */
+    fun secondsSince(event: TunnelEvent): Long = (tick - event.tick) * pollIntervalMillis / 1000
+
+    /** Wipes the window and the journal (vault lock): they describe connections that no longer exist. */
+    fun reset() {
+        history = emptyList()
+        events = emptyList()
+        failing.clear()
+    }
+
+    private fun record(event: TunnelEvent) {
+        events = (listOf(event) + events).take(EVENT_CAPACITY)
+    }
+
+    companion object {
+        /** One minute of one-second samples — the width the sparkline can actually resolve. */
+        const val HISTORY_CAPACITY = 60
+
+        /** As many rows as the card has room for. */
+        const val EVENT_CAPACITY = 4
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsMockData.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsMockData.kt
@@ -1,0 +1,38 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.tunnel.Tunnel
+import app.skerry.shared.tunnel.TunnelDirection
+
+/**
+ * Sample rows for the offscreen/preview render of the section, where there is no [TunnelManager]
+ * to list. Built as real [TunnelEntry] values so the preview goes through the same table as the
+ * live path — a separate mock table would drift the moment a column changes.
+ *
+ * `-R` listens on the server, hence the wildcard bind address on the webhook row.
+ */
+internal fun mockTunnelEntries(): List<Pair<TunnelEntry, String>> = listOf(
+    mockEntry(
+        Tunnel("m1", "Postgres", "mock", TunnelDirection.Local, "127.0.0.1", 5432, "10.0.2.11", 5432),
+        TunnelStatus.Active(5432), bytes = 41_200_000,
+    ) to "db-master",
+    mockEntry(
+        Tunnel("m2", "Browser proxy", "mock", TunnelDirection.Dynamic, "127.0.0.1", 1080),
+        TunnelStatus.Active(1080), bytes = 318_000_000,
+    ) to "vps-edge",
+    mockEntry(
+        Tunnel("m3", "Webhook callback", "mock", TunnelDirection.Remote, "0.0.0.0", 9000, "127.0.0.1", 8080),
+        TunnelStatus.Active(9000), bytes = 1_100_000,
+    ) to "vps-edge",
+    mockEntry(
+        Tunnel("m4", "Redis", "mock", TunnelDirection.Local, "127.0.0.1", 6379, "10.0.2.11", 6379),
+        TunnelStatus.Inactive, bytes = 0,
+    ) to "db-master",
+)
+
+private fun mockEntry(tunnel: Tunnel, status: TunnelStatus, bytes: Long): TunnelEntry {
+    val entry = TunnelEntry(tunnel)
+    entry.status = status
+    entry.bytesUp = bytes / 2
+    entry.bytesDown = bytes - bytes / 2
+    return entry
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
@@ -7,21 +7,15 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,112 +26,44 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import app.skerry.shared.ssh.usesSshAuth
-import app.skerry.shared.tunnel.TunnelDirection
-import app.skerry.ui.forward.humanRate
-import app.skerry.ui.forward.rateFraction
-import app.skerry.ui.host.HostManagerController
-import app.skerry.ui.tunnel.TunnelEntry
-import app.skerry.ui.tunnel.TunnelManager
-import app.skerry.ui.tunnel.TunnelStatus
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ports_active_tunnel_one
-import app.skerry.ui.generated.resources.ports_active_tunnels_other
-import app.skerry.ui.generated.resources.ports_add_tunnel_right
-import app.skerry.ui.generated.resources.ports_already_forwarded
-import app.skerry.ui.generated.resources.ports_changes_apply_after_restart
-import app.skerry.ui.generated.resources.ports_col_active
-import app.skerry.ui.generated.resources.ports_col_destination
-import app.skerry.ui.generated.resources.ports_col_source
-import app.skerry.ui.generated.resources.ports_col_type
-import app.skerry.ui.generated.resources.ports_col_via_host
-import app.skerry.ui.generated.resources.ports_dynamic_proxy
-import app.skerry.ui.generated.resources.ports_field_bind_address
-import app.skerry.ui.generated.resources.ports_field_destination
-import app.skerry.ui.generated.resources.ports_field_live_throughput
-import app.skerry.ui.generated.resources.ports_field_name
-import app.skerry.ui.generated.resources.ports_field_port
-import app.skerry.ui.generated.resources.ports_field_type
-import app.skerry.ui.generated.resources.ports_field_via_host
-import app.skerry.ui.generated.resources.ports_find_services
-import app.skerry.ui.generated.resources.ports_forward
-import app.skerry.ui.generated.resources.ports_new_tunnel
-import app.skerry.ui.generated.resources.ports_no_saved_hosts
-import app.skerry.ui.generated.resources.ports_no_services
-import app.skerry.ui.generated.resources.ports_no_tunnels_yet
-import app.skerry.ui.generated.resources.ports_open_in_browser
-import app.skerry.ui.generated.resources.ports_ph_web_tunnel
-import app.skerry.ui.generated.resources.ports_pick_host_to_scan
-import app.skerry.ui.generated.resources.ports_port_forwarding
-import app.skerry.ui.generated.resources.ports_remove
-import app.skerry.ui.generated.resources.ports_remove_active_message
-import app.skerry.ui.generated.resources.ports_remove_confirm_title
-import app.skerry.ui.generated.resources.ports_remove_inactive_message
-import app.skerry.ui.generated.resources.ports_save
-import app.skerry.ui.generated.resources.ports_saved_tunnels_subtitle
-import app.skerry.ui.generated.resources.ports_scan
-import app.skerry.ui.generated.resources.ports_scanning
-import app.skerry.ui.generated.resources.ports_select_host
-import app.skerry.ui.generated.resources.ports_service_port
-import app.skerry.ui.generated.resources.ports_services_hint
-import app.skerry.ui.generated.resources.ports_services_title
-import app.skerry.ui.generated.resources.ports_services_unsupported
-import app.skerry.ui.generated.resources.ports_socks_hint
-import app.skerry.ui.generated.resources.ports_tunnel_detail
-import org.jetbrains.compose.resources.stringResource
-import app.skerry.ui.design.AnchoredDropdown
-import app.skerry.ui.design.Badge
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.LocalTunnels
 import app.skerry.ui.design.ConfirmActionDialog
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
-import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.LocalFonts
-import app.skerry.ui.design.labelUppercase
-import app.skerry.ui.app.LocalHosts
-import app.skerry.ui.app.LocalTunnels
-import app.skerry.ui.design.MeterBar
 import app.skerry.ui.design.PrimaryButton
-import app.skerry.ui.design.Sym
-import app.skerry.ui.design.Toggle
-import app.skerry.ui.design.Txt
+import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.VLine
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_add_tunnel_right
+import app.skerry.ui.generated.resources.ports_autostart
+import app.skerry.ui.generated.resources.ports_find_services
+import app.skerry.ui.generated.resources.ports_new_tunnel
+import app.skerry.ui.generated.resources.ports_no_tunnels_yet
+import app.skerry.ui.generated.resources.ports_remove
+import app.skerry.ui.generated.resources.ports_remove_active_message
+import app.skerry.ui.generated.resources.ports_remove_confirm_title
+import app.skerry.ui.generated.resources.ports_remove_inactive_message
+import app.skerry.ui.generated.resources.ports_tunnels
+import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
 
-private data class TunnelRule(
-    val type: String,
-    val source: String, val arrow: String, val dest: String, val destDim: Boolean,
-    val via: String, val active: Boolean,
-)
-
-private val TUNNELS = listOf(
-    TunnelRule("LOCAL", "127.0.0.1:8080", "arrow_forward", "10.0.0.5:80", false, "prod-web-01", true),
-    TunnelRule("REMOTE", "0.0.0.0:9000", "arrow_forward", "localhost:3000", false, "homelab-pi", true),
-    TunnelRule("SOCKS", "127.0.0.1:1080", "all_inclusive", "dynamic proxy", true, "db-master", false),
-)
-
-/** Badge colors (bg, fg) for a tunnel type chip, from the active theme. */
-@Composable
-private fun tunnelTypeColors(type: String): Pair<Color, Color> = when (type) {
-    "LOCAL" -> Skerry.colors.cyan.copy(alpha = 0.12f) to Skerry.colors.cyanBright
-    "REMOTE" -> Skerry.colors.amberSoft to Skerry.colors.amber
-    else -> Skerry.colors.moss.copy(alpha = 0.14f) to Skerry.colors.moss
-}
+/** What the right-hand column is showing. Exactly one at a time — they share the slot. */
+private enum class TunnelPanel { None, Editor, Services, Autostart }
 
 /**
- * Port forwarding (Tunnels) — global section: list of saved tunnels with on/off toggles plus an
- * editor on the right. A tunnel is standalone (references a host by id) and opens its own SSH
- * connection via [TunnelManager] on activation. When a manager is supplied ([LocalTunnels]) shows
- * the live list; otherwise (offscreen render/preview) shows a static mock ([TUNNELS]).
+ * Tunnels — global section: a table of saved tunnels with their live status and throughput, a
+ * dashboard of what is flowing, what starts by itself and what recently broke, plus a side panel
+ * that edits one tunnel, scans a host for services, or manages autostart.
+ *
+ * A tunnel is standalone (references a host by id) and opens its own SSH connection via
+ * [TunnelManager] on activation. With no manager supplied ([LocalTunnels] is null — offscreen
+ * render/preview) the table renders sample rows instead.
  */
 @Composable
 fun TunnelsView() {
@@ -145,74 +71,84 @@ fun TunnelsView() {
     val manager = LocalTunnels.current
     val hosts = LocalHosts.current
 
-    // Right-panel state: selected tunnel, "create new" mode (New tunnel button), and service
-    // discovery, which takes over the same panel.
     var selectedId by remember { mutableStateOf<String?>(null) }
-    var adding by remember { mutableStateOf(false) }
     // Discovery survives leaving and re-entering the section: the panel reopens on whatever the
     // scan still holds, and only closing it (which resets the scan) puts the editor back.
-    var discovering by remember { mutableStateOf(manager?.services?.state != ServiceScanState.Idle) }
+    var panel by remember {
+        mutableStateOf(if (manager?.services?.state != ServiceScanState.Idle) TunnelPanel.Services else TunnelPanel.None)
+    }
+    // Editor with no selection means "new tunnel"; selecting a row keeps the same panel open.
+    var adding by remember { mutableStateOf(false) }
+
+    val counts = tunnelCounts(manager?.tunnels.orEmpty())
 
     Column(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
         SectionHeader(
-            title = stringResource(Res.string.ports_port_forwarding),
-            subtitle = stringResource(Res.string.ports_saved_tunnels_subtitle),
+            title = stringResource(Res.string.ports_tunnels),
+            subtitle = tunnelCountsSubtitle(counts),
             actions = {
-                GhostButton(stringResource(Res.string.ports_find_services), onClick = { discovering = true; adding = false; selectedId = null }, icon = "radar")
+                GhostButton(
+                    stringResource(Res.string.ports_find_services),
+                    onClick = { panel = TunnelPanel.Services; adding = false; selectedId = null },
+                    icon = "radar",
+                )
+                GhostButton(
+                    stringResource(Res.string.ports_autostart),
+                    onClick = { panel = TunnelPanel.Autostart; adding = false; selectedId = null },
+                    icon = "bolt",
+                )
                 PrimaryButton(
                     stringResource(Res.string.ports_new_tunnel),
-                    onClick = { adding = true; selectedId = null; discovering = false },
+                    onClick = { panel = TunnelPanel.Editor; adding = true; selectedId = null },
                     icon = "add",
                 )
             },
         )
         Box(Modifier.weight(1f).fillMaxWidth()) {
             if (manager == null) {
-                MockTunnelsBody()
+                MockTunnelsBody(mono)
             } else {
                 GlobalTunnelsBody(
                     manager = manager,
                     hosts = hosts,
                     mono = mono,
+                    panel = panel,
                     adding = adding,
-                    discovering = discovering,
                     selectedId = selectedId,
-                    onSelect = { selectedId = it; adding = false; discovering = false },
-                    onCloseDiscovery = { discovering = false; manager.services.reset() },
-                    onCloseEditor = { adding = false; selectedId = null; discovering = false },
+                    onSelect = { selectedId = it; adding = false; panel = TunnelPanel.Editor },
+                    onClosePanel = {
+                        if (panel == TunnelPanel.Services) manager.services.reset()
+                        panel = TunnelPanel.None
+                        adding = false
+                        selectedId = null
+                    },
                     // After deletion, returns to "New tunnel" mode instead of jumping to an
                     // arbitrary remaining tunnel: selectedId still holds the removed id, and
                     // without resetting it, selected would resolve via firstOrNull().
-                    onNew = { selectedId = null; adding = true; discovering = false },
+                    onNew = { selectedId = null; adding = true; panel = TunnelPanel.Editor },
                 )
             }
         }
     }
 }
 
-// Live path: global list of saved tunnels plus an editor on the right.
-
 @Composable
 private fun GlobalTunnelsBody(
     manager: TunnelManager,
     hosts: HostManagerController?,
     mono: FontFamily,
+    panel: TunnelPanel,
     adding: Boolean,
-    discovering: Boolean,
     selectedId: String?,
     onSelect: (String) -> Unit,
-    onCloseDiscovery: () -> Unit,
-    onCloseEditor: () -> Unit,
+    onClosePanel: () -> Unit,
     onNew: () -> Unit,
 ) {
     val tunnels = manager.tunnels
-    val activeCount = tunnels.count { it.status is TunnelStatus.Active }
     // No auto-selection: the right panel stays closed until the user opens it (New tunnel / a row /
-    // Find services). `selected` is null unless a real tunnel is being edited.
+    // Scan ports / Autostart). `selected` is null unless a real tunnel is being edited.
     val selected = tunnels.firstOrNull { it.id == selectedId }
-    // Editor slides in for a new tunnel (adding) or when editing a selected one; never together with
-    // the services panel (they share the right column).
-    val editorVisible = !discovering && (adding || selected != null)
+    val editorVisible = panel == TunnelPanel.Editor && (adding || selected != null)
 
     fun hostLabel(hostId: String): String = hosts?.find(hostId)?.label ?: hostId
 
@@ -230,8 +166,12 @@ private fun GlobalTunnelsBody(
                     modifier = Modifier.weight(1f),
                 )
             } else {
-                Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState()).padding(horizontal = 22.dp, vertical = 18.dp)) {
-                    Column(Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(10.dp))) {
+                Column(
+                    Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())
+                        .padding(horizontal = 22.dp, vertical = 18.dp),
+                ) {
+                    AutostartFailureBanner(manager, Modifier.padding(bottom = 14.dp))
+                    TableFrame {
                         TunnelHeaderRow()
                         tunnels.forEach { entry ->
                             HLine()
@@ -245,7 +185,7 @@ private fun GlobalTunnelsBody(
                                     else manager.activate(entry.id)
                                 }
                             }
-                            TunnelRowGlobal(
+                            TunnelRow(
                                 entry = entry,
                                 via = hostLabel(entry.tunnel.hostId),
                                 mono = mono,
@@ -255,33 +195,31 @@ private fun GlobalTunnelsBody(
                             )
                         }
                     }
-                    Row(Modifier.padding(top = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Sym("bolt", size = 15.sp, color = Skerry.colors.moss)
-                        Txt(
-                            if (activeCount == 1) stringResource(Res.string.ports_active_tunnel_one, activeCount)
-                            else stringResource(Res.string.ports_active_tunnels_other, activeCount),
-                            color = Skerry.colors.faint, size = 11.5.sp,
-                        )
-                    }
+                    TunnelDashboard(
+                        manager = manager,
+                        hostLabel = ::hostLabel,
+                        mono = mono,
+                        modifier = Modifier.padding(top = 16.dp),
+                    )
                 }
             }
-            // Right column: editor and services share ONE slide-in slot (not two sibling
-            // AnimatedVisibility blocks — those each reserved width in the Row, so switching
-            // editor↔services briefly expanded both at once and jolted the list width). A single
-            // slot expands from the right edge (the list reflows to fill the freed width);
-            // clipToBounds keeps the 308dp content from painting outside the animating slot.
+            // Right column: the panels share ONE slide-in slot (not sibling AnimatedVisibility
+            // blocks — those each reserved width in the Row, so switching between them briefly
+            // expanded both at once and jolted the list width). A single slot expands from the
+            // right edge (the list reflows to fill the freed width); clipToBounds keeps the panel
+            // content from painting outside the animating slot.
             //
             // `shown*` latch what the panel is displaying and only update while it's open, so the
             // outgoing content survives the slide-out unchanged — otherwise the exit would recompose
             // against the just-cleared state and flash (a blank "New tunnel" form on editor close, or
             // the editor on services close).
-            val panelVisible = editorVisible || discovering
-            var shownServices by remember { mutableStateOf(discovering) }
+            val panelVisible = editorVisible || panel == TunnelPanel.Services || panel == TunnelPanel.Autostart
+            var shownPanel by remember { mutableStateOf(panel) }
             var shownEntry by remember { mutableStateOf<TunnelEntry?>(null) }
             var shownAdding by remember { mutableStateOf(false) }
             if (panelVisible) {
-                shownServices = discovering
-                if (!discovering) { shownEntry = selected; shownAdding = adding }
+                shownPanel = panel
+                if (panel == TunnelPanel.Editor) { shownEntry = selected; shownAdding = adding }
             }
             AnimatedVisibility(
                 visible = panelVisible,
@@ -290,17 +228,21 @@ private fun GlobalTunnelsBody(
             ) {
                 Row(Modifier.clipToBounds()) {
                     VLine(Skerry.colors.line)
-                    if (shownServices) {
-                        ServicesPanel(manager = manager, hosts = hosts, mono = mono, onClose = onCloseDiscovery)
-                    } else {
-                        TunnelEditor(
+                    // Exhaustive on purpose: `None` cannot reach here (the slot is invisible for
+                    // it), but a catch-all `else` would silently render an empty editor if that ever
+                    // stopped holding, instead of failing where the invariant broke.
+                    when (shownPanel) {
+                        TunnelPanel.None -> Unit
+                        TunnelPanel.Services -> ServicesPanel(manager, hosts, mono, onClose = onClosePanel)
+                        TunnelPanel.Autostart -> AutostartPanel(manager, ::hostLabel, onClose = onClosePanel)
+                        TunnelPanel.Editor -> TunnelEditor(
                             manager = manager,
                             hosts = hosts,
                             mono = mono,
                             existing = if (shownAdding) null else shownEntry,
                             onSaved = { onSelect(it) },
                             onRequestRemove = { shownEntry?.let { pendingRemove = it } },
-                            onClose = onCloseEditor,
+                            onClose = onClosePanel,
                         )
                     }
                 }
@@ -322,518 +264,30 @@ private fun GlobalTunnelsBody(
     }
 }
 
+/** Offscreen render/preview without a manager: the same table over sample rows. */
 @Composable
-private fun TunnelRowGlobal(
-    entry: TunnelEntry,
-    via: String,
-    mono: FontFamily,
-    selected: Boolean,
-    onSelect: () -> Unit,
-    onToggle: () -> Unit,
-) {
-    val t = entry.tunnel
-    val (bg, fg) = t.direction.badgeColors()
-    val arrow = if (t.direction == TunnelDirection.Dynamic) "all_inclusive" else "arrow_forward"
-    val dest = if (t.direction == TunnelDirection.Dynamic) null else "${t.destHost}:${t.destPort}"
-    val dim = entry.status !is TunnelStatus.Active
-    Column(Modifier.fillMaxWidth().clickable(onClick = onSelect).background(if (selected) Skerry.colors.cyan08 else Color.Transparent)) {
-        Row(
-            Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 13.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
-        ) {
-            Box(Modifier.width(76.dp)) {
-                Badge(t.direction.badgeLabel(), bg = bg, fg = fg, radius = 4, size = 10.sp)
-            }
-            Txt(sourceText(entry), color = if (dim) Skerry.colors.dim else Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
-            Box(Modifier.width(20.dp)) { Sym(arrow, size = 16.sp, color = Skerry.colors.faint) }
-            Txt(dest ?: stringResource(Res.string.ports_dynamic_proxy), color = if (dest == null || dim) Skerry.colors.dim else Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
-            Txt(via, color = Skerry.colors.dim, size = 11.5.sp, font = mono, modifier = Modifier.width(110.dp))
-            Row(Modifier.width(84.dp), horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End), verticalAlignment = Alignment.CenterVertically) {
-                OpenInBrowserAction(entry)
-                ActiveCellGlobal(entry, onToggle)
-            }
-        }
-        (entry.status as? TunnelStatus.Failed)?.let {
-            Txt(tunnelFailureText(it), color = Skerry.colors.sunset, size = 11.sp, font = mono, modifier = Modifier.padding(start = 16.dp, bottom = 10.dp))
-        }
-    }
-}
-
-/** Source: bind address and listener port (actual boundPort when active, otherwise the requested one). */
-private fun sourceText(entry: TunnelEntry): String {
-    val port = (entry.status as? TunnelStatus.Active)?.boundPort ?: entry.tunnel.bindPort
-    return "${entry.tunnel.bindHost}:$port"
-}
-
-/**
- * Opens a live local forward in the browser. Only shown when there is something to open: `-R`
- * listens on the server and `-D` is a SOCKS proxy, so neither gets a link.
- */
-@Composable
-private fun OpenInBrowserAction(entry: TunnelEntry) {
-    val url = tunnelBrowserUrl(entry) ?: return
-    val uriHandler = LocalUriHandler.current
-    Sym(
-        "open_in_new",
-        size = 15.sp,
-        color = Skerry.colors.cyanBright,
-        // A failing system handler must not throw into the composition (see AboutSection).
-        modifier = Modifier.clickable { runCatching { uriHandler.openUri(url) } },
-    )
-}
-
-/** ACTIVE cell: on toggle when active, hourglass while connecting, otherwise off toggle (activate/retry). */
-@Composable
-private fun ActiveCellGlobal(entry: TunnelEntry, onToggle: () -> Unit) {
-    when (entry.status) {
-        is TunnelStatus.Active -> Toggle(on = true, onToggle = onToggle)
-        TunnelStatus.Connecting -> Sym("hourglass_top", size = 16.sp, color = Skerry.colors.amber)
-        else -> Toggle(on = false, onToggle = onToggle)
-    }
-}
-
-/**
- * Service discovery panel: pick a saved host, scan it for listening TCP ports, and forward one in a
- * tap (a local forward is created and activated right away). Occupies the editor's column — the two
- * are alternative uses of the same panel, never both at once.
- */
-@Composable
-private fun ServicesPanel(
-    manager: TunnelManager,
-    hosts: HostManagerController?,
-    mono: FontFamily,
-    onClose: () -> Unit,
-) {
-    val scan = manager.services
-    // Only SSH-authenticated hosts can be scanned: the scan is an SSH exec round-trip, so Telnet/
-    // Serial/VNC profiles (no command channel) are excluded from the picker rather than offered and
-    // then rejected as Unsupported. MOSH qualifies — it dials the same SSH hop.
-    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
-    var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
-    val hostLabel = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
-        ?: stringResource(Res.string.ports_select_host)
-
+private fun MockTunnelsBody(mono: FontFamily) {
     Column(
-        Modifier.width(308.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp),
+        Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(horizontal = 22.dp, vertical = 18.dp),
     ) {
-        Row(Modifier.fillMaxWidth().padding(bottom = 6.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Sym("radar", size = 16.sp, color = Skerry.colors.cyanBright)
-                Txt(stringResource(Res.string.ports_services_title), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-            }
-            Sym("close", size = 16.sp, color = Skerry.colors.faint, modifier = Modifier.clickable(onClick = onClose))
-        }
-        Txt(stringResource(Res.string.ports_services_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(bottom = 14.dp))
-        FieldLabel(stringResource(Res.string.ports_field_via_host))
-        HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { hostId = it })
-        Box(Modifier.padding(bottom = 12.dp))
-        PrimaryButton(
-            label = stringResource(Res.string.ports_scan),
-            onClick = { hostId?.let { scan.scan(it) } },
-            modifier = Modifier.fillMaxWidth(),
-            icon = "radar",
-            enabled = hostId != null,
-        )
-        Box(Modifier.padding(bottom = 14.dp))
-        when (val state = scan.state) {
-            ServiceScanState.Idle -> ScanNote(stringResource(Res.string.ports_pick_host_to_scan), Skerry.colors.faint)
-            ServiceScanState.Scanning -> ScanNote(stringResource(Res.string.ports_scanning), Skerry.colors.amber)
-            ServiceScanState.Unsupported -> ScanNote(stringResource(Res.string.ports_services_unsupported), Skerry.colors.dim)
-            is ServiceScanState.Failed -> ScanNote(serviceScanFailureText(state), Skerry.colors.sunset)
-            is ServiceScanState.Ready -> {
-                val scanned = scan.scannedHostId
-                if (state.services.isEmpty() || scanned == null) {
-                    ScanNote(stringResource(Res.string.ports_no_services), Skerry.colors.faint)
-                } else {
-                    val taken = forwardedPorts(manager.tunnels.map { it.tunnel }, scanned)
-                    Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        state.services.forEach { service ->
-                            ServiceRow(
-                                service = service,
-                                mono = mono,
-                                forwarded = service.port in taken,
-                                // Saved and raised in one go — the point of the panel is not to
-                                // land in the editor with fields pre-filled.
-                                onForward = { label -> manager.activate(manager.save(serviceTunnelDraft(service, scanned, label))) },
-                            )
-                        }
-                    }
-                }
+        TableFrame {
+            TunnelHeaderRow()
+            mockTunnelEntries().forEach { (entry, host) ->
+                HLine()
+                TunnelRow(entry = entry, via = host, mono = mono, selected = false, onSelect = {}, onToggle = {})
             }
         }
     }
 }
 
+/** The outlined frame the table sits in. */
 @Composable
-private fun ScanNote(text: String, color: Color) {
-    Txt(text, color = color, size = 11.5.sp, lineHeight = 16.sp)
-}
-
-/** One discovered service: port, owning process, and the one-tap forward action. */
-@Composable
-private fun ServiceRow(service: ListeningService, mono: FontFamily, forwarded: Boolean, onForward: (String) -> Unit) {
-    // Name for the tunnel when the host didn't disclose the process; localized here, since the
-    // draft is built outside the composition.
-    val fallback = stringResource(Res.string.ports_service_port, service.port)
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(7.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Txt("${service.port}", color = Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.width(46.dp))
-        Txt(serviceLabel(service), color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.weight(1f))
-        if (forwarded) {
-            Txt(stringResource(Res.string.ports_already_forwarded), color = Skerry.colors.moss, size = 10.5.sp)
-        } else {
-            Txt(
-                stringResource(Res.string.ports_forward),
-                color = Skerry.colors.cyanBright,
-                size = 10.5.sp,
-                weight = FontWeight.SemiBold,
-                modifier = Modifier.clickable { onForward(fallback) }.padding(horizontal = 4.dp, vertical = 2.dp),
-            )
-        }
-    }
-}
-
-/**
- * Tunnel editor (create/edit): name, type, via-host (host dropdown), bind and dest. Save builds
- * [TunnelFormState.draft] and writes it via [TunnelManager]; for an existing tunnel, shows Remove
- * and live throughput (when active). Fields reset when [existing] changes (via `key`).
- */
-@Composable
-private fun TunnelEditor(
-    manager: TunnelManager,
-    hosts: HostManagerController?,
-    mono: FontFamily,
-    existing: TunnelEntry?,
-    onSaved: (String) -> Unit,
-    onRequestRemove: () -> Unit,
-    onClose: () -> Unit,
-) {
-    val editingId = existing?.id
-    // Keyed by editingId: the form is an isolated edit buffer, populated once per selected
-    // tunnel. Mutations to entry.tunnel from elsewhere (save for the same id) intentionally
-    // don't propagate here — unfinished user edits take priority.
-    val form = remember(editingId) { TunnelFormState.fromEntry(existing) }
-
-    val draft = form.draft
-    val (badgeBg, badgeFg) = form.direction.badgeColors()
-    // The tunnel dials this host over SSH, so remote desktops are not candidates.
-    val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
-    val hostLabel = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
-
+private fun TableFrame(content: @Composable () -> Unit) {
     Column(
-        Modifier.width(308.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp),
+        Modifier.fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(10.dp)),
     ) {
-        Row(Modifier.fillMaxWidth().padding(bottom = 16.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.SpaceBetween) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Badge(form.direction.badgeLabel(), bg = badgeBg, fg = badgeFg, radius = 4, size = 10.sp)
-                Txt(if (existing == null) stringResource(Res.string.ports_new_tunnel) else stringResource(Res.string.ports_tunnel_detail), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-            }
-            Sym("close", size = 16.sp, color = Skerry.colors.faint, modifier = Modifier.clickable(onClick = onClose))
-        }
-        FieldLabel(stringResource(Res.string.ports_field_name))
-        EditField(form.label, { form.label = it }, stringResource(Res.string.ports_ph_web_tunnel), mono)
-        Box(Modifier.padding(bottom = 12.dp))
-        FieldLabel(stringResource(Res.string.ports_field_type))
-        TypePicker(form.direction, onPick = { form.direction = it })
-        Box(Modifier.padding(bottom = 12.dp))
-        FieldLabel(stringResource(Res.string.ports_field_via_host))
-        HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { form.hostId = it })
-        Box(Modifier.padding(bottom = 12.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Column(Modifier.weight(1f)) { FieldLabel(stringResource(Res.string.ports_field_bind_address)); EditField(form.bindHost, { form.bindHost = it }, "127.0.0.1", mono) }
-            Column(Modifier.width(70.dp)) { FieldLabel(stringResource(Res.string.ports_field_port)); EditField(form.bindPort, { form.bindPort = it }, "0", mono, KeyboardType.Number) }
-        }
-        if (!form.isDynamic) {
-            Box(Modifier.padding(bottom = 12.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Column(Modifier.weight(1f)) { FieldLabel(stringResource(Res.string.ports_field_destination)); EditField(form.destHost, { form.destHost = it }, "10.0.0.5", mono) }
-                Column(Modifier.width(70.dp)) { FieldLabel(stringResource(Res.string.ports_field_port)); EditField(form.destPort, { form.destPort = it }, "80", mono, KeyboardType.Number) }
-            }
-        } else {
-            Box(Modifier.padding(bottom = 4.dp))
-            Txt(stringResource(Res.string.ports_socks_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
-        }
-        if (existing != null && existing.status is TunnelStatus.Active) {
-            tunnelBrowserUrl(existing)?.let { url ->
-                val uriHandler = LocalUriHandler.current
-                Box(Modifier.padding(bottom = 14.dp))
-                GhostButton(
-                    stringResource(Res.string.ports_open_in_browser),
-                    onClick = { runCatching { uriHandler.openUri(url) } },
-                    icon = "open_in_new",
-                    fg = Skerry.colors.cyanBright,
-                    border = Skerry.colors.cyan20,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-            Box(Modifier.padding(bottom = 16.dp))
-            FieldLabel(stringResource(Res.string.ports_field_live_throughput))
-            ThroughputRow("arrow_upward", Skerry.colors.cyanBright, rateFraction(existing.upRate), humanRate(existing.upRate), mono)
-            Box(Modifier.padding(bottom = 8.dp))
-            ThroughputRow("arrow_downward", Skerry.colors.moss, rateFraction(existing.downRate), humanRate(existing.downRate), mono)
-            Box(Modifier.padding(bottom = 10.dp))
-            // Editing an active tunnel saves fine, but the forward is already up — new
-            // parameters take effect on the next activation (save doesn't restart the connection).
-            Txt(stringResource(Res.string.ports_changes_apply_after_restart), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp)
-        }
-        Box(Modifier.padding(bottom = 18.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            PrimaryButton(
-                label = stringResource(Res.string.ports_save),
-                onClick = { draft?.let { onSaved(manager.save(it)) } },
-                modifier = Modifier.weight(1f),
-                enabled = draft != null,
-            )
-            if (existing != null) {
-                GhostButton(stringResource(Res.string.ports_remove), onClick = onRequestRemove, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
-            }
-        }
-    }
-}
-
-/** Tunnel-type dropdown (-L/-R/-D) over the form (via [AnchoredDropdown]). */
-@Composable
-private fun TypePicker(current: TunnelDirection, onPick: (TunnelDirection) -> Unit) {
-    var open by remember { mutableStateOf(false) }
-    AnchoredDropdown(
-        expanded = open,
-        onDismiss = { open = false },
-        trigger = {
-            Row(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).clickable { open = !open }.background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Txt(current.displayLabel(), color = Skerry.colors.text, size = 12.5.sp)
-                Sym("expand_more", size = 16.sp, color = Skerry.colors.faint)
-            }
-        },
-        menu = { width ->
-            Column(
-                Modifier.width(width).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.surface2).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)),
-            ) {
-                listOf(TunnelDirection.Local, TunnelDirection.Remote, TunnelDirection.Dynamic).forEach { option ->
-                    Txt(
-                        option.displayLabel(),
-                        color = if (option == current) Skerry.colors.cyanBright else Skerry.colors.text,
-                        size = 12.5.sp,
-                        modifier = Modifier.fillMaxWidth().clickable { onPick(option); open = false }.padding(horizontal = 12.dp, vertical = 9.dp),
-                    )
-                }
-            }
-        },
-    )
-}
-
-/** Host dropdown over the form (via [AnchoredDropdown]); empty shows a hint to add a host. */
-@Composable
-private fun HostPicker(current: String, options: List<Pair<String, String>>, onPick: (String) -> Unit) {
-    var open by remember { mutableStateOf(false) }
-    AnchoredDropdown(
-        expanded = open,
-        onDismiss = { open = false },
-        trigger = {
-            Row(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).clickable { open = !open }.background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Txt(current, color = Skerry.colors.text, size = 12.5.sp)
-                Sym("expand_more", size = 16.sp, color = Skerry.colors.faint)
-            }
-        },
-        menu = { width ->
-            Column(
-                Modifier.width(width).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.surface2).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).heightIn(max = 240.dp).verticalScroll(rememberScrollState()),
-            ) {
-                if (options.isEmpty()) {
-                    Txt(stringResource(Res.string.ports_no_saved_hosts), color = Skerry.colors.faint, size = 12.sp, modifier = Modifier.padding(12.dp))
-                } else {
-                    options.forEach { (id, name) ->
-                        Txt(
-                            name, color = Skerry.colors.text, size = 12.5.sp,
-                            modifier = Modifier.fillMaxWidth().clickable { onPick(id); open = false }.padding(horizontal = 12.dp, vertical = 9.dp),
-                        )
-                    }
-                }
-            }
-        },
-    )
-}
-
-// Mock path (offscreen render/preview): static table plus detail form.
-
-@Composable
-private fun MockTunnelsBody() {
-    Row(Modifier.fillMaxSize()) {
-        Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState()).padding(horizontal = 22.dp, vertical = 18.dp)) {
-            Column(Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(10.dp))) {
-                TunnelHeaderRow()
-                TUNNELS.forEach { rule ->
-                    HLine()
-                    TunnelRow(rule)
-                }
-            }
-            Row(Modifier.padding(top = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Sym("bolt", size = 15.sp, color = Skerry.colors.moss)
-                Txt("2 active tunnels", color = Skerry.colors.faint, size = 11.5.sp)
-            }
-        }
-        VLine(Skerry.colors.line)
-        TunnelDetail()
-    }
-}
-
-@Composable
-private fun TunnelHeaderRow() {
-    Row(
-        Modifier.fillMaxWidth().background(Skerry.colors.overlayFaint).padding(horizontal = 16.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        HeaderCell(stringResource(Res.string.ports_col_type), Modifier.width(76.dp))
-        HeaderCell(stringResource(Res.string.ports_col_source), Modifier.weight(1f))
-        Box(Modifier.width(20.dp))
-        HeaderCell(stringResource(Res.string.ports_col_destination), Modifier.weight(1f))
-        HeaderCell(stringResource(Res.string.ports_col_via_host), Modifier.width(110.dp))
-        HeaderCell(stringResource(Res.string.ports_col_active), Modifier.width(84.dp), end = true)
-    }
-}
-
-@Composable
-private fun HeaderCell(text: String, modifier: Modifier = Modifier, end: Boolean = false) {
-    Box(modifier, contentAlignment = if (end) Alignment.CenterEnd else Alignment.CenterStart) {
-        Txt(text, color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
-    }
-}
-
-@Composable
-private fun TunnelRow(rule: TunnelRule) {
-    val mono = LocalFonts.current.mono
-    Row(
-        Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 13.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        Box(Modifier.width(76.dp)) {
-            val (typeBg, typeFg) = tunnelTypeColors(rule.type)
-            Badge(rule.type, bg = typeBg, fg = typeFg, radius = 4, size = 10.sp)
-        }
-        Txt(rule.source, color = Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
-        Box(Modifier.width(20.dp)) { Sym(rule.arrow, size = 16.sp, color = Skerry.colors.faint) }
-        Txt(rule.dest, color = if (rule.destDim) Skerry.colors.dim else Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
-        Txt(rule.via, color = Skerry.colors.dim, size = 11.5.sp, font = mono, modifier = Modifier.width(110.dp))
-        Box(Modifier.width(84.dp), contentAlignment = Alignment.CenterEnd) {
-            Toggle(rule.active, onToggle = {})
-        }
-    }
-}
-
-@Composable
-private fun TunnelDetail() {
-    val mono = LocalFonts.current.mono
-    Column(
-        Modifier.width(308.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp),
-    ) {
-        Row(Modifier.padding(bottom = 16.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Badge("LOCAL", bg = Skerry.colors.cyan.copy(alpha = 0.12f), fg = Skerry.colors.cyanBright, radius = 4, size = 10.sp)
-            Txt("Tunnel detail", color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-        }
-        FieldLabel("Name")
-        InputField("web tunnel", mono)
-        Box(Modifier.padding(bottom = 12.dp))
-        FieldLabel("Type")
-        SelectField("Local forward")
-        Box(Modifier.padding(bottom = 12.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Column(Modifier.weight(1f)) { FieldLabel("Bind address"); InputField("127.0.0.1", mono) }
-            Column(Modifier.width(70.dp)) { FieldLabel("Port"); InputField("8080", mono) }
-        }
-        Box(Modifier.padding(bottom = 12.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Column(Modifier.weight(1f)) { FieldLabel("Destination"); InputField("10.0.0.5", mono) }
-            Column(Modifier.width(70.dp)) { FieldLabel("Port"); InputField("80", mono) }
-        }
-        Box(Modifier.padding(bottom = 16.dp))
-        FieldLabel("Live throughput")
-        ThroughputRow("arrow_upward", Skerry.colors.cyanBright, 0.38f, "42 KB/s", mono)
-        Box(Modifier.padding(bottom = 8.dp))
-        ThroughputRow("arrow_downward", Skerry.colors.moss, 0.71f, "1.1 MB/s", mono)
-        Box(Modifier.padding(bottom = 18.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            PrimaryButton("Save", onClick = {}, modifier = Modifier.weight(1f))
-            GhostButton("Remove", onClick = {}, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
-        }
-    }
-}
-
-@Composable
-private fun FieldLabel(text: String) {
-    Txt(labelUppercase(text), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 5.dp))
-}
-
-@Composable
-private fun SelectField(value: String) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Txt(value, color = Skerry.colors.text, size = 12.5.sp)
-        Sym("expand_more", size = 16.sp, color = Skerry.colors.faint)
-    }
-}
-
-@Composable
-private fun InputField(value: String, mono: FontFamily) {
-    Box(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-    ) {
-        Txt(value, color = Skerry.colors.text, size = 12.5.sp, font = mono)
-    }
-}
-
-/** Editable tunnel form field ([InputField] style plus placeholder and input). */
-@Composable
-private fun EditField(
-    value: String,
-    onValueChange: (String) -> Unit,
-    placeholder: String,
-    mono: FontFamily,
-    keyboardType: KeyboardType = KeyboardType.Text,
-) {
-    val textColor = Skerry.colors.text
-    val textStyle = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 12.5.sp, fontFamily = mono) }
-    BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
-        singleLine = true,
-        textStyle = textStyle,
-        cursorBrush = SolidColor(Skerry.colors.cyan),
-        keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-        modifier = Modifier.fillMaxWidth(),
-        decorationBox = { inner ->
-            Box(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)).padding(horizontal = 10.dp, vertical = 8.dp),
-            ) {
-                if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, font = mono)
-                inner()
-            }
-        },
-    )
-}
-
-@Composable
-private fun ThroughputRow(icon: String, color: Color, fraction: Float, value: String, mono: FontFamily) {
-    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        Sym(icon, size = 14.sp, color = color)
-        MeterBar(fraction, color, Modifier.weight(1f))
-        Box(Modifier.width(64.dp), contentAlignment = Alignment.CenterEnd) {
-            Txt(value, color = Skerry.colors.dim, size = 11.sp, font = mono)
-        }
+        content()
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
@@ -9,8 +9,10 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.connection.JumpChainProblem
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TunnelFormTest {
 
@@ -121,5 +123,20 @@ class TunnelFormTest {
             resolveTunnelHost(tunnel.hostId, findHost = { hosts[it] }, findCredential = { if (it == "c1") credential else null }),
         )
         assertEquals(TunnelUnavailable.Jump(JumpChainProblem.NO_CREDENTIAL), r.reason)
+    }
+
+    @Test
+    fun `the form seeds autostart from the edited tunnel and carries it into the draft`() {
+        val form = TunnelFormState.fromEntry(TunnelEntry(tunnel.copy(autostart = true)))
+
+        assertTrue(form.autostart)
+        assertEquals(true, form.draft?.autostart)
+    }
+
+    @Test
+    fun `a new tunnel starts with autostart off`() {
+        val form = TunnelFormState.fromEntry(null)
+
+        assertFalse(form.autostart)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
@@ -306,6 +306,203 @@ class TunnelManagerTest {
     }
 
     @Test
+    fun `flipping autostart through a draft keeps every other field`() = runTest {
+        // What the autostart list does on a toggle: round-trip the saved tunnel through a draft and
+        // change one flag. A field dropped from `toDraft` would silently rewrite the tunnel.
+        val store = FakeTunnelStore()
+        val manager = managerWith(FakeTunnelTransport(), store)
+        val id = manager.save(localDraft(label = "web"))
+        val before = manager.find(id)!!.tunnel
+
+        manager.save(before.toDraft().copy(autostart = true))
+
+        val after = store.all().single()
+        assertEquals(before.copy(autostart = true), after)
+    }
+
+    @Test
+    fun `startAutostart raises only the flagged tunnels`() = runTest {
+        val manager = managerWith(FakeTunnelTransport(FakeTunnelConnection(localPort = 50050)))
+        val flagged = manager.save(localDraft(label = "flagged").copy(autostart = true))
+        val plain = manager.save(localDraft(label = "plain"))
+
+        manager.startAutostart()
+
+        assertEquals(TunnelStatus.Active(50050), manager.find(flagged)!!.status)
+        assertEquals(TunnelStatus.Inactive, manager.find(plain)!!.status)
+    }
+
+    @Test
+    fun `startAutostart runs once per unlock and does not re-raise what the user stopped`() = runTest {
+        // reloadManagers fires on every synced change, so autostart has to be a one-shot per unlock:
+        // otherwise a tunnel switched off by hand would come back up on the next sync tick.
+        val manager = managerWith(FakeTunnelTransport(FakeTunnelConnection(localPort = 50051)))
+        val id = manager.save(localDraft().copy(autostart = true))
+
+        manager.startAutostart()
+        manager.deactivate(id)
+        manager.startAutostart()
+
+        assertEquals(TunnelStatus.Inactive, manager.find(id)!!.status)
+    }
+
+    @Test
+    fun `closeAll re-arms autostart for the next unlock`() = runTest {
+        val manager = managerWith(FakeTunnelTransport(FakeTunnelConnection(localPort = 50052)))
+        val id = manager.save(localDraft().copy(autostart = true))
+        manager.startAutostart()
+
+        manager.closeAll() // vault lock
+        manager.startAutostart() // unlocked again
+
+        assertEquals(TunnelStatus.Active(50052), manager.find(id)!!.status)
+    }
+
+    @Test
+    fun `autostart failures are reported as a set, not left one per row`() = runTest {
+        // Unlock succeeding and every autostart tunnel being up are two different things. Without an
+        // aggregate, a user who doesn't open the section has nothing to notice.
+        var available = false
+        val manager = managerWith(
+            FakeTunnelTransport(FakeTunnelConnection(localPort = 50080)),
+            resolve = {
+                if (available) TunnelResolution.Ready(target, auth) else TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
+            },
+        )
+        val broken = manager.save(localDraft(label = "broken").copy(autostart = true))
+        manager.save(localDraft(label = "plain"))
+
+        manager.startAutostart()
+
+        assertEquals(listOf(broken), manager.autostartFailures.map { it.id })
+    }
+
+    @Test
+    fun `a tunnel that came up is not reported as an autostart failure`() = runTest {
+        val manager = managerWith(FakeTunnelTransport(FakeTunnelConnection(localPort = 50081)))
+        manager.save(localDraft().copy(autostart = true))
+
+        manager.startAutostart()
+
+        assertTrue(manager.autostartFailures.isEmpty())
+    }
+
+    @Test
+    fun `a tunnel that came up is not blamed for a later manual failure`() = runTest {
+        // The banner claims the autostart run left something down. A tunnel the user toggled by
+        // hand hours later, against a server that has since gone away, is not that.
+        var available = true
+        val manager = managerWith(
+            FakeTunnelTransport(FakeTunnelConnection(localPort = 50090)),
+            resolve = {
+                if (available) TunnelResolution.Ready(target, auth) else TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
+            },
+        )
+        val id = manager.save(localDraft().copy(autostart = true))
+        manager.startAutostart()
+
+        manager.deactivate(id)
+        available = false
+        manager.activate(id)
+
+        assertIs<TunnelStatus.Failed>(manager.find(id)!!.status)
+        assertTrue(manager.autostartFailures.isEmpty(), "autostart already answered for this tunnel")
+    }
+
+    @Test
+    fun `dismissing the autostart report clears it without touching the tunnels`() = runTest {
+        val manager = managerWith(
+            FakeTunnelTransport(),
+            resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) },
+        )
+        val id = manager.save(localDraft().copy(autostart = true))
+        manager.startAutostart()
+
+        manager.dismissAutostartReport()
+
+        assertTrue(manager.autostartFailures.isEmpty())
+        assertIs<TunnelStatus.Failed>(manager.find(id)!!.status) // the row still says what happened
+    }
+
+    @Test
+    fun `a lock clears the autostart report`() = runTest {
+        val manager = managerWith(
+            FakeTunnelTransport(),
+            resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) },
+        )
+        manager.save(localDraft().copy(autostart = true))
+        manager.startAutostart()
+
+        manager.closeAll()
+
+        assertTrue(manager.autostartFailures.isEmpty())
+    }
+
+    @Test
+    fun `polling records aggregate throughput of every active tunnel`() = runTest {
+        val conn = FakeTunnelConnection(localPort = 50060)
+        val manager = managerWith(FakeTunnelTransport(conn))
+        val a = manager.save(localDraft(label = "a"))
+        manager.activate(a)
+        val handle = conn.lastForward!!
+        handle.bytesUp = 2000
+        handle.bytesDown = 3000
+
+        manager.pollTelemetry()
+
+        assertEquals(ThroughputSample(up = 2000, down = 3000), manager.telemetry.history.last())
+    }
+
+    @Test
+    fun `a failed raise is written to the events journal`() = runTest {
+        val manager = managerWith(
+            FakeTunnelTransport(),
+            resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) },
+        )
+        val id = manager.save(localDraft(label = "Redis"))
+
+        manager.activate(id)
+
+        val event = manager.telemetry.events.single()
+        assertEquals("Redis", event.label)
+        assertEquals(TunnelEventKind.Failed(TunnelFailureKind.Unavailable), event.kind)
+    }
+
+    @Test
+    fun `coming up after a failure is written as recovered`() = runTest {
+        var available = false
+        val manager = managerWith(
+            FakeTunnelTransport(FakeTunnelConnection(localPort = 50070)),
+            resolve = {
+                if (available) TunnelResolution.Ready(target, auth) else TunnelResolution.Unavailable(TunnelUnavailable.NoCredential)
+            },
+        )
+        val id = manager.save(localDraft(label = "Redis"))
+
+        manager.activate(id)
+        available = true
+        manager.activate(id)
+
+        assertEquals(TunnelEventKind.Recovered, manager.telemetry.events.first().kind)
+    }
+
+    @Test
+    fun `deleting a tunnel forgets its failure`() = runTest {
+        val manager = managerWith(
+            FakeTunnelTransport(),
+            resolve = { TunnelResolution.Unavailable(TunnelUnavailable.NoCredential) },
+        )
+        val id = manager.save(localDraft(label = "Redis"))
+        manager.activate(id)
+
+        manager.delete(id)
+        val again = manager.save(localDraft(label = "Redis"))
+        manager.activate(again)
+
+        assertEquals(2, manager.telemetry.events.size)
+    }
+
+    @Test
     fun `loads previously saved tunnels on construction`() = runTest {
         val store = FakeTunnelStore()
         store.put(Tunnel("x", "saved", "h1", TunnelDirection.Local, "127.0.0.1", 22, "a", 1))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelPresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelPresentationTest.kt
@@ -1,0 +1,124 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.shared.ssh.PortForwardException
+import app.skerry.shared.ssh.SshAuthenticationException
+import app.skerry.shared.ssh.SshConnectionException
+import app.skerry.shared.ssh.SshHostKeyRejectedException
+import app.skerry.shared.tunnel.Tunnel
+import app.skerry.shared.tunnel.TunnelDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TunnelPresentationTest {
+
+    private fun entry(
+        id: String,
+        status: TunnelStatus,
+        hostId: String = "h1",
+        autostart: Boolean = false,
+    ): TunnelEntry {
+        val tunnel = Tunnel(id, id, hostId, TunnelDirection.Local, "127.0.0.1", 8080, "10.0.0.5", 80, autostart)
+        return TunnelEntry(tunnel).also { it.status = status }
+    }
+
+    @Test
+    fun `the header counts what is up and what is not`() {
+        val counts = tunnelCounts(
+            listOf(
+                entry("a", TunnelStatus.Active(1)),
+                entry("b", TunnelStatus.Active(2)),
+                entry("c", TunnelStatus.Inactive),
+                entry("d", TunnelStatus.Failed("boom")),
+                entry("e", TunnelStatus.Connecting),
+            ),
+        )
+
+        // Anything not carrying traffic is "stopped" — a failed or still-dialling tunnel is not
+        // active, and the header must not claim otherwise.
+        assertEquals(TunnelCounts(active = 2, stopped = 3), counts)
+    }
+
+    @Test
+    fun `each status maps to its own row badge`() {
+        assertEquals(TunnelStatusBadge.Active, TunnelStatus.Active(1).badge())
+        assertEquals(TunnelStatusBadge.Connecting, TunnelStatus.Connecting.badge())
+        assertEquals(TunnelStatusBadge.Failed, TunnelStatus.Failed("boom").badge())
+        assertEquals(TunnelStatusBadge.Stopped, TunnelStatus.Inactive.badge())
+    }
+
+    @Test
+    fun `the listen and target columns swap arrow direction for a remote forward`() {
+        // -L/-D listen locally and reach out; -R listens on the server and traffic comes back at us.
+        // The mock-up draws that as the arrow between the two address columns.
+        assertEquals(TunnelFlow.Outbound, TunnelDirection.Local.flow())
+        assertEquals(TunnelFlow.Outbound, TunnelDirection.Dynamic.flow())
+        assertEquals(TunnelFlow.Inbound, TunnelDirection.Remote.flow())
+    }
+
+    @Test
+    fun `autostart tunnels are grouped by host, hosts without one are absent`() {
+        val grouped = autostartByHost(
+            listOf(
+                entry("a", TunnelStatus.Active(1), hostId = "db", autostart = true),
+                entry("b", TunnelStatus.Inactive, hostId = "db", autostart = true),
+                entry("c", TunnelStatus.Inactive, hostId = "edge", autostart = true),
+                entry("d", TunnelStatus.Inactive, hostId = "quiet", autostart = false),
+            ),
+        )
+
+        assertEquals(listOf("db" to 2, "edge" to 1), grouped)
+    }
+
+    @Test
+    fun `a bind address is only quiet when it is loopback`() {
+        // The warning drives whether the editor tells the user the listener is reachable from the
+        // network. Empty means the form will substitute 127.0.0.1, so it is quiet too.
+        assertFalse(bindsBeyondLoopback(""))
+        assertFalse(bindsBeyondLoopback("127.0.0.1"))
+        assertFalse(bindsBeyondLoopback(" 127.1.2.3 "))
+        assertFalse(bindsBeyondLoopback("localhost"))
+        assertFalse(bindsBeyondLoopback("::1"))
+        assertFalse(bindsBeyondLoopback("[::1]"))
+
+        assertTrue(bindsBeyondLoopback("0.0.0.0"))
+        assertTrue(bindsBeyondLoopback("::"))
+        assertTrue(bindsBeyondLoopback("192.168.1.10"))
+        // A name we cannot resolve is assumed to be reachable — the warning must not be the thing
+        // that goes quiet when we are unsure.
+        assertTrue(bindsBeyondLoopback("nas.lan"))
+    }
+
+    @Test
+    fun `a hostname that merely starts like loopback is not loopback`() {
+        // "127." was once a text prefix check, so any domain whose first label starts with those
+        // four characters silenced the warning. A DNS label is free to begin that way and resolve
+        // wherever its owner likes, which is exactly the case the warning exists for.
+        assertTrue(bindsBeyondLoopback("127.0.0.1.attacker.example"))
+        assertTrue(bindsBeyondLoopback("127.tunnel.example"))
+
+        // Anything that isn't a clean dotted quad in 127/8 is treated as reachable, because we
+        // cannot tell what it resolves to.
+        assertTrue(bindsBeyondLoopback("127.0.0"))
+        assertTrue(bindsBeyondLoopback("127.0.0.256"))
+        assertTrue(bindsBeyondLoopback("127.0.0.1.1"))
+        assertTrue(bindsBeyondLoopback("127.00.0.1")) // a leading zero reads as octal to some resolvers
+        assertTrue(bindsBeyondLoopback("127.+0.0.1"))
+        assertTrue(bindsBeyondLoopback("2130706433")) // decimal-encoded 127.0.0.1
+
+        assertFalse(bindsBeyondLoopback("127.0.0.1"))
+        assertFalse(bindsBeyondLoopback("127.255.255.254"))
+    }
+
+    @Test
+    fun `a transport failure is classified without reading its message`() {
+        // The card shows a one-word cause, and it must not come from sniffing an exception string
+        // that is localized and rewritten for the user.
+        assertEquals(TunnelFailureKind.HostKey, tunnelFailureKind(SshHostKeyRejectedException("h", null)))
+        assertEquals(TunnelFailureKind.Auth, tunnelFailureKind(SshAuthenticationException("nope")))
+        assertEquals(TunnelFailureKind.Forward, tunnelFailureKind(PortForwardException("busy")))
+        assertEquals(TunnelFailureKind.Connection, tunnelFailureKind(SshConnectionException("down")))
+        assertEquals(TunnelFailureKind.Connection, tunnelFailureKind(IllegalStateException("who knows")))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelTelemetryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelTelemetryTest.kt
@@ -1,0 +1,157 @@
+package app.skerry.ui.tunnel
+
+import androidx.compose.runtime.snapshots.Snapshot
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TunnelTelemetryTest {
+
+    private fun telemetry() = TunnelTelemetry(pollIntervalMillis = 1000)
+
+    @Test
+    fun `sampling records aggregate throughput in arrival order`() {
+        val t = telemetry()
+
+        t.sample(up = 100, down = 200)
+        t.sample(up = 300, down = 400)
+
+        assertEquals(listOf(ThroughputSample(100, 200), ThroughputSample(300, 400)), t.history)
+    }
+
+    @Test
+    fun `history is bounded and keeps the newest samples`() {
+        // The sparkline draws a fixed window; an unbounded list would grow for as long as the app
+        // runs, one entry per second, for a chart that can only show the tail anyway.
+        val t = telemetry()
+
+        repeat(TunnelTelemetry.HISTORY_CAPACITY + 5) { i -> t.sample(up = i.toLong(), down = 0) }
+
+        assertEquals(TunnelTelemetry.HISTORY_CAPACITY, t.history.size)
+        assertEquals(5L, t.history.first().up) // the first five fell off the front
+        assertEquals((TunnelTelemetry.HISTORY_CAPACITY + 4).toLong(), t.history.last().up)
+    }
+
+    @Test
+    fun `a failure is recorded once, not on every retry of the same tunnel`() {
+        val t = telemetry()
+
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        assertEquals(1, t.events.size)
+        assertEquals(TunnelEventKind.Failed(TunnelFailureKind.Connection), t.events.single().kind)
+    }
+
+    @Test
+    fun `a different cause for the same tunnel is news, not a repeat`() {
+        // Retrying a failed tunnel is one tap, and the second attempt can fail for a different
+        // reason than the first (credential fixed, network down). Suppressing that leaves the card
+        // asserting a cause that is no longer true, while the row right above it says otherwise.
+        val t = telemetry()
+
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Auth)
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        assertEquals(
+            listOf(TunnelEventKind.Failed(TunnelFailureKind.Connection), TunnelEventKind.Failed(TunnelFailureKind.Auth)),
+            t.events.map { it.kind },
+        )
+    }
+
+    @Test
+    fun `coming up after a failure is recorded as recovered`() {
+        val t = telemetry()
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        t.active("t1", "Redis", 6379)
+
+        assertEquals(listOf(TunnelEventKind.Recovered, TunnelEventKind.Failed(TunnelFailureKind.Connection)), t.events.map { it.kind })
+    }
+
+    @Test
+    fun `a tunnel that never failed produces no recovered event`() {
+        val t = telemetry()
+
+        t.active("t1", "Redis", 6379)
+
+        assertTrue(t.events.isEmpty())
+    }
+
+    @Test
+    fun `recovery is reported once, not on every reconnect`() {
+        val t = telemetry()
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        t.active("t1", "Redis", 6379)
+        t.active("t1", "Redis", 6379)
+
+        assertEquals(2, t.events.size)
+    }
+
+    @Test
+    fun `events are newest first and bounded`() {
+        val t = telemetry()
+
+        repeat(TunnelTelemetry.EVENT_CAPACITY + 2) { i ->
+            t.failed("t$i", "Tunnel $i", 1000 + i, TunnelFailureKind.Auth)
+        }
+
+        assertEquals(TunnelTelemetry.EVENT_CAPACITY, t.events.size)
+        assertEquals("Tunnel ${TunnelTelemetry.EVENT_CAPACITY + 1}", t.events.first().label)
+    }
+
+    @Test
+    fun `forgetting a deleted tunnel lets a later failure be reported again`() {
+        // Delete-and-recreate must not be silently swallowed because the old id was still marked
+        // as failing.
+        val t = telemetry()
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        t.forget("t1")
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        assertEquals(2, t.events.size)
+    }
+
+    @Test
+    fun `event age counts poll ticks, not wall clock`() {
+        val t = telemetry()
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+        val event = t.events.single()
+
+        repeat(12) { t.sample(up = 0, down = 0) }
+
+        assertEquals(12, t.secondsSince(event))
+    }
+
+    @Test
+    fun `the age of an event is snapshot state, so the card can tick`() {
+        // The errors card renders the age of its newest entry. `events` stops changing the moment a
+        // failure is recorded, so if the tick counter is not snapshot-backed the card never
+        // recomposes and freezes at "0 s ago" forever.
+        val t = telemetry()
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+        val event = t.events.single()
+
+        var stateReads = 0
+        Snapshot.observe(readObserver = { stateReads++ }) { t.secondsSince(event) }
+
+        assertTrue(stateReads > 0, "secondsSince must read snapshot state, else the age never updates")
+    }
+
+    @Test
+    fun `reset clears history, events and the failing set`() {
+        val t = telemetry()
+        t.sample(up = 1, down = 1)
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+
+        t.reset()
+
+        assertTrue(t.history.isEmpty())
+        assertTrue(t.events.isEmpty())
+        // The failing set went with it: the same tunnel failing after a lock is news again.
+        t.failed("t1", "Redis", 6379, TunnelFailureKind.Connection)
+        assertEquals(1, t.events.size)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -49,6 +49,8 @@ import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.shared.tunnel.TunnelStore
 import app.skerry.ui.tunnel.SERVICE_SCAN_COMMAND
 import app.skerry.ui.tunnel.TunnelManager
+import app.skerry.ui.tunnel.TunnelTelemetry
+import app.skerry.ui.tunnel.TunnelStatus
 import app.skerry.ui.tunnel.TunnelResolution
 import app.skerry.ui.tunnel.TunnelUnavailable
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
@@ -85,10 +87,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.File
 import app.skerry.ui.vault.DesktopCorruptedScreen
 import app.skerry.ui.vault.DesktopCreateScreen
@@ -606,9 +611,9 @@ private fun seededTunnels(hosts: HostManagerController): TunnelManager {
     }
     val hostIds = hosts.hosts.map { it.id }
     fun hostAt(i: Int) = hostIds.getOrElse(i) { hostIds.first() }
-    store.put(Tunnel("t1", "web tunnel", hostAt(0), TunnelDirection.Local, "127.0.0.1", 8080, "10.0.0.5", 80))
+    store.put(Tunnel("t1", "web tunnel", hostAt(0), TunnelDirection.Local, "127.0.0.1", 8080, "10.0.0.5", 80, autostart = true))
     store.put(Tunnel("t2", "app callback", hostAt(1), TunnelDirection.Remote, "0.0.0.0", 9000, "localhost", 3000))
-    store.put(Tunnel("t3", "socks", hostAt(2), TunnelDirection.Dynamic, "127.0.0.1", 1080, null, null))
+    store.put(Tunnel("t3", "socks", hostAt(2), TunnelDirection.Dynamic, "127.0.0.1", 1080, null, null, autostart = true))
     var next = 0
     val manager = TunnelManager(
         store = store,
@@ -624,6 +629,11 @@ private fun seededTunnels(hosts: HostManagerController): TunnelManager {
         scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
     ) { "seed-${next++}" }
     manager.activate("t1")
+    // The scene renders one frame at t=0, so everything the one-second telemetry poll feeds — the
+    // traffic column, the throughput sparkline — would be empty. Wait for the forward, then drive
+    // the poll by hand to fill the window.
+    runBlocking { withTimeoutOrNull(2000) { while (manager.find("t1")?.status !is TunnelStatus.Active) delay(10) } }
+    repeat(TunnelTelemetry.HISTORY_CAPACITY) { manager.pollTelemetry() }
     // -Dskerry.screenshot.portsScan=true renders the Services panel instead of the tunnel editor
     // (the offscreen scene can't press Find services / Scan itself).
     if (System.getProperty("skerry.screenshot.portsScan", "false").toBoolean()) manager.services.scan(hostAt(0))
@@ -862,8 +872,12 @@ private class FakePortForward(override val boundPort: Int) : PortForward {
     override val isActive: Boolean = true
     override var isPaused: Boolean = false
         private set
-    override val bytesUp: Long = 0
-    override val bytesDown: Long = 0
+
+    // Counters grow with every read, on a small wave, so the traffic column and the throughput
+    // sparkline render with something in them. A constant would draw a flat line and read as a bug.
+    private var reads = 0L
+    override val bytesUp: Long get() = 46_000L * ++reads + (reads % 11) * 2_400
+    override val bytesDown: Long get() = 138_000L * reads + (reads % 13) * 5_800
     override suspend fun pause() { isPaused = true }
     override suspend fun resume() { isPaused = false }
     override suspend fun close() = Unit

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -387,6 +387,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val onVaultUnlocked: () -> Unit = {
         // Vault opened, so reload managers (including AI BYOK settings) from decrypted records.
         reloadManagers()
+        // Tunnels flagged for autostart come up now, not in reloadManagers: that one also runs on
+        // every synced change, and raising there would fight the user's own toggles.
+        tunnels.startAutostart()
         // Apply the trash retention window here, not only when its screen is opened: otherwise a
         // deleted secret a user never goes looking for would sit in the vault (and keep being
         // pushed to the server) long past the 30 days the UI promises.

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/tunnel/TunnelCountPluralTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/tunnel/TunnelCountPluralTest.kt
@@ -1,0 +1,78 @@
+package app.skerry.ui.tunnel
+
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ports_autostart_failed
+import app.skerry.ui.generated.resources.ports_count_active
+import app.skerry.ui.generated.resources.ports_count_stopped
+import app.skerry.ui.generated.resources.ports_tunnel_count
+import kotlinx.coroutines.test.runTest
+import org.jetbrains.compose.resources.getPluralString
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Plural agreement of the tunnel counts. Lives in the desktop source set, not `commonTest`: it
+ * drives `java.util.Locale`, which is a platform API, and it mutates a process-global.
+ *
+ * The autostart card's tunnel count. Pinned because the obvious implementation — `if (count == 1)`
+ * — is right in English and wrong in Russian, where 2–4 take their own form ("3 туннеля") and only
+ * 5 and up take the one that looks like a plural ("5 туннелей").
+ */
+class TunnelCountPluralTest {
+
+    @Test
+    fun `russian picks a different form for one, a few and many`() = runTest {
+        runBlockingLocale("ru") {
+            assertEquals("1 туннель", getPluralString(Res.plurals.ports_tunnel_count, 1, 1))
+            assertEquals("3 туннеля", getPluralString(Res.plurals.ports_tunnel_count, 3, 3))
+            assertEquals("7 туннелей", getPluralString(Res.plurals.ports_tunnel_count, 7, 7))
+            // 21 is "one" in Russian, not "many" — the rule is about the last digit, not the size.
+            assertEquals("21 туннель", getPluralString(Res.plurals.ports_tunnel_count, 21, 21))
+        }
+    }
+
+    @Test
+    fun `the header tally agrees with its own numbers in russian`() = runTest {
+        // Regression: the tally was one flat template, so a single active tunnel read
+        // "1 активных". English never showed it — the adjective there doesn't inflect.
+        runBlockingLocale("ru") {
+            assertEquals("1 активный", getPluralString(Res.plurals.ports_count_active, 1, 1))
+            assertEquals("3 активных", getPluralString(Res.plurals.ports_count_active, 3, 3))
+            assertEquals("21 активный", getPluralString(Res.plurals.ports_count_active, 21, 21))
+            assertEquals("0 остановленных", getPluralString(Res.plurals.ports_count_stopped, 0, 0))
+            assertEquals("1 остановленный", getPluralString(Res.plurals.ports_count_stopped, 1, 1))
+        }
+    }
+
+    @Test
+    fun `the autostart failure banner agrees with its own count in russian`() = runTest {
+        runBlockingLocale("ru") {
+            assertEquals("1 туннель автостарта не поднялся", getPluralString(Res.plurals.ports_autostart_failed, 1, 1))
+            assertEquals("2 туннеля автостарта не поднялись", getPluralString(Res.plurals.ports_autostart_failed, 2, 2))
+            assertEquals("5 туннелей автостарта не поднялись", getPluralString(Res.plurals.ports_autostart_failed, 5, 5))
+        }
+    }
+
+    @Test
+    fun `english keeps the singular for one and the plural for everything else`() = runTest {
+        runBlockingLocale("en") {
+            assertEquals("1 tunnel", getPluralString(Res.plurals.ports_tunnel_count, 1, 1))
+            assertEquals("3 tunnels", getPluralString(Res.plurals.ports_tunnel_count, 3, 3))
+        }
+    }
+
+    /**
+     * Compose resources read the JVM default locale outside a composition, so the assertions have
+     * to set it. Restored afterwards — the suite shares one JVM.
+     */
+    private suspend fun runBlockingLocale(tag: String, block: suspend () -> Unit) {
+        val previous = Locale.getDefault()
+        Locale.setDefault(Locale.forLanguageTag(tag))
+        try {
+            block()
+        } finally {
+            Locale.setDefault(previous)
+        }
+    }
+}

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -61,6 +61,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Fonts | `ui/design/DesignFoundation`: `rememberUiFont`, `rememberMono`, `rememberMaterialSymbols` |
 | Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` |
 | Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` |
+| A setting as a label + switch row | `ToggleRow` (optional second line); `SettingToggleRow` / `MobileSyncToggleRow` are its settings and sync scales and should converge onto it |
 | Chips | `Chip` (label, active/inactive) vs `ChipButton` (action chip: colour, outline/filled, enabled) — pick one, don't add a third |
 | Rules and separators | `HLine`, `VLine` |
 | Dropdowns and modals | `AnchoredDropdown`, `DropdownField`, `ModalScrim` |

--- a/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/Tunnel.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/Tunnel.kt
@@ -18,6 +18,10 @@ enum class TunnelDirection { Local, Remote, Dynamic }
  *
  * The secret itself is not stored here — the tunnel references a host, and the host references
  * a vault keychain record.
+ *
+ * [autostart] raises the tunnel once per vault unlock, without waiting for a session to its host.
+ * It defaults to off, which is also what a record written before the field existed decodes to —
+ * an update must not start dialling hosts nobody asked it to.
  */
 @Serializable
 data class Tunnel(
@@ -29,4 +33,5 @@ data class Tunnel(
     val bindPort: Int,
     val destHost: String? = null,
     val destPort: Int? = null,
+    val autostart: Boolean = false,
 )

--- a/shared/src/commonTest/kotlin/app/skerry/shared/tunnel/VaultTunnelStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/tunnel/VaultTunnelStoreTest.kt
@@ -1,8 +1,11 @@
 package app.skerry.shared.tunnel
 
 import app.skerry.shared.vault.FakeVault
+import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class VaultTunnelStoreTest {
 
@@ -39,5 +42,22 @@ class VaultTunnelStoreTest {
         val vault = FakeVault()
         VaultTunnelStore(vault).put(tunnel("t1"))
         assertEquals(listOf("t1"), VaultTunnelStore(vault).all().map { it.id })
+    }
+
+    @Test
+    fun `autostart survives a round trip through the vault`() {
+        val vault = FakeVault()
+        VaultTunnelStore(vault).put(tunnel("t1").copy(autostart = true))
+        assertTrue(VaultTunnelStore(vault).all().single().autostart)
+    }
+
+    @Test
+    fun `a record written before autostart existed decodes as off`() {
+        // The field arrived after tunnels shipped, so records already in a synced vault carry no
+        // `autostart` key. They must decode, and decode to off — a tunnel nobody asked to raise
+        // must not start dialling by itself after an update.
+        val legacy = """{"id":"t1","label":"Prod DB","hostId":"h1","direction":"Local","bindHost":"127.0.0.1","bindPort":8080,"destHost":"10.0.0.5","destPort":80}"""
+        val decoded = Json { ignoreUnknownKeys = true }.decodeFromString(Tunnel.serializer(), legacy)
+        assertFalse(decoded.autostart)
     }
 }


### PR DESCRIPTION
## What this does

The Tunnels section becomes a status surface rather than a list of rules.

**The table** lists every saved tunnel by name, with its type, both endpoints, the host it rides, the bytes it has carried and its status. The arrow between the two address columns follows the traffic: `-L` and `-D` listen here and reach out, `-R` listens on the server and traffic comes back.

**The dashboard** under it answers three questions at a glance — what is flowing right now (aggregate throughput over the last minute), what comes up on its own, and what recently broke. The failure journal records a cause per tunnel and reports a recovery when one comes back; a retry that fails for a different reason is recorded as its own event rather than folded into the first.

**Autostart** is a new per-tunnel flag. A flagged tunnel raises itself once the vault is unlocked — it needs the host's secret, so there is nothing to raise before that. The run happens once per unlock and re-arms on lock, so a synced reload never fights a switch the user threw by hand. Tunnels the run leaves down are reported as a set, not one row at a time.

The flag is a field of the saved tunnel, so it syncs with the rest of the record; a client built before it decodes such a record with autostart off.

## Exposure

The editor warns when a listener is bound beyond loopback, and the autostart list names the listener each switch arms — that switch, not the editor, is what makes a forward come up unattended. Only a clean dotted quad inside `127.0.0.0/8` counts as loopback: a hostname that merely starts with `127.` may resolve anywhere, so it is treated as reachable.

## Platforms

Android keeps the same capabilities in its own shape. The tunnel card gained the name and the traffic it has carried; the editor sheet gained the autostart switch and the same bind warning; the autostart report appears above the list. The bulk autostart panel and the three-card dashboard are desktop layout, and the failure journal has no phone surface.

## Verifying it

1. Open Tunnels. The header reads `N active · M stopped` and updates as you toggle rows.
2. Raise a tunnel — TRAFFIC fills, STATUS turns `active`, and the Throughput card starts drawing.
3. Open a tunnel, switch on **Start on unlock**, save. It appears under **Autostart**, grouped by host.
4. Set the bind address to `0.0.0.0` — the editor says the listener is reachable from the network.
5. Lock and unlock the vault. Flagged tunnels come up by themselves; any that don't are named in a banner above the table.
6. Point a tunnel at a host that is down and raise it — the row turns `failed` with a reason, and **Recent errors** names the cause.

## Not verified

Android on a device (compiles only), and a real autostart run against a live host after unlock.