### PR TITLE
Titlebar drag: send the pointer in X11 pixels so a scaled session still moves the window

### DIFF
--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
@@ -3,7 +3,11 @@ package app.skerry.ui.desktop
 import com.sun.jna.Native
 import com.sun.jna.NativeLong
 import com.sun.jna.platform.unix.X11
+import java.awt.GraphicsEnvironment
+import java.awt.Point
 import java.awt.Window
+import java.awt.geom.AffineTransform
+import kotlin.math.roundToLong
 
 /**
  * Hands an interactive window drag to the X11 window manager via `_NET_WM_MOVERESIZE`, instead of
@@ -55,12 +59,14 @@ object NativeWindowMove {
     fun isAvailable(): Boolean = session != null
 
     /**
-     * Asks the WM to start moving [window], following the pointer, from screen coordinates
-     * [screenX]/[screenY] (where the drag began). Returns false if unavailable or the window has no
-     * X11 id yet, so the caller can fall back. [button] is the mouse button held (1 = left).
+     * Asks the WM to start moving [window], following the pointer, from AWT screen coordinates
+     * [screenX]/[screenY] (where the drag began). [button] is the mouse button held (1 = left).
+     * Returns false when the request never reached the WM — the gesture is then over either way,
+     * since the caller commits to this path once, on [isAvailable], not per drag.
      */
     fun startMove(window: Window, screenX: Int, screenY: Int, button: Int = 1): Boolean {
         val s = session ?: return false
+        val request = moveRequest(Point(screenX, screenY), screenTransform(window), button)
         val xid = try {
             Native.getWindowID(window)
         } catch (_: Throwable) {
@@ -79,19 +85,65 @@ object NativeWindowMove {
             event.xclient.message_type = s.moveResizeAtom
             event.xclient.format = 32
             event.xclient.data.setType("l")
-            event.xclient.data.l[0] = NativeLong(screenX.toLong())
-            event.xclient.data.l[1] = NativeLong(screenY.toLong())
-            event.xclient.data.l[2] = NativeLong(NET_WM_MOVERESIZE_MOVE.toLong())
-            event.xclient.data.l[3] = NativeLong(button.toLong())
-            event.xclient.data.l[4] = NativeLong(1) // source indication: normal application
+            request.words().forEachIndexed { i, word -> event.xclient.data.l[i] = NativeLong(word) }
             event.write()
             // Under XWayland the real pointer belongs to the compositor, so the WM starts the move
             // without us having to release an X pointer grab first.
-            s.x11.XSendEvent(s.display, s.root, 0, ROOT_EVENT_MASK, event)
+            val sent = s.x11.XSendEvent(s.display, s.root, 0, ROOT_EVENT_MASK, event)
             s.x11.XFlush(s.display)
-            true
+            sent != 0
         } catch (_: Throwable) {
             false
         }
     }
+
+    /**
+     * The window's user-space→device transform, or null when it can't be determined. A window that
+     * isn't on a screen yet has no [java.awt.GraphicsConfiguration] of its own, so fall back to the
+     * default screen's rather than assuming an unscaled session.
+     */
+    private fun screenTransform(window: Window): AffineTransform? = try {
+        (
+            window.graphicsConfiguration
+                ?: GraphicsEnvironment.getLocalGraphicsEnvironment()
+                    .defaultScreenDevice.defaultConfiguration
+            )?.defaultTransform
+    } catch (_: Throwable) {
+        null
+    }
+
+    /** The `_NET_WM_MOVERESIZE` payload, in the order the protocol lays out `data.l`. */
+    internal data class MoveResizeRequest(
+        val rootX: Long,
+        val rootY: Long,
+        val direction: Long,
+        val button: Long,
+        val source: Long,
+    ) {
+        fun words(): List<Long> = listOf(rootX, rootY, direction, button, source)
+    }
+
+    /**
+     * Builds the request that moves the window the pointer is over.
+     *
+     * [pointer] is an AWT screen position, which under HiDPI is in user space — Compose Desktop
+     * turns AWT's ui scaling on, so `MouseInfo` and window bounds are scaled down by [transform].
+     * The protocol is specified in X11 pixels, and a point in the wrong space lands far from the
+     * real pointer: Mutter looks for one within 64 px before it starts the grab, finds nothing, and
+     * drops the request without a word. Hence the conversion back to device pixels here.
+     */
+    internal fun moveRequest(pointer: Point, transform: AffineTransform?, button: Int) =
+        MoveResizeRequest(
+            rootX = (pointer.x * usableScale(transform?.scaleX)).roundToLong(),
+            rootY = (pointer.y * usableScale(transform?.scaleY)).roundToLong(),
+            direction = NET_WM_MOVERESIZE_MOVE.toLong(),
+            button = button.toLong(),
+            source = 1L, // source indication: normal application
+        )
+
+    // A scale that isn't a positive finite number (0, NaN, a mirrored display's negative factor)
+    // would throw the drag onto 0,0 or the wrong side of the screen, nowhere near the pointer. An
+    // unscaled point at least still works on an unscaled session.
+    private fun usableScale(scale: Double?): Double =
+        if (scale != null && scale.isFinite() && scale > 0.0) scale else 1.0
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/NativeWindowMoveTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/NativeWindowMoveTest.kt
@@ -1,0 +1,107 @@
+package app.skerry.ui.desktop
+
+import java.awt.Point
+import java.awt.geom.AffineTransform
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class NativeWindowMoveTest {
+
+    @Test
+    fun `unscaled session puts the pointer on the wire as is`() {
+        val request = NativeWindowMove.moveRequest(Point(1319, 102), AffineTransform(), button = 1)
+        assertEquals(1319L, request.rootX)
+        assertEquals(102L, request.rootY)
+    }
+
+    @Test
+    fun `scaled session puts the pointer on the wire in device pixels`() {
+        // Measured on GNOME 50 Wayland with Xft.dpi=192: AWT reports the pointer at 1319,102 while
+        // XQueryPointer puts it at ~2632,204 — the same place, in the X11 pixels the protocol wants.
+        // (The X reading lags the AWT one by a frame, hence "~".)
+        val request = NativeWindowMove.moveRequest(
+            Point(1319, 102),
+            AffineTransform.getScaleInstance(2.0, 2.0),
+            button = 1,
+        )
+        assertEquals(2638L, request.rootX)
+        assertEquals(204L, request.rootY)
+    }
+
+    @Test
+    fun `fractional scale rounds to the nearest device pixel`() {
+        val request = NativeWindowMove.moveRequest(
+            Point(1319, 102),
+            AffineTransform.getScaleInstance(1.25, 1.25),
+            button = 1,
+        )
+        assertEquals(1649L, request.rootX)
+        assertEquals(128L, request.rootY)
+    }
+
+    @Test
+    fun `axes scale independently`() {
+        val request = NativeWindowMove.moveRequest(
+            Point(1319, 102),
+            AffineTransform.getScaleInstance(2.0, 1.0),
+            button = 1,
+        )
+        assertEquals(2638L, request.rootX)
+        assertEquals(102L, request.rootY)
+    }
+
+    @Test
+    fun `a monitor left of the primary keeps its negative coordinates`() {
+        val request = NativeWindowMove.moveRequest(
+            Point(-640, -200),
+            AffineTransform.getScaleInstance(2.0, 2.0),
+            button = 1,
+        )
+        assertEquals(-1280L, request.rootX)
+        assertEquals(-400L, request.rootY)
+    }
+
+    @Test
+    fun `a negative coordinate under a fractional scale rounds towards zero at the half`() {
+        // Math.round is half-up, so -961.5 lands on -961, not -962. A one-pixel drift is harmless
+        // here (Mutter allows 64), but pinning it keeps a rounding swap from going unnoticed.
+        val request = NativeWindowMove.moveRequest(
+            Point(-641, -200),
+            AffineTransform.getScaleInstance(1.5, 1.5),
+            button = 1,
+        )
+        assertEquals(-961L, request.rootX)
+        assertEquals(-300L, request.rootY)
+    }
+
+    @Test
+    fun `an unknown scale leaves the pointer alone instead of collapsing it`() {
+        // No transform (window not on a screen yet) or a degenerate one would otherwise send the
+        // drag to 0,0 — the WM would either ignore it or jump the window to the corner.
+        for (transform in listOf(null, AffineTransform.getScaleInstance(0.0, 0.0))) {
+            val request = NativeWindowMove.moveRequest(Point(1319, 102), transform, button = 1)
+            assertEquals(1319L, request.rootX, "transform=$transform")
+            assertEquals(102L, request.rootY, "transform=$transform")
+        }
+    }
+
+    @Test
+    fun `one degenerate axis does not disarm the other`() {
+        val request = NativeWindowMove.moveRequest(
+            Point(1319, 102),
+            AffineTransform.getScaleInstance(0.0, 2.0),
+            button = 1,
+        )
+        assertEquals(1319L, request.rootX)
+        assertEquals(204L, request.rootY)
+    }
+
+    @Test
+    fun `the request asks for a move with the held button`() {
+        val request = NativeWindowMove.moveRequest(Point(10, 20), AffineTransform(), button = 3)
+        assertEquals(8L, request.direction) // _NET_WM_MOVERESIZE_MOVE
+        assertEquals(3L, request.button)
+        assertEquals(1L, request.source) // source indication: normal application
+        assertEquals(listOf(10L, 20L, 8L, 3L, 1L), request.words())
+    }
+}


### PR DESCRIPTION
`_NET_WM_MOVERESIZE` carries X11 pixels, but Compose Desktop enables AWT ui scaling, so
`MouseInfo` reports the pointer in user space. On a session scaled above 100% the point sent to the
window manager named a place far from the pointer, and the window could not be dragged at all.

Mutter's side of it: the incoming point is divided by the XWayland scale
(`meta_window_xwayland_protocol_to_stage`), then `guess_nearest_device` looks for a pointer with the
named button held within 64 px of the result. Finding none, it returns without starting the grab and
without any error — which is why the request looked accepted and did nothing.

The payload now comes from `moveRequest()`, which scales the pointer by the window's device
transform, falls back to the default screen's configuration when the window has no configuration of
its own, and ignores a scale that isn't a positive finite number rather than collapsing the drag
onto the screen corner. `startMove` returns the result of `XSendEvent` instead of a hardcoded true.

Closes #143

## Verification

Drag the titlebar of the main window on a Linux session. The window follows the pointer immediately,
at any display scale. Checked by hand at 100%, 133%, 150% and 166% on GNOME 50 Wayland.

Unit tests cover the wire payload: identity, integer and fractional scale, per-axis scale, negative
coordinates from a monitor left of the primary, and the null/degenerate transform fallbacks.

Not covered by tests: the single line that reads `graphicsConfiguration`, and the JNA send itself —
both need a display and a live X11 session. The `XSendEvent` status now propagating to the caller is
a behaviour change with no test behind it for the same reason.