### PR TITLE
SFTP screen from the design mockup, a transfer queue, and a grouped session action row

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -111,6 +111,5 @@
 
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
-    <string name="sftp_queue_speed">%1$s/с</string>
     <string name="sftp_queue_done">готово</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -2,12 +2,17 @@
     <!-- SFTP / передача файлов -->
 
     <!-- Заголовки и шапка -->
-    <string name="sftp_title">Передача файлов</string>
-    <string name="sftp_subtitle_host">%1$s · SFTP</string>
+    <string name="sftp_wbar_subtitle">SFTP · %1$s</string>
     <string name="sftp_files_title">Файлы</string>
 
+    <!-- Tooltips of the work-bar icons -->
+    <string name="sftp_tip_back">Вернуться в терминал (F10)</string>
+    <string name="sftp_tip_refresh">Обновить обе панели (F9)</string>
+    <string name="sftp_tip_filter">Фильтр списка (Ctrl+F)</string>
+    <string name="sftp_tip_upload">Загрузить выбранное (F5)</string>
+    <string name="sftp_tip_download">Скачать выбранное (F5)</string>
+
     <!-- Действия тулбара / FAB -->
-    <string name="sftp_upload">Загрузить</string>
     <string name="sftp_new_folder">Новая папка</string>
     <string name="sftp_create">Создать</string>
     <string name="sftp_create_directory">Создать директорию</string>
@@ -65,8 +70,12 @@
     <!-- Встроенный просмотрщик/редактор (F3/F4) -->
     <!-- Колонки списка (дата изменения / права) и быстрый фильтр по имени -->
     <string name="sftp_columns">Колонки</string>
+    <string name="sftp_col_name">Имя</string>
+    <string name="sftp_col_size">Размер</string>
     <string name="sftp_col_modified">Дата изменения</string>
     <string name="sftp_col_permissions">Права</string>
+    <!-- Caption over the permissions column: the full word does not fit the slot -->
+    <string name="sftp_col_permissions_short">Права</string>
     <string name="sftp_filter_hint">Фильтр (имя или маска *.conf)</string>
     <string name="sftp_meta_joined">%1$s · %2$s</string>
     <string name="sftp_date_recent">%2$d %1$s %3$s</string>
@@ -99,4 +108,9 @@
     <string name="sftp_edit_discard">Отменить</string>
     <string name="sftp_edit_conflict_q">Файл изменился в источнике?</string>
     <string name="sftp_edit_conflict_body">«%1$s» изменился после того, как вы его открыли. Сохранение перезапишет его вашей версией.</string>
+
+    <!-- Transfer queue under the panes -->
+    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_speed">%1$s/с</string>
+    <string name="sftp_queue_done">готово</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -105,7 +105,6 @@
     <string name="shell_tip_more_actions">Ещё действия</string>
     <string name="shell_tip_sync_panes">Синхронизация ввода между панелями</string>
     <string name="shell_tip_files">Файлы (SFTP)</string>
-    <string name="shell_tip_ports">Проброс портов</string>
     <string name="shell_tip_snippets">Сниппеты</string>
     <string name="shell_tip_record">Записать сессию</string>
     <string name="shell_tip_record_stop">Остановить запись</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -111,6 +111,5 @@
 
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
-    <string name="sftp_queue_speed">%1$s/秒</string>
     <string name="sftp_queue_done">完成</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -2,12 +2,17 @@
     <!-- SFTP / file transfer: двухпанельный desktop (SftpView) и мобильный Files (MobileFilesView) -->
 
     <!-- Заголовки и шапка -->
-    <string name="sftp_title">文件传输</string>
-    <string name="sftp_subtitle_host">%1$s · SFTP</string>
+    <string name="sftp_wbar_subtitle">SFTP · %1$s</string>
     <string name="sftp_files_title">文件</string>
 
+    <!-- Tooltips of the work-bar icons -->
+    <string name="sftp_tip_back">返回终端 (F10)</string>
+    <string name="sftp_tip_refresh">刷新两个面板 (F9)</string>
+    <string name="sftp_tip_filter">筛选列表 (Ctrl+F)</string>
+    <string name="sftp_tip_upload">上传所选 (F5)</string>
+    <string name="sftp_tip_download">下载所选 (F5)</string>
+
     <!-- Действия тулбара / FAB -->
-    <string name="sftp_upload">上传</string>
     <string name="sftp_new_folder">新建文件夹</string>
     <string name="sftp_create">创建</string>
     <string name="sftp_create_directory">创建目录</string>
@@ -65,8 +70,12 @@
     <!-- 内置查看器/编辑器（F3/F4） -->
     <!-- Listing columns (modified date / permissions) and the quick name filter -->
     <string name="sftp_columns">显示列</string>
+    <string name="sftp_col_name">名称</string>
+    <string name="sftp_col_size">大小</string>
     <string name="sftp_col_modified">修改时间</string>
     <string name="sftp_col_permissions">权限</string>
+    <!-- Caption over the permissions column: the full word does not fit the slot -->
+    <string name="sftp_col_permissions_short">权限</string>
     <string name="sftp_filter_hint">筛选（名称或 *.掩码）</string>
     <string name="sftp_meta_joined">%1$s · %2$s</string>
     <string name="sftp_date_recent">%1$s%2$d日 %3$s</string>
@@ -99,4 +108,9 @@
     <string name="sftp_edit_discard">放弃</string>
     <string name="sftp_edit_conflict_q">文件在源端已被修改？</string>
     <string name="sftp_edit_conflict_body">「%1$s」在你打开后已更改。保存将用你的版本覆盖它。</string>
+
+    <!-- Transfer queue under the panes -->
+    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_speed">%1$s/秒</string>
+    <string name="sftp_queue_done">完成</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -105,7 +105,6 @@
     <string name="shell_tip_more_actions">更多操作</string>
     <string name="shell_tip_sync_panes">窗格间输入同步</string>
     <string name="shell_tip_files">文件 (SFTP)</string>
-    <string name="shell_tip_ports">端口转发</string>
     <string name="shell_tip_snippets">代码片段</string>
     <string name="shell_tip_record">录制会话</string>
     <string name="shell_tip_record_stop">停止录制</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -2,12 +2,17 @@
     <!-- SFTP / file transfer: двухпанельный desktop (SftpView) и мобильный Files (MobileFilesView) -->
 
     <!-- Заголовки и шапка -->
-    <string name="sftp_title">File transfer</string>
-    <string name="sftp_subtitle_host">%1$s · SFTP</string>
+    <string name="sftp_wbar_subtitle">SFTP · %1$s</string>
     <string name="sftp_files_title">Files</string>
 
+    <!-- Tooltips of the work-bar icons -->
+    <string name="sftp_tip_back">Back to terminal (F10)</string>
+    <string name="sftp_tip_refresh">Refresh both panes (F9)</string>
+    <string name="sftp_tip_filter">Filter listing (Ctrl+F)</string>
+    <string name="sftp_tip_upload">Upload selection (F5)</string>
+    <string name="sftp_tip_download">Download selection (F5)</string>
+
     <!-- Действия тулбара / FAB -->
-    <string name="sftp_upload">Upload</string>
     <string name="sftp_new_folder">New folder</string>
     <string name="sftp_create">Create</string>
     <string name="sftp_create_directory">Create directory</string>
@@ -64,8 +69,12 @@
 
     <!-- Listing columns (modified date / permissions) and the quick name filter -->
     <string name="sftp_columns">Columns</string>
+    <string name="sftp_col_name">Name</string>
+    <string name="sftp_col_size">Size</string>
     <string name="sftp_col_modified">Modified</string>
     <string name="sftp_col_permissions">Permissions</string>
+    <!-- Caption over the permissions column: the full word doesn't fit the slot -->
+    <string name="sftp_col_permissions_short">Perms</string>
     <string name="sftp_filter_hint">Filter (name or *.mask)</string>
     <string name="sftp_meta_joined">%1$s · %2$s</string>
     <!-- Modified column date: recent — current year (month, day, HH:mm), day — without time,
@@ -101,4 +110,9 @@
     <string name="sftp_edit_discard">Discard</string>
     <string name="sftp_edit_conflict_q">File changed on the source?</string>
     <string name="sftp_edit_conflict_body">«%1$s» changed since you opened it. Saving overwrites it with your version.</string>
+
+    <!-- Transfer queue under the panes -->
+    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_speed">%1$s/s</string>
+    <string name="sftp_queue_done">done</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -113,6 +113,5 @@
 
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
-    <string name="sftp_queue_speed">%1$s/s</string>
     <string name="sftp_queue_done">done</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -105,7 +105,6 @@
     <string name="shell_tip_more_actions">More actions</string>
     <string name="shell_tip_sync_panes">Synchronized input between panes</string>
     <string name="shell_tip_files">Files (SFTP)</string>
-    <string name="shell_tip_ports">Port forwarding</string>
     <string name="shell_tip_snippets">Snippets</string>
     <string name="shell_tip_record">Record session</string>
     <string name="shell_tip_record_stop">Stop recording</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.files
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import app.skerry.shared.files.FileBrowser
@@ -15,6 +16,7 @@ import app.skerry.shared.sftp.SftpEntryType
 import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sftp.UploadSource
