### PR TITLE
Sync: finish an owed reactivation reconcile on the unlock that enables it

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -60,8 +60,8 @@ data class SyncConfig(
      * Durable "this device must rebuild from the server before pushing" marker for the revoked→reactivated
      * flow. The server clears revocation on the SRP verify that reports `reactivated`, so it never reports
      * it again; persisting the intent here (set before the vault is cleared, cleared only after the first
-     * sync succeeds) means an interrupted reconcile is retried on the next connect/restore instead of
-     * silently resurrecting a purged record. Default `false`; older config files without the key load as `false`.
+     * sync succeeds) means an interrupted reconcile is retried on the next connect/restore — or on the
+     * unlock that lets a failed clear through — instead of silently resurrecting a purged record. Default `false`; older config files without the key load as `false`.
      */
     val pendingReconcile: Boolean = false,
 )
@@ -181,9 +181,9 @@ enum class SyncFailureReason {
     TooManyRequests,       // the server's rate limiter turned the request away — retrying later works
     ServerError,           // the server (or the proxy in front of it) is broken or restarting
     // This device still owes the reactivation rebuild ([SyncConfig.pendingReconcile]) and its vault was
-    // never cleared, so every sync cycle is refused rather than push records the account purged. Only a
-    // reconnect (or a keep-connected restore) redoes the reconcile — hence a named reason and not the
-    // silent Configured that reads as "vault locked".
+    // never cleared, so every sync cycle is refused rather than push records the account purged. Redoing
+    // the reconcile takes a reconnect, a keep-connected restore, or the unlock of a vault that was locked
+    // when the clear ran — hence a named reason and not the silent Configured that reads as "vault locked".
     ReconcileRequired,
 }
 
