### PR TITLE
Vault: a list that states facts, and a keychain that remembers its own use

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -39,6 +39,7 @@ import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
 import app.skerry.shared.vault.FileBioArtifactStore
 import app.skerry.shared.vault.FileBiometricSupportStore
 import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.FileCredentialUsageLog
 import app.skerry.shared.vault.FileSecurityLog
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
@@ -448,7 +449,14 @@ class MainActivity : FragmentActivity() {
         // snapshot (More -> Trash). Passed explicitly — the stores default to deleting outright so a
         // team vault never grows a trash of its own.
         val trash = TrashStore(vault)
-        val credentials = CredentialManagerController(CredentialStore(vault, trash)) { UUID.randomUUID().toString() }
+        // Local (non-synced) usage trail the Vault sheet reports: added / last used / copies. Ids and
+        // timestamps only, hardened like the security log above.
+        val credentialUsage = FileCredentialUsageLog(
+            dir.resolve("credential_usage.json").absolutePath.toPath(),
+            FileSystem.SYSTEM,
+            harden = { app.skerry.shared.io.PrivateConfig.harden(java.io.File(it.toString()).toPath()) },
+        ) { Instant.now().toString() }
+        val credentials = CredentialManagerController(CredentialStore(vault, trash), credentialUsage) { UUID.randomUUID().toString() }
         // SSH transport (sshj, shared JVM source set). TOFU: a host's first key is remembered in the
         // vault (RecordType.KNOWN_HOST, synced across devices); a key change is rejected and logged to
         // the local (non-synced) known_hosts_mismatches so the known-hosts manager can warn and let the
@@ -535,7 +543,8 @@ class MainActivity : FragmentActivity() {
         val tunnels = TunnelManager(
             store = VaultTunnelStore(vault, trash),
             transport = tunnelTransport,
-            resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::find) },
+            // useForConnect (desktop parity): a tunnel authenticates with the secret on every start.
+            resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::useForConnect) },
             scope = scope,
             scanTransport = probeTransport,
         ) { UUID.randomUUID().toString() }
