### PR TITLE
HiDPI: wait for the session's display scale before the first window

### DIFF
--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/DisplayScaleReadiness.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/DisplayScaleReadiness.kt
@@ -1,0 +1,157 @@
+package app.skerry.ui.desktop
+
+/**
+ * Waits for the X resource database to report a settled `Xft.dpi` before anything reads the display
+ * scale.
+ *
+ * Skiko decides the UI scale exactly once, at startup: `Setup.init` reads `Xft.dpi` from the X
+ * resource database and writes it into `sun.java2d.uiScale`, which AWT then caches for the lifetime
+ * of the JVM. On a Wayland session GNOME starts XWayland on demand, so the first X11 client of the
+ * session is the one that brings it up — and `gsd-xsettings` only fills RESOURCE_MANAGER in
+ * afterwards. Measured on GNOME 50 at 166%: the database is missing for ~220 ms, arrives carrying
+ * the 96 dpi default, and reaches the display's real 192 some 40 ms later. An app that reads it
+ * inside that window runs the whole session unscaled — which is why only the first launch after
+ * login was wrong, and every later one was fine.
+ */
+internal object DisplayScaleReadiness {
+    /**
+     * Overall wait, ms — the cap once the database is in sight and only its dpi is still moving.
+     * Reached only on a session that keeps rewriting the property.
+     */
+    const val DEFAULT_BUDGET_MS = 1000L
+
+    /**
+     * How long to wait for an absent database to show up at all, ms. Separate from (and much
+     * shorter than) [DEFAULT_BUDGET_MS] because this is the wait a compositor with no settings
+     * daemon at all — sway, Hyprland, river — pays on **every** start, for a value that will never
+     * arrive. GNOME publishes at ~220 ms, so this is roughly double the measured need.
+     */
+    const val DEFAULT_APPEARANCE_BUDGET_MS = 500L
+
+    /** How long the whole wait may take, including the native calls that ignore the budgets above. */
+    private const val HARD_DEADLINE_MS = DEFAULT_BUDGET_MS + 500L
+
+    /** How long the value has to hold still before it counts as final, ms. */
+    const val DEFAULT_QUIET_MS = 250L
+
+    /** Interval between reads, ms. */
+    const val DEFAULT_POLL_MS = 20L
+
+    // Entries are "name:<whitespace>value" lines; the name is matched whole so that a longer key
+    // starting with the same text can't be mistaken for it.
+    private val XFT_DPI = Regex("""^Xft\.dpi:[ \t]*(\S+)[ \t]*$""", RegexOption.MULTILINE)
+
+    /**
+     * Blocks until the session's display scale is readable, so that Skiko's one and only look at
+     * `Xft.dpi` sees the real value. Call before anything touches AWT, Skiko or Compose — after
+     * that, the scale is already frozen into `sun.java2d.uiScale`.
+     *
+     * Costs nothing on a session that already published the database, and nothing at all outside a
+     * Wayland session: with a real X server the display and its settings daemon both outlive every
+     * app, so there is no window to lose the race in.
+     */
+    fun awaitDisplayScale(
+        sessionType: String? = System.getenv("XDG_SESSION_TYPE"),
+        waylandDisplay: String? = System.getenv("WAYLAND_DISPLAY"),
+        deadlineMs: Long = HARD_DEADLINE_MS,
+        openDatabase: () -> XResourceDatabase? = XResourceDatabase::open,
+    ) {
+        // On a daemon thread with a deadline: `XOpenDisplay` and `XGetWindowProperty` block on the
+        // X socket, and the budgets below only count between calls — a compositor that never
+        // answers would otherwise hang startup before a window ever exists. An unscaled UI beats an
+        // app that doesn't come up, so the deadline wins and the abandoned thread dies with the JVM.
+        val worker = Thread(
+            { runCatching { settleDisplayScale(sessionType, waylandDisplay, openDatabase) } },
+            "skerry-display-scale",
+        )
+        worker.isDaemon = true
+        worker.start()
+        try {
+            worker.join(deadlineMs)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    /**
+     * The wait itself, with its inputs handed in. Returns the settled `Xft.dpi`, or null when there
+     * was nothing to wait for (not a Wayland session, no display) or nothing was published.
+     */
+    fun settleDisplayScale(
+        sessionType: String?,
+        waylandDisplay: String?,
+        openDatabase: () -> XResourceDatabase?,
+    ): String? {
+        if (!isWaylandSession(sessionType, waylandDisplay)) return null
+        val database = openDatabase() ?: return null
+        return database.use {
+            val start = System.nanoTime()
+            awaitSettledDpi(
+                readResources = it::read,
+                sleep = Thread::sleep,
+                elapsedMs = { (System.nanoTime() - start) / 1_000_000 },
+            )
+        }
+    }
+
+    /**
+     * Whether this is a Wayland session, where XWayland starts on demand and can therefore be
+     * younger than the app reading its settings.
+     *
+     * Both signals are needed: inside the Flatpak sandbox `WAYLAND_DISPLAY` is empty (the app is
+     * granted the X11 socket only), while `XDG_SESSION_TYPE` is passed through.
+     */
+    fun isWaylandSession(sessionType: String?, waylandDisplay: String?): Boolean =
+        sessionType.equals("wayland", ignoreCase = true) || !waylandDisplay.isNullOrEmpty()
+
+    /** The `Xft.dpi` entry of an X resource database dump, or null when it carries no usable value. */
+    fun parseXftDpi(resources: String?): String? =
+        resources?.let { XFT_DPI.find(it)?.groupValues?.get(1) }
+
+    /**
+     * Returns the settled `Xft.dpi`, or null when no database showed up inside [appearanceBudgetMs]
+     * (a session with no settings daemon at all, or a headless display).
+     *
+     * A database that is already there is returned as-is without waiting: that's the common case
+     * (XWayland already running), and startup must not pay for the rare one. It does leave a narrow
+     * exposure — if some other client started XWayland 40-odd ms before us, the database exists but
+     * still carries the 96 dpi default — accepted deliberately, because closing it would mean every
+     * launch on every machine waiting out a [quietMs] period for a value that is already correct.
+     *
+     * A database that appears while we watch is instead followed until its dpi stops changing for
+     * [quietMs], bounded by [budgetMs]: the first thing the daemon publishes is that same 96 dpi
+     * default rather than the display's real scale, and the dpi entry can even trail the rest of
+     * the database.
+     */
+    fun awaitSettledDpi(
+        readResources: () -> String?,
+        sleep: (Long) -> Unit,
+        elapsedMs: () -> Long,
+        budgetMs: Long = DEFAULT_BUDGET_MS,
+        appearanceBudgetMs: Long = DEFAULT_APPEARANCE_BUDGET_MS,
+        quietMs: Long = DEFAULT_QUIET_MS,
+        pollMs: Long = DEFAULT_POLL_MS,
+    ): String? {
+        var resources = readResources()
+        // A database that already carries a dpi is the answer. One without it isn't: the entry can
+        // trail the rest of the property by tens of ms, so fall through to the settle loop, which
+        // gives it a quiet period to arrive instead of declaring the session unscaled.
+        parseXftDpi(resources)?.let { return it }
+        while (resources == null && elapsedMs() < appearanceBudgetMs) {
+            sleep(pollMs)
+            resources = readResources()
+        }
+        if (resources == null) return null
+        var dpi = parseXftDpi(resources)
+        var lastChange = elapsedMs()
+        while (elapsedMs() - lastChange < quietMs && elapsedMs() < budgetMs) {
+            sleep(pollMs)
+            val next = parseXftDpi(readResources())
+            if (next != null && next != dpi) {
+                dpi = next
+                lastChange = elapsedMs()
+            }
+        }
+        return dpi
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/NativeWindowMove.kt
@@ -38,19 +38,18 @@ object NativeWindowMove {
     private val session: X11Session? by lazy { initSession() }
 
     private fun initSession(): X11Session? {
-        val os = System.getProperty("os.name")?.lowercase().orEmpty()
-        if (!os.contains("linux")) return null
-        if (System.getenv("DISPLAY").isNullOrEmpty()) return null
+        // Our own connection to $DISPLAY. The XID from Native.getWindowID is server-wide, so a
+        // client message sent from this connection to the root window reaches the WM fine.
+        val connection = X11Connection.open() ?: return null
         return try {
-            val x11 = X11.INSTANCE
-            // Our own connection to $DISPLAY. The XID from Native.getWindowID is server-wide, so a
-            // client message sent from this connection to the root window reaches the WM fine.
-            val display = x11.XOpenDisplay(null) ?: return null
+            val x11 = connection.x11
+            val display = connection.display
             val root = x11.XDefaultRootWindow(display)
             val atom = x11.XInternAtom(display, "_NET_WM_MOVERESIZE", false)
             X11Session(x11, display, root, atom)
         } catch (_: Throwable) {
-            // UnsatisfiedLinkError (no libX11), NoClassDefFoundError, etc. — fall back to manual drag.
+            // The connection is live but unusable for this — release it and fall back to manual drag.
+            connection.close()
             null
         }
     }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/X11Connection.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/X11Connection.kt
@@ -1,0 +1,45 @@
+package app.skerry.ui.desktop
+
+import com.sun.jna.platform.unix.X11
+
+/**
+ * A connection to `$DISPLAY` for the desktop's own X11 work (window moves, reading session
+ * settings), separate from the one AWT keeps for itself.
+ *
+ * One place decides whether talking to X11 is possible at all, so availability doesn't drift
+ * between the callers.
+ */
+internal class X11Connection private constructor(
+    val x11: X11,
+    val display: X11.Display,
+) : AutoCloseable {
+
+    override fun close() {
+        try {
+            x11.XCloseDisplay(display)
+        } catch (_: Throwable) {
+            // Best effort: the connection may already be gone, and nothing depends on the release.
+        }
+    }
+
+    companion object {
+        /**
+         * Opens a connection, or returns null when there is no X11 to talk to: another platform, no
+         * `DISPLAY`, no libX11. On a Wayland session opening one is what starts XWayland, if no
+         * other client has yet.
+         */
+        fun open(): X11Connection? {
+            val os = System.getProperty("os.name")?.lowercase().orEmpty()
+            if (!os.contains("linux")) return null
+            if (System.getenv("DISPLAY").isNullOrEmpty()) return null
+            return try {
+                val x11 = X11.INSTANCE
+                val display = x11.XOpenDisplay(null) ?: return null
+                X11Connection(x11, display)
+            } catch (_: Throwable) {
+                // UnsatisfiedLinkError (no libX11), NoClassDefFoundError — same as having no display.
+                null
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/XResourceDatabase.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/XResourceDatabase.kt
@@ -1,0 +1,95 @@
+package app.skerry.ui.desktop
+
+import com.sun.jna.NativeLong
+import com.sun.jna.platform.unix.X11
+import com.sun.jna.ptr.IntByReference
+import com.sun.jna.ptr.NativeLongByReference
+import com.sun.jna.ptr.PointerByReference
+
+/**
+ * Reads the session's X resource database (the root window's `RESOURCE_MANAGER`, what `xrdb -query`
+ * prints) over its own X11 connection.
+ *
+ * Opened before AWT so that reading it can't be confused with AWT's own display: the point is to
+ * observe the property as it changes, which `XResourceManagerString` cannot do — Xlib caches that
+ * string when the connection opens.
+ */
+internal class XResourceDatabase private constructor(
+    private val connection: X11Connection,
+    private val root: X11.Window,
+    private val atom: X11.Atom,
+) : AutoCloseable {
+
+    private val x11 get() = connection.x11
+    private val display get() = connection.display
+
+    /** The database as a single string, or null when the property is absent or unreadable. */
+    fun read(): String? = try {
+        val type = X11.AtomByReference()
+        val format = IntByReference()
+        val items = NativeLongByReference()
+        val remaining = NativeLongByReference()
+        val data = PointerByReference()
+        val status = x11.XGetWindowProperty(
+            display,
+            root,
+            atom,
+            NativeLong(0),
+            // In 32-bit words: the database is a few hundred bytes, this is room to spare.
+            NativeLong(MAX_LENGTH_WORDS),
+            false,
+            X11.Atom(X11.AnyPropertyType.toLong()),
+            type,
+            format,
+            items,
+            remaining,
+            data,
+        )
+        if (status != X11.Success) return null
+        // Whatever the format, a property that exists came with a buffer that has to be released —
+        // so take it first, and let the format decide only whether it is worth reading.
+        val pointer = data.value ?: return null
+        try {
+            // 8-bit string data is the only shape we know how to read; anything else (a property
+            // some other client wrote in another format) counts as unreadable, not parsed blind.
+            if (format.value != BYTE_FORMAT) return null
+            pointer.getString(0).takeIf { it.isNotEmpty() }
+        } finally {
+            x11.XFree(pointer)
+        }
+    } catch (_: Throwable) {
+        // The connection can go away under us (XWayland restart); an unreadable database is the
+        // same answer as an empty one — the caller keeps waiting or gives up on its budget.
+        null
+    }
+
+    override fun close() = connection.close()
+
+    companion object {
+        private const val MAX_LENGTH_WORDS = 65_536L
+
+        /** `format` for 8-bit data, the only property shape this reads. */
+        private const val BYTE_FORMAT = 8
+
+        /**
+         * Opens a connection to `$DISPLAY`, or returns null when there is none (non-Linux, headless,
+         * no X server) or the native bindings are missing. Opening is what starts XWayland on a
+         * Wayland session with no X11 client yet, which is exactly the case this guards.
+         */
+        fun open(): XResourceDatabase? {
+            val connection = X11Connection.open() ?: return null
+            return try {
+                XResourceDatabase(
+                    connection,
+                    connection.x11.XDefaultRootWindow(connection.display),
+                    connection.x11.XInternAtom(connection.display, "RESOURCE_MANAGER", false),
+                )
+            } catch (_: Throwable) {
+                // The connection is live at this point, so it has to be released here — the object
+                // that would have owned it was never built.
+                connection.close()
+                null
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -12,6 +12,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.skerry_icon
 import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.window.rememberWindowState
+import app.skerry.ui.desktop.DisplayScaleReadiness
 import app.skerry.ui.desktop.SkerryWindowFrame
 import app.skerry.ui.desktop.optimalWindowSize
 import app.skerry.ui.desktop.rememberSkerryWindowChrome
@@ -514,6 +515,9 @@ fun main(args: Array<String>) {
     // vault, no window. A packaged build has no bundled `java` to spawn, so the app re-launches its
     // own launcher with this flag; the branch must come before anything touches AWT or Skia.
     if (LlmHostCommandLine.isHostRun(args)) return LlmHostMain.main(args)
+    // Before AWT/Skiko: the UI scale is read from the X resource database exactly once, and the
+    // first X11 client of a Wayland session gets there before the settings daemon has published it.
+    DisplayScaleReadiness.awaitDisplayScale()
     // libsodium (ionspin) requires async init before the first VaultCrypto call; on desktop startup
     // this is done blocking so the dependency graph is already built and ready.
     runBlocking { initializeVaultCrypto() }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/DisplayScaleReadinessTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/DisplayScaleReadinessTest.kt
@@ -1,0 +1,199 @@
+package app.skerry.ui.desktop
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The startup wait for `Xft.dpi`. Timings are simulated: the fake clock only advances inside
+ * [Session.sleep], so a test never depends on wall-clock scheduling.
+ */
+class DisplayScaleReadinessTest {
+
+    /** Resource-database reads scripted by elapsed time: `at` ms -> what the X server reports from then on. */
+    private class Session(vararg timeline: Pair<Long, String?>) {
+        private val script = timeline.sortedBy { it.first }
+        var now = 0L
+            private set
+        var slept = 0L
+            private set
+
+        fun read(): String? = script.lastOrNull { it.first <= now }?.second
+
+        fun sleep(ms: Long) {
+            slept += ms
+            now += ms
+        }
+    }
+
+    private fun database(dpi: String?): String =
+        "Xcursor.size:\t24\nXft.antialias:\t1\n" + if (dpi != null) "Xft.dpi:\t$dpi\n" else ""
+
+    private fun Session.await(
+        budgetMs: Long = 1000L,
+        appearanceBudgetMs: Long = 500L,
+        quietMs: Long = 250L,
+        pollMs: Long = 20L,
+    ) = DisplayScaleReadiness.awaitSettledDpi(
+        readResources = ::read,
+        sleep = ::sleep,
+        elapsedMs = { now },
+        budgetMs = budgetMs,
+        appearanceBudgetMs = appearanceBudgetMs,
+        quietMs = quietMs,
+        pollMs = pollMs,
+    )
+
+    @Test
+    fun `reads Xft dpi out of the resource database`() {
+        val resources = "Xcursor.size:\t24\nXft.antialias:\t1\nXft.dpi:\t192\nXft.hinting:\t1\n"
+
+        assertEquals("192", DisplayScaleReadiness.parseXftDpi(resources))
+    }
+
+    @Test
+    fun `reports no value when the resource database has no dpi`() {
+        assertNull(DisplayScaleReadiness.parseXftDpi(""))
+        assertNull(DisplayScaleReadiness.parseXftDpi(null))
+        assertNull(DisplayScaleReadiness.parseXftDpi("Xft.antialias:\t1\n"))
+        // A key that merely starts the same is not the one we want, and neither is an empty value.
+        assertNull(DisplayScaleReadiness.parseXftDpi("Xft.dpiFoo:\t192\n"))
+        assertNull(DisplayScaleReadiness.parseXftDpi("Xft.dpi:\t\n"))
+    }
+
+    @Test
+    fun `recognises a Wayland session even without the Wayland socket`() {
+        // The Flatpak build is granted the X11 socket only, so WAYLAND_DISPLAY is empty there.
+        assertTrue(DisplayScaleReadiness.isWaylandSession("wayland", null))
+        assertTrue(DisplayScaleReadiness.isWaylandSession("wayland", ""))
+        assertTrue(DisplayScaleReadiness.isWaylandSession(null, "wayland-0"))
+        assertFalse(DisplayScaleReadiness.isWaylandSession("x11", null))
+        assertFalse(DisplayScaleReadiness.isWaylandSession(null, null))
+    }
+
+    @Test
+    fun `never opens a display outside a Wayland session`() {
+        var opened = 0
+
+        val settled = DisplayScaleReadiness.settleDisplayScale(
+            sessionType = "x11",
+            waylandDisplay = null,
+            openDatabase = { opened++; null },
+        )
+
+        assertNull(settled)
+        assertEquals(0, opened, "an X11 session has no race to wait out")
+    }
+
+    @Test
+    fun `gives up when the display cannot be opened`() {
+        var opened = 0
+
+        val settled = DisplayScaleReadiness.settleDisplayScale(
+            sessionType = "wayland",
+            waylandDisplay = null,
+            openDatabase = { opened++; null },
+        )
+
+        assertNull(settled)
+        assertEquals(1, opened)
+    }
+
+    @Test
+    fun `hands startup back on the deadline when the X calls block`() {
+        // The budgets only count between reads; this is the guard for a compositor that accepts the
+        // socket and then never answers, which would otherwise hang main() before any window exists.
+        val started = System.nanoTime()
+
+        DisplayScaleReadiness.awaitDisplayScale(
+            sessionType = "wayland",
+            waylandDisplay = null,
+            deadlineMs = 200L,
+            openDatabase = { Thread.sleep(30_000); null },
+        )
+
+        val elapsed = (System.nanoTime() - started) / 1_000_000
+        // Under the default deadline (1500 ms), so falling back to it instead of honouring the one
+        // passed in fails here too — not just removing the bound altogether.
+        assertTrue(elapsed < 1_000, "startup waited $elapsed ms on a display that never answers")
+    }
+
+    @Test
+    fun `waits out a database that arrives without its dpi yet`() {
+        // The property is already there when we look, but the dpi entry lands a moment later — the
+        // fast path must not read that as "this session has no scale".
+        val session = Session(0L to database(null), 60L to database("192"))
+
+        assertEquals("192", session.await())
+    }
+
+    @Test
+    fun `returns the value already published without waiting`() {
+        val session = Session(0L to database("192"))
+
+        assertEquals("192", session.await())
+        assertEquals(0L, session.slept, "a session that already has a database must not delay startup")
+    }
+
+    @Test
+    fun `waits for a database that is not there yet`() {
+        val session = Session(0L to null, 200L to database("192"))
+
+        assertEquals("192", session.await())
+        assertTrue(session.slept >= 200L, "expected to wait for the database, slept ${session.slept} ms")
+    }
+
+    @Test
+    fun `outlasts the default the daemon publishes first`() {
+        // What GNOME 50 actually does on a fresh XWayland at 166%: nothing, then 96, then 192.
+        val session = Session(0L to null, 220L to database("96"), 262L to database("192"))
+
+        assertEquals("192", session.await())
+    }
+
+    @Test
+    fun `picks up a dpi that lands after the rest of the database`() {
+        val session = Session(0L to null, 200L to database(null), 260L to database("192"))
+
+        assertEquals("192", session.await())
+    }
+
+    @Test
+    fun `keeps following a value that changes again`() {
+        val session = Session(0L to null, 100L to database("96"), 300L to database("144"), 500L to database("192"))
+
+        assertEquals("192", session.await())
+    }
+
+    @Test
+    fun `gives up on the shorter appearance budget when nothing is published`() {
+        // A compositor with no settings daemon (sway, Hyprland) pays this on every start, so it
+        // must be the short budget, not the full one.
+        val session = Session(0L to null)
+
+        assertNull(session.await(budgetMs = 1000L, appearanceBudgetMs = 400L))
+        assertTrue(session.slept <= 400L + 20L, "overshot the appearance budget: slept ${session.slept} ms")
+    }
+
+    @Test
+    fun `settles a late dpi past the appearance budget once the database is in hand`() {
+        // The appearance budget only caps the wait for the database itself; chasing the value it
+        // then publishes is the full budget's job.
+        val session = Session(0L to null, 300L to database("96"), 500L to database("192"))
+
+        assertEquals("192", session.await(budgetMs = 1000L, appearanceBudgetMs = 400L))
+        assertTrue(session.slept > 400L, "stopped at the appearance budget: slept ${session.slept} ms")
+    }
+
+    @Test
+    fun `stops at the budget even while the value is still moving`() {
+        val session = Session(0L to null, 100L to database("96"), 380L to database("192"))
+
+        // The budget is the hard stop: a value in hand beats waiting for a quiet period that may
+        // never come.
+        assertEquals("96", session.await(budgetMs = 300L))
+        assertTrue(session.slept <= 320L, "overshot the budget: slept ${session.slept} ms")
+    }
+}


### PR DESCRIPTION
On a Wayland session the first launch after login ran unscaled, while every later launch was correct.

Skiko decides the UI scale once at startup: it reads `Xft.dpi` from the X resource database and writes it into `sun.java2d.uiScale`, which AWT then caches for the lifetime of the JVM. XWayland starts on demand, so the first X11 client of the session is the one that brings it up — and `gsd-xsettings` fills `RESOURCE_MANAGER` in only afterwards. Measured on GNOME 50 at 166%: the database is absent for ~220 ms, arrives carrying the 96 dpi default, and reaches the display's real 192 some 40 ms later. Skerry, usually the only X11 client, read that window.

Startup now waits until the resource database appears and its dpi stops changing, before AWT or Skiko touch anything:

- a session that already published a database pays nothing;
- a session that is not Wayland never opens a display at all;
- a compositor with no settings daemon (sway, Hyprland) waits out a short appearance budget instead of the full one;
- the wait runs on a daemon thread with a hard deadline, so a compositor that accepts the X socket and never answers cannot hang startup before a window exists.

The X11 connection bootstrap `NativeWindowMove` already carried is now shared with the new reader.

## Verification

Reproduced and fixed on GNOME 50 / Wayland at 166%, with the app started as the first X11 client of the session: window geometry 1680x1050 (scale ignored) before the fix, 3360x1498 (scale applied) after — the latter matching a normal launch. `test allTests`, `build` and `detektAll` are green; the wait logic is covered by unit tests over a simulated clock, including the measured 96 -> 192 sequence, the budget stops and the deadline.

Not verified: the Flatpak build carrying this change (the fix was exercised through the desktop build; the Skiko code path is the same), and other platforms — the wait is skipped outside a Wayland session.