### PR TITLE
feat(mobile): configurable terminal header auto-hide delay + header position (top/bottom)

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -49,6 +49,7 @@ import app.skerry.shared.vault.VaultBiometrics
 import app.skerry.shared.vault.initializeVaultCrypto
 import app.skerry.ui.AppDependencies
 import app.skerry.ui.ai.LocalAiDeps
+import app.skerry.ui.mobile.HeaderAutoHideDelay
 import app.skerry.ui.mobile.MobileDesignApp
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.secure.WindowBridge
@@ -191,6 +192,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalScrollbackChange = { writeTerminalScrollback(dir, it) },
                     initialTerminalCursorStyle = readTerminalCursorStyle(dir),
                     onTerminalCursorStyleChange = { writeTerminalCursorStyle(dir, it) },
+                    initialHeaderAutoHide = readHeaderAutoHide(dir),
+                    onHeaderAutoHideChange = { writeHeaderAutoHide(dir, it) },
                     initialTerminalTheme = readTerminalTheme(dir),
                     onTerminalThemeChange = { writeTerminalTheme(dir, it) },
                     initialCustomTerminalTheme = readCustomTerminalTheme(dir),
@@ -378,6 +381,21 @@ class MainActivity : FragmentActivity() {
         val id = style.id
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_cursor_style").writeText(id) }
+        }
+    }
+
+    /**
+     * Mobile terminal header auto-hide delay (More → Appearance → Terminal): stable id
+     * ([HeaderAutoHideDelay.id]) in `header_auto_hide`. Missing/unreadable/unknown →
+     * [HeaderAutoHideDelay.DEFAULT] (header always visible). Write is best-effort, off the UI thread.
+     */
+    private fun readHeaderAutoHide(dir: File): HeaderAutoHideDelay =
+        HeaderAutoHideDelay.fromId(runCatching { File(dir, "header_auto_hide").readText().trim() }.getOrNull())
+
+    private fun writeHeaderAutoHide(dir: File, delay: HeaderAutoHideDelay) {
+        val id = delay.id
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "header_auto_hide").writeText(id) }
         }
     }
 

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -50,6 +50,7 @@ import app.skerry.shared.vault.initializeVaultCrypto
 import app.skerry.ui.AppDependencies
 import app.skerry.ui.ai.LocalAiDeps
 import app.skerry.ui.mobile.HeaderAutoHideDelay
+import app.skerry.ui.mobile.HeaderPosition
 import app.skerry.ui.mobile.MobileDesignApp
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.secure.WindowBridge
@@ -194,6 +195,8 @@ class MainActivity : FragmentActivity() {
                     onTerminalCursorStyleChange = { writeTerminalCursorStyle(dir, it) },
                     initialHeaderAutoHide = readHeaderAutoHide(dir),
                     onHeaderAutoHideChange = { writeHeaderAutoHide(dir, it) },
+                    initialHeaderPosition = readHeaderPosition(dir),
+                    onHeaderPositionChange = { writeHeaderPosition(dir, it) },
                     initialTerminalTheme = readTerminalTheme(dir),
                     onTerminalThemeChange = { writeTerminalTheme(dir, it) },
                     initialCustomTerminalTheme = readCustomTerminalTheme(dir),
@@ -396,6 +399,16 @@ class MainActivity : FragmentActivity() {
         val id = delay.id
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "header_auto_hide").writeText(id) }
+        }
+    }
+
+    private fun readHeaderPosition(dir: File): HeaderPosition =
+        HeaderPosition.fromId(runCatching { File(dir, "header_position").readText().trim() }.getOrNull())
+
+    private fun writeHeaderPosition(dir: File, position: HeaderPosition) {
+        val id = position.id
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "header_position").writeText(id) }
         }
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -83,6 +83,9 @@
     <string name="settings_terminal_header_auto_hide_15s">15 секунд</string>
     <string name="settings_terminal_header_auto_hide_30s">30 секунд</string>
     <string name="settings_terminal_header_auto_hide_60s">60 секунд</string>
+    <string name="settings_terminal_header_position">Положение заголовка терминала</string>
+    <string name="settings_terminal_header_position_top">Сверху</string>
+    <string name="settings_terminal_header_position_bottom">Снизу</string>
     <string name="settings_terminal_cursor_block_blink">Блок (мигающий)</string>
     <string name="settings_terminal_cursor_block_steady">Блок</string>
     <string name="settings_terminal_cursor_underline_blink">Подчёркивание (мигающее)</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -75,6 +75,14 @@
     <string name="settings_terminal_scrollback">Буфер прокрутки</string>
     <string name="settings_terminal_scrollback_desc">Строк на сессию.</string>
     <string name="settings_terminal_cursor_style">Стиль курсора</string>
