### PR TITLE
Floating action bar over the remote desktop, and a full-window mode

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -39,4 +39,13 @@
     <string name="rd_audio">Звук</string>
     <string name="rd_audio_device_lost">Аудиоустройство перестало принимать звук. Выберите другой вывод в профиле и переподключитесь.</string>
     <string name="rd_clipboard_share">Общий буфер обмена</string>
+    <string name="rd_display">Экран</string>
+    <string name="rd_fullscreen">Во всё окно</string>
+    <string name="rd_fullscreen_exit">Выйти из полного окна</string>
+    <string name="rd_disconnect">Отключиться</string>
+    <string name="rd_bar_pin">Закрепить панель</string>
+    <string name="rd_bar_unpin">Открепить панель</string>
+    <string name="rd_bar_hide">Скрыть панель</string>
+    <string name="rd_ctrl_alt_del_view_only">Только просмотр — ввод не отправляется</string>
+    <string name="rd_clipboard_failed">Системный буфер обмена недоступен</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -39,4 +39,13 @@
     <string name="rd_audio">声音</string>
     <string name="rd_audio_device_lost">音频设备已停止接收声音。请在配置中改选输出设备后重新连接。</string>
     <string name="rd_clipboard_share">共享剪贴板</string>
+    <string name="rd_display">显示</string>
+    <string name="rd_fullscreen">铺满窗口</string>
+    <string name="rd_fullscreen_exit">退出铺满窗口</string>
+    <string name="rd_disconnect">断开连接</string>
+    <string name="rd_bar_pin">固定操作栏</string>
+    <string name="rd_bar_unpin">取消固定操作栏</string>
+    <string name="rd_bar_hide">隐藏操作栏</string>
+    <string name="rd_ctrl_alt_del_view_only">仅查看 — 不发送输入</string>
+    <string name="rd_clipboard_failed">系统剪贴板拒绝访问</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -39,4 +39,13 @@
     <string name="rd_audio">Sound</string>
     <string name="rd_audio_device_lost">The audio device stopped taking sound. Pick another output in the profile, then reconnect.</string>
     <string name="rd_clipboard_share">Share the clipboard</string>
+    <string name="rd_display">Display</string>
+    <string name="rd_fullscreen">Fill the window</string>
+    <string name="rd_fullscreen_exit">Leave full window</string>
+    <string name="rd_disconnect">Disconnect</string>
+    <string name="rd_bar_pin">Keep the bar open</string>
+    <string name="rd_bar_unpin">Let the bar hide itself</string>
+    <string name="rd_bar_hide">Hide the bar</string>
+    <string name="rd_ctrl_alt_del_view_only">View only — input is not sent</string>
+    <string name="rd_clipboard_failed">The system clipboard refused</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopDesignState.kt
@@ -84,6 +84,15 @@ fun workAreaSection(active: Tab?, section: HostSection): HostSection = when {
     else -> HostSection.Terminal
 }
 
+/**
+ * Whether the app chrome (titlebar, rail, status bar, hosts sidebar) gives way to the remote
+ * desktop. The flag alone is not enough: the picture has to be the thing on screen, so a session is
+ * required ([desktopSession]) and an app-level view over the work area ([overlayOpen]) takes the
+ * chrome back — it has no floating bar of its own to leave the mode with.
+ */
+fun remoteChromeHidden(immersive: Boolean, desktopSession: Boolean, overlayOpen: Boolean): Boolean =
+    immersive && desktopSession && !overlayOpen
+
 /** Settings panel tabs. */
 enum class SettingsTab { AI, Sync, Security, Appearance, Terminal, Keyboard, Trash, About }
 
@@ -220,8 +229,12 @@ class DesktopDesignState(
     /** Whether the terminal's left host sidebar is hidden (toggled from the icon rail). */
     var sidebarHidden: Boolean by mutableStateOf(false); private set
 
-    /** Whether the session panel beside a live remote desktop is hidden. */
-    var remotePanelHidden: Boolean by mutableStateOf(false); private set
+    /**
+     * Whether a live remote desktop is shown without the app's own chrome — no titlebar, rail,
+     * status bar or hosts sidebar, only the picture and its floating bar. Session-scoped and not
+     * persisted: it is entered for a piece of work, not left standing.
+     */
+    var remoteImmersive: Boolean by mutableStateOf(false); private set
 
     /**
      * Which catalog the work area is showing: terminal-style connections or remote desktops (the
@@ -431,7 +444,14 @@ class DesktopDesignState(
     fun toggleSplit() { split = !split }
     fun toggleSidebar() { sidebarHidden = !sidebarHidden }
 
-    fun toggleRemotePanel() { remotePanelHidden = !remotePanelHidden }
+    fun toggleRemoteImmersive() { remoteImmersive = !remoteImmersive }
+
+    /**
+     * Leave immersive mode. Called when the desktop the mode was entered for goes off screen — the
+     * flag must not outlive it, or coming back to another tab would find the window stripped with
+     * nothing on it explaining why.
+     */
+    fun exitRemoteImmersive() { remoteImmersive = false }
 
     fun toggleAssistant() { assistantPanel = !assistantPanel }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
@@ -4,11 +4,7 @@ import app.skerry.ui.connection.toRdpPassword
 import app.skerry.shared.ssh.isRdp
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -87,7 +83,6 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.connection.DesktopPasswordDialog
 import app.skerry.ui.connection.connectableSecrets
 import app.skerry.ui.app.DesktopView
-import app.skerry.ui.design.HLine
 import app.skerry.ui.design.NoticeDialog
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.app.LocalShowTerminal
@@ -105,9 +100,9 @@ import app.skerry.ui.host.NewConnectionModal
 import app.skerry.ui.host.SshConfigImportModal
 import app.skerry.ui.sync.PairingShowDialog
 import app.skerry.ui.app.PendingClose
+import app.skerry.ui.app.remoteChromeHidden
 import app.skerry.ui.settings.SettingsPanel
 import app.skerry.ui.sync.SyncSetupDialog
-import app.skerry.ui.design.VLine
 import app.skerry.ui.i18n.label
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.theme.Skerry
@@ -355,18 +350,14 @@ internal fun DesktopChrome(
                 }
             }
         }
