### PR TITLE
Sync: finish the reconcile before Online, and one wait budget for the coordinator tests

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -366,6 +366,13 @@ class SyncCoordinator(
     @Volatile
     private var retryJob: Job? = null
 
+    // Whether THIS coordinator has actually started a reactivation reconcile (records dropped, cursor
+    // reset) — the permission [clearPendingReconcile] needs before it may retire the durable marker.
+    // The marker alone isn't enough: it is persisted before the vault is touched, so it can be up while
+    // nothing was cleared. Every read and write is under [syncMutex].
+    @Volatile
+    private var reconcileArmed = false
+
     // Set by [pauseForLock], cleared by [resumeAfterUnlock]: which of the two the coordinator should end
     // up obeying when they queue up behind a long operation holding [opMutex], regardless of the order
     // their coroutines get dispatched in.
@@ -678,26 +685,32 @@ class SyncCoordinator(
         // then be pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the
         // maximal (everything-on) filter covers any server settings; only never-synced, device-local types
         // (terminal history) are kept.
-        if (clearLocalRecords) {
-            // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
-            // verify that reported `reactivated` and never reports it again, so a crash between here and the
-            // first successful sync would otherwise lose the signal and let the stale records push. The
-            // marker is cleared only after runSync succeeds below, so an interrupted reconcile is retried.
-            configStore.save(config.copy(pendingReconcile = true))
-            val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
-            vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
-            syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
-        } else {
-            if (resetCursor) syncState.setCursor(config.accountId, 0)
-            configStore.save(config)
+        //
+        // Under [syncMutex]: a cycle that isn't ours (a manual syncNow, the previous session's watch)
+        // could otherwise read the vault mid-clear, sync off the old cursor, and finish after
+        // [reconcileArmed] went up — retiring the marker for a cycle that was never the full re-pull. It
+        // does NOT cover the gap before this lock, where the session published above is already syncable
+        // over an un-cleared vault: that is issue #142. Lock order holds: we're under opMutex.
+        syncMutex.withLock {
+            if (clearLocalRecords) {
+                // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
+                // verify that reported `reactivated` and never reports it again, so a crash between here and
+                // the first successful sync would otherwise lose the signal and let the stale records push.
+                configStore.save(config.copy(pendingReconcile = true))
+                val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
+                vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
+                syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
+                reconcileArmed = true // only now — see [clearPendingReconcile]
+            } else {
+                if (resetCursor) syncState.setCursor(config.accountId, 0)
+                configStore.save(config)
+                reconcileArmed = false
+            }
         }
         health.setTarget(config.serverUrl)
+        // The marker raised above is dropped by the sync cycle itself ([clearPendingReconcile]) — not
+        // here, because a first cycle that fails leaves it to a later retry to finish the reconcile.
         runSync()
-        // The reconcile is complete only once the first full re-pull actually succeeded (status Online);
-        // until then keep the marker so an interrupted or failed reconcile is redone on the next connect.
-        if (clearLocalRecords && _status.value is SyncStatus.Online) {
-            configStore.save(config.copy(pendingReconcile = false))
-        }
         startWatch()
         startLocalPush()
         // Reconnecting over a live session (switching accounts, a confirmed password replace) leaves the
@@ -1257,11 +1270,44 @@ class SyncCoordinator(
     // One sync attempt + the Online bookkeeping; exceptions propagate to runSyncLocked.
     private suspend fun runSyncAttempt(c: SyncClient, s: SyncSession) {
         val outcome = engineFactory(c).sync(s)
+        clearPendingReconcile(s.accountId)
         _status.value = SyncStatus.Online(s.accountId, outcome.pushed, outcome.pulled)
         // Pulled records from the server → refresh list managers, else synced data isn't visible until reopen.
         if (outcome.pulled > 0) {
             refreshSyncSettings() // another device may have changed "what to sync"
             runCatching { onSynced() }
+        }
+    }
+
+    /**
+     * Drop the durable reactivation marker ([SyncConfig.pendingReconcile]) once a sync cycle for that
+     * account has actually succeeded. [reconcileArmed] says this coordinator dropped the local records
+     * and reset the cursor, so the cycle that just finished IS the full re-pull the marker is waiting
+     * for — including one reached by a later retry (backoff loop, reachability trigger, manual sync)
+     * after the reconcile's own first cycle failed.
+     *
+     * The marker on its own would be the wrong permission: [activateSession] persists it BEFORE it
+     * touches the vault (a crash in between must not lose the signal), so a clear that threw — an
+     * auto-lock landing inside the connect — leaves it up over a vault nothing was dropped from, on a
+     * session that is already published and can still sync. Retiring it there would strand the
+     * pre-revocation records; the next connect redoes the reconcile instead.
+     *
+     * Called before the status is published: [SyncStatus.Online] is what every observer reacts to, and
+     * clearing the marker afterwards leaves a window in which Online is on screen while the saved config
+     * still says a reconcile is pending. Reads the live config rather than a captured copy — the cycle
+     * that just ran may have rotated a fresh sealed refresh token into it.
+     *
+     * Best-effort like [resealRefreshToken]: a config store that fails must not turn a sync that
+     * succeeded into a failure — [reconcileArmed] stays up so the next cycle retries the clear.
+     */
+    private fun clearPendingReconcile(accountId: String) {
+        if (!reconcileArmed) return
+        runCatching {
+            val cfg = configStore.load()
+            if (cfg != null && cfg.accountId == accountId) {
+                if (cfg.pendingReconcile) configStore.save(cfg.copy(pendingReconcile = false))
+                reconcileArmed = false // also when the marker was already down: nothing left to retry
+            }
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
@@ -110,7 +110,7 @@ class SyncCoordinatorLockPauseTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
 
             // Lock: no live subscription may survive it — otherwise the WS keeps retrying against a
@@ -123,7 +123,7 @@ class SyncCoordinatorLockPauseTest {
             // Unlock: sync resumes on its own, no password retyped and no manual "Sync".
             assertTrue(vault.unlock(password.toCharArray()) is UnlockResult.Success)
             sut.resumeAfterUnlock()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
             assertEquals(1, client.peakWatchers.get(), "resume must not stack a second live-pull subscription")
         } finally {
@@ -140,7 +140,7 @@ class SyncCoordinatorLockPauseTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { client.registering.await() } // the connect now holds opMutex
+            awaitSync("the connect to reach register") { client.registering.await() } // the connect now holds opMutex
 
             // The vault locks mid-connect. The pause queues behind the connect on opMutex and tears down
             // what it published; without that, live sync survives the lock unnoticed.
@@ -148,7 +148,7 @@ class SyncCoordinatorLockPauseTest {
             sut.pauseForLock()
             gate.complete(Unit)
 
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Configured } }
+            sut.status.awaitStatus("the status to come Configured") { it is SyncStatus.Configured }
             withTimeout(5_000) { while (client.watchers.get() != 0) delay(10) }
             delay(200) // and it stays down: nothing restarts them behind the lock screen
             assertEquals(0, client.watchers.get())
@@ -171,7 +171,7 @@ class SyncCoordinatorLockPauseTest {
             delay(100) // let the pause run to completion, so it cannot tear the connect down for us
             sut.connect(serverUrl, account, password.toCharArray())
 
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Configured } }
+            sut.status.awaitStatus("the status to come Configured") { it is SyncStatus.Configured }
             delay(200)
             assertEquals(0, client.watchers.get(), "no live-pull may survive behind a locked vault")
         } finally {
@@ -187,7 +187,7 @@ class SyncCoordinatorLockPauseTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             withTimeout(5_000) { while (client.watchers.get() == 0) delay(10) }
 
             // A stray unlock callback (biometric re-prompt, gate recomposition) must not tear down or

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
@@ -117,7 +117,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             withTimeout(5_000) { sut.serverReachable.first { it == ServerReachable.REACHABLE } }
 
             // The network drops: a sync cycle fails with NETWORK and the status parks on Failed.
@@ -158,7 +158,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
 
             // A transient blip: the sync path fails with NETWORK while the health ping stays green, so
             // no reachability transition will ever fire — only the coordinator's own retry can heal it.
@@ -199,7 +199,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
 
             // A sync is in flight (parked inside the engine) when the vault locks: pauseForLock joins
             // only watch/push, so it parks Configured while this cycle is still running.
@@ -250,7 +250,7 @@ class SyncCoordinatorNetworkRecoveryTest {
             // present, no session yet — but by the time it gets the mutex the disconnect has erased the
             // link. Restoring from the stale copy would silently re-link the device.
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { client.registering.await() }
+            awaitSync("the connect to reach register") { client.registering.await() }
             sut.disconnect()
             delay(100) // keep the queue order deterministic: disconnect enters the mutex queue first
             sut.restoreSession()
@@ -279,7 +279,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         val first = coordinator(vault, client, configStore)
         try {
             first.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            withTimeout(30_000) { first.status.first { it is SyncStatus.Online } }
+            first.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             assertTrue(configStore.load()?.sealedRefreshToken != null, "keep-connected must seal the refresh token")
         } finally {
             first.close()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -18,9 +18,7 @@ import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
@@ -73,11 +71,12 @@ class SyncCoordinatorPasswordReplaceTest {
                 expectedAuthKey = null
                 wrappedAccountKey = null
             } else {
-                val mk = crypto.deriveMasterKey(existingAccountPassword.toCharArray(), crypto.deriveSyncSalt(account))
+                // Shared cache, not zeroized here: this class builds a client per test and the Argon2id
+                // derivation is what makes the class the slowest in the suite (issue #141).
+                val mk = syncAccountKey(crypto, existingAccountPassword, account)
                 expectedAuthKey = crypto.deriveAuthKey(mk)
                 val key = accountDataKey ?: crypto.newDataKey()
                 wrappedAccountKey = crypto.wrapDataKey(mk, key)
-                mk.zeroize()
                 key.zeroize()
             }
         }
@@ -177,7 +176,7 @@ class SyncCoordinatorPasswordReplaceTest {
         val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             // The bug: the vault unlock password must NOT have silently changed.
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must still work")
             assertFalse(vault.verifyPassword(accountPassword.toCharArray()), "account password must not have replaced it yet")
@@ -193,9 +192,9 @@ class SyncCoordinatorPasswordReplaceTest {
         val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             sut.confirmPasswordReplace()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             assertFalse(vault.verifyPassword(vaultPassword.toCharArray()), "old vault password must no longer work")
             assertTrue(vault.verifyPassword(accountPassword.toCharArray()), "account password now unlocks the vault")
         } finally {
@@ -210,9 +209,9 @@ class SyncCoordinatorPasswordReplaceTest {
         val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             sut.cancelPasswordReplace()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Disabled } }
+            sut.status.awaitStatus("the status to come Disabled") { it is SyncStatus.Disabled }
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "local vault password must be untouched")
             assertFalse(vault.verifyPassword(accountPassword.toCharArray()), "account password must not unlock the vault")
         } finally {
@@ -228,12 +227,12 @@ class SyncCoordinatorPasswordReplaceTest {
         var closed = false
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             // Esc on the desktop modal (and leaving the mobile screen): it must decline the replace, not
             // leave the connect paused with the
             // kept password alive and the status stuck on NeedsPasswordReplaceConfirm ("Syncing…" forever).
             dismissPasswordReplace(sut) { closed = true }.invoke()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Disabled } }
+            sut.status.awaitStatus("the status to come Disabled") { it is SyncStatus.Disabled }
             assertTrue(closed, "the modal still closes")
             // Nothing left pending: a stale confirm (reopened dialog, queued tap) can't re-key the vault.
             sut.confirmPasswordReplace()
@@ -263,9 +262,9 @@ class SyncCoordinatorPasswordReplaceTest {
             // The vault password drifts away from the account password (Settings → Security).
             assertTrue(vault.changePassword(vaultPassword.toCharArray(), "changed-X".toCharArray()))
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             sut.confirmPasswordReplace()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "connects: the key is ours, only the wrap changes")
             assertTrue(vault.verifyPassword(accountPassword.toCharArray()), "the account password now unlocks the vault")
             assertFalse(vault.verifyPassword("changed-X".toCharArray()), "the old local password no longer unlocks")
@@ -287,9 +286,9 @@ class SyncCoordinatorPasswordReplaceTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             sut.confirmPasswordReplace()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Failed, "must not report success on a replace that didn't happen")
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is left as it was")
         } finally {
@@ -305,7 +304,7 @@ class SyncCoordinatorPasswordReplaceTest {
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, vaultPassword.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             assertTrue(client.registered, "account should be registered under the vault password")
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "vault password is unchanged")
         } finally {
@@ -322,8 +321,8 @@ class SyncCoordinatorPasswordReplaceTest {
         try {
             // "wrong-C" is neither the vault password nor a real account password.
             sut.connect(serverUrl, account, "wrong-C".toCharArray())
-            withTimeout(30_000) {
-                sut.status.first { it is SyncStatus.Failed && it.reason == SyncFailureReason.Unauthorized }
+            sut.status.awaitStatus("the connect to be refused as unauthorized") {
+                it is SyncStatus.Failed && it.reason == SyncFailureReason.Unauthorized
             }
             assertFalse(client.registered, "must not register a divergent account under a non-vault password")
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "vault password is untouched")
@@ -345,7 +344,7 @@ class SyncCoordinatorPasswordReplaceTest {
         try {
             val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
             assertTrue(result is AccountPasswordChange.Success, "rotation succeeds, was $result")
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
             assertTrue(vault.verifyPassword(rotated.toCharArray()), "the vault now unlocks with the new password")
             assertFalse(vault.verifyPassword(vaultPassword.toCharArray()), "the old password no longer unlocks")
         } finally {
@@ -411,9 +410,9 @@ class SyncCoordinatorPasswordReplaceTest {
         val heal = coordinator(vault, client, store)
         try {
             heal.connect(serverUrl, account, rotated.toCharArray())
-            withTimeout(30_000) { heal.status.first { it is SyncStatus.NeedsPasswordReplaceConfirm } }
+            heal.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             heal.confirmPasswordReplace()
-            withTimeout(30_000) { heal.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            heal.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(heal.status.value is SyncStatus.Online, "reconnect with the new password heals the device, was ${heal.status.value}")
             assertTrue(vault.verifyPassword(rotated.toCharArray()), "the local vault now unlocks with the new password")
         } finally {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -17,14 +17,17 @@ import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -57,15 +60,23 @@ class SyncCoordinatorReactivationTest {
     private inner class ReactivatingClient(
         private val ownWrappedKey: ByteArray,
         private val reactivated: Boolean = true,
+        /** Makes the reconcile's own first cycle fail, leaving the rebuild to a later sync. */
+        private val failFirstPull: Boolean = false,
     ) : SyncClient {
         val pushed = mutableListOf<RemoteRecord>()
+        private val pulls = AtomicInteger(0)
 
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
             throw SyncException(SyncException.Kind.CONFLICT, "account exists")
         override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
             SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = reactivated)
         override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
-        override suspend fun pull(session: SyncSession, since: Long): RecordPage = RecordPage(emptyList(), 1)
+        override suspend fun pull(session: SyncSession, since: Long): RecordPage {
+            // Not a SyncException(NETWORK): that one arms the backoff retry loop, and the test wants the
+            // next cycle to be the one it triggers itself.
+            if (failFirstPull && pulls.getAndIncrement() == 0) error("pull unreachable")
+            return RecordPage(emptyList(), 1)
+        }
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
             pushed += records
             return RecordPage(emptyList(), 1)
@@ -81,6 +92,29 @@ class SyncCoordinatorReactivationTest {
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
     }
 
+    /**
+     * A real vault whose reconcile-time clear fails — what an auto-lock landing inside the connect does
+     * (`clearRecords` requires an unlocked vault), leaving the durable marker up with nothing cleared.
+     */
+    private class ClearFailingVault(private val delegate: Vault) : Vault by delegate {
+        override fun clearRecords(types: Set<RecordType>): Unit = error("vault is locked")
+    }
+
+    /** Config store that refuses exactly the write retiring the reconcile marker (a full disk). */
+    private class MarkerClearFailingStore(private val delegate: SyncConfigStore) : SyncConfigStore {
+        @Volatile
+        var refuseClear = true
+
+        override fun load(): SyncConfig? = delegate.load()
+        override fun save(config: SyncConfig) {
+            if (refuseClear && !config.pendingReconcile && delegate.load()?.pendingReconcile == true) {
+                error("config write failed")
+            }
+            delegate.save(config)
+        }
+        override fun clear() = delegate.clear()
+    }
+
     /** A fresh unlocked account vault under [password], with its own random dataKey. */
     private fun freshVault(): Vault {
         val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()
@@ -91,11 +125,8 @@ class SyncCoordinatorReactivationTest {
 
     /** This vault's own dataKey wrapped under the account (= vault) password, so the connect adopts nothing. */
     private fun ownWrap(vault: Vault): ByteArray {
-        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
         val dk = vault.exportDataKey()!!
-        val wrapped = crypto.wrapDataKey(mk, dk)
-        mk.zeroize(); dk.zeroize()
-        return wrapped
+        return crypto.wrapDataKey(syncAccountKey(crypto, password, account), dk).also { dk.zeroize() }
     }
 
     @Test
@@ -110,7 +141,7 @@ class SyncCoordinatorReactivationTest {
         val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
             assertFalse(vault.records().any { it.id == "r1" }, "a reactivated device must discard its pre-revocation records")
             assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
@@ -136,11 +167,135 @@ class SyncCoordinatorReactivationTest {
         val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "reconnect should come Online")
             assertFalse(vault.records().any { it.id == "r1" }, "a pending reconcile must still rebuild the vault")
             assertFalse(client.pushed.any { it.id == "r1" }, "a pending reconcile must not let the stale record push")
             assertEquals(false, config.load()?.pendingReconcile, "the redone reconcile clears the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * [SyncStatus.Online] is what the UI and every other observer react to, so it must not arrive while the
+     * reconcile marker is still up: an observer would read a config the reconcile has already left behind.
+     * The sample is taken by an unconfined collector, i.e. inside the emission itself, so it sees exactly
+     * what the coordinator published rather than what it got around to writing afterwards.
+     */
+    @Test
+    fun `the reconcile marker is already down when the connect publishes Online`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val markerAtOnline = CompletableDeferred<Boolean?>()
+        val observer = launch(Dispatchers.Unconfined) {
+            sut.status.collect { if (it is SyncStatus.Online) markerAtOnline.complete(config.load()?.pendingReconcile) }
+        }
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            assertEquals(
+                false,
+                awaitSync("the reactivation connect to publish Online") { markerAtOnline.await() },
+                "Online must not be published while the reconcile marker is still up",
+            )
+        } finally {
+            observer.cancel()
+            sut.close()
+        }
+    }
+
+    /**
+     * The reconcile is finished by whichever cycle first succeeds, not only by the one the connect
+     * starts: a first cycle that fails leaves the vault cleared and the cursor at 0, so the next sync is
+     * still the full re-pull the marker is waiting for. Clearing it only in the connect's own cycle would
+     * leave the marker up for good and redo the reconcile on every later connect.
+     */
+    @Test
+    fun `a reconcile whose first cycle failed is completed by the next sync that succeeds`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, failFirstPull = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the reconcile's first cycle to fail") { it is SyncStatus.Failed }
+            assertEquals(true, config.load()?.pendingReconcile, "a failed cycle must leave the marker up")
+
+            sut.syncNow()
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
+            assertEquals(false, config.load()?.pendingReconcile, "the cycle that succeeded completes the reconcile")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The marker is persisted BEFORE the vault is cleared (a crash in between must not lose the signal),
+     * so it can be up on a device whose reconcile never actually ran. The session is published by then,
+     * so an ordinary cycle can still succeed — and it is not the rebuild the marker is waiting for.
+     * Retiring the marker there would strand the pre-revocation records for good.
+     */
+    @Test
+    fun `a marker whose reconcile never cleared the vault survives a later successful sync`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault),
+            configStore = config,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+            assertEquals(true, config.load()?.pendingReconcile, "a reconcile that could not clear the vault keeps the marker")
+
+            sut.syncNow()
+            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
+            assertEquals(true, config.load()?.pendingReconcile, "only a reconcile that actually ran may retire the marker")
+            assertTrue(vault.records().any { it.id == "r1" }, "the stale record is still there — the reconcile never ran")
+            // That cycle also pushes the un-cleared record back to the server: the session is published
+            // before the clear runs, so a failed clear leaves a syncable session — issue #142.
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Retiring the marker is a config write, and a config write can fail. It must not turn a sync that
+     * actually succeeded into a reported failure — the marker simply stays up, and the next cycle retires
+     * it, the same fallback an interrupted reconcile relies on.
+     */
+    @Test
+    fun `a refused marker write keeps the sync green and is retried by the next cycle`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = MarkerClearFailingStore(InMemorySyncConfigStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "a refused marker write must not fail a sync that succeeded")
+            assertEquals(true, config.load()?.pendingReconcile, "a refused write leaves the marker up")
+
+            config.refuseClear = false
+            sut.syncNow()
+            awaitSync("the retried clear to land") { while (config.load()?.pendingReconcile != false) delay(20) }
         } finally {
             sut.close()
         }
@@ -161,7 +316,7 @@ class SyncCoordinatorReactivationTest {
         val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
             assertFalse(
                 vault.records().any { it.id == "r1" },

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
@@ -17,10 +17,8 @@ import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
@@ -111,7 +109,7 @@ class SyncCoordinatorServerFailureTest {
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Failed } as SyncStatus.Failed }
+            sut.status.awaitStatus("the status to come Failed") { it is SyncStatus.Failed } as SyncStatus.Failed
         } finally {
             sut.close()
         }
@@ -220,7 +218,7 @@ class SyncCoordinatorServerFailureTest {
             )
             try {
                 sut.connect(serverUrl, account, password.toCharArray())
-                withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+                sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             } finally {
                 sut.close()
             }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
@@ -17,10 +17,8 @@ import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
@@ -105,11 +103,8 @@ class SyncCoordinatorTokenRefreshTest {
 
     /** This vault's own dataKey wrapped under the account (= vault) password, so the connect adopts nothing. */
     private fun ownWrap(vault: Vault): ByteArray {
-        val mk = crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(account))
         val dk = vault.exportDataKey()!!
-        val wrapped = crypto.wrapDataKey(mk, dk)
-        mk.zeroize(); dk.zeroize()
-        return wrapped
+        return crypto.wrapDataKey(syncAccountKey(crypto, password, account), dk).also { dk.zeroize() }
     }
 
     /** Coordinator whose sync cycle fails with 401 whenever the session's access token is expired. */
@@ -136,7 +131,7 @@ class SyncCoordinatorTokenRefreshTest {
         val sut = coordinator(client, vault, config)
         try {
             sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "connect should come Online, got ${sut.status.value}")
             val sealedAtConnect = config.load()?.sealedRefreshToken
             assertNotNull(sealedAtConnect, "keep-connected must seal the refresh token at connect")
@@ -144,8 +139,8 @@ class SyncCoordinatorTokenRefreshTest {
             // The 15-minute TTL passes: the server now rejects the session's access token.
             client.expiredTokens += "access-1"
             sut.syncNow()
-            val terminal = withTimeout(30_000) {
-                sut.status.first { (it is SyncStatus.Online && client.refreshCalls.get() > 0) || it is SyncStatus.Failed || it is SyncStatus.Configured }
+            val terminal = sut.status.awaitStatus("the expired sync to refresh and retry") {
+                (it is SyncStatus.Online && client.refreshCalls.get() > 0) || it is SyncStatus.Failed || it is SyncStatus.Configured
             }
             assertTrue(terminal is SyncStatus.Online, "an expired access token must refresh+retry, not surface as $terminal")
             assertEquals(1, client.refreshCalls.get(), "exactly one refresh for one expired sync")
@@ -174,7 +169,7 @@ class SyncCoordinatorTokenRefreshTest {
         val sut = coordinator(client, vault, config)
         try {
             sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online)
 
             // Both tokens are dead (device revoked / 30-day refresh expiry): the link survives, the
@@ -182,8 +177,8 @@ class SyncCoordinatorTokenRefreshTest {
             client.expiredTokens += "access-1"
             client.refreshUnauthorized = true
             sut.syncNow()
-            val terminal = withTimeout(30_000) {
-                sut.status.first { it is SyncStatus.Configured || it is SyncStatus.Failed }
+            val terminal = sut.status.awaitStatus("the dead session to be torn down") {
+                it is SyncStatus.Configured || it is SyncStatus.Failed
             }
             assertTrue(terminal is SyncStatus.Configured, "a dead refresh token must ask for the password (Configured), got $terminal")
             assertEquals(null, sut.currentSession(), "the dead session must be dropped")
@@ -203,7 +198,7 @@ class SyncCoordinatorTokenRefreshTest {
         val sut = coordinator(client, vault, config)
         try {
             sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online)
 
             // Access token expired AND the refresh round trip hits a network blip: the truthful status
@@ -212,14 +207,14 @@ class SyncCoordinatorTokenRefreshTest {
             client.expiredTokens += "access-1"
             client.refreshNetworkError = true
             sut.syncNow()
-            val failed = withTimeout(30_000) { sut.status.first { it is SyncStatus.Failed || it is SyncStatus.Configured } }
+            val failed = sut.status.awaitStatus("the failed refresh to surface") { it is SyncStatus.Failed || it is SyncStatus.Configured }
             assertTrue(failed is SyncStatus.Failed && failed.reason == SyncFailureReason.Network, "a refresh network blip must surface as Network, got $failed")
             assertTrue(sut.currentSession() != null, "the session must survive a transient refresh failure")
 
             // The blip passes: the next sync recovers through the normal refresh+retry path.
             client.refreshNetworkError = false
             sut.syncNow()
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+            sut.status.awaitStatus("the recovered sync to come Online") { it is SyncStatus.Online }
             assertEquals(2, client.refreshCalls.get(), "one failed and one successful refresh")
         } finally {
             sut.close()
@@ -235,13 +230,13 @@ class SyncCoordinatorTokenRefreshTest {
         val sut = coordinator(client, vault, config)
         try {
             sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            withTimeout(30_000) { sut.status.first { it is SyncStatus.Online || it is SyncStatus.Failed } }
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online)
 
             // Every WS drop rotates the session (best-effort refresh) — the NEXT handshake must use
             // the fresh token, not the one captured when the watch started (a dead captured token
             // would otherwise loop 401 forever while the status stays Online).
-            withTimeout(30_000) {
+            awaitSync("the watch to reconnect") {
                 while (client.watchTokens.size < 2) delay(50)
             }
             assertEquals("access-1", client.watchTokens[0])

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorWebAccessTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorWebAccessTest.kt
@@ -22,10 +22,8 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withTimeout
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
@@ -145,7 +143,7 @@ class SyncCoordinatorWebAccessTest {
         initializeVaultCrypto()
         val sut = coordinator(localVault(), client)
         sut.connect(serverUrl, account, password.toCharArray())
-        withTimeout(30_000) { sut.status.first { it is SyncStatus.Online } }
+        sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
         return sut
     }
 
@@ -289,7 +287,7 @@ class SyncCoordinatorWebAccessTest {
             client.entered = gate
             val typed = "web-pw-123".toCharArray()
             val job = launch { sut.setWebPassword(typed) }
-            withTimeout(30_000) { gate.await() }
+            awaitSync("the web-password call to reach the client") { gate.await() }
             job.cancelAndJoin()
             assertTrue(typed.all { it == ' ' }, "a cancelled submit must not leave the password in the array")
         } finally {
@@ -305,8 +303,8 @@ class SyncCoordinatorWebAccessTest {
             val before = client.refreshes
             val set = async { sut.setWebPassword("web-pw-123".toCharArray()) }
             val state = async { sut.webAccessEnabled() }
-            assertEquals(WebAccessChange.Success, withTimeout(30_000) { set.await() })
-            withTimeout(30_000) { state.await() }
+            assertEquals(WebAccessChange.Success, awaitSync("the web-password call to land") { set.await() })
+            awaitSync("the web-access read to land") { state.await() }
             // One rotation, not one per caller: the second finds the session already replaced under
             // syncMutex and retries with it rather than spending another refresh token.
             assertEquals(1, client.refreshes - before)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncTestKeys.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncTestKeys.kt
@@ -1,0 +1,25 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.vault.MasterKey
+import app.skerry.shared.vault.VaultCrypto
+import java.util.concurrent.ConcurrentHashMap
+
+private val accountKeys = ConcurrentHashMap<Pair<String, String>, MasterKey>()
+
+/**
+ * The account master key the coordinator tests wrap their fixture dataKey under — derived once per
+ * (password, accountId) for the whole test JVM instead of once per test.
+ *
+ * Argon2id at m = 64 MiB is the bulk of these classes' wall-clock cost and every test in them uses the
+ * same pair, so repeating the derivation only makes the suite slower and more sensitive to machine load
+ * (issue #141). Deliberately never zeroized: the coordinator derives and wipes its own key, this one is
+ * a fixture over a hardcoded test password and only ever feeds `wrapDataKey`.
+ *
+ * The cache is keyed by (password, accountId) only, and a hit never touches [crypto] — fine while every
+ * caller passes a real [app.skerry.shared.vault.IonspinVaultCrypto] after `initializeVaultCrypto()`, but
+ * a caller handing in a different implementation would silently get the Ionspin-derived key.
+ */
+fun syncAccountKey(crypto: VaultCrypto, password: String, accountId: String): MasterKey =
+    accountKeys.getOrPut(password to accountId) {
+        crypto.deriveMasterKey(password.toCharArray(), crypto.deriveSyncSalt(accountId))
+    }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncWaits.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncWaits.kt
@@ -1,0 +1,42 @@
+package app.skerry.ui.sync
+
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.test.fail
+
+/**
+ * How long the coordinator tests wait for the coordinator to get somewhere.
+ *
+ * These tests drive a real `FileVault` over real Argon2id (m = 64 MiB) on the coordinator's own
+ * `Dispatchers.Default` scope, so what they wait for costs milliseconds on an idle machine and can
+ * cost orders of magnitude more on one that is simultaneously running the rest of the build — a
+ * memory-hard KDF is the first thing to lose to paging. The number is therefore not a latency
+ * assertion: it only has to be large enough that anything slower is a wedged coordinator rather than
+ * a busy machine (issue #141). A slow honest failure is cheap; a false one discredits the suite.
+ *
+ * Waits that assert a *period* (a health poll reacting within its own injected interval) keep their
+ * own explicit, small budget — that budget is the assertion.
+ */
+private const val SYNC_WAIT_BUDGET_MS = 120_000L
+
+/** Boxed so a `null` returned by the awaited block isn't read as a timeout. */
+private class Awaited<T>(val value: T)
+
+private fun timedOut(what: String, detail: String): Nothing =
+    fail("timed out after ${SYNC_WAIT_BUDGET_MS / 1_000}s waiting for $what$detail")
+
+/**
+ * Waits for [block] under the shared budget, failing with [what] instead of a bare
+ * [kotlinx.coroutines.TimeoutCancellationException] — a timeout that names nothing reads like a sync
+ * regression until someone re-runs the suite.
+ */
+suspend fun <T> awaitSync(what: String, block: suspend () -> T): T =
+    (withTimeoutOrNull(SYNC_WAIT_BUDGET_MS) { Awaited(block()) } ?: timedOut(what, "")).value
+
+/** [awaitSync] for the common case: the first status matching [predicate]. */
+suspend fun StateFlow<SyncStatus>.awaitStatus(what: String, predicate: (SyncStatus) -> Boolean): SyncStatus =
+    (
+        withTimeoutOrNull(SYNC_WAIT_BUDGET_MS) { Awaited(first(predicate)) }
+            ?: timedOut(what, "; last status: $value")
+        ).value


### PR DESCRIPTION
Closes #141.

## The reconcile marker and `SyncStatus.Online`

A reactivation reconcile raises a durable marker (`SyncConfig.pendingReconcile`), drops the local records, resets the cursor, and clears the marker once a full re-pull has actually succeeded. The clear used to happen after `runSync()` returned — that is, after `SyncStatus.Online` had already been published from inside the sync cycle. Anything reacting to `Online` therefore read a config the reconcile had already left behind.

The sync cycle now retires the marker itself, immediately before publishing `Online`:

- it happens on whichever cycle first succeeds, not only the one the connect starts, so a reconcile whose first cycle failed is finished by the retry that follows;
- a marker whose reconcile never ran is not retired. The marker is persisted before the vault is touched, so it can be up over a vault nothing was cleared from; the coordinator arms itself only after the clear and the cursor reset return, and only an armed coordinator may retire the marker;
- the marker write, the clear and the cursor reset run under `syncMutex`, so a foreign cycle cannot interleave with them;
- the write reads the live config instead of a copy captured before the cycle, so a refresh token rotated during that cycle is no longer overwritten by a stale copy;
- it is best-effort: a config write that fails leaves the marker up and the coordinator armed, and the next cycle retries — a failed write no longer turns a sync that succeeded into a reported failure.

## Test waits

45 `withTimeout(30_000)` waits across the seven coordinator test classes become one shared budget in `SyncWaits.kt`. These tests drive a real vault over real Argon2id on the coordinator own dispatchers, so no wall-clock number is both tight and load-proof; the budget is a wedge detector, and a timeout now fails naming what was awaited and the last status seen instead of raising a bare `TimeoutCancellationException` that reads like a sync regression. Waits whose short budget is itself the assertion — a health poll reacting within its own injected interval — keep theirs.

Three test classes take the account master key from one per-JVM derivation instead of deriving it per test. `SyncCoordinatorTokenRefreshTest` 2.69 s to 1.89 s, `SyncCoordinatorPasswordReplaceTest` 9.43 s to 5.97 s.

## Verifying

`./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll`, `./gradlew :androidApp:compileDebugKotlin` — all green, plus three consecutive full `:composeApp:desktopTest` runs with no failures. Each of the four new tests in `SyncCoordinatorReactivationTest` was re-run with its production change reverted and fails there for its own reason.

## Not in this PR

- A reactivation connect publishes the session before the reconcile clear runs, so a clear that throws leaves a live session that can push the un-cleared records back to the server. Pre-existing and unchanged here — filed as #142 with both fix options, because closing it changes what a failed connect leaves behind.
- The atomicity of the reconcile block has no test: a deterministic one needs a negative timing assertion ("no cycle completed within X"), which is the wall-clock bet this PR removes.
- `SyncCoordinator` grows by ~30 lines while `LargeClass` is baselined for it. Not split here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)