@@ -668,6 +677,8 @@ class MainActivity : FragmentActivity() {
             sync.disconnect()
             // The security event log belongs to the wiped vault; always clear it on reset.
             securityLog.clear()
+            // The usage trail names secrets the reset erased — it goes with them.
+            credentialUsage.clear()
             // Hosts/groups are wiped with the vault on any reset; clear their local UI trace
             // (collapsed state) too, or stale group names would remain visible.
             writeCollapsedGroups(dir, emptySet())

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -4,15 +4,10 @@
     <string name="vault_sidebar_header">ХРАНИЛИЩЕ</string>
     <string name="vault_e2e_encrypted">Сквозное шифрование</string>
     <string name="vault_e2e_description">Приватные ключи зашифрованы мастер-паролем и никогда не синхронизируются в открытом виде.</string>
-    <string name="vault_banner_encrypted">Сквозное шифрование · запечатано мастер-паролем</string>
     <string name="vault_generate_key">Создать ключ</string>
     <string name="vault_add_password">Добавить пароль</string>
     <string name="vault_import_certificate">Импортировать сертификат</string>
 
-    <!-- Мета карточки секрета (ведущее слово + рантайм-фрагмент «используется»). -->
-    <string name="vault_meta_certificate">Сертификат · %1$s</string>
-    <string name="vault_meta_any_principal">любой principal · %1$s</string>
-    <string name="vault_meta_password">Пароль · %1$s</string>
 
     <!-- Пустые состояния категорий. -->
     <string name="vault_empty_ssh_title">Пока нет SSH-ключей</string>
@@ -30,7 +25,6 @@
     <string name="vault_subtitle_password">Пароль</string>
     <string name="vault_label_public_key">Открытый ключ</string>
     <string name="vault_key_unreadable">Не удалось прочитать ключ</string>
-    <string name="vault_label_fingerprint">Отпечаток</string>
     <string name="vault_copy_certificate">Скопировать сертификат</string>
     <string name="vault_copy_public_key">Скопировать открытый ключ</string>
     <string name="vault_copy_password">Скопировать пароль</string>
@@ -135,6 +129,45 @@
     <string name="vault_label_key_path">ФАЙЛ КЛЮЧА</string>
     <string name="vault_label_cert_path">ФАЙЛ СЕРТИФИКАТА</string>
     <string name="vault_key_file_missing">Недоступен с этого устройства</string>
-    <string name="vault_meta_key_file">файл · %1$s</string>
     <string name="vault_cert_from_file_unreadable">Файл сертификата не читается</string>
+
+    <plurals name="vault_item_count">
+        <item quantity="one">%1$d запись</item>
+        <item quantity="few">%1$d записи</item>
+        <item quantity="many">%1$d записей</item>
+        <item quantity="other">%1$d записи</item>
+    </plurals>
+    <string name="vault_header_summary">%1$s · XChaCha20-Poly1305 · Argon2id</string>
+
+
+    <string name="vault_kv_type">Тип</string>
+    <string name="vault_kv_fingerprint">Отпечаток</string>
+    <string name="vault_kv_passphrase">Пароль ключа</string>
+    <string name="vault_kv_added">Добавлен</string>
+    <string name="vault_kv_last_used">Последний раз</string>
+    <string name="vault_value_unknown">—</string>
+    <string name="vault_value_never">не использовался</string>
+    <string name="vault_passphrase_set">задан</string>
+    <string name="vault_passphrase_none">нет</string>
+
+    <string name="vault_section_encryption">Шифрование</string>
+    <string name="vault_kv_cipher">Шифр</string>
+    <string name="vault_kv_kdf">Вывод ключа</string>
+    <string name="vault_kv_stored">На сервере</string>
+    <string name="vault_kdf_value">Argon2id · %1$d МиБ</string>
+    <string name="vault_stored_ciphertext">только шифротекст</string>
+    <string name="vault_stored_local">только это устройство</string>
+
+    <string name="vault_section_audit">Аудит</string>
+    <string name="vault_kv_copied">Копировали</string>
+    <plurals name="vault_copies_window">
+        <item quantity="one">%1$d раз за %2$d дней</item>
+        <item quantity="few">%1$d раза за %2$d дней</item>
+        <item quantity="many">%1$d раз за %2$d дней</item>
+        <item quantity="other">%1$d раза за %2$d дней</item>
+    </plurals>
+
+    <string name="vault_meta_rotated">сменён %1$s</string>
+    <string name="vault_meta_valid_until">действует до %1$s</string>
+    <string name="vault_kv_changed">Изменён</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
@@ -30,8 +30,6 @@
     <string name="vtail_error_biometric_unsupported">Биометрия на этом телефоне не работает — введите мастер-пароль.</string>
 
     <!-- Фрагмент «используется» на карточке секрета, ед./мн. (ключи готовы; проводка блокируется VaultPresentationTest). -->
-    <string name="vtail_used_by_one">используется 1 хостом</string>
-    <string name="vtail_used_by_other">используется %1$d хостами</string>
     <string name="vtail_used_by_snippets_one">используется 1 сниппетом</string>
     <string name="vtail_used_by_snippets_other">используется %1$d сниппетами</string>
     <string name="vtail_snippets_frag_one">1 сниппетом</string>
@@ -43,7 +41,5 @@
     <string name="vtail_category_certificates">Сертификаты</string>
 
     <!-- Строка метаданных карточки секрета: %1$s — принципалы сертификата / отпечаток ключа, %2$s — фрагмент «используется». -->
-    <string name="vtail_meta_principals">%1$s · %2$s</string>
-    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
     <string name="vtail_picker_type_key_file">Файл ключа</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -4,15 +4,10 @@
     <string name="vault_sidebar_header">保险库</string>
     <string name="vault_e2e_encrypted">端到端加密</string>
     <string name="vault_e2e_description">私钥由你的主密码加密，绝不以明文同步。</string>
-    <string name="vault_banner_encrypted">端到端加密 · 由主密码加密保护</string>
     <string name="vault_generate_key">生成密钥</string>
     <string name="vault_add_password">添加密码</string>
     <string name="vault_import_certificate">导入证书</string>
 
-    <!-- 密钥卡片元数据 -->
-    <string name="vault_meta_certificate">证书 · %1$s</string>
-    <string name="vault_meta_any_principal">任意主体 · %1$s</string>
-    <string name="vault_meta_password">密码 · %1$s</string>
 
     <!-- 空分类状态 -->
     <string name="vault_empty_ssh_title">暂无 SSH 密钥</string>
@@ -30,7 +25,6 @@
     <string name="vault_subtitle_password">密码</string>
     <string name="vault_label_public_key">公钥</string>
     <string name="vault_key_unreadable">无法读取密钥</string>
-    <string name="vault_label_fingerprint">指纹</string>
     <string name="vault_copy_certificate">复制证书</string>
     <string name="vault_copy_public_key">复制公钥</string>
     <string name="vault_copy_password">复制密码</string>
@@ -135,6 +129,39 @@
     <string name="vault_label_key_path">密钥文件</string>
     <string name="vault_label_cert_path">证书文件</string>
     <string name="vault_key_file_missing">此设备无法读取</string>
-    <string name="vault_meta_key_file">文件 · %1$s</string>
     <string name="vault_cert_from_file_unreadable">无法读取证书文件</string>
+
+    <plurals name="vault_item_count">
+        <item quantity="other">%1$d 项</item>
+    </plurals>
+    <string name="vault_header_summary">%1$s · XChaCha20-Poly1305 · Argon2id</string>
+
+
+    <string name="vault_kv_type">类型</string>
+    <string name="vault_kv_fingerprint">指纹</string>
+    <string name="vault_kv_passphrase">密钥口令</string>
+    <string name="vault_kv_added">添加于</string>
+    <string name="vault_kv_last_used">最近使用</string>
+    <string name="vault_value_unknown">—</string>
+    <string name="vault_value_never">从未使用</string>
+    <string name="vault_passphrase_set">已设置</string>
+    <string name="vault_passphrase_none">无</string>
+
+    <string name="vault_section_encryption">加密</string>
+    <string name="vault_kv_cipher">加密算法</string>
+    <string name="vault_kv_kdf">密钥派生</string>
+    <string name="vault_kv_stored">服务器存储</string>
+    <string name="vault_kdf_value">Argon2id · %1$d MiB</string>
+    <string name="vault_stored_ciphertext">仅密文</string>
+    <string name="vault_stored_local">仅本设备</string>
+
+    <string name="vault_section_audit">审计</string>
+    <string name="vault_kv_copied">复制</string>
+    <plurals name="vault_copies_window">
+        <item quantity="other">%2$d 天内 %1$d 次</item>
+    </plurals>
+
+    <string name="vault_meta_rotated">%1$s 轮换</string>
+    <string name="vault_meta_valid_until">有效期至 %1$s</string>
+    <string name="vault_kv_changed">更改于</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -30,8 +30,6 @@
     <string name="vtail_error_biometric_unsupported">此手机不支持生物识别解锁 — 请输入主密码。</string>
 
     <!-- 密钥卡片\"被使用\"片段，单数 / 复数 -->
-    <string name="vtail_used_by_one">被 1 台主机使用</string>
-    <string name="vtail_used_by_other">被 %1$d 台主机使用</string>
     <string name="vtail_used_by_snippets_one">被 1 个片段使用</string>
     <string name="vtail_used_by_snippets_other">被 %1$d 个片段使用</string>
     <string name="vtail_snippets_frag_one">1 个片段</string>
@@ -43,7 +41,5 @@
     <string name="vtail_category_certificates">证书</string>
 
     <!-- 密钥卡片元信息行：%1$s — 证书主体 / 密钥指纹，%2$s — “使用者”片段。 -->
-    <string name="vtail_meta_principals">%1$s · %2$s</string>
-    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
     <string name="vtail_picker_type_key_file">密钥文件</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -4,15 +4,10 @@
     <string name="vault_sidebar_header">VAULT</string>
     <string name="vault_e2e_encrypted">End-to-end encrypted</string>
     <string name="vault_e2e_description">Private keys are encrypted with your master password and never sync in plaintext.</string>
-    <string name="vault_banner_encrypted">End-to-end encrypted · sealed with your master password</string>
     <string name="vault_generate_key">Generate key</string>
     <string name="vault_add_password">Add password</string>
     <string name="vault_import_certificate">Import certificate</string>
 
-    <!-- Secret card meta (leading word + a runtime "used by" fragment). -->
-    <string name="vault_meta_certificate">Certificate · %1$s</string>
-    <string name="vault_meta_any_principal">any principal · %1$s</string>
-    <string name="vault_meta_password">Password · %1$s</string>
 
     <!-- Empty category states. -->
     <string name="vault_empty_ssh_title">No SSH keys yet</string>
@@ -30,7 +25,6 @@
     <string name="vault_subtitle_password">Password</string>
     <string name="vault_label_public_key">Public key</string>
     <string name="vault_key_unreadable">Key could not be read</string>
-    <string name="vault_label_fingerprint">Fingerprint</string>
     <string name="vault_copy_certificate">Copy certificate</string>
     <string name="vault_copy_public_key">Copy public key</string>
     <string name="vault_copy_password">Copy password</string>
@@ -135,6 +129,47 @@
     <string name="vault_label_key_path">KEY FILE</string>
     <string name="vault_label_cert_path">CERTIFICATE FILE</string>
     <string name="vault_key_file_missing">Not readable from this device</string>
-    <string name="vault_meta_key_file">file · %1$s</string>
     <string name="vault_cert_from_file_unreadable">Certificate file not readable</string>
+
+    <!-- Section header: how much the vault holds and how it is protected. -->
+    <plurals name="vault_item_count">
+        <item quantity="one">%1$d item</item>
+        <item quantity="other">%1$d items</item>
+    </plurals>
+    <string name="vault_header_summary">%1$s · XChaCha20-Poly1305 · Argon2id</string>
+
+    <!-- Type badges in the secret list. -->
+
+    <!-- Detail panel: facts about the selected secret. -->
+    <string name="vault_kv_type">Type</string>
+    <string name="vault_kv_fingerprint">Fingerprint</string>
+    <string name="vault_kv_passphrase">Passphrase</string>
+    <string name="vault_kv_added">Added</string>
+    <string name="vault_kv_last_used">Last used</string>
+    <string name="vault_value_unknown">—</string>
+    <string name="vault_value_never">never</string>
+    <string name="vault_passphrase_set">set</string>
+    <string name="vault_passphrase_none">none</string>
+
+    <!-- Detail panel: how the secret is stored. -->
+    <string name="vault_section_encryption">Encryption</string>
+    <string name="vault_kv_cipher">Cipher</string>
+    <string name="vault_kv_kdf">Key derivation</string>
+    <string name="vault_kv_stored">Stored on server</string>
+    <string name="vault_kdf_value">Argon2id · %1$d MiB</string>
+    <string name="vault_stored_ciphertext">ciphertext only</string>
+    <string name="vault_stored_local">this device only</string>
+
+    <!-- Detail panel: what this device did with the secret. -->
+    <string name="vault_section_audit">Audit</string>
+    <string name="vault_kv_copied">Copied</string>
+    <plurals name="vault_copies_window">
+        <item quantity="one">%1$d time in %2$d days</item>
+        <item quantity="other">%1$d times in %2$d days</item>
+    </plurals>
+
+    <!-- Row meta line: the facts about a secret, type excluded (the badge says it). -->
+    <string name="vault_meta_rotated">rotated %1$s</string>
+    <string name="vault_meta_valid_until">valid until %1$s</string>
+    <string name="vault_kv_changed">Changed</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
@@ -30,8 +30,6 @@
     <string name="vtail_error_biometric_unsupported">Biometrics won't work on this phone — use your master password.</string>
 
     <!-- Secret card "used by" fragment, singular / plural (keys ready; wiring blocked by VaultPresentationTest). -->
-    <string name="vtail_used_by_one">used by 1 host</string>
-    <string name="vtail_used_by_other">used by %1$d hosts</string>
     <string name="vtail_used_by_snippets_one">used by 1 snippet</string>
     <string name="vtail_used_by_snippets_other">used by %1$d snippets</string>
     <string name="vtail_snippets_frag_one">1 snippet</string>
@@ -43,7 +41,5 @@
     <string name="vtail_category_certificates">Certificates</string>
 
     <!-- Secret card meta line: %1$s — cert principals / key fingerprint, %2$s — "used by" fragment. -->
-    <string name="vtail_meta_principals">%1$s · %2$s</string>
-    <string name="vtail_meta_fingerprint">%1$s · %2$s</string>
     <string name="vtail_picker_type_key_file">Key file</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/KeyValueRow.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/KeyValueRow.kt
@@ -1,0 +1,50 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.theme.Skerry
+
+/**
+ * One fact in a detail panel: a dim label on the left, its value in monospace on the right, both on
+ * a single line — the type/fingerprint/added rows of the Vault panel. Two older rows of the same
+ * shape (`InfoRow` in the session info panel, `CardRow` in the tunnel dashboard) still spell out
+ * their own spacing; converging them onto this one is a separate change, noted in the guidelines.
+ *
+ * The value is right-aligned and elided rather than wrapped — a panel of facts stays a scannable
+ * column, and a value too long to fit (a full public key, a path) belongs in a code block, not here.
+ */
+@Composable
+fun KeyValueRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+    valueColor: Color = Skerry.colors.text,
+) {
+    Row(
+        modifier.fillMaxWidth().padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(label, color = Skerry.colors.dim, size = 12.sp, maxLines = 1)
+        Txt(
+            value,
+            modifier = Modifier.weight(1f, fill = false),
+            color = valueColor,
+            size = 11.5.sp,
+            font = LocalFonts.current.mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            align = TextAlign.End,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -690,7 +690,9 @@ private fun DesktopChrome(
     // opens — so a password prompt in between can't act on a stale chain.
     fun openResolved(target: PendingAuth, auth: SshAuth) {
         val jump = when (
-            val chain = resolveJumpChain(target.host, { id -> hostManager?.find(id) }, { id -> credentials?.find(id) })
+            // A jump hop authenticates with its own secret — resolved through useForConnect so the
+            // key of a host reached only as a bastion doesn't read as "never used".
+            val chain = resolveJumpChain(target.host, { id -> hostManager?.find(id) }, { id -> credentials?.useForConnect(id) })
         ) {
             is JumpChainResolution.Unavailable -> { jumpProblem = chain.problem; return }
             is JumpChainResolution.Resolved -> chain.jump
@@ -750,7 +752,7 @@ private fun DesktopChrome(
                     // straight away; without one the prompt asks for it, exactly as VNC does. A
                     // profile with no user name at all (what an imported `.rdp` file usually is)
                     // has nothing to prompt for, so its form opens instead.
-                    val password = credentials?.find(host.credentialId)?.toRdpPassword()
+                    val password = credentials?.useForConnect(host.credentialId)?.toRdpPassword()
                     when {
                         password != null -> openRdpWith(host, password)
                         host.username.isBlank() -> state.openEditModal(host)
@@ -760,7 +762,7 @@ private fun DesktopChrome(
                 } else if (host.connectionType.isVnc) {
                     // VNC opens a framebuffer tab (not a terminal). A stored password is used directly;
                     // "ask every time" (no bound secret) prompts for one first. No ProxyJump/host-key path.
-                    val cred = credentials?.find(host.credentialId)
+                    val cred = credentials?.useForConnect(host.credentialId)
                     if (cred != null) {
                         state.recordRecentHost(host.id)
                         sessions?.openVnc(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/HostAuth.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/HostAuth.kt
@@ -32,6 +32,8 @@ fun resolveHostAuth(host: Host, credentials: CredentialManagerController?): Host
     // demanding a password the profile deliberately doesn't have.
     host.interactiveAuth -> HostAuthResolution.Resolved(SshAuth.Interactive)
     else ->
-        credentials?.find(host.credentialId)?.let { HostAuthResolution.Resolved(it.toSshAuth()) }
+        // useForConnect, not find: resolving a binding here is the moment the secret authenticates
+        // something, and that is what the Vault panel reports as "last used".
+        credentials?.useForConnect(host.credentialId)?.let { HostAuthResolution.Resolved(it.toSshAuth()) }
             ?: HostAuthResolution.NeedsPassword
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -696,7 +696,8 @@ private fun formSshAuth(form: NewConnectionFormState, credentials: CredentialMan
         AuthMode.NEW_PASSWORD -> form.password.takeIf { it.isNotEmpty() }?.let { SshAuth.Password(it) }
         AuthMode.NEW_KEY -> form.privateKeyPem.takeIf { it.isNotBlank() }
             ?.let { SshAuth.PublicKey(it, form.passphrase.ifBlank { null }) }
-        AuthMode.EXISTING -> credentials?.credentials?.firstOrNull { it.id == form.existingCredentialId }?.toSshAuth()
+        // useForConnect: this is a real connection about to be opened, so the secret counts as used.
+        AuthMode.EXISTING -> credentials?.useForConnect(form.existingCredentialId)?.toSshAuth()
         AuthMode.ASK -> null
         AuthMode.INTERACTIVE -> SshAuth.Interactive
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -7,6 +7,14 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.CredentialUsage
+import app.skerry.shared.vault.CredentialUsageLog
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 /** Kind of keychain secret in the form; expands into [CredentialSecret]. */
 enum class CredentialKind { PASSWORD, PRIVATE_KEY, CERTIFICATE, KEY_FILE }
@@ -47,26 +55,98 @@ data class CredentialDraft(
  * List state for keychain secrets ([Credential]) over [CredentialStore]: holds the list as
  * Compose state and reduces mutations to store calls, reloading after each. Synchronous (vault
  * CRUD is rare). Requires an unlocked vault (lives behind the master password gate).
+ *
+ * [usage] is the per-device trail the Vault panel reports (added / last used / copied). It is
+ * optional: without it every call below still works, the panel just has nothing to show. The trail
+ * lives in a file, so it is mirrored into Compose state here and written on [scope] — the panel asks
+ * for a secret's dates on every frame it draws, and a copy is recorded from a click handler.
  */
+/**
+ * The one lane every usage-log event runs on (see [CredentialManagerController.scope]). Built once:
+ * a `limitedParallelism` view is cheap but there is no reason to make a new one per controller.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun usageDispatcher(): CoroutineDispatcher = Dispatchers.Default.limitedParallelism(1)
+
 @Stable
 class CredentialManagerController(
     private val store: CredentialStore,
+    private val usage: CredentialUsageLog? = null,
+    /**
+     * Scope for the usage log's file IO — writes must not block a click or a connect, so they leave
+     * the caller's thread. Its dispatcher is deliberately **single-threaded**
+     * (`limitedParallelism(1)`): events are read-modify-writes of both the file and the [usageById]
+     * mirror, so two of them running in parallel would lose one another's update, and a `forget`
+     * could land before a still-in-flight `recordUsed` and resurrect the entry it just dropped.
+     * One lane keeps them in the order they were submitted. Tests pass an unconfined scope so a
+     * recorded event is visible the moment the call returns.
+     */
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + usageDispatcher()),
     private val newId: () -> String,
 ) {
     var credentials by mutableStateOf(emptyList<Credential>())
         private set
 
+    /**
+     * In-memory mirror of the usage log, keyed by credential id. Compose state, so the panel
+     * re-reads it for free and redraws when a date actually changes.
+     */
+    private var usageById by mutableStateOf(emptyMap<String, CredentialUsage>())
+
     /** Reloads the list from the vault. Requires an unlocked vault (call after unlock). */
     fun reload() {
         credentials = store.all()
+        val log = usage ?: return
+        // Same best-effort rule as `record`: an unreadable trail leaves the panel without dates, it
+        // does not stop the keychain from loading.
+        scope.launch { runCatching { log.all() }.onSuccess { all -> usageById = all.associateBy { it.credentialId } } }
     }
 
     fun find(id: String?): Credential? = id?.let { wanted -> credentials.firstOrNull { it.id == wanted } }
 
+    /**
+     * [find] for the connect path: the same lookup, plus a note that the secret authenticated
+     * something. Every place that turns a host binding into an [app.skerry.shared.ssh.SshAuth] goes
+     * through here, so "last used" means what it says instead of "last rendered in a list".
+     */
+    fun useForConnect(id: String?): Credential? = find(id)?.also { record(it.id, CredentialUsageLog::recordUsed) }
+
+    /**
+     * Note that a secret was copied to the clipboard. Only passwords are counted: for a key or a
+     * certificate what leaves the vault is the public half, which is not a secret and not worth an
+     * audit line.
+     */
+    fun recordCopied(id: String) = record(id, CredentialUsageLog::recordCopied)
+
+    /** Usage trail of a secret: added / last used / copies. `null` when nothing was ever recorded. */
+    fun usageOf(id: String): CredentialUsage? = usageById[id]
+
+    /**
+     * Applies one usage event off the caller's thread and mirrors the result into [usageById].
+     *
+     * A failed write is swallowed on purpose: the trail is an audit convenience, and a full disk must
+     * not turn a saved secret, a copied password or an opened connection into an error. The cost is
+     * that the panel's dates fall behind until the next successful write.
+     */
+    private fun record(id: String, event: CredentialUsageLog.(String) -> CredentialUsage) {
+        val log = usage ?: return
+        scope.launch { runCatching { log.event(id) }.onSuccess { usageById = usageById + (id to it) } }
+    }
+
     /** Creates (if [CredentialDraft.id] == null) or updates a secret; returns the assigned id. */
     fun save(draft: CredentialDraft): String {
         val id = draft.id ?: newId()
-        store.put(Credential(id = id, label = draft.label, secret = draft.toSecret()))
+        val secret = draft.toSecret()
+        // Compared before the write: afterwards the store already holds the new material.
+        val rotated = draft.id != null && find(draft.id)?.secret?.let { it != secret } == true
+        store.put(Credential(id = id, label = draft.label, secret = secret))
+        // Only a new secret is born here; replacing the material of an existing one is a rotation,
+        // which is what the row reports as "rotated 12 days ago". Re-saving the same material is
+        // neither — a rename must not read as a key change.
+        when {
+            draft.id == null -> record(id, CredentialUsageLog::recordAdded)
+            rotated -> record(id, CredentialUsageLog::recordChanged)
+        }
         credentials = store.all()
         return id
     }
@@ -86,12 +166,18 @@ class CredentialManagerController(
      * import whose hosts already reference them) and reload once.
      */
     fun importCredentials(imported: List<Credential>) {
-        for (credential in imported) store.put(credential)
+        for (credential in imported) {
+            store.put(credential)
+            record(credential.id, CredentialUsageLog::recordAdded)
+        }
         credentials = store.all()
     }
 
     fun delete(id: String) {
         store.remove(id)
+        // The trail dies with the secret: keeping it would let a deleted key's history reappear
+        // under a recycled id, and it is of no use to anyone once the material is gone.
+        usage?.let { log -> scope.launch { runCatching { log.forget(id) }; usageById = usageById - id } }
         credentials = store.all()
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -449,7 +449,7 @@ private fun MobileChrome(
                     // with no user name at all (what an imported `.rdp` file usually is) has nothing
                     // to prompt for and opens its form; anything else asks. A team-shared profile
                     // arrives with its credential link stripped and has no other way in.
-                    val password = credentials?.find(host.credentialId)?.toRdpPassword()
+                    val password = credentials?.useForConnect(host.credentialId)?.toRdpPassword()
                     when {
                         password != null -> openMobileRdp(sessions, state, hostManager, host, password)
                         host.username.isBlank() -> state.openEditConn(host)
@@ -459,7 +459,7 @@ private fun MobileChrome(
                 } else if (host.connectionType.isVnc) {
                     // VNC opens a framebuffer screen (not a terminal). A stored password is used directly;
                     // "ask every time" (no bound secret) prompts for one first.
-                    val cred = credentials?.find(host.credentialId)
+                    val cred = credentials?.useForConnect(host.credentialId)
                     if (cred != null) {
                         sessions?.openVnc(
                             host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
@@ -484,11 +484,13 @@ private fun MobileChrome(
                             existing?.let { sessions.close(it.id) }
                             // ProxyJump chain first — resolved before the password prompt so a broken
                             // chain surfaces immediately, not after the user typed a password.
-                            when (val chain = resolveJumpChain(host, { id -> hostManager?.find(id) }, { id -> credentials?.find(id) })) {
+                            // Jump hops go through useForConnect too — see the desktop shell.
+                            when (val chain = resolveJumpChain(host, { id -> hostManager?.find(id) }, { id -> credentials?.useForConnect(id) })) {
                                 is JumpChainResolution.Unavailable -> jumpProblem = chain.problem
                                 is JumpChainResolution.Resolved -> {
                                     // Single-level resolve: host → keychain secret by credentialId → SshAuth; no binding → password.
-                                    val credential = credentials?.find(host.credentialId)
+                                    // useForConnect stamps "last used" on the secret, as the desktop path does.
+                                    val credential = credentials?.useForConnect(host.credentialId)
                                     when {
                                         // Telnet/Serial have no auth — connect immediately, no password
                                         // prompt. SSH and Mosh resolve a credential or ask for a password.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -549,7 +549,8 @@ private fun mobileFormAuth(
     AuthMode.NEW_PASSWORD -> form.password.takeIf { it.isNotEmpty() }?.let { SshAuth.Password(it) }
     AuthMode.NEW_KEY -> form.privateKeyPem.takeIf { it.isNotBlank() }
         ?.let { SshAuth.PublicKey(it, form.passphrase.ifBlank { null }) }
-    AuthMode.EXISTING -> credentials?.credentials?.firstOrNull { it.id == form.existingCredentialId }?.toSshAuth()
+    // useForConnect: the sheet is opening a connection, not listing secrets (desktop parity).
+    AuthMode.EXISTING -> credentials?.useForConnect(form.existingCredentialId)?.toSshAuth()
     AuthMode.ASK -> null
     AuthMode.INTERACTIVE -> SshAuth.Interactive
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
@@ -32,16 +33,17 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vault_add_password
 import app.skerry.ui.generated.resources.vault_any_principal
 import app.skerry.ui.generated.resources.vault_badge_expired
-import app.skerry.ui.generated.resources.vault_banner_encrypted
 import app.skerry.ui.generated.resources.vault_copy_certificate
 import app.skerry.ui.generated.resources.vault_copy_password
 import app.skerry.ui.generated.resources.vault_copy_public_key
@@ -54,15 +56,12 @@ import app.skerry.ui.generated.resources.vault_empty_ssh_hint
 import app.skerry.ui.generated.resources.vault_empty_ssh_title
 import app.skerry.ui.generated.resources.vault_export
 import app.skerry.ui.generated.resources.vault_generate_key
+import app.skerry.ui.generated.resources.vault_header_summary
+import app.skerry.ui.generated.resources.vault_item_count
 import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_key_unreadable
-import app.skerry.ui.generated.resources.vault_label_fingerprint
 import app.skerry.ui.generated.resources.vault_label_public_key
 import app.skerry.ui.generated.resources.vault_link_key_file
-import app.skerry.ui.generated.resources.vault_meta_any_principal
-import app.skerry.ui.generated.resources.vault_meta_certificate
-import app.skerry.ui.generated.resources.vault_meta_key_file
-import app.skerry.ui.generated.resources.vault_meta_password
 import app.skerry.ui.generated.resources.vault_rename
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
@@ -71,8 +70,6 @@ import app.skerry.ui.generated.resources.vault_subtitle_key_file_cert
 import app.skerry.ui.generated.resources.vault_subtitle_password
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_title
-import app.skerry.ui.generated.resources.vtail_meta_fingerprint
-import app.skerry.ui.generated.resources.vtail_meta_principals
 import app.skerry.ui.secure.SecureScreen
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -88,6 +85,7 @@ import app.skerry.ui.vault.exportTextFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.vault.AddPasswordDialog
 import app.skerry.ui.design.Badge
@@ -101,6 +99,8 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.app.LocalSync
+import app.skerry.ui.sync.SyncStatus
 import app.skerry.ui.app.LocalSecretFileReader
 import app.skerry.ui.vault.KeyFileBadges
 import app.skerry.ui.vault.KeyFileDetailBody
@@ -117,9 +117,18 @@ import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.vault.SecretIcon
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.vault.SecretAuditRows
+import app.skerry.ui.vault.SecretEncryptionRows
+import app.skerry.ui.vault.SecretFactRows
+import app.skerry.ui.vault.SecretRow
+import app.skerry.ui.vault.SecretSectionLabel
 import app.skerry.ui.vault.UsedByHosts
+import app.skerry.ui.vault.auditSectionTitle
+import app.skerry.ui.vault.encryptionSectionTitle
+import app.skerry.ui.vault.mockSecrets
 import app.skerry.ui.vault.rememberCertInfo
 import app.skerry.ui.vault.rememberKeyInfo
+import app.skerry.ui.vault.secretMetaLine
 import app.skerry.ui.vault.unbindCredential
 import app.skerry.ui.theme.Skerry
 
@@ -169,6 +178,8 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
     val selectedCred = credItems.firstOrNull { it.id == selectedId }
+    // Same rule as desktop: "stored on server" only holds once a sync account exists.
+    val syncing = LocalSync.current?.status?.collectAsState()?.value.let { it != null && it !is SyncStatus.Disabled }
 
     // Any open overlay (create/delete dialogs + detail sheet) hides the tab bar: otherwise it floats
     // over the centered dialog and covers the bottom input fields above the keyboard. LaunchedEffect
@@ -188,7 +199,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
             Box(Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp)) {
                 MobileScreenTitle(stringResource(Res.string.vault_title))
             }
-            MobileVaultBanner()
+            MobileVaultSummary(allCreds.size)
             MobileCategoryPills(category, allCreds) { category = it; selectedId = null }
             MobileVaultAction(
                 category = category,
@@ -200,18 +211,17 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onImportCert = { showImportCert = true },
                 onLinkKeyFile = { showLinkKeyFile = true },
             )
-            Column(
-                Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 6.dp),
-                verticalArrangement = Arrangement.spacedBy(9.dp),
-            ) {
+            // 6dp on top of the row's own 12dp: the list lines up with the pills and the title above it.
+            Column(Modifier.fillMaxWidth().padding(horizontal = 6.dp).padding(top = 6.dp)) {
                 if (credItems.isEmpty()) {
                     MobileVaultEmpty(category)
                 } else {
                     credItems.forEach { credential ->
-                        MobileSecretCard(
+                        MobileSecretRow(
                             credential = credential,
+                            usage = credentials.usageOf(credential.id),
                             usedBy = VaultPresentation.usedByLabel(
-                                hostCount = VaultPresentation.hostsUsing(credential.id, hosts).size,
+                                hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.label },
                                 snippetCount = VaultPresentation.snippetsUsing(credential.label, snippetList).size,
                             ),
                             mono = mono,
@@ -322,11 +332,15 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
         selectedCred?.let { credential ->
             MobileSecretDetailSheet(
                 credential = credential,
+                usage = credentials.usageOf(credential.id),
+                syncing = syncing,
                 hosts = VaultPresentation.hostsUsing(credential.id, hosts),
                 snippetLabels = VaultPresentation.snippetsUsing(credential.label, snippetList).map { it.label },
                 mono = mono,
                 onCopy = { copyTextToClipboard(it) },
-                onCopyPassword = { pwd -> copyAuth.authorize { copyPasswordToClipboard(pwd) } },
+                onCopyPassword = { pwd ->
+                    copyAuth.authorize { credentials.recordCopied(credential.id); copyPasswordToClipboard(pwd) }
+                },
                 onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
                 // Close the detail sheet before showing a centered dialog (rename/delete): otherwise the
                 // sheet, drawn on top, would cover it and leave only its edge visible.
@@ -354,18 +368,33 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
 
 // Header, categories, action.
 
+/**
+ * What the desktop header states, folded into one mobile line: how much the keychain holds and how it
+ * is protected, with the live lock state on the right. Replaces the old static "everything here is
+ * encrypted" banner — the same claim, but with a number and a deadline attached.
+ */
 @Composable
-private fun MobileVaultBanner() {
+private fun MobileVaultSummary(itemCount: Int) {
     Row(
-        Modifier.padding(horizontal = 22.dp).padding(bottom = 12.dp)
-            .clip(RoundedCornerShape(12.dp)).background(Skerry.colors.moss.copy(alpha = 0.06f))
-            .border(1.dp, Skerry.colors.moss.copy(alpha = 0.18f), RoundedCornerShape(12.dp))
-            .padding(horizontal = 14.dp, vertical = 12.dp),
+        Modifier.fillMaxWidth().padding(horizontal = 22.dp).padding(bottom = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Sym("lock", size = 19.sp, color = Skerry.colors.moss)
-        Txt(stringResource(Res.string.vault_banner_encrypted), color = Skerry.colors.dim, size = 12.sp)
+        // Two lines allowed: on a narrow screen the cipher/KDF names don't fit beside the badge on
+        // one, and truncating them to "Argo…" would state nothing.
+        Txt(
+            stringResource(
+                Res.string.vault_header_summary,
+                pluralStringResource(Res.plurals.vault_item_count, itemCount, itemCount),
+            ),
+            modifier = Modifier.weight(1f),
+            color = Skerry.colors.faint,
+            size = 10.5.sp,
+            lineHeight = 15.sp,
+            font = LocalFonts.current.mono,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
     }
 }
 
@@ -423,65 +452,48 @@ private fun MobileVaultAction(
 
 // Secret card.
 
-/** Keychain secret card (key/password/certificate) in the category list. */
+/**
+ * Keychain secret in the category list — the same dense row the desktop list draws ([SecretRow]), so
+ * a key looks like the same object on both platforms. Selection isn't rendered here: on mobile a tap
+ * opens the detail sheet rather than filling a panel beside the list.
+ */
 @Composable
-private fun MobileSecretCard(credential: Credential, usedBy: String?, mono: FontFamily, onClick: () -> Unit) {
+private fun MobileSecretRow(
+    credential: Credential,
+    usage: CredentialUsage?,
+    usedBy: String?,
+    mono: FontFamily,
+    onClick: () -> Unit,
+) {
     val generator = LocalSshKeyGenerator.current
     val inspector = LocalSshCertificateInspector.current
-    // Compute metadata once per card (each helper is a separate produceState slot, so a repeat call
+    val secret = credential.secret
+    // Compute metadata once per row (each helper is a separate produceState slot, so a repeat call
     // would parse the same secret twice). null for a mismatched type — no work.
     val keyInfo = rememberKeyInfo(credential, generator)
     val certInfo = rememberCertInfo(credential, inspector)
-    val (icon, iconColor) = VaultPresentation.secretStyle(credential.secret, Skerry.colors)
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(14.dp)).background(Skerry.colors.card)
-            .border(1.dp, Skerry.colors.cyan.copy(alpha = 0.1f), RoundedCornerShape(14.dp))
-            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
-            .padding(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(13.dp),
-    ) {
-        Box(
-            Modifier.size(38.dp).clip(RoundedCornerShape(10.dp)).background(iconColor.copy(alpha = 0.12f)),
-            contentAlignment = Alignment.Center,
-        ) { Sym(icon, size = 20.sp, color = iconColor) }
-        Column(Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                Txt(credential.label, color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
-                when (credential.secret) {
-                    is CredentialSecret.PrivateKey ->
-                        keyInfo?.keyTypeLabel?.let { Badge(it, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, size = 9.sp) }
-                    is CredentialSecret.Certificate -> {
-                        certInfo?.keyTypeLabel?.let { Badge(it, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, size = 9.sp) }
-                        if (certInfo?.expired == true) Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, size = 9.sp)
+    val fileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
+    val style = VaultPresentation.secretStyle(secret, Skerry.colors)
+    SecretRow(
+        icon = style.icon,
+        iconColor = style.color,
+        tintedIcon = style.tinted,
+        name = credential.label,
+        meta = secretMetaLine(secret, keyInfo, certInfo, usage, usedBy),
+        mono = mono,
+        selected = false,
+        onClick = onClick,
+        status = {
+            when (secret) {
+                is CredentialSecret.KeyFile -> KeyFileBadges(fileState)
+                is CredentialSecret.Certificate ->
+                    if (certInfo?.expired == true) {
+                        Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, size = 9.sp)
                     }
-                    is CredentialSecret.Password -> Unit
-                    is CredentialSecret.KeyFile -> KeyFileBadges(rememberKeyFileState(credential.secret as CredentialSecret.KeyFile, LocalSecretFileReader.current, LocalSshCertificateInspector.current))
-                }
+                is CredentialSecret.Password, is CredentialSecret.PrivateKey -> Unit
             }
-            val meta = when (val secret = credential.secret) {
-                is CredentialSecret.PrivateKey -> when {
-                    keyInfo != null && usedBy != null ->
-                        stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(keyInfo.fingerprintSha256), usedBy)
-                    keyInfo != null -> shortFingerprint(keyInfo.fingerprintSha256)
-                    else -> usedBy ?: stringResource(Res.string.vault_subtitle_private_key)
-                }
-                is CredentialSecret.Certificate -> when {
-                    certInfo == null -> usedBy?.let { stringResource(Res.string.vault_meta_certificate, it) }
-                        ?: stringResource(Res.string.vault_subtitle_certificate)
-                    certInfo.principals.isEmpty() -> usedBy?.let { stringResource(Res.string.vault_meta_any_principal, it) }
-                        ?: stringResource(Res.string.vault_any_principal)
-                    else -> usedBy?.let { stringResource(Res.string.vtail_meta_principals, certInfo.principals.joinToString(", "), it) }
-                        ?: certInfo.principals.joinToString(", ")
-                }
-                is CredentialSecret.Password ->
-                    usedBy?.let { stringResource(Res.string.vault_meta_password, it) } ?: stringResource(Res.string.vault_subtitle_password)
-                is CredentialSecret.KeyFile -> stringResource(Res.string.vault_meta_key_file, secret.privateKeyRef)
-            }
-            Txt(meta, color = Skerry.colors.dim, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
-        }
-        Sym("chevron_right", size = 20.sp, color = Skerry.colors.faint)
-    }
+        },
+    )
 }
 
 @Composable
@@ -510,6 +522,8 @@ private fun MobileVaultEmpty(category: VaultCategoryKind) {
 @Composable
 private fun MobileSecretDetailSheet(
     credential: Credential,
+    usage: CredentialUsage?,
+    syncing: Boolean,
     hosts: List<Host>,
     snippetLabels: List<String>,
     mono: FontFamily,
@@ -542,22 +556,28 @@ private fun MobileSecretDetailSheet(
         // weight(fill = false): with short content the column hugs it; with long content it fills the
         // remaining sheet height and scrolls (rather than overflowing the edge).
         Column(Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 16.dp)) {
-                Row(Modifier.padding(bottom = 18.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(11.dp)) {
+                Row(Modifier.padding(bottom = 14.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(11.dp)) {
                     SecretIcon(icon, tinted = tinted, color = color, size = 40)
-                    Column {
-                        Txt(credential.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold)
-                        Txt(subtitle, color = Skerry.colors.dim, size = 11.5.sp)
-                    }
+                    // No subtitle here: the Type fact row right below states it, and stating it twice
+                    // 14dp apart is the noise this redesign removed from the rows.
+                    Txt(credential.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold)
                 }
+                SecretFactRows(
+                    typeLabel = subtitle,
+                    fingerprint = keyInfo?.fingerprintSha256?.let { shortFingerprint(it) }
+                        ?: keyFileState?.certificate?.caFingerprintSha256?.let { shortFingerprint(it) },
+                    secret = secret,
+                    usage = usage,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
                 when (secret) {
                     is CredentialSecret.Certificate -> CertificateDetailBody(certInfo, mono)
                     is CredentialSecret.PrivateKey -> {
                         DetailLabel(stringResource(Res.string.vault_label_public_key))
+                        // The fingerprint is a fact row above; here the sheet shows the key itself.
                         Box(Modifier.fillMaxWidth().padding(bottom = 16.dp).clip(RoundedCornerShape(7.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan.copy(alpha = 0.1f), RoundedCornerShape(7.dp)).padding(horizontal = 12.dp, vertical = 10.dp)) {
                             Txt(keyInfo?.publicKeyOpenSsh ?: stringResource(Res.string.vault_key_unreadable), color = Skerry.colors.dim, size = 10.5.sp, font = mono, lineHeight = 16.sp)
                         }
-                        DetailLabel(stringResource(Res.string.vault_label_fingerprint))
-                        Txt(keyInfo?.fingerprintSha256 ?: "—", color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = 16.dp))
                     }
                     is CredentialSecret.Password -> Unit
                     is CredentialSecret.KeyFile -> KeyFileDetailBody(secret, keyFileState, mono)
@@ -593,6 +613,13 @@ private fun MobileSecretDetailSheet(
                             MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.fillMaxWidth())
                     }
                 }
+                SecretSectionLabel(encryptionSectionTitle())
+                SecretEncryptionRows(syncing)
+                // Only a password is ever copied out of the vault; see the desktop panel.
+                if (secret is CredentialSecret.Password) {
+                    SecretSectionLabel(auditSectionTitle())
+                    SecretAuditRows(usage)
+                }
                 Spacer(Modifier.height(8.dp))
             }
         }
@@ -608,47 +635,22 @@ private fun MobileVaultMock() {
         Box(Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp)) {
             MobileScreenTitle(stringResource(Res.string.vault_title))
         }
-        MobileVaultBanner()
-        Txt(
-            "SSH KEYS",
-            color = Skerry.colors.faint, size = 12.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp,
-            modifier = Modifier.padding(start = 22.dp, end = 22.dp, bottom = 4.dp),
-        )
-        Column(Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 8.dp), verticalArrangement = Arrangement.spacedBy(9.dp)) {
-            MockKeyShell(Skerry.colors.cyanBright, Skerry.colors.cyan.copy(alpha = 0.05f), Skerry.colors.cyan.copy(alpha = 0.16f)) {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                    Txt("id_ed25519", color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
-                    Badge("DEFAULT", bg = Skerry.colors.cyan.copy(alpha = 0.14f), fg = Skerry.colors.cyanBright, size = 9.sp)
-                }
-                Txt("SHA256:8c3F1a…Qz9pK", color = Skerry.colors.dim, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
-            }
-            MockKeyShell(Skerry.colors.dim, Skerry.colors.card, Skerry.colors.cyan.copy(alpha = 0.08f)) {
-                Txt("id_rsa_legacy", color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
-                Txt("SHA256:2dE7b…Lm4xR", color = Skerry.colors.dim, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
-            }
-            MockKeyShell(Skerry.colors.sunset, Skerry.colors.sunset.copy(alpha = 0.05f), Skerry.colors.sunset.copy(alpha = 0.22f), icon = "warning") {
-                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-                    Txt("deploy_ci", color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
-                    Badge("ROTATE", bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, size = 9.sp)
-                }
-                Txt("created 412 days ago", color = Skerry.colors.dim, size = 10.5.sp, font = mono, modifier = Modifier.padding(top = 3.dp))
+        MobileVaultSummary(itemCount = mockSecrets().size)
+        Column(Modifier.fillMaxWidth().padding(top = 8.dp)) {
+            mockSecrets().forEach { (credential, meta) ->
+                val style = VaultPresentation.secretStyle(credential.secret, Skerry.colors)
+                SecretRow(
+                    icon = style.icon,
+                    iconColor = style.color,
+                    tintedIcon = style.tinted,
+                    name = credential.label,
+                    meta = meta,
+                    mono = mono,
+                    selected = false,
+                    onClick = {},
+                )
             }
         }
         Spacer(Modifier.height(96.dp))
-    }
-}
-
-@Composable
-private fun MockKeyShell(iconColor: Color, cardBg: Color, cardBorder: Color, icon: String = "key", content: @Composable () -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(14.dp)).background(cardBg)
-            .border(1.dp, cardBorder, RoundedCornerShape(14.dp)).padding(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(13.dp),
-    ) {
-        Box(Modifier.size(38.dp).clip(RoundedCornerShape(10.dp)).background(iconColor.copy(alpha = 0.12f)), contentAlignment = Alignment.Center) {
-            Sym(icon, size = 20.sp, color = iconColor)
-        }
-        Column(Modifier.weight(1f)) { content() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
@@ -1,0 +1,156 @@
+package app.skerry.ui.vault
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
+import app.skerry.shared.vault.VaultCrypto
+import app.skerry.shared.vault.securityMoment
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.settings_time_days_ago
+import app.skerry.ui.generated.resources.settings_time_today
+import app.skerry.ui.generated.resources.settings_time_yesterday
+import app.skerry.ui.generated.resources.vault_copies_window
+import app.skerry.ui.generated.resources.vault_kdf_value
+import app.skerry.ui.generated.resources.vault_kv_added
+import app.skerry.ui.generated.resources.vault_kv_changed
+import app.skerry.ui.generated.resources.vault_kv_cipher
+import app.skerry.ui.generated.resources.vault_kv_copied
+import app.skerry.ui.generated.resources.vault_kv_fingerprint
+import app.skerry.ui.generated.resources.vault_kv_kdf
+import app.skerry.ui.generated.resources.vault_kv_last_used
+import app.skerry.ui.generated.resources.vault_kv_passphrase
+import app.skerry.ui.generated.resources.vault_kv_stored
+import app.skerry.ui.generated.resources.vault_kv_type
+import app.skerry.ui.generated.resources.vault_passphrase_none
+import app.skerry.ui.generated.resources.vault_passphrase_set
+import app.skerry.ui.generated.resources.vault_section_audit
+import app.skerry.ui.generated.resources.vault_section_encryption
+import app.skerry.ui.generated.resources.vault_stored_ciphertext
+import app.skerry.ui.generated.resources.vault_stored_local
+import app.skerry.ui.generated.resources.vault_value_never
+import app.skerry.ui.generated.resources.vault_value_unknown
+import app.skerry.ui.design.KeyValueRow
+import org.jetbrains.compose.resources.pluralStringResource
+import org.jetbrains.compose.resources.stringResource
+
+/** Window the audit line counts copies over — long enough to show a habit, short enough to mean today. */
+private const val COPY_WINDOW_DAYS = 30
+
+/** Cipher every vault record is sealed with. An algorithm name, not UI copy — identical in every locale. */
+private const val VAULT_CIPHER = "XChaCha20-Poly1305"
+
+/**
+ * Relative label for a stored ISO timestamp: "today 09:14" / "yesterday 18:02" / "12 days ago", the
+ * same wording Settings → Security uses for its event log. A `null` timestamp (never recorded) or one
+ * the platform clock can't parse reads as an em dash — the panel states what it knows and nothing more.
+ */
+@Composable
+fun momentLabel(iso: String?): String {
+    val moment = iso?.let { securityMoment(it) } ?: return stringResource(Res.string.vault_value_unknown)
+    return when (moment.daysAgo) {
+        0 -> stringResource(Res.string.settings_time_today, moment.timeOfDay)
+        1 -> stringResource(Res.string.settings_time_yesterday, moment.timeOfDay)
+        else -> stringResource(Res.string.settings_time_days_ago, moment.daysAgo)
+    }
+}
+
+/**
+ * The facts about the selected secret, as key/value rows: what it is, its fingerprint, whether a
+ * passphrase guards it, and the dates this device recorded ([usage] — added / last authenticated).
+ *
+ * Everything here is read off real state. A secret older than the usage log (or never used) shows
+ * "—"/"never" rather than a plausible date, and [fingerprint] is left out entirely for secret types
+ * that have none (a password).
+ */
+@Composable
+fun SecretFactRows(
+    typeLabel: String,
+    fingerprint: String?,
+    secret: CredentialSecret,
+    usage: CredentialUsage?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.fillMaxWidth()) {
+        KeyValueRow(stringResource(Res.string.vault_kv_type), typeLabel)
+        if (fingerprint != null) KeyValueRow(stringResource(Res.string.vault_kv_fingerprint), fingerprint)
+        passphraseGuarded(secret)?.let { guarded ->
+            KeyValueRow(
+                stringResource(Res.string.vault_kv_passphrase),
+                stringResource(if (guarded) Res.string.vault_passphrase_set else Res.string.vault_passphrase_none),
+            )
+        }
+        KeyValueRow(stringResource(Res.string.vault_kv_added), momentLabel(usage?.addedAt))
+        // Only for a secret whose material was actually replaced — an untouched one has nothing to say.
+        usage?.changedAt?.let { KeyValueRow(stringResource(Res.string.vault_kv_changed), momentLabel(it)) }
+        KeyValueRow(
+            stringResource(Res.string.vault_kv_last_used),
+            usage?.lastUsedAt?.let { momentLabel(it) } ?: stringResource(Res.string.vault_value_never),
+        )
+    }
+}
+
+/**
+ * How the secret is protected and where its ciphertext goes. Static facts of this build's crypto
+ * (see [VaultCrypto]) plus one live one: whether a sync account exists at all — without it
+ * "stored on server" would be a claim about a server the user never connected to.
+ */
+@Composable
+fun SecretEncryptionRows(syncing: Boolean, modifier: Modifier = Modifier) {
+    Column(modifier.fillMaxWidth()) {
+        KeyValueRow(stringResource(Res.string.vault_kv_cipher), VAULT_CIPHER)
+        KeyValueRow(
+            stringResource(Res.string.vault_kv_kdf),
+            stringResource(Res.string.vault_kdf_value, VaultCrypto.KDF_MEMORY_MIB),
+        )
+        KeyValueRow(
+            stringResource(Res.string.vault_kv_stored),
+            stringResource(if (syncing) Res.string.vault_stored_ciphertext else Res.string.vault_stored_local),
+        )
+    }
+}
+
+/**
+ * What this device did with the secret: how often it was copied to the clipboard inside the audit
+ * window. Per-device by design (see [app.skerry.shared.vault.CredentialUsageLog]) — a copy made on
+ * the phone is not counted here, and the log is not synced.
+ */
+@Composable
+fun SecretAuditRows(usage: CredentialUsage?, modifier: Modifier = Modifier) {
+    val copies = VaultPresentation.copiesWithin(usage, COPY_WINDOW_DAYS) { at -> securityMoment(at)?.daysAgo }
+    Column(modifier.fillMaxWidth()) {
+        KeyValueRow(
+            stringResource(Res.string.vault_kv_copied),
+            pluralStringResource(Res.plurals.vault_copies_window, copies, copies, COPY_WINDOW_DAYS),
+        )
+    }
+}
+
+/** Section caption used by the panels above; kept next to them so both platforms space it alike. */
+@Composable
+fun SecretSectionLabel(text: String, modifier: Modifier = Modifier) {
+    Column(modifier.padding(top = 16.dp, bottom = 6.dp)) { DetailLabel(text) }
+}
+
+/** Localized caption for the encryption section. */
+@Composable
+fun encryptionSectionTitle(): String = stringResource(Res.string.vault_section_encryption)
+
+/** Localized caption for the audit section. */
+@Composable
+fun auditSectionTitle(): String = stringResource(Res.string.vault_section_audit)
+
+/**
+ * Whether a passphrase guards the private material, or `null` for a secret type that has none (a
+ * stored password): the row is omitted rather than answering a question that doesn't apply.
+ */
+private fun passphraseGuarded(secret: CredentialSecret): Boolean? = when (secret) {
+    is CredentialSecret.Password -> null
+    is CredentialSecret.PrivateKey -> !secret.passphrase.isNullOrEmpty()
+    is CredentialSecret.Certificate -> !secret.passphrase.isNullOrEmpty()
+    is CredentialSecret.KeyFile -> !secret.passphrase.isNullOrEmpty()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockData.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockData.kt
@@ -1,0 +1,34 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
+
+/**
+ * Sample secrets for the offscreen/preview render of the Vault section, where there is no unlocked
+ * keychain to list. Built as real [Credential] values with the meta line already resolved (parsing a
+ * fake PEM would fail), so the preview goes through the same row and panel as the live path — a
+ * separate mock layout would drift the moment a column changes.
+ */
+internal fun mockSecrets(): List<Pair<Credential, String>> = listOf(
+    Credential("m1", "id_ed25519 — deploy", CredentialSecret.PrivateKey("mock-pem", passphrase = "mock")) to
+        "ED25519 · SHA256:9pQk…dR2f · prod-web-01, prod-web-02",
+    Credential("m2", "id_rsa — legacy jump", CredentialSecret.PrivateKey("mock-pem")) to
+        "RSA-4096 · SHA256:1cTz…88Aa · jump.corp",
+    Credential("m3", "db-master · postgres", CredentialSecret.Password("mock")) to
+        "rotated 12 days ago · db-master",
+    Credential("m4", "skerry-ca — user cert", CredentialSecret.Certificate("mock-pem", "mock-cert")) to
+        "ED25519-cert · valid until 14 Sep 2026",
+    Credential("m5", "vps-edge · root", CredentialSecret.Password("mock")) to
+        "rotated 3 days ago · vps-edge",
+    Credential("m6", "work SSH CA", CredentialSecret.KeyFile("~/.ssh/id_ed25519", "~/.ssh/id_ed25519-cert.pub")) to
+        "~/.ssh/id_ed25519",
+)
+
+/** Usage trail of the mock selection, so the preview panel shows the same dates the live one would. */
+internal fun mockUsage(): CredentialUsage = CredentialUsage(
+    credentialId = "m1",
+    addedAt = "2026-06-14T09:14:00Z",
+    lastUsedAt = "2026-06-14T09:14:00Z",
+    copiedAt = listOf("2026-06-14T09:14:00Z"),
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultPresentation.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultPresentation.kt
@@ -8,14 +8,13 @@ import app.skerry.shared.snippet.SnippetTemplate
 import app.skerry.shared.snippet.SnippetVariableKind
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vtail_category_certificates
 import app.skerry.ui.generated.resources.vtail_category_passwords
 import app.skerry.ui.generated.resources.vtail_category_ssh_keys
 import app.skerry.ui.generated.resources.vtail_snippets_frag_one
 import app.skerry.ui.generated.resources.vtail_snippets_frag_other
-import app.skerry.ui.generated.resources.vtail_used_by_one
-import app.skerry.ui.generated.resources.vtail_used_by_other
 import app.skerry.ui.generated.resources.vtail_used_by_snippets_one
 import app.skerry.ui.generated.resources.vtail_used_by_snippets_other
 import org.jetbrains.compose.resources.stringResource
@@ -52,6 +51,9 @@ data class SecretTypeStyle(val icon: String, val color: Color, val tinted: Boole
  * secret). No Compose/IO; [VaultView] only renders the result.
  */
 object VaultPresentation {
+
+    /** How many host names a row spells out before switching to "+N". */
+    private const val MAX_NAMED_HOSTS = 3
 
     /** Categories shown in the Vault sidebar. */
     val sidebarCategories: List<VaultCategoryKind> = VaultCategoryKind.entries
@@ -96,6 +98,14 @@ object VaultPresentation {
     fun count(kind: VaultCategoryKind, credentials: List<Credential>): Int =
         credentialsIn(kind, credentials).size
 
+    /**
+     * How many clipboard copies of a secret fall inside the last [days] days. [daysAgo] resolves a
+     * stored ISO timestamp to whole days back (the platform clock, [app.skerry.shared.vault.securityMoment]);
+     * a timestamp it can't parse is not counted — an unreadable date is not evidence of a copy.
+     */
+    fun copiesWithin(usage: CredentialUsage?, days: Int, daysAgo: (String) -> Int?): Int =
+        usage?.copiedAt?.count { at -> daysAgo(at)?.let { it <= days } == true } ?: 0
+
     /** Hosts bound to keychain secret [credentialId] (via [Host.credentialId]); used for "used by" and unbinding on delete. */
     fun hostsUsing(credentialId: String, hosts: List<Host>): List<Host> =
         hosts.filter { it.credentialId == credentialId }
@@ -112,17 +122,24 @@ object VaultPresentation {
         }
 
     /**
-     * Localized "used by N host(s) · M snippet(s)" label for a secret card (desktop + mobile).
-     * `null` when nothing references the secret — the card then shows only the type word instead
-     * of a noisy "used by 0 hosts".
+     * Host names a secret is bound to, as one line: up to [max] of them, then "+N" for the rest.
+     * `null` for none. Names, not a count — a row saying "prod-web-01, prod-web-02" answers the
+     * question the count only hints at, and the row elides what doesn't fit anyway.
+     */
+    fun hostNames(labels: List<String>, max: Int = MAX_NAMED_HOSTS): String? = when {
+        labels.isEmpty() -> null
+        labels.size <= max -> labels.joinToString(", ")
+        else -> labels.take(max).joinToString(", ") + " +" + (labels.size - max)
+    }
+
+    /**
+     * Localized "prod-web-01, prod-web-02 · M snippet(s)" label for a secret row (desktop + mobile).
+     * `null` when nothing references the secret — the row then carries only its own facts instead of
+     * a noisy "used by 0 hosts".
      */
     @Composable
-    fun usedByLabel(hostCount: Int, snippetCount: Int): String? {
-        val hostsPart = when {
-            hostCount == 1 -> stringResource(Res.string.vtail_used_by_one)
-            hostCount > 1 -> stringResource(Res.string.vtail_used_by_other, hostCount)
-            else -> null
-        }
+    fun usedByLabel(hostLabels: List<String>, snippetCount: Int): String? {
+        val hostsPart = hostNames(hostLabels)
         return when {
             hostsPart != null && snippetCount > 0 -> {
                 val fragment =

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultRows.kt
@@ -1,0 +1,155 @@
+package app.skerry.ui.vault
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
+import app.skerry.shared.vault.SshCertificateInfo
+import app.skerry.shared.vault.SshPublicKeyInfo
+import app.skerry.shared.vault.securityMoment
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vault_meta_rotated
+import app.skerry.ui.generated.resources.vault_meta_valid_until
+import app.skerry.ui.known.shortFingerprint
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Width of the selection edge on the left of a selected row. */
+private val EDGE_WIDTH = 2.dp
+
+/**
+ * One secret in the vault list: type glyph, name, a monospace line of what it actually is
+ * (algorithm, fingerprint, what uses it), and the type badge on the right. Dense by design — a
+ * keychain is scanned, not admired, so rows sit close and are separated by a hairline rather than
+ * floating as cards.
+ *
+ * The selected row carries a teal edge and a lifted background, the same signal the host tree and
+ * the tunnel table use for "this is what the panel on the right is showing".
+ *
+ * [status] renders extra badges the row must not hide (an expired certificate, an unreadable key
+ * file); they sit before the type badge, loudest first.
+ */
+@Composable
+fun SecretRow(
+    icon: String,
+    iconColor: Color,
+    tintedIcon: Boolean,
+    name: String,
+    meta: String,
+    mono: FontFamily,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    status: @Composable () -> Unit = {},
+) {
+    Column(modifier.fillMaxWidth()) {
+        val edge = Skerry.colors.teal
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(if (selected) Skerry.colors.overlaySoft else Color.Transparent)
+                // The selection edge is painted, not laid out: a strip inside a Row can't stretch to
+                // the row's height (the Row is still measuring it), and it must not shift the text of
+                // an unselected row by so much as a pixel.
+                .drawBehind { if (selected) drawRect(edge, size = Size(EDGE_WIDTH.toPx(), size.height)) }
+                .clickable(onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 9.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                Modifier.size(30.dp).clip(RoundedCornerShape(9.dp))
+                    .background(if (tintedIcon) iconColor.copy(alpha = 0.12f) else Skerry.colors.overlayMed),
+                contentAlignment = Alignment.Center,
+            ) {
+                Sym(icon, size = 16.sp, color = if (tintedIcon) iconColor else Skerry.colors.dim)
+            }
+            Column(Modifier.weight(1f)) {
+                Txt(
+                    name,
+                    color = Skerry.colors.text, size = 12.5.sp, weight = FontWeight.Medium,
+                    maxLines = 1, overflow = TextOverflow.Ellipsis,
+                )
+                // A secret with nothing to say about it (a fresh password bound to nothing) gets no
+                // empty second line reserving height under its name.
+                if (meta.isNotEmpty()) {
+                    Txt(
+                        meta,
+                        modifier = Modifier.padding(top = 2.dp),
+                        color = Skerry.colors.faint, size = 11.sp, font = mono,
+                        maxLines = 1, overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
+                status()
+            }
+        }
+        HLine()
+    }
+}
+
+/** Separator between the facts on a row's meta line — typography, identical in every locale. */
+private const val META_SEPARATOR = " · "
+
+/**
+ * The monospace line under a secret's name: the facts about it, separated by dots — what it is
+ * technically (algorithm and fingerprint for a key, length and rotation for a password, validity for
+ * a certificate, the path for a file-backed one), then what depends on it ([usedBy]).
+ *
+ * The *type* is deliberately absent: the glyph on the left and the sidebar category already say it.
+ * So is the length of a password — a character count narrows a guess for anyone reading the screen.
+ * Metadata still being parsed off the main thread ([rememberKeyInfo]) simply contributes nothing
+ * rather than a placeholder.
+ */
+@Composable
+fun secretMetaLine(
+    secret: CredentialSecret,
+    keyInfo: SshPublicKeyInfo?,
+    certInfo: SshCertificateInfo?,
+    usage: CredentialUsage?,
+    usedBy: String?,
+): String {
+    val facts = when (secret) {
+        is CredentialSecret.Certificate -> listOfNotNull(
+            certInfo?.let { "${it.keyTypeLabel}-cert" },
+            certInfo?.let { stringResource(Res.string.vault_meta_valid_until, it.validUntil) },
+        )
+        is CredentialSecret.PrivateKey -> listOfNotNull(
+            keyInfo?.keyTypeLabel,
+            keyInfo?.let { shortFingerprint(it.fingerprintSha256) },
+        )
+        is CredentialSecret.Password -> listOfNotNull(
+            // Only when the date actually parses: "rotated —" would read as data rather than as
+            // "unknown", unlike the standalone em dash in the panel's fact rows.
+            usage?.changedAt?.takeIf { securityMoment(it) != null }
+                ?.let { stringResource(Res.string.vault_meta_rotated, momentLabel(it)) },
+        )
+        // The location is the whole secret here; the badge already says it lives in a file.
+        is CredentialSecret.KeyFile -> listOf(secret.privateKeyRef)
+    }
+    return (facts + listOfNotNull(usedBy)).joinToString(META_SEPARATOR)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -58,6 +59,7 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.SshCertificateInfo
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
@@ -111,6 +113,9 @@ import app.skerry.ui.generated.resources.vault_field_passphrase
 import app.skerry.ui.generated.resources.vault_field_password
 import app.skerry.ui.generated.resources.vault_field_private_key_pem
 import app.skerry.ui.generated.resources.vault_generate
+import app.skerry.ui.generated.resources.vault_header_summary
+import app.skerry.ui.generated.resources.vault_item_count
+import app.skerry.ui.generated.resources.vault_title
 import app.skerry.ui.generated.resources.vault_generate_key
 import app.skerry.ui.generated.resources.vault_hint_cert_sibling
 import app.skerry.ui.generated.resources.vault_hint_cert_sibling_opaque
@@ -119,7 +124,6 @@ import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_key_file_missing
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_cert_path
-import app.skerry.ui.generated.resources.vault_label_fingerprint
 import app.skerry.ui.generated.resources.vault_label_key_path
 import app.skerry.ui.generated.resources.vault_label_principals
 import app.skerry.ui.generated.resources.vault_label_public_key
@@ -128,10 +132,6 @@ import app.skerry.ui.generated.resources.vault_label_signing_ca
 import app.skerry.ui.generated.resources.vault_label_valid
 import app.skerry.ui.generated.resources.vault_link
 import app.skerry.ui.generated.resources.vault_link_key_file
-import app.skerry.ui.generated.resources.vault_meta_any_principal
-import app.skerry.ui.generated.resources.vault_meta_certificate
-import app.skerry.ui.generated.resources.vault_meta_key_file
-import app.skerry.ui.generated.resources.vault_meta_password
 import app.skerry.ui.generated.resources.vault_not_attached
 import app.skerry.ui.generated.resources.vault_password_mismatch_retry
 import app.skerry.ui.generated.resources.vault_placeholder_master_password
@@ -154,8 +154,6 @@ import app.skerry.ui.generated.resources.vault_used_by
 import app.skerry.ui.generated.resources.vault_used_by_one
 import app.skerry.ui.generated.resources.vault_used_by_snippets
 import app.skerry.ui.generated.resources.vault_used_by_snippets_one
-import app.skerry.ui.generated.resources.vtail_meta_fingerprint
-import app.skerry.ui.generated.resources.vtail_meta_principals
 import app.skerry.ui.host.HostDraft
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -173,7 +171,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.app.LocalSync
+import app.skerry.ui.sync.SyncStatus
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.Chip
@@ -198,6 +199,12 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.theme.Skerry
+
+/**
+ * Width of the secret detail panel — wide enough for a fingerprint and a wrapped public key to sit
+ * next to their labels without the key block turning into a column of fragments.
+ */
+private val DETAIL_PANEL_WIDTH = 400.dp
 
 /**
  * Vault view. With a live keychain ([LocalCredentials]) renders the open vault's real data:
@@ -245,6 +252,9 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
     val selectedCred = credItems.firstOrNull { it.id == selectedId } ?: credItems.firstOrNull()
+    // "Stored on server" is only true once an account exists; without sync the ciphertext never
+    // leaves this device, and the panel has to say so.
+    val syncing = LocalSync.current?.status?.collectAsState()?.value.let { it != null && it !is SyncStatus.Disabled }
 
     Box(Modifier.fillMaxSize()) {
         Row(Modifier.fillMaxSize()) {
@@ -253,6 +263,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
             Column(Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg)) {
                 VaultHeader(
                     category = category,
+                    itemCount = allCreds.size,
                     canGenerate = generator != null,
                     canImportCert = inspector != null,
                     canLinkFile = secretFiles != null,
@@ -265,18 +276,16 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                     if (credItems.isEmpty()) {
                         VaultEmptyCategory(category, Modifier.weight(1f).fillMaxHeight())
                     } else {
-                        Column(
-                            Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState()).padding(horizontal = 22.dp, vertical = 16.dp),
-                            verticalArrangement = Arrangement.spacedBy(10.dp),
-                        ) {
+                        Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())) {
                             credItems.forEach { credential ->
-                                LiveSecretCard(
+                                LiveSecretRow(
                                     credential = credential,
-                                    active = credential.id == selectedCred?.id,
+                                    selected = credential.id == selectedCred?.id,
                                     generator = generator,
                                     inspector = inspector,
+                                    usage = credentials.usageOf(credential.id),
                                     usedBy = VaultPresentation.usedByLabel(
-                                        hostCount = VaultPresentation.hostsUsing(credential.id, hosts).size,
+                                        hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.label },
                                         snippetCount = VaultPresentation.snippetsUsing(credential.label, snippetList).size,
                                     ),
                                     mono = mono,
@@ -291,11 +300,15 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                             credential = credential,
                             generator = generator,
                             inspector = inspector,
+                            usage = credentials.usageOf(credential.id),
+                            syncing = syncing,
                             hosts = VaultPresentation.hostsUsing(credential.id, hosts),
                             snippetLabels = VaultPresentation.snippetsUsing(credential.label, snippetList).map { it.label },
                             mono = mono,
                             onCopy = { copyTextToClipboard(it) },
-                            onCopyPassword = { pwd -> copyAuth.authorize { copyPasswordToClipboard(pwd) } },
+                            onCopyPassword = { pwd ->
+                                copyAuth.authorize { credentials.recordCopied(credential.id); copyPasswordToClipboard(pwd) }
+                            },
                             onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
                             onRename = { pendingRenameCred = credential },
                             onDelete = { pendingDeleteCred = credential },
@@ -473,6 +486,7 @@ private fun VaultCategoryRow(icon: String, label: String, count: String, active:
 @Composable
 private fun VaultHeader(
     category: VaultCategoryKind,
+    itemCount: Int,
     canGenerate: Boolean,
     canImportCert: Boolean,
     canLinkFile: Boolean,
@@ -482,7 +496,13 @@ private fun VaultHeader(
     onLinkKeyFile: () -> Unit,
 ) {
     SectionHeader(
-        title = category.title(),
+        // The section names the whole keychain and how it is protected; which slice of it is on
+        // screen is what the sidebar highlights.
+        title = stringResource(Res.string.vault_title),
+        subtitle = stringResource(
+            Res.string.vault_header_summary,
+            pluralStringResource(Res.plurals.vault_item_count, itemCount, itemCount),
+        ),
         actions = {
             when (category) {
                 // "Link file" sits in both key and certificate categories: which one a file-backed
@@ -504,86 +524,41 @@ private fun VaultHeader(
 // Keychain secret card (key/password/certificate) + account card + empty states.
 
 @Composable
-private fun LiveSecretCard(
+private fun LiveSecretRow(
     credential: Credential,
-    active: Boolean,
+    selected: Boolean,
     generator: SshKeyGenerator?,
     inspector: SshCertificateInspector?,
+    usage: CredentialUsage?,
     usedBy: String?,
     mono: FontFamily,
     onClick: () -> Unit,
 ) {
-    val border = if (active) Skerry.colors.cyan.copy(alpha = 0.18f) else Skerry.colors.cyan08
-    val bg = if (active) Skerry.colors.cyan.copy(alpha = 0.04f) else Color.Transparent
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).background(bg).border(1.dp, border, RoundedCornerShape(10.dp)).clickable(onClick = onClick).padding(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        when (val secret = credential.secret) {
-            is CredentialSecret.Certificate -> {
-                val info = rememberCertInfo(credential, inspector)
-                SecretIcon("workspace_premium", tinted = true, color = Skerry.colors.moss)
-                Column(Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Txt(credential.label, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
-                        info?.keyTypeLabel?.let { Badge(it, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, radius = 3, size = 9.5.sp) }
-                        if (info?.expired == true) Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, radius = 3, size = 9.5.sp)
+    val secret = credential.secret
+    val style = VaultPresentation.secretStyle(secret, Skerry.colors)
+    val keyInfo = rememberKeyInfo(credential, generator)
+    val certInfo = rememberCertInfo(credential, inspector)
+    val fileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
+    SecretRow(
+        icon = style.icon,
+        iconColor = style.color,
+        tintedIcon = style.tinted,
+        name = credential.label,
+        meta = secretMetaLine(secret, keyInfo, certInfo, usage, usedBy),
+        mono = mono,
+        selected = selected,
+        onClick = onClick,
+        status = {
+            when (secret) {
+                is CredentialSecret.KeyFile -> KeyFileBadges(fileState)
+                is CredentialSecret.Certificate ->
+                    if (certInfo?.expired == true) {
+                        Badge(stringResource(Res.string.vault_badge_expired), bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, radius = 3, size = 9.5.sp)
                     }
-                    val meta = when {
-                        info == null -> usedBy?.let { stringResource(Res.string.vault_meta_certificate, it) }
-                            ?: stringResource(Res.string.vault_subtitle_certificate)
-                        info.principals.isEmpty() -> usedBy?.let { stringResource(Res.string.vault_meta_any_principal, it) }
-                            ?: stringResource(Res.string.vault_any_principal)
-                        else -> usedBy?.let { stringResource(Res.string.vtail_meta_principals, info.principals.joinToString(", "), it) }
-                            ?: info.principals.joinToString(", ")
-                    }
-                    Txt(meta, color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
-                }
+                is CredentialSecret.Password, is CredentialSecret.PrivateKey -> Unit
             }
-            is CredentialSecret.KeyFile -> {
-                val state = rememberKeyFileState(secret, LocalSecretFileReader.current, inspector)
-                SecretIcon(VaultPresentation.secretIcon(secret), tinted = true, color = if (secret.certificateRef.isNullOrBlank()) Skerry.colors.cyanBright else Skerry.colors.moss)
-                Column(Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Txt(credential.label, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
-                        KeyFileBadges(state)
-                    }
-                    Txt(
-                        stringResource(Res.string.vault_meta_key_file, secret.privateKeyRef),
-                        color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp),
-                    )
-                }
-            }
-            is CredentialSecret.PrivateKey -> {
-                val info = rememberKeyInfo(credential, generator)
-                SecretIcon("key", tinted = true, color = Skerry.colors.cyanBright)
-                Column(Modifier.weight(1f)) {
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Txt(credential.label, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
-                        info?.keyTypeLabel?.let { Badge(it, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, radius = 3, size = 9.5.sp) }
-                    }
-                    val meta = when {
-                        info != null && usedBy != null ->
-                            stringResource(Res.string.vtail_meta_fingerprint, shortFingerprint(info.fingerprintSha256), usedBy)
-                        info != null -> shortFingerprint(info.fingerprintSha256)
-                        else -> usedBy ?: stringResource(Res.string.vault_subtitle_private_key)
-                    }
-                    Txt(meta, color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
-                }
-            }
-            is CredentialSecret.Password -> {
-                SecretIcon("password", tinted = false, color = Skerry.colors.dim)
-                Column(Modifier.weight(1f)) {
-                    Txt(credential.label, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
-                    Txt(
-                        usedBy?.let { stringResource(Res.string.vault_meta_password, it) } ?: stringResource(Res.string.vault_subtitle_password),
-                        color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp),
-                    )
-                }
-            }
-        }
-    }
+        },
+    )
 }
 
 /** Square secret icon in the card/detail panel (cyan/moss tint for keys/certificates, neutral for passwords). */
@@ -642,6 +617,8 @@ private fun LiveSecretDetail(
     credential: Credential,
     generator: SshKeyGenerator?,
     inspector: SshCertificateInspector?,
+    usage: CredentialUsage?,
+    syncing: Boolean,
     hosts: List<Host>,
     snippetLabels: List<String>,
     mono: FontFamily,
@@ -655,7 +632,6 @@ private fun LiveSecretDetail(
     val keyInfo = rememberKeyInfo(credential, generator)
     val certInfo = rememberCertInfo(credential, inspector)
     val keyFileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
-    val (icon, color, tinted) = VaultPresentation.secretStyle(secret, Skerry.colors)
     val subtitle = when (secret) {
         is CredentialSecret.Certificate -> certInfo?.keyTypeLabel?.let { stringResource(Res.string.vault_subtitle_certificate_typed, it) } ?: stringResource(Res.string.vault_subtitle_certificate)
         is CredentialSecret.PrivateKey -> keyInfo?.keyTypeLabel ?: stringResource(Res.string.vault_subtitle_private_key)
@@ -664,23 +640,27 @@ private fun LiveSecretDetail(
             if (secret.certificateRef.isNullOrBlank()) stringResource(Res.string.vault_subtitle_key_file)
             else stringResource(Res.string.vault_subtitle_key_file_cert)
     }
-    Column(Modifier.width(340.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
-        Row(Modifier.padding(bottom = 18.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(11.dp)) {
-            SecretIcon(icon, tinted = tinted, color = color, size = 40)
-            Column {
-                Txt(credential.label, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
-                Txt(subtitle, color = Skerry.colors.dim, size = 11.5.sp)
-            }
-        }
+    Column(Modifier.width(DETAIL_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
+        DetailLabel(credential.label)
+        SecretFactRows(
+            typeLabel = subtitle,
+            // A password has no fingerprint, and a key still being parsed has none yet — the row is
+            // dropped rather than filled with a placeholder that reads like data.
+            fingerprint = keyInfo?.fingerprintSha256?.let { shortFingerprint(it) }
+                ?: keyFileState?.certificate?.caFingerprintSha256?.let { shortFingerprint(it) },
+            secret = secret,
+            usage = usage,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
         when (secret) {
             is CredentialSecret.Certificate -> CertificateDetailBody(certInfo, mono)
             is CredentialSecret.PrivateKey -> {
                 DetailLabel(stringResource(Res.string.vault_label_public_key))
+                // The fingerprint itself is already a fact row above; what the panel adds here is the
+                // key the user actually has to paste somewhere.
                 Box(Modifier.fillMaxWidth().padding(bottom = 16.dp).clip(RoundedCornerShape(7.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan.copy(alpha = 0.1f), RoundedCornerShape(7.dp)).padding(horizontal = 12.dp, vertical = 10.dp)) {
                     Txt(keyInfo?.publicKeyOpenSsh ?: stringResource(Res.string.vault_key_unreadable), color = Skerry.colors.dim, size = 10.5.sp, font = mono, lineHeight = 16.sp)
                 }
-                DetailLabel(stringResource(Res.string.vault_label_fingerprint))
-                Txt(keyInfo?.fingerprintSha256 ?: "—", color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = 16.dp))
             }
             is CredentialSecret.Password -> Unit
             is CredentialSecret.KeyFile -> KeyFileDetailBody(secret, keyFileState, mono)
@@ -715,6 +695,14 @@ private fun LiveSecretDetail(
                 is CredentialSecret.Password, is CredentialSecret.KeyFile ->
                     GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.fillMaxWidth())
             }
+        }
+        SecretSectionLabel(encryptionSectionTitle())
+        SecretEncryptionRows(syncing)
+        // Audit counts clipboard copies, and only a password ever leaves the vault that way: for a
+        // key or a certificate the copy button hands over the public half, which is not a secret.
+        if (secret is CredentialSecret.Password) {
+            SecretSectionLabel(auditSectionTitle())
+            SecretAuditRows(usage)
         }
     }
 }
@@ -1140,18 +1128,26 @@ internal fun DialogButtons(confirmLabel: String, confirmEnabled: Boolean, onDism
     }
 }
 
-// Mock path (offscreen render/preview): static categories/keys/details.
+// Mock path (offscreen render/preview): the same sidebar, rows and panel over sample secrets.
 
-/** Vault view (mock): secret categories (sidebar) + SSH key list + key detail panel. */
+/** Vault view (mock): categories, the secret list and the detail panel, over [mockSecrets]. */
 @Composable
 private fun MockVaultView() {
     val mono = LocalFonts.current.mono
+    val secrets = mockSecrets()
+    val selected = secrets.first().first
     Row(Modifier.fillMaxSize()) {
         Column(Modifier.width(SIDEBAR_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).padding(horizontal = 8.dp, vertical = 14.dp)) {
             SidebarSectionTitle(stringResource(Res.string.vault_sidebar_header), Modifier.padding(start = 10.dp, bottom = 10.dp))
-            VaultCategory("key", "SSH keys", "4", active = true)
-            VaultCategory("password", "Passwords", "12")
-            VaultCategory("vpn_lock", "Certificates", "2")
+            VaultPresentation.sidebarCategories.forEach { kind ->
+                VaultCategoryRow(
+                    icon = kind.icon,
+                    label = kind.title(),
+                    count = VaultPresentation.count(kind, secrets.map { it.first }).toString(),
+                    active = kind == VaultCategoryKind.SSH_KEYS,
+                    onClick = {},
+                )
+            }
             Spacer(Modifier.weight(1f))
             Column(
                 Modifier.clip(RoundedCornerShape(8.dp)).background(Skerry.colors.moss.copy(alpha = 0.06f)).border(1.dp, Skerry.colors.moss.copy(alpha = 0.16f), RoundedCornerShape(8.dp)).padding(10.dp),
@@ -1166,134 +1162,56 @@ private fun MockVaultView() {
         VLine(Skerry.colors.line)
         Column(Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg)) {
             SectionHeader(
-                title = "SSH keys",
+                title = stringResource(Res.string.vault_title),
+                subtitle = stringResource(
+                    Res.string.vault_header_summary,
+                    pluralStringResource(Res.plurals.vault_item_count, secrets.size, secrets.size),
+                ),
                 actions = { PrimaryButton(stringResource(Res.string.vault_generate_key), onClick = {}, icon = "add") },
             )
             Row(Modifier.weight(1f).fillMaxWidth()) {
-                Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState()).padding(horizontal = 22.dp, vertical = 16.dp), verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    KeyCard(
-                        iconBg = Skerry.colors.cyan.copy(alpha = 0.12f), iconColor = Skerry.colors.cyanBright, icon = "key",
-                        name = "id_ed25519", badges = listOf("ED25519" to false, "DEFAULT" to true),
-                        meta = "SHA256:8c3F1a…Qz9pK · used by 6 hosts", mono = mono,
-                        border = Skerry.colors.cyan.copy(alpha = 0.18f), bg = Skerry.colors.cyan.copy(alpha = 0.04f),
-                        trailing = { CopyButton() },
-                    )
-                    KeyCard(
-                        iconBg = Skerry.colors.overlayMed, iconColor = Skerry.colors.dim, icon = "key",
-                        name = "id_rsa_legacy", badges = listOf("RSA-4096" to null),
-                        meta = "SHA256:2dE7b…Lm4xR · used by 2 hosts", mono = mono,
-                        border = Skerry.colors.cyan08, bg = Color.Transparent,
-                        trailing = { CopyButton() },
-                    )
-                    KeyCard(
-                        iconBg = Skerry.colors.sunset.copy(alpha = 0.12f), iconColor = Skerry.colors.sunset, icon = "warning",
-                        name = "deploy_ci", badges = listOf("ROTATE SOON" to false), rotateBadge = true,
-                        meta = "SHA256:9aB0c…Tn2wE · created 412 days ago", mono = mono,
-                        border = Skerry.colors.sunset.copy(alpha = 0.25f), bg = Skerry.colors.sunset.copy(alpha = 0.04f),
-                        trailing = {
-                            Box(Modifier.clip(RoundedCornerShape(6.dp)).border(1.dp, Skerry.colors.sunset.copy(alpha = 0.4f), RoundedCornerShape(6.dp)).padding(horizontal = 12.dp, vertical = 7.dp)) {
-                                Txt("Rotate", color = Skerry.colors.sunset, size = 11.5.sp, weight = FontWeight.SemiBold)
-                            }
-                        },
-                    )
-                }
-                VLine(Skerry.colors.line)
-                KeyDetail(mono)
-            }
-        }
-    }
-}
-
-@Composable
-private fun VaultCategory(icon: String, label: String, count: String, active: Boolean = false) {
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(6.dp))
-            .background(if (active) Skerry.colors.cyan10 else Color.Transparent)
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Sym(icon, size = 16.sp, color = if (active) Skerry.colors.cyanBright else Skerry.colors.dim)
-        Txt(label, color = if (active) Skerry.colors.cyanBright else Skerry.colors.dim, size = 12.5.sp, modifier = Modifier.weight(1f))
-        Txt(count, color = Skerry.colors.faint, size = 10.sp)
-    }
-}
-
-@Composable
-private fun KeyCard(
-    iconBg: Color,
-    iconColor: Color,
-    icon: String,
-    name: String,
-    badges: List<Pair<String, Boolean?>>,
-    meta: String,
-    mono: FontFamily,
-    border: Color,
-    bg: Color,
-    rotateBadge: Boolean = false,
-    trailing: @Composable () -> Unit,
-) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(10.dp)).background(bg).border(1.dp, border, RoundedCornerShape(10.dp)).padding(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
-    ) {
-        Box(Modifier.size(38.dp).clip(RoundedCornerShape(9.dp)).background(iconBg), contentAlignment = Alignment.Center) {
-            Sym(icon, size = 20.sp, color = iconColor)
-        }
-        Column(Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Txt(name, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.SemiBold)
-                badges.forEach { (text, default) ->
-                    when {
-                        rotateBadge -> Badge(text, bg = Skerry.colors.sunset.copy(alpha = 0.16f), fg = Skerry.colors.sunset, radius = 3, size = 9.5.sp)
-                        default == true -> Badge(text, bg = Skerry.colors.cyan14, fg = Skerry.colors.cyanBright, radius = 3, size = 9.5.sp)
-                        default == false -> Badge(text, bg = Skerry.colors.moss.copy(alpha = 0.16f), fg = Skerry.colors.moss, radius = 3, size = 9.5.sp)
-                        else -> Badge(text, bg = Skerry.colors.overlayMed, fg = Skerry.colors.dim, radius = 3, size = 9.5.sp)
+                Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())) {
+                    secrets.forEach { (credential, meta) ->
+                        val style = VaultPresentation.secretStyle(credential.secret, Skerry.colors)
+                        SecretRow(
+                            icon = style.icon,
+                            iconColor = style.color,
+                            tintedIcon = style.tinted,
+                            name = credential.label,
+                            meta = meta,
+                            mono = mono,
+                            selected = credential.id == selected.id,
+                            onClick = {},
+                        )
                     }
                 }
+                VLine(Skerry.colors.line)
+                MockSecretDetail(selected, mono)
             }
-            Txt(meta, color = Skerry.colors.dim, size = 11.sp, font = mono, modifier = Modifier.padding(top = 6.dp))
         }
-        trailing()
     }
 }
 
+/** Detail panel of the mock selection: the same fact rows, key block and sections as the live one. */
 @Composable
-private fun CopyButton() {
-    Box(Modifier.size(30.dp).clip(RoundedCornerShape(6.dp)).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp)), contentAlignment = Alignment.Center) {
-        Sym("content_copy", size = 16.sp, color = Skerry.colors.dim)
-    }
-}
-
-@Composable
-private fun KeyDetail(mono: FontFamily) {
-    Column(Modifier.width(340.dp).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
-        Row(Modifier.padding(bottom = 18.dp), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(11.dp)) {
-            Box(Modifier.size(40.dp).clip(RoundedCornerShape(9.dp)).background(Skerry.colors.cyan.copy(alpha = 0.12f)), contentAlignment = Alignment.Center) {
-                Sym("key", size = 21.sp, color = Skerry.colors.cyanBright)
-            }
-            Column {
-                Txt("id_ed25519", color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
-                Txt("ED25519 · 256-bit", color = Skerry.colors.dim, size = 11.5.sp)
-            }
-        }
+private fun MockSecretDetail(credential: Credential, mono: FontFamily) {
+    Column(Modifier.width(DETAIL_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
+        DetailLabel(credential.label)
+        SecretFactRows(
+            typeLabel = "ED25519",
+            fingerprint = "SHA256:9pQk…dR2f",
+            secret = credential.secret,
+            usage = mockUsage(),
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
         DetailLabel(stringResource(Res.string.vault_label_public_key))
         Box(Modifier.fillMaxWidth().padding(bottom = 16.dp).clip(RoundedCornerShape(7.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan.copy(alpha = 0.1f), RoundedCornerShape(7.dp)).padding(horizontal = 12.dp, vertical = 10.dp)) {
-            Txt("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIH8c3F1a2bQz9pK7mLwR0vNqz9pKmaya@skerry.dev", color = Skerry.colors.dim, size = 10.5.sp, font = mono, lineHeight = 16.sp)
+            Txt("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP9k2RmXq7f0LcV8m1Zb4t6Yh3sJdQ1oNp5uWxK deploy@skerry", color = Skerry.colors.dim, size = 10.5.sp, font = mono, lineHeight = 16.sp)
         }
-        DetailLabel(stringResource(Res.string.vault_label_fingerprint))
-        Txt("SHA256:8c3F1a2bQz9pK7mLwR0vNqz9pK", color = Skerry.colors.textBright, size = 11.sp, font = mono, modifier = Modifier.padding(bottom = 16.dp))
-        DetailLabel("Used by · 6 hosts")
+        DetailLabel(stringResource(Res.string.vault_used_by, 2))
         Row(Modifier.fillMaxWidth().padding(bottom = 20.dp), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
             HostPill("prod-web-01", mono)
             HostPill("prod-web-02", mono)
-        }
-        Row(Modifier.fillMaxWidth().padding(bottom = 20.dp), horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-            HostPill("db-master", mono)
-            HostPill("homelab-pi", mono)
-            HostPill("+2", mono, dim = true)
         }
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             PrimaryButton(stringResource(Res.string.vault_copy_public_key), onClick = {}, icon = "content_copy", modifier = Modifier.fillMaxWidth())
@@ -1302,6 +1220,8 @@ private fun KeyDetail(mono: FontFamily) {
                 GhostButton(stringResource(Res.string.vault_delete), onClick = {}, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
             }
         }
+        SecretSectionLabel(encryptionSectionTitle())
+        SecretEncryptionRows(syncing = true)
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
@@ -1,7 +1,10 @@
 package app.skerry.ui.identity
 
+import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.CredentialUsage
+import app.skerry.shared.vault.CredentialUsageLog
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.MergeResult
 import app.skerry.shared.vault.RecordType
@@ -9,6 +12,11 @@ import app.skerry.shared.vault.SyncMeta
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecord
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -121,6 +129,154 @@ class CredentialManagerControllerTest {
         assertNull(controller.find("missing"))
         assertNull(controller.find(null))
     }
+
+    @Test
+    fun `creating a secret stamps it as added, updating one does not`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+        assertEquals(listOf("added:gen"), usage.events)
+
+        // An edit of the same secret is not a second birth — it is a rotation (see the test below).
+        controller.save(CredentialDraft(id = "gen", label = "Key", kind = CredentialKind.PASSWORD, password = "p2"))
+        assertEquals(listOf("added:gen", "changed:gen"), usage.events)
+    }
+
+    @Test
+    fun `replacing the material of a secret is recorded as a rotation`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+        usage.events.clear()
+
+        controller.save(CredentialDraft(id = "gen", label = "Key", kind = CredentialKind.PASSWORD, password = "p2"))
+        assertEquals(listOf("changed:gen"), usage.events)
+
+        // Re-saving the same material (a rename goes through save too) is not a rotation.
+        controller.save(CredentialDraft(id = "gen", label = "Renamed", kind = CredentialKind.PASSWORD, password = "p2"))
+        assertEquals(listOf("changed:gen"), usage.events)
+    }
+
+    @Test
+    fun `imported secrets are stamped as added`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+
+        controller.importCredentials(listOf(Credential("i1", "Imported", CredentialSecret.Password("p"))))
+
+        assertEquals(listOf("added:i1"), usage.events)
+    }
+
+    @Test
+    fun `deleting a secret forgets its usage`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+
+        controller.delete("gen")
+
+        assertEquals(listOf("added:gen", "forgot:gen"), usage.events)
+    }
+
+    @Test
+    fun `resolving a secret for a connection marks it used`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+        usage.events.clear()
+
+        assertEquals("Key", controller.useForConnect("gen")?.label)
+        assertEquals(listOf("used:gen"), usage.events)
+
+        // A host with no binding (or a dangling one) has nothing to mark.
+        assertNull(controller.useForConnect("missing"))
+        assertNull(controller.useForConnect(null))
+        assertEquals(listOf("used:gen"), usage.events)
+    }
+
+    @Test
+    fun `copying a secret is recorded against it`() {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+
+        controller.recordCopied("gen")
+
+        assertEquals(listOf("copied:gen"), usage.events)
+    }
+
+    @Test
+    fun `usage events run off the caller thread in the order they were submitted`() = runTest {
+        // The production lane: one thread, so a forget can't overtake a still-pending recordUsed and
+        // the in-memory mirror can't lose an update to a concurrent one.
+        @OptIn(ExperimentalCoroutinesApi::class)
+        val lane = Dispatchers.Default.limitedParallelism(1)
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(lane)) { "gen" }
+
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+        controller.useForConnect("gen")
+        controller.delete("gen")
+        // Barrier: the lane is FIFO, so once our own block runs everything queued before it is done.
+        withContext(lane) { }
+
+        assertEquals(listOf("added:gen", "used:gen", "forgot:gen"), usage.events)
+        assertNull(controller.usageOf("gen"))
+    }
+
+    @Test
+    fun `works without a usage log`() {
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+        controller.save(CredentialDraft(label = "Key", kind = CredentialKind.PASSWORD, password = "p"))
+
+        assertEquals("Key", controller.useForConnect("gen")?.label)
+        controller.recordCopied("gen")
+        controller.delete("gen")
+
+        assertEquals(emptyList(), controller.credentials)
+    }
+}
+
+/** Records what the controller reported, in order, so tests assert on the calls themselves. */
+private class FakeUsageLog : CredentialUsageLog {
+    val events = mutableListOf<String>()
+    private val entries = mutableMapOf<String, CredentialUsage>()
+
+    override fun of(credentialId: String): CredentialUsage? = entries[credentialId]
+    override fun all(): List<CredentialUsage> = entries.values.toList()
+
+    override fun recordAdded(credentialId: String): CredentialUsage {
+        events += "added:$credentialId"
+        return store(credentialId) { it.copy(addedAt = it.addedAt ?: "t") }
+    }
+
+    override fun recordChanged(credentialId: String): CredentialUsage {
+        events += "changed:$credentialId"
+        return store(credentialId) { it.copy(changedAt = "t") }
+    }
+
+    override fun recordUsed(credentialId: String): CredentialUsage {
+        events += "used:$credentialId"
+        return store(credentialId) { it.copy(lastUsedAt = "t") }
+    }
+
+    override fun recordCopied(credentialId: String): CredentialUsage {
+        events += "copied:$credentialId"
+        return store(credentialId) { it.copy(copiedAt = it.copiedAt + "t") }
+    }
+
+    override fun forget(credentialId: String) {
+        events += "forgot:$credentialId"
+        entries -= credentialId
+    }
+
+    override fun clear() {
+        events += "cleared"
+        entries.clear()
+    }
+
+    private fun store(id: String, edit: (CredentialUsage) -> CredentialUsage): CredentialUsage =
+        edit(entries[id] ?: CredentialUsage(id)).also { entries[id] = it }
 }
 
 /** In-memory [Vault] storing records (put/openPayload/records/remove, tombstone) for tests. */

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultPresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultPresentationTest.kt
@@ -5,6 +5,7 @@ import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import app.skerry.ui.theme.nightSeaColors
 
@@ -66,6 +67,15 @@ class VaultPresentationTest {
 
     // usedByLabel is now @Composable (plural string resource), so its string unit test was dropped;
     // the label resolves in composition.
+
+    @Test
+    fun `names the hosts a secret is bound to, and counts the rest`() {
+        assertEquals("web-01", VaultPresentation.hostNames(listOf("web-01"), max = 3))
+        assertEquals("web-01, web-02", VaultPresentation.hostNames(listOf("web-01", "web-02"), max = 3))
+        // Beyond the cap the row would not fit anyway: the remainder becomes a tail count.
+        assertEquals("a, b, c +2", VaultPresentation.hostNames(listOf("a", "b", "c", "d", "e"), max = 3))
+        assertNull(VaultPresentation.hostNames(emptyList(), max = 3))
+    }
 
     @Test
     fun `hostsUsing returns only hosts referencing the credential`() {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultUsagePresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultUsagePresentationTest.kt
@@ -1,0 +1,33 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.CredentialUsage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pure presentation over [CredentialUsage]: what the detail panel states as fact — how many
+ * copies of a secret fall inside the audit window. Read off real state, so it has to be honest at the
+ * edges (a timestamp the platform clock can't parse must not be counted as a copy).
+ */
+class VaultUsagePresentationTest {
+
+    // Stub "days ago" resolver: the tests speak in ISO strings shaped "d<N>" meaning N days back.
+    private val daysAgo: (String) -> Int? = { iso -> iso.removePrefix("d").toIntOrNull() }
+
+    @Test
+    fun `counts only copies inside the window`() {
+        val usage = CredentialUsage("c1", copiedAt = listOf("d0", "d3", "d29", "d31"))
+        assertEquals(3, VaultPresentation.copiesWithin(usage, days = 30, daysAgo = daysAgo))
+    }
+
+    @Test
+    fun `unparsable copy timestamps are not counted`() {
+        val usage = CredentialUsage("c1", copiedAt = listOf("d1", "garbage"))
+        assertEquals(1, VaultPresentation.copiesWithin(usage, days = 30, daysAgo = daysAgo))
+    }
+
+    @Test
+    fun `no usage means no copies`() {
+        assertEquals(0, VaultPresentation.copiesWithin(null, days = 30, daysAgo = daysAgo))
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -33,6 +33,7 @@ import app.skerry.shared.ssh.SshjCaKeyParser
 import app.skerry.shared.ssh.TofuHostKeyVerifier
 import app.skerry.shared.ssh.VaultTrustedCaStore
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
+import app.skerry.shared.vault.FileCredentialUsageLog
 import app.skerry.shared.vault.FileSecurityLog
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.CredentialStore
@@ -246,7 +247,15 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val workspaceLayout = WorkspaceLayoutStore(vault)
     // Flat vault model: keychain secrets are CREDENTIAL records; a host references a secret
     // directly via credentialId.
-    val credentials = CredentialManagerController(CredentialStore(vault, trash)) { UUID.randomUUID().toString() }
+    // Local (non-synced) usage trail behind the Vault panel's dates: when a secret was added, when it
+    // last authenticated, how often it was copied. Ids and timestamps only — hardened like the
+    // security log, since it is audit metadata about this device.
+    val credentialUsage = FileCredentialUsageLog(
+        dir.resolve("credential_usage.json").toString().toPath(),
+        FileSystem.SYSTEM,
+        harden = { PrivateConfig.harden(Path.of(it.toString())) },
+    ) { Instant.now().toString() }
+    val credentials = CredentialManagerController(CredentialStore(vault, trash), credentialUsage) { UUID.randomUUID().toString() }
     // Self-hosted sync: coordinator ties together the network client (Ktor+SRP), crypto, and the
     // local vault. The server binding persists to sync.json (0600): non-secret data
     // (URL/accountId/deviceId) plus an optional refresh token sealed under dataKey (keep-connected).
@@ -319,7 +328,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
     val tunnels = TunnelManager(
         store = VaultTunnelStore(vault, trash),
         transport = tunnelTransport,
-        resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::find) },
+        // useForConnect, not find: a tunnel authenticates with the secret every time it comes up,
+        // which is exactly what "last used" in the Vault panel reports.
+        resolve = { hostId -> resolveTunnelHost(hostId, findHost = hosts::find, findCredential = credentials::useForConnect) },
         scope = tunnelScope,
         scanTransport = probeTransport,
     ) { UUID.randomUUID().toString() }
@@ -410,6 +421,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         // The security log refers to the erased vault (password change/biometrics/pairing); on any
         // reset it becomes stale and could leak device names, so it's always cleared.
         securityLog.clear()
+        // Same for the usage trail: its ids point at secrets that no longer exist, and a new vault
+        // must not inherit dates from the erased one.
+        credentialUsage.clear()
         // The reset erased the dataKey, so the sealed sync refresh token is wrapped under a dead key.
         // Disconnects from the server, otherwise settings would show "Linked" with no way to log in.
         // (No biometrics on desktop: deps.biometrics=null.) Clean start: create a new vault and

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -62,6 +62,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` |
 | Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` |
 | A setting as a label + switch row | `ToggleRow` (optional second line); `SettingToggleRow` / `MobileSyncToggleRow` are its settings and sync scales and should converge onto it |
+| A fact as a label + value row in a detail panel | `KeyValueRow`; `InfoRow` (session info panel) and `CardRow` (tunnel dashboard) are the same shape and should converge onto it |
 | Chips | `Chip` (label, active/inactive) vs `ChipButton` (action chip: colour, outline/filled, enabled) — pick one, don't add a third |
 | Rules and separators | `HLine`, `VLine` |
 | Dropdowns and modals | `AnchoredDropdown`, `DropdownField`, `ModalScrim` |

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialUsage.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialUsage.kt
@@ -1,0 +1,151 @@
+package app.skerry.shared.vault
+
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okio.FileSystem
+import okio.Path
+
+/**
+ * What the app can honestly say about one keychain secret's life: when it was added
+ * ([addedAt] — first stamp wins, a later edit is not a second birth), when its material was last
+ * replaced ([changedAt] — a rotated password, a re-imported key; a rename is not a rotation), when
+ * it last authenticated a connection ([lastUsedAt]) and when it was copied to the clipboard
+ * ([copiedAt], oldest first).
+ *
+ * Timestamps are ISO-8601 strings from the app's clock, as in [SecurityEvent] — the UI turns them
+ * into "today 09:14" / "3 days ago" via [securityMoment]. A secret with no entry has never been
+ * touched since this log existed; the UI shows "—" rather than inventing a date.
+ */
+@Serializable
+data class CredentialUsage(
+    val credentialId: String,
+    val addedAt: String? = null,
+    val changedAt: String? = null,
+    val lastUsedAt: String? = null,
+    val copiedAt: List<String> = emptyList(),
+)
+
+/**
+ * Per-device usage trail for keychain secrets. Deliberately **not** synced and **not** stored in the
+ * vault: a copy on this laptop says nothing about the phone, and writing a record on every copy
+ * would push a new vault version (and a sync round) for an event that isn't account state.
+ *
+ * It holds secret ids and timestamps — never labels or material. Ids are already plaintext in the
+ * vault file's record metadata, so this file reveals no more than the vault does, but it is still
+ * audit metadata: implementations give the file private permissions (see [FileCredentialUsageLog]).
+ */
+interface CredentialUsageLog {
+    /** Usage of one secret, or `null` if nothing was ever recorded for it. */
+    fun of(credentialId: String): CredentialUsage?
+
+    /**
+     * Everything recorded so far, in one read. Callers hold the result in memory and re-read only
+     * after they change it — this is a file, and the UI asks for a secret's dates on every frame it
+     * draws the panel.
+     */
+    fun all(): List<CredentialUsage>
+
+    /**
+     * Stamp the moment a secret entered the keychain. Ignored if it already carries one. Returns the
+     * stored entry, so a caller keeping an in-memory copy doesn't have to read the file back.
+     */
+    fun recordAdded(credentialId: String): CredentialUsage
+
+    /** Stamp the moment a secret's material was replaced (rotation), overwriting the previous one. */
+    fun recordChanged(credentialId: String): CredentialUsage
+
+    /** Stamp the moment a secret authenticated a connection (overwrites the previous one). */
+    fun recordUsed(credentialId: String): CredentialUsage
+
+    /** Append a clipboard copy of the secret. */
+    fun recordCopied(credentialId: String): CredentialUsage
+
+    /** Drop everything known about a secret (it was deleted from the keychain). */
+    fun forget(credentialId: String)
+
+    /** Drop the whole log (vault reset). */
+    fun clear()
+}
+
+/**
+ * [CredentialUsageLog] over okio [FileSystem]: one JSON array of [CredentialUsage] entries, shared
+ * by desktop and Android (like [FileSecurityLog]). A corrupt or missing file reads as an empty log,
+ * so a damaged audit trail degrades to "nothing known" instead of blocking the keychain.
+ *
+ * Only the last [maxCopies] copies of a secret are kept — the panel counts copies inside a window,
+ * not since the beginning of time, and an unbounded list would grow with every clipboard action.
+ *
+ * Mutations are read-modify-write and are serialized with a multiplatform [SynchronizedObject]
+ * (like [FileSecurityLog]): copies are recorded from the UI coroutine while a connection being
+ * dialled in the background can stamp the same secret as used.
+ *
+ * [harden] sets private permissions (0600 on POSIX) on the temp file before the atomic move — see
+ * [atomicWriteUtf8]. Both platforms pass `PrivateConfig.harden`; the no-op default is for tests on
+ * `FakeFileSystem`.
+ */
+class FileCredentialUsageLog(
+    private val path: Path,
+    private val fileSystem: FileSystem,
+    private val maxCopies: Int = 64,
+    private val harden: (Path) -> Unit = {},
+    private val clock: () -> String,
+) : CredentialUsageLog {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val lock = SynchronizedObject()
+
+    override fun of(credentialId: String): CredentialUsage? = synchronized(lock) {
+        read().firstOrNull { it.credentialId == credentialId }
+    }
+
+    override fun all(): List<CredentialUsage> = synchronized(lock) { read() }
+
+    override fun recordAdded(credentialId: String): CredentialUsage = update(credentialId) { current ->
+        // First stamp wins: re-saving a secret (an edit, an import re-run) must not rewrite its age.
+        if (current.addedAt != null) current else current.copy(addedAt = clock())
+    }
+
+    override fun recordChanged(credentialId: String): CredentialUsage = update(credentialId) { it.copy(changedAt = clock()) }
+
+    override fun recordUsed(credentialId: String): CredentialUsage = update(credentialId) { it.copy(lastUsedAt = clock()) }
+
+    override fun recordCopied(credentialId: String): CredentialUsage = update(credentialId) {
+        it.copy(copiedAt = (it.copiedAt + clock()).takeLast(maxCopies))
+    }
+
+    override fun forget(credentialId: String): Unit = synchronized(lock) {
+        val entries = read()
+        if (entries.none { it.credentialId == credentialId }) return
+        write(entries.filterNot { it.credentialId == credentialId })
+    }
+
+    override fun clear(): Unit = synchronized(lock) {
+        if (fileSystem.exists(path)) fileSystem.delete(path)
+    }
+
+    /**
+     * Read-modify-write of one secret's entry, creating it if this is the first thing recorded.
+     * Returns the stored entry — unchanged when the edit was a no-op (a second "added"), in which
+     * case nothing is written.
+     */
+    private fun update(credentialId: String, edit: (CredentialUsage) -> CredentialUsage): CredentialUsage =
+        synchronized(lock) {
+            val entries = read()
+            val current = entries.firstOrNull { it.credentialId == credentialId } ?: CredentialUsage(credentialId)
+            val updated = edit(current)
+            if (updated == current && entries.contains(current)) return updated
+            write(entries.filterNot { it.credentialId == credentialId } + updated)
+            updated
+        }
+
+    /** Any error (missing file / corrupt JSON) reads as an empty log. */
+    private fun read(): List<CredentialUsage> = runCatching {
+        if (!fileSystem.exists(path)) return emptyList()
+        json.decodeFromString<List<CredentialUsage>>(fileSystem.read(path) { readUtf8() })
+    }.getOrDefault(emptyList())
+
+    private fun write(entries: List<CredentialUsage>) {
+        atomicWriteUtf8(fileSystem, path, json.encodeToString(entries), harden)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/IonspinVaultCrypto.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/IonspinVaultCrypto.kt
@@ -269,7 +269,9 @@ class IonspinVaultCrypto : VaultCrypto {
         // literal for a named preset would silently change the strength. Parallelism p from the
         // cryptoPwHash spec is fixed at 1 — a libsodium limitation shared by all platforms.
         const val OPS_LIMIT = 3UL                     // t = 3 iterations
-        const val MEM_LIMIT: Int = 64 * 1024 * 1024   // m = 64 MiB (explicit Int: guards against overflow)
+        // m = 64 MiB, taken from the published constant so the UI can state it (explicit Int
+        // arithmetic: guards against overflow).
+        const val MEM_LIMIT: Int = VaultCrypto.KDF_MEMORY_MIB * 1024 * 1024
 
         // Domain AAD for the dataKey wrapper: separates it from records (sealed with a slot AAD) so
         // the wrapper can't be substituted for a record or vice versa even if keys match.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultCrypto.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultCrypto.kt
@@ -50,6 +50,14 @@ interface VaultCrypto {
     companion object {
         /** Empty AAD — no slot binding; the getter returns a fresh array (no shared mutable state). */
         val EMPTY_AAD: ByteArray get() = ByteArray(0)
+
+        /**
+         * Memory cost of the Argon2id master-key derivation, in MiB. A strength parameter of the
+         * implementation, published here for the one place that legitimately reports it — the Vault
+         * panel, which states how the secrets on screen are protected. The implementation derives its
+         * own limit from this constant, so the number the UI shows can't drift from the one in use.
+         */
+        const val KDF_MEMORY_MIB: Int = 64
     }
 
     /** New random salt for master-key derivation (length required by Argon2id). */

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileCredentialUsageLogTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileCredentialUsageLogTest.kt
@@ -1,0 +1,149 @@
+package app.skerry.shared.vault
+
+import okio.Path.Companion.toPath
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * [FileCredentialUsageLog] over [FakeFileSystem] (like [FileSecurityLogTest]): what the vault can
+ * honestly say about a secret's life — when it was added, when it last authenticated, how often it
+ * was copied. Covers the first-write-wins rule for "added", the copy cap, forgetting a deleted
+ * secret, and survival across restart.
+ */
+class FileCredentialUsageLogTest {
+    private val fs = FakeFileSystem()
+    private val path = "/cfg/credential_usage.json".toPath()
+
+    // Controlled clock: the test sets timestamps itself so ordering stays deterministic.
+    private var clock = 0L
+    private fun log(maxCopies: Int = 64) =
+        FileCredentialUsageLog(path, fs, maxCopies = maxCopies) { "2026-01-01T00:00:${clock.toString().padStart(2, '0')}Z" }
+
+    @AfterTest
+    fun tearDown() = fs.checkNoOpenFiles()
+
+    @Test
+    fun unknownCredentialHasNoUsage() {
+        assertNull(log().of("cred-1"))
+    }
+
+    @Test
+    fun addedIsStampedOnceAndNeverMoves() {
+        val l = log()
+        clock = 1
+        l.recordAdded("cred-1")
+        // A second "added" (import re-running, a save over the same id) must not rewrite history.
+        clock = 9
+        l.recordAdded("cred-1")
+        assertTrue(l.of("cred-1")!!.addedAt!!.endsWith(":01Z"))
+    }
+
+    @Test
+    fun lastUsedTracksTheNewestConnection() {
+        val l = log()
+        clock = 1
+        l.recordUsed("cred-1")
+        clock = 4
+        l.recordUsed("cred-1")
+        assertTrue(l.of("cred-1")!!.lastUsedAt!!.endsWith(":04Z"))
+        assertNull(l.of("cred-1")!!.addedAt)
+    }
+
+    @Test
+    fun changedTracksTheNewestRotation() {
+        val l = log()
+        clock = 3
+        l.recordChanged("cred-1")
+        clock = 8
+        l.recordChanged("cred-1")
+        assertTrue(l.of("cred-1")!!.changedAt!!.endsWith(":08Z"))
+        // Rotating the material is not the moment the secret was added.
+        assertNull(l.of("cred-1")!!.addedAt)
+    }
+
+    @Test
+    fun copiesAccumulateNewestLast() {
+        val l = log()
+        clock = 2
+        l.recordCopied("cred-1")
+        clock = 5
+        l.recordCopied("cred-1")
+        val copies = l.of("cred-1")!!.copiedAt
+        assertEquals(2, copies.size)
+        assertTrue(copies.last().endsWith(":05Z"))
+    }
+
+    @Test
+    fun copyCapDropsOldest() {
+        val l = log(maxCopies = 3)
+        repeat(5) { clock = it.toLong(); l.recordCopied("cred-1") }
+        val copies = l.of("cred-1")!!.copiedAt
+        assertEquals(3, copies.size)
+        assertTrue(copies.first().endsWith(":02Z"))
+        assertTrue(copies.last().endsWith(":04Z"))
+    }
+
+    @Test
+    fun usageIsPerCredential() {
+        val l = log()
+        clock = 1
+        l.recordAdded("cred-1")
+        clock = 2
+        l.recordAdded("cred-2")
+        l.recordCopied("cred-2")
+        assertTrue(l.of("cred-1")!!.copiedAt.isEmpty())
+        assertEquals(1, l.of("cred-2")!!.copiedAt.size)
+    }
+
+    @Test
+    fun forgetDropsOnlyThatCredential() {
+        val l = log()
+        clock = 1
+        l.recordAdded("cred-1")
+        l.recordAdded("cred-2")
+        l.forget("cred-1")
+        assertNull(l.of("cred-1"))
+        assertTrue(l.of("cred-2") != null)
+    }
+
+    @Test
+    fun persistsAcrossInstances() {
+        clock = 7
+        log().recordUsed("cred-1")
+        assertTrue(log().of("cred-1")!!.lastUsedAt!!.endsWith(":07Z"))
+    }
+
+    @Test
+    fun clearEmptiesTheLog() {
+        val l = log()
+        clock = 1
+        l.recordAdded("cred-1")
+        l.clear()
+        assertNull(l.of("cred-1"))
+    }
+
+    @Test
+    fun hardensFileBeforeMove() {
+        // Which secret was used and when is audit metadata: the file gets private permissions on the
+        // temp copy, before atomicMove, so the target never exists with umask-default permissions.
+        val hardened = mutableListOf<String>()
+        val l = FileCredentialUsageLog(path, fs, harden = { hardened += it.name }) { "2026-01-01T00:00:00Z" }
+        l.recordAdded("cred-1")
+        assertEquals(listOf("${path.name}.tmp"), hardened)
+    }
+
+    @Test
+    fun corruptFileReadsAsEmpty() {
+        fs.createDirectories(path.parent!!)
+        fs.write(path) { writeUtf8("{ not json") }
+        val l = log()
+        assertNull(l.of("cred-1"))
+        clock = 1
+        l.recordAdded("cred-1")
+        assertTrue(l.of("cred-1") != null)
+    }
+}


### PR DESCRIPTION
The Vault section follows the app mockup.

**Secret list.** Dense rows instead of cards, separated by a hairline, with a teal edge on the
selected one. Each row states what the secret is: algorithm and fingerprint for a key, rotation
date for a password, validity for a certificate, the path for a file-backed one — then the hosts
that depend on it (up to three names, then `+N`). The type word is absent by design: the glyph and
the sidebar category already carry it, and a password's length is not shown at all.

**Detail panel.** The selected secret as a column of facts — type, fingerprint, whether a
passphrase guards it, when it was added, changed and last used — followed by its public material,
what uses it, and how it is protected: cipher, Argon2id memory cost (read from the same constant the
derivation uses, so the two cannot drift), and whether the ciphertext reaches a server at all. For
passwords only, an audit line counts clipboard copies inside a 30-day window; a key or certificate
hands over its public half, which is not worth auditing.

**Usage log.** A new per-device file next to the security event log: credential ids and timestamps,
never labels or secret material, written with private permissions, not synced and not stored in the
vault. It records when a secret was added, when its material was replaced, when it authenticated a
connection and when a password was copied. It is cleared when the secret is deleted and when the
vault is reset. Every path that turns a host binding into an `SshAuth` — sessions, jump chains,
tunnels, RDP, VNC, the new-connection form — records the use, so a key reached only through a
bastion no longer reads as never used. Writes leave the caller's thread on a single-threaded lane,
so a click, a connect or an import never waits on the file and the events keep their order.

**Android.** Same rows and the same fact blocks in the detail sheet; the category pills stay. The
static "end-to-end encrypted" banner is replaced by the live summary line.

Verify: open Vault, select secrets of each type, copy a password twice and reopen the panel, rename
a secret (must not read as a rotation), change a password (must), delete a secret and check the
dates are gone. Not verified on a physical Android device.