### PR TITLE
Titlebar drag: fall back to an in-app drag when the window manager ignores the request

### DIFF
--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
@@ -17,8 +17,10 @@ import java.awt.Window
  * false and the caller keeps using the manual drag.
  */
 object NativeWindowMove {
-    // From X11/Xutil.h: the direction telling the WM to start a plain move (not a resize).
+    // From X11/Xutil.h: the direction telling the WM to start a plain move (not a resize), and the
+    // one withdrawing a request it hasn't acted on.
     private const val NET_WM_MOVERESIZE_MOVE = 8
+    private const val NET_WM_MOVERESIZE_CANCEL = 11
     // SubstructureRedirectMask (1<<20) | SubstructureNotifyMask (1<<19): the mask the WM listens on
     // for client messages posted to the root window.
     private val ROOT_EVENT_MASK = NativeLong((1L shl 20) or (1L shl 19))
@@ -59,7 +61,17 @@ object NativeWindowMove {
      * [screenX]/[screenY] (where the drag began). Returns false if unavailable or the window has no
      * X11 id yet, so the caller can fall back. [button] is the mouse button held (1 = left).
      */
-    fun startMove(window: Window, screenX: Int, screenY: Int, button: Int = 1): Boolean {
+    fun startMove(window: Window, screenX: Int, screenY: Int, button: Int = 1): Boolean =
+        send(window, screenX, screenY, NET_WM_MOVERESIZE_MOVE, button)
+
+    /**
+     * Withdraws a move request the WM never acted on. Without it a WM that answers late would start
+     * dragging a window the app has meanwhile taken over, and the two would fight over it.
+     */
+    fun cancelMove(window: Window, screenX: Int, screenY: Int, button: Int = 1): Boolean =
+        send(window, screenX, screenY, NET_WM_MOVERESIZE_CANCEL, button)
+
+    private fun send(window: Window, screenX: Int, screenY: Int, direction: Int, button: Int): Boolean {
         val s = session ?: return false
         val xid = try {
             Native.getWindowID(window)
@@ -81,7 +93,7 @@ object NativeWindowMove {
             event.xclient.data.setType("l")
             event.xclient.data.l[0] = NativeLong(screenX.toLong())
             event.xclient.data.l[1] = NativeLong(screenY.toLong())
-            event.xclient.data.l[2] = NativeLong(NET_WM_MOVERESIZE_MOVE.toLong())
+            event.xclient.data.l[2] = NativeLong(direction.toLong())
             event.xclient.data.l[3] = NativeLong(button.toLong())
             event.xclient.data.l[4] = NativeLong(1) // source indication: normal application
             event.write()

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
@@ -1,11 +1,17 @@
 package app.skerry.ui.desktop
 
 import java.awt.Point
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /**
- * Where a titlebar drag should put the window, for the in-app drag used on platforms the window
- * manager can't do it for (see [NativeWindowMove]). Fed absolute pointer positions, it answers with
- * the window origin to apply, or `null` while the window has to stay put.
+ * Where a titlebar drag should put the window when the app moves it itself. Fed absolute pointer
+ * positions, it answers with the window origin to apply, or `null` while the window has to stay put.
+ *
+ * This is the drag on platforms the window manager can't do it for ([NativeWindowMove]) — and also
+ * on those where it can but won't, since a WM that ignores `_NET_WM_MOVERESIZE` hands the gesture
+ * back here (see [NativeMoveWatch]).
  *
  * Two cases deliberately stay put: a press that hasn't left [deadZone] yet, so a plain click and the
  * double-click-to-maximize gesture never nudge the window, and a window that stopped floating
@@ -17,7 +23,10 @@ class WindowDragGesture(private val deadZone: Int) {
 
     private var pressedAt: Point? = null
 
-    /** Window origin minus pointer, captured once the drag leaves the dead zone; `null` until then. */
+    /**
+     * Window origin minus pointer, captured once the drag leaves the dead zone — or straight away
+     * when a drag already under way is taken over ([takeOver]); `null` until then.
+     */
     private var grab: Point? = null
 
     /** Button pressed at absolute [pointer]; arms the gesture. */
@@ -48,6 +57,16 @@ class WindowDragGesture(private val deadZone: Int) {
         return Point(pointer.x + grab.x, pointer.y + grab.y)
     }
 
+    /**
+     * Claims a drag already under way, with [pointer] over the window sitting at [windowOrigin]:
+     * the dead zone is behind us (the gesture crossed it before the WM was asked to take the window
+     * and didn't), so the very next [drag] follows the pointer from here without moving the window.
+     */
+    fun takeOver(pointer: Point, windowOrigin: Point) {
+        pressedAt = Point(pointer)
+        grab = Point(windowOrigin.x - pointer.x, windowOrigin.y - pointer.y)
+    }
+
     /** Button released: [drag] does nothing until the next [press]. */
     fun release() {
         pressedAt = null
@@ -58,5 +77,244 @@ class WindowDragGesture(private val deadZone: Int) {
         val dx = to.x - from.x
         val dy = to.y - from.y
         return dx * dx + dy * dy >= deadZone * deadZone
+    }
+}
+
+/**
+ * Watches whether the window manager actually picked up a [NativeWindowMove] request. Asking it to
+ * move the window is fire-and-forget — the client message is delivered (and reports success) even
+ * when the WM does nothing with it, which is what GNOME 50's Mutter does to this window, leaving it
+ * frozen under the pointer. So the drag gives the WM [settle] to move the window; if it hasn't, the
+ * gesture goes back to dragging in-app.
+ *
+ * Once the window has moved the WM owns the gesture for good: it may well move the window back over
+ * the original spot, and that must not read as "the WM ignored us".
+ *
+ * One request at a time: the window has a single titlebar and a single pointer, so a second
+ * [started] before the first is settled would overwrite a cycle still in flight.
+ */
+class NativeMoveWatch(
+    private val settle: Duration,
+    private val source: TimeSource = TimeSource.Monotonic,
+) {
+
+    private var startedAt: TimeMark? = null
+    private var startOrigin: Point? = null
+    private var wmTookOver = false
+    private var ignoredInARow = 0
+
+    /**
+     * False once the WM has ignored [IGNORES_BEFORE_GIVING_UP] drags in a row: paying the settle
+     * delay on every drag is what makes dragging unusable, so the native path is dropped for the
+     * session and the gesture drags in-app from the first pointer move. It takes more than one
+     * refusal because a single slow compositor frame must not cost the smooth drag for good.
+     */
+    val worthTrying: Boolean get() = ignoredInARow < IGNORES_BEFORE_GIVING_UP
+
+    /** A native move was just requested, with the window at [windowOrigin]. */
+    fun started(windowOrigin: Point) {
+        startedAt = source.markNow()
+        startOrigin = Point(windowOrigin)
+        wmTookOver = false
+    }
+
+    /** True once the WM has moved the window, which means it owns this gesture. */
+    fun wmTookOver(windowOrigin: Point): Boolean {
+        val startOrigin = this.startOrigin ?: return false
+        if (windowOrigin != startOrigin) {
+            wmTookOver = true
+            // It answered, so whatever it did before was not a pattern.
+            ignoredInARow = 0
+        }
+        return wmTookOver
+    }
+
+    /** True once it's clear the WM will not move the window and the in-app drag should take over. */
+    fun givenUp(windowOrigin: Point): Boolean {
+        val startedAt = this.startedAt ?: return false
+        if (wmTookOver(windowOrigin)) return false
+        if (startedAt.elapsedNow() < settle) return false
+        // This gesture is settled either way; a second call must not count as a second refusal.
+        this.startedAt = null
+        ignoredInARow++
+        return true
+    }
+
+    private companion object {
+        const val IGNORES_BEFORE_GIVING_UP = 2
+    }
+}
+
+/** The window being dragged, as the drag arbitration sees it: an origin and two ways to move it. */
+interface DragTarget {
+
+    /** The window's current top-left on screen. */
+    val origin: Point
+
+    /** Moves the window itself, frame by frame from the app thread. */
+    fun moveTo(target: Point)
+
+    /** Asks the WM to take the window over from [pointer]; false when it refuses outright. */
+    fun startNativeMove(pointer: Point): Boolean
+
+    /**
+     * Withdraws a native move the WM never acted on, so a late WM can't move a window nobody is
+     * dragging any more. False when the request could not be withdrawn.
+     */
+    fun cancelNativeMove(pointer: Point): Boolean
+}
+
+/** Who is moving the window during a titlebar drag. */
+enum class DragMode {
+    /** Nothing dragged yet: waiting for the pointer to leave the dead zone. */
+    Idle,
+
+    /** The WM was asked to take the window; watching whether it does. */
+    HandedToWm,
+
+    /** This gesture moves the window itself, frame by frame. */
+    InApp,
+
+    /** Over: the WM took the window, and the release belongs to the compositor, not to the app. */
+    Ended,
+}
+
+/**
+ * What the gesture does next, and whether the pointer event that caused it belongs to the drag.
+ * A `null` [mode] ends the gesture: the WM owns the window from here, and the next press starts a
+ * fresh one.
+ */
+data class DragStep(val mode: DragMode?, val consume: Boolean)
+
+/**
+ * Decides, press by press and move by move, who drags the window: the WM (asked once per gesture,
+ * where [native] support exists) or the app itself.
+ *
+ * [watch] is passed in rather than owned because it carries the verdict on a WM that ignores
+ * `_NET_WM_MOVERESIZE`, and that has to outlive this arbiter: an arbiter belongs to one pointer-input
+ * node (the titlebar, the vault gate — each drag area has its own, and a node is rebuilt whenever
+ * the screen around it changes), while the WM's behaviour belongs to the window.
+ */
+class WindowDragArbiter(
+    private val target: DragTarget,
+    deadZone: Int,
+    private val watch: NativeMoveWatch,
+    private val native: Boolean,
+) {
+
+    private val gesture = WindowDragGesture(deadZone)
+
+    /** Where the pointer was last seen, so a gesture cut short can still address the WM. */
+    private var lastPointer = Point()
+
+    /** Who is dragging right now; only meaningful between [press] and [release]. */
+    var mode: DragMode = DragMode.InApp
+        private set
+
+    /** Button pressed at absolute [pointer]. A WM known to ignore us is not asked again. */
+    fun press(pointer: Point) {
+        gesture.press(pointer)
+        lastPointer = Point(pointer)
+        mode = if (native && watch.worthTrying) DragMode.Idle else DragMode.InApp
+    }
+
+    /**
+     * Pointer moved to absolute [pointer] with the button still down; [pastDeadZone] tells whether
+     * it has travelled far enough to count as a drag rather than a click, [floating] whether the
+     * window is still floating.
+     */
+    fun moved(pointer: Point, pastDeadZone: Boolean, floating: Boolean): DragStep {
+        lastPointer = Point(pointer)
+        // A window maximized mid-gesture is nobody's to drag — not the app's (issue #76), and not
+        // the WM's either, which would restore it behind WindowState's back. A request the WM has
+        // not acted on yet goes back now rather than at the release, so it can't move the maximized
+        // window in the meantime.
+        if (!floating) {
+            if (mode == DragMode.HandedToWm) withdrawRequest()
+            mode = DragMode.InApp
+            return moveWindow(pointer, floating = false)
+        }
+        val step = when (mode) {
+            DragMode.Idle -> handOffToWm(pointer, pastDeadZone)
+            DragMode.HandedToWm -> reclaimIfIgnored(pointer)
+            DragMode.InApp, DragMode.Ended -> moveWindow(pointer, floating)
+        }
+        // A step without a mode ends the gesture, and the arbiter has to know: a later release must
+        // not withdraw a move the WM is actually performing.
+        mode = step.mode ?: DragMode.Ended
+        return step
+    }
+
+    /**
+     * Button released. A gesture that ends after the settle window elapsed without the WM moving
+     * anything counts as a refusal like any other — that is what stops the next drag from paying the
+     * settle delay again. Either way the request is withdrawn on the way out, or a WM answering late
+     * would move a window nobody is dragging any more.
+     */
+    fun release() {
+        // A WM that took the window usually swallows every event including this release, so the
+        // gesture can reach here still nominally waiting: check the window itself before withdrawing
+        // anything, or a completed move would be cancelled after the fact.
+        if (mode == DragMode.HandedToWm && !watch.wmTookOver(target.origin)) {
+            reportGiveUp()
+            withdrawRequest()
+        }
+        mode = DragMode.Ended
+        gesture.release()
+    }
+
+    /**
+     * Hands the window to the WM once the pointer left the dead zone — which is what keeps a plain
+     * click (and the double-click-to-maximize) from starting a move. A WM that refuses outright
+     * drops the gesture straight into the in-app drag.
+     */
+    private fun handOffToWm(pointer: Point, pastDeadZone: Boolean): DragStep {
+        if (!pastDeadZone) return DragStep(DragMode.Idle, consume = false)
+        if (!target.startNativeMove(pointer)) {
+            gesture.takeOver(pointer, target.origin)
+            return DragStep(DragMode.InApp, consume = false)
+        }
+        watch.started(target.origin)
+        return DragStep(DragMode.HandedToWm, consume = true)
+    }
+
+    /**
+     * Pointer events still arriving means the compositor never grabbed the pointer; once the window
+     * has stayed put for the settle window, this gesture takes it back and drags it itself.
+     *
+     * If the window did move, the WM owns the drag and the app is out of the loop: whatever event
+     * shows up here belongs to the next gesture, so this one ends rather than waiting for a release
+     * the compositor swallowed — waiting forever is what would leave the titlebar dead.
+     */
+    private fun reclaimIfIgnored(pointer: Point): DragStep {
+        if (watch.wmTookOver(target.origin)) return DragStep(mode = null, consume = false)
+        if (!reportGiveUp()) return DragStep(DragMode.HandedToWm, consume = false)
+        withdrawRequest()
+        gesture.takeOver(pointer, target.origin)
+        return DragStep(DragMode.InApp, consume = true)
+    }
+
+    private fun withdrawRequest() {
+        if (target.cancelNativeMove(lastPointer)) return
+        System.err.println("Skerry: could not withdraw the pending window move from the window manager")
+    }
+
+    private fun moveWindow(pointer: Point, floating: Boolean): DragStep {
+        val origin = gesture.drag(pointer, target.origin, floating)
+            ?: return DragStep(DragMode.InApp, consume = false)
+        target.moveTo(origin)
+        return DragStep(DragMode.InApp, consume = true)
+    }
+
+    /**
+     * Asks the watch for its verdict and says so once — a WM that silently drops the request is the
+     * bug this whole fallback exists for, and it should leave a trace instead of only a slow drag.
+     */
+    private fun reportGiveUp(): Boolean {
+        if (!watch.givenUp(target.origin)) return false
+        System.err.println(
+            "Skerry: the window manager ignored _NET_WM_MOVERESIZE; dragging the window in-app from here on",
+        )
+        return true
     }
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.window.WindowScope
 import androidx.compose.ui.window.WindowState
 import java.awt.Cursor
 import java.awt.MouseInfo
+import java.awt.Point
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Custom chrome for the undecorated main window: dragging the empty titlebar space (with
@@ -41,9 +43,13 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
                 else WindowPlacement.Maximized
         }
         val isFloating = { state.placement == WindowPlacement.Floating }
-        // On X11 the WM moves the window itself (smooth, compositor-driven — see NativeWindowMove);
-        // elsewhere fall back to moving it frame by frame from the app thread.
+        // On X11 the WM is asked to move the window itself (smooth, compositor-driven — see
+        // NativeWindowMove); where it doesn't answer, the same gesture drags the window from the app
+        // thread instead.
         val useNativeMove = NativeWindowMove.isAvailable()
+        // One per window, not per drag area: whether this WM answers at all is a property of the
+        // session, and a pointer-input node is rebuilt whenever the screen around it changes.
+        val nativeMoveWatch = NativeMoveWatch(NATIVE_MOVE_SETTLE)
         WindowChrome(
             isMaximized = { state.placement == WindowPlacement.Maximized },
             onMinimize = { state.isMinimized = true },
@@ -53,66 +59,70 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
                 val doubleClick = Modifier.onUnconsumedDoubleClick(toggleMaximize)
                 when {
                     state.placement == WindowPlacement.Maximized -> Box(doubleClick) { content() }
-                    useNativeMove -> Box(doubleClick.then(Modifier.nativeWindowDrag(awtWindow))) { content() }
-                    else -> Box(doubleClick.then(Modifier.inAppWindowDrag(awtWindow, isFloating))) { content() }
+                    else -> Box(
+                        doubleClick.then(Modifier.windowDrag(awtWindow, isFloating, useNativeMove, nativeMoveWatch)),
+                    ) { content() }
                 }
             },
         )
     }
 }
 
-/**
- * Moves the window frame by frame from the app thread, for platforms without [NativeWindowMove].
- * Gated by [WindowDragGesture] (dead zone, floating only), and driven by absolute pointer positions
- * ([MouseInfo]) because local ones shift together with the window and would feed back. [isFloating]
- * is read per event, so a double-click that maximizes the window mid-gesture stops the drag instead
- * of dragging the now screen-sized window back to the floating origin (issue #76). Only unconsumed
- * presses arm it, so buttons/tabs that consume their own press are excluded.
- */
-private fun Modifier.inAppWindowDrag(window: java.awt.Window, isFloating: () -> Boolean): Modifier =
-    pointerInput(window) {
-        val gesture = WindowDragGesture(viewConfiguration.touchSlop.toInt())
-        awaitEachGesture {
-            awaitFirstDown(requireUnconsumed = true)
-            gesture.press(MouseInfo.getPointerInfo()?.location ?: return@awaitEachGesture)
-            try {
-                while (true) {
-                    val event = awaitPointerEvent()
-                    val change = event.changes.firstOrNull() ?: break
-                    if (!change.pressed) break
-                    val pointer = MouseInfo.getPointerInfo()?.location ?: continue
-                    val target = gesture.drag(pointer, window.location, isFloating()) ?: continue
-                    change.consume()
-                    window.setLocation(target.x, target.y)
-                }
-            } finally {
-                gesture.release()
-            }
-        }
-    }
+// How long a requested native move has to actually move the window before the drag stops waiting
+// for the WM. Long enough for a compositor round-trip, short enough to pass for a slow first frame —
+// and paid only while the WM still looks like it might answer (see NativeMoveWatch.worthTrying).
+private val NATIVE_MOVE_SETTLE = 60.milliseconds
+
+/** The real window behind the drag arbitration in [WindowDragArbiter]. */
+private class AwtDragTarget(private val window: java.awt.Window) : DragTarget {
+
+    override val origin: Point get() = window.location
+
+    override fun moveTo(target: Point) = window.setLocation(target.x, target.y)
+
+    override fun startNativeMove(pointer: Point) = NativeWindowMove.startMove(window, pointer.x, pointer.y)
+
+    override fun cancelNativeMove(pointer: Point) = NativeWindowMove.cancelMove(window, pointer.x, pointer.y)
+}
 
 /**
- * Starts a native WM drag ([NativeWindowMove]) once the pointer moves past touch-slop from the
- * initial press — the slop threshold keeps clicks on titlebar buttons and the double-click-to-
- * maximize gesture working, since a plain click never crosses it. Only unconsumed presses arm the
- * drag, so buttons/tabs that consume their own press are excluded. Once handed off, the compositor
- * owns the pointer and this gesture simply ends.
+ * Drags the undecorated window by its titlebar. Where [native] is available the WM is asked to take
+ * the window over ([NativeWindowMove]) so the move is compositor-driven and smooth; that request is
+ * fire-and-forget, and a WM that ignores it would otherwise leave the window frozen under the
+ * pointer, so [NativeMoveWatch] gives it [NATIVE_MOVE_SETTLE] and then hands the gesture back to the
+ * in-app drag ([DragMode]). A WM that does take the window swallows the rest of the events, so the
+ * gesture ends on the first event that arrives after the window moved — otherwise it would sit here
+ * waiting for a release that never comes and the next press would land inside the stale gesture.
+ *
+ * Driven by absolute pointer positions ([MouseInfo]) because local ones shift together with the
+ * window and would feed back. [isFloating] is read per event, so a double-click that maximizes the
+ * window mid-gesture stops the drag instead of dragging the now screen-sized window back to the
+ * floating origin (issue #76). Only unconsumed presses arm it, so buttons/tabs that consume their
+ * own press are excluded.
  */
-private fun Modifier.nativeWindowDrag(window: java.awt.Window): Modifier = pointerInput(window) {
+private fun Modifier.windowDrag(
+    window: java.awt.Window,
+    isFloating: () -> Boolean,
+    native: Boolean,
+    watch: NativeMoveWatch,
+): Modifier = pointerInput(window, native) {
+    val slop = viewConfiguration.touchSlop
+    val arbiter = WindowDragArbiter(AwtDragTarget(window), slop.toInt(), watch, native)
     awaitEachGesture {
         val down = awaitFirstDown(requireUnconsumed = true)
-        val slop = viewConfiguration.touchSlop
-        while (true) {
-            val event = awaitPointerEvent()
-            val change = event.changes.firstOrNull() ?: break
-            if (!change.pressed) break // released without dragging — leave it for click/double-click
-            if ((change.position - down.position).getDistance() > slop) {
-                val mouse = MouseInfo.getPointerInfo()?.location
-                if (mouse != null && NativeWindowMove.startMove(window, mouse.x, mouse.y)) {
-                    change.consume()
-                }
-                break
+        arbiter.press(MouseInfo.getPointerInfo()?.location ?: return@awaitEachGesture)
+        try {
+            while (true) {
+                val change = awaitPointerEvent().changes.firstOrNull() ?: break
+                if (!change.pressed) break // released — left for click/double-click
+                val pointer = MouseInfo.getPointerInfo()?.location ?: continue
+                val pastDeadZone = (change.position - down.position).getDistance() > slop
+                val step = arbiter.moved(pointer, pastDeadZone, isFloating())
+                if (step.consume) change.consume()
+                if (step.mode == null) break // the WM has the window; the next press starts fresh
             }
+        } finally {
+            arbiter.release()
         }
     }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/NativeMoveWatchTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/NativeMoveWatchTest.kt
@@ -1,0 +1,92 @@
+package app.skerry.ui.desktop
+
+import java.awt.Point
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TestTimeSource
+
+class NativeMoveWatchTest {
+
+    private val settle = 60.milliseconds
+    private val origin = Point(100, 200)
+    private val time = TestTimeSource()
+
+    private fun watch() = NativeMoveWatch(settle, time)
+
+    @Test
+    fun watchThatWasNeverStartedNeverGivesUp() {
+        val watch = watch()
+        time += settle * 10
+        assertFalse(watch.givenUp(origin))
+    }
+
+    @Test
+    fun windowStillAtItsOriginWithinTheSettleWindowKeepsWaiting() {
+        val watch = watch()
+        watch.started(origin)
+        time += settle - 1.milliseconds
+        assertFalse(watch.givenUp(origin))
+    }
+
+    /** The WM ignored the request: nothing moved, the settle window elapsed — the drag falls back. */
+    @Test
+    fun windowThatNeverMovedGivesUpOnceTheSettleWindowElapsed() {
+        val watch = watch()
+        watch.started(origin)
+        time += settle
+        assertTrue(watch.givenUp(origin))
+    }
+
+    /** The WM took the window: it moved, so the in-app drag must never claim the gesture. */
+    @Test
+    fun windowMovedByTheWindowManagerNeverGivesUp() {
+        val watch = watch()
+        watch.started(origin)
+        time += 10.milliseconds
+        assertFalse(watch.givenUp(Point(140, 260)))
+        assertTrue(watch.wmTookOver(origin))
+        // Long past the settle window, and even back at the original spot: the WM owns this gesture.
+        time += settle * 10
+        assertFalse(watch.givenUp(origin))
+    }
+
+    /**
+     * A single slow first frame must not cost the smooth native drag for the whole session, but a WM
+     * that keeps ignoring the request should stop being asked — otherwise every drag pays the settle
+     * delay, which is what makes dragging unusable.
+     */
+    @Test
+    fun theNativePathIsAbandonedOnlyAfterTheWindowManagerIgnoredTwoDragsInARow() {
+        val watch = watch()
+        watch.started(origin)
+        time += settle
+        assertTrue(watch.givenUp(origin))
+        assertTrue(watch.worthTrying)
+
+        watch.started(origin)
+        time += settle
+        assertTrue(watch.givenUp(origin))
+        assertFalse(watch.worthTrying)
+    }
+
+    @Test
+    fun aWindowManagerThatAnsweredResetsTheDoubt() {
+        val watch = watch()
+        watch.started(origin)
+        time += settle
+        assertTrue(watch.givenUp(origin))
+
+        // The next drag is honoured: the window moves, so the WM is back in good standing...
+        watch.started(origin)
+        time += 5.milliseconds
+        assertTrue(watch.wmTookOver(Point(300, 400)))
+
+        // ...and a later refusal starts counting from scratch instead of abandoning the native path.
+        watch.started(origin)
+        time += settle
+        assertTrue(watch.givenUp(origin))
+        assertTrue(watch.worthTrying)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragArbiterTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragArbiterTest.kt
@@ -1,0 +1,318 @@
+package app.skerry.ui.desktop
+
+import java.awt.Point
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TestTimeSource
+
+/** Drives the drag arbitration without a real window: the WM's answer is just a flag here. */
+private class FakeDragTarget(
+    start: Point = Point(100, 200),
+    private val wmAccepts: Boolean = true,
+) : DragTarget {
+
+    override var origin: Point = start
+        private set
+
+    var nativeMoveRequests: Int = 0
+        private set
+
+    var nativeMovesCancelled: Int = 0
+        private set
+
+    override fun moveTo(target: Point) {
+        origin = Point(target)
+    }
+
+    override fun startNativeMove(pointer: Point): Boolean {
+        nativeMoveRequests++
+        return wmAccepts
+    }
+
+    override fun cancelNativeMove(pointer: Point): Boolean {
+        nativeMovesCancelled++
+        cancelledAt = Point(pointer)
+        return true
+    }
+
+    /** Where the last withdrawal was addressed from; `null` until one happens. */
+    var cancelledAt: Point? = null
+        private set
+
+    /** The WM moving the window itself, behind the app's back. */
+    fun movedByWindowManager(to: Point) {
+        origin = Point(to)
+    }
+}
+
+class WindowDragArbiterTest {
+
+    private val settle = 60.milliseconds
+    private val time = TestTimeSource()
+
+    private val watch = NativeMoveWatch(settle, time)
+
+    private fun arbiter(target: DragTarget, native: Boolean = true) =
+        WindowDragArbiter(target, deadZone = 18, watch = watch, native = native)
+
+    /** A press that never leaves the dead zone is a click, not a drag: nobody moves the window. */
+    @Test
+    fun insideTheDeadZoneNothingHappens() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        val step = arbiter.moved(Point(505, 25), pastDeadZone = false, floating = true)
+        assertEquals(DragStep(DragMode.Idle, consume = false), step)
+        assertEquals(0, target.nativeMoveRequests)
+        assertEquals(Point(100, 200), target.origin)
+    }
+
+    @Test
+    fun pastTheDeadZoneTheWindowManagerIsAskedFirst() {
+        val target = FakeDragTarget(wmAccepts = true)
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        val step = arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(DragStep(DragMode.HandedToWm, consume = true), step)
+        assertEquals(1, target.nativeMoveRequests)
+    }
+
+    @Test
+    fun aWindowManagerThatRefusesOutrightLeavesTheDragToTheApp() {
+        val target = FakeDragTarget(wmAccepts = false)
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        assertEquals(DragMode.InApp, arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true).mode)
+        // Taken over at that very pointer, so the next move drags from there without a jump.
+        arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true)
+        assertEquals(Point(110, 210), target.origin)
+    }
+
+    @Test
+    fun whileTheWindowManagerMayStillAnswerTheAppKeepsItsHandsOff() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        time += settle - 1.milliseconds
+        val step = arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true)
+        assertEquals(DragStep(DragMode.HandedToWm, consume = false), step)
+        assertEquals(Point(100, 200), target.origin)
+    }
+
+    /** The bug this exists for: the WM reports success, does nothing, and the window stays put. */
+    @Test
+    fun aWindowManagerThatNeverMovedTheWindowLosesTheGesture() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        time += settle
+        assertEquals(DragMode.InApp, arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true).mode)
+        // The stale request is withdrawn so a late WM can't fight the in-app drag...
+        assertEquals(1, target.nativeMovesCancelled)
+        // ...the take-over itself is jump-free...
+        assertEquals(Point(100, 200), target.origin)
+        // ...and from there the window follows the pointer.
+        arbiter.moved(Point(580, 90), pastDeadZone = true, floating = true)
+        assertEquals(Point(110, 220), target.origin)
+    }
+
+    /**
+     * The WM took the window, so it also owns the release the app never sees: the gesture ends here
+     * instead of waiting for it, which is what would otherwise leave the titlebar dead.
+     */
+    @Test
+    fun onceTheWindowManagerMovedTheWindowTheGestureEnds() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        target.movedByWindowManager(Point(300, 400))
+        time += settle * 10
+        assertNull(arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true).mode)
+        assertEquals(0, target.nativeMovesCancelled)
+    }
+
+    /**
+     * The release after such a gesture belongs to the compositor: withdrawing the request here would
+     * cancel a move the WM is in the middle of performing.
+     */
+    @Test
+    fun releasingAfterTheWindowManagerTookOverWithdrawsNothing() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        target.movedByWindowManager(Point(300, 400))
+        arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true)
+        arbiter.release()
+        assertEquals(0, target.nativeMovesCancelled)
+        assertTrue(watch.worthTrying)
+    }
+
+    /**
+     * Issue #76 again, one step earlier: the window is maximized before the pointer crosses the
+     * dead zone, so the WM must not be handed a window it would restore behind WindowState's back.
+     */
+    @Test
+    fun aWindowMaximizedBeforeTheDragStartedIsNeverHandedToTheWindowManager() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        val step = arbiter.moved(Point(560, 60), pastDeadZone = true, floating = false)
+        assertEquals(DragStep(DragMode.InApp, consume = false), step)
+        assertEquals(0, target.nativeMoveRequests)
+        assertEquals(Point(100, 200), target.origin)
+    }
+
+    /**
+     * The window is maximized while the WM still owes an answer: the request goes back immediately,
+     * or the WM could pick it up and drag the maximized window.
+     */
+    @Test
+    fun maximizingWhileTheWindowManagerStillOwesAnAnswerWithdrawsTheRequest() {
+        val target = FakeDragTarget(wmAccepts = true)
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(1, target.nativeMoveRequests)
+        arbiter.moved(Point(600, 100), pastDeadZone = true, floating = false)
+        assertEquals(1, target.nativeMovesCancelled)
+        assertEquals(Point(100, 200), target.origin)
+    }
+
+    /** Issue #76: the double-click maximizes the window while the button is still down. */
+    @Test
+    fun aWindowMaximizedMidGestureIsNeverMoved() {
+        val target = FakeDragTarget(wmAccepts = false)
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        val step = arbiter.moved(Point(600, 100), pastDeadZone = true, floating = false)
+        assertEquals(DragStep(DragMode.InApp, consume = false), step)
+        assertEquals(Point(100, 200), target.origin)
+    }
+
+    @Test
+    fun withoutNativeSupportTheWindowManagerIsNeverAsked() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target, native = false)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(0, target.nativeMoveRequests)
+        assertEquals(DragMode.InApp, arbiter.mode)
+    }
+
+    /** The settle delay is paid while the WM might still answer — not on every drag forever. */
+    @Test
+    fun aWindowManagerThatKeepsIgnoringUsIsEventuallyDroppedForTheSession() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        repeat(2) {
+            arbiter.press(Point(500, 20))
+            arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+            time += settle
+            arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true)
+            arbiter.release()
+        }
+        val asked = target.nativeMoveRequests
+
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(DragMode.InApp, arbiter.mode)
+        assertEquals(asked, target.nativeMoveRequests)
+    }
+
+    /**
+     * The drag areas are rebuilt whenever the screen around them changes, so a verdict that only
+     * lived as long as one arbiter meant every rebuild paid the settle delay all over again — which
+     * is exactly what made the fallback feel unusable.
+     */
+    @Test
+    fun theVerdictSurvivesArbitersBeingRebuilt() {
+        val target = FakeDragTarget()
+        repeat(2) {
+            val arbiter = arbiter(target)
+            arbiter.press(Point(500, 20))
+            arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+            time += settle
+            arbiter.moved(Point(570, 70), pastDeadZone = true, floating = true)
+            arbiter.release()
+        }
+        val asked = target.nativeMoveRequests
+
+        val rebuilt = arbiter(target)
+        rebuilt.press(Point(500, 20))
+        rebuilt.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(DragMode.InApp, rebuilt.mode)
+        assertEquals(asked, target.nativeMoveRequests)
+    }
+
+    /**
+     * The button comes up while the WM still owes an answer: the request has to be withdrawn, or a
+     * WM answering afterwards would move a window nobody is dragging any more.
+     */
+    @Test
+    fun releasingWhileWaitingWithdrawsTheRequest() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        arbiter.release()
+        assertEquals(1, target.nativeMovesCancelled)
+        assertEquals(Point(560, 60), target.cancelledAt)
+    }
+
+    /** Same, but the settle window had not elapsed yet — the request is just as outstanding. */
+    @Test
+    fun releasingBeforeTheSettleWindowElapsedAlsoWithdrawsTheRequest() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        time += settle - 1.milliseconds
+        arbiter.release()
+        assertEquals(1, target.nativeMovesCancelled)
+    }
+
+    /**
+     * The compositor usually swallows every event of a move it owns, release included, so the app
+     * can reach the release still nominally waiting. Withdrawing there would cancel a move the WM
+     * already performed — the window position is what settles it.
+     */
+    @Test
+    fun releasingAfterAWindowManagerMoveWithNoEventsInBetweenWithdrawsNothing() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        target.movedByWindowManager(Point(300, 400))
+        time += settle * 10
+        arbiter.release()
+        assertEquals(0, target.nativeMovesCancelled)
+        assertTrue(watch.worthTrying)
+    }
+
+    /** A gesture dropped after the settle window elapsed counts as a refusal like any other. */
+    @Test
+    fun releasingAfterTheSettleWindowElapsedCountsAsARefusal() {
+        val target = FakeDragTarget()
+        val arbiter = arbiter(target)
+        repeat(2) {
+            arbiter.press(Point(500, 20))
+            arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+            time += settle
+            arbiter.release()
+        }
+        val asked = target.nativeMoveRequests
+
+        arbiter.press(Point(500, 20))
+        arbiter.moved(Point(560, 60), pastDeadZone = true, floating = true)
+        assertEquals(DragMode.InApp, arbiter.mode)
+        assertEquals(asked, target.nativeMoveRequests)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
@@ -64,6 +64,28 @@ class WindowDragGestureTest {
         assertEquals(Point(110, 200), gesture.drag(Point(450, 30), origin, floating = true))
     }
 
+    /**
+     * The native WM drag was asked for and never happened: the in-app drag takes the gesture over
+     * mid-flight, from wherever the pointer and the window are right now.
+     */
+    @Test
+    fun takeOverGrabsTheWindowWithoutWaitingForTheDeadZone() {
+        val gesture = gesture(Point(500, 20))
+        gesture.takeOver(Point(560, 60), origin)
+        // No further dead zone: the very next move repositions the window by the pointer delta...
+        assertEquals(Point(110, 210), gesture.drag(Point(570, 70), origin, floating = true))
+        // ...and a move back to the take-over point leaves the window exactly where it started.
+        assertEquals(origin, gesture.drag(Point(560, 60), Point(110, 210), floating = true))
+    }
+
+    @Test
+    fun takenOverGestureStillStopsWhenTheWindowStopsFloating() {
+        val gesture = gesture(Point(500, 20))
+        gesture.takeOver(Point(560, 60), origin)
+        assertNull(gesture.drag(Point(600, 100), Point(0, 0), floating = false))
+        assertNull(gesture.drag(Point(640, 140), Point(0, 0), floating = true))
+    }
+
     @Test
     fun dragWithoutPressIsIgnored() {
         val gesture = WindowDragGesture(deadZone)


### PR DESCRIPTION
Draft: the drag works again on a WM that ignores the move request, but it does not yet feel native
there. Opened for testing on a machine whose WM honours the request. See #143 for the underlying
problem and what is still unanswered.

## What it does

The titlebar drag asks the window manager to move the window (`_NET_WM_MOVERESIZE`) and now checks
whether it actually did:

- `WindowDragArbiter` owns the gesture and decides who drags: the WM, or the app frame by frame.
- `NativeMoveWatch` gives the WM a 60 ms settle window. If the window has not moved by then, the
  request is withdrawn (`_NET_WM_MOVERESIZE_CANCEL`) and the same gesture continues as an in-app
  drag, picked up at the current pointer so the window does not jump.
- A WM that ignores two drags in a row is not asked again for the rest of the session — otherwise
  every drag pays the settle delay. Two, not one, so a single slow compositor frame does not cost
  the smooth path. The verdict lives with the window, not with a drag area, because pointer-input
  nodes are rebuilt whenever the screen around them changes.
- A WM that does take the window ends the gesture: the compositor owns the pointer from there and
  the release never reaches the app, so waiting for it would strand the gesture and leave the
  titlebar dead for the rest of the session.
- When the WM ignores the request, one line goes to stderr. This bug was invisible in logs.

`WindowFrame.kt` is left as a thin pointer-input pump over the arbiter; the two former drag paths
(native-only and in-app-only) are gone.

## Test plan

Unit (`./gradlew test allTests`, green):

- `WindowDragArbiterTest` — WM answers / ignores / refuses outright, release mid-wait, verdict
  surviving arbiter rebuilds, maximize mid-gesture (#76), no native support at all.
- `NativeMoveWatchTest` — settle boundaries, WM taking over, two-strikes verdict, recovery after
  the WM answers again.
- `WindowDragGestureTest` — take-over geometry against the existing dead-zone rules.

Manual, on a WM that **ignores** the request (GNOME 50 Wayland, verified):

- [x] Drag the window by empty titlebar space — it follows the pointer.
- [x] Double-click the titlebar — maximize/restore.
- [x] Click tabs and window buttons — the window does not move.
- [x] stderr carries exactly two "ignored `_NET_WM_MOVERESIZE`" lines per session, not one per drag.

Manual, on a WM that **honours** the request — not yet done:

- [ ] Drag by the titlebar — the move is compositor-driven and smooth, as before this branch.
- [ ] Drag repeatedly, ten or more times in a row — every gesture still starts a move (this is the
      path that would break if ending the gesture after the WM takes over were wrong).
- [ ] Drag, release, then immediately press the titlebar again — the second press starts a new drag.
- [ ] Double-click to maximize and restore, drag a restored window.
- [ ] Nothing is printed to stderr.

Not verified: Windows, macOS, and any non-GNOME WM.