+    <string name="settings_terminal_header_auto_hide">Автоскрытие заголовка</string>
+    <string name="settings_terminal_header_auto_hide_never">Не скрывать</string>
+    <string name="settings_terminal_header_auto_hide_3s">3 секунды</string>
+    <string name="settings_terminal_header_auto_hide_5s">5 секунд</string>
+    <string name="settings_terminal_header_auto_hide_10s">10 секунд</string>
+    <string name="settings_terminal_header_auto_hide_15s">15 секунд</string>
+    <string name="settings_terminal_header_auto_hide_30s">30 секунд</string>
+    <string name="settings_terminal_header_auto_hide_60s">60 секунд</string>
     <string name="settings_terminal_cursor_block_blink">Блок (мигающий)</string>
     <string name="settings_terminal_cursor_block_steady">Блок</string>
     <string name="settings_terminal_cursor_underline_blink">Подчёркивание (мигающее)</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -75,7 +75,7 @@
     <string name="settings_terminal_scrollback">Буфер прокрутки</string>
     <string name="settings_terminal_scrollback_desc">Строк на сессию.</string>
     <string name="settings_terminal_cursor_style">Стиль курсора</string>
-    <string name="settings_terminal_header_auto_hide">Автоскрытие заголовка</string>
+    <string name="settings_terminal_header_auto_hide">Автоскрытие заголовка терминала</string>
     <string name="settings_terminal_header_auto_hide_never">Не скрывать</string>
     <string name="settings_terminal_header_auto_hide_3s">3 секунды</string>
     <string name="settings_terminal_header_auto_hide_5s">5 секунд</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -75,7 +75,7 @@
     <string name="settings_terminal_scrollback">滚动缓冲</string>
     <string name="settings_terminal_scrollback_desc">每个会话保留的行数。</string>
     <string name="settings_terminal_cursor_style">光标样式</string>
-    <string name="settings_terminal_header_auto_hide">顶栏自动隐藏</string>
+    <string name="settings_terminal_header_auto_hide">终端顶栏自动隐藏</string>
     <string name="settings_terminal_header_auto_hide_never">永不隐藏</string>
     <string name="settings_terminal_header_auto_hide_3s">3 秒</string>
     <string name="settings_terminal_header_auto_hide_5s">5 秒</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -75,6 +75,14 @@
     <string name="settings_terminal_scrollback">滚动缓冲</string>
     <string name="settings_terminal_scrollback_desc">每个会话保留的行数。</string>
     <string name="settings_terminal_cursor_style">光标样式</string>
+    <string name="settings_terminal_header_auto_hide">顶栏自动隐藏</string>
+    <string name="settings_terminal_header_auto_hide_never">永不隐藏</string>
+    <string name="settings_terminal_header_auto_hide_3s">3 秒</string>
+    <string name="settings_terminal_header_auto_hide_5s">5 秒</string>
+    <string name="settings_terminal_header_auto_hide_10s">10 秒</string>
+    <string name="settings_terminal_header_auto_hide_15s">15 秒</string>
+    <string name="settings_terminal_header_auto_hide_30s">30 秒</string>
+    <string name="settings_terminal_header_auto_hide_60s">60 秒</string>
     <string name="settings_terminal_cursor_block_blink">方块（闪烁）</string>
     <string name="settings_terminal_cursor_block_steady">方块</string>
     <string name="settings_terminal_cursor_underline_blink">下划线（闪烁）</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -75,7 +75,7 @@
     <string name="settings_terminal_scrollback">滚动缓冲</string>
     <string name="settings_terminal_scrollback_desc">每个会话保留的行数。</string>
     <string name="settings_terminal_cursor_style">光标样式</string>
-    <string name="settings_terminal_header_auto_hide">终端顶栏自动隐藏</string>
+    <string name="settings_terminal_header_auto_hide">终端状态栏自动隐藏</string>
     <string name="settings_terminal_header_auto_hide_never">永不隐藏</string>
     <string name="settings_terminal_header_auto_hide_3s">3 秒</string>
     <string name="settings_terminal_header_auto_hide_5s">5 秒</string>
@@ -83,7 +83,7 @@
     <string name="settings_terminal_header_auto_hide_15s">15 秒</string>
     <string name="settings_terminal_header_auto_hide_30s">30 秒</string>
     <string name="settings_terminal_header_auto_hide_60s">60 秒</string>