+import app.skerry.ui.sync.nowMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -84,6 +86,39 @@ sealed interface TransferState {
  */
 class OverwriteConflict(val names: List<String>, val proceed: () -> Unit)
 
+/** Where a queue entry stands: still moving bytes, finished, or stopped by a failure. */
+sealed interface TransferStatus {
+    data object Active : TransferStatus
+    data object Done : TransferStatus
+    data class Failed(val failure: FileTransferFailure) : TransferStatus
+}
+
+/**
+ * One line of the transfer queue: a single operation (F5/F6, a picked upload, a download to a
+ * target), which may cover several files. [name] is the file currently moving ([fileIndex] of
+ * [fileCount]), [transferred] of [total] its bytes ([total] = 0 when the source doesn't report a
+ * size). [bytesDone] and [elapsedMillis] count the whole operation and are what the speed is read
+ * off ([app.skerry.ui.sftp.transferSpeed]).
+ */
+data class TransferEntry(
+    val id: Long,
+    val direction: TransferDirection,
+    val name: String,
+    val fileIndex: Int,
+    val fileCount: Int,
+    val transferred: Long,
+    val total: Long,
+    val bytesDone: Long,
+    val elapsedMillis: Long,
+    val status: TransferStatus,
+)
+
+/**
+ * How many finished entries the queue keeps. The strip is a live view of what is moving, with just
+ * enough history to see how the last transfers ended — not a transfer log.
+ */
+const val MAX_COMPLETED_TRANSFERS = 3
+
 /**
  * Coordinates file transfer between the [local] and [remote] panes over a single [SftpClient].
  * Transfer is always local-FS-to-SFTP, so it maps directly onto `SftpClient.download`/`upload`.
@@ -101,9 +136,38 @@ class TransferCoordinator(
     val remote: FilePaneController,
     private val remoteBrowser: FileContentBrowser,
     private val scope: CoroutineScope,
+    // Wall clock behind the entries' elapsed time (hence the speed); injected so tests pin it.
+    private val now: () -> Long = ::nowMillis,
 ) {
-    var transfer: TransferState by mutableStateOf(TransferState.Idle)
-        private set
+    private val entries = mutableStateListOf<TransferEntry>()
+
+    /** The transfer queue, oldest first: what is moving now plus the last few finished entries. */
+    val queue: List<TransferEntry> get() = entries
+
+    /**
+     * What a single-line view (the mobile Files card) shows: the state of the *latest* operation
+     * only. Reading the latest entry rather than the latest failing one is the point — a transfer
+     * that failed and was then retried successfully must stop showing an error, or the user retries
+     * something that already went through. Derived from [queue], so the strip and the card can
+     * never disagree.
+     */
+    val transfer: TransferState
+        get() {
+            val last = entries.lastOrNull() ?: return TransferState.Idle
+            return when (val status = last.status) {
+                // The running operation is always the newest entry (transfers are serialized).
+                TransferStatus.Active ->
+                    TransferState.Active(last.name, last.direction, last.fileIndex, last.fileCount, last.transferred, last.total)
+                TransferStatus.Done -> TransferState.Idle
+                is TransferStatus.Failed -> TransferState.Failed(last.name, status.failure)
+            }
+        }
+
+    private var nextEntryId = 1L
+
+    /** When the running operation started, and how many bytes its finished files already moved. */
+    private var operationStartedAt = 0L
+    private var operationBytesDone = 0L
 
     /**
      * Overwrite conflict awaiting confirmation: the destination directory already has entries
@@ -131,6 +195,72 @@ class TransferCoordinator(
     /** Suspends until no editor write is in flight. Called before the transport is closed. */
     suspend fun awaitEditorWrites() {
         editorWrites.withLock { }
+    }
+
+    // Queue bookkeeping. One entry per operation: opened by the operation itself (it knows the
+    // direction), closed by [launchExclusive] — success, failure and cancellation all pass there,
+    // so no path can leave an entry stuck on Active.
+
+    /** Opens the queue entry of an operation about to start. */
+    private fun beginOperation(direction: TransferDirection) {
+        operationStartedAt = now()
+        operationBytesDone = 0
+        entries += TransferEntry(
+            id = nextEntryId++,
+            direction = direction,
+            name = "",
+            fileIndex = 0,
+            fileCount = 0,
+            transferred = 0,
+            total = 0,
+            bytesDone = 0,
+            elapsedMillis = 0,
+            status = TransferStatus.Active,
+        )
+    }
+
+    /** Progress of the file the running operation is on ([index] of [count] in the operation). */
+    private fun stepFile(name: String, index: Int, count: Int, transferred: Long, total: Long) {
+        updateActive {
+            it.copy(
+                name = name,
+                fileIndex = index,
+                fileCount = count,
+                transferred = transferred,
+                total = total,
+                bytesDone = operationBytesDone + transferred,
+                elapsedMillis = now() - operationStartedAt,
+            )
+        }
+    }
+
+    /**
+     * Carries a finished file's bytes into the operation's running total (the speed reads it).
+     * The entry is updated here too: a source that reports no progress callbacks would otherwise
+     * leave the total at whatever the last callback said — nothing, for the whole operation.
+     */
+    private fun fileFinished(bytes: Long) {
+        operationBytesDone += bytes
+        updateActive { it.copy(bytesDone = operationBytesDone, elapsedMillis = now() - operationStartedAt) }
+    }
+
+    /** Marks the running operation as failed with a typed reason, naming the item it stopped on. */
+    private fun failOperation(name: String, failure: FileTransferFailure) {
+        endOperation(TransferStatus.Failed(failure), name)
+    }
+
+    /** Closes the running entry (if any is still open) and trims the finished ones. */
+    private fun endOperation(status: TransferStatus, name: String? = null) {
+        updateActive { it.copy(status = status, name = name ?: it.name, elapsedMillis = now() - operationStartedAt) }
+        // Oldest finished entries go first; the running one is never touched.
+        while (entries.count { it.status != TransferStatus.Active } > MAX_COMPLETED_TRANSFERS) {
+            entries.removeAt(entries.indexOfFirst { it.status != TransferStatus.Active })
+        }
+    }
+
+    private fun updateActive(edit: (TransferEntry) -> TransferEntry) {
+        val index = entries.indexOfLast { it.status == TransferStatus.Active }
+        if (index >= 0) entries[index] = edit(entries[index])
     }
 
     /**
@@ -189,7 +319,7 @@ class TransferCoordinator(
                     val failed = deleteSources(items) { localBrowser.delete(it) }
                     remote.refresh()
                     local.refresh()
-                    if (failed == null) local.clearSelection() else transfer = failed
+                    if (failed == null) local.clearSelection() else failOperation(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
         } else {
@@ -208,7 +338,7 @@ class TransferCoordinator(
                     val failed = deleteSources(items) { remoteBrowser.delete(it.copy(path = safeRemoteChild(it.name, remoteDir))) }
                     local.refresh()
                     remote.refresh()
-                    if (failed == null) remote.clearSelection() else transfer = failed
+                    if (failed == null) remote.clearSelection() else failOperation(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
         }
@@ -216,16 +346,16 @@ class TransferCoordinator(
 
     /**
      * Deletes source [items] after a successful transfer. A deletion failure doesn't lose data
-     * (files already reached the destination) but leaves a partially-moved state; returns
-     * [TransferState.Failed] naming the specific failed item ([transfer] is already Idle by this
-     * point). Null means all sources were deleted. [CancellationException] propagates.
+     * (files already reached the destination) but leaves a partially-moved state; returns the item
+     * that could not be removed, so the caller can name it on the queue entry. Null means all
+     * sources were deleted. [CancellationException] propagates.
      */
-    private suspend fun deleteSources(items: List<FileItem>, delete: suspend (FileItem) -> Unit): TransferState.Failed? {
+    private suspend fun deleteSources(items: List<FileItem>, delete: suspend (FileItem) -> Unit): FileItem? {
         for (item in items) {
             try {
                 delete(item)
             } catch (_: FileBrowserException) {
-                return TransferState.Failed(item.name, FileTransferFailure.DeleteSource)
+                return item
             }
         }
         return null
@@ -244,12 +374,12 @@ class TransferCoordinator(
         if (item.type != FileItemType.File) return
         launchExclusive {
             try {
-                transfer = TransferState.Active(target.displayName, TransferDirection.Download, 1, 1, 0, item.size)
+                beginOperation(TransferDirection.Download)
+                stepFile(target.displayName, 1, 1, 0, item.size)
                 sftp.download(item.path, target.stagingPath) { transferred, total ->
-                    transfer = TransferState.Active(target.displayName, TransferDirection.Download, 1, 1, transferred, total)
+                    stepFile(target.displayName, 1, 1, transferred, total)
                 }
                 target.finalize()
-                transfer = TransferState.Idle
             } catch (e: Exception) { // Includes CancellationException — staging is cleaned up either way.
                 runCatching { target.discard() }
                 throw e
@@ -279,11 +409,11 @@ class TransferCoordinator(
     private fun runUploadSource(source: UploadSource, destDir: String) {
         launchExclusive(onFinally = { runCatching { source.cleanup() } }) {
             val target = childPath(destDir, source.name)
-            transfer = TransferState.Active(source.name, TransferDirection.Upload, 1, 1, 0, 0)
+            beginOperation(TransferDirection.Upload)
+            stepFile(source.name, 1, 1, 0, 0)
             sftp.upload(source.stagingPath, target) { transferred, total ->
-                transfer = TransferState.Active(source.name, TransferDirection.Upload, 1, 1, transferred, total)
+                stepFile(source.name, 1, 1, transferred, total)
             }
-            transfer = TransferState.Idle
             remote.refresh()
         }
     }
@@ -311,9 +441,14 @@ class TransferCoordinator(
         ).also { it.open() }
     }
 
-    /** Closes the transfer bar (resets to [TransferState.Idle]); doesn't touch an active transfer. */
-    fun clearTransfer() {
-        if (transfer !is TransferState.Active) transfer = TransferState.Idle
+    /** Drops one finished queue entry ([id]); a transfer still running is left alone. */
+    fun dismissTransfer(id: Long) {
+        entries.removeAll { it.id == id && it.status != TransferStatus.Active }
+    }
+
+    /** Drops every finished entry at once, leaving only what is still running. */
+    fun dismissCompleted() {
+        entries.removeAll { it.status != TransferStatus.Active }
     }
 
     /**
@@ -355,13 +490,18 @@ class TransferCoordinator(
         scope.launch {
             try {
                 block()
+                // A block can finish normally having already closed its own entry as failed
+                // (a move whose transfer went through but whose source delete didn't) — that
+                // verdict wins, so the entry is only marked done while it is still open.
+                if (entries.lastOrNull()?.status == TransferStatus.Active) endOperation(TransferStatus.Done)
             } catch (e: CancellationException) {
+                // A cancelled operation is over too: leaving the entry Active would show a
+                // progress bar that never moves again.
+                endOperation(TransferStatus.Failed(FileTransferFailure.Transfer))
                 throw e
             } catch (e: Exception) {
-                // Blank name = no file was active yet; the UI fills in a localized placeholder.
-                val name = (transfer as? TransferState.Active)?.name.orEmpty()
                 val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
-                transfer = TransferState.Failed(name, failure)
+                endOperation(TransferStatus.Failed(failure))
             } finally {
                 onFinally()
                 busy = false
@@ -376,16 +516,17 @@ class TransferCoordinator(
      * [launchExclusive] block.
      */
     private suspend fun runUpload(items: List<FileItem>, remoteDir: String) {
+        beginOperation(TransferDirection.Upload)
         val plan = buildUploadPlan(items, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(remoteBrowser, it) }
         plan.files.forEachIndexed { index, task ->
-            transfer = TransferState.Active(task.name, TransferDirection.Upload, index + 1, plan.files.size, 0, task.size)
+            stepFile(task.name, index + 1, plan.files.size, 0, task.size)
             sftp.upload(task.localPath, task.remotePath) { transferred, total ->
-                transfer = TransferState.Active(task.name, TransferDirection.Upload, index + 1, plan.files.size, transferred, total)
+                stepFile(task.name, index + 1, plan.files.size, transferred, total)
             }
+            fileFinished(task.size)
         }
-        transfer = TransferState.Idle
     }
 
     /**
@@ -395,16 +536,17 @@ class TransferCoordinator(
      * [launchExclusive] block.
      */
     private suspend fun runDownload(items: List<FileItem>, localDir: String, remoteDir: String) {
+        beginOperation(TransferDirection.Download)
         val plan = buildDownloadPlan(items, localDir, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(localBrowser, it) }
         plan.files.forEachIndexed { index, task ->
-            transfer = TransferState.Active(task.name, TransferDirection.Download, index + 1, plan.files.size, 0, task.size)
+            stepFile(task.name, index + 1, plan.files.size, 0, task.size)
             sftp.download(task.remotePath, task.localPath) { transferred, total ->
-                transfer = TransferState.Active(task.name, TransferDirection.Download, index + 1, plan.files.size, transferred, total)
+                stepFile(task.name, index + 1, plan.files.size, transferred, total)
             }
+            fileFinished(task.size)
         }
-        transfer = TransferState.Idle
     }
 
     /** One download task: [name] for the progress bar, remote [remotePath] to local [localPath]. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -2,17 +2,14 @@ package app.skerry.ui.files
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.sftp.SftpClient
-import app.skerry.shared.sftp.SftpEntryType
 import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sftp.UploadSource
@@ -86,39 +83,6 @@ sealed interface TransferState {
  */
 class OverwriteConflict(val names: List<String>, val proceed: () -> Unit)
 
-/** Where a queue entry stands: still moving bytes, finished, or stopped by a failure. */
-sealed interface TransferStatus {
-    data object Active : TransferStatus
-    data object Done : TransferStatus
-    data class Failed(val failure: FileTransferFailure) : TransferStatus
-}
-
-/**
- * One line of the transfer queue: a single operation (F5/F6, a picked upload, a download to a
- * target), which may cover several files. [name] is the file currently moving ([fileIndex] of
- * [fileCount]), [transferred] of [total] its bytes ([total] = 0 when the source doesn't report a
- * size). [bytesDone] and [elapsedMillis] count the whole operation and are what the speed is read
- * off ([app.skerry.ui.sftp.transferSpeed]).
- */
-data class TransferEntry(
-    val id: Long,
-    val direction: TransferDirection,
-    val name: String,
-    val fileIndex: Int,
-    val fileCount: Int,
-    val transferred: Long,
-    val total: Long,
-    val bytesDone: Long,
-    val elapsedMillis: Long,
-    val status: TransferStatus,
-)
-
-/**
- * How many finished entries the queue keeps. The strip is a live view of what is moving, with just
- * enough history to see how the last transfers ended — not a transfer log.
- */
-const val MAX_COMPLETED_TRANSFERS = 3
-
 /**
  * Coordinates file transfer between the [local] and [remote] panes over a single [SftpClient].
  * Transfer is always local-FS-to-SFTP, so it maps directly onto `SftpClient.download`/`upload`.
@@ -139,35 +103,16 @@ class TransferCoordinator(
     // Wall clock behind the entries' elapsed time (hence the speed); injected so tests pin it.
     private val now: () -> Long = ::nowMillis,
 ) {
-    private val entries = mutableStateListOf<TransferEntry>()
+    private val transfers = TransferQueue(now)
 
     /** The transfer queue, oldest first: what is moving now plus the last few finished entries. */
-    val queue: List<TransferEntry> get() = entries
+    val queue: List<TransferEntry> get() = transfers.list
 
     /**
-     * What a single-line view (the mobile Files card) shows: the state of the *latest* operation
-     * only. Reading the latest entry rather than the latest failing one is the point — a transfer
-     * that failed and was then retried successfully must stop showing an error, or the user retries
-     * something that already went through. Derived from [queue], so the strip and the card can
-     * never disagree.
+     * What a single-line view (the mobile Files card) shows: the state of the latest operation.
+     * Derived from [queue], so the strip and the card can never disagree.
      */
-    val transfer: TransferState
-        get() {
-            val last = entries.lastOrNull() ?: return TransferState.Idle
-            return when (val status = last.status) {
-                // The running operation is always the newest entry (transfers are serialized).
-                TransferStatus.Active ->
-                    TransferState.Active(last.name, last.direction, last.fileIndex, last.fileCount, last.transferred, last.total)
-                TransferStatus.Done -> TransferState.Idle
-                is TransferStatus.Failed -> TransferState.Failed(last.name, status.failure)
-            }
-        }
-
-    private var nextEntryId = 1L
-
-    /** When the running operation started, and how many bytes its finished files already moved. */
-    private var operationStartedAt = 0L
-    private var operationBytesDone = 0L
+    val transfer: TransferState get() = transfers.latest
 
     /**
      * Overwrite conflict awaiting confirmation: the destination directory already has entries
@@ -195,72 +140,6 @@ class TransferCoordinator(
     /** Suspends until no editor write is in flight. Called before the transport is closed. */
     suspend fun awaitEditorWrites() {
         editorWrites.withLock { }
-    }
-
-    // Queue bookkeeping. One entry per operation: opened by the operation itself (it knows the
-    // direction), closed by [launchExclusive] — success, failure and cancellation all pass there,
-    // so no path can leave an entry stuck on Active.
-
-    /** Opens the queue entry of an operation about to start. */
-    private fun beginOperation(direction: TransferDirection) {
-        operationStartedAt = now()
-        operationBytesDone = 0
-        entries += TransferEntry(
-            id = nextEntryId++,
-            direction = direction,
-            name = "",
-            fileIndex = 0,
-            fileCount = 0,
-            transferred = 0,
-            total = 0,
-            bytesDone = 0,
-            elapsedMillis = 0,
-            status = TransferStatus.Active,
-        )
-    }
-
-    /** Progress of the file the running operation is on ([index] of [count] in the operation). */
-    private fun stepFile(name: String, index: Int, count: Int, transferred: Long, total: Long) {
-        updateActive {
-            it.copy(
-                name = name,
-                fileIndex = index,
-                fileCount = count,
-                transferred = transferred,
-                total = total,
-                bytesDone = operationBytesDone + transferred,
-                elapsedMillis = now() - operationStartedAt,
-            )
-        }
-    }
-
-    /**
-     * Carries a finished file's bytes into the operation's running total (the speed reads it).
-     * The entry is updated here too: a source that reports no progress callbacks would otherwise
-     * leave the total at whatever the last callback said — nothing, for the whole operation.
-     */
-    private fun fileFinished(bytes: Long) {
-        operationBytesDone += bytes
-        updateActive { it.copy(bytesDone = operationBytesDone, elapsedMillis = now() - operationStartedAt) }
-    }
-
-    /** Marks the running operation as failed with a typed reason, naming the item it stopped on. */
-    private fun failOperation(name: String, failure: FileTransferFailure) {
-        endOperation(TransferStatus.Failed(failure), name)
-    }
-
-    /** Closes the running entry (if any is still open) and trims the finished ones. */
-    private fun endOperation(status: TransferStatus, name: String? = null) {
-        updateActive { it.copy(status = status, name = name ?: it.name, elapsedMillis = now() - operationStartedAt) }
-        // Oldest finished entries go first; the running one is never touched.
-        while (entries.count { it.status != TransferStatus.Active } > MAX_COMPLETED_TRANSFERS) {
-            entries.removeAt(entries.indexOfFirst { it.status != TransferStatus.Active })
-        }
-    }
-
-    private fun updateActive(edit: (TransferEntry) -> TransferEntry) {
-        val index = entries.indexOfLast { it.status == TransferStatus.Active }
-        if (index >= 0) entries[index] = edit(entries[index])
     }
 
     /**
@@ -319,7 +198,7 @@ class TransferCoordinator(
                     val failed = deleteSources(items) { localBrowser.delete(it) }
                     remote.refresh()
                     local.refresh()
-                    if (failed == null) local.clearSelection() else failOperation(failed.name, FileTransferFailure.DeleteSource)
+                    if (failed == null) local.clearSelection() else transfers.fail(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
         } else {
@@ -338,7 +217,7 @@ class TransferCoordinator(
                     val failed = deleteSources(items) { remoteBrowser.delete(it.copy(path = safeRemoteChild(it.name, remoteDir))) }
                     local.refresh()
                     remote.refresh()
-                    if (failed == null) remote.clearSelection() else failOperation(failed.name, FileTransferFailure.DeleteSource)
+                    if (failed == null) remote.clearSelection() else transfers.fail(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
         }
@@ -374,10 +253,10 @@ class TransferCoordinator(
         if (item.type != FileItemType.File) return
         launchExclusive {
             try {
-                beginOperation(TransferDirection.Download)
-                stepFile(target.displayName, 1, 1, 0, item.size)
+                transfers.begin(TransferDirection.Download)
+                transfers.step(target.displayName, 1, 1, 0, item.size)
                 sftp.download(item.path, target.stagingPath) { transferred, total ->
-                    stepFile(target.displayName, 1, 1, transferred, total)
+                    transfers.step(target.displayName, 1, 1, transferred, total)
                 }
                 target.finalize()
             } catch (e: Exception) { // Includes CancellationException — staging is cleaned up either way.
@@ -408,11 +287,13 @@ class TransferCoordinator(
 
     private fun runUploadSource(source: UploadSource, destDir: String) {
         launchExclusive(onFinally = { runCatching { source.cleanup() } }) {
+            // Opened first, like every other operation: whatever the block does afterwards, the
+            // entry exists to carry the outcome.
+            transfers.begin(TransferDirection.Upload)
             val target = childPath(destDir, source.name)
-            beginOperation(TransferDirection.Upload)
-            stepFile(source.name, 1, 1, 0, 0)
+            transfers.step(source.name, 1, 1, 0, 0)
             sftp.upload(source.stagingPath, target) { transferred, total ->
-                stepFile(source.name, 1, 1, transferred, total)
+                transfers.step(source.name, 1, 1, transferred, total)
             }
             remote.refresh()
         }
@@ -443,12 +324,12 @@ class TransferCoordinator(
 
     /** Drops one finished queue entry ([id]); a transfer still running is left alone. */
     fun dismissTransfer(id: Long) {
-        entries.removeAll { it.id == id && it.status != TransferStatus.Active }
+        transfers.dismiss(id)
     }
 
     /** Drops every finished entry at once, leaving only what is still running. */
     fun dismissCompleted() {
-        entries.removeAll { it.status != TransferStatus.Active }
+        transfers.dismissCompleted()
     }
 
     /**
@@ -493,15 +374,15 @@ class TransferCoordinator(
                 // A block can finish normally having already closed its own entry as failed
                 // (a move whose transfer went through but whose source delete didn't) — that
                 // verdict wins, so the entry is only marked done while it is still open.
-                if (entries.lastOrNull()?.status == TransferStatus.Active) endOperation(TransferStatus.Done)
+                if (transfers.hasOpenEntry) transfers.end(TransferStatus.Done)
             } catch (e: CancellationException) {
                 // A cancelled operation is over too: leaving the entry Active would show a
                 // progress bar that never moves again.
-                endOperation(TransferStatus.Failed(FileTransferFailure.Transfer))
+                transfers.end(TransferStatus.Failed(FileTransferFailure.Transfer))
                 throw e
             } catch (e: Exception) {
                 val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
-                endOperation(TransferStatus.Failed(failure))
+                transfers.end(TransferStatus.Failed(failure))
             } finally {
                 onFinally()
                 busy = false
@@ -516,16 +397,16 @@ class TransferCoordinator(
      * [launchExclusive] block.
      */
     private suspend fun runUpload(items: List<FileItem>, remoteDir: String) {
-        beginOperation(TransferDirection.Upload)
-        val plan = buildUploadPlan(items, remoteDir)
+        transfers.begin(TransferDirection.Upload)
+        val plan = buildUploadPlan(localBrowser, items, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(remoteBrowser, it) }
         plan.files.forEachIndexed { index, task ->
-            stepFile(task.name, index + 1, plan.files.size, 0, task.size)
+            transfers.step(task.name, index + 1, plan.files.size, 0, task.size)
             sftp.upload(task.localPath, task.remotePath) { transferred, total ->
-                stepFile(task.name, index + 1, plan.files.size, transferred, total)
+                transfers.step(task.name, index + 1, plan.files.size, transferred, total)
             }
-            fileFinished(task.size)
+            transfers.fileFinished(task.size)
         }
     }
 
@@ -536,153 +417,16 @@ class TransferCoordinator(
      * [launchExclusive] block.
      */
     private suspend fun runDownload(items: List<FileItem>, localDir: String, remoteDir: String) {
-        beginOperation(TransferDirection.Download)
-        val plan = buildDownloadPlan(items, localDir, remoteDir)
+        transfers.begin(TransferDirection.Download)
+        val plan = buildDownloadPlan(sftp, items, localDir, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(localBrowser, it) }
         plan.files.forEachIndexed { index, task ->
-            stepFile(task.name, index + 1, plan.files.size, 0, task.size)
+            transfers.step(task.name, index + 1, plan.files.size, 0, task.size)
             sftp.download(task.remotePath, task.localPath) { transferred, total ->
-                stepFile(task.name, index + 1, plan.files.size, transferred, total)
+                transfers.step(task.name, index + 1, plan.files.size, transferred, total)
             }
-            fileFinished(task.size)
+            transfers.fileFinished(task.size)
         }
     }
-
-    /** One download task: [name] for the progress bar, remote [remotePath] to local [localPath]. */
-    private data class DownloadTask(val name: String, val remotePath: String, val localPath: String, val size: Long)
-
-    /** Recursive download plan: [dirs] are local directories in creation order, [files] are the files. */
-    private class DownloadPlan {
-        val dirs = mutableListOf<String>()
-        val files = mutableListOf<DownloadTask>()
-    }
-
-    /**
-     * Builds the download plan for top-level [items] from remote [remoteDir] into local
-     * [localDir]. The top-level remote path is rebuilt ourselves ([childPath] from [remoteDir] +
-     * name), not trusted from the listing's `item.path` — same as for children in [walkDownload].
-     */
-    private suspend fun buildDownloadPlan(items: List<FileItem>, localDir: String, remoteDir: String): DownloadPlan {
-        val plan = DownloadPlan()
-        items.forEach { walkDownload(it.name, childPath(remoteDir, it.name), it.type, it.size, localDir, plan) }
-        return plan
-    }
-
-    /**
-     * Walks a remote tree entry, filling [plan]. A file becomes a download task; a directory adds
-     * a local subdirectory and recurses; symlinks/other are skipped.
-     *
-     * Path-traversal guard against an untrusted server: [name] must be a plain name (no `/`/`\`
-     * separators, not `.`/`..`, not empty). Child remote paths are rebuilt from the parent + a
-     * validated name ([childPath]), never trusted from the listing's `child.path` — otherwise the
-     * server could redirect the walk (and writes) outside the target tree.
-     */
-    private suspend fun walkDownload(
-        name: String,
-        remotePath: String,
-        type: FileItemType,
-        size: Long,
-        localDir: String,
-        plan: DownloadPlan,
-    ) {
-        if (isUnsafeListingName(name)) {
-            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
-        }
-        val localPath = childPath(localDir, name)
-        when (type) {
-            FileItemType.File -> plan.files += DownloadTask(name, remotePath, localPath, size)
-            FileItemType.Directory -> {
-                plan.dirs += localPath
-                sftp.list(remotePath).forEach { child ->
-                    walkDownload(child.name, childPath(remotePath, child.name), child.type.toItemType(), child.size, localPath, plan)
-                }
-            }
-            FileItemType.Symlink, FileItemType.Other -> Unit
-        }
-    }
-
-    /**
-     * Creates directory [path] in [browser] (local or remote) if missing. `mkdir` without `-p`
-     * throws on an already-existing directory, which is normal on a repeat transfer: a listing
-     * check confirms the directory exists before the error is ignored; otherwise (no permission/
-     * it's a file) the original mkdir error is rethrown.
-     */
-    private suspend fun ensureDir(browser: FileBrowser, path: String) {
-        try {
-            browser.mkdir(path)
-        } catch (e: FileBrowserException) {
-            try {
-                browser.list(path)
-            } catch (_: FileBrowserException) {
-                throw e
-            }
-        }
-    }
-
-    /** One upload task: [name] for the progress bar, local [localPath] to remote [remotePath]. */
-    private data class UploadTask(val name: String, val localPath: String, val remotePath: String, val size: Long)
-
-    /** Recursive upload plan: [dirs] are remote directories in creation order, [files] are the files. */
-    private class UploadPlan {
-        val dirs = mutableListOf<String>()
-        val files = mutableListOf<UploadTask>()
-    }
-
-    /** Builds the upload plan for top-level [items] into remote directory [remoteDir]. */
-    private suspend fun buildUploadPlan(items: List<FileItem>, remoteDir: String): UploadPlan {
-        val plan = UploadPlan()
-        items.forEach { walkUpload(it.name, it.path, it.type, it.size, remoteDir, plan) }
-        return plan
-    }
-
-    /**
-     * Walks a local tree entry, filling [plan] (mirrors [walkDownload]). A file becomes an upload
-     * task; a directory adds a remote subdirectory and recurses ([localBrowser] lists the local
-     * FS); symlinks/other are skipped. Remote paths are rebuilt from [remoteDir] + a validated
-     * name; local paths come from the trusted local listing.
-     */
-    private suspend fun walkUpload(
-        name: String,
-        localPath: String,
-        type: FileItemType,
-        size: Long,
-        remoteDir: String,
-        plan: UploadPlan,
-    ) {
-        if (isUnsafeListingName(name)) {
-            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
-        }
-        val remotePath = childPath(remoteDir, name)
-        when (type) {
-            FileItemType.File -> plan.files += UploadTask(name, localPath, remotePath, size)
-            FileItemType.Directory -> {
-                plan.dirs += remotePath
-                localBrowser.list(localPath).forEach { child ->
-                    walkUpload(child.name, child.path, child.type, child.size, remotePath, plan)
-                }
-            }
-            FileItemType.Symlink, FileItemType.Other -> Unit
-        }
-    }
-
-    /**
-     * Safe remote path of [name] under [remoteDir] for delete operations: validates that [name]
-     * is a plain name, then rebuilds the path from [remoteDir] (a pane directory snapshot),
-     * never trusting server-controlled `item.path`.
-     */
-    private fun safeRemoteChild(name: String, remoteDir: String): String {
-        if (isUnsafeListingName(name)) {
-            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
-        }
-        return childPath(remoteDir, name)
-    }
-}
-
-/** Maps an SFTP entry type to the neutral [FileItemType] (for the download tree walk). */
-private fun SftpEntryType.toItemType(): FileItemType = when (this) {
-    SftpEntryType.File -> FileItemType.File
-    SftpEntryType.Directory -> FileItemType.Directory
-    SftpEntryType.Symlink -> FileItemType.Symlink
-    SftpEntryType.Other -> FileItemType.Other
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
@@ -1,0 +1,148 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.shared.sftp.SftpClient
+import app.skerry.shared.sftp.SftpEntryType
+
+/**
+ * What a transfer will move, worked out before a byte goes over the wire: [dirs] are the
+ * directories to create, in pre-order (a parent always before its children), [files] the transfers
+ * themselves, in order.
+ */
+internal class TransferPlan<T> {
+    val dirs = mutableListOf<String>()
+    val files = mutableListOf<T>()
+}
+
+/** One download task: [name] for the progress bar, remote [remotePath] to local [localPath]. */
+internal data class DownloadTask(val name: String, val remotePath: String, val localPath: String, val size: Long)
+
+/** One upload task: [name] for the progress bar, local [localPath] to remote [remotePath]. */
+internal data class UploadTask(val name: String, val localPath: String, val remotePath: String, val size: Long)
+
+/**
+ * Builds the download plan for top-level [items] from remote [remoteDir] into local [localDir],
+ * walking the remote tree through [sftp]. The top-level remote path is rebuilt here ([childPath]
+ * from [remoteDir] + name), not trusted from the listing's `item.path` — same as for children in
+ * [DownloadWalk].
+ */
+internal suspend fun buildDownloadPlan(
+    sftp: SftpClient,
+    items: List<FileItem>,
+    localDir: String,
+    remoteDir: String,
+): TransferPlan<DownloadTask> {
+    val walk = DownloadWalk(sftp)
+    items.forEach { walk.walk(it.name, childPath(remoteDir, it.name), it.type, it.size, localDir) }
+    return walk.plan
+}
+
+/**
+ * Walks a remote tree entry, filling the plan it carries. A file becomes a download task; a directory adds a
+ * local subdirectory and recurses; symlinks/other are skipped.
+ *
+ * Path-traversal guard against an untrusted server: [name] must be a plain name (no `/`/`\`
+ * separators, not `.`/`..`, not empty). Child remote paths are rebuilt from the parent + a
+ * validated name ([childPath]), never trusted from the listing's `child.path` — otherwise the
+ * server could redirect the walk (and writes) outside the target tree.
+ */
+private class DownloadWalk(private val sftp: SftpClient) {
+    val plan = TransferPlan<DownloadTask>()
+
+    suspend fun walk(name: String, remotePath: String, type: FileItemType, size: Long, localDir: String) {
+        if (isUnsafeListingName(name)) {
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+        }
+        val localPath = childPath(localDir, name)
+        when (type) {
+            FileItemType.File -> plan.files += DownloadTask(name, remotePath, localPath, size)
+            FileItemType.Directory -> {
+                plan.dirs += localPath
+                sftp.list(remotePath).forEach { child ->
+                    walk(child.name, childPath(remotePath, child.name), child.type.toItemType(), child.size, localPath)
+                }
+            }
+            FileItemType.Symlink, FileItemType.Other -> Unit
+        }
+    }
+}
+
+/** Builds the upload plan for top-level [items] into remote directory [remoteDir]. */
+internal suspend fun buildUploadPlan(
+    localBrowser: FileBrowser,
+    items: List<FileItem>,
+    remoteDir: String,
+): TransferPlan<UploadTask> {
+    val walk = UploadWalk(localBrowser)
+    items.forEach { walk.walk(it.name, it.path, it.type, it.size, remoteDir) }
+    return walk.plan
+}
+
+/**
+ * Walks a local tree entry, filling the plan it carries (mirrors [DownloadWalk]). A file becomes an upload task;
+ * a directory adds a remote subdirectory and recurses ([localBrowser] lists the local FS);
+ * symlinks/other are skipped. Remote paths are rebuilt from [remoteDir] + a validated name; local
+ * paths come from the trusted local listing.
+ */
+private class UploadWalk(private val localBrowser: FileBrowser) {
+    val plan = TransferPlan<UploadTask>()
+
+    suspend fun walk(name: String, localPath: String, type: FileItemType, size: Long, remoteDir: String) {
+        if (isUnsafeListingName(name)) {
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+        }
+        val remotePath = childPath(remoteDir, name)
+        when (type) {
+            FileItemType.File -> plan.files += UploadTask(name, localPath, remotePath, size)
+            FileItemType.Directory -> {
+                plan.dirs += remotePath
+                localBrowser.list(localPath).forEach { child ->
+                    walk(child.name, child.path, child.type, child.size, remotePath)
+                }
+            }
+            FileItemType.Symlink, FileItemType.Other -> Unit
+        }
+    }
+}
+
+/**
+ * Creates directory [path] in [browser] (local or remote) if missing. `mkdir` without `-p` throws
+ * on an already-existing directory, which is normal on a repeat transfer: a listing check confirms
+ * the directory exists before the error is ignored; otherwise (no permission / it's a file) the
+ * original mkdir error is rethrown.
+ */
+internal suspend fun ensureDir(browser: FileBrowser, path: String) {
+    try {
+        browser.mkdir(path)
+    } catch (e: FileBrowserException) {
+        try {
+            browser.list(path)
+        } catch (_: FileBrowserException) {
+            throw e
+        }
+    }
+}
+
+/**
+ * Safe remote path of [name] under [remoteDir] for delete operations: validates that [name] is a
+ * plain name, then rebuilds the path from [remoteDir] (a pane directory snapshot), never trusting
+ * server-controlled `item.path`.
+ */
+internal fun safeRemoteChild(name: String, remoteDir: String): String {
+    if (isUnsafeListingName(name)) {
+        throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+    }
+    return childPath(remoteDir, name)
+}
+
+/** Maps an SFTP entry type to the neutral [FileItemType] (for the download tree walk). */
+private fun SftpEntryType.toItemType(): FileItemType = when (this) {
+    SftpEntryType.File -> FileItemType.File
+    SftpEntryType.Directory -> FileItemType.Directory
+    SftpEntryType.Symlink -> FileItemType.Symlink
+    SftpEntryType.Other -> FileItemType.Other
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferQueue.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferQueue.kt
@@ -1,0 +1,156 @@
+package app.skerry.ui.files
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateListOf
+import app.skerry.ui.sftp.TransferDirection
+import app.skerry.ui.sync.nowMillis
+
+/** Where a queue entry stands: still moving bytes, finished, or stopped by a failure. */
+sealed interface TransferStatus {
+    data object Active : TransferStatus
+    data object Done : TransferStatus
+    data class Failed(val failure: FileTransferFailure) : TransferStatus
+}
+
+/**
+ * One line of the transfer queue: a single operation (F5/F6, a picked upload, a download to a
+ * target), which may cover several files. [name] is the file currently moving ([fileIndex] of
+ * [fileCount]), [transferred] of [total] its bytes ([total] = 0 when the source doesn't report a
+ * size). [bytesDone] and [elapsedMillis] count the whole operation and are what the speed is read
+ * off ([app.skerry.ui.sftp.transferSpeed]).
+ */
+data class TransferEntry(
+    val id: Long,
+    val direction: TransferDirection,
+    val name: String,
+    val fileIndex: Int,
+    val fileCount: Int,
+    val transferred: Long,
+    val total: Long,
+    val bytesDone: Long,
+    val elapsedMillis: Long,
+    val status: TransferStatus,
+)
+
+/**
+ * How many finished entries the queue keeps. The strip is a live view of what is moving, with just
+ * enough history to see how the last transfers ended — not a transfer log.
+ */
+const val MAX_COMPLETED_TRANSFERS = 3
+
+/**
+ * What the transfer strip lists: the running operation plus the last few finished ones. One entry
+ * per operation, opened by the operation itself (it knows the direction) and closed once, by
+ * whoever runs it — [TransferCoordinator.launchExclusive] does that for every exit path, so no
+ * operation can leave an entry open.
+ *
+ * Transfers are serialized by the coordinator, so at most one entry is [TransferStatus.Active] and
+ * it is always the newest; every lookup here relies on that. [now] is the wall clock behind the
+ * entries' elapsed time (hence the speed), injected so tests can pin it.
+ */
+@Stable
+class TransferQueue(private val now: () -> Long = ::nowMillis) {
+
+    private val entries = mutableStateListOf<TransferEntry>()
+
+    /** The queue, oldest first. */
+    val list: List<TransferEntry> get() = entries
+
+    /**
+     * State of the *latest* operation, for a single-line view (the mobile Files card). Reading the
+     * latest entry rather than the latest failing one is the point — a transfer that failed and was
+     * then retried successfully must stop showing an error, or the user retries something that
+     * already went through.
+     */
+    val latest: TransferState
+        get() {
+            val last = entries.lastOrNull() ?: return TransferState.Idle
+            return when (val status = last.status) {
+                TransferStatus.Active ->
+                    TransferState.Active(last.name, last.direction, last.fileIndex, last.fileCount, last.transferred, last.total)
+                TransferStatus.Done -> TransferState.Idle
+                is TransferStatus.Failed -> TransferState.Failed(last.name, status.failure)
+            }
+        }
+
+    /** Whether the newest entry is still running — the caller's cue that it is theirs to close. */
+    val hasOpenEntry: Boolean get() = entries.lastOrNull()?.status == TransferStatus.Active
+
+    private var nextEntryId = 1L
+
+    /** When the running operation started, and how many bytes its finished files already moved. */
+    private var startedAt = 0L
+    private var bytesDone = 0L
+
+    /** Opens the entry of an operation about to start. */
+    fun begin(direction: TransferDirection) {
+        startedAt = now()
+        bytesDone = 0
+        entries += TransferEntry(
+            id = nextEntryId++,
+            direction = direction,
+            name = "",
+            fileIndex = 0,
+            fileCount = 0,
+            transferred = 0,
+            total = 0,
+            bytesDone = 0,
+            elapsedMillis = 0,
+            status = TransferStatus.Active,
+        )
+    }
+
+    /** Progress of the file the running operation is on ([index] of [count] in the operation). */
+    fun step(name: String, index: Int, count: Int, transferred: Long, total: Long) {
+        updateActive {
+            it.copy(
+                name = name,
+                fileIndex = index,
+                fileCount = count,
+                transferred = transferred,
+                total = total,
+                bytesDone = bytesDone + transferred,
+                elapsedMillis = now() - startedAt,
+            )
+        }
+    }
+
+    /**
+     * Carries a finished file's bytes into the operation's running total (the speed reads it).
+     * The entry is updated here too: a source that reports no progress callbacks would otherwise
+     * leave the total at whatever the last callback said — nothing, for the whole operation.
+     */
+    fun fileFinished(bytes: Long) {
+        bytesDone += bytes
+        updateActive { it.copy(bytesDone = bytesDone, elapsedMillis = now() - startedAt) }
+    }
+
+    /** Closes the running operation as failed, naming the item it stopped on. */
+    fun fail(name: String, failure: FileTransferFailure) {
+        end(TransferStatus.Failed(failure), name)
+    }
+
+    /** Closes the running entry (if one is still open) and trims the finished ones. */
+    fun end(status: TransferStatus, name: String? = null) {
+        updateActive { it.copy(status = status, name = name ?: it.name, elapsedMillis = now() - startedAt) }
+        // Oldest finished entries go first; the running one is never touched.
+        while (entries.count { it.status != TransferStatus.Active } > MAX_COMPLETED_TRANSFERS) {
+            entries.removeAt(entries.indexOfFirst { it.status != TransferStatus.Active })
+        }
+    }
+
+    /** Drops one finished entry ([id]); a transfer still running is left alone. */
+    fun dismiss(id: Long) {
+        entries.removeAll { it.id == id && it.status != TransferStatus.Active }
+    }
+
+    /** Drops every finished entry at once, leaving only what is still running. */
+    fun dismissCompleted() {
+        entries.removeAll { it.status != TransferStatus.Active }
+    }
+
+    private fun updateActive(edit: (TransferEntry) -> TransferEntry) {
+        val index = entries.indexOfLast { it.status == TransferStatus.Active }
+        if (index >= 0) entries[index] = edit(entries[index])
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -201,7 +201,7 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                         onOpenEditor = openEditor,
                         modifier = Modifier.weight(1f),
                     )
-                    MobileTransferCard(c.transfer, mono, onDismiss = c::clearTransfer)
+                    MobileTransferCard(c.transfer, mono, onDismiss = c::dismissCompleted)
                     Spacer(Modifier.height(88.dp)) // room for the floating FAB (push screen has no tab bar)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpFormat.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpFormat.kt
@@ -76,6 +76,56 @@ fun sizeText(parts: SizeParts): String = when (parts.unit) {
 @Composable
 fun humanSize(bytes: Long): String = sizeText(sizeParts(bytes))
 
+// Transfer queue: progress of one running entry.
+
+/**
+ * Percentage of [transferred] against [total], clamped to 0..100. `null` when [total] is unknown
+ * (0) — a size the source never reported must not read as "0% done", and a source that overshoots
+ * its promise must not read as "104%".
+ */
+fun transferPercent(transferred: Long, total: Long): Int? {
+    if (total <= 0) return null
+    return (transferred * 100 / total).coerceIn(0, 100).toInt()
+}
+
+/** Below this the elapsed time is too short to divide by: the number would jump every frame. */
+private const val SPEED_FLOOR_MILLIS = 250L
+
+/**
+ * Bytes per second of an operation that has moved [bytesDone] in [elapsedMillis]. The average over
+ * the whole operation, not the last frame — a rate that flickers is unreadable. `null` until there
+ * is enough of both to divide.
+ */
+fun transferSpeed(bytesDone: Long, elapsedMillis: Long): Long? {
+    if (bytesDone <= 0 || elapsedMillis < SPEED_FLOOR_MILLIS) return null
+    return bytesDone * 1000 / elapsedMillis
+}
+
+// Row icon.
+
+/** Extensions that earn an icon of their own; everything else is a plain document. */
+private val ICON_BY_EXTENSION: Map<String, String> = buildMap {
+    listOf("gz", "tgz", "zip", "xz", "bz2", "7z", "rar", "tar", "zst").forEach { put(it, "archive") }
+    listOf("key", "pem", "pub", "crt", "cer", "p12", "pfx").forEach { put(it, "key") }
+    listOf("png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico").forEach { put(it, "image") }
+    listOf("sh", "bash", "zsh", "fish", "ps1", "bat", "cmd").forEach { put(it, "terminal") }
+}
+
+/**
+ * Material icon ([Sym] ligature) for a listing row: the type decides for everything that isn't a
+ * plain file, a file is read by its extension ([ICON_BY_EXTENSION]). A leading dot is part of the
+ * name, not an extension — `.env` is a document, not an "env" type.
+ */
+fun sftpFileIcon(name: String, type: FileItemType): String = when (type) {
+    FileItemType.Directory -> "folder"
+    FileItemType.Symlink -> "link"
+    FileItemType.File, FileItemType.Other -> {
+        val dot = name.lastIndexOf('.')
+        val extension = if (dot > 0) name.substring(dot + 1).lowercase() else ""
+        ICON_BY_EXTENSION[extension] ?: "description"
+    }
+}
+
 // Permissions column (ls -l long format).
 
 private val PERMISSION_TRIPLETS = listOf(6, 3, 0) // shift of the owner/group/other rwx triplet

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpListing.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpListing.kt
@@ -1,0 +1,391 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.AwaitPointerEventScope
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.ui.app.LocalSftpPrefs
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.files.FilePaneController
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_col_modified
+import app.skerry.ui.generated.resources.sftp_col_name
+import app.skerry.ui.generated.resources.sftp_col_permissions_short
+import app.skerry.ui.generated.resources.sftp_col_size
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Double-click threshold for a row (ms between two LMB presses → enter directory). */
+private const val DOUBLE_CLICK_MS = 350L
+
+@Composable
+internal fun LivePaneList(
+    pane: FilePaneController,
+    entries: List<FileItem>,
+    mono: FontFamily,
+    listState: LazyListState,
+    active: Boolean,
+    onActivate: () -> Unit,
+) {
+    val prefs = LocalSftpPrefs.current
+    // The optional columns are fixed-width and the row has no horizontal scroll: on a narrow pane
+    // (small window, 50/50 split) they'd push past the pane edge while the weighted name shrinks
+    // to nothing. Below these widths the optional columns yield — permissions first, then the date.
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        // The permissions slot also needs data to exist for this pane at all (the local okio
+        // source reports no mode bits) — otherwise it would be a dead 76dp on every local row.
+        val showPermissions = prefs.showPermissions && maxWidth >= 460.dp && entries.any { it.permissions != null }
+        val showModified = prefs.showModified && maxWidth >= 360.dp
+        Column(Modifier.fillMaxSize()) {
+            ColumnHeaderRow(showModified = showModified, showPermissions = showPermissions)
+            LazyColumn(Modifier.fillMaxSize(), state = listState) {
+                if (pane.path != "/") {
+                    item(key = "..") {
+                        LiveFileRow(
+                            // Folder icon, like the mockup: the row is the parent directory, and the
+                        // way up is what double-clicking it does, not what it is.
+                        "folder", Skerry.colors.faint, "..",
+                            // The parent row has nothing to report in any column, but takes the
+                            // same slots the entries take — otherwise its dash drifts right,
+                            // under whichever column happens to be last.
+                            columns = FileRowColumns(
+                                permissions = if (showPermissions) "" else null,
+                                modified = if (showModified) "" else null,
+                                size = NO_SIZE,
+                            ),
+                            selected = false, cursored = pane.cursorOnParent, active = active, mono = mono,
+                            // A single click only puts the cursor on ".."; going up is a double click (like entering a directory).
+                            onPress = { onActivate(); pane.setCursorOnParent() },
+                            onDoubleClick = { onActivate(); pane.goUp() },
+                            rubberBand = null, // the ".." row can't be marked — no rubber-band needed on it
+                        )
+                    }
+                }
+                items(entries, key = { it.path }) { entry ->
+                    // Single click (on press): activate the pane and place the cursor — doesn't mark or enter.
+                    // Entering a directory is a double click (open; no-op for a file). Selection — RMB/Space/Insert.
+                    val onPress = {
+                        onActivate()
+                        pane.setCursor(entry)
+                    }
+                    val onDoubleClick = {
+                        onActivate()
+                        pane.setCursor(entry)
+                        pane.open(entry)
+                    }
+                    LiveFileRow(
+                        icon = sftpFileIcon(entry.name, entry.type),
+                        iconColor = if (entry.type == FileItemType.Directory) Skerry.colors.cyanBright else Skerry.colors.faint,
+                        name = entry.name,
+                        directory = entry.type == FileItemType.Directory,
+                        // An enabled column always occupies its fixed-width slot — an empty value
+                        // renders as a blank slot, otherwise rows with a missing value (a directory's
+                        // size, an unreported mtime) would let the remaining columns drift right and
+                        // break the vertical alignment.
+                        columns = FileRowColumns(
+                            permissions = if (showPermissions) permissionsText(entry.type, entry.permissions).orEmpty() else null,
+                            modified = if (showModified) fileDateText(entry.modifiedEpochSeconds) else null,
+                            size = if (entry.type == FileItemType.File) humanSize(entry.size) else NO_SIZE,
+                        ),
+                        selected = entry.path in pane.selection,
+                        cursored = entry.path == pane.cursor,
+                        active = active,
+                        mono = mono,
+                        onPress = onPress,
+                        onDoubleClick = onDoubleClick,
+                        rubberBand = RowRubberBand(entry, pane, listState, entries, onActivate),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Column captions above a pane's listing (NAME / SIZE / MODIFIED / PERMS). Fixed, not part of the
+ * scrolled list: the listing is read by column, and a header that scrolls away leaves the numbers
+ * unnamed. Slot widths mirror [LiveFileRow]'s, so captions stay over their values.
+ */
+@Composable
+internal fun ColumnHeaderRow(showModified: Boolean, showPermissions: Boolean) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(Skerry.colors.overlayFaint)
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        ColumnCaption(stringResource(Res.string.sftp_col_name), Modifier.padding(start = ICON_SLOT_WIDTH).weight(1f))
+        ColumnCaption(stringResource(Res.string.sftp_col_size), Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
+        if (showModified) ColumnCaption(stringResource(Res.string.sftp_col_modified), Modifier.width(MODIFIED_COLUMN_WIDTH))
+        if (showPermissions) ColumnCaption(stringResource(Res.string.sftp_col_permissions_short), Modifier.width(PERMISSIONS_COLUMN_WIDTH))
+    }
+    HLine()
+}
+
+@Composable
+private fun ColumnCaption(text: String, modifier: Modifier, align: TextAlign = TextAlign.Start) {
+    Txt(
+        labelUppercase(text),
+        color = Skerry.colors.faint,
+        size = 9.5.sp,
+        weight = FontWeight.SemiBold,
+        letterSpacing = 0.9.sp,
+        maxLines = 1,
+        align = align,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Row rubber-band gesture (mc-style selection with held RMB). A press paints [entry] (toggle by its
+ * current state), dragging down/up paints the whole range with the same sign. The mouse cursor captured
+ * by the pressed row is translated into list coordinates via the row offset in [listState], then the row
+ * under it is found in [listState] and painted up to it. No scroll on edge drag (the right button doesn't
+ * scroll the list) — offsets are stable for the whole gesture.
+ */
+internal class RowRubberBand(
+    val entry: FileItem,
+    val pane: FilePaneController,
+    val listState: LazyListState,
+    val entries: List<FileItem>,
+    val onActivate: () -> Unit,
+) {
+    // Member-extension on the restricted-scope AwaitPointerEventScope — else awaitPointerEvent() can't be called.
+    suspend fun AwaitPointerEventScope.dragSelect(press: PointerEvent) {
+        onActivate() // painting in this pane — make it active (F-keys go here)
+        // Fix the sign by the pressed row: not marked → paint, marked → clear.
+        val select = entry.path !in pane.selection
+        pane.rubberBandTo(entry, entry, select)
+        press.changes.forEach { it.consume() }
+        val anchorOffset = listState.layoutInfo.visibleItemsInfo
+            .firstOrNull { it.key == entry.path }?.offset ?: 0
+        while (true) {
+            val drag = awaitPointerEvent()
+            if (!drag.buttons.isSecondaryPressed) break // RMB released — end of gesture
+            val listY = anchorOffset + drag.changes.first().position.y
+            val key = listState.layoutInfo.visibleItemsInfo
+                .firstOrNull { listY >= it.offset && listY < it.offset + it.size }?.key as? String
+            key?.let { k -> entries.firstOrNull { it.path == k } }
+                ?.let { target -> pane.rubberBandTo(entry, target, select) }
+            drag.changes.forEach { it.consume() }
+        }
+    }
+}
+
+/**
+ * Right-side row columns, each `null` when hidden/empty for this row: [size] (files carry a size,
+ * anything else the [NO_SIZE] dash), [modified] (mtime), [permissions] (`ls -l` style, remote pane
+ * only — the local okio source doesn't report mode bits). Fixed widths keep the columns aligned
+ * across rows; the order matches the captions in [ColumnHeaderRow].
+ */
+internal data class FileRowColumns(
+    val permissions: String? = null,
+    val modified: String? = null,
+    val size: String? = null,
+)
+
+/**
+ * Size cell of a row that has no size of its own (directory, symlink). Not translatable: an em
+ * dash is typography, not copy.
+ */
+internal const val NO_SIZE = "—"
+
+private val PERMISSIONS_COLUMN_WIDTH = 76.dp
+
+private val MODIFIED_COLUMN_WIDTH = 96.dp
+
+private val SIZE_COLUMN_WIDTH = 62.dp
+
+/** Width of the row's leading icon slot; the column captions indent by it to clear the icons. */
+private val ICON_SLOT_WIDTH = 27.dp
+
+/** Hairline between listing rows. */
+private val ROW_SEPARATOR_WIDTH = 1.dp
+
+@Composable
+internal fun LiveFileRow(
+    icon: String,
+    iconColor: Color,
+    name: String,
+    columns: FileRowColumns,
+    selected: Boolean,
+    cursored: Boolean,
+    active: Boolean,
+    mono: FontFamily,
+    onPress: () -> Unit,
+    onDoubleClick: () -> Unit,
+    // A directory reads by its name colour, the way a file manager's listing does — the icon alone
+    // is too small to sort a long listing by eye.
+    directory: Boolean = false,
+    // Data for held-RMB rubber-band (mc): the anchor row, controller, list state for translating the
+    // cursor position to a row, and the current listing. null for the synthetic ".." row.
+    rubberBand: RowRubberBand?,
+) {
+    // Latest callbacks without restarting the gesture (pointerInput is keyed on Unit — it lives the row's whole life).
+    val currentPress by rememberUpdatedState(onPress)
+    val currentDouble by rememberUpdatedState(onDoubleClick)
+    // Cursor (navigation position) and selection (marked files) are distinct in mc: the active pane's
+    // cursor is a bright bar, the inactive one's a neutral one; selection is a highlight + bold name.
+    val rowBg = when {
+        cursored && active -> Skerry.colors.cyan20
+        cursored -> Skerry.colors.overlayMed
+        selected -> Skerry.colors.cyan06
+        else -> Color.Transparent
+    }
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(rowBg)
+            .listingRowHairline()
+            // LMB: our own tap parsing in one loop — more reliable than detectTapGestures (which lost
+            // double clicks to slop/timeouts). Each LMB press instantly places the cursor (currentPress);
+            // two presses closer than DOUBLE_CLICK_MS are a double click (enter directory). Time comes
+            // from the event itself (uptimeMillis) — deterministic. RMB is skipped (rubber-band below handles it).
+            .pointerInput(Unit) {
+                var lastDownMs = 0L
+                awaitPointerEventScope {
+                    while (true) {
+                        val e = awaitPointerEvent()
+                        if (e.type != PointerEventType.Press || e.buttons.isSecondaryPressed) continue
+                        val t = e.changes.first().uptimeMillis
+                        currentPress()
+                        if (t - lastDownMs <= DOUBLE_CLICK_MS) {
+                            currentDouble()
+                            lastDownMs = 0L // reset so a triple click doesn't give a second enter
+                        } else {
+                            lastDownMs = t
+                        }
+                    }
+                }
+            }
+            // RMB (mc): a press paints the row (toggle by sign), dragging down/up paints the range with
+            // the same sign — rubber-band. It runs after the tap detector (inner) and consumes the right
+            // button in the Main pass earlier — so detectTapGestures (requireUnconsumed) ignores it, while
+            // LMB is untouched (no consume) and reaches the tap detector.
+            .then(
+                if (rubberBand != null) {
+                    // Key — anchor+listing (stable during a drag: a selection change doesn't touch them,
+                    // so the gesture isn't restarted mid rubber-band).
+                    Modifier.pointerInput(rubberBand.entry, rubberBand.entries) {
+                        awaitPointerEventScope {
+                            while (true) {
+                                val press = awaitPointerEvent()
+                                if (press.type != PointerEventType.Press) continue
+                                if (!press.buttons.isSecondaryPressed) continue
+                                with(rubberBand) { dragSelect(press) }
+                            }
+                        }
+                    }
+                } else {
+                    Modifier
+                },
+            )
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        FileRowIcon(icon, iconColor)
+        FileRowName(name, selected, directory, mono, Modifier.weight(1f))
+        FileRowColumnCells(columns, mono)
+    }
+}
+
+/**
+ * Name cell of a listing row. A marked row and a directory both read by colour — the 16sp icon is
+ * too small to sort a long listing by eye — and a marked one is bold on top of that. One line
+ * always: a wrapped name would grow the row and drag its own columns off the captions.
+ */
+@Composable
+internal fun FileRowName(
+    name: String,
+    selected: Boolean,
+    directory: Boolean,
+    mono: FontFamily,
+    modifier: Modifier = Modifier,
+) {
+    Txt(
+        name,
+        color = when {
+            name == ".." -> Skerry.colors.dim
+            selected || directory -> Skerry.colors.cyanBright
+            else -> Skerry.colors.text
+        },
+        size = 12.sp,
+        font = mono,
+        weight = if (selected) FontWeight.Bold else FontWeight.Normal,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
+/**
+ * Leading icon slot of a listing row. [ColumnHeaderRow] indents its NAME caption by the same width,
+ * so the caption stands over the names rather than over the icons.
+ */
+@Composable
+internal fun FileRowIcon(icon: String, tint: Color) {
+    Box(Modifier.width(ICON_SLOT_WIDTH - 10.dp), contentAlignment = Alignment.Center) {
+        Sym(icon, size = 16.sp, color = tint)
+    }
+}
+
+/**
+ * Full-bleed hairline under a listing row: the listing reads as a table, and rounded rows over a
+ * table grid read as cards instead.
+ */
+@Composable
+internal fun Modifier.listingRowHairline(): Modifier {
+    val separator = ROW_SEPARATOR_WIDTH
+    val separatorColor = Skerry.colors.line
+    return drawBehind {
+        val y = size.height - separator.toPx() / 2
+        drawLine(separatorColor, Offset(0f, y), Offset(size.width, y), separator.toPx())
+    }
+}
+
+/**
+ * The right-side cells of a listing row, in the same fixed slots as [ColumnHeaderRow]'s captions.
+ * Shared so the static design render lines up under the same captions as the live listing.
+ */
+@Composable
+internal fun FileRowColumnCells(columns: FileRowColumns, mono: FontFamily) {
+    columns.size?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(SIZE_COLUMN_WIDTH)) }
+    columns.modified?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, modifier = Modifier.width(MODIFIED_COLUMN_WIDTH)) }
+    columns.permissions?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, modifier = Modifier.width(PERMISSIONS_COLUMN_WIDTH)) }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpMockView.kt
@@ -10,40 +10,36 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.files.FileItemType
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.sftp_new_folder
 import app.skerry.ui.generated.resources.sftp_no_session
 import app.skerry.ui.generated.resources.sftp_no_session_hint
 import app.skerry.ui.generated.resources.sftp_pane_local
-import app.skerry.ui.generated.resources.sftp_pane_remote
-import app.skerry.ui.generated.resources.sftp_title
-import app.skerry.ui.generated.resources.sftp_upload
 import org.jetbrains.compose.resources.stringResource
-import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.MeterBar
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.design.Badge
+import app.skerry.ui.session.SessionStatus
+import app.skerry.ui.terminal.WorkBarLabel
+import app.skerry.ui.generated.resources.sftp_wbar_subtitle
 
 private data class FileEntry(val icon: String, val name: String, val meta: String, val selected: Boolean = false)
+
+/** Host the static preview pretends to be connected to (same one the design mockups use). */
+private const val MOCK_HOST = "prod-web-01"
+
+private const val MOCK_REMOTE_PATH = "/var/www"
 
 private val LOCAL_FILES = listOf(
     FileEntry("arrow_upward", "..", ""),
@@ -63,27 +59,19 @@ private val REMOTE_FILES = listOf(
     FileEntry("terminal", "deploy.sh", "1.8 KB"),
 )
 
-/** Mock row icon tint by icon kind, from the active theme (folders — cyan, files — dim). */
+/** Mock row icon tint by icon kind, from the active theme (folders — cyan, files — faint). */
 @Composable
 private fun mockFileIconTint(icon: String): Color = when (icon) {
     "folder" -> Skerry.colors.cyanBright
-    "arrow_upward" -> Skerry.colors.faint
-    else -> Skerry.colors.dim
+    else -> Skerry.colors.faint
 }
 
-/** Material icon name ([Sym] ligature) for a file-pane item type. */
-internal fun fileItemIcon(type: FileItemType): String = when (type) {
-    FileItemType.Directory -> "folder"
-    FileItemType.Symlink -> "link"
-    FileItemType.File, FileItemType.Other -> "description"
-}
-
-/** A live session exists but isn't connected: header + notice. */
+/** A live session exists but isn't connected: bar + notice. */
 @Composable
-internal fun NoSessionSftpView(mono: FontFamily) {
+internal fun NoSessionSftpView(onBack: () -> Unit) {
     Column(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
-        SftpTopBar(stringResource(Res.string.sftp_no_session), mono)
-        HLine()
+        // No connection, hence no title and no actions: the bar carries the way back only.
+        SftpWorkBar(label = null, onBack = onBack) {}
         Box(Modifier.weight(1f).fillMaxWidth()) {
             PaneNotice("cloud_off", stringResource(Res.string.sftp_no_session), stringResource(Res.string.sftp_no_session_hint), Skerry.colors.faint)
         }
@@ -94,26 +82,23 @@ internal fun NoSessionSftpView(mono: FontFamily) {
 @Composable
 internal fun MockSftpView(mono: FontFamily) {
     Column(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
-        Row(
-            Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(horizontal = 18.dp, vertical = 9.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
+        SftpWorkBar(
+            label = WorkBarLabel.Solo(MOCK_HOST, stringResource(Res.string.sftp_wbar_subtitle, MOCK_REMOTE_PATH), SessionStatus.Live),
+            onBack = {},
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                Sym("drive_file_move", size = 18.sp, color = Skerry.colors.cyanBright)
-                Txt(stringResource(Res.string.sftp_title), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-                Txt("root@prod-web-01 · SFTP", color = Skerry.colors.faint, size = 11.5.sp, font = mono)
-            }
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                GhostButton(stringResource(Res.string.sftp_upload), onClick = {}, icon = "upload")
-                GhostButton(stringResource(Res.string.sftp_new_folder), onClick = {}, icon = "create_new_folder")
-            }
+            SftpWorkBarActions(
+                localActive = true,
+                enabled = false,
+                onRefresh = {},
+                onNewFolder = {},
+                onFilter = {},
+                onTransfer = {},
+            )
         }
-        HLine()
         Row(Modifier.weight(1f).fillMaxWidth()) {
-            MockPane("computer", Skerry.colors.dim, stringResource(Res.string.sftp_pane_local), "~/projects", LOCAL_FILES, mono, Modifier.weight(1f))
+            MockPane("computer", Skerry.colors.dim, stringResource(Res.string.sftp_pane_local), false, "~/projects", LOCAL_FILES, mono, Modifier.weight(1f))
             VLine(Skerry.colors.line)
-            MockPane("dns", Skerry.colors.moss, stringResource(Res.string.sftp_pane_remote), "/var/www", REMOTE_FILES, mono, Modifier.weight(1f))
+            MockPane("dns", Skerry.colors.moss, MOCK_HOST, true, MOCK_REMOTE_PATH, REMOTE_FILES, mono, Modifier.weight(1f))
         }
         HLine()
         Row(
@@ -133,7 +118,8 @@ internal fun MockSftpView(mono: FontFamily) {
 private fun MockPane(
     icon: String,
     iconColor: Color,
-    label: String,
+    badge: String,
+    badgeAccent: Boolean,
     path: String,
     files: List<FileEntry>,
     mono: FontFamily,
@@ -141,16 +127,22 @@ private fun MockPane(
 ) {
     Column(modifier.fillMaxHeight()) {
         Row(
-            Modifier.fillMaxWidth().background(Skerry.colors.panel).padding(horizontal = 14.dp, vertical = 9.dp),
+            Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 10.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Sym(icon, size = 16.sp, color = iconColor)
-            Txt(label.uppercase(), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
-            Txt(path, color = Skerry.colors.textBright, size = 11.5.sp, font = mono)
+            Txt(path, color = Skerry.colors.textBright, size = 11.5.sp, font = mono, modifier = Modifier.weight(1f))
+            Badge(
+                badge,
+                bg = if (badgeAccent) Skerry.colors.cyan14 else Skerry.colors.overlayMed,
+                fg = if (badgeAccent) Skerry.colors.cyanBright else Skerry.colors.dim,
+                radius = 6,
+                size = 10.sp,
+            )
         }
         HLine()
-        Column(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(6.dp)) {
+        Column(Modifier.weight(1f).verticalScroll(rememberScrollState())) {
             files.forEach { MockRow(it, mono) }
         }
     }
@@ -161,14 +153,23 @@ private fun MockRow(entry: FileEntry, mono: FontFamily) {
     Row(
         Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(5.dp))
             .background(if (entry.selected) Skerry.colors.cyan06 else Color.Transparent)
             .padding(horizontal = 10.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Sym(entry.icon, size = 17.sp, color = mockFileIconTint(entry.icon))
-        Txt(entry.name, color = if (entry.name == "..") Skerry.colors.dim else Skerry.colors.textBright, size = 12.sp, font = mono, modifier = Modifier.weight(1f))
-        if (entry.meta.isNotEmpty()) Txt(entry.meta, color = Skerry.colors.faint, size = 11.sp)
+        Sym(entry.icon, size = 16.sp, color = mockFileIconTint(entry.icon))
+        Txt(
+            entry.name,
+            color = when {
+                entry.name == ".." -> Skerry.colors.dim
+                entry.icon == "folder" -> Skerry.colors.cyanBright
+                else -> Skerry.colors.text
+            },
+            size = 12.sp,
+            font = mono,
+            modifier = Modifier.weight(1f),
+        )
+        if (entry.meta.isNotEmpty()) Txt(entry.meta, color = Skerry.colors.faint, size = 11.sp, font = mono)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpMockView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.generated.resources.Res
@@ -24,47 +25,80 @@ import app.skerry.ui.generated.resources.sftp_no_session_hint
 import app.skerry.ui.generated.resources.sftp_pane_local
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.HLine
-import app.skerry.ui.design.MeterBar
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.design.Badge
+import app.skerry.ui.files.TransferStatus
+import app.skerry.ui.files.TransferEntry
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.terminal.WorkBarLabel
 import app.skerry.ui.generated.resources.sftp_wbar_subtitle
 
-private data class FileEntry(val icon: String, val name: String, val meta: String, val selected: Boolean = false)
+private data class FileEntry(
+    val icon: String,
+    val name: String,
+    val size: String = NO_SIZE,
+    val modified: String = "",
+    val permissions: String = "",
+    val selected: Boolean = false,
+)
 
 /** Host the static preview pretends to be connected to (same one the design mockups use). */
 private const val MOCK_HOST = "prod-web-01"
 
 private const val MOCK_REMOTE_PATH = "/var/www"
 
+private val MOCK_TRANSFERS = listOf(
+    TransferEntry(
+        id = 1,
+        direction = TransferDirection.Upload,
+        name = "release-0.2.1.tar.gz",
+        fileIndex = 1,
+        fileCount = 1,
+        transferred = 7_444_889,
+        total = 11_744_051,
+        bytesDone = 7_444_889,
+        elapsedMillis = 1_460,
+        status = TransferStatus.Active,
+    ),
+    TransferEntry(
+        id = 2,
+        direction = TransferDirection.Download,
+        name = "nginx.conf",
+        fileIndex = 1,
+        fileCount = 1,
+        transferred = 2_867,
+        total = 2_867,
+        bytesDone = 2_867,
+        elapsedMillis = 400,
+        status = TransferStatus.Done,
+    ),
+)
+
 private val LOCAL_FILES = listOf(
-    FileEntry("arrow_upward", "..", ""),
-    FileEntry("folder", "skerry-app", "Jun 21 09:14"),
-    FileEntry("folder", "deploy-scripts", "Jun 18 22:40"),
-    FileEntry("description", "docker-compose.yml", "2.4 KB"),
-    FileEntry("key", "id_ed25519.pub", "96 B"),
-    FileEntry("description", "backup.tar.gz", "418 MB"),
+    FileEntry("folder", ".."),
+    FileEntry("folder", "skerry-app", modified = "Jun 21 09:14", permissions = "drwxr-xr-x"),
+    FileEntry("folder", "deploy-scripts", modified = "Jun 18 22:40", permissions = "drwxr-xr-x"),
+    FileEntry("description", "docker-compose.yml", size = "2.4 KB", modified = "Jun 18 22:40", permissions = "-rw-r--r--"),
+    FileEntry("key", "id_ed25519.pub", size = "96 B", modified = "May 04 11:02", permissions = "-rw-r--r--"),
+    FileEntry("archive", "backup.tar.gz", size = "418 MB", modified = "Jun 20 03:15", permissions = "-rw-r--r--"),
 )
 
 private val REMOTE_FILES = listOf(
-    FileEntry("arrow_upward", "..", ""),
-    FileEntry("folder", "html", "drwxr-xr-x"),
-    FileEntry("folder", "releases", "drwxr-xr-x"),
-    FileEntry("description", "nginx.conf", "3.1 KB", selected = true),
-    FileEntry("description", "robots.txt", "112 B"),
-    FileEntry("terminal", "deploy.sh", "1.8 KB"),
+    FileEntry("folder", ".."),
+    FileEntry("folder", "html", modified = "Jun 21 08:40", permissions = "drwxr-xr-x"),
+    FileEntry("folder", "releases", modified = "Jun 20 19:12", permissions = "drwxr-xr-x"),
+    FileEntry("description", "nginx.conf", size = "3.1 KB", modified = "Jun 18 08:41", permissions = "-rw-r--r--", selected = true),
+    FileEntry("description", "robots.txt", size = "112 B", modified = "Jun 02 10:00", permissions = "-rw-r--r--"),
+    FileEntry("terminal", "deploy.sh", size = "1.8 KB", modified = "Jun 18 08:41", permissions = "-rwxr-xr-x"),
 )
 
-/** Mock row icon tint by icon kind, from the active theme (folders — cyan, files — faint). */
+/** Mock row icon tint, matching the live listing: folders cyan, the parent row and files faint. */
 @Composable
-private fun mockFileIconTint(icon: String): Color = when (icon) {
-    "folder" -> Skerry.colors.cyanBright
-    else -> Skerry.colors.faint
-}
+private fun mockFileIconTint(entry: FileEntry): Color =
+    if (entry.icon == "folder" && entry.name != "..") Skerry.colors.cyanBright else Skerry.colors.faint
 
 /** A live session exists but isn't connected: bar + notice. */
 @Composable
@@ -96,21 +130,33 @@ internal fun MockSftpView(mono: FontFamily) {
             )
         }
         Row(Modifier.weight(1f).fillMaxWidth()) {
-            MockPane("computer", Skerry.colors.dim, stringResource(Res.string.sftp_pane_local), false, "~/projects", LOCAL_FILES, mono, Modifier.weight(1f))
+            MockPane(
+                "computer",
+                Skerry.colors.dim,
+                stringResource(Res.string.sftp_pane_local),
+                false,
+                "~/projects",
+                LOCAL_FILES,
+                mono,
+                active = true,
+                modifier = Modifier.weight(1f),
+            )
             VLine(Skerry.colors.line)
-            MockPane("dns", Skerry.colors.moss, MOCK_HOST, true, MOCK_REMOTE_PATH, REMOTE_FILES, mono, Modifier.weight(1f))
+            MockPane(
+                "dns",
+                Skerry.colors.moss,
+                MOCK_HOST,
+                true,
+                MOCK_REMOTE_PATH,
+                REMOTE_FILES,
+                mono,
+                active = false,
+                modifier = Modifier.weight(1f),
+            )
         }
-        HLine()
-        Row(
-            Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(horizontal = 16.dp, vertical = 10.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Sym("upload", size = 16.sp, color = Skerry.colors.cyan)
-            Txt("backup.tar.gz", color = Skerry.colors.textBright, size = 11.5.sp, font = mono)
-            MeterBar(0.64f, Skerry.colors.cyan, Modifier.weight(1f))
-            Txt("64% · 12.4 MB/s · 02:18 left", color = Skerry.colors.dim, size = 11.sp, font = mono)
-        }
+        // The same strip the live screen uses, over static entries: the design render must show
+        // what ships, not a second hand-drawn progress bar.
+        TransferQueueStrip(MOCK_TRANSFERS, mono, onDismiss = {})
     }
 }
 
@@ -123,6 +169,7 @@ private fun MockPane(
     path: String,
     files: List<FileEntry>,
     mono: FontFamily,
+    active: Boolean,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxHeight()) {
@@ -131,8 +178,17 @@ private fun MockPane(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            Sym(icon, size = 16.sp, color = iconColor)
-            Txt(path, color = Skerry.colors.textBright, size = 11.5.sp, font = mono, modifier = Modifier.weight(1f))
+            // Only one pane is ever focused; the live header greys the other one's glyph out.
+            Sym(icon, size = 16.sp, color = if (active) iconColor else Skerry.colors.faint)
+            Txt(
+                path,
+                color = Skerry.colors.textBright,
+                size = 11.5.sp,
+                font = mono,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
             Badge(
                 badge,
                 bg = if (badgeAccent) Skerry.colors.cyan14 else Skerry.colors.overlayMed,
@@ -142,6 +198,7 @@ private fun MockPane(
             )
         }
         HLine()
+        ColumnHeaderRow(showModified = true, showPermissions = true)
         Column(Modifier.weight(1f).verticalScroll(rememberScrollState())) {
             files.forEach { MockRow(it, mono) }
         }
@@ -154,22 +211,16 @@ private fun MockRow(entry: FileEntry, mono: FontFamily) {
         Modifier
             .fillMaxWidth()
             .background(if (entry.selected) Skerry.colors.cyan06 else Color.Transparent)
+            .listingRowHairline()
             .padding(horizontal = 10.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Sym(entry.icon, size = 16.sp, color = mockFileIconTint(entry.icon))
-        Txt(
-            entry.name,
-            color = when {
-                entry.name == ".." -> Skerry.colors.dim
-                entry.icon == "folder" -> Skerry.colors.cyanBright
-                else -> Skerry.colors.text
-            },
-            size = 12.sp,
-            font = mono,
-            modifier = Modifier.weight(1f),
+        FileRowIcon(entry.icon, mockFileIconTint(entry))
+        FileRowName(entry.name, entry.selected, entry.icon == "folder", mono, Modifier.weight(1f))
+        FileRowColumnCells(
+            FileRowColumns(permissions = entry.permissions, modified = entry.modified, size = entry.size),
+            mono,
         )
-        if (entry.meta.isNotEmpty()) Txt(entry.meta, color = Skerry.colors.faint, size = 11.sp, font = mono)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
@@ -74,9 +74,6 @@ import app.skerry.ui.generated.resources.sftp_filter_hint
 import app.skerry.ui.generated.resources.sftp_error
 import app.skerry.ui.generated.resources.sftp_loading
 import app.skerry.ui.generated.resources.sftp_new_folder
-import app.skerry.ui.generated.resources.sftp_subtitle_host
-import app.skerry.ui.generated.resources.sftp_title
-import app.skerry.ui.generated.resources.sftp_upload
 import app.skerry.ui.sftp.fileDateText
 import app.skerry.ui.sftp.humanSize
 import app.skerry.ui.sftp.permissionsText
@@ -84,7 +81,6 @@ import org.jetbrains.compose.resources.stringResource
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.text.style.TextAlign
 import app.skerry.ui.design.AnchoredDropdown
-import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.labelUppercase
@@ -94,38 +90,75 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import app.skerry.ui.design.Badge
+import app.skerry.ui.terminal.WorkBar
+import app.skerry.ui.terminal.WorkBarLeading
+import app.skerry.ui.generated.resources.sftp_tip_back
+import app.skerry.ui.terminal.WorkBarLabel
+import app.skerry.ui.generated.resources.sftp_tip_refresh
+import app.skerry.ui.generated.resources.sftp_tip_filter
+import app.skerry.ui.generated.resources.sftp_tip_upload
+import app.skerry.ui.generated.resources.sftp_tip_download
+import app.skerry.ui.generated.resources.sftp_col_name
+import app.skerry.ui.generated.resources.sftp_col_size
+import app.skerry.ui.generated.resources.sftp_col_permissions_short
 
 /** Double-click threshold for a row (ms between two LMB presses → enter directory). */
 private const val DOUBLE_CLICK_MS = 350L
 
 /**
- * The two-pane screen's header: "File transfer" + the session's subtitle on the left, Upload and
- * New folder on the right. [onUpload] transfers the local pane's selection, or falls back to the
- * native picker; [onNewFolder] creates a directory in the active pane.
+ * The bar above the SFTP work area — the same strip the terminal uses, so the two views read as one
+ * window: the tab on the left ([label]), what can be done to it on the right ([actions]). The host
+ * is never picked from here (the pane already holds a live connection), hence no picker.
+ *
+ * The leading chevron goes back to the terminal ([onBack], the same thing F10 does) rather than
+ * toggling the hosts sidebar: this screen fills the whole work area and shows no sidebar, so the
+ * toggle would move nothing on screen.
  */
 @Composable
-internal fun LivePaneHeader(
-    subtitle: String,
-    mono: FontFamily,
-    onUpload: () -> Unit,
-    onNewFolder: () -> Unit,
+internal fun SftpWorkBar(
+    label: WorkBarLabel?,
+    onBack: () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
 ) {
-    Row(
-        Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(horizontal = 18.dp, vertical = 9.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            Sym("drive_file_move", size = 18.sp, color = Skerry.colors.cyanBright)
-            Txt(stringResource(Res.string.sftp_title), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-            Txt(stringResource(Res.string.sftp_subtitle_host, subtitle), color = Skerry.colors.faint, size = 11.5.sp, font = mono)
-        }
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            GhostButton(stringResource(Res.string.sftp_upload), onClick = onUpload, icon = "upload")
-            GhostButton(stringResource(Res.string.sftp_new_folder), onClick = onNewFolder, icon = "create_new_folder")
-            ColumnsMenu(LocalSftpPrefs.current)
-        }
-    }
+    WorkBar(
+        label = label,
+        tabKey = null,
+        leading = WorkBarLeading.back(Res.string.sftp_tip_back, onBack),
+        onPickHost = null,
+        actions = actions,
+    )
+}
+
+/**
+ * The bar's action row: refresh both panes, create a directory, open the quick filter, choose the
+ * listing columns, transfer the active pane's selection. Each one is an F-key of the bottom bar —
+ * the bar names them, the icons are the reachable-by-mouse half of the same commands. The transfer
+ * icon follows the active pane's direction: local active means the bytes go up, remote — down.
+ */
+@Composable
+internal fun SftpWorkBarActions(
+    localActive: Boolean,
+    enabled: Boolean,
+    onRefresh: () -> Unit,
+    onNewFolder: () -> Unit,
+    onFilter: () -> Unit,
+    onTransfer: () -> Unit,
+) {
+    IconBtn("refresh", onClick = onRefresh, box = 26, tooltip = stringResource(Res.string.sftp_tip_refresh), enabled = enabled)
+    IconBtn("create_new_folder", onClick = onNewFolder, box = 26, tooltip = stringResource(Res.string.sftp_new_folder), enabled = enabled)
+    IconBtn("filter_alt", onClick = onFilter, box = 26, tooltip = stringResource(Res.string.sftp_tip_filter), enabled = enabled)
+    ColumnsMenu(LocalSftpPrefs.current)
+    IconBtn(
+        if (localActive) "upload" else "download",
+        onClick = onTransfer,
+        box = 26,
+        tooltip = stringResource(if (localActive) Res.string.sftp_tip_upload else Res.string.sftp_tip_download),
+        enabled = enabled,
+    )
 }
 
 /**
@@ -170,6 +203,9 @@ internal fun ensureOperandSelection(pane: FilePaneController) {
     if (pane.selection.isEmpty()) pane.cursoredItem()?.let { pane.selectOnly(it) }
 }
 
+/** Nothing for a batch F-operation to act on: no marks and no cursored row to fall back on. */
+internal fun FilePaneController.hasNoOperand(): Boolean = selection.isEmpty() && cursoredItem() == null
+
 /** The file panel's own key legend (mc/Total Commander order, adapted for Skerry). */
 internal val PANEL_FKEYS = listOf(
     FKeyDef(2, Res.string.ftail_fkey_rename),
@@ -184,16 +220,18 @@ internal val PANEL_FKEYS = listOf(
 )
 
 /**
- * One live pane over [FilePaneController]: header [label] + path (no toolbar — up-navigation via the
- * ".." row) and the listing. File operations go through the bottom F-key bar; selection is left-click
- * (toggle) and rubber-band with held right-click.
+ * One live pane over [FilePaneController]: header (side icon + path + [badge] naming the side) and
+ * the listing. No toolbar — up-navigation is the ".." row, file operations go through the bottom
+ * F-key bar; selection is left-click (toggle) and rubber-band with held right-click. [badgeAccent]
+ * marks the remote side, which carries the host's name rather than a fixed word.
  */
 @Composable
 internal fun LivePane(
     pane: FilePaneController,
     icon: String,
     iconColor: Color,
-    label: String,
+    badge: String,
+    badgeAccent: Boolean,
     mono: FontFamily,
     listState: LazyListState,
     active: Boolean,
@@ -230,18 +268,11 @@ internal fun LivePane(
             .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onActivate),
     ) {
         Row(
-            Modifier.fillMaxWidth().background(Skerry.colors.panel).padding(horizontal = 14.dp, vertical = 9.dp),
+            Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 10.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Sym(icon, size = 16.sp, color = if (active) iconColor else Skerry.colors.faint)
-            Txt(
-                labelUppercase(label),
-                color = if (active) Skerry.colors.cyanBright else Skerry.colors.faint,
-                size = 11.sp,
-                weight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
-            )
             PathField(
                 pane = pane,
                 mono = mono,
@@ -249,6 +280,13 @@ internal fun LivePane(
                 onEditingPath = onEditingPath,
                 restoreFocus = restoreFocus,
                 modifier = Modifier.weight(1f),
+            )
+            Badge(
+                badge,
+                bg = if (badgeAccent) Skerry.colors.cyan14 else Skerry.colors.overlayMed,
+                fg = if (badgeAccent) Skerry.colors.cyanBright else Skerry.colors.dim,
+                radius = 6,
+                size = 10.sp,
             )
         }
         HLine()
@@ -433,60 +471,104 @@ private fun LivePaneList(
         // source reports no mode bits) — otherwise it would be a dead 76dp on every local row.
         val showPermissions = prefs.showPermissions && maxWidth >= 460.dp && entries.any { it.permissions != null }
         val showModified = prefs.showModified && maxWidth >= 360.dp
-        LazyColumn(Modifier.fillMaxSize().padding(6.dp), state = listState) {
-            if (pane.path != "/") {
-                item(key = "..") {
+        Column(Modifier.fillMaxSize()) {
+            ColumnHeaderRow(showModified = showModified, showPermissions = showPermissions)
+            LazyColumn(Modifier.fillMaxSize(), state = listState) {
+                if (pane.path != "/") {
+                    item(key = "..") {
+                        LiveFileRow(
+                            "arrow_upward", Skerry.colors.faint, "..",
+                            // The parent row has nothing to report in any column, but takes the
+                            // same slots the entries take — otherwise its dash drifts right,
+                            // under whichever column happens to be last.
+                            columns = FileRowColumns(
+                                permissions = if (showPermissions) "" else null,
+                                modified = if (showModified) "" else null,
+                                size = NO_SIZE,
+                            ),
+                            selected = false, cursored = pane.cursorOnParent, active = active, mono = mono,
+                            // A single click only puts the cursor on ".."; going up is a double click (like entering a directory).
+                            onPress = { onActivate(); pane.setCursorOnParent() },
+                            onDoubleClick = { onActivate(); pane.goUp() },
+                            rubberBand = null, // the ".." row can't be marked — no rubber-band needed on it
+                        )
+                    }
+                }
+                items(entries, key = { it.path }) { entry ->
+                    // Single click (on press): activate the pane and place the cursor — doesn't mark or enter.
+                    // Entering a directory is a double click (open; no-op for a file). Selection — RMB/Space/Insert.
+                    val onPress = {
+                        onActivate()
+                        pane.setCursor(entry)
+                    }
+                    val onDoubleClick = {
+                        onActivate()
+                        pane.setCursor(entry)
+                        pane.open(entry)
+                    }
                     LiveFileRow(
-                        "arrow_upward", Skerry.colors.faint, "..",
-                        columns = FileRowColumns(),
-                        selected = false, cursored = pane.cursorOnParent, active = active, mono = mono,
-                        // A single click only puts the cursor on ".."; going up is a double click (like entering a directory).
-                        onPress = { onActivate(); pane.setCursorOnParent() },
-                        onDoubleClick = { onActivate(); pane.goUp() },
-                        rubberBand = null, // the ".." row can't be marked — no rubber-band needed on it
+                        icon = sftpFileIcon(entry.name, entry.type),
+                        iconColor = if (entry.type == FileItemType.Directory) Skerry.colors.cyanBright else Skerry.colors.faint,
+                        name = entry.name,
+                        directory = entry.type == FileItemType.Directory,
+                        // An enabled column always occupies its fixed-width slot — an empty value
+                        // renders as a blank slot, otherwise rows with a missing value (a directory's
+                        // size, an unreported mtime) would let the remaining columns drift right and
+                        // break the vertical alignment.
+                        columns = FileRowColumns(
+                            permissions = if (showPermissions) permissionsText(entry.type, entry.permissions).orEmpty() else null,
+                            modified = if (showModified) fileDateText(entry.modifiedEpochSeconds) else null,
+                            size = if (entry.type == FileItemType.File) humanSize(entry.size) else NO_SIZE,
+                        ),
+                        selected = entry.path in pane.selection,
+                        cursored = entry.path == pane.cursor,
+                        active = active,
+                        mono = mono,
+                        onPress = onPress,
+                        onDoubleClick = onDoubleClick,
+                        rubberBand = RowRubberBand(entry, pane, listState, entries, onActivate),
                     )
                 }
             }
-            items(entries, key = { it.path }) { entry ->
-                // Single click (on press): activate the pane and place the cursor — doesn't mark or enter.
-                // Entering a directory is a double click (open; no-op for a file). Selection — RMB/Space/Insert.
-                val onPress = {
-                    onActivate()
-                    pane.setCursor(entry)
-                }
-                val onDoubleClick = {
-                    onActivate()
-                    pane.setCursor(entry)
-                    pane.open(entry)
-                }
-                LiveFileRow(
-                    icon = fileItemIcon(entry.type),
-                    iconColor = if (entry.type == FileItemType.Directory) Skerry.colors.cyanBright else Skerry.colors.dim,
-                    name = entry.name,
-                    // An enabled column always occupies its fixed-width slot — an empty value
-                    // renders as a blank slot, otherwise rows with a missing value (a directory's
-                    // size, an unreported mtime) would let the remaining columns drift right and
-                    // break the vertical alignment.
-                    columns = FileRowColumns(
-                        permissions = if (showPermissions) permissionsText(entry.type, entry.permissions).orEmpty() else null,
-                        modified = if (showModified) fileDateText(entry.modifiedEpochSeconds) else null,
-                        size = when {
-                            entry.type == FileItemType.File -> humanSize(entry.size)
-                            showPermissions || showModified -> ""
-                            else -> null
-                        },
-                    ),
-                    selected = entry.path in pane.selection,
-                    cursored = entry.path == pane.cursor,
-                    active = active,
-                    mono = mono,
-                    onPress = onPress,
-                    onDoubleClick = onDoubleClick,
-                    rubberBand = RowRubberBand(entry, pane, listState, entries, onActivate),
-                )
-            }
         }
     }
+}
+
+/**
+ * Column captions above a pane's listing (NAME / SIZE / MODIFIED / PERMS). Fixed, not part of the
+ * scrolled list: the listing is read by column, and a header that scrolls away leaves the numbers
+ * unnamed. Slot widths mirror [LiveFileRow]'s, so captions stay over their values.
+ */
+@Composable
+private fun ColumnHeaderRow(showModified: Boolean, showPermissions: Boolean) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(Skerry.colors.overlayFaint)
+            .padding(horizontal = 10.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        ColumnCaption(stringResource(Res.string.sftp_col_name), Modifier.padding(start = ICON_SLOT_WIDTH).weight(1f))
+        ColumnCaption(stringResource(Res.string.sftp_col_size), Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
+        if (showModified) ColumnCaption(stringResource(Res.string.sftp_col_modified), Modifier.width(MODIFIED_COLUMN_WIDTH), TextAlign.End)
+        if (showPermissions) ColumnCaption(stringResource(Res.string.sftp_col_permissions_short), Modifier.width(PERMISSIONS_COLUMN_WIDTH))
+    }
+    HLine()
+}
+
+@Composable
+private fun ColumnCaption(text: String, modifier: Modifier, align: TextAlign = TextAlign.Start) {
+    Txt(
+        labelUppercase(text),
+        color = Skerry.colors.faint,
+        size = 9.5.sp,
+        weight = FontWeight.SemiBold,
+        letterSpacing = 0.9.sp,
+        maxLines = 1,
+        align = align,
+        modifier = modifier,
+    )
 }
 
 /**
@@ -526,9 +608,10 @@ internal class RowRubberBand(
 }
 
 /**
- * Right-side row columns, each `null` when hidden/empty for this row: [permissions] (`ls -l`
- * style, remote pane only — the local okio source doesn't report mode bits), [modified] (mtime),
- * [size] (files only). Fixed widths keep the columns aligned across rows.
+ * Right-side row columns, each `null` when hidden/empty for this row: [size] (files carry a size,
+ * anything else the [NO_SIZE] dash), [modified] (mtime), [permissions] (`ls -l` style, remote pane
+ * only — the local okio source doesn't report mode bits). Fixed widths keep the columns aligned
+ * across rows; the order matches the captions in [ColumnHeaderRow].
  */
 internal data class FileRowColumns(
     val permissions: String? = null,
@@ -536,11 +619,23 @@ internal data class FileRowColumns(
     val size: String? = null,
 )
 
+/**
+ * Size cell of a row that has no size of its own (directory, symlink). Not translatable: an em
+ * dash is typography, not copy.
+ */
+internal const val NO_SIZE = "—"
+
 private val PERMISSIONS_COLUMN_WIDTH = 76.dp
 
 private val MODIFIED_COLUMN_WIDTH = 96.dp
 
 private val SIZE_COLUMN_WIDTH = 62.dp
+
+/** Width of the row's leading icon slot; the column captions indent by it to clear the icons. */
+private val ICON_SLOT_WIDTH = 27.dp
+
+/** Hairline between listing rows. */
+private val ROW_SEPARATOR_WIDTH = 1.dp
 
 @Composable
 internal fun LiveFileRow(
@@ -554,6 +649,9 @@ internal fun LiveFileRow(
     mono: FontFamily,
     onPress: () -> Unit,
     onDoubleClick: () -> Unit,
+    // A directory reads by its name colour, the way a file manager's listing does — the icon alone
+    // is too small to sort a long listing by eye.
+    directory: Boolean = false,
     // Data for held-RMB rubber-band (mc): the anchor row, controller, list state for translating the
     // cursor position to a row, and the current listing. null for the synthetic ".." row.
     rubberBand: RowRubberBand?,
@@ -562,18 +660,25 @@ internal fun LiveFileRow(
     val currentPress by rememberUpdatedState(onPress)
     val currentDouble by rememberUpdatedState(onDoubleClick)
     // Cursor (navigation position) and selection (marked files) are distinct in mc: the active pane's
-    // cursor is a bright bar, the inactive one's a border; selection is a highlight + bold name.
+    // cursor is a bright bar, the inactive one's a neutral one; selection is a highlight + bold name.
     val rowBg = when {
-        cursored && active -> Skerry.colors.cyan.copy(alpha = 0.22f)
+        cursored && active -> Skerry.colors.cyan20
+        cursored -> Skerry.colors.overlayMed
         selected -> Skerry.colors.cyan06
         else -> Color.Transparent
     }
+    val separator = ROW_SEPARATOR_WIDTH
+    val separatorColor = Skerry.colors.line
     Row(
         Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(5.dp))
             .background(rowBg)
-            .then(if (cursored && !active) Modifier.border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(5.dp)) else Modifier)
+            .drawBehind {
+                // Full-bleed hairline under every row: the listing reads as a table, and rounded
+                // rows over a table grid read as cards instead.
+                val y = size.height - separator.toPx() / 2
+                drawLine(separatorColor, Offset(0f, y), Offset(size.width, y), separator.toPx())
+            }
             // LMB: our own tap parsing in one loop — more reliable than detectTapGestures (which lost
             // double clicks to slop/timeouts). Each LMB press instantly places the cursor (currentPress);
             // two presses closer than DOUBLE_CLICK_MS are a double click (enter directory). Time comes
@@ -621,13 +726,16 @@ internal fun LiveFileRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Sym(icon, size = 17.sp, color = iconColor)
+        Box(Modifier.width(ICON_SLOT_WIDTH - 10.dp), contentAlignment = Alignment.Center) {
+            Sym(icon, size = 16.sp, color = iconColor)
+        }
         Txt(
             name,
             color = when {
                 name == ".." -> Skerry.colors.dim
                 selected -> Skerry.colors.cyanBright
-                else -> Skerry.colors.textBright
+                directory -> Skerry.colors.cyanBright
+                else -> Skerry.colors.text
             },
             size = 12.sp,
             font = mono,
@@ -636,8 +744,8 @@ internal fun LiveFileRow(
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
-        columns.permissions?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, modifier = Modifier.width(PERMISSIONS_COLUMN_WIDTH)) }
+        columns.size?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(SIZE_COLUMN_WIDTH)) }
         columns.modified?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(MODIFIED_COLUMN_WIDTH)) }
-        columns.size?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(SIZE_COLUMN_WIDTH)) }
+        columns.permissions?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, modifier = Modifier.width(PERMISSIONS_COLUMN_WIDTH)) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
@@ -6,17 +6,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.runtime.Composable
@@ -24,7 +19,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -39,19 +33,11 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.input.pointer.AwaitPointerEventScope
-import androidx.compose.ui.input.pointer.PointerEvent
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.isSecondaryPressed
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.files.FileItem
-import app.skerry.shared.files.FileItemType
 import app.skerry.ui.files.FKeyDef
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
@@ -67,133 +53,17 @@ import app.skerry.ui.generated.resources.ftail_fkey_quit
 import app.skerry.ui.generated.resources.ftail_fkey_refresh
 import app.skerry.ui.generated.resources.ftail_fkey_rename
 import app.skerry.ui.generated.resources.ftail_fkey_view
-import app.skerry.ui.generated.resources.sftp_col_modified
-import app.skerry.ui.generated.resources.sftp_col_permissions
-import app.skerry.ui.generated.resources.sftp_columns
 import app.skerry.ui.generated.resources.sftp_filter_hint
 import app.skerry.ui.generated.resources.sftp_error
 import app.skerry.ui.generated.resources.sftp_loading
-import app.skerry.ui.generated.resources.sftp_new_folder
-import app.skerry.ui.sftp.fileDateText
-import app.skerry.ui.sftp.humanSize
-import app.skerry.ui.sftp.permissionsText
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.ui.text.style.TextAlign
-import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
-import app.skerry.ui.design.labelUppercase
-import app.skerry.ui.app.LocalSftpPrefs
-import app.skerry.ui.app.SftpPrefs
 import app.skerry.ui.design.Sym
-import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
-import androidx.compose.foundation.layout.RowScope
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
 import app.skerry.ui.design.Badge
-import app.skerry.ui.terminal.WorkBar
-import app.skerry.ui.terminal.WorkBarLeading
-import app.skerry.ui.generated.resources.sftp_tip_back
-import app.skerry.ui.terminal.WorkBarLabel
-import app.skerry.ui.generated.resources.sftp_tip_refresh
-import app.skerry.ui.generated.resources.sftp_tip_filter
-import app.skerry.ui.generated.resources.sftp_tip_upload
-import app.skerry.ui.generated.resources.sftp_tip_download
-import app.skerry.ui.generated.resources.sftp_col_name
-import app.skerry.ui.generated.resources.sftp_col_size
-import app.skerry.ui.generated.resources.sftp_col_permissions_short
-
-/** Double-click threshold for a row (ms between two LMB presses → enter directory). */
-private const val DOUBLE_CLICK_MS = 350L
-
-/**
- * The bar above the SFTP work area — the same strip the terminal uses, so the two views read as one
- * window: the tab on the left ([label]), what can be done to it on the right ([actions]). The host
- * is never picked from here (the pane already holds a live connection), hence no picker.
- *
- * The leading chevron goes back to the terminal ([onBack], the same thing F10 does) rather than
- * toggling the hosts sidebar: this screen fills the whole work area and shows no sidebar, so the
- * toggle would move nothing on screen.
- */
-@Composable
-internal fun SftpWorkBar(
-    label: WorkBarLabel?,
-    onBack: () -> Unit,
-    actions: @Composable RowScope.() -> Unit,
-) {
-    WorkBar(
-        label = label,
-        tabKey = null,
-        leading = WorkBarLeading.back(Res.string.sftp_tip_back, onBack),
-        onPickHost = null,
-        actions = actions,
-    )
-}
-
-/**
- * The bar's action row: refresh both panes, create a directory, open the quick filter, choose the
- * listing columns, transfer the active pane's selection. Each one is an F-key of the bottom bar —
- * the bar names them, the icons are the reachable-by-mouse half of the same commands. The transfer
- * icon follows the active pane's direction: local active means the bytes go up, remote — down.
- */
-@Composable
-internal fun SftpWorkBarActions(
-    localActive: Boolean,
-    enabled: Boolean,
-    onRefresh: () -> Unit,
-    onNewFolder: () -> Unit,
-    onFilter: () -> Unit,
-    onTransfer: () -> Unit,
-) {
-    IconBtn("refresh", onClick = onRefresh, box = 26, tooltip = stringResource(Res.string.sftp_tip_refresh), enabled = enabled)
-    IconBtn("create_new_folder", onClick = onNewFolder, box = 26, tooltip = stringResource(Res.string.sftp_new_folder), enabled = enabled)
-    IconBtn("filter_alt", onClick = onFilter, box = 26, tooltip = stringResource(Res.string.sftp_tip_filter), enabled = enabled)
-    ColumnsMenu(LocalSftpPrefs.current)
-    IconBtn(
-        if (localActive) "upload" else "download",
-        onClick = onTransfer,
-        box = 26,
-        tooltip = stringResource(if (localActive) Res.string.sftp_tip_upload else Res.string.sftp_tip_download),
-        enabled = enabled,
-    )
-}
-
-/**
- * Listing column visibility popup ("view_column" in the header): toggles for the modified-date and
- * permissions columns. One setting for both panes (like show-hidden), persisted via [SftpPrefs].
- */
-@Composable
-private fun ColumnsMenu(prefs: SftpPrefs) {
-    var open by remember { mutableStateOf(false) }
-    AnchoredDropdown(
-        expanded = open,
-        onDismiss = { open = false },
-        trigger = { IconBtn("view_column", onClick = { open = !open }, box = 26, icon = 16.sp) },
-    ) { _ ->
-        Column(
-            Modifier
-                .width(220.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(Skerry.colors.surface2)
-                .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(8.dp))
-                .padding(horizontal = 12.dp, vertical = 10.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
-        ) {
-            Txt(
-                labelUppercase(stringResource(Res.string.sftp_columns)),
-                color = Skerry.colors.faint,
-                size = 10.sp,
-                weight = FontWeight.SemiBold,
-                letterSpacing = 0.5.sp,
-            )
-            ToggleRow(stringResource(Res.string.sftp_col_modified), prefs.showModified, onToggle = { prefs.setShowModified(!prefs.showModified) })
-            ToggleRow(stringResource(Res.string.sftp_col_permissions), prefs.showPermissions, onToggle = { prefs.setShowPermissions(!prefs.showPermissions) })
-        }
-    }
-}
 
 /**
  * Target of the active pane's batch F-operations: if nothing is marked — select the cursored row (mc
@@ -450,302 +320,5 @@ private fun PathField(
                 .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(6.dp))
                 .padding(horizontal = 8.dp, vertical = 4.dp),
         ) { inner() }
-    }
-}
-
-@Composable
-private fun LivePaneList(
-    pane: FilePaneController,
-    entries: List<FileItem>,
-    mono: FontFamily,
-    listState: LazyListState,
-    active: Boolean,
-    onActivate: () -> Unit,
-) {
-    val prefs = LocalSftpPrefs.current
-    // The optional columns are fixed-width and the row has no horizontal scroll: on a narrow pane
-    // (small window, 50/50 split) they'd push past the pane edge while the weighted name shrinks
-    // to nothing. Below these widths the optional columns yield — permissions first, then the date.
-    BoxWithConstraints(Modifier.fillMaxSize()) {
-        // The permissions slot also needs data to exist for this pane at all (the local okio
-        // source reports no mode bits) — otherwise it would be a dead 76dp on every local row.
-        val showPermissions = prefs.showPermissions && maxWidth >= 460.dp && entries.any { it.permissions != null }
-        val showModified = prefs.showModified && maxWidth >= 360.dp
-        Column(Modifier.fillMaxSize()) {
-            ColumnHeaderRow(showModified = showModified, showPermissions = showPermissions)
-            LazyColumn(Modifier.fillMaxSize(), state = listState) {
-                if (pane.path != "/") {
-                    item(key = "..") {
-                        LiveFileRow(
-                            "arrow_upward", Skerry.colors.faint, "..",
-                            // The parent row has nothing to report in any column, but takes the
-                            // same slots the entries take — otherwise its dash drifts right,
-                            // under whichever column happens to be last.
-                            columns = FileRowColumns(
-                                permissions = if (showPermissions) "" else null,
-                                modified = if (showModified) "" else null,
-                                size = NO_SIZE,
-                            ),
-                            selected = false, cursored = pane.cursorOnParent, active = active, mono = mono,
-                            // A single click only puts the cursor on ".."; going up is a double click (like entering a directory).
-                            onPress = { onActivate(); pane.setCursorOnParent() },
-                            onDoubleClick = { onActivate(); pane.goUp() },
-                            rubberBand = null, // the ".." row can't be marked — no rubber-band needed on it
-                        )
-                    }
-                }
-                items(entries, key = { it.path }) { entry ->
-                    // Single click (on press): activate the pane and place the cursor — doesn't mark or enter.
-                    // Entering a directory is a double click (open; no-op for a file). Selection — RMB/Space/Insert.
-                    val onPress = {
-                        onActivate()
-                        pane.setCursor(entry)
-                    }
-                    val onDoubleClick = {
-                        onActivate()
-                        pane.setCursor(entry)
-                        pane.open(entry)
-                    }
-                    LiveFileRow(
-                        icon = sftpFileIcon(entry.name, entry.type),
-                        iconColor = if (entry.type == FileItemType.Directory) Skerry.colors.cyanBright else Skerry.colors.faint,
-                        name = entry.name,
-                        directory = entry.type == FileItemType.Directory,
-                        // An enabled column always occupies its fixed-width slot — an empty value
-                        // renders as a blank slot, otherwise rows with a missing value (a directory's
-                        // size, an unreported mtime) would let the remaining columns drift right and
-                        // break the vertical alignment.
-                        columns = FileRowColumns(
-                            permissions = if (showPermissions) permissionsText(entry.type, entry.permissions).orEmpty() else null,
-                            modified = if (showModified) fileDateText(entry.modifiedEpochSeconds) else null,
-                            size = if (entry.type == FileItemType.File) humanSize(entry.size) else NO_SIZE,
-                        ),
-                        selected = entry.path in pane.selection,
-                        cursored = entry.path == pane.cursor,
-                        active = active,
-                        mono = mono,
-                        onPress = onPress,
-                        onDoubleClick = onDoubleClick,
-                        rubberBand = RowRubberBand(entry, pane, listState, entries, onActivate),
-                    )
-                }
-            }
-        }
-    }
-}
-
-/**
- * Column captions above a pane's listing (NAME / SIZE / MODIFIED / PERMS). Fixed, not part of the
- * scrolled list: the listing is read by column, and a header that scrolls away leaves the numbers
- * unnamed. Slot widths mirror [LiveFileRow]'s, so captions stay over their values.
- */
-@Composable
-private fun ColumnHeaderRow(showModified: Boolean, showPermissions: Boolean) {
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .background(Skerry.colors.overlayFaint)
-            .padding(horizontal = 10.dp, vertical = 5.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        ColumnCaption(stringResource(Res.string.sftp_col_name), Modifier.padding(start = ICON_SLOT_WIDTH).weight(1f))
-        ColumnCaption(stringResource(Res.string.sftp_col_size), Modifier.width(SIZE_COLUMN_WIDTH), TextAlign.End)
-        if (showModified) ColumnCaption(stringResource(Res.string.sftp_col_modified), Modifier.width(MODIFIED_COLUMN_WIDTH), TextAlign.End)
-        if (showPermissions) ColumnCaption(stringResource(Res.string.sftp_col_permissions_short), Modifier.width(PERMISSIONS_COLUMN_WIDTH))
-    }
-    HLine()
-}
-
-@Composable
-private fun ColumnCaption(text: String, modifier: Modifier, align: TextAlign = TextAlign.Start) {
-    Txt(
-        labelUppercase(text),
-        color = Skerry.colors.faint,
-        size = 9.5.sp,
-        weight = FontWeight.SemiBold,
-        letterSpacing = 0.9.sp,
-        maxLines = 1,
-        align = align,
-        modifier = modifier,
-    )
-}
-
-/**
- * Row rubber-band gesture (mc-style selection with held RMB). A press paints [entry] (toggle by its
- * current state), dragging down/up paints the whole range with the same sign. The mouse cursor captured
- * by the pressed row is translated into list coordinates via the row offset in [listState], then the row
- * under it is found in [listState] and painted up to it. No scroll on edge drag (the right button doesn't
- * scroll the list) — offsets are stable for the whole gesture.
- */
-internal class RowRubberBand(
-    val entry: FileItem,
-    val pane: FilePaneController,
-    val listState: LazyListState,
-    val entries: List<FileItem>,
-    val onActivate: () -> Unit,
-) {
-    // Member-extension on the restricted-scope AwaitPointerEventScope — else awaitPointerEvent() can't be called.
-    suspend fun AwaitPointerEventScope.dragSelect(press: PointerEvent) {
-        onActivate() // painting in this pane — make it active (F-keys go here)
-        // Fix the sign by the pressed row: not marked → paint, marked → clear.
-        val select = entry.path !in pane.selection
-        pane.rubberBandTo(entry, entry, select)
-        press.changes.forEach { it.consume() }
-        val anchorOffset = listState.layoutInfo.visibleItemsInfo
-            .firstOrNull { it.key == entry.path }?.offset ?: 0
-        while (true) {
-            val drag = awaitPointerEvent()
-            if (!drag.buttons.isSecondaryPressed) break // RMB released — end of gesture
-            val listY = anchorOffset + drag.changes.first().position.y
-            val key = listState.layoutInfo.visibleItemsInfo
-                .firstOrNull { listY >= it.offset && listY < it.offset + it.size }?.key as? String
-            key?.let { k -> entries.firstOrNull { it.path == k } }
-                ?.let { target -> pane.rubberBandTo(entry, target, select) }
-            drag.changes.forEach { it.consume() }
-        }
-    }
-}
-
-/**
- * Right-side row columns, each `null` when hidden/empty for this row: [size] (files carry a size,
- * anything else the [NO_SIZE] dash), [modified] (mtime), [permissions] (`ls -l` style, remote pane
- * only — the local okio source doesn't report mode bits). Fixed widths keep the columns aligned
- * across rows; the order matches the captions in [ColumnHeaderRow].
- */
-internal data class FileRowColumns(
-    val permissions: String? = null,
-    val modified: String? = null,
-    val size: String? = null,
-)
-
-/**
- * Size cell of a row that has no size of its own (directory, symlink). Not translatable: an em
- * dash is typography, not copy.
- */
-internal const val NO_SIZE = "—"
-
-private val PERMISSIONS_COLUMN_WIDTH = 76.dp
-
-private val MODIFIED_COLUMN_WIDTH = 96.dp
-
-private val SIZE_COLUMN_WIDTH = 62.dp
-
-/** Width of the row's leading icon slot; the column captions indent by it to clear the icons. */
-private val ICON_SLOT_WIDTH = 27.dp
-
-/** Hairline between listing rows. */
-private val ROW_SEPARATOR_WIDTH = 1.dp
-
-@Composable
-internal fun LiveFileRow(
-    icon: String,
-    iconColor: Color,
-    name: String,
-    columns: FileRowColumns,
-    selected: Boolean,
-    cursored: Boolean,
-    active: Boolean,
-    mono: FontFamily,
-    onPress: () -> Unit,
-    onDoubleClick: () -> Unit,
-    // A directory reads by its name colour, the way a file manager's listing does — the icon alone
-    // is too small to sort a long listing by eye.
-    directory: Boolean = false,
-    // Data for held-RMB rubber-band (mc): the anchor row, controller, list state for translating the
-    // cursor position to a row, and the current listing. null for the synthetic ".." row.
-    rubberBand: RowRubberBand?,
-) {
-    // Latest callbacks without restarting the gesture (pointerInput is keyed on Unit — it lives the row's whole life).
-    val currentPress by rememberUpdatedState(onPress)
-    val currentDouble by rememberUpdatedState(onDoubleClick)
-    // Cursor (navigation position) and selection (marked files) are distinct in mc: the active pane's
-    // cursor is a bright bar, the inactive one's a neutral one; selection is a highlight + bold name.
-    val rowBg = when {
-        cursored && active -> Skerry.colors.cyan20
-        cursored -> Skerry.colors.overlayMed
-        selected -> Skerry.colors.cyan06
-        else -> Color.Transparent
-    }
-    val separator = ROW_SEPARATOR_WIDTH
-    val separatorColor = Skerry.colors.line
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .background(rowBg)
-            .drawBehind {
-                // Full-bleed hairline under every row: the listing reads as a table, and rounded
-                // rows over a table grid read as cards instead.
-                val y = size.height - separator.toPx() / 2
-                drawLine(separatorColor, Offset(0f, y), Offset(size.width, y), separator.toPx())
-            }
-            // LMB: our own tap parsing in one loop — more reliable than detectTapGestures (which lost
-            // double clicks to slop/timeouts). Each LMB press instantly places the cursor (currentPress);
-            // two presses closer than DOUBLE_CLICK_MS are a double click (enter directory). Time comes
-            // from the event itself (uptimeMillis) — deterministic. RMB is skipped (rubber-band below handles it).
-            .pointerInput(Unit) {
-                var lastDownMs = 0L
-                awaitPointerEventScope {
-                    while (true) {
-                        val e = awaitPointerEvent()
-                        if (e.type != PointerEventType.Press || e.buttons.isSecondaryPressed) continue
-                        val t = e.changes.first().uptimeMillis
-                        currentPress()
-                        if (t - lastDownMs <= DOUBLE_CLICK_MS) {
-                            currentDouble()
-                            lastDownMs = 0L // reset so a triple click doesn't give a second enter
-                        } else {
-                            lastDownMs = t
-                        }
-                    }
-                }
-            }
-            // RMB (mc): a press paints the row (toggle by sign), dragging down/up paints the range with
-            // the same sign — rubber-band. It runs after the tap detector (inner) and consumes the right
-            // button in the Main pass earlier — so detectTapGestures (requireUnconsumed) ignores it, while
-            // LMB is untouched (no consume) and reaches the tap detector.
-            .then(
-                if (rubberBand != null) {
-                    // Key — anchor+listing (stable during a drag: a selection change doesn't touch them,
-                    // so the gesture isn't restarted mid rubber-band).
-                    Modifier.pointerInput(rubberBand.entry, rubberBand.entries) {
-                        awaitPointerEventScope {
-                            while (true) {
-                                val press = awaitPointerEvent()
-                                if (press.type != PointerEventType.Press) continue
-                                if (!press.buttons.isSecondaryPressed) continue
-                                with(rubberBand) { dragSelect(press) }
-                            }
-                        }
-                    }
-                } else {
-                    Modifier
-                },
-            )
-            .padding(horizontal = 10.dp, vertical = 6.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(Modifier.width(ICON_SLOT_WIDTH - 10.dp), contentAlignment = Alignment.Center) {
-            Sym(icon, size = 16.sp, color = iconColor)
-        }
-        Txt(
-            name,
-            color = when {
-                name == ".." -> Skerry.colors.dim
-                selected -> Skerry.colors.cyanBright
-                directory -> Skerry.colors.cyanBright
-                else -> Skerry.colors.text
-            },
-            size = 12.sp,
-            font = mono,
-            weight = if (selected) FontWeight.Bold else FontWeight.Normal,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        columns.size?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(SIZE_COLUMN_WIDTH)) }
-        columns.modified?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, align = TextAlign.End, modifier = Modifier.width(MODIFIED_COLUMN_WIDTH)) }
-        columns.permissions?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp, font = mono, maxLines = 1, modifier = Modifier.width(PERMISSIONS_COLUMN_WIDTH)) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -43,14 +43,12 @@ import app.skerry.ui.files.FKeyBar
 import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.TransferCoordinator
-import app.skerry.ui.files.TransferState
 import app.skerry.ui.files.platformLocalBrowser
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_open_failed
 import app.skerry.ui.generated.resources.ftail_transfer_counter
-import app.skerry.ui.generated.resources.ftail_transfer_progress
 import app.skerry.ui.generated.resources.sftp_create
 import app.skerry.ui.generated.resources.sftp_overwrite
 import app.skerry.ui.generated.resources.sftp_overwrite_many
@@ -61,8 +59,6 @@ import app.skerry.ui.generated.resources.sftp_opening
 import app.skerry.ui.generated.resources.sftp_pane_local
 import app.skerry.ui.generated.resources.sftp_pane_remote
 import app.skerry.ui.generated.resources.sftp_rename
-import app.skerry.ui.generated.resources.sftp_title
-import app.skerry.ui.generated.resources.sftp_transfer_error
 import app.skerry.ui.generated.resources.sftp_unavailable
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.sftp.TransferDirection
@@ -81,6 +77,18 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.theme.Skerry
+import app.skerry.ui.session.SessionStatus
+import app.skerry.ui.terminal.WorkBarLabel
+import app.skerry.ui.generated.resources.sftp_wbar_subtitle
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.key
+import app.skerry.ui.files.TransferEntry
+import app.skerry.ui.files.TransferStatus
+import app.skerry.ui.generated.resources.sftp_queue_done
+import app.skerry.ui.generated.resources.sftp_queue_progress
+import app.skerry.ui.generated.resources.sftp_queue_speed
+import app.skerry.ui.generated.resources.sftp_meta_joined
 
 /**
  * SFTP view (two-pane, Total Commander style): header + Local pane (local FS) + Remote pane (host) +
@@ -98,26 +106,14 @@ fun SftpView() {
         sessions == null -> MockSftpView(mono)
         active != null && active.controller.uiState is ConnectionUiState.Connected ->
             LiveSftpView(
-                active.controller,
-                active.subtitle,
-                mono,
+                controller = active.controller,
+                hostLabel = active.subtitle,
+                hostName = active.title,
+                status = active.status,
+                mono = mono,
                 onQuit = { sessions.setActiveView(SessionView.Terminal) },
             )
-        else -> NoSessionSftpView(mono)
-    }
-}
-
-/** View top bar: icon + "File transfer" + session subtitle. */
-@Composable
-internal fun SftpTopBar(subtitle: String, mono: FontFamily) {
-    Row(
-        Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(horizontal = 18.dp, vertical = 9.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Sym("drive_file_move", size = 18.sp, color = Skerry.colors.cyanBright)
-        Txt(stringResource(Res.string.sftp_title), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.SemiBold)
-        Txt(subtitle, color = Skerry.colors.faint, size = 11.5.sp, font = mono)
+        else -> NoSessionSftpView(onBack = { sessions.setActiveView(SessionView.Terminal) })
     }
 }
 
@@ -126,13 +122,16 @@ internal fun SftpTopBar(subtitle: String, mono: FontFamily) {
 /**
  * Live two-pane SFTP over the session's cached [TransferCoordinator]. The coordinator is opened once
  * ([ConnectionController.openTransferCoordinator]) and lives on the session scope — switching views
- * doesn't reset the panes' path/selection, `disconnect()` closes the channel. [subtitle] is the remote
- * pane's label.
+ * doesn't reset the panes' path/selection, `disconnect()` closes the channel. [hostLabel] is the
+ * session's address (it names the remote browser); [hostName] is the host's catalog name, which
+ * titles the bar and badges the remote pane.
  */
 @Composable
 private fun LiveSftpView(
     controller: ConnectionController,
-    subtitle: String,
+    hostLabel: String,
+    hostName: String,
+    status: SessionStatus,
     mono: FontFamily,
     onQuit: () -> Unit,
 ) {
@@ -173,7 +172,7 @@ private fun LiveSftpView(
     LaunchedEffect(controller) {
         openError = null
         try {
-            coord = controller.openTransferCoordinator(platformLocalBrowser(), subtitle)
+            coord = controller.openTransferCoordinator(platformLocalBrowser(), hostLabel)
         } catch (e: CancellationException) {
             throw e
         } catch (_: Exception) {
@@ -289,26 +288,36 @@ private fun LiveSftpView(
             }
             .focusable(),
     ) {
-        // The panel's header is hidden while the editor is open: the editor brings its own, and two
-        // stacked bars over one file — the upper one offering Upload/New folder that do nothing
-        // there — are noise.
-        if (editor == null) {
-            LivePaneHeader(
-                subtitle = subtitle,
-                mono = mono,
-                onUpload = {
-                    val coord = c
-                    if (coord != null) {
-                        if (coord.local.selection.isNotEmpty()) {
-                            coord.uploadSelection()
-                        } else {
+        // The bar's actions are the panel's own (refresh/mkdir/filter/columns/transfer) and mean
+        // nothing over an open file — the editor brings its own header and key bar, so the bar
+        // keeps only the title while it is up.
+        SftpWorkBar(
+            onBack = onQuit,
+            label = WorkBarLabel.Solo(
+                hostName,
+                stringResource(Res.string.sftp_wbar_subtitle, c?.remote?.path.orEmpty()),
+                status,
+            ),
+        ) {
+            if (editor == null) {
+                SftpWorkBarActions(
+                    localActive = active == ActivePane.Local,
+                    enabled = c != null,
+                    onRefresh = { fKey(9) },
+                    onNewFolder = { fKey(7) },
+                    onFilter = { if (active == ActivePane.Local) localFilterTick++ else remoteFilterTick++ },
+                    onTransfer = {
+                        val coord = c
+                        // Nothing marked on the local side and no cursor to fall back on: the
+                        // native picker is the way in, the way the old Upload button worked.
+                        if (coord != null && active == ActivePane.Local && coord.local.hasNoOperand()) {
                             uiScope.launch { pickUploadSource()?.let { coord.uploadSource(it) } }
+                        } else {
+                            fKey(5)
                         }
-                    }
-                },
-                onNewFolder = { if (c != null) creatingFolder = true },
-            )
-            HLine()
+                    },
+                )
+            }
         }
         val openEditor = editor
         when {
@@ -328,7 +337,8 @@ private fun LiveSftpView(
             else -> {
                 Row(Modifier.weight(1f).fillMaxWidth()) {
                     LivePane(
-                        c.local, "computer", Skerry.colors.dim, stringResource(Res.string.sftp_pane_local), mono,
+                        c.local, "computer", Skerry.colors.dim,
+                        badge = stringResource(Res.string.sftp_pane_local), badgeAccent = false, mono = mono,
                         listState = localList,
                         active = active == ActivePane.Local,
                         onActivate = { active = ActivePane.Local; focus.requestFocus() },
@@ -341,7 +351,8 @@ private fun LiveSftpView(
                     )
                     VLine(Skerry.colors.line)
                     LivePane(
-                        c.remote, "dns", Skerry.colors.moss, stringResource(Res.string.sftp_pane_remote), mono,
+                        c.remote, "dns", Skerry.colors.moss,
+                        badge = hostName, badgeAccent = true, mono = mono,
                         listState = remoteList,
                         active = active == ActivePane.Remote,
                         onActivate = { active = ActivePane.Remote; focus.requestFocus() },
@@ -353,7 +364,7 @@ private fun LiveSftpView(
                         modifier = Modifier.weight(1f),
                     )
                 }
-                LiveTransferStrip(c.transfer, mono, onDismiss = c::clearTransfer)
+                TransferQueueStrip(c.queue, mono, onDismiss = c::dismissTransfer)
             }
         }
         // The editor brings its own key bar (Save/Edit/Search/Quit) — the panel's would be a legend
@@ -473,62 +484,104 @@ private fun LiveSftpView(
 /** Which of the two panes is active (receives the keyboard and cursor highlight). */
 private enum class ActivePane { Local, Remote }
 
-/** Transfer progress bar: active (bar + counter), error (with a close), or nothing when Idle. */
+/**
+ * Transfer queue under the panes: one row per operation — what is moving now, and the last few
+ * that finished, so the outcome of a transfer is still readable after it ends. Empty queue, no
+ * strip. [onDismiss] drops a finished row by its id.
+ */
 @Composable
-private fun LiveTransferStrip(transfer: TransferState, mono: FontFamily, onDismiss: () -> Unit) {
-    when (transfer) {
-        TransferState.Idle -> Unit
-
-        is TransferState.Active -> {
-            HLine()
-            Row(
-                Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(horizontal = 16.dp, vertical = 10.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                val up = transfer.direction == TransferDirection.Upload
-                Sym(if (up) "upload" else "download", size = 16.sp, color = Skerry.colors.cyan)
-                val title = if (transfer.fileCount > 1) {
-                    stringResource(Res.string.ftail_transfer_counter, transfer.name, transfer.fileIndex, transfer.fileCount)
-                } else {
-                    transfer.name
-                }
-                Txt(title, color = Skerry.colors.textBright, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
-                val fraction = if (transfer.total > 0) transfer.transferred.toFloat() / transfer.total else 0f
-                MeterBar(fraction, Skerry.colors.cyan, Modifier.weight(1f))
-                val tail = if (transfer.total > 0) {
-                    stringResource(Res.string.ftail_transfer_progress, humanSize(transfer.transferred), humanSize(transfer.total))
-                } else {
-                    humanSize(transfer.transferred)
-                }
-                Txt(tail, color = Skerry.colors.dim, size = 11.sp, font = mono)
-            }
-        }
-
-        is TransferState.Failed -> {
-            HLine()
-            Row(
-                Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(start = 16.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-            ) {
-                Sym("error", size = 16.sp, color = Skerry.colors.sunset)
-                Txt(
-                    stringResource(
-                        Res.string.sftp_transfer_error,
-                        transfer.name.ifBlank { stringResource(Res.string.ftail_file_fallback) },
-                        transferFailureText(transfer.failure),
-                    ),
-                    color = Skerry.colors.sunset,
-                    size = 11.5.sp,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f),
-                )
-                IconBtn("close", onClick = onDismiss, box = 26, icon = 16.sp)
-            }
-        }
+private fun TransferQueueStrip(queue: List<TransferEntry>, mono: FontFamily, onDismiss: (Long) -> Unit) {
+    if (queue.isEmpty()) return
+    HLine()
+    Column(
+        Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        queue.forEach { entry -> key(entry.id) { TransferQueueRow(entry, mono, onDismiss) } }
     }
+}
+
+/** Name column of a queue row — wide enough for a release archive, fixed so the bars line up. */
+private val QUEUE_NAME_WIDTH = 180.dp
+
+@Composable
+private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: (Long) -> Unit) {
+    val done = entry.status == TransferStatus.Done
+    val failed = entry.status as? TransferStatus.Failed
+    val active = entry.status == TransferStatus.Active
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val up = entry.direction == TransferDirection.Upload
+        Sym(
+            if (failed != null) "error" else if (up) "upload" else "download",
+            size = 15.sp,
+            color = when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.teal
+            },
+        )
+        val title = if (entry.fileCount > 1) {
+            stringResource(Res.string.ftail_transfer_counter, entry.name, entry.fileIndex, entry.fileCount)
+        } else {
+            entry.name.ifBlank { stringResource(Res.string.ftail_file_fallback) }
+        }
+        Txt(
+            title,
+            color = if (active) Skerry.colors.textBright else Skerry.colors.dim,
+            size = 11.5.sp,
+            font = mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.width(QUEUE_NAME_WIDTH),
+        )
+        val percent = transferPercent(entry.transferred, entry.total)
+        MeterBar(
+            if (done) 1f else (percent ?: 0) / 100f,
+            when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.cyan
+            },
+            Modifier.weight(1f),
+        )
+        Txt(
+            transferTailText(entry),
+            color = when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.dim
+            },
+            size = 11.sp,
+            font = mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        // A finished row is the user's to clear; a running one has nothing to dismiss yet.
+        if (active) Box(Modifier.size(22.dp)) else IconBtn("close", onClick = { onDismiss(entry.id) }, box = 22, icon = 14.sp)
+    }
+}
+
+/** Right-hand text of a queue row: the failure, "done", or percent · bytes · speed while running. */
+@Composable
+private fun transferTailText(entry: TransferEntry): String {
+    (entry.status as? TransferStatus.Failed)?.let { return transferFailureText(it.failure) }
+    if (entry.status == TransferStatus.Done) return stringResource(Res.string.sftp_queue_done)
+    val speed = transferSpeed(entry.bytesDone, entry.elapsedMillis)
+    val speedText = speed?.let { stringResource(Res.string.sftp_queue_speed, humanSize(it)) }
+    val percent = transferPercent(entry.transferred, entry.total)
+    // Without a reported size there is no percentage and no "of": what is left is how much has
+    // moved so far, and how fast.
+    val progress = if (percent != null) {
+        stringResource(Res.string.sftp_queue_progress, percent, humanSize(entry.transferred), humanSize(entry.total))
+    } else {
+        humanSize(entry.transferred)
+    }
+    return if (speedText != null) stringResource(Res.string.sftp_meta_joined, progress, speedText) else progress
 }
 
 // Dialogs.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,7 +29,6 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.files.FileItem
@@ -44,11 +41,8 @@ import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.files.platformLocalBrowser
-import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_open_failed
-import app.skerry.ui.generated.resources.ftail_transfer_counter
 import app.skerry.ui.generated.resources.sftp_create
 import app.skerry.ui.generated.resources.sftp_overwrite
 import app.skerry.ui.generated.resources.sftp_overwrite_many
@@ -61,18 +55,14 @@ import app.skerry.ui.generated.resources.sftp_pane_remote
 import app.skerry.ui.generated.resources.sftp_rename
 import app.skerry.ui.generated.resources.sftp_unavailable
 import app.skerry.ui.session.SessionView
-import app.skerry.ui.sftp.TransferDirection
-import app.skerry.ui.sftp.humanSize
 import app.skerry.ui.sftp.pickUploadSource
 import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 import app.skerry.ui.design.HLine
-import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSftpPrefs
-import app.skerry.ui.design.MeterBar
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
@@ -80,15 +70,6 @@ import app.skerry.ui.theme.Skerry
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.terminal.WorkBarLabel
 import app.skerry.ui.generated.resources.sftp_wbar_subtitle
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.runtime.key
-import app.skerry.ui.files.TransferEntry
-import app.skerry.ui.files.TransferStatus
-import app.skerry.ui.generated.resources.sftp_queue_done
-import app.skerry.ui.generated.resources.sftp_queue_progress
-import app.skerry.ui.generated.resources.sftp_queue_speed
-import app.skerry.ui.generated.resources.sftp_meta_joined
 
 /**
  * SFTP view (two-pane, Total Commander style): header + Local pane (local FS) + Remote pane (host) +
@@ -293,9 +274,12 @@ private fun LiveSftpView(
         // keeps only the title while it is up.
         SftpWorkBar(
             onBack = onQuit,
+            // Until the coordinator opens (or when it failed to) there is no remote path to name,
+            // and "SFTP ·" with nothing after it reads as a truncated title — the session's own
+            // address stands in.
             label = WorkBarLabel.Solo(
                 hostName,
-                stringResource(Res.string.sftp_wbar_subtitle, c?.remote?.path.orEmpty()),
+                c?.remote?.path?.let { stringResource(Res.string.sftp_wbar_subtitle, it) } ?: hostLabel,
                 status,
             ),
         ) {
@@ -475,116 +459,8 @@ private fun LiveSftpView(
     }
 }
 
-/**
- * A live listing row (icon + name + size, no ⋮). Left-click just places the cursor (doesn't mark or
- * enter a directory) — responds instantly on press ([onPress]) so there's no double-click recognition
- * delay. A double click enters the directory ([onDoubleClick]). Selection — RMB press/drag (rubber-band,
- * [RowRubberBand]) or Space/Insert. No context menu: actions go through the bottom F-key bar.
- */
 /** Which of the two panes is active (receives the keyboard and cursor highlight). */
 private enum class ActivePane { Local, Remote }
-
-/**
- * Transfer queue under the panes: one row per operation — what is moving now, and the last few
- * that finished, so the outcome of a transfer is still readable after it ends. Empty queue, no
- * strip. [onDismiss] drops a finished row by its id.
- */
-@Composable
-private fun TransferQueueStrip(queue: List<TransferEntry>, mono: FontFamily, onDismiss: (Long) -> Unit) {
-    if (queue.isEmpty()) return
-    HLine()
-    Column(
-        Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 12.dp, vertical = 6.dp),
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        queue.forEach { entry -> key(entry.id) { TransferQueueRow(entry, mono, onDismiss) } }
-    }
-}
-
-/** Name column of a queue row — wide enough for a release archive, fixed so the bars line up. */
-private val QUEUE_NAME_WIDTH = 180.dp
-
-@Composable
-private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: (Long) -> Unit) {
-    val done = entry.status == TransferStatus.Done
-    val failed = entry.status as? TransferStatus.Failed
-    val active = entry.status == TransferStatus.Active
-    Row(
-        Modifier.fillMaxWidth().padding(vertical = 2.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        val up = entry.direction == TransferDirection.Upload
-        Sym(
-            if (failed != null) "error" else if (up) "upload" else "download",
-            size = 15.sp,
-            color = when {
-                failed != null -> Skerry.colors.sunset
-                done -> Skerry.colors.moss
-                else -> Skerry.colors.teal
-            },
-        )
-        val title = if (entry.fileCount > 1) {
-            stringResource(Res.string.ftail_transfer_counter, entry.name, entry.fileIndex, entry.fileCount)
-        } else {
-            entry.name.ifBlank { stringResource(Res.string.ftail_file_fallback) }
-        }
-        Txt(
-            title,
-            color = if (active) Skerry.colors.textBright else Skerry.colors.dim,
-            size = 11.5.sp,
-            font = mono,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.width(QUEUE_NAME_WIDTH),
-        )
-        val percent = transferPercent(entry.transferred, entry.total)
-        MeterBar(
-            if (done) 1f else (percent ?: 0) / 100f,
-            when {
-                failed != null -> Skerry.colors.sunset
-                done -> Skerry.colors.moss
-                else -> Skerry.colors.cyan
-            },
-            Modifier.weight(1f),
-        )
-        Txt(
-            transferTailText(entry),
-            color = when {
-                failed != null -> Skerry.colors.sunset
-                done -> Skerry.colors.moss
-                else -> Skerry.colors.dim
-            },
-            size = 11.sp,
-            font = mono,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
-        // A finished row is the user's to clear; a running one has nothing to dismiss yet.
-        if (active) Box(Modifier.size(22.dp)) else IconBtn("close", onClick = { onDismiss(entry.id) }, box = 22, icon = 14.sp)
-    }
-}
-
-/** Right-hand text of a queue row: the failure, "done", or percent · bytes · speed while running. */
-@Composable
-private fun transferTailText(entry: TransferEntry): String {
-    (entry.status as? TransferStatus.Failed)?.let { return transferFailureText(it.failure) }
-    if (entry.status == TransferStatus.Done) return stringResource(Res.string.sftp_queue_done)
-    val speed = transferSpeed(entry.bytesDone, entry.elapsedMillis)
-    val speedText = speed?.let { stringResource(Res.string.sftp_queue_speed, humanSize(it)) }
-    val percent = transferPercent(entry.transferred, entry.total)
-    // Without a reported size there is no percentage and no "of": what is left is how much has
-    // moved so far, and how fast.
-    val progress = if (percent != null) {
-        stringResource(Res.string.sftp_queue_progress, percent, humanSize(entry.transferred), humanSize(entry.total))
-    } else {
-        humanSize(entry.transferred)
-    }
-    return if (speedText != null) stringResource(Res.string.sftp_meta_joined, progress, speedText) else progress
-}
-
-// Dialogs.
 
 /** Centered notice in the listing area (opening/error/no session). */
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpWorkBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpWorkBar.kt
@@ -1,0 +1,128 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalSftpPrefs
+import app.skerry.ui.app.SftpPrefs
+import app.skerry.ui.design.AnchoredDropdown
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.ToggleRow
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_col_modified
+import app.skerry.ui.generated.resources.sftp_col_permissions
+import app.skerry.ui.generated.resources.sftp_columns
+import app.skerry.ui.generated.resources.sftp_new_folder
+import app.skerry.ui.generated.resources.sftp_tip_back
+import app.skerry.ui.generated.resources.sftp_tip_download
+import app.skerry.ui.generated.resources.sftp_tip_filter
+import app.skerry.ui.generated.resources.sftp_tip_refresh
+import app.skerry.ui.generated.resources.sftp_tip_upload
+import app.skerry.ui.terminal.WorkBar
+import app.skerry.ui.terminal.WorkBarLabel
+import app.skerry.ui.terminal.WorkBarLeading
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The bar above the SFTP work area — the same strip the terminal uses, so the two views read as one
+ * window: the tab on the left ([label]), what can be done to it on the right ([actions]). The host
+ * is never picked from here (the pane already holds a live connection), hence no picker.
+ *
+ * The leading chevron goes back to the terminal ([onBack], the same thing F10 does) rather than
+ * toggling the hosts sidebar: this screen fills the whole work area and shows no sidebar, so the
+ * toggle would move nothing on screen.
+ */
+@Composable
+internal fun SftpWorkBar(
+    label: WorkBarLabel?,
+    onBack: () -> Unit,
+    actions: @Composable RowScope.() -> Unit,
+) {
+    WorkBar(
+        label = label,
+        tabKey = null,
+        leading = WorkBarLeading.back(Res.string.sftp_tip_back, onBack),
+        onPickHost = null,
+        actions = actions,
+    )
+}
+
+/**
+ * The bar's action row: refresh both panes, create a directory, open the quick filter, choose the
+ * listing columns, transfer the active pane's selection. Each one is an F-key of the bottom bar —
+ * the bar names them, the icons are the reachable-by-mouse half of the same commands. The transfer
+ * icon follows the active pane's direction: local active means the bytes go up, remote — down.
+ */
+@Composable
+internal fun SftpWorkBarActions(
+    localActive: Boolean,
+    enabled: Boolean,
+    onRefresh: () -> Unit,
+    onNewFolder: () -> Unit,
+    onFilter: () -> Unit,
+    onTransfer: () -> Unit,
+) {
+    IconBtn("refresh", onClick = onRefresh, box = 26, tooltip = stringResource(Res.string.sftp_tip_refresh), enabled = enabled)
+    IconBtn("create_new_folder", onClick = onNewFolder, box = 26, tooltip = stringResource(Res.string.sftp_new_folder), enabled = enabled)
+    IconBtn("filter_alt", onClick = onFilter, box = 26, tooltip = stringResource(Res.string.sftp_tip_filter), enabled = enabled)
+    ColumnsMenu(LocalSftpPrefs.current)
+    IconBtn(
+        if (localActive) "upload" else "download",
+        onClick = onTransfer,
+        box = 26,
+        tooltip = stringResource(if (localActive) Res.string.sftp_tip_upload else Res.string.sftp_tip_download),
+        enabled = enabled,
+    )
+}
+
+/**
+ * Listing column visibility popup ("view_column" in the header): toggles for the modified-date and
+ * permissions columns. One setting for both panes (like show-hidden), persisted via [SftpPrefs].
+ */
+@Composable
+private fun ColumnsMenu(prefs: SftpPrefs) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = { IconBtn("view_column", onClick = { open = !open }, box = 26, icon = 16.sp) },
+    ) { _ ->
+        Column(
+            Modifier
+                .width(220.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(Skerry.colors.surface2)
+                .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Txt(
+                labelUppercase(stringResource(Res.string.sftp_columns)),
+                color = Skerry.colors.faint,
+                size = 10.sp,
+                weight = FontWeight.SemiBold,
+                letterSpacing = 0.5.sp,
+            )
+            ToggleRow(stringResource(Res.string.sftp_col_modified), prefs.showModified, onToggle = { prefs.setShowModified(!prefs.showModified) })
+            ToggleRow(stringResource(Res.string.sftp_col_permissions), prefs.showPermissions, onToggle = { prefs.setShowPermissions(!prefs.showPermissions) })
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
@@ -1,0 +1,144 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.MeterBar
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.files.TransferEntry
+import app.skerry.ui.files.TransferStatus
+import app.skerry.ui.files.transferFailureText
+import app.skerry.ui.forward.humanRate
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_file_fallback
+import app.skerry.ui.generated.resources.ftail_transfer_counter
+import app.skerry.ui.generated.resources.sftp_meta_joined
+import app.skerry.ui.generated.resources.sftp_queue_done
+import app.skerry.ui.generated.resources.sftp_queue_progress
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Transfer queue under the panes: one row per operation — what is moving now, and the last few
+ * that finished, so the outcome of a transfer is still readable after it ends. Empty queue, no
+ * strip. [onDismiss] drops a finished row by its id.
+ */
+@Composable
+internal fun TransferQueueStrip(queue: List<TransferEntry>, mono: FontFamily, onDismiss: (Long) -> Unit) {
+    if (queue.isEmpty()) return
+    HLine()
+    Column(
+        Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 12.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        queue.forEach { entry -> key(entry.id) { TransferQueueRow(entry, mono, onDismiss) } }
+    }
+}
+
+/** Name column of a queue row — wide enough for a release archive, fixed so the bars line up. */
+private val QUEUE_NAME_WIDTH = 180.dp
+
+/** How wide the trailing status text may grow before it starts to ellipsize. */
+private val QUEUE_TAIL_MAX_WIDTH = 220.dp
+
+@Composable
+private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: (Long) -> Unit) {
+    val done = entry.status == TransferStatus.Done
+    val failed = entry.status as? TransferStatus.Failed
+    val active = entry.status == TransferStatus.Active
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val up = entry.direction == TransferDirection.Upload
+        Sym(
+            if (failed != null) "error" else if (up) "upload" else "download",
+            size = 15.sp,
+            color = when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.teal
+            },
+        )
+        val title = if (entry.fileCount > 1) {
+            stringResource(Res.string.ftail_transfer_counter, entry.name, entry.fileIndex, entry.fileCount)
+        } else {
+            entry.name.ifBlank { stringResource(Res.string.ftail_file_fallback) }
+        }
+        Txt(
+            title,
+            color = if (active) Skerry.colors.textBright else Skerry.colors.dim,
+            size = 11.5.sp,
+            font = mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.width(QUEUE_NAME_WIDTH),
+        )
+        val percent = transferPercent(entry.transferred, entry.total)
+        MeterBar(
+            if (done) 1f else (percent ?: 0) / 100f,
+            when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.cyan
+            },
+            Modifier.weight(1f),
+        )
+        Txt(
+            transferTailText(entry),
+            color = when {
+                failed != null -> Skerry.colors.sunset
+                done -> Skerry.colors.moss
+                else -> Skerry.colors.dim
+            },
+            size = 11.sp,
+            font = mono,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            // Bounded rather than weighted: the meter is what the row is about (the mockup gives
+            // it nearly the whole width), but a long failure message must not push the meter and
+            // the dismiss button out of the row either.
+            modifier = Modifier.widthIn(max = QUEUE_TAIL_MAX_WIDTH),
+        )
+        // A finished row is the user's to clear; a running one has nothing to dismiss yet.
+        if (active) Box(Modifier.size(22.dp)) else IconBtn("close", onClick = { onDismiss(entry.id) }, box = 22, icon = 14.sp)
+    }
+}
+
+/** Right-hand text of a queue row: the failure, "done", or percent · bytes · speed while running. */
+@Composable
+private fun transferTailText(entry: TransferEntry): String {
+    (entry.status as? TransferStatus.Failed)?.let { return transferFailureText(it.failure) }
+    if (entry.status == TransferStatus.Done) return stringResource(Res.string.sftp_queue_done)
+    // Throughput goes through the app's one rate formatter (the tunnel table, the host monitor and
+    // the mobile terminal header all read it), so the same speed never gets two spellings.
+    val speedText = transferSpeed(entry.bytesDone, entry.elapsedMillis)?.let { humanRate(it) }
+    val percent = transferPercent(entry.transferred, entry.total)
+    // Without a reported size there is no percentage and no "of": what is left is how much has
+    // moved so far, and how fast.
+    val progress = if (percent != null) {
+        stringResource(Res.string.sftp_queue_progress, percent, humanSize(entry.transferred), humanSize(entry.total))
+    } else {
+        humanSize(entry.transferred)
+    }
+    return if (speedText != null) stringResource(Res.string.sftp_meta_joined, progress, speedText) else progress
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -35,6 +36,7 @@ import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.VLine
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_toolbar_tip
 import app.skerry.ui.generated.resources.share_session
@@ -45,7 +47,6 @@ import app.skerry.ui.generated.resources.shell_tip_files
 import app.skerry.ui.generated.resources.shell_tip_info
 import app.skerry.ui.generated.resources.shell_tip_more_actions
 import app.skerry.ui.generated.resources.shell_tip_play
-import app.skerry.ui.generated.resources.shell_tip_ports
 import app.skerry.ui.generated.resources.shell_tip_record
 import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.generated.resources.shell_tip_sync_panes
@@ -59,14 +60,74 @@ import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 
 /**
+ * What an action is about, and where the row's separators fall: [Workspace] shapes what the tab
+ * holds, [Session] does something to the shell running in it, [Global] belongs to the app rather
+ * than to any one session. Declared in row order.
+ */
+internal enum class ToolbarGroup { Workspace, Session, Global }
+
+/**
  * One entry of the session action row. A narrow window narrows the row, so when the icons stop
  * fitting the ones listed here give way in this order — the rarely-reached first, the ones a session
  * is steered with last. [Sync], [AddPane] and [Disconnect] are not in the list: they never overflow.
+ *
+ * [group] places the action between the row's separators; [needsSession] marks the ones that act on
+ * a live shell and are simply not drawn without one.
  */
-internal enum class ToolbarAction { Play, Record, Share, Runbook, Snippets, Tunnels, Info, Files }
+internal enum class ToolbarAction(val group: ToolbarGroup, val needsSession: Boolean) {
+    Play(ToolbarGroup.Global, needsSession = false),
+    Record(ToolbarGroup.Session, needsSession = true),
+    Share(ToolbarGroup.Session, needsSession = true),
+    Runbook(ToolbarGroup.Session, needsSession = true),
+    Snippets(ToolbarGroup.Session, needsSession = true),
+    Info(ToolbarGroup.Global, needsSession = true),
+    Files(ToolbarGroup.Workspace, needsSession = true),
+}
+
+/**
+ * The row, left to right: groups in order, actions in the order they are drawn inside one. The
+ * enum's own order is the overflow priority (rarest first) and says nothing about placement, so
+ * the row's order has to be written down separately — the row draws it by hand, and
+ * [OverflowActionsButton] sorts the menu by it so a hidden action keeps its place.
+ */
+internal val TOOLBAR_ROW_ORDER: List<ToolbarAction> = listOf(
+    ToolbarAction.Files,
+    ToolbarAction.Snippets,
+    ToolbarAction.Runbook,
+    ToolbarAction.Share,
+    ToolbarAction.Record,
+    ToolbarAction.Play,
+    ToolbarAction.Info,
+)
+
+/**
+ * Which actions the row draws at all. Without a session the ones that steer one are left out
+ * rather than dimmed: a button that cannot do anything is worse than no button. What remains is
+ * the recording player, which opens a recording in a tab of its own.
+ */
+internal fun availableActions(hasSession: Boolean): Set<ToolbarAction> =
+    ToolbarAction.entries.filterTo(mutableSetOf()) { hasSession || !it.needsSession }
 
 /** Width one icon claims in the row: the button box plus the spacing in front of it. */
 private val ACTION_SLOT_WIDTH = 30.dp
+
+/** Width a group separator claims: the 1dp hairline, its 2×4dp air, and the row gap it adds. */
+private val SEPARATOR_SLOT_WIDTH = 11.dp
+
+/**
+ * Whether [group] has anything on its side of a separator: an action the row still draws ([drawn]),
+ * or one of the buttons that never overflow and so are not in [ToolbarAction] — the sync toggle and
+ * add-pane sit in [ToolbarGroup.Workspace], the power button and the assistant in
+ * [ToolbarGroup.Global], and all of those come with a session. A separator needs both of its sides:
+ * with a whole group overflowed into the menu two hairlines would otherwise land side by side.
+ */
+private fun groupHasContent(group: ToolbarGroup, hasSession: Boolean, drawn: (ToolbarAction) -> Boolean): Boolean =
+    ToolbarAction.entries.any { it.group == group && drawn(it) } ||
+        (hasSession && (group == ToolbarGroup.Workspace || group == ToolbarGroup.Global))
+
+/** How many hairlines the row draws for a given set of visible actions. */
+private fun separatorCount(hasSession: Boolean, drawn: (ToolbarAction) -> Boolean): Int =
+    (ToolbarGroup.entries.count { groupHasContent(it, hasSession, drawn) } - 1).coerceAtLeast(0)
 
 /**
  * Room the work bar keeps for its own title. Enough for the host label, its address and the status
@@ -83,8 +144,8 @@ private val WORK_BAR_TITLE_ROOM = 240.dp
 private val WORK_BAR_CHROME = 62.dp
 
 /**
- * Session action icons (sync / add pane / SFTP / tunnels / snippets / runbooks / recording / player
- * / info panel / disconnect), filling the right end of the [WorkBar].
+ * Session action icons (sync / add pane / SFTP / snippets / runbooks / sharing / recording / player
+ * / assistant / info panel / disconnect), filling the right end of the [WorkBar].
  *
  * [available] is the width of the work area the bar spans, or `null` when it cannot be measured
  * yet. Once the icons no longer fit beside the bar's own title they collapse into an overflow menu,
@@ -105,9 +166,21 @@ internal fun RowScope.SessionActions(
     val teams = LocalTeams.current
     // Non-null only on a split tab, which is the only place the sync toggle is drawn.
     val syncTab = tab?.takeIf { it.isSplit }
-    val hidden = overflowedActions(available, syncShown = syncTab != null, assistantShown = assistantShown)
+    // The static preview has no session manager at all and is meant to show the full row; a live
+    // window with no terminal tab in focus has nothing for the session-scoped actions to act on —
+    // every one of them is bound to `active`, which is null in exactly that state.
+    val hasSession = sessions == null || tab != null
+    val shown = availableActions(hasSession)
+    val hidden = overflowedActions(
+        available,
+        syncShown = syncTab != null,
+        assistantShown = assistantShown,
+        hasSession = hasSession,
+    )
+    val drawn = { action: ToolbarAction -> action in shown && action !in hidden }
+    val groupDrawn = { group: ToolbarGroup -> groupHasContent(group, hasSession, drawn) }
 
-    // Files / tunnels / info are stateless, so the overflow menu can run them directly. The palettes
+    // Files and the info panel are stateless, so the overflow menu can run them directly. The palettes
     // and the recorder own their popups and save dialogs, so those are parked below instead and
     // reached through the request signals they already listen on.
     val openSftp = {
@@ -130,6 +203,7 @@ internal fun RowScope.SessionActions(
         }
     }
 
+    // Group 1 — the workspace: what the tab holds and which of its views is on screen.
     // Synchronized input: typing in one pane reaches every connected pane of this tab. Lit while on,
     // since it changes where every keystroke goes. Shown only once the tab is actually split — with
     // a single pane there is nothing to synchronize it with.
@@ -145,42 +219,48 @@ internal fun RowScope.SessionActions(
     // MAX_PANES); mock/preview toggles the demo split. Dimmed and inert once the tab is full — the
     // same treatment the info button gets when there is nothing for it to open.
     val canAddPane = tab?.layout?.isFull != true && tab?.isPlayer != true
-    IconBtn(
-        "splitscreen_right",
-        onClick = { if (sessions == null) state.toggleSplit() else if (canAddPane) sessions.addPane() },
-        tint = if (canAddPane) Skerry.colors.dim else Skerry.colors.faint,
-        tooltip = stringResource(Res.string.shell_tip_add_pane),
-    )
+    if (hasSession) {
+        IconBtn(
+            "splitscreen_right",
+            onClick = { if (sessions == null) state.toggleSplit() else if (canAddPane) sessions.addPane() },
+            tint = if (canAddPane) Skerry.colors.dim else Skerry.colors.faint,
+            tooltip = stringResource(Res.string.shell_tip_add_pane),
+        )
+    }
     // Switches the active tab's subview (live mode, plus overlay reset) / mock fallback.
-    if (ToolbarAction.Files !in hidden) {
+    if (drawn(ToolbarAction.Files)) {
         IconBtn("folder", onClick = openSftp, tooltip = stringResource(Res.string.shell_tip_files))
     }
-    // Tunnels is a global section, always opens as an overlay.
-    if (ToolbarAction.Tunnels !in hidden) {
-        IconBtn("lan", onClick = { state.showView(DesktopView.Ports) }, tooltip = stringResource(Res.string.shell_tip_ports))
-    }
+
+    // Group 2 — what can be sent into the session running there.
+    ActionGroupSeparator(shown = groupDrawn(ToolbarGroup.Workspace) && groupDrawn(ToolbarGroup.Session))
     // Quick snippet launch into the active session without leaving for the Snippets section.
-    if (ToolbarAction.Snippets !in hidden) SnippetPaletteButton(active, state.snippetPaletteRequests)
+    if (drawn(ToolbarAction.Snippets)) SnippetPaletteButton(active, state.snippetPaletteRequests)
     // Same idea one size up: start a saved procedure here instead of going to its section.
-    if (ToolbarAction.Runbook !in hidden) RunbookPaletteButton(active, state.runbookPaletteRequests)
+    if (drawn(ToolbarAction.Runbook)) RunbookPaletteButton(active, state.runbookPaletteRequests)
     // Streams this session to a team over the sync relay (viewers watch; the host decides whether
     // they may type).
-    if (ToolbarAction.Share !in hidden) {
+    if (drawn(ToolbarAction.Share)) {
         ShareSessionButton(active, LocalSessionShare.current, shareableTeams(), state.sharePanelRequests)
     }
     // Asciinema recording of this session; the stop click offers a Save-As for the .cast.
-    if (ToolbarAction.Record !in hidden) {
+    if (drawn(ToolbarAction.Record)) {
         RecordSessionButton(
             active,
             state.recordingToggleRequests,
             onSaved = { hostId, seconds -> teams?.reportSessionRecorded(hostId, seconds) },
         ) { state.showRecordingNotice(it) }
     }
+
+    // Group 3 — the app around the session: sections that stand on their own, and the way out.
+    ActionGroupSeparator(
+        shown = (groupDrawn(ToolbarGroup.Workspace) || groupDrawn(ToolbarGroup.Session)) && groupDrawn(ToolbarGroup.Global),
+    )
     // Plays a .cast back. Not tied to a session (a recording is watched, not run), which is why it
     // sits here rather than behind a connected-only guard. Live mode opens the recording in its own
     // tab, so the shells stay reachable while it plays; the mock path (no session manager) has no
     // tabs and falls back to the overlay.
-    if (ToolbarAction.Play !in hidden) PlayRecordingButton(state.castOpenRequests, onCastOpened)
+    if (drawn(ToolbarAction.Play)) PlayRecordingButton(state.castOpenRequests, onCastOpened)
     // Opens the assistant beside the terminal. Lit while it is open, like the info toggle; absent
     // entirely when AI is off for this host or globally, so a host that opted out shows no AI
     // affordance at all.
@@ -195,7 +275,7 @@ internal fun RowScope.SessionActions(
     // Lit while the info panel is open — the only action here with a visible on/off state. The panel
     // is session-scoped, so with no active session there is nothing to show: the button dims and
     // no-ops rather than toggling a panel that can't appear.
-    if (ToolbarAction.Info !in hidden) {
+    if (drawn(ToolbarAction.Info)) {
         IconBtn(
             "info",
             onClick = { if (infoAvailable) state.settings.toggleInfoPanel() },
@@ -207,13 +287,15 @@ internal fun RowScope.SessionActions(
         OverflowActionsButton(hidden, state, infoAvailable, tabKey = tab?.id, onOpenSftp = openSftp)
     }
     // Power: closes the active session (live path) with a confirmation prompt (destructive, no
-    // auto-reconnect); no-op stub in mock mode.
-    IconBtn(
-        "power_settings_new",
-        onClick = { if (tab != null) state.requestCloseSession(tab.id) },
-        tint = Skerry.colors.sunset,
-        tooltip = stringResource(Res.string.shell_tip_disconnect),
-    )
+    // auto-reconnect); no-op stub in mock mode. With no session open there is nothing to close.
+    if (hasSession) {
+        IconBtn(
+            "power_settings_new",
+            onClick = { if (tab != null) state.requestCloseSession(tab.id) },
+            tint = Skerry.colors.sunset,
+            tooltip = stringResource(Res.string.shell_tip_disconnect),
+        )
+    }
     // Parked out of sight, still in composition: these buttons own the palettes, the recorder and
     // the file pickers behind them, and dropping them from the tree would take that state with them
     // — the overflow menu drives them through their request signals instead.
@@ -235,6 +317,19 @@ internal fun RowScope.SessionActions(
 }
 
 /**
+ * Hairline between two action groups. Drawn only while both sides of it exist ([shown]) — with no
+ * session the row is one group, and a separator with nothing before it would read as a border.
+ */
+@Composable
+private fun ActionGroupSeparator(shown: Boolean) {
+    if (!shown) return
+    VLine(Skerry.colors.line, Modifier.padding(horizontal = 4.dp).height(SEPARATOR_HEIGHT))
+}
+
+/** How tall the group separator stands inside the bar — shorter than the icons it parts. */
+private val SEPARATOR_HEIGHT = 16.dp
+
+/**
  * Whether the info panel has anything to say about the pane in focus. Everything it shows — host
  * profile, cipher, uptime, live metrics — comes from a connection this app owns, so a pane merely
  * watching a colleague's shared session ([watched]) gets the button dimmed and the panel hidden
@@ -252,17 +347,30 @@ internal fun infoPanelAvailable(hasSession: Boolean, watched: Boolean, mock: Boo
  * Pure so the thresholds can be tested without a window: the row must also keep room for the
  * overflow button itself once anything is hidden.
  */
-internal fun overflowedActions(available: Dp?, syncShown: Boolean, assistantShown: Boolean = false): Set<ToolbarAction> {
+internal fun overflowedActions(
+    available: Dp?,
+    syncShown: Boolean,
+    assistantShown: Boolean = false,
+    hasSession: Boolean = true,
+): Set<ToolbarAction> {
     if (available == null) return emptySet()
-    // + add-pane and power, plus the two conditional buttons when they are actually drawn.
-    val total = ToolbarAction.entries.size + 2 + (if (syncShown) 1 else 0) + if (assistantShown) 1 else 0
+    // Only what the row actually draws can overflow: without a session the session-scoped actions
+    // were never there to hide (see availableActions).
+    val order = ToolbarAction.entries.filter { it in availableActions(hasSession) }
+    // + add-pane and power, which a session brings, plus the two conditional buttons when drawn.
+    val fixed = (if (hasSession) 2 else 0) + (if (syncShown) 1 else 0) + if (assistantShown) 1 else 0
     val room = available - WORK_BAR_TITLE_ROOM - WORK_BAR_CHROME
-    val fits = (room / ACTION_SLOT_WIDTH).toInt()
-    if (fits >= total) return emptySet()
-    // One slot goes to the overflow button; whatever still doesn't fit gives way in enum order.
-    val keep = (fits - 1).coerceAtLeast(0)
-    val drop = (total - keep).coerceIn(0, ToolbarAction.entries.size)
-    return ToolbarAction.entries.take(drop).toSet()
+    // Give way in enum order until the row fits, re-counting the separators at every step: a group
+    // emptied into the menu stops drawing its hairline, and so stops costing its width too.
+    for (drop in 0..order.size) {
+        val kept = order.drop(drop).toSet()
+        // One slot goes to the overflow button, from the moment there is anything in it.
+        val icons = kept.size + fixed + if (drop > 0) 1 else 0
+        val width = ACTION_SLOT_WIDTH * icons +
+            SEPARATOR_SLOT_WIDTH * separatorCount(hasSession) { it in kept }
+        if (width <= room) return order.take(drop).toSet()
+    }
+    return order.toSet()
 }
 
 /**
@@ -293,10 +401,9 @@ private fun OverflowActionsButton(
                         .padding(4.dp),
                 ) {
                     // Listed the way they sit in the row, so the menu reads as its continuation.
-                    hidden.sortedByDescending { it.ordinal }.forEach { action ->
+                    hidden.sortedBy { TOOLBAR_ROW_ORDER.indexOf(it) }.forEach { action ->
                         val run: () -> Unit = when (action) {
                             ToolbarAction.Files -> onOpenSftp
-                            ToolbarAction.Tunnels -> ({ state.showView(DesktopView.Ports) })
                             ToolbarAction.Info -> ({ if (infoAvailable) state.settings.toggleInfoPanel() })
                             ToolbarAction.Snippets -> state::requestSnippetPalette
                             ToolbarAction.Runbook -> state::requestRunbookPalette
@@ -336,7 +443,6 @@ internal fun MenuActionRow(icon: String, label: String, onClick: () -> Unit) {
 private val ToolbarAction.icon: String
     get() = when (this) {
         ToolbarAction.Files -> "folder"
-        ToolbarAction.Tunnels -> "lan"
         ToolbarAction.Snippets -> "bolt"
         ToolbarAction.Runbook -> "checklist"
         ToolbarAction.Record -> "radio_button_checked"
@@ -349,7 +455,6 @@ private val ToolbarAction.icon: String
 private val ToolbarAction.label: StringResource
     get() = when (this) {
         ToolbarAction.Files -> Res.string.shell_tip_files
-        ToolbarAction.Tunnels -> Res.string.shell_tip_ports
         ToolbarAction.Snippets -> Res.string.shell_tip_snippets
         ToolbarAction.Runbook -> Res.string.runbook_toolbar_tip
         ToolbarAction.Record -> Res.string.shell_tip_record

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -124,8 +124,7 @@ fun TerminalView(state: DesktopDesignState) {
             WorkBar(
                 label = activeWorkBarLabel(state, tab, soloPlaceholder = stringResource(Res.string.term_select_host_placeholder)),
                 tabKey = tab?.id,
-                sidebarHidden = state.sidebarHidden,
-                onToggleSidebar = state::toggleSidebar,
+                leading = WorkBarLeading.sidebarToggle(state.sidebarHidden, state::toggleSidebar),
                 onPickHost = soloHostPicker(state, tab),
                 actions = {
                     SessionActions(state, available = workAreaWidth, assistantShown = assistantController != null)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/WorkBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/WorkBar.kt
@@ -34,6 +34,7 @@ import app.skerry.ui.generated.resources.term_wbar_panes
 import app.skerry.ui.generated.resources.term_wbar_sync
 import app.skerry.ui.session.sessionDotColor
 import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -42,6 +43,22 @@ import org.jetbrains.compose.resources.stringResource
  * their own content at the same line, so the three read as one row across the window.
  */
 val WORK_BAR_HEIGHT = 38.dp
+
+/**
+ * The bar's leftmost button. What it does depends on what the work area holds: the terminal
+ * collapses the hosts sidebar there ([sidebarToggle] — the chevron points the way the panel will
+ * travel, and it is the terminal's only sidebar handle), a view that fills the whole work area and
+ * shows no sidebar leaves the terminal instead ([back]). Whatever the button does, it stays in the
+ * same place across views.
+ */
+data class WorkBarLeading(val icon: String, val tooltip: StringResource, val onClick: () -> Unit) {
+    companion object {
+        fun sidebarToggle(hidden: Boolean, onToggle: () -> Unit) =
+            WorkBarLeading(if (hidden) "chevron_right" else "chevron_left", Res.string.term_tip_sidebar, onToggle)
+
+        fun back(tooltip: StringResource, onBack: () -> Unit) = WorkBarLeading("chevron_left", tooltip, onBack)
+    }
+}
 
 /**
  * The strip above the work area: what is open on the left, what can be done to it on the right.
@@ -61,8 +78,7 @@ val WORK_BAR_HEIGHT = 38.dp
 fun WorkBar(
     label: WorkBarLabel?,
     tabKey: Any?,
-    sidebarHidden: Boolean,
-    onToggleSidebar: () -> Unit,
+    leading: WorkBarLeading,
     onPickHost: ((Host) -> Unit)?,
     actions: @Composable RowScope.() -> Unit,
 ) {
@@ -72,14 +88,11 @@ fun WorkBar(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            // Collapses the hosts sidebar and brings it back; the chevron points the way the panel
-            // will travel. This is the terminal's only sidebar handle — there is no reopen strip at
-            // the work area's edge any more.
             IconBtn(
-                if (sidebarHidden) "chevron_right" else "chevron_left",
-                onClick = onToggleSidebar,
+                leading.icon,
+                onClick = leading.onClick,
                 box = 26,
-                tooltip = stringResource(Res.string.term_tip_sidebar),
+                tooltip = stringResource(leading.tooltip),
             )
             WorkBarTitle(label, tabKey, onPickHost, Modifier.weight(1f))
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(2.dp), content = actions)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -755,6 +755,53 @@ class TransferCoordinatorTest {
     }
 
     @Test
+    fun `dismissing the finished entries leaves a running one alone`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val r = rig(remote = remote)
+        // One transfer all the way through, then a second held open: the bulk dismiss has to tell
+        // them apart, not simply clear or spare the whole list.
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+        remote.transferGate = CompletableDeferred()
+        r.local.toggle(r.local.entry("b.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+        assertEquals(2, r.coordinator.queue.size)
+
+        r.coordinator.dismissCompleted()
+
+        val left = r.coordinator.queue.single()
+        assertEquals(TransferStatus.Active, left.status)
+        assertEquals("b.txt", left.name)
+        remote.transferGate!!.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a picked upload that fails still lands on the queue`() = runTest {
+        // The fallback upload path (native picker, nothing selected in the local pane) had only
+        // success coverage: its failure has to reach the queue like any other.
+        val remote = remoteFake().apply { uploadError = "disk full" }
+        val r = rig(remote = remote)
+        val source = object : UploadSource {
+            override val name = "picked.txt"
+            override val stagingPath = "/tmp/picked.txt"
+            var cleaned = false
+            override suspend fun cleanup() { cleaned = true }
+        }
+
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        val status = assertIs<TransferStatus.Failed>(r.coordinator.queue.single().status)
+        assertEquals(FileTransferFailure.Transfer, status.failure)
+        // The staged copy the picker made is the coordinator's to delete on the way out — a failed
+        // upload leaves it behind otherwise, and nothing else ever comes back for it.
+        assertTrue(source.cleaned)
+    }
+
+    @Test
     fun `dismissing a finished entry drops it from the queue`() = runTest {
         val r = rig()
         r.local.toggle(r.local.entry("a.txt"))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.cancel
 
 private const val LHOME = "/local/home"
 private const val RHOME = "/remote/app"
@@ -57,13 +58,14 @@ class TransferCoordinatorTest {
     private fun TestScope.rig(
         local: FakeSftpClient = localFake(),
         remote: FakeSftpClient = remoteFake(),
+        now: () -> Long = { 0L },
     ): Rig {
         val localBrowser = SftpFileBrowser(local, "This Mac")
         val remoteBrowser = SftpFileBrowser(remote, "prod-web-01")
         val localCtl = FilePaneController(localBrowser, scope())
         val remoteCtl = FilePaneController(remoteBrowser, scope())
         localCtl.start(); remoteCtl.start(); advanceUntilIdle()
-        val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope())
+        val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope(), now)
         return Rig(localCtl, remoteCtl, local, remote, coordinator)
     }
 
@@ -489,5 +491,294 @@ class TransferCoordinatorTest {
         assertTrue(released)
         assertEquals("after\n", remote.contentOf("$RHOME/nginx.conf"))
         waiter.cancel()
+    }
+
+    // Transfer queue: what the bottom strip lists. One entry per operation, kept after it ends so
+    // the result of a finished transfer is still on screen.
+
+    @Test
+    fun `a finished upload stays in the queue as a completed entry`() = runTest {
+        val r = rig()
+        r.local.toggle(r.local.entry("a.txt"))
+
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val entry = r.coordinator.queue.single()
+        assertEquals(TransferDirection.Upload, entry.direction)
+        assertEquals("a.txt", entry.name)
+        assertEquals(TransferStatus.Done, entry.status)
+        assertEquals(TransferState.Idle, r.coordinator.transfer)
+    }
+
+    @Test
+    fun `a running transfer is the queue's active entry, with its byte counts`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.local.toggle(r.local.entry("b.txt"))
+
+        r.coordinator.uploadSelection()
+        advanceUntilIdle() // blocks on the gate at the first file
+
+        val entry = r.coordinator.queue.single()
+        assertEquals(TransferStatus.Active, entry.status)
+        assertEquals(1, entry.fileIndex)
+        assertEquals(2, entry.fileCount)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(TransferStatus.Done, r.coordinator.queue.single().status)
+    }
+
+    @Test
+    fun `a failed transfer names its reason in the queue`() = runTest {
+        val remote = remoteFake().apply { uploadError = "disk full" }
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val status = assertIs<TransferStatus.Failed>(r.coordinator.queue.single().status)
+        assertEquals(FileTransferFailure.Transfer, status.failure)
+    }
+
+    @Test
+    fun `the queue counts the whole operation's bytes and the time it took`() = runTest {
+        // Speed is read off these two numbers, so they are the coordinator's job: the clock is
+        // injected, the total is the sum over the operation's files, not the last one's. The gate
+        // holds the transfer mid-flight so the clock can move while it runs.
+        var clock = 1_000L
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote, now = { clock })
+        r.local.toggle(r.local.entry("a.txt")) // 10 bytes
+        r.local.toggle(r.local.entry("b.txt")) // 20 bytes
+
+        r.coordinator.uploadSelection()
+        advanceUntilIdle() // waiting on the gate, inside the first file
+        clock = 3_000L
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        val entry = r.coordinator.queue.single()
+        assertEquals(30, entry.bytesDone)
+        assertEquals(2_000, entry.elapsedMillis)
+    }
+
+    @Test
+    fun `the queue keeps only the last few finished entries, dropping the oldest`() = runTest {
+        val r = rig()
+        val seen = mutableListOf<Long>()
+        repeat(MAX_COMPLETED_TRANSFERS + 2) { index ->
+            r.local.toggle(r.local.entry("a.txt"))
+            r.coordinator.uploadSelection()
+            advanceUntilIdle()
+            // Each round overwrites the same remote name — confirm the conflict so it runs.
+            r.coordinator.overwrite?.let { r.coordinator.resolveOverwrite(true) }
+            advanceUntilIdle()
+            assertTrue(r.coordinator.queue.size <= MAX_COMPLETED_TRANSFERS, "round $index")
+            seen += r.coordinator.queue.last().id
+        }
+        // What survives is the tail of the history, in order — eviction takes the oldest, never
+        // the entry the user just watched finish.
+        assertEquals(seen.takeLast(MAX_COMPLETED_TRANSFERS), r.coordinator.queue.map { it.id })
+    }
+
+    @Test
+    fun `a successful transfer clears the error left by the one before it`() = runTest {
+        // The single-line view (mobile card) reads `transfer`. A failure followed by a success must
+        // read as "nothing wrong": showing the old error after a working retry sends the user
+        // retrying something that already went through.
+        val remote = remoteFake().apply { uploadError = "disk full" }
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+        assertIs<TransferState.Failed>(r.coordinator.transfer)
+
+        remote.uploadError = null
+        r.local.toggle(r.local.entry("b.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        assertEquals(TransferState.Idle, r.coordinator.transfer)
+        assertEquals(2, r.coordinator.queue.size, "the failed entry stays in the queue's history")
+    }
+
+    @Test
+    fun `the single-line state and the queue describe the same running transfer`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.local.toggle(r.local.entry("b.txt"))
+
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val entry = r.coordinator.queue.single { it.status == TransferStatus.Active }
+        val active = assertIs<TransferState.Active>(r.coordinator.transfer)
+        assertEquals(entry.name, active.name)
+        assertEquals(entry.direction, active.direction)
+        assertEquals(entry.fileIndex, active.fileIndex)
+        assertEquals(entry.fileCount, active.fileCount)
+        assertEquals(entry.transferred, active.transferred)
+        assertEquals(entry.total, active.total)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a move that transferred but could not delete the source ends as a failure`() = runTest {
+        // The block closes its own entry (failOperation) and then returns normally, so the
+        // operation-wide "done" that follows must not flip it back to success.
+        val local = localFake().apply { removeError = "permission denied" }
+        val r = rig(local = local)
+        r.local.toggle(r.local.entry("a.txt"))
+
+        r.coordinator.moveSelection(fromLocal = true)
+        advanceUntilIdle()
+
+        val status = assertIs<TransferStatus.Failed>(r.coordinator.queue.single().status)
+        assertEquals(FileTransferFailure.DeleteSource, status.failure)
+    }
+
+    @Test
+    fun `a cancelled transfer does not leave its entry running forever`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        remote.transferGate = CompletableDeferred()
+        val scope = scope()
+        val localBrowser = SftpFileBrowser(localFake(), "This Mac")
+        val remoteBrowser = SftpFileBrowser(remote, "prod-web-01")
+        val localCtl = FilePaneController(localBrowser, scope)
+        val remoteCtl = FilePaneController(remoteBrowser, scope)
+        localCtl.start(); remoteCtl.start(); advanceUntilIdle()
+        val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope)
+        localCtl.toggle((localCtl.state as FilePaneState.Loaded).entries.first { it.name == "a.txt" })
+
+        coordinator.uploadSelection()
+        advanceUntilIdle() // waiting on the gate
+        assertEquals(TransferStatus.Active, coordinator.queue.single().status)
+
+        scope.cancel() // the session goes away mid-transfer
+        advanceUntilIdle()
+
+        assertIs<TransferStatus.Failed>(coordinator.queue.single().status)
+    }
+
+    @Test
+    fun `a second transfer requested while one runs does not open a second entry`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        remote.transferGate = CompletableDeferred()
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        r.local.toggle(r.local.entry("b.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        assertEquals(1, r.coordinator.queue.size)
+        remote.transferGate!!.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a download counts its bytes on the queue entry too`() = runTest {
+        val remote = remoteFake()
+        val r = rig(remote = remote)
+        r.remote.toggle(r.remote.entry("r.txt")) // 30 bytes
+
+        r.coordinator.downloadSelection()
+        advanceUntilIdle()
+
+        val entry = r.coordinator.queue.single()
+        assertEquals(TransferDirection.Download, entry.direction)
+        assertEquals(30, entry.bytesDone)
+    }
+
+    @Test
+    fun `a picked upload and a download to a target each get their own queue entry`() = runTest {
+        val r = rig()
+        val source = object : UploadSource {
+            override val name = "picked.txt"
+            override val stagingPath = "/tmp/picked.txt"
+            override suspend fun cleanup() = Unit
+        }
+
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        val uploaded = r.coordinator.queue.single()
+        assertEquals("picked.txt", uploaded.name)
+        assertEquals(TransferDirection.Upload, uploaded.direction)
+        assertEquals(TransferStatus.Done, uploaded.status)
+
+        val target = object : DownloadTarget {
+            override val displayName = "r.txt"
+            override val stagingPath = "/tmp/r.txt"
+            override suspend fun finalize() = Unit
+            override suspend fun discard() = Unit
+        }
+        r.coordinator.downloadToTarget(r.remote.entry("r.txt"), target)
+        advanceUntilIdle()
+
+        val downloaded = r.coordinator.queue.last()
+        assertEquals("r.txt", downloaded.name)
+        assertEquals(TransferDirection.Download, downloaded.direction)
+        assertEquals(TransferStatus.Done, downloaded.status)
+        assertEquals(2, r.coordinator.queue.size)
+    }
+
+    @Test
+    fun `dismissing the finished entries clears them all at once`() = runTest {
+        val r = rig()
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+        r.local.toggle(r.local.entry("b.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+        assertEquals(2, r.coordinator.queue.size)
+
+        r.coordinator.dismissCompleted()
+
+        assertTrue(r.coordinator.queue.isEmpty())
+    }
+
+    @Test
+    fun `dismissing a finished entry drops it from the queue`() = runTest {
+        val r = rig()
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        r.coordinator.dismissTransfer(r.coordinator.queue.single().id)
+
+        assertTrue(r.coordinator.queue.isEmpty())
+    }
+
+    @Test
+    fun `dismissing does not touch a transfer still running`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        remote.transferGate = CompletableDeferred()
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        r.coordinator.dismissTransfer(r.coordinator.queue.single().id)
+
+        assertEquals(1, r.coordinator.queue.size)
+        remote.transferGate!!.complete(Unit)
+        advanceUntilIdle()
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
@@ -1,0 +1,171 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.ui.sftp.FakeSftpClient
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+private const val LOCAL = "/local/home"
+private const val REMOTE = "/remote/app"
+
+/**
+ * What a transfer will move, worked out before any bytes flow: directory order, which entries
+ * become tasks, and the path-traversal guard against a hostile listing. The walk runs over
+ * [FakeSftpClient] trees — no coordinator, no transfers.
+ */
+class TransferPlanTest {
+
+    private fun remote() = FakeSftpClient(startDir = REMOTE).apply {
+        seedDir("$REMOTE/proj")
+        seedFile("$REMOTE/proj/top.txt", size = 5)
+        seedDir("$REMOTE/proj/nested")
+        seedFile("$REMOTE/proj/nested/deep.txt", size = 7)
+        seedFile("$REMOTE/loose.txt", size = 3)
+    }
+
+    private fun item(name: String, type: FileItemType, path: String, size: Long = 0) =
+        FileItem(name = name, path = path, type = type, size = size, modifiedEpochSeconds = 0)
+
+    @Test
+    fun `a file becomes one task under the destination directory`() = runTest {
+        val plan = buildDownloadPlan(
+            remote(),
+            listOf(item("loose.txt", FileItemType.File, "$REMOTE/loose.txt", size = 3)),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertTrue(plan.dirs.isEmpty())
+        assertEquals(
+            listOf(DownloadTask("loose.txt", "$REMOTE/loose.txt", "$LOCAL/loose.txt", 3)),
+            plan.files,
+        )
+    }
+
+    @Test
+    fun `a directory is walked recursively, parents before children`() = runTest {
+        val plan = buildDownloadPlan(
+            remote(),
+            listOf(item("proj", FileItemType.Directory, "$REMOTE/proj")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        // Creation order matters: the nested directory cannot be created before its parent.
+        assertEquals(listOf("$LOCAL/proj", "$LOCAL/proj/nested"), plan.dirs)
+        assertEquals(
+            listOf("$LOCAL/proj/top.txt", "$LOCAL/proj/nested/deep.txt"),
+            plan.files.map { it.localPath },
+        )
+    }
+
+    @Test
+    fun `a hostile listing name stops the walk instead of escaping the tree`() = runTest {
+        val remote = remote().apply { seedFile("$REMOTE/proj/..\\evil.txt", size = 9) }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildDownloadPlan(
+                remote,
+                listOf(item("proj", FileItemType.Directory, "$REMOTE/proj")),
+                localDir = LOCAL,
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.IllegalName, failure.failure)
+    }
+
+    @Test
+    fun `symlinks are planned neither as files nor as directories`() = runTest {
+        val plan = buildDownloadPlan(
+            remote(),
+            listOf(item("link", FileItemType.Symlink, "$REMOTE/link")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertTrue(plan.files.isEmpty() && plan.dirs.isEmpty())
+    }
+
+    @Test
+    fun `an upload plan mirrors the download one, over the local browser`() = runTest {
+        val local = FakeSftpClient(startDir = LOCAL).apply {
+            seedDir("$LOCAL/sub")
+            seedFile("$LOCAL/sub/inner.txt", size = 7)
+        }
+        val browser = SftpFileBrowser(local, "This Mac")
+
+        val plan = buildUploadPlan(
+            browser,
+            listOf(item("sub", FileItemType.Directory, "$LOCAL/sub")),
+            remoteDir = REMOTE,
+        )
+
+        assertEquals(listOf("$REMOTE/sub"), plan.dirs)
+        assertEquals(
+            listOf(UploadTask("inner.txt", "$LOCAL/sub/inner.txt", "$REMOTE/sub/inner.txt", 7)),
+            plan.files,
+        )
+    }
+
+    @Test
+    fun `a hostile name in a local listing stops the upload walk too`() = runTest {
+        // The upload walk carries its own copy of the guard; the download one being covered says
+        // nothing about it.
+        val local = FakeSftpClient(startDir = LOCAL).apply {
+            seedDir("$LOCAL/sub")
+            seedFile("$LOCAL/sub/..\\escape.txt", size = 4)
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildUploadPlan(
+                SftpFileBrowser(local, "This Mac"),
+                listOf(item("sub", FileItemType.Directory, "$LOCAL/sub")),
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.IllegalName, failure.failure)
+    }
+
+    @Test
+    fun `a directory that is already there is not an error`() = runTest {
+        // A repeat transfer walks into directories the previous run created; mkdir has no `-p`, so
+        // the collision has to be tolerated or every second transfer of a tree fails.
+        val remote = remote()
+
+        ensureDir(SftpFileBrowser(remote, "prod"), "$REMOTE/proj")
+
+        // Creating first and excusing the failure afterwards, not probing first: a listing that
+        // says nothing is there is stale the moment it returns, and the ordering decides which of
+        // the two errors the user is told about.
+        assertEquals(1, remote.mkdirCalls)
+    }
+
+    @Test
+    fun `a directory that cannot be created reports the mkdir failure, not the listing one`() = runTest {
+        // The path is taken by a *file*: mkdir fails, the listing that would have excused it fails
+        // too, and what the user hears has to be why the directory could not be made — the "no
+        // directory" from the probe explains nothing.
+        val browser = SftpFileBrowser(remote(), "prod")
+
+        val failure = assertFailsWith<FileBrowserException> { ensureDir(browser, "$REMOTE/loose.txt") }
+
+        assertEquals(FileBrowserFailure.Sftp, failure.failure)
+        assertTrue(failure.detail.orEmpty().startsWith("Path taken"), "got: ${failure.detail}")
+    }
+
+    @Test
+    fun `a delete path is rebuilt from the pane's directory, never from the listing`() {
+        assertEquals("$REMOTE/a.txt", safeRemoteChild("a.txt", REMOTE))
+        assertFailsWith<FileBrowserException> { safeRemoteChild("../a.txt", REMOTE) }
+        assertFailsWith<FileBrowserException> { safeRemoteChild("..", REMOTE) }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferQueueTest.kt
@@ -1,0 +1,136 @@
+package app.skerry.ui.files
+
+import app.skerry.ui.sftp.TransferDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The queue's own contract, driven directly rather than through a transfer: what an entry says
+ * while it runs, what closes it, what the single-line view reads off it, and what dismissing does.
+ * The clock is injected, so elapsed time is exact.
+ */
+class TransferQueueTest {
+
+    private var clock = 1_000L
+    private fun queue() = TransferQueue { clock }
+
+    @Test
+    fun `an opened entry is the running one until it is closed`() {
+        val queue = queue()
+        assertFalse(queue.hasOpenEntry)
+
+        queue.begin(TransferDirection.Upload)
+        assertTrue(queue.hasOpenEntry)
+
+        queue.end(TransferStatus.Done)
+        assertFalse(queue.hasOpenEntry)
+    }
+
+    @Test
+    fun `progress lands on the running entry, bytes and time accumulate over the operation`() {
+        val queue = queue()
+        queue.begin(TransferDirection.Upload)
+        queue.step("a.txt", index = 1, count = 2, transferred = 4, total = 10)
+        queue.fileFinished(10)
+        clock = 3_000L
+        queue.step("b.txt", index = 2, count = 2, transferred = 5, total = 20)
+
+        val entry = queue.list.single()
+        assertEquals("b.txt", entry.name)
+        assertEquals(2, entry.fileIndex)
+        assertEquals(2, entry.fileCount)
+        assertEquals(5, entry.transferred)
+        assertEquals(20, entry.total)
+        assertEquals(15, entry.bytesDone, "the finished file's bytes plus what the current one moved")
+        assertEquals(2_000, entry.elapsedMillis)
+    }
+
+    @Test
+    fun `the single-line state follows the newest entry, not the newest failure`() {
+        val queue = queue()
+        queue.begin(TransferDirection.Upload)
+        queue.fail("a.txt", FileTransferFailure.Transfer)
+        assertIs<TransferState.Failed>(queue.latest)
+
+        queue.begin(TransferDirection.Upload)
+        queue.step("b.txt", 1, 1, 0, 10)
+        val active = assertIs<TransferState.Active>(queue.latest)
+        assertEquals("b.txt", active.name)
+
+        queue.end(TransferStatus.Done)
+        assertEquals(TransferState.Idle, queue.latest, "a finished transfer is nothing to report")
+    }
+
+    @Test
+    fun `an empty queue has nothing to say`() {
+        assertEquals(TransferState.Idle, queue().latest)
+    }
+
+    @Test
+    fun `closing an already closed entry leaves its verdict alone`() {
+        // The coordinator's blocks may close their own entry as failed and then return normally;
+        // the generic "done" that follows must not overwrite the failure.
+        val queue = queue()
+        queue.begin(TransferDirection.Download)
+        queue.fail("r.txt", FileTransferFailure.DeleteSource)
+
+        queue.end(TransferStatus.Done)
+
+        val status = assertIs<TransferStatus.Failed>(queue.list.single().status)
+        assertEquals(FileTransferFailure.DeleteSource, status.failure)
+    }
+
+    @Test
+    fun `entries keep distinct ids in the order they were opened`() {
+        val queue = queue()
+        repeat(3) {
+            queue.begin(TransferDirection.Upload)
+            queue.end(TransferStatus.Done)
+        }
+        val ids = queue.list.map { it.id }
+        assertEquals(ids.sorted(), ids)
+        assertEquals(ids.toSet().size, ids.size)
+    }
+
+    @Test
+    fun `only the last few finished entries are kept, oldest evicted first`() {
+        val queue = queue()
+        val ids = mutableListOf<Long>()
+        repeat(MAX_COMPLETED_TRANSFERS + 2) {
+            queue.begin(TransferDirection.Upload)
+            queue.end(TransferStatus.Done)
+            ids += queue.list.last().id
+        }
+        assertEquals(ids.takeLast(MAX_COMPLETED_TRANSFERS), queue.list.map { it.id })
+    }
+
+    @Test
+    fun `dismissing separates the finished entries from the one still running`() {
+        val queue = queue()
+        queue.begin(TransferDirection.Upload)
+        queue.end(TransferStatus.Done)
+        queue.begin(TransferDirection.Download)
+        queue.step("r.txt", 1, 1, 0, 30)
+        val runningId = queue.list.last().id
+
+        queue.dismissCompleted()
+
+        val left = queue.list.single()
+        assertEquals(runningId, left.id)
+        assertEquals(TransferStatus.Active, left.status)
+    }
+
+    @Test
+    fun `dismissing by id refuses to drop a running entry`() {
+        val queue = queue()
+        queue.begin(TransferDirection.Upload)
+        val id = queue.list.single().id
+
+        queue.dismiss(id)
+
+        assertEquals(1, queue.list.size)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -159,7 +159,11 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
         children[norm] = mutableMapOf()
     }
 
+    /** When set, the next [remove] throws [SftpException] with this text (tests a failed delete). */
+    var removeError: String? = null
+
     override suspend fun remove(path: String) {
+        removeError?.let { throw SftpException(it) }
         val norm = realpathSync(path)
         val parent = children[parentOf(norm)] ?: throw SftpException("No parent for $path")
         val entry = parent[nameOf(norm)] ?: throw SftpException("No file $path")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -151,7 +151,12 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
         onProgress.onProgress(total, total)
     }
 
+    /** How many times a directory creation was attempted (tests that pin mkdir-first ordering). */
+    var mkdirCalls = 0
+        private set
+
     override suspend fun mkdir(path: String) {
+        mkdirCalls++
         val norm = realpathSync(path)
         val parent = children[parentOf(norm)] ?: throw SftpException("No parent for $path")
         if (nameOf(norm) in parent) throw SftpException("Path taken: $path")

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SftpFormatTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SftpFormatTest.kt
@@ -85,4 +85,73 @@ class SftpFormatTest {
         // 1048575 B = 1024 KiB - 1 B: rounding pushes it to 1024.0 KB, so we show 1.0 MB.
         assertEquals(SizeParts(SizeUnit.MB, 1, 0), sizeParts(1024L * 1024 - 1))
     }
+
+    // Row icon: the type decides for everything that isn't a plain file; a file is read by extension.
+
+    @Test
+    fun directories_and_symlinks_ignore_the_extension() {
+        assertEquals("folder", sftpFileIcon("releases.tar.gz", FileItemType.Directory))
+        assertEquals("link", sftpFileIcon("current.png", FileItemType.Symlink))
+    }
+
+    @Test
+    fun archives_keys_images_and_scripts_have_their_own_icon() {
+        assertEquals("archive", sftpFileIcon("release-0.2.1.tar.gz", FileItemType.File))
+        assertEquals("archive", sftpFileIcon("backup.zip", FileItemType.File))
+        assertEquals("key", sftpFileIcon("deploy.key", FileItemType.File))
+        assertEquals("key", sftpFileIcon("id_ed25519.pub", FileItemType.File))
+        assertEquals("image", sftpFileIcon("og.png", FileItemType.File))
+        assertEquals("terminal", sftpFileIcon("deploy.sh", FileItemType.File))
+    }
+
+    @Test
+    fun extension_case_does_not_matter() {
+        assertEquals("image", sftpFileIcon("SCREEN.PNG", FileItemType.File))
+        assertEquals("archive", sftpFileIcon("Backup.TGZ", FileItemType.File))
+    }
+
+    // Transfer queue: percentage and speed of a running transfer.
+
+    @Test
+    fun percentage_needs_a_known_total() {
+        assertEquals(63, transferPercent(transferred = 7_100_000, total = 11_200_000))
+        assertEquals(0, transferPercent(transferred = 0, total = 1_000))
+        assertEquals(100, transferPercent(transferred = 1_000, total = 1_000))
+        // Unknown size (the source didn't report one): no percentage at all rather than a fake 0%.
+        assertNull(transferPercent(transferred = 512, total = 0))
+    }
+
+    @Test
+    fun percentage_never_leaves_the_scale() {
+        // A source that reports more bytes than it promised must not render "104%".
+        assertEquals(100, transferPercent(transferred = 1_040, total = 1_000))
+        assertEquals(0, transferPercent(transferred = -10, total = 1_000))
+    }
+
+    @Test
+    fun speed_is_the_transferred_bytes_over_the_elapsed_time() {
+        assertEquals(5_000_000, transferSpeed(bytesDone = 10_000_000, elapsedMillis = 2_000))
+        assertEquals(1_000, transferSpeed(bytesDone = 500, elapsedMillis = 500))
+    }
+
+    @Test
+    fun speed_is_unknown_until_the_transfer_has_run_long_enough() {
+        // The first frames divide a handful of bytes by a few milliseconds — a number that jumps
+        // between "2 GB/s" and "3 KB/s" is worse than no number.
+        assertNull(transferSpeed(bytesDone = 4_096, elapsedMillis = 40))
+        assertNull(transferSpeed(bytesDone = 0, elapsedMillis = 5_000))
+        assertNull(transferSpeed(bytesDone = 4_096, elapsedMillis = 0))
+        // The floor itself is enough to divide by; one millisecond below it is not.
+        assertEquals(16_384, transferSpeed(bytesDone = 4_096, elapsedMillis = 250))
+        assertNull(transferSpeed(bytesDone = 4_096, elapsedMillis = 249))
+    }
+
+    @Test
+    fun anything_else_is_a_plain_document() {
+        assertEquals("description", sftpFileIcon("nginx.conf", FileItemType.File))
+        assertEquals("description", sftpFileIcon("LICENSE", FileItemType.File))
+        // A leading dot is the name, not an extension: ".env" must not read as an "env" type.
+        assertEquals("description", sftpFileIcon(".env", FileItemType.File))
+        assertEquals("description", sftpFileIcon("socket", FileItemType.Other))
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarOverflowTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarOverflowTest.kt
@@ -27,10 +27,13 @@ class ToolbarOverflowTest {
         assertTrue(ToolbarAction.Files !in hidden)
     }
 
+    // 534dp is wide enough that both groups still hold something either way, so one extra button
+    // costs exactly one action and nothing else moves. Narrower, a group empties and its hairline
+    // pays part of the bill — that is the subject of its own test below.
     @Test
     fun `the sync toggle costs one more slot, so it pushes one more action out`() {
-        val without = overflowedActions(available = 500.dp, syncShown = false)
-        val with = overflowedActions(available = 500.dp, syncShown = true)
+        val without = overflowedActions(available = 534.dp, syncShown = false)
+        val with = overflowedActions(available = 534.dp, syncShown = true)
         assertEquals(without.size + 1, with.size)
     }
 
@@ -38,8 +41,8 @@ class ToolbarOverflowTest {
     fun `the assistant button costs a slot only while it is shown`() {
         // Hidden for a host with AI off, so its slot must not be reserved: the row would collapse
         // one action early for every such host.
-        val off = overflowedActions(available = 500.dp, syncShown = false, assistantShown = false)
-        val on = overflowedActions(available = 500.dp, syncShown = false, assistantShown = true)
+        val off = overflowedActions(available = 534.dp, syncShown = false, assistantShown = false)
+        val on = overflowedActions(available = 534.dp, syncShown = false, assistantShown = true)
         assertEquals(off.size + 1, on.size)
     }
 
@@ -60,16 +63,79 @@ class ToolbarOverflowTest {
         assertTrue(tight.isNotEmpty())
     }
 
+    @Test
+    fun `a group emptied by overflow stops costing its separator`() {
+        // 465dp fits five icons and one hairline. With all four session actions in the menu the
+        // Workspace-Session separator is not drawn any more, so charging for it anyway would push
+        // the info panel out of a row that still has room for it.
+        assertEquals(
+            setOf(
+                ToolbarAction.Play,
+                ToolbarAction.Record,
+                ToolbarAction.Share,
+                ToolbarAction.Runbook,
+                ToolbarAction.Snippets,
+            ),
+            overflowedActions(available = 465.dp, syncShown = false),
+        )
+    }
+
     /**
      * Pins the threshold to the bar's actual geometry, not just to "somewhere between 400 and 800":
-     * title room (240) + the bar's own chrome — padding 2×10, the sidebar chevron 26 and the two
-     * 8dp gaps around the title (62) — plus 10 slots of 30 = 602dp. Sliding any of those constants
-     * without re-deriving this number has to break the test.
+     * title room (240) + the bar's own chrome — padding 2×10, the leading chevron 26 and the two
+     * 8dp gaps around the title (62) — plus the two group separators (2×11) and 9 slots of
+     * 30 = 594dp. Sliding any of those constants without re-deriving this number has to break the
+     * test.
      */
     @Test
     fun `the threshold sits exactly where the bar's geometry puts it`() {
-        assertTrue(overflowedActions(available = 602.dp, syncShown = false).isEmpty())
-        assertTrue(overflowedActions(available = 601.dp, syncShown = false).isNotEmpty())
+        assertTrue(overflowedActions(available = 594.dp, syncShown = false).isEmpty())
+        assertTrue(overflowedActions(available = 593.dp, syncShown = false).isNotEmpty())
+    }
+}
+
+/** What the action row offers when there is no session for the actions to act on. */
+class ToolbarAvailabilityTest {
+
+    @Test
+    fun `with a session the row offers everything`() {
+        assertEquals(ToolbarAction.entries.toSet(), availableActions(hasSession = true))
+    }
+
+    @Test
+    fun `without a session only the actions that do not need one are drawn`() {
+        // The player opens a recording in its own tab; every other action steers a session, and
+        // with none open they would be buttons that quietly do nothing.
+        assertEquals(setOf(ToolbarAction.Play), availableActions(hasSession = false))
+    }
+
+    @Test
+    fun `the actions are split into three groups, in row order`() {
+        assertEquals(
+            listOf(ToolbarGroup.Workspace, ToolbarGroup.Session, ToolbarGroup.Global),
+            ToolbarGroup.entries,
+        )
+        // An action missing from the row order sorts to -1, i.e. to the top of the overflow menu
+        // instead of into its group's place — and nothing else would say so.
+        assertEquals(ToolbarAction.entries.toSet(), TOOLBAR_ROW_ORDER.toSet())
+        assertEquals(ToolbarAction.entries.size, TOOLBAR_ROW_ORDER.size)
+        assertEquals(ToolbarGroup.Workspace, ToolbarAction.Files.group)
+        assertEquals(ToolbarGroup.Session, ToolbarAction.Snippets.group)
+        assertEquals(ToolbarGroup.Global, ToolbarAction.Play.group)
+    }
+
+    @Test
+    fun `a row with no session has room to spare, so nothing overflows`() {
+        // One icon left: a window that would collapse the full row keeps it.
+        assertTrue(overflowedActions(available = 400.dp, syncShown = false, hasSession = false).isEmpty())
+    }
+
+    @Test
+    fun `overflow only ever hides actions the row would have drawn`() {
+        // A window too narrow for anything: the one session-free action is all there is to hide,
+        // and the session-scoped ones must not turn up in the overflow menu they never entered.
+        val hidden = overflowedActions(available = 150.dp, syncShown = false, hasSession = false)
+        assertEquals(setOf(ToolbarAction.Play), hidden)
     }
 }
 


### PR DESCRIPTION
## SFTP screen

The screen sits under the shared work bar the terminal uses, with refresh, new folder, filter, columns and transfer as icon actions. The leading chevron returns to the terminal rather than toggling the hosts sidebar, which this screen never shows.

Each pane header carries its path and a badge naming the side; the listing has NAME / SIZE / MODIFIED / PERMS captions over columns in that order, flat rows with a hairline between them, directory names in cyan, and row icons chosen by extension.

## Transfer queue

Transfers moved from a single progress strip to a queue: one entry per operation, showing percentage, transferred bytes and speed while it runs, keeping its result on screen afterwards, and retaining the last few finished entries. The single-line state the mobile Files card reads is derived from that queue, so the two cannot disagree.

## Session action row

The row is split into three groups — workspace, session, global — parted by hairlines that render only with content on both sides. Actions that steer a live shell are left out entirely when no session is open rather than dimmed, so a window with nothing connected offers the recording player alone. Port forwarding leaves the row: the icon rail already opens the same screen. The overflow budget measures the separators the row will actually draw, through the same predicate it renders by, so a group emptied into the menu stops costing its hairline width.

## Structure

`TransferCoordinator` (690 lines) gave up the transfer planner and the queue to `TransferPlan.kt` and `TransferQueue.kt`, leaving it the transfer engine at 432; both extracted pieces are now unit-tested directly instead of only through a running transfer. `SftpPane.kt` (753) and `SftpView.kt` (605) split into `SftpListing.kt`, `SftpWorkBar.kt` and `TransferQueueStrip.kt`. The listing row's icon slot, name cell, column cells and hairline are shared with the static design render, so the offscreen preview matches what ships.

## Tests

`kotlin.test` on JUnit 5, hand-written fakes. New: `TransferPlanTest` (tree walks, pre-order directories, path-traversal guard on both walks, `ensureDir`'s tolerance and its original-error rethrow), `TransferQueueTest` (the queue as a state machine — progress accumulation, verdict immutability, eviction, dismissal), `ToolbarAvailabilityTest` (what the row offers without a session, group placement, row-order completeness), plus coordinator cases for cancellation, re-entry, a move with a failed delete, and cleanup on a failed picker upload. Every new test was run against a sabotaged implementation and observed to fail.

`./gradlew test allTests`, `build`, `detektAll` and `:androidApp:compileDebugKotlin` all green.

## Verifying by hand

`./gradlew :composeApp:run`, connect to a host, `Ctrl+Shift+E`. Check the column captions and row icons, drag a window narrow and watch the action row collapse group by group, close the session and see the session-scoped icons leave the row, and press the leading chevron to return to the terminal. A live SFTP host is required for the panes; Android was compiled but not run on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)