### PR TITLE
Sync: refuse a cycle while a reactivation reconcile is still owed

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sync.xml
@@ -116,6 +116,7 @@
     <string name="sync_fail_server_error">Сервер отвечает с ошибкой — попробуйте позже</string>
     <string name="sync_fail_rejected">Сервер отклонил запрос — обратитесь к его администратору</string>
     <string name="sync_fail_registration_refused_signin">Сервер отклонил регистрацию и вход — проверьте пароль</string>
+    <string name="sync_fail_reconcile_required">Устройство должно перечитать данные с сервера — подключитесь заново</string>
 
     <!-- issue #28: подключение к существующему аккаунту с другим паролём меняет пароль этого устройства -->
     <string name="sync_password_replace_title">Использовать пароль аккаунта?</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -116,6 +116,7 @@
     <string name="sync_fail_server_error">服务器响应异常，请稍后重试</string>
     <string name="sync_fail_rejected">服务器拒绝了该请求 — 请联系服务器管理员</string>
     <string name="sync_fail_registration_refused_signin">服务器拒绝了注册和登录 — 请检查密码</string>
+    <string name="sync_fail_reconcile_required">此设备需要从服务器重建数据 — 请重新连接后同步</string>
 
     <!-- issue #28: 连接到使用其他密码的现有账户会将本设备改用该密码 -->
     <string name="sync_password_replace_title">使用账户密码？</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -116,6 +116,7 @@
     <string name="sync_fail_server_error">The server isn't responding correctly — try again later</string>
     <string name="sync_fail_rejected">The server refused this request — ask its administrator</string>
     <string name="sync_fail_registration_refused_signin">The server refused registration and sign-in — check the password</string>