-    <string name="settings_terminal_header_position">终端顶栏位置</string>
+    <string name="settings_terminal_header_position">终端状态栏位置</string>
     <string name="settings_terminal_header_position_top">顶部</string>
     <string name="settings_terminal_header_position_bottom">底部</string>
     <string name="settings_terminal_cursor_block_blink">方块（闪烁）</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -83,6 +83,9 @@
     <string name="settings_terminal_header_auto_hide_15s">15 秒</string>
     <string name="settings_terminal_header_auto_hide_30s">30 秒</string>
     <string name="settings_terminal_header_auto_hide_60s">60 秒</string>
+    <string name="settings_terminal_header_position">终端顶栏位置</string>
+    <string name="settings_terminal_header_position_top">顶部</string>
+    <string name="settings_terminal_header_position_bottom">底部</string>
     <string name="settings_terminal_cursor_block_blink">方块（闪烁）</string>
     <string name="settings_terminal_cursor_block_steady">方块</string>
     <string name="settings_terminal_cursor_underline_blink">下划线（闪烁）</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -75,6 +75,14 @@
     <string name="settings_terminal_scrollback">Scrollback buffer</string>
     <string name="settings_terminal_scrollback_desc">Lines kept per session.</string>
     <string name="settings_terminal_cursor_style">Cursor style</string>
+    <string name="settings_terminal_header_auto_hide">Header auto-hide</string>
+    <string name="settings_terminal_header_auto_hide_never">Never hide</string>
+    <string name="settings_terminal_header_auto_hide_3s">3 seconds</string>
+    <string name="settings_terminal_header_auto_hide_5s">5 seconds</string>
+    <string name="settings_terminal_header_auto_hide_10s">10 seconds</string>
+    <string name="settings_terminal_header_auto_hide_15s">15 seconds</string>
+    <string name="settings_terminal_header_auto_hide_30s">30 seconds</string>
+    <string name="settings_terminal_header_auto_hide_60s">60 seconds</string>
     <string name="settings_terminal_cursor_block_blink">Block (blink)</string>
     <string name="settings_terminal_cursor_block_steady">Block</string>
     <string name="settings_terminal_cursor_underline_blink">Underline (blink)</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -83,6 +83,9 @@
     <string name="settings_terminal_header_auto_hide_15s">15 seconds</string>
     <string name="settings_terminal_header_auto_hide_30s">30 seconds</string>
     <string name="settings_terminal_header_auto_hide_60s">60 seconds</string>
+    <string name="settings_terminal_header_position">Terminal header position</string>
+    <string name="settings_terminal_header_position_top">Top</string>
+    <string name="settings_terminal_header_position_bottom">Bottom</string>
     <string name="settings_terminal_cursor_block_blink">Block (blink)</string>
     <string name="settings_terminal_cursor_block_steady">Block</string>
     <string name="settings_terminal_cursor_underline_blink">Underline (blink)</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -75,7 +75,7 @@
     <string name="settings_terminal_scrollback">Scrollback buffer</string>
     <string name="settings_terminal_scrollback_desc">Lines kept per session.</string>
     <string name="settings_terminal_cursor_style">Cursor style</string>
-    <string name="settings_terminal_header_auto_hide">Header auto-hide</string>
+    <string name="settings_terminal_header_auto_hide">Terminal header auto-hide</string>
     <string name="settings_terminal_header_auto_hide_never">Never hide</string>
     <string name="settings_terminal_header_auto_hide_3s">3 seconds</string>
     <string name="settings_terminal_header_auto_hide_5s">5 seconds</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -17,6 +17,7 @@ import app.skerry.ui.terminal.clampTerminalLetterSpacing
 import app.skerry.ui.terminal.clampTerminalLineHeight
 import app.skerry.ui.i18n.UiLanguage
 import app.skerry.ui.session.BroadcastController