@@ -687,26 +687,11 @@ class SyncCoordinator(
             // A retry loop armed for the previous session must not carry its escalated backoff into
             // this one — the fresh session's first network failure re-arms from the minimum.
             retryJob?.cancel()
-            // Reactivation reconcile: drop the local records BEFORE resetting the cursor and running the
-            // first sync, so the following full re-pull rebuilds them from the server snapshot and the
-            // subsequent push can't resurrect a record the server purged while this device was revoked.
-            //
-            // The drop set is EVERY sync-capable type, NOT the currently-enabled ones: the push after the
-            // reconciling pull filters by the SERVER's "what syncs" settings (the pull applies them), which
-            // can differ from this device's stale local settings. If we gated the clear by the local
-            // settings, a type disabled locally but enabled on the server would keep its stale record
-            // through the clear and then be pushed once the pull flips the filter on — resurrecting the
-            // purged record. Clearing by the maximal (everything-on) filter covers any server settings;
-            // only never-synced, device-local types (terminal history) are kept.
+            // Uncaught on purpose: a clear that throws must abort the activation before it starts the
+            // subscriptions, both because a session that owes a reconcile has nothing to subscribe for and
+            // because [resumeAfterUnlock]'s redo stands down on a live `watchJob`.
             if (clearLocalRecords) {
-                // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
-                // verify that reported `reactivated` and never reports it again, so a crash between here and
-                // the first successful sync would otherwise lose the signal and let the stale records push.
-                configStore.save(config.copy(pendingReconcile = true))
-                val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
-                vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
-                syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
-                reconcileArmed = true // only now — see [clearPendingReconcile]
+                reconcileLocked(config)
             } else {
                 if (resetCursor) syncState.setCursor(config.accountId, 0)
                 configStore.save(config)
@@ -736,6 +721,37 @@ class SyncCoordinator(
             stopSubscriptions()
             _status.value = SyncStatus.Configured(config.serverUrl, config.accountId)
         }
+    }
+
+    /**
+     * The reactivation reconcile itself: drop the local records BEFORE resetting the cursor and running the
+     * first sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
+     * push can't resurrect a record the server purged while this device was revoked.
+     *
+     * The drop set is EVERY sync-capable type, NOT the currently-enabled ones: the push after the
+     * reconciling pull filters by the SERVER's "what syncs" settings (the pull applies them), which can
+     * differ from this device's stale local settings. If we gated the clear by the local settings, a type
+     * disabled locally but enabled on the server would keep its stale record through the clear and then be
+     * pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the maximal
+     * (everything-on) filter covers any server settings; only never-synced, device-local types (terminal
+     * history) are kept.
+     *
+     * Throws whatever the clear throws — a vault locked at this moment ([Vault.clearRecords] needs an
+     * unlocked one) leaves the marker up over an un-cleared vault, which is what [reconcileOwed] reads.
+     *
+     * Call with [syncMutex] held (kotlinx [Mutex] is not reentrant): both callers — [activateSession] and
+     * the redo in [resumeAfterUnlock] — take it themselves, and every [reconcileArmed]/cursor/config write
+     * in here shares that lock with the sync cycles.
+     */
+    private fun reconcileLocked(config: SyncConfig) {
+        // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
+        // verify that reported `reactivated` and never reports it again, so a crash between here and
+        // the first successful sync would otherwise lose the signal and let the stale records push.
+        configStore.save(config.copy(pendingReconcile = true))
+        val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
+        vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
+        syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
+        reconcileArmed = true // only now — see [clearPendingReconcile]
     }
 
     /**
@@ -1178,8 +1194,8 @@ class SyncCoordinator(
         // This device owes a reconcile it never performed (see [reconcileOwed]): its vault still holds
         // the records the server purged while it was revoked, and pushing them is exactly the
         // resurrection the marker exists to prevent — silently, under an Online status. Refuse the cycle
-        // and name the reason: only a connect/restore redoes the reconcile, so the user has to act, and
-        // a bare Configured would render as "vault locked" over a vault that is open. The session stays
+        // and name the reason: nothing but a connect/restore/unlock redoes the reconcile, so the user has
+        // to act, and a bare Configured would render as "vault locked" over a vault that is open. The session stays
         // published (tearing it down needs [opMutex], which nests outside this lock) but is inert —
         // every cycle lands here until the reconcile actually runs.
         if (reconcileOwed(s.accountId)) {
@@ -1332,7 +1348,9 @@ class SyncCoordinator(
      * touches the vault (a crash in between must not lose the signal), so a clear that threw — an
      * auto-lock landing inside the connect — leaves it up over a vault nothing was dropped from, on a
      * session that is already published. Retiring it there would strand the pre-revocation records; that
-     * session's cycles are refused ([reconcileOwed]) and the next connect redoes the reconcile instead.
+     * session's cycles are refused ([reconcileOwed]) and the reconcile is redone instead — by the next
+     * connect/restore, or by the unlock that hands the clear the vault it needed
+     * ([redoOwedReconcileLocked]).
      *
      * Called before the status is published: [SyncStatus.Online] is what every observer reacts to, and
      * clearing the marker afterwards leaves a window in which Online is on screen while the saved config
@@ -1705,6 +1723,10 @@ class SyncCoordinator(
      * Bring sync back after the vault is unlocked. A session paused by [pauseForLock] is still in
      * memory — resubscribe and pull what was missed; otherwise (cold start) fall back to
      * [restoreSession]. Called from `onVaultUnlocked` on both platforms.
+     *
+     * An unlock is also the one event that can finish a reconcile this session still owes
+     * ([redoOwedReconcileLocked]): the clear that failed needed exactly the unlocked vault the user has
+     * just handed us.
      */
     fun resumeAfterUnlock() {
         lockPaused = false
@@ -1718,13 +1740,48 @@ class SyncCoordinator(
         scope.launch {
             opMutex.withLock {
                 // A disconnect or a fresh connect may have run while we waited for the mutex; a
-                // reconnect has already restarted the subscriptions itself.
+                // reconnect has already restarted the subscriptions itself — and it redid the reconcile
+                // on its way, which is why the redo below sits behind this guard and not in front of it.
                 if (lockPaused || session == null || watchJob != null) return@withLock
+                // Before the cycle, not after: a reconcile still owed would refuse every cycle below.
+                // Lock order holds — syncMutex nests inside the opMutex we're under.
+                syncMutex.withLock { redoOwedReconcileLocked() }
                 runSync()
                 startWatch()
                 startLocalPush()
             }
         }
+    }
+
+    /**
+     * Finish a reactivation reconcile this live session owes ([reconcileOwed]) now that the vault is
+     * unlocked. The situation is an auto-lock landing inside a reactivating connect or silent restore: the session was
+     * published, [Vault.clearRecords] threw, and the durable marker stayed up over an un-cleared vault, so
+     * every cycle is refused with [SyncFailureReason.ReconcileRequired]. Only a connect/restore used to
+     * redo the reconcile, which asked the user for the master password — for a rebuild that needs none
+     * (drop the records, reset the cursor, arm the flag). Issue #147.
+     *
+     * A reconcile that fails again — the vault re-locked between the unlock and here, or the marker write
+     * was refused — is not a new failure: it leaves the marker up and the session owing the same
+     * reconcile, and the cycle right after this call republishes [SyncFailureReason.ReconcileRequired] —
+     * the state the user already sees, with the same recovery. Any cause lands there; naming them apart
+     * would only rename a stop whose exit is the same.
+     *
+     * Call under [syncMutex] with [opMutex] held by the caller: it writes [reconcileArmed], the cursor and
+     * the config exactly like the activation path does.
+     */
+    private fun redoOwedReconcileLocked() {
+        val accountId = session?.accountId ?: return
+        // Matched on the account before anything is dropped: reconciling under a config saved for another
+        // account would clear this vault against a marker that says nothing about it. ([reconcileOwed]
+        // matches the same way on its own read — the two agree because nothing suspends in between.)
+        val cfg = configStore.load()?.takeIf { it.accountId == accountId } ?: return
+        if (!reconcileOwed(accountId)) return
+        // Not swallowed silently: the cycle the caller runs next reads the same marker this clear failed to
+        // retire and publishes the refusal, so the failure keeps its own status — see the KDoc above.
+        // runCatching is safe here: [reconcileLocked] has no suspension point, so there is no
+        // CancellationException for it to absorb.
+        runCatching { reconcileLocked(cfg) }
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.sync
 
 import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.InMemorySyncStateStore
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
 import app.skerry.shared.sync.RecordPage
@@ -15,6 +16,7 @@ import app.skerry.shared.sync.SyncSignal
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.CompletableDeferred
@@ -64,6 +66,9 @@ class SyncCoordinatorReactivationTest {
         private val failFirstPull: Boolean = false,
     ) : SyncClient {
         val pushed = mutableListOf<RemoteRecord>()
+
+        /** What each pull asked for — `0` is the full re-pull a reconcile's cursor reset forces. */
+        val pulledSince = mutableListOf<Long>()
         private val pulls = AtomicInteger(0)
 
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
@@ -72,6 +77,7 @@ class SyncCoordinatorReactivationTest {
             SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = reactivated)
         override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
         override suspend fun pull(session: SyncSession, since: Long): RecordPage {
+            pulledSince += since
             // Not a SyncException(NETWORK): that one arms the backoff retry loop, and the test wants the
             // next cycle to be the one it triggers itself.
             if (failFirstPull && pulls.getAndIncrement() == 0) error("pull unreachable")
@@ -102,10 +108,13 @@ class SyncCoordinatorReactivationTest {
      * the next connect and the reconcile finally runs.
      */
     private class ClearFailingVault(private val delegate: Vault, private val failures: Int = Int.MAX_VALUE) : Vault by delegate {
-        private var attempts = 0
+        private val attempts = AtomicInteger(0)
+
+        /** How many clears were tried — the observable "the reconcile ran again" for a retry that fails too. */
+        val clearAttempts: Int get() = attempts.get()
 
         override fun clearRecords(types: Set<RecordType>) {
-            if (attempts++ < failures) error("vault is locked")
+            if (attempts.getAndIncrement() < failures) error("vault is locked")
             delegate.clearRecords(types)
         }
     }
@@ -327,6 +336,136 @@ class SyncCoordinatorReactivationTest {
             assertFalse(vault.records().any { it.id == "r1" }, "the redone reconcile must drop the pre-revocation record")
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never have been pushed")
             assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The clear fails because the vault locked inside the connect, and what the user does next is unlock it
+     * — exactly the condition the reconcile was missing. The unlock must redo the reconcile on the session
+     * that is still live, not only re-run the cycle that keeps being refused: the rebuild needs no password,
+     * so sending the user back to Settings → Sync to retype the master password is a dead end (issue #147).
+     */
+    @Test
+    fun `an unlock finishes the reconcile the refused cycle was waiting for`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        // A cursor from before the revocation: the reconcile has to reset it, or the re-pull that rebuilds
+        // the vault would ask for changes since the tip and get nothing back.
+        val state = InMemorySyncStateStore().also { it.setCursor(account, 42) }
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault, failures = 1),
+            configStore = config,
+            syncState = state,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+            sut.syncNow()
+            sut.status.awaitStatus("the cycle to be refused") {
+                (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
+            }
+
+            // The whole lock cycle, not just the resume callback: this is the state the user is actually
+            // in — the vault that made the clear fail is locked, and they unlock it.
+            vault.lock()
+            sut.pauseForLock()
+            sut.status.awaitStatus("the lock to park the status") { it is SyncStatus.Configured }
+            assertTrue(vault.unlock(password.toCharArray()) is UnlockResult.Success)
+            sut.resumeAfterUnlock()
+            sut.status.awaitStatus("the unlock to finish the reconcile") { it is SyncStatus.Online }
+            assertFalse(vault.records().any { it.id == "r1" }, "the redone reconcile must drop the pre-revocation record")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never have been pushed")
+            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+            // The cycle the connect would have run never happened (the clear threw first), so the first
+            // pull of the whole test is the one the redo armed.
+            assertEquals(0L, client.pulledSince.firstOrNull(), "the rebuild must be a full re-pull, not one from the stale cursor")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The redone reconcile can fail too — the vault re-locked between the unlock and the clear. That must
+     * stay the same stop as before (the marker up, the cycle refused), not turn the unlock into a new
+     * failure that hides the recovery the status names.
+     *
+     * The lock is real here (`pauseForLock` parks the status on Configured), so the refusal after the
+     * resume is a status the redo path has to publish rather than the one already on screen: a redo that
+     * lets the clear's exception escape kills the resume before its cycle runs, and the status stays
+     * Configured.
+     */
+    @Test
+    fun `an unlock whose reconcile fails again keeps the refusal, not a new failure`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val clearFailing = ClearFailingVault(vault)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = clearFailing, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+            sut.syncNow()
+            sut.status.awaitStatus("the cycle to be refused") {
+                (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
+            }
+
+            vault.lock()
+            sut.pauseForLock()
+            sut.status.awaitStatus("the lock to park the status") { it is SyncStatus.Configured }
+            assertTrue(vault.unlock(password.toCharArray()) is UnlockResult.Success)
+            sut.resumeAfterUnlock()
+
+            sut.status.awaitStatus("the refusal to be published again") {
+                (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
+            }
+            assertEquals(2, clearFailing.clearAttempts, "the unlock must have retried the reconcile exactly once")
+            assertEquals(true, config.load()?.pendingReconcile, "a reconcile that failed again keeps the marker")
+            assertTrue(vault.records().any { it.id == "r1" }, "nothing was cleared — the record is still there")
+            assertFalse(client.pushed.any { it.id == "r1" }, "and it must not have been pushed")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The other branch of the same guard, and the one with teeth: an unlock on a session that owes nothing
+     * must not reconcile. Without the [SyncCoordinator] check, every ordinary unlock would raise a fresh
+     * marker and wipe every host and snippet in the vault — the mirror image of the bug this path fixes.
+     */
+    @Test
+    fun `an unlock with no reconcile owed leaves the vault alone`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        // Not a reactivation and no pending marker: an ordinary connected device.
+        val client = ReactivatingClient(ownWrap(vault), reactivated = false)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to come Online") { it is SyncStatus.Online }
+
+            vault.lock()
+            sut.pauseForLock()
+            sut.status.awaitStatus("the lock to park the status") { it is SyncStatus.Configured }
+            assertTrue(vault.unlock(password.toCharArray()) is UnlockResult.Success)
+            sut.resumeAfterUnlock()
+            sut.status.awaitStatus("the unlock to bring sync back") { it is SyncStatus.Online }
+
+            assertTrue(vault.records().any { it.id == "r1" }, "an unlock that owes no reconcile must not clear the vault")
+            assertEquals(false, config.load()?.pendingReconcile, "and must not raise a reconcile marker of its own")
         } finally {
             sut.close()
         }


### PR DESCRIPTION
A reactivated device rebuilds its vault from the server before it may push (`pendingReconcile`). When the vault auto-locks inside the connect that reconciles, `Vault.clearRecords` throws, the durable marker stays up over an un-cleared vault, and every sync cycle is refused with `ReconcileRequired`. The recovery the status names is a reconnect — which asks for the master password, for a rebuild that needs none. Unlocking the vault, the one action that would let the clear through, did nothing: `resumeAfterUnlock` took the live-session branch and re-ran the cycle that keeps being refused.

`resumeAfterUnlock` now redoes the reconcile for a live session that still owes one, before the cycle it runs. The reconcile block moved into `reconcileLocked`, called with `syncMutex` already held by both the activation path and the redo. A clear that fails again — the vault re-locked in between — keeps the marker up and leaves the status on `ReconcileRequired` rather than turning the unlock into a new failure.

Tests: the unlock finishes the reconcile (record dropped, never pushed, marker retired, full re-pull from cursor 0); a redo that fails again keeps the refusal; an unlock with nothing owed leaves the vault untouched.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)