+    <string name="sync_fail_reconcile_required">This device must rebuild its data from the server — reconnect to sync</string>
 
     <!-- issue #28: joining an existing account whose password differs re-keys this device to it -->
     <string name="sync_password_replace_title">Use your account password?</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -180,6 +180,11 @@ enum class SyncFailureReason {
     RegistrationRefusedSignInFailed,
     TooManyRequests,       // the server's rate limiter turned the request away — retrying later works
     ServerError,           // the server (or the proxy in front of it) is broken or restarting
+    // This device still owes the reactivation rebuild ([SyncConfig.pendingReconcile]) and its vault was
+    // never cleared, so every sync cycle is refused rather than push records the account purged. Only a
+    // reconnect (or a keep-connected restore) redoes the reconcile — hence a named reason and not the
+    // silent Configured that reads as "vault locked".
+    ReconcileRequired,
 }
 
 /**
@@ -660,10 +665,19 @@ class SyncCoordinator(
         resetCursor: Boolean,
         clearLocalRecords: Boolean = false,
     ) {
-        // Publish under [syncMutex]: the 401 recovery ([refreshSessionLocked]) rotates/nulls the
-        // session and rewrites the config while holding syncMutex only — without sharing the lock, a
-        // refresh in flight (a suspended network call) would resolve after this activation and clobber
-        // the just-published session and config (including the pendingReconcile marker saved below).
+        // Publish and reconcile in ONE [syncMutex] section. Publishing is what makes a session syncable,
+        // and the reconcile below is what makes it safe to sync: split into two sections, the mutex is
+        // free in between, and any cycle that wins it there (the previous session's watch/push, a manual
+        // syncNow, a retry tick — all of which read the live [client]/[session] fields) runs over the
+        // just-published session with the vault not yet cleared and the marker not yet persisted, so even
+        // [reconcileOwed] cannot see that it must stand down. That cycle pushes the pre-revocation
+        // records: issue #142 again, through a narrower window.
+        //
+        // Sharing the lock with the 401 recovery ([refreshSessionLocked]) is the other reason it is held
+        // here at all: that path rotates/nulls the session and rewrites the config under syncMutex only,
+        // and a refresh in flight would otherwise resolve after this activation and clobber the session
+        // and config it just published (including the pendingReconcile marker).
+        //
         // Lock order holds: we're under opMutex, syncMutex nests inside it.
         val superseded: SyncClient?
         syncMutex.withLock {
@@ -673,25 +687,17 @@ class SyncCoordinator(
             // A retry loop armed for the previous session must not carry its escalated backoff into
             // this one — the fresh session's first network failure re-arms from the minimum.
             retryJob?.cancel()
-        }
-        // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the first
-        // sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
-        // push can't resurrect a record the server purged while this device was revoked.
-        //
-        // The drop set is EVERY sync-capable type, NOT the currently-enabled ones: the push after the
-        // reconciling pull filters by the SERVER's "what syncs" settings (the pull applies them), which can
-        // differ from this device's stale local settings. If we gated the clear by the local settings, a
-        // type disabled locally but enabled on the server would keep its stale record through the clear and
-        // then be pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the
-        // maximal (everything-on) filter covers any server settings; only never-synced, device-local types
-        // (terminal history) are kept.
-        //
-        // Under [syncMutex]: a cycle that isn't ours (a manual syncNow, the previous session's watch)
-        // could otherwise read the vault mid-clear, sync off the old cursor, and finish after
-        // [reconcileArmed] went up — retiring the marker for a cycle that was never the full re-pull. It
-        // does NOT cover the gap before this lock, where the session published above is already syncable
-        // over an un-cleared vault: that is issue #142. Lock order holds: we're under opMutex.
-        syncMutex.withLock {
+            // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the
+            // first sync, so the following full re-pull rebuilds them from the server snapshot and the
+            // subsequent push can't resurrect a record the server purged while this device was revoked.
+            //
+            // The drop set is EVERY sync-capable type, NOT the currently-enabled ones: the push after the
+            // reconciling pull filters by the SERVER's "what syncs" settings (the pull applies them), which
+            // can differ from this device's stale local settings. If we gated the clear by the local
+            // settings, a type disabled locally but enabled on the server would keep its stale record
+            // through the clear and then be pushed once the pull flips the filter on — resurrecting the
+            // purged record. Clearing by the maximal (everything-on) filter covers any server settings;
+            // only never-synced, device-local types (terminal history) are kept.
             if (clearLocalRecords) {
                 // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
                 // verify that reported `reactivated` and never reports it again, so a crash between here and
@@ -704,7 +710,12 @@ class SyncCoordinator(
             } else {
                 if (resetCursor) syncState.setCursor(config.accountId, 0)
                 configStore.save(config)
-                reconcileArmed = false
+                // Disarm only if the config just saved carries no marker for this account. A re-activation
+                // that doesn't reconcile ([doChangeAccountPassword]) can still carry one — a reconcile that
+                // ran here but whose marker write was refused — and the records it dropped stay dropped.
+                // Disarming there would make [reconcileOwed] refuse every later cycle, including the one
+                // that would finally retire the marker.
+                reconcileArmed = reconcileArmed && config.pendingReconcile
             }
         }
         health.setTarget(config.serverUrl)
@@ -1164,6 +1175,17 @@ class SyncCoordinator(
             parkOnConfigured()
             return
         }
+        // This device owes a reconcile it never performed (see [reconcileOwed]): its vault still holds
+        // the records the server purged while it was revoked, and pushing them is exactly the
+        // resurrection the marker exists to prevent — silently, under an Online status. Refuse the cycle
+        // and name the reason: only a connect/restore redoes the reconcile, so the user has to act, and
+        // a bare Configured would render as "vault locked" over a vault that is open. The session stays
+        // published (tearing it down needs [opMutex], which nests outside this lock) but is inert —
+        // every cycle lands here until the reconcile actually runs.
+        if (reconcileOwed(s.accountId)) {
+            _status.value = SyncStatus.Failed(SyncFailureReason.ReconcileRequired)
+            return
+        }
         try {
             runSyncAttempt(c, s)
         } catch (e: CancellationException) {
@@ -1231,6 +1253,26 @@ class SyncCoordinator(
         if ((_status.value as? SyncStatus.Failed)?.reason == SyncFailureReason.Network) scheduleNetworkRetry()
     }
 
+    /**
+     * Whether a reactivation reconcile is owed on this account but was never performed here: the durable
+     * marker ([SyncConfig.pendingReconcile]) is up while [reconcileArmed] is down.
+     *
+     * [activateSession] publishes the session and reconciles in one locked section, so a cycle can no
+     * longer slip in mid-reconcile — but the clear itself can throw (an auto-lock landing inside the
+     * connect: [Vault.clearRecords] needs an unlocked vault), and the marker is persisted before the
+     * vault is touched. That leaves a live session over a vault full of pre-revocation records, as does
+     * any activation that doesn't reconcile at all ([doChangeAccountPassword]) while the marker is up.
+     * Issue #142.
+     *
+     * Read under [syncMutex] like [reconcileArmed] itself, and matched on [accountId] — a marker saved
+     * for another account says nothing about this session.
+     */
+    private fun reconcileOwed(accountId: String): Boolean {
+        if (reconcileArmed) return false
+        val cfg = configStore.load() ?: return false
+        return cfg.accountId == accountId && cfg.pendingReconcile
+    }
+
     /** Park the status on Configured (the vault-locked resting state); Disabled without a link. */
     private fun parkOnConfigured() {
         _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) }