+import app.skerry.ui.mobile.HeaderAutoHideDelay
 import app.skerry.ui.snippet.SnippetLibraryState
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.shared.terminal.Asciicast
@@ -142,6 +143,10 @@ class MobileDesignState(
     private val onTerminalScrollbackChange: (Int) -> Unit = {},
     initialTerminalCursorStyle: TerminalCursorStyle = TerminalCursorStyle.DEFAULT,
     private val onTerminalCursorStyleChange: (TerminalCursorStyle) -> Unit = {},
+    // Mobile terminal header auto-hide (More -> Appearance -> Terminal). Initial value from
+    // persistence, callback writes back. Never = header always visible (default).
+    initialHeaderAutoHide: HeaderAutoHideDelay = HeaderAutoHideDelay.DEFAULT,
+    private val onHeaderAutoHideChange: (HeaderAutoHideDelay) -> Unit = {},
 ) {
     var tab: MobileTab by mutableStateOf(MobileTab.Hosts); private set
 
@@ -372,6 +377,12 @@ class MobileDesignState(
     /** Default cursor style (More -> Appearance -> Terminal). Applies to new sessions. */
     var terminalCursorStyle: TerminalCursorStyle by mutableStateOf(initialTerminalCursorStyle); private set
 
+    /**
+     * How long the mobile terminal's header stays before auto-hiding (More -> Appearance ->
+     * Terminal). [HeaderAutoHideDelay.Never] keeps it permanently visible. Persisted per device.
+     */
+    var headerAutoHide: HeaderAutoHideDelay by mutableStateOf(initialHeaderAutoHide); private set
+
     /** Choose the auto-lock threshold and report outward (for persistence). Repeating the same value is a no-op. */
     fun chooseAutoLock(duration: AutoLockDuration) {
         if (duration == autoLock) return
@@ -479,5 +490,12 @@ class MobileDesignState(
         if (style == terminalCursorStyle) return
         terminalCursorStyle = style
         onTerminalCursorStyleChange(style)
+    }
+
+    /** Choose the mobile terminal header auto-hide delay and report outward (for persistence). */
+    fun chooseHeaderAutoHide(delay: HeaderAutoHideDelay) {
+        if (delay == headerAutoHide) return
+        headerAutoHide = delay
+        onHeaderAutoHideChange(delay)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -18,6 +18,7 @@ import app.skerry.ui.terminal.clampTerminalLineHeight
 import app.skerry.ui.i18n.UiLanguage
 import app.skerry.ui.session.BroadcastController
 import app.skerry.ui.mobile.HeaderAutoHideDelay
+import app.skerry.ui.mobile.HeaderPosition
 import app.skerry.ui.snippet.SnippetLibraryState
 import app.skerry.ui.vault.AutoLockDuration
 import app.skerry.shared.terminal.Asciicast
@@ -147,6 +148,8 @@ class MobileDesignState(
     // persistence, callback writes back. Never = header always visible (default).
     initialHeaderAutoHide: HeaderAutoHideDelay = HeaderAutoHideDelay.DEFAULT,
     private val onHeaderAutoHideChange: (HeaderAutoHideDelay) -> Unit = {},
+    initialHeaderPosition: HeaderPosition = HeaderPosition.DEFAULT,
+    private val onHeaderPositionChange: (HeaderPosition) -> Unit = {},
 ) {
     var tab: MobileTab by mutableStateOf(MobileTab.Hosts); private set
 
@@ -383,6 +386,12 @@ class MobileDesignState(
      */
     var headerAutoHide: HeaderAutoHideDelay by mutableStateOf(initialHeaderAutoHide); private set
 
+    /**
+     * Where the mobile terminal's header sits (More -> Appearance -> Terminal). [HeaderPosition.Bottom]
+     * moves it below the key bar for punch-hole/notch phones. Persisted per device.
+     */
+    var headerPosition: HeaderPosition by mutableStateOf(initialHeaderPosition); private set
+
     /** Choose the auto-lock threshold and report outward (for persistence). Repeating the same value is a no-op. */
     fun chooseAutoLock(duration: AutoLockDuration) {
         if (duration == autoLock) return
@@ -497,5 +506,12 @@ class MobileDesignState(
         if (delay == headerAutoHide) return
         headerAutoHide = delay
         onHeaderAutoHideChange(delay)
+    }
+
+    /** Choose where the mobile terminal header sits and report outward (for persistence). */
+    fun chooseHeaderPosition(position: HeaderPosition) {
+        if (position == headerPosition) return
+        headerPosition = position
+        onHeaderPositionChange(position)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderAutoHide.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderAutoHide.kt
@@ -15,8 +15,8 @@ enum class HeaderAutoHideDelay(val id: String, val hideAfterMs: Long?) {
     SixtySeconds("60s", 60_000L);
 
     companion object {
-        /** Default: keep the header visible (no auto-hide). */
-        val DEFAULT: HeaderAutoHideDelay = Never
+        /** Default: auto-hide after 3 seconds (the pre-setting behaviour). */
+        val DEFAULT: HeaderAutoHideDelay = ThreeSeconds
 
         /** Parses a stable [id] from storage; unknown/blank falls back to [DEFAULT]. */
         fun fromId(id: String?): HeaderAutoHideDelay = entries.firstOrNull { it.id == id } ?: DEFAULT

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderAutoHide.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderAutoHide.kt
@@ -1,0 +1,24 @@
+package app.skerry.ui.mobile
+
+/**
+ * How long the mobile terminal's session header stays visible before it auto-hides
+ * (More → Appearance → Terminal → Header auto-hide). [Never] keeps it permanently
+ * visible — the swipe-down reveal exists but a permanently shown header needs no gesture.
+ */
+enum class HeaderAutoHideDelay(val id: String, val hideAfterMs: Long?) {
+    Never("never", null),
+    ThreeSeconds("3s", 3_000L),
+    FiveSeconds("5s", 5_000L),
+    TenSeconds("10s", 10_000L),
+    FifteenSeconds("15s", 15_000L),
+    ThirtySeconds("30s", 30_000L),
+    SixtySeconds("60s", 60_000L);
+
+    companion object {
+        /** Default: keep the header visible (no auto-hide). */
+        val DEFAULT: HeaderAutoHideDelay = Never
+
+        /** Parses a stable [id] from storage; unknown/blank falls back to [DEFAULT]. */
+        fun fromId(id: String?): HeaderAutoHideDelay = entries.firstOrNull { it.id == id } ?: DEFAULT
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderPosition.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/HeaderPosition.kt
@@ -1,0 +1,20 @@
+package app.skerry.ui.mobile
+
+/**
+ * Where the mobile terminal's session header sits (More → Appearance → Terminal → Header
+ * position). [Top] is the default — the upstream layout; [Bottom] moves the status bar to the
+ * bottom edge for phones whose punch-hole/notch cuts off the top of the screen. Persisted per
+ * device, like the other appearance settings.
+ */
+enum class HeaderPosition(val id: String) {
+    Top("top"),
+    Bottom("bottom");
+
+    companion object {
+        /** Default: keep the header at the top (upstream layout). */
+        val DEFAULT: HeaderPosition = Top
+
+        /** Parses a stable [id] from storage; unknown/blank falls back to [DEFAULT]. */
+        fun fromId(id: String?): HeaderPosition = entries.firstOrNull { it.id == id } ?: DEFAULT
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -67,6 +67,14 @@ import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc_mobil
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_never
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_3s
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_5s
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_10s
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_15s
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_30s
+import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_60s
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.appearance_title
 import app.skerry.ui.generated.resources.lib_snippets_screen_title
@@ -620,6 +628,10 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
             FontSettingRow(stringResource(Res.string.settings_terminal_cursor_style)) {
                 MobileCursorStylePicker(state.terminalCursorStyle, onPick = state::chooseTerminalCursorStyle)
             }
+            HLine()
+            FontSettingRow(stringResource(Res.string.settings_terminal_header_auto_hide)) {
+                MobileHeaderAutoHidePicker(state.headerAutoHide, onPick = state::chooseHeaderAutoHide)
+            }
             // Clickable file paths in output (desktop parity): here the affordance is a chip over a
             // selected path rather than Ctrl+click, and this switch governs both.
             HLine()
@@ -896,6 +908,38 @@ private fun MobileCursorStylePicker(current: TerminalCursorStyle, onPick: (Termi
         },
     )
 }
+
+/** Header auto-hide delay dropdown ([HeaderAutoHideDelay.entries]; "Never hide" keeps it visible). */
+@Composable
+private fun MobileHeaderAutoHidePicker(current: HeaderAutoHideDelay, onPick: (HeaderAutoHideDelay) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { MobileSelectTrigger(current.headerAutoHideLabel(), onClick = { open = !open }) },
+        menu = { width ->
+            MobileDropdownMenu(width) {
+                HeaderAutoHideDelay.entries.forEach { option ->
+                    MobileDropdownOption(option.headerAutoHideLabel(), selected = option == current) { onPick(option); open = false }
+                }
+            }
+        },
+    )
+}
+
+/** Localized header auto-hide label. */
+@Composable
+internal fun HeaderAutoHideDelay.headerAutoHideLabel(): String = stringResource(
+    when (this) {
+        HeaderAutoHideDelay.Never -> Res.string.settings_terminal_header_auto_hide_never
+        HeaderAutoHideDelay.ThreeSeconds -> Res.string.settings_terminal_header_auto_hide_3s
+        HeaderAutoHideDelay.FiveSeconds -> Res.string.settings_terminal_header_auto_hide_5s
+        HeaderAutoHideDelay.TenSeconds -> Res.string.settings_terminal_header_auto_hide_10s
+        HeaderAutoHideDelay.FifteenSeconds -> Res.string.settings_terminal_header_auto_hide_15s
+        HeaderAutoHideDelay.ThirtySeconds -> Res.string.settings_terminal_header_auto_hide_30s
+        HeaderAutoHideDelay.SixtySeconds -> Res.string.settings_terminal_header_auto_hide_60s
+    },
+)
 
 /** Setting row with a stepper (mobile): label + default-value hint on the left, [NumberStepper] on the right. */
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -75,6 +75,9 @@ import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_10s
 import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_15s
 import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_30s
 import app.skerry.ui.generated.resources.settings_terminal_header_auto_hide_60s
+import app.skerry.ui.generated.resources.settings_terminal_header_position
+import app.skerry.ui.generated.resources.settings_terminal_header_position_top
+import app.skerry.ui.generated.resources.settings_terminal_header_position_bottom
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
 import app.skerry.ui.generated.resources.appearance_title
 import app.skerry.ui.generated.resources.lib_snippets_screen_title
@@ -632,6 +635,11 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
             FontSettingRow(stringResource(Res.string.settings_terminal_header_auto_hide)) {
                 MobileHeaderAutoHidePicker(state.headerAutoHide, onPick = state::chooseHeaderAutoHide)
             }
+            // Header position (top/bottom): bottom sidesteps punch-hole/notch phones that clip the top.
+            HLine()
+            FontSettingRow(stringResource(Res.string.settings_terminal_header_position)) {
+                MobileHeaderPositionPicker(state.headerPosition, onPick = state::chooseHeaderPosition)
+            }
             // Clickable file paths in output (desktop parity): here the affordance is a chip over a
             // selected path rather than Ctrl+click, and this switch governs both.
             HLine()
@@ -938,6 +946,33 @@ internal fun HeaderAutoHideDelay.headerAutoHideLabel(): String = stringResource(
         HeaderAutoHideDelay.FifteenSeconds -> Res.string.settings_terminal_header_auto_hide_15s
         HeaderAutoHideDelay.ThirtySeconds -> Res.string.settings_terminal_header_auto_hide_30s
         HeaderAutoHideDelay.SixtySeconds -> Res.string.settings_terminal_header_auto_hide_60s
+    },
+)
+
+/** Header position dropdown ([HeaderPosition.entries]): top = upstream layout, bottom = punch-hole safe. */
+@Composable
+private fun MobileHeaderPositionPicker(current: HeaderPosition, onPick: (HeaderPosition) -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { MobileSelectTrigger(current.headerPositionLabel(), onClick = { open = !open }) },
+        menu = { width ->
+            MobileDropdownMenu(width) {
+                HeaderPosition.entries.forEach { option ->
+                    MobileDropdownOption(option.headerPositionLabel(), selected = option == current) { onPick(option); open = false }
+                }
+            }
+        },
+    )
+}
+
+/** Localized header position label. */
+@Composable
+internal fun HeaderPosition.headerPositionLabel(): String = stringResource(
+    when (this) {
+        HeaderPosition.Top -> Res.string.settings_terminal_header_position_top
+        HeaderPosition.Bottom -> Res.string.settings_terminal_header_position_bottom
     },
 )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -314,31 +314,67 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                 is ConnectionUiState.Disconnected ->
                     TerminalScreen(st.terminal, Modifier.weight(1f).fillMaxWidth())
             }
+            // Bottom position: the header joins the layout flow below the key bar (it never covers
+            // the key bar this way), sliding up from the bottom edge. It also gets a swipe-up strip
+            // at the bottom edge to bring it back when hidden.
+            if (state.headerPosition == HeaderPosition.Bottom) {
+                AnimatedVisibility(
+                    visible = headerVisible,
+                    enter = slideInVertically { it },
+                    exit = slideOutVertically { it },
+                ) {
+                    MobileTerminalHeader(
+                        title = active?.displayTitle ?: stringResource(Res.string.term_mobile_title_fallback),
+                        status = active?.controller?.uiState,
+                        controller = active?.controller,
+                        onBack = state::pop,
+                        onMenu = { menuOpen = true },
+                        onSnippets = if (canRunSnippet) ({ paletteOpen = true }) else null,
+                    )
+                }
+            }
         }
-        // Swipe down near the top brings the header back. Starts below the edge: a swipe from the very
-        // edge is the system's own gesture for restoring the hidden bars and never reaches us.
-        Box(
-            Modifier.align(Alignment.TopCenter).fillMaxWidth()
-                .padding(top = SYSTEM_EDGE_GESTURE).height(TOP_EDGE_STRIP)
-                .pointerInput(Unit) {
-                    detectVerticalDragGestures { _, dy ->
-                        if (dy > 0f) { headerVisible = true; revealNonce++ }
-                    }
-                },
-        )
-        AnimatedVisibility(
-            visible = headerVisible,
-            modifier = Modifier.align(Alignment.TopCenter),
-            enter = slideInVertically { -it },
-            exit = slideOutVertically { -it },
-        ) {
-            MobileTerminalHeader(
-                title = active?.displayTitle ?: stringResource(Res.string.term_mobile_title_fallback),
-                status = active?.controller?.uiState,
-                controller = active?.controller,
-                onBack = state::pop,
-                onMenu = { menuOpen = true },
-                onSnippets = if (canRunSnippet) ({ paletteOpen = true }) else null,
+        // Swipe down near the top brings the header back (top position). Starts below the edge: a
+        // swipe from the very edge is the system's own gesture for restoring the hidden bars and
+        // never reaches us. When the header sits at the bottom, the same strip moves to the bottom
+        // edge and the gesture flips to swipe-up.
+        if (state.headerPosition == HeaderPosition.Top) {
+            Box(
+                Modifier.align(Alignment.TopCenter).fillMaxWidth()
+                    .padding(top = SYSTEM_EDGE_GESTURE).height(TOP_EDGE_STRIP)
+                    .pointerInput(Unit) {
+                        detectVerticalDragGestures { _, dy ->
+                            if (dy > 0f) { headerVisible = true; revealNonce++ }
+                        }
+                    },
+            )
+        }
+        if (state.headerPosition == HeaderPosition.Top) {
+            AnimatedVisibility(
+                visible = headerVisible,
+                modifier = Modifier.align(Alignment.TopCenter),
+                enter = slideInVertically { -it },
+                exit = slideOutVertically { -it },
+            ) {
+                MobileTerminalHeader(
+                    title = active?.displayTitle ?: stringResource(Res.string.term_mobile_title_fallback),
+                    status = active?.controller?.uiState,
+                    controller = active?.controller,
+                    onBack = state::pop,
+                    onMenu = { menuOpen = true },
+                    onSnippets = if (canRunSnippet) ({ paletteOpen = true }) else null,
+                )
+            }
+        }
+        if (state.headerPosition == HeaderPosition.Bottom) {
+            Box(
+                Modifier.align(Alignment.BottomCenter).fillMaxWidth()
+                    .padding(bottom = SYSTEM_EDGE_GESTURE).height(TOP_EDGE_STRIP)
+                    .pointerInput(Unit) {
+                        detectVerticalDragGestures { _, dy ->
+                            if (dy < 0f) { headerVisible = true; revealNonce++ }
+                        }
+                    },
             )
         }
         if (paletteOpen && snippets != null && activeTerminal != null) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -141,7 +141,6 @@ import app.skerry.ui.ai.commandRiskReasonText
 /** ESC (0x1B) — prefix of arrow CSI sequences and the esc key itself. */
 private const val ESC = "\u001b"
 
-private const val HEADER_AUTO_HIDE_MS = 3000L
 // Where the header's reveal strip starts and how tall it is: clear of the system's edge-swipe zone.
 private val SYSTEM_EDGE_GESTURE = 40.dp
 private val TOP_EDGE_STRIP = 72.dp
@@ -186,7 +185,8 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     // The AI input is off by default and raised by the sparkle key: on a phone it is a whole row of
     // screen that most sessions never use, and the terminal wants every line it can get.
     var aiOpen by remember(active?.id) { mutableStateOf(false) }
-    // Session chrome auto-hides like the VNC screen's bar; a swipe down near the top brings it back.
+    // Session chrome auto-hides per the setting (More -> Appearance -> Terminal); a swipe down
+    // near the top brings it back. Never = always visible (default).
     var headerVisible by remember(active?.id) { mutableStateOf(true) }
     // See MobileVncScreen: keyed into the auto-hide effect so a swipe restarts the timer even when
     // the header is already up.
@@ -230,11 +230,15 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     val canRunSnippet = snippets != null && activeTerminal != null
 
     ImmersiveScreen()
+    // Header auto-hide per the setting (More -> Appearance -> Terminal); Never keeps it visible.
+    val autoHideMs = state.headerAutoHide.hideAfterMs
     // Held open while a sheet launched from it is up: the header is where they were opened from, and
     // hiding it under an open menu reads as the app losing its place.
-    LaunchedEffect(headerVisible, menuOpen, paletteOpen, revealNonce) {
-        if (headerVisible && !menuOpen && !paletteOpen) {
-            delay(HEADER_AUTO_HIDE_MS)
+    LaunchedEffect(headerVisible, menuOpen, paletteOpen, revealNonce, autoHideMs) {
+        val autoHide = autoHideMs
+        val panelsClosed = !menuOpen && !paletteOpen
+        if (autoHide != null && headerVisible && panelsClosed) {
+            delay(autoHide)
             headerVisible = false
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -233,11 +233,14 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     // Header auto-hide per the setting (More -> Appearance -> Terminal); Never keeps it visible.
     val autoHideMs = state.headerAutoHide.hideAfterMs
     // Held open while a sheet launched from it is up: the header is where they were opened from, and
-    // hiding it under an open menu reads as the app losing its place.
-    LaunchedEffect(headerVisible, menuOpen, paletteOpen, revealNonce, autoHideMs) {
+    // hiding it under an open menu reads as the app losing its place. The timer only starts once the
+    // session is Connected — while connecting/error/disconnected the user needs the status visible.
+    LaunchedEffect(headerVisible, menuOpen, paletteOpen, revealNonce, autoHideMs, active?.controller?.uiState) {
         val autoHide = autoHideMs
         val panelsClosed = !menuOpen && !paletteOpen
-        if (autoHide != null && headerVisible && panelsClosed) {
+        val connected = active?.controller?.uiState is ConnectionUiState.Connected
+        val shouldAutoHide = autoHide != null && headerVisible && panelsClosed && connected
+        if (shouldAutoHide) {
             delay(autoHide)
             headerVisible = false
         }


### PR DESCRIPTION
## Summary

On mobile, the terminal session header (host name + connection status + back/menu) currently hides after a fixed 3 seconds of inactivity and is revealed by swiping down near the top of the screen. Two real-world problems:

1. **The 3s delay is not configurable, and the reveal gesture collides with the system.** On phones, swiping down from the top edge triggers the notification shade / control centre, which often intercepts the gesture before the header can be revealed. And when output keeps scrolling (tail -f, build logs), 3s is too short to glance at the status.

2. **Punch-hole / notch phones clip the header at the top.** The header sits at the very top edge, so the host name and connection status dot land right in the cut-out and are partially unreadable.

## Changes

### 1. Configurable auto-hide delay

- New enum `HeaderAutoHideDelay`: 3s / 5s / 10s / 15s / 30s / 60s / Never. Default stays **3s** (existing default behaviour unchanged).
- New setting: **Settings → Appearance → Terminal → Terminal header auto-hide** (dropdown).
- The auto-hide logic reads the setting instead of the hardcoded 3000ms; `Never` keeps the header permanently visible.
- The timer now **only starts once the session is Connected** — while connecting / on error / after a drop, the header stays visible because the user needs the status. (Previously the timer started as soon as the terminal screen was entered, so a slow handshake could hide the header mid-connect.)
- Value persisted per device (same pattern as the other local appearance settings: theme, scrollback, cursor style), not part of cloud sync.

### 2. Header position (top / bottom)

- New enum `HeaderPosition`: Top / Bottom. Default stays **Top** (existing layout unchanged).
- New setting: **Settings → Appearance → Terminal → Terminal header position** (dropdown).
- **Bottom mode:** the header moves to the bottom edge, below the key bar (ESC / arrow keys row) — it never covers the key bar. It slides up from the bottom and is revealed by swiping **up** near the bottom edge (Top mode keeps the swipe-down reveal).
- The two settings combine independently: bottom + 3s auto-hide, bottom + Never hide, etc.

## Code changes

| File | Change |
|---|---|
| `HeaderAutoHide.kt` (new) | `HeaderAutoHideDelay` enum + stable-id parsing, mirroring the existing `AutoLockDuration` pattern |
| `HeaderPosition.kt` (new) | `HeaderPosition` enum (Top/Bottom) + stable-id parsing |
| `MobileDesignState.kt` | New `headerAutoHide` / `headerPosition` state + `choose*` methods (callbacks report outward for persistence) |
| `MobileMoreView.kt` | Two new dropdown pickers in Appearance → Terminal (auto-hide delay, position) |
| `MobileTerminalView.kt` | Auto-hide reads the configured delay and gates on Connected; layout switches by position: top = overlay + swipe-down reveal, bottom = in the layout flow below the key bar + swipe-up reveal |
| `MainActivity.kt` (Android) | Per-device file persistence for both settings (`header_auto_hide` / `header_position`) |
| `strings_settings.xml` (en/zh/ru) | New setting and option labels |

## Naming note (open question for you)

In the Chinese UI we've been calling this element the **顶栏** (lit. "top bar"), but since it can now sit at the bottom too, that name no longer fits. We've provisionally settled on:

- **状态栏 / "status bar"** for the header element itself (host name + status),
- **按键栏 / "key bar"** for the existing bottom key row (`MobileKeybar`).

If you have a preferred term for the header (or a different convention in the codebase), happy to align — the UI strings are in one place and easy to adjust.

## Design principles

- Default behaviour unchanged (3s delay, top position) — no surprise for existing users.
- New enums/settings are standalone files plus state injection; minimal intrusion into existing code.
- Settings stay per-device, following the existing "data sync, UI preferences local" direction.
- No server-side changes.
