### PR TITLE
Window: a minimum size the WM honors, restore-on-drag, and a titlebar-sized drag area on the gate screens

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -1354,7 +1354,7 @@ private fun TitleBarRow(state: DesktopDesignState, onLock: (() -> Unit)?, window
     Row(
         Modifier
             .fillMaxWidth()
-            .height(44.dp)
+            .height(TITLEBAR_HEIGHT)
             .background(Brush.verticalGradient(listOf(Skerry.colors.titleTop, Skerry.colors.titleBottom)))
             .padding(start = 14.dp, end = if (windowChrome != null) 8.dp else 12.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowChrome.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -29,6 +31,9 @@ class WindowChrome(
     val dragArea: @Composable (content: @Composable () -> Unit) -> Unit,
 )
 
+/** Height of the window titlebar, shared by the main one and the drag strip over the gate screens. */
+val TITLEBAR_HEIGHT = 44.dp
+
 /** Minimize / maximize-restore / close buttons drawn in the app palette. */
 @Composable
 fun WindowButtons(chrome: WindowChrome, modifier: Modifier = Modifier) {
@@ -46,9 +51,11 @@ fun WindowButtons(chrome: WindowChrome, modifier: Modifier = Modifier) {
 
 /**
  * Window chrome for full-window screens outside the main titlebar (vault gate: create/unlock/
- * corrupted/reset/sync-onboarding): the whole screen becomes the drag area and the window buttons
- * float in the top-right corner — otherwise an undecorated window could be neither moved nor
- * closed while locked. With `chrome == null` (decorated window) it renders [content] as-is.
+ * corrupted/reset/sync-onboarding): a drag strip the height of the real titlebar sits over the top
+ * of the screen with the window buttons in it — otherwise an undecorated window could be neither
+ * moved nor closed while locked. The strip is only that tall on purpose: a full-screen drag area
+ * turns every double-click on the form into a maximize and lets any press anywhere move the window.
+ * With `chrome == null` (decorated window) it renders [content] as-is.
  */
 @Composable
 fun LockWindowChrome(chrome: WindowChrome?, content: @Composable () -> Unit) {
@@ -56,10 +63,12 @@ fun LockWindowChrome(chrome: WindowChrome?, content: @Composable () -> Unit) {
         content()
         return
     }
-    chrome.dragArea {
-        Box(Modifier.fillMaxSize()) {
-            content()
-            WindowButtons(chrome, Modifier.align(Alignment.TopEnd).padding(10.dp))
+    Box(Modifier.fillMaxSize()) {
+        content()
+        chrome.dragArea {
+            Box(Modifier.fillMaxWidth().height(TITLEBAR_HEIGHT)) {
+                WindowButtons(chrome, Modifier.align(Alignment.CenterEnd).padding(end = 10.dp))
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowSizing.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowSizing.kt
@@ -9,6 +9,17 @@ val MIN_WINDOW: DpSize = DpSize(1100.dp, 720.dp)
 /** Maximum window size; the layout targets a working size, not a fullscreen 4K/ultrawide stretch. */
 val MAX_WINDOW: DpSize = DpSize(1680.dp, 1050.dp)
 
+/**
+ * Floor a resize may reach on the available [screen] area: [MIN_WINDOW], capped by the screen
+ * itself — a floor larger than the display would push the window past its edges instead of
+ * letting it shrink. Fed to the window manager as a size hint, so a WM-driven resize (keyboard,
+ * tiling, super+drag) is bounded the same way the app's own resize handles are.
+ */
+fun minimumWindowSize(screen: DpSize): DpSize = DpSize(
+    width = MIN_WINDOW.width.coerceAtMost(screen.width),
+    height = MIN_WINDOW.height.coerceAtMost(screen.height),
+)
+
 /** Default fraction of the available screen area the window occupies. */
 private const val SCREEN_FRACTION = 0.9f
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/WindowSizingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/WindowSizingTest.kt
@@ -46,6 +46,36 @@ class WindowSizingTest {
     }
 
     @Test
+    fun minimum_is_the_layout_minimum_on_a_large_screen() {
+        assertEquals(MIN_WINDOW, minimumWindowSize(DpSize(3840.dp, 2160.dp)))
+    }
+
+    @Test
+    fun minimum_never_exceeds_the_screen() {
+        val screen = DpSize(1024.dp, 600.dp)
+        val min = minimumWindowSize(screen)
+        // A floor larger than the screen would make the window unshrinkable past the display edge.
+        assertEquals(screen.width, min.width)
+        assertEquals(screen.height, min.height)
+    }
+
+    @Test
+    fun start_size_is_never_below_the_minimum() {
+        listOf(
+            DpSize(800.dp, 600.dp),
+            DpSize(1024.dp, 768.dp),
+            DpSize(1366.dp, 768.dp),
+            DpSize(1920.dp, 1080.dp),
+            DpSize(3840.dp, 2160.dp),
+        ).forEach { screen ->
+            val min = minimumWindowSize(screen)
+            val size = optimalWindowSize(screen)
+            assertTrue(size.width >= min.width, "start width below minimum for $screen")
+            assertTrue(size.height >= min.height, "start height below minimum for $screen")
+        }
+    }
+
+    @Test
     fun never_exceeds_screen_for_a_range_of_sizes() {
         listOf(
             DpSize(800.dp, 600.dp),

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,6 +17,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -23,6 +25,7 @@ import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowScope
 import androidx.compose.ui.window.WindowState
 import java.awt.Cursor
+import java.awt.Dimension
 import java.awt.MouseInfo
 
 /**
@@ -144,12 +147,24 @@ private fun Modifier.onUnconsumedDoubleClick(onDoubleClick: () -> Unit): Modifie
  * Content wrapper for the undecorated window: draws [content] and, while the window is floating
  * (not maximized), overlays invisible resize strips along the borders — an undecorated AWT window
  * has no native resize edges, so edge drags call [resizedWindowBounds] over `window.setBounds`.
+ *
+ * Also declares how far the window may shrink, derived from [screen]: the strips clamp their own
+ * drags, but a window-manager resize (keyboard resize, tiling, super+drag) never asks them, and
+ * without the hint an undecorated window can be squeezed down to a few pixels. The floor follows
+ * the display the app started on — moving the window to a smaller monitor does not recompute it.
  */
 @Composable
-fun WindowScope.SkerryWindowFrame(state: WindowState, content: @Composable () -> Unit) {
+fun WindowScope.SkerryWindowFrame(state: WindowState, screen: DpSize, content: @Composable () -> Unit) {
+    val minimum = remember(screen) { minimumWindowDimension(screen) }
+    // The window is not displayable yet, so AWT stores the value on it and the peer applies it when
+    // realized — either way the hint is in place before the window is shown.
+    DisposableEffect(minimum) {
+        window.minimumSize = minimum
+        onDispose { }
+    }
     Box(Modifier.fillMaxSize()) {
         content()
-        if (state.placement == WindowPlacement.Floating) ResizeBorders()
+        if (state.placement == WindowPlacement.Floating) ResizeBorders(minimum)
     }
 }
 
@@ -158,27 +173,29 @@ private val EDGE = 5.dp
 private val CORNER = 14.dp
 
 @Composable
-private fun WindowScope.ResizeBorders() {
+private fun WindowScope.ResizeBorders(minimum: Dimension) {
     Box(Modifier.fillMaxSize()) {
         // Edges (inset by CORNER so corners keep their diagonal cursor).
-        ResizeStrip(ResizeEdge.Top, Cursor.N_RESIZE_CURSOR, Modifier.align(Alignment.TopCenter).fillMaxWidth().height(EDGE).padding(horizontal = CORNER))
-        ResizeStrip(ResizeEdge.Bottom, Cursor.S_RESIZE_CURSOR, Modifier.align(Alignment.BottomCenter).fillMaxWidth().height(EDGE).padding(horizontal = CORNER))
-        ResizeStrip(ResizeEdge.Left, Cursor.W_RESIZE_CURSOR, Modifier.align(Alignment.CenterStart).fillMaxHeight().width(EDGE).padding(vertical = CORNER))
-        ResizeStrip(ResizeEdge.Right, Cursor.E_RESIZE_CURSOR, Modifier.align(Alignment.CenterEnd).fillMaxHeight().width(EDGE).padding(vertical = CORNER))
+        ResizeStrip(ResizeEdge.Top, Cursor.N_RESIZE_CURSOR, minimum, Modifier.align(Alignment.TopCenter).fillMaxWidth().height(EDGE).padding(horizontal = CORNER))
+        ResizeStrip(ResizeEdge.Bottom, Cursor.S_RESIZE_CURSOR, minimum, Modifier.align(Alignment.BottomCenter).fillMaxWidth().height(EDGE).padding(horizontal = CORNER))
+        ResizeStrip(ResizeEdge.Left, Cursor.W_RESIZE_CURSOR, minimum, Modifier.align(Alignment.CenterStart).fillMaxHeight().width(EDGE).padding(vertical = CORNER))
+        ResizeStrip(ResizeEdge.Right, Cursor.E_RESIZE_CURSOR, minimum, Modifier.align(Alignment.CenterEnd).fillMaxHeight().width(EDGE).padding(vertical = CORNER))
         // Corners on top of the edges.
-        ResizeStrip(ResizeEdge.TopLeft, Cursor.NW_RESIZE_CURSOR, Modifier.align(Alignment.TopStart).size(CORNER))
-        ResizeStrip(ResizeEdge.TopRight, Cursor.NE_RESIZE_CURSOR, Modifier.align(Alignment.TopEnd).size(CORNER))
-        ResizeStrip(ResizeEdge.BottomLeft, Cursor.SW_RESIZE_CURSOR, Modifier.align(Alignment.BottomStart).size(CORNER))
-        ResizeStrip(ResizeEdge.BottomRight, Cursor.SE_RESIZE_CURSOR, Modifier.align(Alignment.BottomEnd).size(CORNER))
+        ResizeStrip(ResizeEdge.TopLeft, Cursor.NW_RESIZE_CURSOR, minimum, Modifier.align(Alignment.TopStart).size(CORNER))
+        ResizeStrip(ResizeEdge.TopRight, Cursor.NE_RESIZE_CURSOR, minimum, Modifier.align(Alignment.TopEnd).size(CORNER))
+        ResizeStrip(ResizeEdge.BottomLeft, Cursor.SW_RESIZE_CURSOR, minimum, Modifier.align(Alignment.BottomStart).size(CORNER))
+        ResizeStrip(ResizeEdge.BottomRight, Cursor.SE_RESIZE_CURSOR, minimum, Modifier.align(Alignment.BottomEnd).size(CORNER))
     }
 }
 
 @Composable
-private fun WindowScope.ResizeStrip(edge: ResizeEdge, cursor: Int, modifier: Modifier) {
+private fun WindowScope.ResizeStrip(edge: ResizeEdge, cursor: Int, minimum: Dimension, modifier: Modifier) {
     Box(
         modifier
             .pointerHoverIcon(PointerIcon(Cursor.getPredefinedCursor(cursor)))
-            .pointerInput(edge) {
+            // Keyed on the floor too: a strip that kept the old one would compute the fixed side of
+            // a left/top drag from a width that AWT then clamps to the new floor, sliding that side.
+            .pointerInput(edge, minimum) {
                 awaitEachGesture {
                     awaitFirstDown().consume()
                     val startBounds = window.bounds
@@ -193,7 +210,7 @@ private fun WindowScope.ResizeStrip(edge: ResizeEdge, cursor: Int, modifier: Mod
                         window.bounds = resizedWindowBounds(
                             startBounds, edge,
                             mouse.x - startMouse.x, mouse.y - startMouse.y,
-                            MIN_WINDOW.width.value.toInt(), MIN_WINDOW.height.value.toInt(),
+                            minimum.width, minimum.height,
                         )
                     }
                 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
@@ -27,12 +28,14 @@ import androidx.compose.ui.window.WindowState
 import java.awt.Cursor
 import java.awt.Dimension
 import java.awt.MouseInfo
+import java.awt.Point
+import java.awt.Rectangle
 
 /**
  * Custom chrome for the undecorated main window: dragging the empty titlebar space (with
  * double-click on it toggling maximize), minimize/maximize through [WindowState], close via [exit].
- * A maximized window is not draggable (only double-click restores it) — moving a maximized AWT
- * window would desync placement from the real bounds.
+ * Dragging a maximized window restores it under the pointer and keeps going, the way a native
+ * titlebar does — see [titlebarDrag].
  */
 @Composable
 fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit): WindowChrome {
@@ -43,7 +46,6 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
                 if (state.placement == WindowPlacement.Maximized) WindowPlacement.Floating
                 else WindowPlacement.Maximized
         }
-        val isFloating = { state.placement == WindowPlacement.Floating }
         // On X11 the WM moves the window itself (smooth, compositor-driven — see NativeWindowMove);
         // elsewhere fall back to moving it frame by frame from the app thread.
         val useNativeMove = NativeWindowMove.isAvailable()
@@ -54,69 +56,123 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
             onClose = exit,
             dragArea = { content ->
                 val doubleClick = Modifier.onUnconsumedDoubleClick(toggleMaximize)
-                when {
-                    state.placement == WindowPlacement.Maximized -> Box(doubleClick) { content() }
-                    useNativeMove -> Box(doubleClick.then(Modifier.nativeWindowDrag(awtWindow))) { content() }
-                    else -> Box(doubleClick.then(Modifier.inAppWindowDrag(awtWindow, isFloating))) { content() }
-                }
+                Box(doubleClick.then(Modifier.titlebarDrag(awtWindow, state, useNativeMove))) { content() }
             },
         )
     }
 }
 
-/**
- * Moves the window frame by frame from the app thread, for platforms without [NativeWindowMove].
- * Gated by [WindowDragGesture] (dead zone, floating only), and driven by absolute pointer positions
- * ([MouseInfo]) because local ones shift together with the window and would feed back. [isFloating]
- * is read per event, so a double-click that maximizes the window mid-gesture stops the drag instead
- * of dragging the now screen-sized window back to the floating origin (issue #76). Only unconsumed
- * presses arm it, so buttons/tabs that consume their own press are excluded.
- */
-private fun Modifier.inAppWindowDrag(window: java.awt.Window, isFloating: () -> Boolean): Modifier =
-    pointerInput(window) {
-        val gesture = WindowDragGesture(viewConfiguration.touchSlop.toInt())
-        awaitEachGesture {
-            awaitFirstDown(requireUnconsumed = true)
-            gesture.press(MouseInfo.getPointerInfo()?.location ?: return@awaitEachGesture)
-            try {
-                while (true) {
-                    val event = awaitPointerEvent()
-                    val change = event.changes.firstOrNull() ?: break
-                    if (!change.pressed) break
-                    val pointer = MouseInfo.getPointerInfo()?.location ?: continue
-                    val target = gesture.drag(pointer, window.location, isFloating()) ?: continue
-                    change.consume()
-                    window.setLocation(target.x, target.y)
-                }
-            } finally {
-                gesture.release()
-            }
-        }
-    }
+// How many pointer events to give the window manager to answer a restore before the drag carries on
+// regardless. The wait is counted in events, not milliseconds, because it happens inside the pointer
+// handler: a drag delivers events continuously, and counting them keeps a release visible instantly.
+private const val RESTORE_EVENTS = 16
 
 /**
- * Starts a native WM drag ([NativeWindowMove]) once the pointer moves past touch-slop from the
- * initial press — the slop threshold keeps clicks on titlebar buttons and the double-click-to-
- * maximize gesture working, since a plain click never crosses it. Only unconsumed presses arm the
- * drag, so buttons/tabs that consume their own press are excluded. Once handed off, the compositor
- * owns the pointer and this gesture simply ends.
+ * The one titlebar drag gesture. It branches per press instead of per placement, because a
+ * placement-keyed modifier would be torn down (cancelling the gesture) the moment the restore below
+ * changes it — mid-drag, before the window is ever placed under the pointer.
+ *
+ * A maximized window is restored to its floating size and put back under the pointer first
+ * ([restoredWindowOrigin]); a floating one is dragged as is. Either way the move itself goes to the
+ * window manager where one is reachable ([NativeWindowMove], smooth and compositor-driven), and is
+ * otherwise walked frame by frame from the app thread ([followPointer]).
+ *
+ * Everything happens inside the pointer handler, with no suspension outside it: Compose delivers an
+ * event only to a handler parked in `awaitPointerEvent`, so a release during a wait taken elsewhere
+ * would go unseen — and the WM move would then start with no button held, leaving the window stuck
+ * to the cursor until the next click.
+ *
+ * Only unconsumed presses arm it, so buttons and tabs inside the drag area keep their own clicks,
+ * and a press that never leaves touch-slop is left alone for the double-click handler.
  */
-private fun Modifier.nativeWindowDrag(window: java.awt.Window): Modifier = pointerInput(window) {
+private fun Modifier.titlebarDrag(
+    window: java.awt.Window,
+    state: WindowState,
+    useNativeMove: Boolean,
+): Modifier = pointerInput(window, state, useNativeMove) {
+    val slop = viewConfiguration.touchSlop
+    val isFloating = { state.placement == WindowPlacement.Floating }
     awaitEachGesture {
-        val down = awaitFirstDown(requireUnconsumed = true)
-        val slop = viewConfiguration.touchSlop
+        var pointer = awaitDragStart(slop) ?: return@awaitEachGesture
+        if (state.placement == WindowPlacement.Maximized) {
+            val maximized = window.bounds
+            state.placement = WindowPlacement.Floating
+            // The window manager answers a restore a frame or two later, and the pointer keeps
+            // travelling meanwhile: read it again afterwards, or the window lands under where the
+            // cursor was and then jumps the travelled distance when the move starts.
+            val restored = awaitRestoredSize(window, maximized) ?: return@awaitEachGesture
+            pointer = MouseInfo.getPointerInfo()?.location ?: pointer
+            window.location = restoredWindowOrigin(maximized, restored, pointer)
+        }
+        if (useNativeMove && NativeWindowMove.startMove(window, pointer.x, pointer.y)) return@awaitEachGesture
+        followPointer(window, pointer, isFloating)
+    }
+}
+
+/**
+ * Waits for a press that turns into a drag and answers with the absolute pointer position it
+ * reached, or null when the press ended as a click. Absolute ([MouseInfo]) rather than local,
+ * because local positions travel with the window being moved and would feed back into the drag.
+ */
+private suspend fun AwaitPointerEventScope.awaitDragStart(slop: Float): Point? {
+    val down = awaitFirstDown(requireUnconsumed = true)
+    while (true) {
+        val event = awaitPointerEvent()
+        val change = event.changes.firstOrNull() ?: return null
+        if (!change.pressed) return null // released without dragging — leave it for click/double-click
+        if ((change.position - down.position).getDistance() <= slop) continue
+        // Consumed only once there is a position to drag from: an unconsumed press still reaches the
+        // double-click detector on the same box, a consumed one would be swallowed for nothing.
+        val pointer = MouseInfo.getPointerInfo()?.location ?: return null
+        change.consume()
+        return pointer
+    }
+}
+
+/**
+ * The window's size once the restore lands. Events are consumed while waiting, so a release is seen
+ * at once (null — the drag is over). A window manager that restores to the very size the window had
+ * while maximized, or one that never answers, ends the wait after [RESTORE_EVENTS] events: the drag
+ * then carries on with the size the window has rather than being dropped on the floor.
+ */
+private suspend fun AwaitPointerEventScope.awaitRestoredSize(
+    window: java.awt.Window,
+    maximized: Rectangle,
+): Dimension? {
+    repeat(RESTORE_EVENTS) {
+        if (window.bounds != maximized) return window.size
+        val change = awaitPointerEvent().changes.firstOrNull() ?: return null
+        if (!change.pressed) return null
+        change.consume()
+    }
+    return window.size
+}
+
+/**
+ * Moves the window with the pointer until the button is released, for platforms the window manager
+ * can't do it for. Gated by [WindowDragGesture], which also stops the drag if the window stops
+ * floating mid-gesture (a double-click maximizes it while the button is still down — issue #76).
+ * The dead zone is zero here: it was already crossed by [awaitDragStart].
+ */
+private suspend fun AwaitPointerEventScope.followPointer(
+    window: java.awt.Window,
+    from: Point,
+    isFloating: () -> Boolean,
+) {
+    val gesture = WindowDragGesture(deadZone = 0)
+    gesture.press(from)
+    try {
         while (true) {
             val event = awaitPointerEvent()
-            val change = event.changes.firstOrNull() ?: break
-            if (!change.pressed) break // released without dragging — leave it for click/double-click
-            if ((change.position - down.position).getDistance() > slop) {
-                val mouse = MouseInfo.getPointerInfo()?.location
-                if (mouse != null && NativeWindowMove.startMove(window, mouse.x, mouse.y)) {
-                    change.consume()
-                }
-                break
-            }
+            val change = event.changes.firstOrNull() ?: return
+            if (!change.pressed) return
+            val pointer = MouseInfo.getPointerInfo()?.location ?: continue
+            val target = gesture.drag(pointer, window.location, isFloating()) ?: continue
+            change.consume()
+            window.setLocation(target.x, target.y)
         }
+    } finally {
+        gesture.release()
     }
 }
 

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowResize.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowResize.kt
@@ -1,6 +1,17 @@
 package app.skerry.ui.desktop
 
+import androidx.compose.ui.unit.DpSize
+import java.awt.Dimension
 import java.awt.Rectangle
+
+/**
+ * [minimumWindowSize] in AWT units, for the window manager's size hint and for the resize strips
+ * that clamp against it. One conversion for both: a floor the WM enforces and a different floor in
+ * the drag math would slide the fixed side of a left/top drag by their difference.
+ */
+fun minimumWindowDimension(screen: DpSize): Dimension = minimumWindowSize(screen).let {
+    Dimension(it.width.value.toInt(), it.height.value.toInt())
+}
 
 /**
  * Which window border a resize drag grabs. [dx]/[dy] mark the moving side per axis:

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowRestore.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowRestore.kt
@@ -1,0 +1,30 @@
+package app.skerry.ui.desktop
+
+import java.awt.Dimension
+import java.awt.Point
+import java.awt.Rectangle
+import kotlin.math.roundToInt
+
+/**
+ * Where to put a window restored from maximized in the middle of a titlebar drag. The pointer keeps
+ * the share of the titlebar it grabbed — press near the right end of a maximized window and the
+ * restored window hangs off to the left of the cursor, the way a native titlebar behaves — instead
+ * of the window jumping back to the origin it had before it was maximized, out from under the hand.
+ *
+ * [maximized] is the area the window is leaving (its own bounds), [restored] the size it returns to.
+ * The result stays inside that area, so a grab at either end doesn't push the window off-screen.
+ */
+fun restoredWindowOrigin(maximized: Rectangle, restored: Dimension, pointer: Point): Point = Point(
+    axisOrigin(pointer.x, maximized.x, maximized.width, restored.width),
+    axisOrigin(pointer.y, maximized.y, maximized.height, restored.height),
+)
+
+private fun axisOrigin(pointer: Int, areaStart: Int, areaSize: Int, windowSize: Int): Int {
+    // A zero-sized area (a window with no bounds yet) has no share to keep: pin the pointer to the
+    // window's leading edge rather than dividing by it.
+    val share = if (areaSize > 0) ((pointer - areaStart).toDouble() / areaSize).coerceIn(0.0, 1.0) else 0.0
+    val origin = pointer - (share * windowSize).roundToInt()
+    // A window wider than the area it came from can only start at its leading edge.
+    val last = (areaStart + areaSize - windowSize).coerceAtLeast(areaStart)
+    return origin.coerceIn(areaStart, last)
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -541,8 +541,9 @@ fun main(args: Array<String>) {
         // the new palette. onThemeModeChange (from DesktopDesignState) updates this state and persists.
         val currentThemeMode = remember { mutableStateOf(prefs.id("app_theme", app.skerry.ui.theme.ThemeMode.DEFAULT, app.skerry.ui.theme.ThemeMode::fromId)) }
         val screen = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
+        val screenSize = DpSize(screen.width.dp, screen.height.dp)
         val windowState = rememberWindowState(
-            size = optimalWindowSize(DpSize(screen.width.dp, screen.height.dp)),
+            size = optimalWindowSize(screenSize),
             position = WindowPosition(Alignment.Center),
         )
         val appIcon = painterResource(Res.drawable.skerry_icon)
@@ -556,7 +557,8 @@ fun main(args: Array<String>) {
             undecorated = true,
         ) {
           val windowChrome = rememberSkerryWindowChrome(windowState, ::exitApplication)
-          SkerryWindowFrame(windowState) {
+          // The frame owns the whole resize contract of the undecorated window, the minimum size included.
+          SkerryWindowFrame(windowState, screenSize) {
             // Live vault + hosts + sessions + known-hosts are wired up: chrome is behind the master
             // password gate, clicking a host opens a live SSH terminal in a tab (transport+identities
             // from `deps`), and the known-hosts manager runs over its own stores (knownHosts from `deps`).

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
@@ -29,6 +29,19 @@ class WindowDragGestureTest {
         assertEquals(Point(140, 215), gesture.drag(Point(570, 35), origin, floating = true))
     }
 
+    /**
+     * A drag handed over after a restore (WindowFrame.followPointer) starts with no dead zone: it was
+     * already crossed before the window was restored, so the very first event must arm the gesture.
+     */
+    @Test
+    fun zeroDeadZoneArmsOnTheFirstEvent() {
+        val gesture = WindowDragGesture(deadZone = 0).apply { press(Point(500, 20)) }
+        // Not even a pixel of movement: the first event still only captures the grab...
+        assertNull(gesture.drag(Point(500, 20), origin, floating = true))
+        // ...and every event after it moves the window.
+        assertEquals(Point(101, 200), gesture.drag(Point(501, 20), origin, floating = true))
+    }
+
     /** Issue #76: the double-click maximizes the window while the button is still down. */
     @Test
     fun windowMaximizedMidGestureIsNeverMoved() {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowResizeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowResizeTest.kt
@@ -1,8 +1,40 @@
 package app.skerry.ui.desktop
 
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import java.awt.Dimension
 import java.awt.Rectangle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+
+/**
+ * The AWT floor handed to the window manager and to the resize strips: [MIN_WINDOW] in AWT units,
+ * capped by the screen the app started on.
+ */
+class MinimumWindowDimensionTest {
+
+    @Test
+    fun large_screen_yields_the_layout_minimum() {
+        assertEquals(Dimension(1100, 720), minimumWindowDimension(DpSize(3840.dp, 2160.dp)))
+    }
+
+    @Test
+    fun small_screen_caps_the_floor_at_the_screen() {
+        assertEquals(Dimension(1024, 600), minimumWindowDimension(DpSize(1024.dp, 600.dp)))
+    }
+
+    @Test
+    fun a_drag_cannot_shrink_below_the_screen_capped_floor() {
+        // The floor the strips clamp at comes from this very function, so a netbook-sized screen
+        // resizes down to its own edge instead of the (larger) layout minimum.
+        val floor = minimumWindowDimension(DpSize(1024.dp, 600.dp))
+        val bounds = resizedWindowBounds(
+            Rectangle(0, 0, 1024, 600), ResizeEdge.BottomRight, -900, -900,
+            floor.width, floor.height,
+        )
+        assertEquals(Rectangle(0, 0, 1024, 600), bounds)
+    }
+}
 
 class WindowResizeTest {
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowRestoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowRestoreTest.kt
@@ -1,0 +1,67 @@
+package app.skerry.ui.desktop
+
+import java.awt.Dimension
+import java.awt.Point
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Where a window restored from maximized mid-drag lands: the pointer keeps its relative place along
+ * the titlebar, so the shrinking window stays under the cursor instead of jumping to its old origin.
+ */
+class WindowRestoreTest {
+
+    private val maximized = Rectangle(0, 0, 1920, 1080)
+    private val restored = Dimension(800, 600)
+
+    private fun origin(x: Int, y: Int) = restoredWindowOrigin(maximized, restored, Point(x, y))
+
+    @Test
+    fun pointer_in_the_middle_centers_the_window_under_it() {
+        // Half the maximized width -> half the restored width to the left of the pointer. The same
+        // share applies vertically, so a press 10px down a 1080px window lands 6px down a 600px one.
+        assertEquals(Point(560, 4), origin(960, 10))
+    }
+
+    @Test
+    fun pointer_keeps_its_share_of_the_titlebar() {
+        // A quarter along the maximized titlebar stays a quarter along the restored one.
+        assertEquals(Point(280, 4), origin(480, 10))
+    }
+
+    @Test
+    fun window_never_starts_left_of_the_area() {
+        assertEquals(0, origin(0, 5).x)
+    }
+
+    @Test
+    fun window_never_starts_above_the_area() {
+        val area = Rectangle(0, 27, 1920, 1053)
+        assertEquals(27, restoredWindowOrigin(area, restored, Point(960, 27)).y)
+    }
+
+    @Test
+    fun window_never_hangs_off_the_bottom_edge() {
+        assertEquals(1080 - 600, origin(960, 1080).y)
+    }
+
+    @Test
+    fun window_never_hangs_off_the_right_edge() {
+        val point = origin(1920, 10)
+        assertEquals(1920 - 800, point.x)
+    }
+
+    @Test
+    fun a_degenerate_area_does_not_divide_by_zero() {
+        val point = restoredWindowOrigin(Rectangle(0, 0, 0, 0), restored, Point(40, 12))
+        assertTrue(point.x <= 40 && point.y <= 12)
+    }
+
+    @Test
+    fun a_restored_window_wider_than_the_area_starts_at_its_left_edge() {
+        val point = restoredWindowOrigin(maximized, Dimension(2400, 600), Point(960, 10))
+        assertEquals(0, point.x)
+    }
+}


### PR DESCRIPTION
Three fixes to the undecorated desktop window.

**Minimum size.** The window carried no size hint, so a window-manager resize (keyboard resize, tiling, super+drag) could squeeze it down to a few pixels — the app's own resize strips clamped their drags, but nothing else asked them. `SkerryWindowFrame` now declares the floor to AWT and clamps its own drags against the same value: `MIN_WINDOW` capped by the screen, because a floor larger than the display would push the window past its edges. The floor follows the display the app started on.

**Drag to restore.** Dragging the titlebar of a maximized window did nothing; only a double-click restored it. It now restores to its floating size under the pointer — keeping the share of the titlebar the press grabbed — and the drag carries on. The native WM move, the in-app move and the maximized no-op collapse into a single gesture that branches per press: a placement-keyed modifier would be torn down mid-drag by the very restore it asked for. The gesture never suspends outside the pointer handler, so a release during the restore is seen immediately instead of handing the window manager a move with no button held.

**Gate screens.** The vault gate (unlock, create, corrupted, reset, sync onboarding) made the entire screen a drag area, so a double-click anywhere on the form maximized the window and any press moved it. It now carries a drag strip the height of the titlebar with the window buttons in it; the height is a shared constant with the real titlebar.

## Verification

`./gradlew test allTests`, `build`, `detektAll` and `:androidApp:compileDebugKotlin` are green. New unit tests cover the pure parts: the screen-capped floor and its AWT conversion, the restored-window origin (both axes, both clamps, degenerate area), and `WindowDragGesture` with a zero dead zone. The WM size hint was confirmed with `xprop` (`program specified minimum size: 1100 by 720`); the gestures were verified by hand on X11/GNOME — restore-drag, flick-drag, and the gate screens.

Not verified: Windows, macOS, and a pure Wayland backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)