+        // Full-window remote desktop: the picture takes the window, chrome and all — see [DesktopShell].
+        val bareDesktop = remoteChromeHidden(
+            immersive = state.remoteImmersive,
+            desktopSession = sessions?.activeDesktop != null,
+            overlayOpen = state.appOverlay != null,
+        )
         Box(Modifier.fillMaxSize().background(Skerry.colors.bg).onPreviewKeyEvent(onRootKey)) {
-            Column(Modifier.fillMaxSize()) {
-                TitleBar(state, onLockWithTunnels, windowChrome)
-                HLine()
-                Row(Modifier.weight(1f).fillMaxWidth()) {
-                    IconRail(state)
-                    VLine(Skerry.colors.line)
-                    Box(Modifier.weight(1f).fillMaxHeight()) { Viewport(state) }
-                }
-                HLine()
-                StatusBar()
-            }
+            DesktopShell(state, onLockWithTunnels, windowChrome, bare = bareDesktop)
             // Mock/preview only: with live sessions a recording opens in its own tab (SessionView.Player),
             // and this state is never set. Esc (via ModalScrim) closes the overlay.
             state.castRecording?.let { cast -> CastPlayerOverlay(cast, onDismiss = state::closeCast) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShell.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShell.kt
@@ -1,0 +1,55 @@
+package app.skerry.ui.desktop
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.Modifier
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.VLine
+import app.skerry.ui.theme.Skerry
+
+/**
+ * The window's own furniture around the work area: titlebar → rail + viewport → status bar.
+ *
+ * With [bare] it draws none of it and hands the whole window to [Viewport] — a live remote desktop
+ * shown full-window, where the only chrome left is the session's own floating bar
+ * ([app.skerry.ui.remote.RemoteDesktopBar]). The OS window follows the same flag through
+ * [WindowChrome.setFullscreen]: a stripped app window still sitting inside a desktop would be half
+ * the mode. Leaving the composition (the vault locking) takes the window back out of full screen —
+ * an undecorated fullscreen window with the unlock screen in it could be neither moved nor closed.
+ */
+@Composable
+internal fun DesktopShell(
+    state: DesktopDesignState,
+    onLock: (() -> Unit)?,
+    windowChrome: WindowChrome?,
+    bare: Boolean,
+) {
+    DisposableEffect(bare, windowChrome) {
+        windowChrome?.setFullscreen(bare)
+        onDispose { windowChrome?.setFullscreen(false) }
+    }
+    Column(Modifier.fillMaxSize()) {
+        if (!bare) {
+            TitleBar(state, onLock, windowChrome)
+            HLine()
+        }
+        Row(Modifier.weight(1f).fillMaxWidth()) {
+            if (!bare) {
+                IconRail(state)
+                VLine(Skerry.colors.line)
+            }
+            Box(Modifier.weight(1f).fillMaxHeight()) { Viewport(state) }
+        }
+        if (!bare) {
+            HLine()
+            StatusBar()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/WindowChrome.kt
@@ -27,6 +27,11 @@ class WindowChrome(
     val onMinimize: () -> Unit,
     val onToggleMaximize: () -> Unit,
     val onClose: () -> Unit,
+    /**
+     * Puts the window on the whole screen (no OS chrome, no app chrome) and takes it back to where
+     * it was. Driven by the full-window remote desktop; a no-op on a decorated window.
+     */
+    val setFullscreen: (Boolean) -> Unit = {},
     /** Wraps [content] in a window-drag area (empty space drags, double-click toggles maximize). */
     val dragArea: @Composable (content: @Composable () -> Unit) -> Unit,
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -2,6 +2,8 @@ package app.skerry.ui.mobile
 
 import app.skerry.ui.remote.remoteKeyEvent
 import app.skerry.ui.remote.RemoteDesktopPanel
+import app.skerry.ui.remote.rememberClipboardActions
+import app.skerry.ui.remote.rememberScreenshotAction
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopUiState
 import app.skerry.ui.remote.ReportOutputVisibility
@@ -11,13 +13,11 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,8 +34,8 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -48,26 +48,17 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.graphics.RemoteDesktopQuality
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.MobileDesignState
-import app.skerry.ui.design.AnchoredDropdown
-import app.skerry.ui.design.HLine
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
-import app.skerry.ui.generated.resources.vnc_quality
-import app.skerry.ui.generated.resources.vnc_reset_zoom
-import app.skerry.ui.generated.resources.vnc_resize_to_window
 import app.skerry.ui.generated.resources.vnc_session_closed
-import app.skerry.ui.generated.resources.vnc_view_only
 import app.skerry.ui.immersive.ImmersiveScreen
 import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.vnc.VncTouchSurface
-import app.skerry.ui.vnc.keySymFor
-import app.skerry.ui.vnc.label
 import androidx.compose.ui.input.key.Key
 import app.skerry.ui.vnc.vncFailureText
 import kotlinx.coroutines.delay
@@ -167,6 +158,10 @@ fun MobileVncScreen(state: MobileDesignState) {
         // the panel would vanish rather than leave.
         var lastScreen by remember { mutableStateOf(connected) }
         if (connected != null) lastScreen = connected
+        // Remembered here rather than in the panel, which slides away and would take an in-flight
+        // save with it (see [rememberScreenshotAction]).
+        val screenshot = rememberScreenshotAction(lastScreen)
+        val clipboardActions = rememberClipboardActions(lastScreen)
         // The panel slides over the picture rather than beside it: on a phone a column of its width
         // would leave the desktop a strip.
         AnimatedVisibility(
@@ -178,6 +173,8 @@ fun MobileVncScreen(state: MobileDesignState) {
             lastScreen?.let {
                 RemoteDesktopPanel(
                     it,
+                    screenshot = screenshot,
+                    clipboardActions = clipboardActions,
                     onHide = { panelOpen = false },
                     modifier = Modifier.hiddenSystemBarsPadding(),
                     // Pinch-zoom is real here, so the fit can be off and worth resetting.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteBarState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteBarState.kt
@@ -1,0 +1,79 @@
+package app.skerry.ui.remote
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+
+/**
+ * Visibility of the floating action bar over a remote desktop: it slides up out of the way on its
+ * own, and comes back when the pointer reaches the top edge of the picture.
+ *
+ * Kept out of the composable so the rules can be tested without a composition. The timer itself
+ * belongs to the screen ([app.skerry.ui.vnc.VncView]); this only says whether one should be armed.
+ */
+@Stable
+class RemoteBarState {
+
+    /** Whether the bar is on screen. It starts up, so the session explains its own controls. */
+    var visible: Boolean by mutableStateOf(true)
+        private set
+
+    /** Pinned: the bar stays until the user hides it themselves. */
+    var pinned: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Bumped by every reveal. Part of the auto-hide effect's key: re-setting an already-true
+     * [visible] is not a state change, so without this a reveal would leave the running timer to
+     * expire on its old schedule and the bar would vanish a moment after being summoned.
+     */
+    var revealCount: Int by mutableStateOf(0)
+        private set
+
+    // The pointer is over the bar, or one of its menus is open — see [setHeld].
+    private var heldOpen by mutableStateOf(false)
+
+    /** Whether an auto-hide timer should be running right now. */
+    val autoHides: Boolean get() = visible && !pinned && !heldOpen
+
+    /** Show the bar and restart the timer. */
+    fun reveal() {
+        visible = true
+        revealCount++
+    }
+
+    /** Hide it now. Works on a pinned bar too: the pin governs the timer, not this button. */
+    fun hide() {
+        visible = false
+        // A pointer cannot be over a bar that is off screen, and a menu cannot outlive its anchor.
+        // Without this a bar hidden while held would come back with its timer disarmed and stay up
+        // for the rest of the session.
+        heldOpen = false
+    }
+
+    fun togglePin() {
+        pinned = !pinned
+        if (pinned) reveal()
+    }
+
+    /**
+     * Hold the bar open while the pointer is on it or a menu it opened is up: sliding away from
+     * under the user's hand would take the menu with it.
+     */
+    fun setHeld(value: Boolean) {
+        heldOpen = value
+    }
+
+    /**
+     * The pointer moved over the picture at [y] pixels from its top. Within [edge] of the top it
+     * summons the bar — the only way back once it has slid away.
+     *
+     * Only while the bar is away: this runs on every mouse move over the framebuffer, and a reveal
+     * of an already-visible bar would cancel and relaunch the auto-hide coroutine dozens of times a
+     * second for nothing. A pointer resting on the visible bar holds it open through [setHeld].
+     */
+    fun onPointerY(y: Float, edge: Float) {
+        if (y <= edge && !visible) reveal()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopBar.kt
@@ -1,0 +1,225 @@
+package app.skerry.ui.remote
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_audio
+import app.skerry.ui.generated.resources.rd_audio_device_lost
+import app.skerry.ui.generated.resources.rd_bar_hide
+import app.skerry.ui.generated.resources.rd_bar_pin
+import app.skerry.ui.generated.resources.rd_bar_unpin
+import app.skerry.ui.generated.resources.rd_clipboard
+import app.skerry.ui.generated.resources.rd_ctrl_alt_del
+import app.skerry.ui.generated.resources.rd_ctrl_alt_del_view_only
+import app.skerry.ui.generated.resources.rd_disconnect
+import app.skerry.ui.generated.resources.rd_display
+import app.skerry.ui.generated.resources.rd_fullscreen
+import app.skerry.ui.generated.resources.rd_fullscreen_exit
+import app.skerry.ui.generated.resources.rd_screenshot
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** How close to the top of the picture the pointer has to come to summon a hidden bar. */
+val REMOTE_BAR_EDGE: Dp = 12.dp
+
+/** How long the bar waits, untouched, before it slides back up. */
+const val REMOTE_BAR_AUTO_HIDE_MS = 3500L
+
+/**
+ * The action bar of a live remote desktop: a floating strip of icons over the top of the picture,
+ * holding what belongs to the session rather than to the image — the secure attention sequence, the
+ * clipboard, sound, the display settings, a screenshot, the full-window mode and the disconnect.
+ *
+ * It floats rather than taking a column beside the desktop: a remote screen is a screen, and every
+ * dp of chrome around it is a dp the user is not working in. It slides away on its own and comes
+ * back when the pointer reaches the top edge — [RemoteBarState] owns those rules.
+ */
+@Composable
+fun RemoteDesktopBar(
+    screen: RemoteDesktopScreenState,
+    bar: RemoteBarState,
+    // Remembered by the screen: the bar slides away on a timer, and a save launched in its scope
+    // would be cancelled mid-write with the file deleted and nothing said.
+    screenshot: ScreenshotAction,
+    clipboardActions: ClipboardActions,
+    immersive: Boolean,
+    onToggleImmersive: () -> Unit,
+    onDisconnect: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var displayOpen by remember { mutableStateOf(false) }
+    var clipboardOpen by remember { mutableStateOf(false) }
+
+    // The bar must outlive the pointer that opened a menu: the menu is a popup, so it is not part of
+    // the bar's own hover area, and a bar that slid away under an open menu would take it along.
+    // Cleared on the way out as well — a bar that left the screen while held would come back with
+    // its auto-hide timer disarmed and then sit there for the rest of the session.
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    DisposableEffect(hovered, displayOpen, clipboardOpen) {
+        bar.setHeld(hovered || displayOpen || clipboardOpen)
+        onDispose { bar.setHeld(false) }
+    }
+
+    val gap = with(LocalDensity.current) { 6.dp.roundToPx() }
+    val below = remember(gap) { belowAnchor(gap) }
+
+    Row(
+        modifier.padding(top = 12.dp).shadow(10.dp, RoundedCornerShape(12.dp)).clip(RoundedCornerShape(12.dp))
+            .background(Skerry.colors.surfaceDeep.copy(alpha = 0.95f))
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(12.dp))
+            .hoverable(interaction)
+            .padding(horizontal = 6.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        // The keyboard cannot produce this one: the local OS takes Ctrl+Alt+Del before any app sees it.
+        RemoteIconButton(
+            "keyboard",
+            stringResource(Res.string.rd_ctrl_alt_del),
+            enabled = !screen.viewOnly,
+            disabledTooltip = stringResource(Res.string.rd_ctrl_alt_del_view_only),
+            onClick = screen::sendCtrlAltDel,
+        )
+
+        if (screen.capabilities.clipboard) {
+            RemoteMenuHost(
+                expanded = clipboardOpen,
+                onDismiss = { clipboardOpen = false },
+                onToggle = { clipboardOpen = !clipboardOpen },
+                position = below,
+                trigger = { toggle ->
+                    RemoteIconButton(
+                        "content_paste",
+                        stringResource(Res.string.rd_clipboard),
+                        active = clipboardOpen,
+                        onClick = toggle,
+                    )
+                },
+            ) {
+                ClipboardMenu(screen, clipboardActions)
+            }
+        }
+
+        if (screen.capabilities.audio) {
+            // A device that died mid-session says so on the button itself: the sound switch is out
+            // here now, so there is no menu row left to carry the explanation.
+            val lost = screen.audioFailed && !screen.audioMuted
+            RemoteIconButton(
+                if (screen.audioMuted) "volume_off" else "volume_up",
+                if (lost) stringResource(Res.string.rd_audio_device_lost) else stringResource(Res.string.rd_audio),
+                active = !screen.audioMuted && !lost,
+                tint = if (lost) Skerry.colors.sunset else null,
+                onClick = screen::toggleAudioMuted,
+            )
+        }
+
+        BarDivider()
+
+        RemoteMenuHost(
+            expanded = displayOpen,
+            onDismiss = { displayOpen = false },
+            onToggle = { displayOpen = !displayOpen },
+            position = below,
+            trigger = { toggle ->
+                RemoteIconButton(
+                    "desktop_windows",
+                    stringResource(Res.string.rd_display),
+                    active = displayOpen,
+                    onClick = toggle,
+                )
+            },
+        ) {
+            // No reset-zoom row and no sound row: the desktop has no pinch zoom, and sound is a
+            // button of its own on this bar.
+            DisplayMenu(screen, showResetZoom = false, showAudio = false)
+        }
+
+        RemoteIconButton(
+            "screenshot_monitor",
+            stringResource(Res.string.rd_screenshot),
+            forcedTooltip = screenshot.note,
+            onClick = screenshot.take,
+        )
+
+        RemoteIconButton(
+            if (immersive) "fullscreen_exit" else "fullscreen",
+            stringResource(if (immersive) Res.string.rd_fullscreen_exit else Res.string.rd_fullscreen),
+            active = immersive,
+            onClick = onToggleImmersive,
+        )
+
+        RemoteIconButton(
+            "power_settings_new",
+            stringResource(Res.string.rd_disconnect),
+            tint = Skerry.colors.sunset,
+            onClick = onDisconnect,
+        )
+
+        BarDivider()
+
+        RemoteIconButton(
+            "push_pin",
+            stringResource(if (bar.pinned) Res.string.rd_bar_unpin else Res.string.rd_bar_pin),
+            active = bar.pinned,
+            size = BAR_SMALL_ICON,
+            onClick = bar::togglePin,
+        )
+        RemoteIconButton(
+            "keyboard_arrow_up",
+            stringResource(Res.string.rd_bar_hide),
+            size = BAR_SMALL_ICON,
+            onClick = bar::hide,
+        )
+    }
+}
+
+/** Drops a menu straight below its button, centered on it and kept inside the window. */
+internal fun belowAnchor(gap: Int): PopupPositionProvider = object : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset = IntOffset(
+        x = (anchorBounds.left + anchorBounds.width / 2 - popupContentSize.width / 2)
+            .coerceIn(0, (windowSize.width - popupContentSize.width).coerceAtLeast(0)),
+        y = (anchorBounds.bottom + gap)
+            .coerceAtMost((windowSize.height - popupContentSize.height).coerceAtLeast(0)),
+    )
+}
+
+@Composable
+private fun BarDivider() {
+    Box(Modifier.padding(horizontal = 5.dp).height(18.dp).width(1.dp).background(Skerry.colors.lineStrong))
+}
+
+private val BAR_SMALL_ICON = 28.dp

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopMenus.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopMenus.kt
@@ -1,0 +1,448 @@
+package app.skerry.ui.remote
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import app.skerry.shared.graphics.RemoteDesktopQuality
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.HoverTooltip
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_audio
+import app.skerry.ui.generated.resources.rd_audio_device_lost
+import app.skerry.ui.generated.resources.rd_clipboard_copy_here
+import app.skerry.ui.generated.resources.rd_clipboard_empty
+import app.skerry.ui.generated.resources.rd_clipboard_failed
+import app.skerry.ui.generated.resources.rd_clipboard_from_remote
+import app.skerry.ui.generated.resources.rd_clipboard_send
+import app.skerry.ui.generated.resources.rd_clipboard_share
+import app.skerry.ui.generated.resources.rd_screenshot_failed
+import app.skerry.ui.generated.resources.rd_screenshot_saved
+import app.skerry.ui.generated.resources.vnc_quality
+import app.skerry.ui.generated.resources.vnc_reset_zoom
+import app.skerry.ui.generated.resources.vnc_resize_to_window
+import app.skerry.ui.generated.resources.vnc_view_only
+import app.skerry.ui.terminal.fetchSystemClipboardText
+import app.skerry.ui.terminal.writeSystemClipboardDirect
+import app.skerry.ui.terminal.plainTextClipEntry
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.vnc.label
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The controls a live remote desktop offers, shared by the two shapes they are shown in: the
+ * desktop's floating bar over the picture ([RemoteDesktopBar]) and the strip beside it on a phone
+ * ([RemoteDesktopPanel]). Both drive the same [RemoteDesktopScreenState]; only the layout differs.
+ */
+
+/** One icon button. [forcedTooltip] shows a message the user did not ask to hover and wins while it lasts. */
+@Composable
+internal fun RemoteIconButton(
+    icon: String,
+    tooltip: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    active: Boolean = false,
+    tint: Color? = null,
+    size: Dp = REMOTE_ICON_BOX,
+    forcedTooltip: String? = null,
+    /** Shown in place of [tooltip] while the button is disabled: a dimmed icon alone says nothing. */
+    disabledTooltip: String? = null,
+    onClick: () -> Unit,
+) {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    // Touch has no hover: a long press is how a phone asks what a button is.
+    var pressedLong by remember { mutableStateOf(false) }
+    LaunchedEffect(pressedLong) {
+        if (pressedLong) {
+            delay(SHOT_NOTE_MS)
+            pressedLong = false
+        }
+    }
+
+    Box(
+        modifier.size(size).clip(RoundedCornerShape(7.dp))
+            .background(
+                when {
+                    active -> Skerry.colors.cyan10
+                    hovered -> Skerry.colors.hover
+                    else -> Color.Transparent
+                },
+            )
+            // Hoverable even when disabled: that is exactly when the tooltip has something to say.
+            .hoverable(interaction)
+            .pointerInput(enabled) {
+                detectTapGestures(
+                    onLongPress = { pressedLong = true },
+                    onTap = { if (enabled) onClick() },
+                )
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym(
+            icon,
+            size = 18.sp,
+            color = when {
+                !enabled -> Skerry.colors.faint
+                tint != null -> tint
+                active -> Skerry.colors.cyanBright
+                else -> Skerry.colors.dim
+            },
+        )
+        val label = if (enabled) tooltip else disabledTooltip ?: tooltip
+        val shown = forcedTooltip ?: label.takeIf { hovered || pressedLong }
+        if (shown != null) HoverTooltip(shown)
+    }
+}
+
+/**
+ * A menu hung off one of those buttons. The caller supplies [position] because the two layouts open
+ * in different directions — down from the floating bar, left from the strip at the right edge.
+ */
+@Composable
+internal fun RemoteMenuHost(
+    expanded: Boolean,
+    onDismiss: () -> Unit,
+    onToggle: () -> Unit,
+    position: PopupPositionProvider,
+    trigger: @Composable (toggle: () -> Unit) -> Unit,
+    content: @Composable () -> Unit,
+) {
+    // A press on the button of an open menu dismisses the popup and then reaches the button, which
+    // would open it straight back up. See [PopupToggleGuard].
+    val guard = remember { PopupToggleGuard() }
+    Box {
+        trigger { if (guard.opensOnClick()) onToggle() }
+        if (expanded) {
+            Popup(
+                popupPositionProvider = position,
+                onDismissRequest = {
+                    guard.onDismissed()
+                    onDismiss()
+                },
+                // Focusable would take the keyboard off the remote surface, and remote typing would
+                // die until the user clicked the picture again.
+                properties = PopupProperties(focusable = false),
+            ) {
+                Box(
+                    Modifier.width(REMOTE_MENU_WIDTH).clip(RoundedCornerShape(9.dp)).background(Skerry.colors.surfaceDeep)
+                        .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(9.dp)).padding(vertical = 4.dp),
+                ) { content() }
+            }
+        }
+    }
+}
+
+/**
+ * What the picture looks like: quality, view-only, following the window. [showResetZoom] is for the
+ * touch platform only — pinch-zoom is real on a phone, while the desktop wheel scrolls the remote
+ * desktop instead, so there the control would be a no-op. [showAudio] likewise: the floating bar
+ * has a sound button of its own, the strip does not.
+ */
+@Composable
+internal fun DisplayMenu(
+    screen: RemoteDesktopScreenState,
+    showResetZoom: Boolean,
+    showAudio: Boolean,
+) {
+    Column(Modifier.fillMaxWidth()) {
+        if (screen.capabilities.adjustableQuality) {
+            Txt(
+                stringResource(Res.string.vnc_quality),
+                color = Skerry.colors.faint,
+                size = 10.5.sp,
+                modifier = Modifier.padding(start = 12.dp, top = 6.dp, bottom = 2.dp),
+            )
+            RemoteDesktopQuality.entries.forEach { q ->
+                MenuRow(q.label(), selected = screen.quality == q) { screen.applyQuality(q) }
+            }
+            HLine(modifier = Modifier.padding(vertical = 4.dp))
+        }
+        CheckRow(stringResource(Res.string.vnc_view_only), screen.viewOnly, screen::toggleViewOnly)
+        // Only offered once the server has said it accepts a resize request.
+        if (screen.canResizeRemote) {
+            CheckRow(stringResource(Res.string.vnc_resize_to_window), screen.remoteResize, screen::toggleRemoteResize)
+        }
+        if (showAudio && screen.capabilities.audio) {
+            CheckRow(stringResource(Res.string.rd_audio), !screen.audioMuted, screen::toggleAudioMuted)
+            if (screen.audioFailed && !screen.audioMuted) AudioLostNote()
+        }
+        if (showResetZoom) {
+            MenuRow(stringResource(Res.string.vnc_reset_zoom), selected = false) { screen.resetZoom() }
+        }
+    }
+}
+
+/**
+ * The switch says sound is on while nothing comes out: without this line the only witness to a
+ * device that died mid-session is a trace nobody has turned on. Never shown while muted — muting
+ * stops the writes, so the player can never see a device take blocks again, and the line would sit
+ * under an off switch for the rest of the session telling the user to reconnect.
+ */
+@Composable
+internal fun AudioLostNote() {
+    Txt(
+        stringResource(Res.string.rd_audio_device_lost),
+        color = Skerry.colors.sunset,
+        size = 10.5.sp,
+        modifier = Modifier.padding(start = 34.dp, end = 12.dp, bottom = 4.dp),
+    )
+}
+
+/**
+ * Whether text crosses at all, what the remote machine last put on its clipboard, and the two ways
+ * to move it. The gate sits here rather than in the display menu: it is the clipboard's own switch,
+ * and it has to be reachable from the button it turns off.
+ */
+@Composable
+internal fun ClipboardMenu(screen: RemoteDesktopScreenState, actions: ClipboardActions) {
+    val shared = screen.clipboardShared
+    Column(Modifier.fillMaxWidth()) {
+        CheckRow(stringResource(Res.string.rd_clipboard_share), shared, screen::toggleClipboardShared)
+        if (shared) {
+            HLine(modifier = Modifier.padding(vertical = 4.dp))
+            val remote = screen.serverClipboard
+            Column(
+                Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Txt(stringResource(Res.string.rd_clipboard_from_remote), color = Skerry.colors.faint, size = 10.sp)
+                Txt(
+                    remote?.take(CLIPBOARD_PREVIEW) ?: stringResource(Res.string.rd_clipboard_empty),
+                    color = if (remote == null) Skerry.colors.dim else Skerry.colors.text,
+                    size = 11.5.sp,
+                    maxLines = 4,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                    if (remote != null) {
+                        SmallButton(stringResource(Res.string.rd_clipboard_copy_here)) { actions.copyHere(remote) }
+                    }
+                    SmallButton(stringResource(Res.string.rd_clipboard_send), onClick = actions.sendMine)
+                }
+                if (actions.failed) {
+                    Txt(stringResource(Res.string.rd_clipboard_failed), color = Skerry.colors.sunset, size = 10.5.sp)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Taking a screenshot, and the answer to the last one. Where the file went is a tooltip on the
+ * button rather than a line of text — neither layout has room for one, and the answer is only
+ * interesting for a moment, so it clears itself on a timer.
+ */
+@Immutable
+class ScreenshotAction(val note: String?, val take: () -> Unit)
+
+/**
+ * Moving text across, and whether the last attempt failed. Remembered by the screen for the same
+ * reason as [ScreenshotAction]: the menu these buttons live in is a popup that closes on the click
+ * that dismisses it, and a clipboard call launched in its scope would be cancelled on the way out.
+ */
+@Immutable
+class ClipboardActions(val failed: Boolean, val copyHere: (String) -> Unit, val sendMine: () -> Unit)
+
+@Composable
+fun rememberClipboardActions(screen: RemoteDesktopScreenState?): ClipboardActions {
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboard.current
+    // The system clipboard refuses often enough to be worth saying so: a busy X11 owner, a sandboxed
+    // Android app. Both directions are user-initiated presses, so silence would read as "nothing to
+    // send" rather than "this did not work".
+    var failed by remember { mutableStateOf(false) }
+    // Counted, not just flagged: a second failure while the note is up is not a state change, so
+    // without this the timer would keep the first one's schedule and the note would vanish right
+    // after the user pressed again — the same reason [RemoteBarState.revealCount] exists.
+    var failures by remember { mutableStateOf(0) }
+    LaunchedEffect(failed, failures) {
+        if (failed) {
+            delay(SHOT_NOTE_MS)
+            failed = false
+        }
+    }
+    val report: (Boolean) -> Unit = { ok ->
+        if (!ok) {
+            failed = true
+            failures++
+        }
+    }
+    return remember(screen, scope, failed) {
+        ClipboardActions(
+            failed = failed,
+            copyHere = { text ->
+                scope.launch {
+                    report(
+                        try {
+                            // Wayland reads go through wl-paste ([fetchSystemClipboardText]), so the
+                            // write takes wl-copy first — otherwise the two ends of this menu would
+                            // be on different buffers and "Send mine" would return older text.
+                            if (!withContext(Dispatchers.Default) { writeSystemClipboardDirect(text) }) {
+                                clipboard.setClipEntry(plainTextClipEntry(text))
+                            }
+                            true
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                            false
+                        },
+                    )
+                }
+                Unit
+            },
+            sendMine = {
+                if (screen != null) {
+                    scope.launch {
+                        report(
+                            try {
+                                fetchSystemClipboardText(clipboard)?.let(screen::onLocalClipboard)
+                                true
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (_: Exception) {
+                                false
+                            },
+                        )
+                    }
+                }
+                Unit
+            },
+        )
+    }
+}
+
+/**
+ * Remembered by the screen rather than by the bar or the panel: both of those come and go (the bar
+ * slides away on a timer), and a save launched in a scope that leaves the composition mid-write is
+ * cancelled with the file deleted and nothing said.
+ */
+@Composable
+fun rememberScreenshotAction(screen: RemoteDesktopScreenState?): ScreenshotAction {
+    val scope = rememberCoroutineScope()
+    var path by remember { mutableStateOf<String?>(null) }
+    var failed by remember { mutableStateOf(false) }
+    LaunchedEffect(path, failed) {
+        if (path != null || failed) {
+            delay(SHOT_NOTE_MS)
+            path = null
+            failed = false
+        }
+    }
+    val note = when {
+        failed -> stringResource(Res.string.rd_screenshot_failed)
+        else -> path?.let { stringResource(Res.string.rd_screenshot_saved, it) }
+    }
+    // The lambda is memoized: it flows into a button's onClick, and a fresh instance on every
+    // recomposition (the note clears itself on a timer) would defeat that button's skipping.
+    val take = remember(screen, scope) {
+        {
+            // Nullable so the caller can remember the action unconditionally: a screen that comes
+            // and goes must not make this a conditional composable call.
+            if (screen != null) {
+                scope.launch {
+                    val saved = saveRemoteScreenshot(screen.imageBitmap, screen.serverName)
+                    path = saved
+                    failed = saved == null
+                }
+            }
+            Unit
+        }
+    }
+    return remember(note, take) { ScreenshotAction(note, take) }
+}
+
+@Composable
+internal fun SmallButton(label: String, onClick: () -> Unit) {
+    Box(
+        Modifier.clip(RoundedCornerShape(6.dp)).background(Skerry.colors.surfaceDeep)
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp))
+            .clickable(onClick = onClick).padding(horizontal = 8.dp, vertical = 5.dp),
+    ) {
+        Txt(label, color = Skerry.colors.cyanBright, size = 11.sp)
+    }
+}
+
+@Composable
+internal fun MenuRow(label: String, selected: Boolean, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
+            .clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(
+            label,
+            color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text,
+            size = 12.5.sp,
+            modifier = Modifier.weight(1f),
+        )
+        if (selected) Sym("check", size = 14.sp, color = Skerry.colors.cyanBright)
+    }
+}
+
+@Composable
+internal fun CheckRow(label: String, checked: Boolean, onClick: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Sym(
+            if (checked) "check_box" else "check_box_outline_blank",
+            size = 15.sp,
+            color = if (checked) Skerry.colors.cyanBright else Skerry.colors.dim,
+        )
+        Txt(
+            label,
+            color = if (checked) Skerry.colors.cyanBright else Skerry.colors.text,
+            size = 12.5.sp,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+internal val REMOTE_ICON_BOX = 34.dp
+internal val REMOTE_MENU_WIDTH = 220.dp
+internal const val CLIPBOARD_PREVIEW = 400
+internal const val SHOT_NOTE_MS = 2500L

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteDesktopPanel.kt
@@ -1,121 +1,65 @@
 package app.skerry.ui.remote
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
-import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupPositionProvider
-import androidx.compose.ui.window.PopupProperties
-import app.skerry.shared.graphics.RemoteDesktopQuality
 import app.skerry.ui.design.HLine
-import app.skerry.ui.design.HoverTooltip
-import app.skerry.ui.design.Sym
-import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.rd_audio
-import app.skerry.ui.generated.resources.rd_audio_device_lost
 import app.skerry.ui.generated.resources.rd_clipboard
-import app.skerry.ui.generated.resources.rd_clipboard_copy_here
-import app.skerry.ui.generated.resources.rd_clipboard_empty
-import app.skerry.ui.generated.resources.rd_clipboard_from_remote
-import app.skerry.ui.generated.resources.rd_clipboard_send
-import app.skerry.ui.generated.resources.rd_clipboard_share
 import app.skerry.ui.generated.resources.rd_ctrl_alt_del
+import app.skerry.ui.generated.resources.rd_ctrl_alt_del_view_only
 import app.skerry.ui.generated.resources.rd_panel_hide
 import app.skerry.ui.generated.resources.rd_screenshot
-import app.skerry.ui.generated.resources.rd_screenshot_failed
-import app.skerry.ui.generated.resources.rd_screenshot_saved
 import app.skerry.ui.generated.resources.rd_settings
-import app.skerry.ui.generated.resources.vnc_quality
-import app.skerry.ui.generated.resources.vnc_reset_zoom
-import app.skerry.ui.generated.resources.vnc_resize_to_window
-import app.skerry.ui.generated.resources.vnc_view_only
-import app.skerry.ui.terminal.fetchSystemClipboardText
-import app.skerry.ui.terminal.plainTextClipEntry
 import app.skerry.ui.theme.Skerry
-import app.skerry.ui.vnc.label
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 
-/** Width of the session panel: a strip of icons, the same figure on both platforms. */
+/** Width of the session panel: a strip of icons. */
 val REMOTE_PANEL_WIDTH: Dp = 44.dp
 
 /**
- * The session panel beside a live remote desktop: the actions that belong to the session rather than
- * to the picture — a screenshot, the secure attention sequence, the clipboard, and the settings that
- * used to sit in the floating gear.
+ * The session panel beside a live remote desktop on a phone: the actions that belong to the session
+ * rather than to the picture. Icons only, each naming itself on a long press — a column of labels
+ * would leave the desktop a strip.
  *
- * Icons only, each naming itself on hover (desktop) or on a long press (touch). A column of labels
- * would cost the desktop a fifth of its width for text the user reads once.
- *
- * [showResetZoom] is for the touch platform only: pinch-zoom is real on a phone, while the desktop
- * wheel scrolls the remote desktop instead, so there the control would be a no-op.
+ * The desktop shows the same actions as a floating bar over the picture ([RemoteDesktopBar]); both
+ * drive the shared menus in [RemoteDesktopMenus].
  */
 @Composable
 fun RemoteDesktopPanel(
     screen: RemoteDesktopScreenState,
+    // Remembered by the screen, not by the panel: the panel slides away, a save in its scope would
+    // die with it. See [rememberScreenshotAction].
+    screenshot: ScreenshotAction,
+    clipboardActions: ClipboardActions,
     onHide: () -> Unit,
     modifier: Modifier = Modifier,
     showResetZoom: Boolean = false,
 ) {
-    val scope = rememberCoroutineScope()
-    val clipboard = LocalClipboard.current
     var settingsOpen by remember { mutableStateOf(false) }
     var clipboardOpen by remember { mutableStateOf(false) }
-    // Where the last screenshot went. Shown as a tooltip on its own button and cleared on a timer:
-    // the strip has no room for a line of text, and the answer is only interesting for a moment.
-    var shotPath by remember { mutableStateOf<String?>(null) }
-    var shotFailed by remember { mutableStateOf(false) }
-    LaunchedEffect(shotPath, shotFailed) {
-        if (shotPath != null || shotFailed) {
-            delay(SHOT_NOTE_MS)
-            shotPath = null
-            shotFailed = false
-        }
-    }
-    val shotNote = when {
-        shotFailed -> stringResource(Res.string.rd_screenshot_failed)
-        else -> shotPath?.let { stringResource(Res.string.rd_screenshot_saved, it) }
-    }
+    val gap = with(LocalDensity.current) { 6.dp.roundToPx() }
+    val menuPosition = remember(gap) { leftOfAnchor(gap) }
 
     Column(
         modifier.width(REMOTE_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2)
@@ -123,307 +67,80 @@ fun RemoteDesktopPanel(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
-        PanelIcon("chevron_right", stringResource(Res.string.rd_panel_hide), onClick = onHide)
+        RemoteIconButton("chevron_right", stringResource(Res.string.rd_panel_hide), onClick = onHide)
         HLine(modifier = Modifier.padding(vertical = 2.dp))
 
-        PanelIcon("photo_camera", stringResource(Res.string.rd_screenshot), forcedTooltip = shotNote) {
-            scope.launch {
-                val saved = saveRemoteScreenshot(screen.imageBitmap, screen.serverName)
-                shotPath = saved
-                shotFailed = saved == null
-            }
-        }
+        RemoteIconButton(
+            "photo_camera",
+            stringResource(Res.string.rd_screenshot),
+            forcedTooltip = screenshot.note,
+            onClick = screenshot.take,
+        )
 
         // The keyboard cannot produce this one: the local OS takes Ctrl+Alt+Del before any app sees it.
-        PanelIcon("keyboard", stringResource(Res.string.rd_ctrl_alt_del), enabled = !screen.viewOnly) {
-            screen.sendCtrlAltDel()
-        }
+        RemoteIconButton(
+            "keyboard",
+            stringResource(Res.string.rd_ctrl_alt_del),
+            enabled = !screen.viewOnly,
+            disabledTooltip = stringResource(Res.string.rd_ctrl_alt_del_view_only),
+            onClick = screen::sendCtrlAltDel,
+        )
 
         if (screen.capabilities.clipboard) {
-            if (!screen.clipboardShared) clipboardOpen = false
-            PanelPopup(
+            RemoteMenuHost(
                 expanded = clipboardOpen,
                 onDismiss = { clipboardOpen = false },
                 onToggle = { clipboardOpen = !clipboardOpen },
+                position = menuPosition,
                 trigger = { toggle ->
-                    PanelIcon(
+                    RemoteIconButton(
                         "content_paste",
                         stringResource(Res.string.rd_clipboard),
-                        // Nothing here works while sharing is off, and a button that answers a press
-                        // with silence reads as a broken one.
-                        enabled = screen.clipboardShared,
                         active = clipboardOpen,
                         onClick = toggle,
                     )
                 },
             ) {
-                ClipboardMenu(
-                    screen,
-                    onCopyHere = { text -> scope.launch { clipboard.setClipEntry(plainTextClipEntry(text)) } },
-                    onSendMine = {
-                        scope.launch { fetchSystemClipboardText(clipboard)?.let(screen::onLocalClipboard) }
-                    },
-                )
+                ClipboardMenu(screen, clipboardActions)
             }
         }
 
-        PanelPopup(
+        RemoteMenuHost(
             expanded = settingsOpen,
             onDismiss = { settingsOpen = false },
             onToggle = { settingsOpen = !settingsOpen },
+            position = menuPosition,
             trigger = { toggle ->
-                PanelIcon("tune", stringResource(Res.string.rd_settings), active = settingsOpen, onClick = toggle)
+                RemoteIconButton("tune", stringResource(Res.string.rd_settings), active = settingsOpen, onClick = toggle)
             },
         ) {
-            SettingsMenu(screen, showResetZoom)
+            DisplayMenu(screen, showResetZoom = showResetZoom, showAudio = true)
         }
     }
 }
 
 /**
- * Slim strip at the right edge while the session panel is collapsed, painted in the panel's own
- * surface so it reads as the panel peeking out. The mirror image of the hosts sidebar's handle.
+ * Opens a menu to the left of its button. The shared [app.skerry.ui.design.AnchoredDropdown] drops
+ * straight down from the anchor's left edge, which against the right screen edge would put the menu
+ * off-screen.
  */
-@Composable
-fun PanelReopenHandle(onClick: () -> Unit) {
-    Box(
-        Modifier.width(16.dp).fillMaxHeight().background(Skerry.colors.surface2).clickable(onClick = onClick),
-        contentAlignment = Alignment.Center,
-    ) {
-        Sym("chevron_left", size = 16.sp, color = Skerry.colors.faint)
-    }
-}
-
-/**
- * One button of the strip. [forcedTooltip] shows a message the user did not ask to hover — the
- * screenshot's answer — and takes precedence over [tooltip] while it lasts.
- */
-@Composable
-private fun PanelIcon(
-    icon: String,
-    tooltip: String,
-    enabled: Boolean = true,
-    active: Boolean = false,
-    forcedTooltip: String? = null,
-    onClick: () -> Unit,
-) {
-    val interaction = remember { MutableInteractionSource() }
-    val hovered by interaction.collectIsHoveredAsState()
-    // Touch has no hover: a long press is how a phone asks what a button is.
-    var pressedLong by remember { mutableStateOf(false) }
-    LaunchedEffect(pressedLong) {
-        if (pressedLong) {
-            delay(SHOT_NOTE_MS)
-            pressedLong = false
-        }
-    }
-
-    Box(
-        Modifier.size(PANEL_ICON_BOX).clip(RoundedCornerShape(7.dp))
-            .background(
-                when {
-                    active -> Skerry.colors.cyan10
-                    hovered -> Skerry.colors.hover
-                    else -> Color.Transparent
-                },
-            )
-            .hoverable(interaction, enabled = enabled)
-            .pointerInput(enabled) {
-                detectTapGestures(
-                    onLongPress = { pressedLong = true },
-                    onTap = { if (enabled) onClick() },
-                )
-            },
-        contentAlignment = Alignment.Center,
-    ) {
-        Sym(
-            icon,
-            size = 18.sp,
-            color = when {
-                !enabled -> Skerry.colors.faint
-                active -> Skerry.colors.cyanBright
-                else -> Skerry.colors.dim
-            },
+internal fun leftOfAnchor(gap: Int): PopupPositionProvider = object : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val left = anchorBounds.left - popupContentSize.width - gap
+        return IntOffset(
+            // Falls back to the right of the anchor on a window too narrow for either side, where a
+            // negative x would clip the menu against the window edge.
+            x = if (left >= 0) left else (anchorBounds.right + gap).coerceAtMost(
+                (windowSize.width - popupContentSize.width).coerceAtLeast(0),
+            ),
+            y = anchorBounds.top.coerceAtMost(
+                (windowSize.height - popupContentSize.height).coerceAtLeast(0),
+            ),
         )
-        val shown = forcedTooltip ?: tooltip.takeIf { hovered || pressedLong }
-        if (shown != null) HoverTooltip(shown)
     }
 }
-
-/**
- * A menu hung off a button of the strip, opening to its left. The shared [app.skerry.ui.design.AnchoredDropdown]
- * drops straight down from the anchor's left edge, which against the right screen edge would put the
- * menu off-screen.
- */
-@Composable
-private fun PanelPopup(
-    expanded: Boolean,
-    onDismiss: () -> Unit,
-    onToggle: () -> Unit,
-    trigger: @Composable (toggle: () -> Unit) -> Unit,
-    content: @Composable () -> Unit,
-) {
-    // A press on the button of an open menu dismisses the popup and then reaches the button, which
-    // would open it straight back up. See [PopupToggleGuard].
-    val guard = remember { PopupToggleGuard() }
-    val gap = with(LocalDensity.current) { 6.dp.roundToPx() }
-    val position = remember(gap) {
-        object : PopupPositionProvider {
-            override fun calculatePosition(
-                anchorBounds: IntRect,
-                windowSize: IntSize,
-                layoutDirection: LayoutDirection,
-                popupContentSize: IntSize,
-            ): IntOffset {
-                val left = anchorBounds.left - popupContentSize.width - gap
-                return IntOffset(
-                    // Falls back to the right of the anchor on a window too narrow for either side,
-                    // where a negative x would clip the menu against the window edge.
-                    x = if (left >= 0) left else (anchorBounds.right + gap).coerceAtMost(
-                        (windowSize.width - popupContentSize.width).coerceAtLeast(0),
-                    ),
-                    y = anchorBounds.top.coerceAtMost(
-                        (windowSize.height - popupContentSize.height).coerceAtLeast(0),
-                    ),
-                )
-            }
-        }
-    }
-    Box {
-        trigger { if (guard.opensOnClick()) onToggle() }
-        if (expanded) {
-            Popup(
-                popupPositionProvider = position,
-                onDismissRequest = {
-                    guard.onDismissed()
-                    onDismiss()
-                },
-                // Focusable would take the keyboard off the remote surface, and remote typing would
-                // die until the user clicked the picture again.
-                properties = PopupProperties(focusable = false),
-            ) {
-                Box(
-                    Modifier.width(MENU_WIDTH).clip(RoundedCornerShape(9.dp)).background(Skerry.colors.surfaceDeep)
-                        .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(9.dp)).padding(vertical = 4.dp),
-                ) { content() }
-            }
-        }
-    }
-}
-
-/** The settings that used to live in the floating gear, now behind the strip's gear. */
-@Composable
-private fun SettingsMenu(screen: RemoteDesktopScreenState, showResetZoom: Boolean) {
-    Column(Modifier.fillMaxWidth()) {
-        if (screen.capabilities.adjustableQuality) {
-            Txt(
-                stringResource(Res.string.vnc_quality),
-                color = Skerry.colors.faint,
-                size = 10.5.sp,
-                modifier = Modifier.padding(start = 12.dp, top = 6.dp, bottom = 2.dp),
-            )
-            RemoteDesktopQuality.entries.forEach { q ->
-                MenuRow(q.label(), selected = screen.quality == q) { screen.applyQuality(q) }
-            }
-            HLine(modifier = Modifier.padding(vertical = 4.dp))
-        }
-        CheckRow(stringResource(Res.string.vnc_view_only), screen.viewOnly, screen::toggleViewOnly)
-        // Only offered once the server has said it accepts a resize request.
-        if (screen.canResizeRemote) {
-            CheckRow(stringResource(Res.string.vnc_resize_to_window), screen.remoteResize, screen::toggleRemoteResize)
-        }
-        if (screen.capabilities.audio) {
-            CheckRow(stringResource(Res.string.rd_audio), !screen.audioMuted, screen::toggleAudioMuted)
-            // The switch says sound is on while nothing comes out: without this line the only
-            // witness to a device that died mid-session is a trace nobody has turned on.
-            // Hidden while muted: muting stops the writes, so the player can never see a device
-            // take blocks again, and the line would sit under an off switch for the rest of the
-            // session telling the user to reconnect.
-            if (screen.audioFailed && !screen.audioMuted) {
-                Txt(
-                    stringResource(Res.string.rd_audio_device_lost),
-                    color = Skerry.colors.sunset,
-                    size = 10.5.sp,
-                    modifier = Modifier.padding(start = 34.dp, end = 12.dp, bottom = 4.dp),
-                )
-            }
-        }
-        if (screen.capabilities.clipboard) {
-            CheckRow(stringResource(Res.string.rd_clipboard_share), screen.clipboardShared, screen::toggleClipboardShared)
-        }
-        if (showResetZoom) {
-            MenuRow(stringResource(Res.string.vnc_reset_zoom), selected = false) { screen.resetZoom() }
-        }
-    }
-}
-
-/** What the remote machine last put on its clipboard, and the two ways to move text across. */
-@Composable
-private fun ClipboardMenu(
-    screen: RemoteDesktopScreenState,
-    onCopyHere: (String) -> Unit,
-    onSendMine: () -> Unit,
-) {
-    val remote = screen.serverClipboard
-    Column(
-        Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
-    ) {
-        Txt(stringResource(Res.string.rd_clipboard_from_remote), color = Skerry.colors.faint, size = 10.sp)
-        Txt(
-            remote?.take(CLIPBOARD_PREVIEW) ?: stringResource(Res.string.rd_clipboard_empty),
-            color = if (remote == null) Skerry.colors.dim else Skerry.colors.text,
-            size = 11.5.sp,
-            maxLines = 4,
-            overflow = TextOverflow.Ellipsis,
-        )
-        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-            if (remote != null) SmallButton(stringResource(Res.string.rd_clipboard_copy_here)) { onCopyHere(remote) }
-            SmallButton(stringResource(Res.string.rd_clipboard_send), onClick = onSendMine)
-        }
-    }
-}
-
-@Composable
-private fun SmallButton(label: String, onClick: () -> Unit) {
-    Box(
-        Modifier.clip(RoundedCornerShape(6.dp)).background(Skerry.colors.surfaceDeep)
-            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(6.dp))
-            .clickable(onClick = onClick).padding(horizontal = 8.dp, vertical = 5.dp),
-    ) {
-        Txt(label, color = Skerry.colors.cyanBright, size = 11.sp)
-    }
-}
-
-@Composable
-private fun MenuRow(label: String, selected: Boolean, onClick: () -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-            .clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Txt(label, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
-        if (selected) Sym("check", size = 14.sp, color = Skerry.colors.cyanBright)
-    }
-}
-
-@Composable
-private fun CheckRow(label: String, checked: Boolean, onClick: () -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().clickable(onClick = onClick).padding(horizontal = 12.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Sym(
-            if (checked) "check_box" else "check_box_outline_blank",
-            size = 15.sp,
-            color = if (checked) Skerry.colors.cyanBright else Skerry.colors.dim,
-        )
-        Txt(label, color = if (checked) Skerry.colors.cyanBright else Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
-    }
-}
-
-private val PANEL_ICON_BOX = 34.dp
-private val MENU_WIDTH = 220.dp
-private const val CLIPBOARD_PREVIEW = 400
-private const val SHOT_NOTE_MS = 2500L

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -1,9 +1,13 @@
 package app.skerry.ui.vnc
 
 import app.skerry.ui.remote.remoteKeyEvent
-import app.skerry.ui.remote.PanelReopenHandle
-import app.skerry.ui.remote.RemoteDesktopPanel
+import app.skerry.ui.remote.REMOTE_BAR_AUTO_HIDE_MS
+import app.skerry.ui.remote.REMOTE_BAR_EDGE
+import app.skerry.ui.remote.RemoteBarState
+import app.skerry.ui.remote.RemoteDesktopBar
 import app.skerry.ui.remote.RemoteDesktopScreenState
+import app.skerry.ui.remote.rememberClipboardActions
+import app.skerry.ui.remote.rememberScreenshotAction
 import app.skerry.ui.remote.RemoteDesktopController
 import app.skerry.ui.remote.RemoteDesktopUiState
 import app.skerry.ui.remote.ReportOutputVisibility
@@ -12,10 +16,10 @@ import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkHorizontally
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -23,16 +27,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,6 +58,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -62,8 +66,6 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.graphics.RemoteDesktopQuality
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalSessions
-import app.skerry.ui.design.AnchoredDropdown
-import app.skerry.ui.design.HLine
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
@@ -71,20 +73,19 @@ import app.skerry.ui.generated.resources.rd_no_session
 import app.skerry.ui.generated.resources.rd_pick_to_connect
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
-import app.skerry.ui.generated.resources.vnc_quality
 import app.skerry.ui.generated.resources.vnc_quality_auto
 import app.skerry.ui.generated.resources.vnc_quality_high
 import app.skerry.ui.generated.resources.vnc_quality_low
 import app.skerry.ui.generated.resources.vnc_quality_medium
-import app.skerry.ui.generated.resources.vnc_resize_to_window
 import app.skerry.ui.generated.resources.vnc_session_closed
-import app.skerry.ui.generated.resources.vnc_view_only
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.terminal.HostsSidebar
 import app.skerry.ui.terminal.SidebarReopenHandle
 import app.skerry.ui.terminal.plainTextClipEntry
 import app.skerry.ui.terminal.readPlainText
+import app.skerry.ui.app.remoteChromeHidden
 import kotlin.math.roundToInt
+import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
@@ -95,11 +96,19 @@ import app.skerry.ui.theme.Skerry
  */
 @Composable
 fun RemoteDesktopsView(state: DesktopDesignState) {
+    val sessions = LocalSessions.current
+    // Full-window mode takes the catalog with the rest of the chrome; the desktop's floating bar is
+    // the way back out.
+    val immersive = remoteChromeHidden(
+        immersive = state.remoteImmersive,
+        desktopSession = sessions?.activeDesktop != null,
+        overlayOpen = state.appOverlay != null,
+    )
     Row(Modifier.fillMaxSize()) {
         // Same collapse behaviour as the terminal sidebar (shared [DesktopDesignState.sidebarHidden]),
         // so hiding the panel in one section hides it in both — one shell, one preference.
         AnimatedVisibility(
-            visible = !state.sidebarHidden,
+            visible = !state.sidebarHidden && !immersive,
             enter = expandHorizontally(expandFrom = Alignment.End),
             exit = shrinkHorizontally(shrinkTowards = Alignment.End),
         ) {
@@ -108,12 +117,12 @@ fun RemoteDesktopsView(state: DesktopDesignState) {
             HostsSidebar(state, state.section)
         }
         AnimatedVisibility(
-            visible = state.sidebarHidden,
+            visible = state.sidebarHidden && !immersive,
             enter = fadeIn() + expandHorizontally(expandFrom = Alignment.Start),
             exit = fadeOut() + shrinkHorizontally(shrinkTowards = Alignment.Start),
         ) { SidebarReopenHandle(onClick = state::toggleSidebar) }
         Box(Modifier.weight(1f).fillMaxHeight()) {
-            if (LocalSessions.current?.activeDesktop != null) {
+            if (sessions?.activeDesktop != null) {
                 VncView(state)
             } else {
                 EmptyState(
@@ -135,24 +144,59 @@ fun RemoteDesktopsView(state: DesktopDesignState) {
 @Composable
 fun VncView(state: DesktopDesignState) {
     val sessions = LocalSessions.current
-    val vnc = sessions?.activeDesktop?.focusedPane?.vncController ?: return
+    val tab = sessions?.activeDesktop ?: return
+    val vnc = tab.focusedPane.vncController ?: return
     Box(Modifier.fillMaxSize()) {
         when (val ui = vnc.uiState) {
             is RemoteDesktopUiState.Connecting -> CenterNotice("hourglass_empty", stringResource(Res.string.vnc_connecting))
-            is RemoteDesktopUiState.Connected -> Row(Modifier.fillMaxSize()) {
-                // A minimised window, or another tab taking the screen, stops the server drawing.
-                ReportOutputVisibility(ui.screen)
-                Box(Modifier.weight(1f).fillMaxHeight()) { VncSurface(ui.screen) }
-                AnimatedVisibility(
-                    visible = !state.remotePanelHidden,
-                    enter = expandHorizontally(expandFrom = Alignment.Start),
-                    exit = shrinkHorizontally(shrinkTowards = Alignment.Start),
-                ) { RemoteDesktopPanel(ui.screen, onHide = state::toggleRemotePanel) }
-                AnimatedVisibility(
-                    visible = state.remotePanelHidden,
-                    enter = fadeIn() + expandHorizontally(expandFrom = Alignment.End),
-                    exit = fadeOut() + shrinkHorizontally(shrinkTowards = Alignment.End),
-                ) { PanelReopenHandle(onClick = state::toggleRemotePanel) }
+            // key(tab.id): switching between two connected desktops keeps this same branch, so
+            // without it Compose reuses the slot and the next session would inherit the previous
+            // one's bar — hidden or pinned, its menus open — and the full-window mode with it.
+            is RemoteDesktopUiState.Connected -> androidx.compose.runtime.key(tab.id) {
+                // clipToBounds: the bar slides out through the top edge, and without a clip it would
+                // be drawn over the chrome above the work area on its way out.
+                Box(Modifier.fillMaxSize().clipToBounds()) {
+                    // A minimised window, or another tab taking the screen, stops the server drawing.
+                    ReportOutputVisibility(ui.screen)
+                    val bar = remember { RemoteBarState() }
+                    val screenshot = rememberScreenshotAction(ui.screen)
+                    val clipboardActions = rememberClipboardActions(ui.screen)
+                    val edge = with(LocalDensity.current) { REMOTE_BAR_EDGE.toPx() }
+                    // The full-window mode belongs to this session: leaving it (another tab, a
+                    // closed desktop) must not leave the window stripped of its chrome.
+                    DisposableEffect(Unit) { onDispose { state.exitRemoteImmersive() } }
+                    // Auto-hide, restarted by every reveal (revealCount) and disarmed while the
+                    // pointer is on the bar, one of its menus is open, or it is pinned.
+                    LaunchedEffect(bar.autoHides, bar.revealCount) {
+                        if (bar.autoHides) {
+                            delay(REMOTE_BAR_AUTO_HIDE_MS)
+                            bar.hide()
+                        }
+                    }
+                    // The screenshot answers on the bar itself, so a failure has to bring the bar
+                    // back — otherwise the only word about an unwritten file lands off screen.
+                    LaunchedEffect(screenshot.note) { if (screenshot.note != null) bar.reveal() }
+                    // The reveal zone is read off the framebuffer's own pointer stream rather than
+                    // from a strip laid over the top of it: a strip would swallow every mouse move
+                    // in its band, and the remote cursor would stop dead a few pixels below the edge.
+                    VncSurface(ui.screen, onPointerY = { y -> bar.onPointerY(y, edge) })
+                    AnimatedVisibility(
+                        visible = bar.visible,
+                        modifier = Modifier.align(Alignment.TopCenter),
+                        enter = slideInVertically { -it } + fadeIn(),
+                        exit = slideOutVertically { -it } + fadeOut(),
+                    ) {
+                        RemoteDesktopBar(
+                            screen = ui.screen,
+                            bar = bar,
+                            screenshot = screenshot,
+                            clipboardActions = clipboardActions,
+                            immersive = state.remoteImmersive,
+                            onToggleImmersive = state::toggleRemoteImmersive,
+                            onDisconnect = { state.requestCloseSession(tab.id) },
+                        )
+                    }
+                }
             }
             is RemoteDesktopUiState.Error -> CenterNotice(
                 "error",
@@ -177,7 +221,13 @@ fun VncView(state: DesktopDesignState) {
  * mapped back through the same [fitGeometry] the draw uses.
  */
 @Composable
-fun VncSurface(screen: RemoteDesktopScreenState, interactive: Boolean = true) {
+fun VncSurface(
+    screen: RemoteDesktopScreenState,
+    interactive: Boolean = true,
+    // Every pointer position over the surface, in pixels from its top edge. The floating bar reads
+    // it to know when the pointer has come up to summon it.
+    onPointerY: (Float) -> Unit = {},
+) {
     val frame = screen.frame
     var canvasSize by remember { mutableStateOf(IntSize.Zero) }
     val focus = remember { FocusRequester() }
@@ -206,6 +256,9 @@ fun VncSurface(screen: RemoteDesktopScreenState, interactive: Boolean = true) {
     ) {
         hiddenPointerIcon()?.let { mod = mod.pointerHoverIcon(it) }
     }
+    // pointerInput is only recreated by the screen key, so the callback is read through
+    // rememberUpdatedState — a captured lambda would go stale on the first recomposition.
+    val reportPointerY = rememberUpdatedState(onPointerY)
     if (interactive) {
         mod = mod
             .pointerInput(screen) {
@@ -213,6 +266,7 @@ fun VncSurface(screen: RemoteDesktopScreenState, interactive: Boolean = true) {
                     while (true) {
                         val event = awaitPointerEvent()
                         val change = event.changes.firstOrNull() ?: continue
+                        reportPointerY.value(change.position.y)
                         // Leaving the surface restores the OS pointer explicitly (as TerminalScreen
                         // does): the exit coordinate isn't guaranteed to land outside the image, and
                         // inferring it from geometry alone could strand the cursor hidden app-wide.

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopDesignStateTest.kt
@@ -471,15 +471,36 @@ class DesktopDesignStateTest {
         assertEquals(null, s.groupDialog)
     }
     @Test
-    fun the_remote_desktop_panel_hides_and_comes_back() {
+    fun a_remote_desktop_takes_the_whole_window_and_gives_it_back() {
         val s = DesktopDesignState()
 
-        assertFalse(s.remotePanelHidden)
-        s.toggleRemotePanel()
-        assertTrue(s.remotePanelHidden)
-        // Independent of the hosts sidebar: they are different edges of the same screen.
+        assertFalse(s.remoteImmersive)
+        s.toggleRemoteImmersive()
+        assertTrue(s.remoteImmersive)
+        // Independent of the hosts sidebar: the sidebar keeps its own collapsed state for the
+        // sections that still have chrome.
         assertFalse(s.sidebarHidden)
-        s.toggleRemotePanel()
-        assertFalse(s.remotePanelHidden)
+        s.toggleRemoteImmersive()
+        assertFalse(s.remoteImmersive)
+    }
+
+    @Test
+    fun leaving_the_desktop_session_leaves_immersive_mode() {
+        val s = DesktopDesignState()
+        s.toggleRemoteImmersive()
+
+        s.exitRemoteImmersive()
+
+        assertFalse(s.remoteImmersive)
+    }
+
+    @Test
+    fun the_chrome_only_goes_away_over_a_live_desktop_with_nothing_on_top() {
+        assertTrue(remoteChromeHidden(immersive = true, desktopSession = true, overlayOpen = false))
+        // No session behind the flag: hiding the rail would strand the user on an empty screen.
+        assertFalse(remoteChromeHidden(immersive = true, desktopSession = false, overlayOpen = false))
+        // An app-level view (Vault/Teams) renders in place of the desktop and needs its own chrome.
+        assertFalse(remoteChromeHidden(immersive = true, desktopSession = true, overlayOpen = true))
+        assertFalse(remoteChromeHidden(immersive = false, desktopSession = true, overlayOpen = false))
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteBarMenuPositionTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteBarMenuPositionTest.kt
@@ -1,0 +1,98 @@
+package app.skerry.ui.remote
+
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class RemoteBarMenuPositionTest {
+
+    private fun place(anchor: IntRect, window: IntSize, menu: IntSize): IntOffset =
+        belowAnchor(gap = 6).calculatePosition(anchor, window, LayoutDirection.Ltr, menu)
+
+    @Test
+    fun a_menu_hangs_below_its_button_centered_on_it() {
+        val at = place(
+            anchor = IntRect(left = 600, top = 20, right = 634, bottom = 54),
+            window = IntSize(1280, 800),
+            menu = IntSize(220, 300),
+        )
+
+        assertEquals(IntOffset(x = 617 - 110, y = 60), at)
+    }
+
+    @Test
+    fun a_menu_near_the_left_edge_stays_inside_the_window() {
+        val at = place(
+            anchor = IntRect(left = 4, top = 20, right = 38, bottom = 54),
+            window = IntSize(1280, 800),
+            menu = IntSize(220, 300),
+        )
+
+        assertEquals(0, at.x)
+    }
+
+    @Test
+    fun a_menu_near_the_right_edge_stays_inside_the_window() {
+        val at = place(
+            anchor = IntRect(left = 1250, top = 20, right = 1284, bottom = 54),
+            window = IntSize(1280, 800),
+            menu = IntSize(220, 300),
+        )
+
+        assertEquals(1280 - 220, at.x)
+    }
+
+    @Test
+    fun a_menu_taller_than_the_space_below_is_lifted_rather_than_cut_off() {
+        val at = place(
+            anchor = IntRect(left = 600, top = 20, right = 634, bottom = 54),
+            window = IntSize(1280, 300),
+            menu = IntSize(220, 280),
+        )
+
+        assertEquals(20, at.y)
+    }
+
+    // The phone strip sits against the right screen edge, so its menus open to the LEFT of the
+    // button — the harder branch, with a fallback for a window too narrow for either side.
+    private fun placeLeft(anchor: IntRect, window: IntSize, menu: IntSize): IntOffset =
+        leftOfAnchor(gap = 6).calculatePosition(anchor, window, LayoutDirection.Ltr, menu)
+
+    @Test
+    fun the_phone_strips_menu_opens_to_the_left_of_its_button() {
+        val at = placeLeft(
+            anchor = IntRect(left = 380, top = 100, right = 424, bottom = 134),
+            window = IntSize(420, 900),
+            menu = IntSize(220, 300),
+        )
+
+        assertEquals(380 - 220 - 6, at.x)
+        assertEquals(100, at.y)
+    }
+
+    @Test
+    fun a_window_too_narrow_for_the_left_side_falls_back_to_the_right_of_the_button() {
+        val at = placeLeft(
+            anchor = IntRect(left = 100, top = 100, right = 144, bottom = 134),
+            window = IntSize(260, 900),
+            menu = IntSize(220, 300),
+        )
+
+        // Not a negative x, which would clip the menu against the window edge.
+        assertEquals(260 - 220, at.x)
+    }
+
+    @Test
+    fun the_phone_strips_menu_is_lifted_when_it_would_run_past_the_bottom() {
+        val at = placeLeft(
+            anchor = IntRect(left = 380, top = 700, right = 424, bottom = 734),
+            window = IntSize(420, 900),
+            menu = IntSize(220, 300),
+        )
+
+        assertEquals(900 - 300, at.y)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteBarStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/remote/RemoteBarStateTest.kt
@@ -1,0 +1,116 @@
+package app.skerry.ui.remote
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RemoteBarStateTest {
+
+    @Test
+    fun starts_visible_and_arms_auto_hide() {
+        val bar = RemoteBarState()
+
+        assertTrue(bar.visible)
+        assertFalse(bar.pinned)
+        assertTrue(bar.autoHides)
+    }
+
+    @Test
+    fun hiding_stops_the_auto_hide_timer_from_re_arming() {
+        val bar = RemoteBarState()
+
+        bar.hide()
+
+        assertFalse(bar.visible)
+        assertFalse(bar.autoHides)
+    }
+
+    @Test
+    fun a_reveal_restarts_the_timer_even_when_the_bar_is_already_up() {
+        val bar = RemoteBarState()
+        val before = bar.revealCount
+
+        bar.reveal()
+
+        assertTrue(bar.visible)
+        assertEquals(before + 1, bar.revealCount)
+    }
+
+    @Test
+    fun the_pointer_only_reveals_the_bar_at_the_top_edge() {
+        val bar = RemoteBarState()
+        bar.hide()
+
+        bar.onPointerY(y = 40f, edge = 12f)
+        assertFalse(bar.visible)
+
+        bar.onPointerY(y = 4f, edge = 12f)
+        assertTrue(bar.visible)
+    }
+
+    @Test
+    fun the_pointer_at_the_edge_does_nothing_while_the_bar_is_already_up() {
+        val bar = RemoteBarState()
+        val before = bar.revealCount
+
+        bar.onPointerY(y = 2f, edge = 12f)
+
+        // This runs for every mouse move over the framebuffer: a reveal here would cancel and
+        // relaunch the auto-hide coroutine dozens of times a second for a bar already on screen.
+        assertEquals(before, bar.revealCount)
+    }
+
+    @Test
+    fun hiding_a_held_bar_lets_the_next_reveal_arm_the_timer_again() {
+        val bar = RemoteBarState()
+        bar.setHeld(true)
+
+        bar.hide()
+        bar.reveal()
+
+        // The pointer cannot be over a bar that left the screen, and a menu cannot outlive its
+        // anchor — a hold carried across the hide would leave the bar up for good.
+        assertTrue(bar.autoHides)
+    }
+
+    @Test
+    fun a_held_bar_never_slides_away_under_the_pointer() {
+        val bar = RemoteBarState()
+
+        bar.setHeld(true)
+        assertFalse(bar.autoHides)
+
+        bar.setHeld(false)
+        assertTrue(bar.autoHides)
+    }
+
+    @Test
+    fun pinning_shows_the_bar_and_disarms_auto_hide() {
+        val bar = RemoteBarState()
+        bar.hide()
+
+        bar.togglePin()
+
+        assertTrue(bar.pinned)
+        assertTrue(bar.visible)
+        assertFalse(bar.autoHides)
+
+        bar.togglePin()
+
+        assertFalse(bar.pinned)
+        assertTrue(bar.autoHides)
+    }
+
+    @Test
+    fun the_hide_button_works_on_a_pinned_bar_too() {
+        val bar = RemoteBarState()
+        bar.togglePin()
+
+        bar.hide()
+
+        assertFalse(bar.visible)
+        // Pin survives the manual hide: it is a preference about the timer, not about this moment.
+        assertTrue(bar.pinned)
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/FullscreenToggle.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/FullscreenToggle.kt
@@ -1,0 +1,33 @@
+package app.skerry.ui.desktop
+
+import androidx.compose.ui.window.WindowPlacement
+
+/**
+ * Puts the window on the whole screen and takes it back off, remembering where it came from: a
+ * remote desktop shown full screen has to end up floating or maximized again exactly as the user
+ * left it.
+ *
+ * Idempotent on purpose — the caller is a Compose effect that can run again for the same value, and
+ * a second "go fullscreen" must not record Fullscreen as the placement to return to.
+ */
+internal class FullscreenToggle(
+    private val placement: () -> WindowPlacement,
+    private val setPlacement: (WindowPlacement) -> Unit,
+) {
+    private var restoreTo: WindowPlacement? = null
+
+    fun apply(fullscreen: Boolean) {
+        val current = placement()
+        if (fullscreen) {
+            if (current == WindowPlacement.Fullscreen) return
+            restoreTo = current
+            setPlacement(WindowPlacement.Fullscreen)
+        } else {
+            if (current != WindowPlacement.Fullscreen) return
+            // Floating when we did not put it there ourselves (the window manager's own fullscreen
+            // key): leaving it full screen would strand a window with no titlebar of its own.
+            setPlacement(restoreTo ?: WindowPlacement.Floating)
+            restoreTo = null
+        }
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/Screenshot.kt
@@ -1,9 +1,14 @@
 package app.skerry.ui.desktop
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.unit.Density
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.foundation.background
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.terminal.TerminalThemes
@@ -14,6 +19,10 @@ import app.skerry.ui.AppDependencies
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.session.SessionsController
+import app.skerry.shared.ssh.isVnc
+import app.skerry.shared.vnc.VncAuth
+import app.skerry.ui.connection.connectionSubtitle
+import app.skerry.ui.connection.toTarget
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.theme.SkerryTheme
 import app.skerry.ui.theme.ThemeMode
@@ -103,6 +112,15 @@ fun main() {
     }
     // Same for the monitor: a sub-view of the active session, not a rail item of its own.
     if (viewName == "Monitor") sessions?.setActiveView(SessionView.Monitor)
+    // A remote desktop lives in a tab of its own: opening the section alone would render its empty
+    // state, so the offscreen run dials the seeded VNC host over the fake session.
+    if (viewName == "RemoteDesktops" && hosts != null) {
+        hosts.hosts.firstOrNull { it.connectionType.isVnc }?.let { desktop ->
+            sessions?.openVnc(
+                desktop.id, desktop.label, desktop.connectionSubtitle(), desktop.toTarget(), VncAuth.None,
+            )
+        }
+    }
     // Assistant panel open over the live terminal (-Dskerry.screenshot.assistantPanel=true): checks
     // that the pinned action row steps aside for the panel's own header.
     if (System.getProperty("skerry.screenshot.assistantPanel", "false").toBoolean()) state.toggleAssistant()
@@ -146,7 +164,11 @@ fun main() {
     // Theme for visual review: -Dskerry.screenshot.theme=<system|light|dark> (default dark).
     val themeMode = ThemeMode.fromId(System.getProperty("skerry.screenshot.theme", "dark"))
     val scene = ImageComposeScene(width = 1280, height = 820, density = Density(1f)) {
-        SkerryTheme(mode = themeMode) { content() }
+        // A live remote desktop reports whether anyone can see it, which reads the lifecycle owner
+        // the window would supply. Offscreen there is no window, so a resumed stub stands in.
+        CompositionLocalProvider(LocalLifecycleOwner provides ScreenshotLifecycleOwner()) {
+            SkerryTheme(mode = themeMode) { content() }
+        }
     }
     // Pumps frames with a real pause so compose-resources can load fonts (async IO) and the fake
     // session can flush its output to the terminal.
@@ -251,4 +273,12 @@ private fun MonitorSheetOverlay() {
             onDismiss = {},
         )
     }
+}
+
+/** Resumed stand-in for the window's lifecycle owner, for the offscreen scenes. */
+@Suppress("VisibleForTests")
+private class ScreenshotLifecycleOwner : LifecycleOwner {
+    // createUnsafe: the offscreen render runs on the JVM main thread, not on the UI dispatcher the
+    // registry enforces, and there is no window here to own a real lifecycle anyway.
+    override val lifecycle = LifecycleRegistry.createUnsafe(this).apply { currentState = Lifecycle.State.RESUMED }
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotFakes.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotFakes.kt
@@ -1,5 +1,12 @@
 package app.skerry.ui.desktop
 
+import app.skerry.shared.graphics.RemoteDesktopCapabilities
+import app.skerry.shared.graphics.RemoteDesktopQuality
+import app.skerry.shared.graphics.RemoteDesktopSession
+import app.skerry.shared.graphics.RemoteDesktopUpdate
+import app.skerry.shared.graphics.RemoteFramebuffer
+import app.skerry.shared.graphics.RemoteKeyEvent
+import app.skerry.shared.graphics.RemoteRect
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntry
 import app.skerry.shared.sftp.SftpEntryType
@@ -148,3 +155,58 @@ internal class FakeSftpClient : SftpClient {
     override suspend fun rename(from: String, to: String) = Unit
     override suspend fun close() = Unit
 }
+
+/**
+ * Fake remote desktop: a still 1440×900 picture (gradient wallpaper with two "windows" on it) and
+ * an update flow that hands it over once and then hangs. Lets the Desktops section render a live
+ * session — its floating bar, its menus — without a VNC/RDP server.
+ */
+internal fun fakeRemoteDesktop(title: String): RemoteDesktopSession = object : RemoteDesktopSession {
+    override val title: String = title
+    override val framebuffer = RemoteFramebuffer(FAKE_DESKTOP_WIDTH, FAKE_DESKTOP_HEIGHT).also { paintFakeDesktop(it) }
+    override val capabilities = RemoteDesktopCapabilities(
+        adjustableQuality = true,
+        remoteResize = true,
+        cursorHandover = true,
+        audio = true,
+        clipboard = true,
+    )
+    override val updates: Flow<RemoteDesktopUpdate> = flow {
+        emit(RemoteDesktopUpdate.Region(listOf(RemoteRect(0, 0, FAKE_DESKTOP_WIDTH, FAKE_DESKTOP_HEIGHT))))
+        awaitCancellation()
+    }
+
+    override suspend fun sendPointer(x: Int, y: Int, buttonMask: Int) = Unit
+    override suspend fun sendKey(event: RemoteKeyEvent, down: Boolean) = Unit
+    override suspend fun sendClipboardText(text: String) = Unit
+    override suspend fun requestFullUpdate() = Unit
+    override suspend fun setQuality(quality: RemoteDesktopQuality) = Unit
+    override suspend fun setDesktopSize(width: Int, height: Int) = Unit
+    override suspend fun setLocalCursor(enabled: Boolean) = Unit
+    override suspend fun setOutputVisible(visible: Boolean) = Unit
+    override suspend fun setAudioMuted(muted: Boolean) = Unit
+    override suspend fun close() = Unit
+}
+
+private fun paintFakeDesktop(fb: RemoteFramebuffer) {
+    for (y in 0 until FAKE_DESKTOP_HEIGHT) {
+        val shade = 0x18 + (y * 0x22 / FAKE_DESKTOP_HEIGHT)
+        val argb = 0xFF shl 24 or (shade / 2 shl 16) or (shade shl 8) or (shade + 0x2A)
+        val row = IntArray(FAKE_DESKTOP_WIDTH) { argb }
+        fb.blitRow(0, y, FAKE_DESKTOP_WIDTH, row, 0)
+    }
+    fakeWindow(fb, x = 90, y = 120, w = 640, h = 380)
+    fakeWindow(fb, x = 500, y = 380, w = 700, h = 440)
+}
+
+private fun fakeWindow(fb: RemoteFramebuffer, x: Int, y: Int, w: Int, h: Int) {
+    for (dy in 0 until h) {
+        val titleBar = dy < 26
+        val argb = if (titleBar) 0xFF2B3550.toInt() else 0xFF10141F.toInt()
+        val row = IntArray(w) { argb }
+        fb.blitRow(x, y + dy, w, row, 0)
+    }
+}
+
+private const val FAKE_DESKTOP_WIDTH = 1440
+private const val FAKE_DESKTOP_HEIGHT = 900

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotSeeds.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotSeeds.kt
@@ -40,6 +40,7 @@ import app.skerry.shared.ssh.TrustedCa
 import app.skerry.shared.ssh.TrustedCaStore
 import app.skerry.ui.known.KnownHostsController
 import app.skerry.ui.known.TrustedCaController
+import app.skerry.ui.remote.RemoteDesktopController
 import app.skerry.ui.session.SessionsController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -365,7 +366,14 @@ internal fun seededAi(): app.skerry.ui.ai.AiAssistantController {
 internal fun seededSessions(hosts: HostManagerController): SessionsController {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     var n = 0
-    val sessions = SessionsController(newId = { "s${n++}" }, controllerFactory = { ConnectionController(fakeTransport(), scope) })
+    val sessions = SessionsController(
+        newId = { "s${n++}" },
+        controllerFactory = { ConnectionController(fakeTransport(), scope) },
+        // Remote-desktop tabs render against a still fake picture, so the Desktops section can be
+        // reviewed offscreen without a VNC/RDP server.
+        vncControllerFactory = { RemoteDesktopController(scope) },
+        openVncSession = { target, _ -> fakeRemoteDesktop(target.host) },
+    )
     // Empty password: the fake transport ignores auth (see FakeConnection); there's no real handshake.
     val h = hosts.hosts.first()
     sessions.open(h.id, h.label, h.connectionSubtitle(), h.toTarget(), SshAuth.Password(""))

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -49,11 +49,13 @@ fun WindowScope.rememberSkerryWindowChrome(state: WindowState, exit: () -> Unit)
         // On X11 the WM moves the window itself (smooth, compositor-driven — see NativeWindowMove);
         // elsewhere fall back to moving it frame by frame from the app thread.
         val useNativeMove = NativeWindowMove.isAvailable()
+        val fullscreen = FullscreenToggle({ state.placement }, { state.placement = it })
         WindowChrome(
             isMaximized = { state.placement == WindowPlacement.Maximized },
             onMinimize = { state.isMinimized = true },
             onToggleMaximize = toggleMaximize,
             onClose = exit,
+            setFullscreen = fullscreen::apply,
             dragArea = { content ->
                 val doubleClick = Modifier.onUnconsumedDoubleClick(toggleMaximize)
                 Box(doubleClick.then(Modifier.titlebarDrag(awtWindow, state, useNativeMove))) { content() }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/FullscreenToggleTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/FullscreenToggleTest.kt
@@ -1,0 +1,66 @@
+package app.skerry.ui.desktop
+
+import androidx.compose.ui.window.WindowPlacement
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FullscreenToggleTest {
+
+    private class Window(var placement: WindowPlacement = WindowPlacement.Floating) {
+        val toggle = FullscreenToggle({ placement }, { placement = it })
+    }
+
+    @Test
+    fun a_floating_window_goes_fullscreen_and_comes_back_floating() {
+        val w = Window(WindowPlacement.Floating)
+
+        w.toggle.apply(true)
+        assertEquals(WindowPlacement.Fullscreen, w.placement)
+
+        w.toggle.apply(false)
+        assertEquals(WindowPlacement.Floating, w.placement)
+    }
+
+    @Test
+    fun a_maximized_window_comes_back_maximized() {
+        val w = Window(WindowPlacement.Maximized)
+
+        w.toggle.apply(true)
+        w.toggle.apply(false)
+
+        assertEquals(WindowPlacement.Maximized, w.placement)
+    }
+
+    @Test
+    fun asking_for_fullscreen_twice_does_not_forget_where_to_return() {
+        val w = Window(WindowPlacement.Maximized)
+
+        w.toggle.apply(true)
+        // A recomposition re-running the effect must not record Fullscreen as the placement to
+        // restore — the window would then have no way back to its own size.
+        w.toggle.apply(true)
+        w.toggle.apply(false)
+
+        assertEquals(WindowPlacement.Maximized, w.placement)
+    }
+
+    @Test
+    fun leaving_a_mode_that_was_never_entered_leaves_the_window_alone() {
+        val w = Window(WindowPlacement.Maximized)
+
+        w.toggle.apply(false)
+
+        assertEquals(WindowPlacement.Maximized, w.placement)
+    }
+
+    @Test
+    fun a_window_the_user_put_fullscreen_themselves_is_restored_to_floating() {
+        // Entered from outside (the WM's own fullscreen key), so nothing was recorded: the window
+        // still has to end up somewhere it can be moved and closed.
+        val w = Window(WindowPlacement.Fullscreen)
+
+        w.toggle.apply(false)
+
+        assertEquals(WindowPlacement.Floating, w.placement)
+    }
+}

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -75,7 +75,8 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Secret display | `VaultPresentation.secretStyle` |
 | Terminal screen state (incl. scrollback search) | `ui/terminal/TerminalScreenState` |
 | Tiled session panes (split/resize/navigate) | `ui/session/PaneLayout` |
-| Remote-desktop screen | `ui/remote/RemoteDesktopController`, `RemoteDesktopScreenState`, `RemoteDesktopPanel` |
+| Remote-desktop screen | `ui/remote/RemoteDesktopController`, `RemoteDesktopScreenState` |
+| Remote-desktop session controls (both platforms) | `ui/remote/RemoteDesktopMenus` (icon button, menu host, display/clipboard menus, screenshot and clipboard actions), laid out by `RemoteDesktopBar` + `RemoteBarState` on desktop and `RemoteDesktopPanel` on a phone |
 | Streaming an AI reply / parsing it | `ui/ai/AiStreamRunner`, `AiReplyParser` |
 | Sealed sync token, health monitoring | `ui/sync/SealedTokenCodec`, `ServerHealthMonitor` |
 | Sync failure reason → localised text | `SyncFailureReason` + `ui/sync/syncFailureText` (don't build strings in the controller) |


### PR DESCRIPTION
## What this does

Replaces the vertical panel beside a live VNC/RDP session on desktop with a floating bar over the top of the picture, and adds a full-window mode for the session.

**The bar** carries what belongs to the session rather than to the image: Ctrl+Alt+Del, the clipboard menu, sound, the display menu (quality, view only, resize to window), a screenshot, the full-window toggle and the disconnect. It slides up out of the way after a few seconds untouched and comes back when the pointer reaches the top edge of the framebuffer. A pin holds it open, a chevron hides it at once, and an open menu or a hovering pointer keeps it in place.

The reveal zone is read off the framebuffer's own pointer stream rather than from a strip laid over the picture — a strip would swallow every mouse move in its band and the remote cursor would stop dead a few pixels below the edge.

**Full-window mode** drops the titlebar, the rail, the status bar and the hosts sidebar, and puts the OS window on the whole screen; leaving it restores the window's previous placement (floating or maximized). Leaving the session, a lost connection, an app-level view and the vault locking all take the window back out of the mode, so an undecorated fullscreen window can never be left with no way back.

**Clipboard and sound.** The clipboard's share toggle moved into the clipboard menu itself, where it stays reachable once sharing is off (the old panel disabled the button that held it). A refused system clipboard is now reported in the menu instead of failing silently, and a copy goes through the same buffer the paste reads from on Wayland. The sound switch became a bar button that names a dead output device on itself.

Android keeps its existing strip by design; both surfaces now drive the same menus, screenshot and clipboard actions from `ui/remote/RemoteDesktopMenus.kt`.

## Tests

- `RemoteBarStateTest` — visibility, pin, hold, the top-edge reveal and the auto-hide arming rules
- `RemoteBarMenuPositionTest` — both menu position providers, including the window-edge clamps and the narrow-window fallback
- `FullscreenToggleTest` — placement round trips, idempotent re-entry, and a window the window manager put fullscreen itself
- `DesktopDesignStateTest` — the immersive flag and the chrome-hidden truth table

## Verification

Run a VNC or RDP session: the bar sits over the top of the picture, leaves on its own and returns when the pointer touches the top edge; the pin holds it, the chevron hides it. The button with the frame icon takes the window to the whole screen and back. The picture area clips the bar's animation, so nothing is drawn over the tab strip.

Not verified: live behaviour on Windows and macOS window managers, and the Android side of the shared menus on a device.