@@ -1289,8 +1331,8 @@ class SyncCoordinator(
      * The marker on its own would be the wrong permission: [activateSession] persists it BEFORE it
      * touches the vault (a crash in between must not lose the signal), so a clear that threw — an
      * auto-lock landing inside the connect — leaves it up over a vault nothing was dropped from, on a
-     * session that is already published and can still sync. Retiring it there would strand the
-     * pre-revocation records; the next connect redoes the reconcile instead.
+     * session that is already published. Retiring it there would strand the pre-revocation records; that
+     * session's cycles are refused ([reconcileOwed]) and the next connect redoes the reconcile instead.
      *
      * Called before the status is published: [SyncStatus.Online] is what every observer reacts to, and
      * clearing the marker afterwards leaves a window in which Online is on screen while the saved config

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncFailureText.kt
@@ -12,6 +12,7 @@ import app.skerry.ui.generated.resources.sync_fail_network
 import app.skerry.ui.generated.resources.sync_fail_pairing
 import app.skerry.ui.generated.resources.sync_fail_pairing_expired
 import app.skerry.ui.generated.resources.sync_fail_protocol
+import app.skerry.ui.generated.resources.sync_fail_reconcile_required
 import app.skerry.ui.generated.resources.sync_fail_registration_refused_signin
 import app.skerry.ui.generated.resources.sync_fail_rejected
 import app.skerry.ui.generated.resources.stail_sync_fail_detail
@@ -65,4 +66,5 @@ internal fun syncFailureResource(reason: SyncFailureReason): StringResource =
         SyncFailureReason.ServerError -> Res.string.sync_fail_server_error
         SyncFailureReason.Rejected -> Res.string.sync_fail_rejected
         SyncFailureReason.RegistrationRefusedSignInFailed -> Res.string.sync_fail_registration_refused_signin
+        SyncFailureReason.ReconcileRequired -> Res.string.sync_fail_reconcile_required
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -87,7 +87,10 @@ class SyncCoordinatorReactivationTest {
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
         override suspend fun refresh(session: SyncSession): SyncSession = throw NotImplementedError()
-        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = throw NotImplementedError()
+        // The rotation itself isn't what these tests are about: they need the activation that follows it,
+        // which re-publishes the session WITHOUT reconciling. Accepts any current password.
+        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+            SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
     }
@@ -95,9 +98,16 @@ class SyncCoordinatorReactivationTest {
     /**
      * A real vault whose reconcile-time clear fails — what an auto-lock landing inside the connect does
      * (`clearRecords` requires an unlocked vault), leaving the durable marker up with nothing cleared.
+     * [failures] bounds how many clears fail, so a test can also drive the recovery: the lock is gone by
+     * the next connect and the reconcile finally runs.
      */
-    private class ClearFailingVault(private val delegate: Vault) : Vault by delegate {
-        override fun clearRecords(types: Set<RecordType>): Unit = error("vault is locked")
+    private class ClearFailingVault(private val delegate: Vault, private val failures: Int = Int.MAX_VALUE) : Vault by delegate {
+        private var attempts = 0
+
+        override fun clearRecords(types: Set<RecordType>) {
+            if (attempts++ < failures) error("vault is locked")
+            delegate.clearRecords(types)
+        }
     }
 
     /** Config store that refuses exactly the write retiring the reconcile marker (a full disk). */
@@ -239,12 +249,14 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * The marker is persisted BEFORE the vault is cleared (a crash in between must not lose the signal),
-     * so it can be up on a device whose reconcile never actually ran. The session is published by then,
-     * so an ordinary cycle can still succeed — and it is not the rebuild the marker is waiting for.
-     * Retiring the marker there would strand the pre-revocation records for good.
+     * so it can be up on a device whose reconcile never actually ran — the clear threw and the session
+     * published a moment earlier is still live. That session must not sync: its vault still holds the
+     * pre-revocation records the server purged, and a cycle would push them straight back and report
+     * Online while doing it (issue #142). The cycle is refused and the status parks on the link state;
+     * the rebuild is left to the next connect/restore, which redoes the reconcile.
      */
     @Test
-    fun `a marker whose reconcile never cleared the vault survives a later successful sync`() = runBlocking {
+    fun `a session whose reconcile never cleared the vault refuses to sync`() = runBlocking {
         initializeVaultCrypto()
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
@@ -263,11 +275,134 @@ class SyncCoordinatorReactivationTest {
             assertEquals(true, config.load()?.pendingReconcile, "a reconcile that could not clear the vault keeps the marker")
 
             sut.syncNow()
-            sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
+            val settled = sut.status.awaitStatus("the manual sync to settle") {
+                it is SyncStatus.Online || (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
+            }
+            assertEquals(
+                SyncStatus.Failed(SyncFailureReason.ReconcileRequired),
+                settled,
+                "a device that owes a reconcile must refuse the cycle, not run it and report Online",
+            )
+            assertFalse(
+                client.pushed.any { it.id == "r1" },
+                "a refused cycle must not push the records the reconcile was supposed to drop",
+            )
             assertEquals(true, config.load()?.pendingReconcile, "only a reconcile that actually ran may retire the marker")
             assertTrue(vault.records().any { it.id == "r1" }, "the stale record is still there — the reconcile never ran")
-            // That cycle also pushes the un-cleared record back to the server: the session is published
-            // before the clear runs, so a failed clear leaves a syncable session — issue #142.
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The refusal is a stop, not a dead end: the marker is still on disk, so the next connect on the SAME
+     * coordinator redoes the reconcile — this time over a vault that lets the clear through — and the
+     * device comes back Online with its records rebuilt from the server. Recovery through a fresh
+     * coordinator (an app restart) is a different path and is covered by the pending-marker test above.
+     */
+    @Test
+    fun `a reconnect finishes the reconcile the refused cycle was waiting for`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault, failures = 1),
+            configStore = config,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+            sut.syncNow()
+            sut.status.awaitStatus("the cycle to be refused") {
+                (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
+            }
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the reconnect to settle") { it is SyncStatus.Online }
+            assertFalse(vault.records().any { it.id == "r1" }, "the redone reconcile must drop the pre-revocation record")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never have been pushed")
+            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A password rotation re-activates the session without reconciling, and the config it saves still
+     * carries the marker. When the reconcile it belongs to already ran here (records dropped, only the
+     * marker write refused), that re-activation must not disarm the coordinator: doing so would make
+     * every later cycle refuse — including the one that would finally retire the marker — and the device
+     * would sit blocked until a reconnect for a rebuild that already happened.
+     */
+    @Test
+    fun `a password rotation over a reconcile that already ran keeps syncing`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = MarkerClearFailingStore(InMemorySyncConfigStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "the reconcile itself succeeded — only its marker write was refused")
+            assertEquals(true, config.load()?.pendingReconcile, "the refused write leaves the marker up")
+
+            // changeAccountPassword awaits the activation it triggers, so the cycle has already run here.
+            assertEquals(
+                AccountPasswordChange.Success,
+                sut.changeAccountPassword(password.toCharArray(), "vault-B".toCharArray()),
+            )
+            assertTrue(
+                sut.status.value is SyncStatus.Online,
+                "a re-activation carrying a marker whose reconcile already ran must keep syncing",
+            )
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The mirror case: the reconcile never ran (the clear threw), and a password rotation re-publishes
+     * the session without reconciling either. The rotation itself succeeds — the server did change the
+     * password — but the vault it re-publishes still holds the purged records, so the cycle is refused
+     * instead of pushing them. The activation path is not the reactivation one, which is the point:
+     * the refusal is keyed on the marker, not on who published the session.
+     */
+    @Test
+    fun `a password rotation cannot sync a vault whose reconcile never ran`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault),
+            configStore = config,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+
+            assertEquals(
+                AccountPasswordChange.Success,
+                sut.changeAccountPassword(password.toCharArray(), "vault-B".toCharArray()),
+            )
+            assertEquals(
+                SyncStatus.Failed(SyncFailureReason.ReconcileRequired),
+                sut.status.value,
+                "an activation that doesn't reconcile must not sync a vault that still owes one",
+            )
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
         } finally {
             sut.close()
         }


### PR DESCRIPTION
A device that was revoked and later reactivated must rebuild its vault from the server before it pushes. Otherwise it re-uploads the records the account purged while the device was locked out, and they spread back to every peer.

Two ways the rebuild could be skipped:

- `activateSession` published `client`/`session` in one `syncMutex` section and reconciled in a second one. The mutex is free in between, so a cycle that won it there — the previous session's watch/push subscription, a manual sync, a retry tick, all of which read the live `client`/`session` fields — ran over the just-published session with the vault not yet cleared and the durable marker not yet persisted.
- When the clear itself threw (an auto-lock landing inside the connect: `clearRecords` needs an unlocked vault), the session published a moment earlier stayed live. Every later cycle pushed the pre-revocation records and reported `Online` while doing it.

Changes:

- Publish and reconcile are one `syncMutex` section, so a session is never syncable before the vault it syncs from is rebuilt-ready.
- A cycle refuses to run while the durable `pendingReconcile` marker is up and this coordinator never performed the reconcile. It reports `SyncFailureReason.ReconcileRequired` — the vault is open, so the plain "linked, locked" resting state would misname it — and the next connect or keep-connected restore redoes the reconcile.
- A re-activation that carries a still-pending marker (a password rotation after a reconcile whose marker write was refused) keeps the coordinator armed. Disarming there would refuse every later cycle, including the one that would finally retire the marker.
- New strings in en/ru/zh for the refusal.

Tests: `SyncCoordinatorReactivationTest` covers the refusal, the reconnect that completes the reconcile on the same coordinator, and both password-rotation directions (over a reconcile that ran, and over one that never did).

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)