### PR TITLE
Team screen from the design mockup, runbook sharing, and per-member last seen

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -204,7 +204,6 @@
     <string name="lib_teams_share_snippet_title">Поделиться сниппетом с командой</string>
     <string name="lib_teams_share_empty">Делиться больше нечем</string>
     <string name="lib_teams_nothing_shared">Пока ничем не поделились</string>
-    <string name="lib_teams_sync_now">Синхронизировать</string>
     <string name="lib_teams_no_key">Ключ команды ещё не доехал до этого устройства</string>
     <string name="lib_teams_remove_member_title">Удалить участника</string>
     <string name="lib_teams_remove_member_message">Удалить %1$s из команды? Доступ на сервере отзывается сразу. Если доверять больше нельзя — ротируйте общие секреты.</string>
@@ -241,4 +240,45 @@
     <string name="lib_teams_scope_members_count">с доступом: %1$d</string>
     <string name="lib_teams_err_already_shared">Эта запись уже расшарена в другой области этой команды — сначала уберите её оттуда</string>
     <string name="lib_teams_err_scopes_unsupported">Этот sync-сервер слишком старый для областей доступа — обновите сервер</string>
+    <!-- Экран команды: шапка, таблица участников, карточки (см. TeamsView) -->
+    <string name="lib_teams_header_title">Команда</string>
+    <!-- %1$s — название команды, %2$d — число участников -->
+    <string name="lib_teams_header_subtitle">%1$s · участников: %2$d · общее хранилище</string>
+    <string name="lib_teams_col_member">Участник</string>
+    <string name="lib_teams_col_role">Роль</string>
+    <string name="lib_teams_col_last_seen">Последний вход</string>
+    <string name="lib_teams_seen_never">никогда</string>
+    <string name="lib_teams_seen_now">сейчас</string>
+    <!-- %1$s — время суток, UTC -->
+    <string name="lib_teams_seen_today">сегодня, %1$s</string>
+    <string name="lib_teams_seen_yesterday">вчера, %1$s</string>
+    <string name="lib_teams_synced_never">ещё не синхронизировано</string>
+    <string name="lib_teams_synced_sec">синхронизировано %1$d с назад</string>
+    <string name="lib_teams_synced_min">синхронизировано %1$d мин назад</string>
+    <string name="lib_teams_synced_hour">синхронизировано %1$d ч назад</string>
+    <string name="lib_teams_synced_day">синхронизировано %1$d дн назад</string>
+    <string name="lib_teams_card_vault">Общее хранилище</string>
+    <string name="lib_teams_card_items">Записей</string>
+    <string name="lib_teams_card_encryption">Шифрование</string>
+    <string name="lib_teams_card_encryption_value">ключ на участника</string>
+    <string name="lib_teams_card_last_rekey">Смена ключа</string>
+    <string name="lib_teams_card_server">Сервер</string>
+    <string name="lib_teams_card_endpoint">Адрес</string>
+    <string name="lib_teams_card_storage">Хранит</string>
+    <string name="lib_teams_card_storage_value">только шифртекст</string>
+    <string name="lib_teams_card_version">Версия</string>
+    <string name="lib_teams_card_devices">Устройства</string>
+    <string name="lib_teams_card_devices_value">привязано: %1$d</string>
+    <string name="lib_teams_card_shared">Общее в команде</string>
+    <string name="lib_teams_card_hosts">Хосты</string>
+    <string name="lib_teams_card_snippets">Сниппеты</string>
+    <string name="lib_teams_card_runbooks">Сценарии</string>
+    <string name="lib_teams_card_live">Живые сессии</string>
+    <string name="lib_teams_card_live_value">сейчас: %1$d</string>
+    <string name="lib_teams_share_runbook">Поделиться сценарием</string>
+    <string name="lib_teams_share_runbook_title">Поделиться сценарием с командой</string>
+    <string name="lib_teams_shared_runbooks_count">Общие сценарии · %1$d</string>
+    <string name="lib_teams_runbook_steps">шагов: %1$d</string>
+    <string name="lib_teams_record_runbook">сценарий</string>
+    <string name="lib_teams_scope_access_unknown">Список доступа не получен — сервер не ответил</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -201,7 +201,6 @@
     <string name="lib_teams_share_snippet_title">与团队共享片段</string>
     <string name="lib_teams_share_empty">没有可共享的内容</string>
     <string name="lib_teams_nothing_shared">暂无共享内容</string>
-    <string name="lib_teams_sync_now">同步</string>
     <string name="lib_teams_no_key">团队密钥尚未到达此设备</string>
     <string name="lib_teams_remove_member_title">移除成员</string>
     <string name="lib_teams_remove_member_message">将 %1$s 移出团队？服务器访问权限立即撤销。若不再信任，请轮换共享密钥。</string>
@@ -238,4 +237,45 @@
     <string name="lib_teams_scope_members_count">%1$d 人可访问</string>
     <string name="lib_teams_err_already_shared">该记录已共享到此团队的另一个范围 — 请先在那里取消共享</string>
     <string name="lib_teams_err_scopes_unsupported">此同步服务器版本过旧，不支持访问范围 — 请更新服务器</string>
+    <!-- 团队界面：标题栏、成员表、汇总卡片（见 TeamsView） -->
+    <string name="lib_teams_header_title">团队</string>
+    <!-- %1$s — 团队名称，%2$d — 成员数 -->
+    <string name="lib_teams_header_subtitle">%1$s · %2$d 名成员 · 共享保险库</string>
+    <string name="lib_teams_col_member">成员</string>
+    <string name="lib_teams_col_role">角色</string>
+    <string name="lib_teams_col_last_seen">最近活动</string>
+    <string name="lib_teams_seen_never">从未</string>
+    <string name="lib_teams_seen_now">刚刚</string>
+    <!-- %1$s — 时间（UTC） -->
+    <string name="lib_teams_seen_today">今天 %1$s</string>
+    <string name="lib_teams_seen_yesterday">昨天 %1$s</string>
+    <string name="lib_teams_synced_never">尚未同步</string>
+    <string name="lib_teams_synced_sec">%1$d 秒前同步</string>
+    <string name="lib_teams_synced_min">%1$d 分钟前同步</string>
+    <string name="lib_teams_synced_hour">%1$d 小时前同步</string>
+    <string name="lib_teams_synced_day">%1$d 天前同步</string>
+    <string name="lib_teams_card_vault">共享保险库</string>
+    <string name="lib_teams_card_items">条目</string>
+    <string name="lib_teams_card_encryption">加密</string>
+    <string name="lib_teams_card_encryption_value">按成员封装密钥</string>
+    <string name="lib_teams_card_last_rekey">上次轮换</string>
+    <string name="lib_teams_card_server">服务器</string>
+    <string name="lib_teams_card_endpoint">地址</string>
+    <string name="lib_teams_card_storage">存储</string>
+    <string name="lib_teams_card_storage_value">仅密文</string>
+    <string name="lib_teams_card_version">版本</string>
+    <string name="lib_teams_card_devices">设备</string>
+    <string name="lib_teams_card_devices_value">已配对 %1$d 台</string>
+    <string name="lib_teams_card_shared">团队共享</string>
+    <string name="lib_teams_card_hosts">主机</string>
+    <string name="lib_teams_card_snippets">片段</string>
+    <string name="lib_teams_card_runbooks">运行手册</string>
+    <string name="lib_teams_card_live">实时会话</string>
+    <string name="lib_teams_card_live_value">当前 %1$d 个</string>
+    <string name="lib_teams_share_runbook">共享运行手册</string>
+    <string name="lib_teams_share_runbook_title">与团队共享运行手册</string>
+    <string name="lib_teams_shared_runbooks_count">共享的运行手册 · %1$d</string>
+    <string name="lib_teams_runbook_steps">%1$d 步</string>
+    <string name="lib_teams_record_runbook">运行手册</string>
+    <string name="lib_teams_scope_access_unknown">无法获取访问列表 — 服务器未响应</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -202,7 +202,6 @@
     <string name="lib_teams_share_snippet_title">Share snippet with team</string>
     <string name="lib_teams_share_empty">Nothing left to share</string>
     <string name="lib_teams_nothing_shared">Nothing shared yet</string>
-    <string name="lib_teams_sync_now">Sync</string>
     <string name="lib_teams_no_key">The team key has not arrived on this device yet</string>
     <string name="lib_teams_remove_member_title">Remove member</string>
     <string name="lib_teams_remove_member_message">Remove %1$s from the team? Server access is revoked at once. Rotate shared secrets if they should no longer be trusted.</string>
@@ -239,4 +238,45 @@
     <string name="lib_teams_scope_members_count">%1$d with access</string>
     <string name="lib_teams_err_already_shared">This record is already shared into another scope of this team — unshare it there first</string>
     <string name="lib_teams_err_scopes_unsupported">This sync server is too old for access scopes — update the server</string>
+    <!-- Teams screen: header, member table, summary cards (see TeamsView) -->
+    <string name="lib_teams_header_title">Team</string>
+    <!-- %1$s — team name, %2$d — member count -->
+    <string name="lib_teams_header_subtitle">%1$s · %2$d members · shared vault</string>
+    <string name="lib_teams_col_member">Member</string>
+    <string name="lib_teams_col_role">Role</string>
+    <string name="lib_teams_col_last_seen">Last seen</string>
+    <string name="lib_teams_seen_never">never</string>
+    <string name="lib_teams_seen_now">now</string>
+    <!-- %1$s — time of day, UTC -->
+    <string name="lib_teams_seen_today">today, %1$s</string>
+    <string name="lib_teams_seen_yesterday">yesterday, %1$s</string>
+    <string name="lib_teams_synced_never">not synced yet</string>
+    <string name="lib_teams_synced_sec">synced %1$d s ago</string>
+    <string name="lib_teams_synced_min">synced %1$d min ago</string>
+    <string name="lib_teams_synced_hour">synced %1$d h ago</string>
+    <string name="lib_teams_synced_day">synced %1$d d ago</string>
+    <string name="lib_teams_card_vault">Shared vault</string>
+    <string name="lib_teams_card_items">Items</string>
+    <string name="lib_teams_card_encryption">Encryption</string>
+    <string name="lib_teams_card_encryption_value">per-member key wrap</string>
+    <string name="lib_teams_card_last_rekey">Last rekey</string>
+    <string name="lib_teams_card_server">Server</string>
+    <string name="lib_teams_card_endpoint">Endpoint</string>
+    <string name="lib_teams_card_storage">Storage</string>
+    <string name="lib_teams_card_storage_value">ciphertext only</string>
+    <string name="lib_teams_card_version">Version</string>
+    <string name="lib_teams_card_devices">Devices</string>
+    <string name="lib_teams_card_devices_value">%1$d paired</string>
+    <string name="lib_teams_card_shared">Shared with the team</string>
+    <string name="lib_teams_card_hosts">Hosts</string>
+    <string name="lib_teams_card_snippets">Snippets</string>
+    <string name="lib_teams_card_runbooks">Runbooks</string>
+    <string name="lib_teams_card_live">Live sessions</string>
+    <string name="lib_teams_card_live_value">%1$d shared now</string>
+    <string name="lib_teams_share_runbook">Share runbook</string>
+    <string name="lib_teams_share_runbook_title">Share runbook with team</string>
+    <string name="lib_teams_shared_runbooks_count">Shared runbooks · %1$d</string>
+    <string name="lib_teams_runbook_steps">%1$d steps</string>
+    <string name="lib_teams_record_runbook">runbook</string>
+    <string name="lib_teams_scope_access_unknown">Access list unavailable — the server did not answer</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
@@ -1,0 +1,182 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.InitialsAvatar
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_nothing_shared
+import app.skerry.ui.generated.resources.lib_teams_status_invited
+import app.skerry.ui.teams.HistoryTarget
+import app.skerry.ui.teams.RoleBadge
+import app.skerry.ui.teams.SharedRecordUi
+import app.skerry.ui.teams.TeamMemberRowUi
+import app.skerry.ui.teams.TeamUi
+import app.skerry.ui.teams.UNKNOWN_VALUE
+import app.skerry.ui.teams.lastSeenText
+import app.skerry.ui.teams.roleBadgeColors
+import app.skerry.ui.teams.teamRoleLabel
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+// Rows and sections of the phone's Team screen, split out of MobileTeamsView so that file stays
+// about state and dialogs rather than about pixels.
+
+/**
+ * One kind of shared record on the phone: heading with its count, the rows with their unshare and
+ * history actions, and the way to share another. Hosts, snippets and runbooks differ only in the
+ * three strings and the record type, so they share this.
+ */
+@Composable
+internal fun MobileSharedSection(
+    heading: String,
+    items: List<SharedRecordUi>,
+    shareLabel: String?,
+    onShare: () -> Unit,
+    canUnshare: Boolean,
+    canAudit: Boolean,
+    onUnshare: (String) -> Unit,
+    onShowRecordHistory: (HistoryTarget) -> Unit,
+) {
+    MobileTeamsSectionLabel(heading)
+    if (items.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
+    items.forEach { item ->
+        MobileSharedRow(
+            item.label, item.detail,
+            canUnshare = canUnshare,
+            onHistory = if (canAudit) { { onShowRecordHistory(HistoryTarget(item.id, item.label)) } } else null,
+            onUnshare = { onUnshare(item.id) },
+        )
+    }
+    if (shareLabel != null) {
+        GhostButton(shareLabel, onClick = onShare, icon = "add", modifier = Modifier.padding(top = 10.dp))
+    }
+}
+
+@Composable
+internal fun MobileTeamsSectionLabel(text: String) {
+    Txt(text.uppercase(), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(top = 24.dp, bottom = 10.dp))
+}
+
+@Composable
+internal fun MobileTeamChip(team: TeamUi, active: Boolean, onClick: () -> Unit) {
+    val invited = team.status == TeamMemberStatus.INVITED
+    val fg = when {
+        active -> Skerry.colors.cyanBright
+        invited -> Skerry.colors.amber
+        else -> Skerry.colors.dim
+    }
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(18.dp))
+            .background(if (active) Skerry.colors.cyan10 else Color.Transparent)
+            .border(1.dp, if (active) Skerry.colors.cyan14 else Skerry.colors.line, RoundedCornerShape(18.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        Sym(if (invited) "mail" else "group", size = 15.sp, color = fg)
+        Txt(team.name, color = fg, size = 12.5.sp)
+    }
+}
+
+/**
+ * A member on the phone: the desktop table's four columns folded into a card — who they are, what
+ * they may do, the scopes they hold, and when they were last around.
+ */
+@Composable
+internal fun MobileMemberRow(
+    row: TeamMemberRowUi,
+    now: Long,
+    onChangeRole: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    val m = row.member
+    val invited = m.status == TeamMemberStatus.INVITED
+    val (roleFg, roleBg) = roleBadgeColors(m.role)
+    Row(
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(9.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(9.dp)).padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        InitialsAvatar(m.accountId, size = 28.dp)
+        Column(Modifier.weight(1f)) {
+            Txt(m.accountId, color = Skerry.colors.text, size = 12.5.sp, font = mono, weight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            // Same rule as the desktop table: an access list we failed to read is "?", never an
+            // empty chip row — the phone is where granting and revoking actually happens.
+            val tags = row.scopes.joinToString(" ") { "#$it" }
+            // A grant list that didn't load leaves a "?" — whether or not other scopes did load.
+            val scopes = listOf(tags, if (row.scopesKnown) "" else UNKNOWN_VALUE).filter { it.isNotEmpty() }.joinToString(" ")
+            Txt(
+                listOf(lastSeenText(m.lastSeenAt, now), scopes).filter { it.isNotEmpty() }.joinToString(" · "),
+                color = if (row.scopesKnown) Skerry.colors.faint else Skerry.colors.amber,
+                size = 10.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (invited) {
+            RoleBadge(stringResource(Res.string.lib_teams_status_invited), Skerry.colors.amber, Skerry.colors.amber.copy(alpha = 0.14f))
+        } else {
+            val badgeModifier = if (row.manageable) Modifier.clip(RoundedCornerShape(20.dp)).clickable(onClick = onChangeRole) else Modifier
+            RoleBadge(teamRoleLabel(m.role), roleFg, roleBg, modifier = badgeModifier)
+        }
+        if (row.manageable) {
+            Box(Modifier.clip(CircleShape).clickable(onClick = onRemove).padding(4.dp)) {
+                Sym("close", size = 15.sp, color = Skerry.colors.faint)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun MobileSharedRow(
+    label: String,
+    detail: String,
+    canUnshare: Boolean,
+    onHistory: (() -> Unit)? = null,
+    onUnshare: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(9.dp),
+    ) {
+        Txt(label, color = Skerry.colors.textBright, size = 12.5.sp, font = mono)
+        Txt(detail, color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.weight(1f))
+        // "What happened to this one" — only for readers who may see the audit log at all.
+        if (onHistory != null) {
+            Box(Modifier.clip(CircleShape).clickable(onClick = onHistory).padding(3.dp)) {
+                Sym("history", size = 14.sp, color = Skerry.colors.faint)
+            }
+        }
+        if (canUnshare) {
+            Box(Modifier.clip(CircleShape).clickable(onClick = onUnshare).padding(3.dp)) {
+                Sym("close", size = 14.sp, color = Skerry.colors.faint)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -56,9 +56,7 @@ import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
 import app.skerry.shared.team.TeamScopeRef
 import app.skerry.shared.vault.RecordType
-import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
-import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.design.ConfirmActionDialog
@@ -92,40 +90,42 @@ import app.skerry.ui.share.rememberJoinSharedSession
 import app.skerry.ui.generated.resources.lib_teams_members_count
 import app.skerry.ui.generated.resources.lib_teams_need_sync
 import app.skerry.ui.generated.resources.lib_teams_no_key
-import app.skerry.ui.generated.resources.lib_teams_nothing_shared
 import app.skerry.ui.generated.resources.lib_teams_remove_member_message
 import app.skerry.ui.generated.resources.lib_teams_remove_member_title
 import app.skerry.ui.generated.resources.lib_teams_history
-import app.skerry.ui.generated.resources.lib_teams_share_empty
 import app.skerry.ui.generated.resources.lib_teams_share_host
-import app.skerry.ui.generated.resources.lib_teams_share_host_title
 import app.skerry.ui.generated.resources.lib_teams_share_snippet
-import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
 import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
-import app.skerry.ui.generated.resources.lib_teams_status_invited
-import app.skerry.ui.generated.resources.lib_teams_sync_now
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.generated.resources.shell_create
 import app.skerry.ui.generated.resources.shell_route_team
 import app.skerry.ui.teams.HistoryTarget
 import app.skerry.ui.teams.TeamActivityDialog
 import app.skerry.ui.teams.InviteMemberDialog
-import app.skerry.ui.teams.RoleBadge
 import app.skerry.ui.teams.RolePickerDialog
-import app.skerry.ui.teams.canModifyMember
-import app.skerry.ui.teams.roleBadgeColors
-import app.skerry.ui.teams.teamRoleLabel
 import app.skerry.ui.teams.InvitePreview
-import app.skerry.ui.teams.ShareItem
-import app.skerry.ui.teams.SharePickerDialog
+import app.skerry.ui.teams.SharedRecordUi
 import app.skerry.ui.teams.TeamScopeUi
 import app.skerry.ui.teams.TeamUi
 import app.skerry.ui.teams.CreateScopeDialog
+import app.skerry.ui.teams.ScopeAccess
 import app.skerry.ui.teams.ScopeAccessDialog
 import app.skerry.ui.teams.ScopeSection
 import app.skerry.ui.teams.TeamsCoordinator
 import app.skerry.ui.teams.teamsFailureText
+import app.skerry.ui.teams.SyncPill
+import app.skerry.ui.teams.SharePicker
+import app.skerry.ui.teams.runbookSummary
+import app.skerry.ui.teams.scopeGrants
+import app.skerry.shared.runbook.VaultRunbookStore
+import app.skerry.shared.terminal.epochMillis
+import app.skerry.ui.generated.resources.lib_teams_share_runbook
+import app.skerry.ui.generated.resources.lib_teams_shared_runbooks_count
+import app.skerry.ui.teams.TeamSummaryCardsStacked
+import app.skerry.ui.teams.teamCards
+import app.skerry.ui.teams.teamFeed
+import app.skerry.ui.teams.teamMemberRows
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -217,6 +217,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     val teams by tc.teams.collectAsState()
     val busy by tc.busy.collectAsState()
     val error by tc.lastError.collectAsState()
+    val syncStamps by tc.lastSyncedAt.collectAsState()
     var selectedId by remember { mutableStateOf<String?>(null) }
     var tick by remember { mutableStateOf(0) }
     LaunchedEffect(Unit) { tc.refresh(); tc.syncAll(); tick++ }
@@ -264,6 +265,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                 scopeId = selected.scopes.firstOrNull { it.id == selectedScope }?.id ?: "",
                 tick = tick,
                 busy = busy,
+                lastSyncedAt = syncStamps[selected.id],
                 onInvite = { showInvite = true; invitePreview = null },
                 onShare = { sharePicker = it },
                 onConfirm = { confirm = it },
@@ -295,8 +297,9 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     val accessScope = scopeAccess
     if (accessScope != null && scopeTeam != null) {
         val scopeMembers by produceState(emptyList<TeamMember>(), scopeTeam.id, tick) { value = tc.members(scopeTeam.id) }
-        val granted by produceState(emptySet<String>(), scopeTeam.id, accessScope.id, tick) {
-            value = tc.scopeGrants(scopeTeam.id, accessScope.id).toSet()
+        val granted by produceState<ScopeAccess>(ScopeAccess.Loading, scopeTeam.id, accessScope.id, tick) {
+            value = tc.scopeGrants(scopeTeam.id, accessScope.id)
+                ?.let { ScopeAccess.Known(it.toSet()) } ?: ScopeAccess.Unavailable
         }
         ScopeAccessDialog(
             scopeName = accessScope.name,
@@ -368,7 +371,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     val shareKind = sharePicker
     if (shareKind != null && shareTeam != null) {
         val shareRef = TeamScopeRef(shareTeam.id, shareTeam.scopes.firstOrNull { it.id == selectedScope }?.id ?: "")
-        MobileSharePicker(tc, shareRef, shareKind, tick, onDone = { sharePicker = null; tick++ }, onDismiss = { sharePicker = null })
+        SharePicker(tc, shareRef, shareKind, tick, onDone = { sharePicker = null; tick++ }, onDismiss = { sharePicker = null })
     }
     confirm?.let { c ->
         val (title, message) = when (c) {
@@ -403,45 +406,13 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
 }
 
 @Composable
-private fun MobileSharePicker(
-    tc: TeamsCoordinator,
-    ref: TeamScopeRef,
-    kind: RecordType,
-    tick: Int,
-    onDone: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val scope = rememberCoroutineScope()
-    val hosts = LocalHosts.current
-    val snippets = LocalSnippets.current
-    // Across every space of the team, not just the selected one: a record lives in exactly one space.
-    val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
-    val items = if (kind == RecordType.HOST) {
-        (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
-    } else {
-        (snippets?.snippets ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.snippet.label, it.snippet.command) }
-    }
-    SharePickerDialog(
-        title = if (kind == RecordType.HOST) stringResource(Res.string.lib_teams_share_host_title) else stringResource(Res.string.lib_teams_share_snippet_title),
-        items = items,
-        emptyText = stringResource(Res.string.lib_teams_share_empty),
-        onPick = { item ->
-            scope.launch {
-                tc.shareRecord(ref, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
-                onDone()
-            }
-        },
-        onDismiss = onDismiss,
-    )
-}
-
-@Composable
 private fun MobileTeamDetail(
     tc: TeamsCoordinator,
     team: TeamUi,
     scopeId: String,
     tick: Int,
     busy: Boolean,
+    lastSyncedAt: Long?,
     onInvite: () -> Unit,
     onShare: (RecordType) -> Unit,
     onConfirm: (MobileTeamsConfirm) -> Unit,
@@ -456,7 +427,6 @@ private fun MobileTeamDetail(
     onNewScope: () -> Unit,
     onScopeAccess: (TeamScopeUi) -> Unit,
 ) {
-    val mono = LocalFonts.current.mono
     val invited = team.status == TeamMemberStatus.INVITED
     val owner = team.role == TeamRole.OWNER && !invited
     val canManage = team.role.canManageMembers && !invited
@@ -466,6 +436,7 @@ private fun MobileTeamDetail(
     val members by produceState(emptyList<TeamMember>(), team.id, team.memberCount, tick) {
         value = tc.members(team.id)
     }
+    val grants = scopeGrants(tc, team, tick, canManage)
     // Records of the selected space only; a scope we hold no key for has nothing readable to show.
     val spaceVault = if (!invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)) {
         tc.spaceVault(TeamScopeRef(team.id, scopeId))
@@ -474,6 +445,7 @@ private fun MobileTeamDetail(
     }
     val sharedHosts = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultHostStore(it).all() } ?: emptyList() }
     val sharedSnippets = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
+    val sharedRunbooks = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultRunbookStore(it).all() } ?: emptyList() }
 
     Txt(team.name, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, modifier = Modifier.padding(top = 10.dp))
     Txt(stringResource(Res.string.lib_teams_members_count, team.memberCount), color = Skerry.colors.dim, size = 12.sp, modifier = Modifier.padding(top = 2.dp))
@@ -503,8 +475,9 @@ private fun MobileTeamDetail(
         Txt(stringResource(Res.string.lib_teams_no_key), color = Skerry.colors.amber, size = 12.sp, modifier = Modifier.padding(top = 10.dp))
     }
 
-    Row(Modifier.padding(top = 12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-        GhostButton(stringResource(Res.string.lib_teams_sync_now), onClick = onSync, icon = "sync")
+    Row(Modifier.padding(top = 12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+        // How stale the screen is, and the way to fix that — the same pill the desktop header carries.
+        SyncPill(lastSyncedAt, onSync)
         if (canAudit) GhostButton(stringResource(Res.string.lib_teams_history), onClick = onShowHistory, icon = "history")
         if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
     }
@@ -523,113 +496,64 @@ private fun MobileTeamDetail(
     MobileTeamsSectionLabel(stringResource(Res.string.share_live_sessions))
     SharedSessionsList(team.id, LocalSharedSessions.current, onJoin = rememberJoinSharedSession(), modifier = Modifier.padding(bottom = 14.dp))
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_members))
+    val rows = remember(team, members, grants, canManage) {
+        teamMemberRows(team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true)
+    }
+    val now = remember(tick, members) { epochMillis() }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        members.forEach { m ->
-            val modifiable = canManage && m.accountId != team.ownerAccountId && canModifyMember(team.role, m.role)
+        rows.forEach { row ->
             MobileMemberRow(
-                m,
-                isOwnerRow = m.accountId == team.ownerAccountId,
-                canManageMember = modifiable,
-                onChangeRole = { onChangeRole(m) },
-                onRemove = { onConfirm(MobileTeamsConfirm.Remove(team.id, m.accountId)) },
+                row,
+                now = now,
+                onChangeRole = { onChangeRole(row.member) },
+                onRemove = { onConfirm(MobileTeamsConfirm.Remove(team.id, row.member.accountId)) },
             )
         }
     }
 
-    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
-    if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
-    sharedHosts.forEach { host ->
-        MobileSharedRow(
-            host.label, host.rowSubtitle(),
-            canUnshare = canWrite,
-            onHistory = if (canAudit) { { onShowRecordHistory(HistoryTarget(host.id, host.label)) } } else null,
-            onUnshare = { onUnshare(host.id) },
-        )
-    }
-    if (canWrite) {
-        GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
-    }
+    MobileSharedSection(
+        heading = stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size),
+        items = sharedHosts.map { SharedRecordUi(it.id, it.label, it.rowSubtitle()) },
+        shareLabel = stringResource(Res.string.lib_teams_share_host).takeIf { canWrite },
+        onShare = { onShare(RecordType.HOST) },
+        canUnshare = canWrite,
+        canAudit = canAudit,
+        onUnshare = onUnshare,
+        onShowRecordHistory = onShowRecordHistory,
+    )
+    MobileSharedSection(
+        heading = stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size),
+        items = sharedSnippets.map { SharedRecordUi(it.id, it.label, it.command) },
+        shareLabel = stringResource(Res.string.lib_teams_share_snippet).takeIf { canWrite },
+        onShare = { onShare(RecordType.SNIPPET) },
+        canUnshare = canWrite,
+        canAudit = canAudit,
+        onUnshare = onUnshare,
+        onShowRecordHistory = onShowRecordHistory,
+    )
+    MobileSharedSection(
+        heading = stringResource(Res.string.lib_teams_shared_runbooks_count, sharedRunbooks.size),
+        items = sharedRunbooks.map { SharedRecordUi(it.id, it.label, runbookSummary(it.steps.size)) },
+        shareLabel = stringResource(Res.string.lib_teams_share_runbook).takeIf { canWrite },
+        onShare = { onShare(RecordType.RUNBOOK) },
+        canUnshare = canWrite,
+        canAudit = canAudit,
+        onUnshare = onUnshare,
+        onShowRecordHistory = onShowRecordHistory,
+    )
 
-    MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
-    if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
-    sharedSnippets.forEach { snippet ->
-        MobileSharedRow(
-            snippet.label, snippet.command,
-            canUnshare = canWrite,
-            onHistory = if (canAudit) { { onShowRecordHistory(HistoryTarget(snippet.id, snippet.label)) } } else null,
-            onUnshare = { onUnshare(snippet.id) },
-        )
-    }
-    if (canWrite) {
-        GhostButton(stringResource(Res.string.lib_teams_share_snippet), onClick = { onShare(RecordType.SNIPPET) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
-    }
+    // The same three summary cards as the desktop screen, stacked; the lists they lead to on the
+    // desktop are already on this screen, so the counts here are plain facts.
+    TeamSummaryCardsStacked(
+        cards = teamCards(tc, team, scopeId, tick, teamFeed(tc, team, tick, canAudit)),
+        modifier = Modifier.padding(top = 24.dp),
+    )
 
     Row(Modifier.padding(top = 24.dp)) {
         if (owner) {
             GhostButton(stringResource(Res.string.lib_teams_delete), onClick = { onConfirm(MobileTeamsConfirm.Delete(team.id)) }, icon = "delete", fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.4f))
         } else {
             GhostButton(stringResource(Res.string.lib_teams_leave), onClick = { onConfirm(MobileTeamsConfirm.Leave(team.id)) }, icon = "logout", fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.4f))
-        }
-    }
-}
-
-@Composable
-private fun MobileTeamsSectionLabel(text: String) {
-    Txt(text.uppercase(), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(top = 24.dp, bottom = 10.dp))
-}
-
-@Composable
-private fun MobileTeamChip(team: TeamUi, active: Boolean, onClick: () -> Unit) {
-    val invited = team.status == TeamMemberStatus.INVITED
-    val fg = when {
-        active -> Skerry.colors.cyanBright
-        invited -> Skerry.colors.amber
-        else -> Skerry.colors.dim
-    }
-    Row(
-        Modifier
-            .clip(RoundedCornerShape(18.dp))
-            .background(if (active) Skerry.colors.cyan10 else Color.Transparent)
-            .border(1.dp, if (active) Skerry.colors.cyan14 else Skerry.colors.line, RoundedCornerShape(18.dp))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(7.dp),
-    ) {
-        Sym(if (invited) "mail" else "group", size = 15.sp, color = fg)
-        Txt(team.name, color = fg, size = 12.5.sp)
-    }
-}
-
-@Composable
-private fun MobileMemberRow(
-    m: TeamMember,
-    isOwnerRow: Boolean,
-    canManageMember: Boolean,
-    onChangeRole: () -> Unit,
-    onRemove: () -> Unit,
-) {
-    val mono = LocalFonts.current.mono
-    val invited = m.status == TeamMemberStatus.INVITED
-    val (roleFg, roleBg) = roleBadgeColors(m.role)
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(9.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(9.dp)).padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(Modifier.size(28.dp).clip(CircleShape).background(if (isOwnerRow) Skerry.colors.cyan else Skerry.colors.moss), contentAlignment = Alignment.Center) {
-            Txt(m.accountId.take(2).uppercase(), color = Skerry.colors.ink, size = 11.5.sp, weight = FontWeight.SemiBold)
-        }
-        Txt(m.accountId, color = Skerry.colors.text, size = 12.5.sp, font = mono, weight = FontWeight.Medium, modifier = Modifier.weight(1f))
-        if (invited) {
-            RoleBadge(stringResource(Res.string.lib_teams_status_invited), Skerry.colors.cyanBright, Skerry.colors.cyan.copy(alpha = 0.12f))
-        }
-        val badgeModifier = if (canManageMember) Modifier.clip(RoundedCornerShape(20.dp)).clickable(onClick = onChangeRole) else Modifier
-        RoleBadge(teamRoleLabel(m.role), roleFg, roleBg, modifier = badgeModifier)
-        if (canManageMember) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onRemove).padding(4.dp)) {
-                Sym("close", size = 15.sp, color = Skerry.colors.faint)
-            }
         }
     }
 }
@@ -724,35 +648,5 @@ private fun MobileTeamHostRow(host: Host, mono: androidx.compose.ui.text.font.Fo
             Txt(host.rowSubtitle(), color = Skerry.colors.dim, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
         Box(Modifier.size(8.dp).clip(CircleShape).background(dotColor))
-    }
-}
-
-@Composable
-private fun MobileSharedRow(
-    label: String,
-    detail: String,
-    canUnshare: Boolean,
-    onHistory: (() -> Unit)? = null,
-    onUnshare: () -> Unit,
-) {
-    val mono = LocalFonts.current.mono
-    Row(
-        Modifier.fillMaxWidth().padding(vertical = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(9.dp),
-    ) {
-        Txt(label, color = Skerry.colors.textBright, size = 12.5.sp, font = mono)
-        Txt(detail, color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.weight(1f))
-        // "What happened to this one" — only for readers who may see the audit log at all.
-        if (onHistory != null) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onHistory).padding(3.dp)) {
-                Sym("history", size = 14.sp, color = Skerry.colors.faint)
-            }
-        }
-        if (canUnshare) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onUnshare).padding(3.dp)) {
-                Sym("close", size = 14.sp, color = Skerry.colors.faint)
-            }
-        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.sync
 
 import app.skerry.shared.platformName
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.RemoteDevice
 import app.skerry.shared.sync.SyncClient
@@ -1386,6 +1387,24 @@ class SyncCoordinator(
             throw e
         } catch (e: Exception) {
             emptyList()
+        }
+    }
+
+    /**
+     * The server's own view of this account — device count, stored ciphertext, instance version — for
+     * the Teams screen's Server card. Null without a session or when the call fails: the card then
+     * shows what it knows (the endpoint) and dashes for the rest, which is what an unreachable server
+     * actually means.
+     */
+    suspend fun serverSummary(): AccountSummary? {
+        val c = client ?: return null
+        val s = session ?: return null
+        return try {
+            c.accountSummary(s)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            null
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
@@ -77,6 +77,7 @@ import app.skerry.ui.generated.resources.lib_teams_record_group
 import app.skerry.ui.generated.resources.lib_teams_record_host
 import app.skerry.ui.generated.resources.lib_teams_record_identity
 import app.skerry.ui.generated.resources.lib_teams_record_other
+import app.skerry.ui.generated.resources.lib_teams_record_runbook
 import app.skerry.ui.generated.resources.lib_teams_record_snippet
 import app.skerry.ui.generated.resources.lib_teams_record_tunnel
 import app.skerry.ui.generated.resources.shell_cancel
@@ -189,7 +190,7 @@ private fun ActivityFilterChips(selected: TeamActivityCategory, onSelect: (TeamA
 
 /** One event: icon, what happened (with the record's name), who and where, and the time. */
 @Composable
-private fun ActivityRow(row: TeamActivityRow, mono: androidx.compose.ui.text.font.FontFamily) {
+internal fun ActivityRow(row: TeamActivityRow, mono: androidx.compose.ui.text.font.FontFamily) {
     Column(
         Modifier
             .fillMaxWidth()
@@ -270,6 +271,7 @@ private fun eventLabel(row: TeamActivityRow): String = when (row.kind) {
 private fun recordNoun(type: RecordType?): String = when (type) {
     RecordType.HOST -> stringResource(Res.string.lib_teams_record_host)
     RecordType.SNIPPET -> stringResource(Res.string.lib_teams_record_snippet)
+    RecordType.RUNBOOK -> stringResource(Res.string.lib_teams_record_runbook)
     RecordType.CREDENTIAL -> stringResource(Res.string.lib_teams_record_credential)
     RecordType.IDENTITY -> stringResource(Res.string.lib_teams_record_identity)
     RecordType.TUNNEL -> stringResource(Res.string.lib_teams_record_tunnel)
@@ -318,13 +320,13 @@ private fun rowColor(kind: TeamActivityKind): Color = when (kind) {
 
 /** Day header: Today/Yesterday, else the date (UTC, like the row times). */
 @Composable
-private fun dayLabel(dayIndex: Long, todayIndex: Long, anyTimestampOfDay: Long): String = when (todayIndex - dayIndex) {
+internal fun dayLabel(dayIndex: Long, todayIndex: Long, anyTimestampOfDay: Long): String = when (todayIndex - dayIndex) {
     0L -> stringResource(Res.string.lib_teams_feed_day_today)
     1L -> stringResource(Res.string.lib_teams_feed_day_yesterday)
     else -> formatEpochUtc(anyTimestampOfDay).substringBefore(' ')
 }
 
 /** `HH:MM` of a timestamp, from the same UTC formatter the rest of the feed uses. */
-private fun timeOfDay(millis: Long): String = formatEpochUtc(millis).substringAfter(' ')
+internal fun timeOfDay(millis: Long): String = formatEpochUtc(millis).substringAfter(' ')
 
-private const val MILLIS_PER_DAY = 86_400_000L
+internal const val MILLIS_PER_DAY = 86_400_000L

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityPanel.kt
@@ -1,0 +1,83 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.TeamActivityDay
+import app.skerry.shared.terminal.epochMillis
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.VLine
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_history
+import app.skerry.ui.generated.resources.lib_teams_history_empty
+import app.skerry.ui.generated.resources.lib_teams_recent_activity
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Width of the activity column — wide enough for an event line plus its actor and time. */
+private val ACTIVITY_WIDTH = 380.dp
+
+/**
+ * The team's activity beside the members, for those allowed to see it (owner/admin). It is the same
+ * feed the History dialog shows, without the filters: the column answers "what happened here
+ * lately", and the dialog stays the place to dig.
+ */
+@Composable
+internal fun TeamActivityPanel(
+    feed: List<TeamActivityDay>,
+    onOpenFull: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val mono = LocalFonts.current.mono
+    // "Today"/"Yesterday" need a reference point; read once per composition, not per row.
+    val todayIndex = remember(feed) { epochMillis().floorDiv(MILLIS_PER_DAY) }
+    Row(modifier.width(ACTIVITY_WIDTH).fillMaxHeight()) {
+        VLine(Skerry.colors.line)
+        Column(Modifier.fillMaxWidth().background(Skerry.colors.surface2).padding(14.dp)) {
+            Row(
+                Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Txt(
+                    stringResource(Res.string.lib_teams_recent_activity).uppercase(),
+                    color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp,
+                )
+                GhostButton(stringResource(Res.string.lib_teams_history), onClick = onOpenFull, icon = "history")
+            }
+            if (feed.isEmpty()) {
+                Txt(stringResource(Res.string.lib_teams_history_empty), color = Skerry.colors.faint, size = 11.5.sp)
+                return@Column
+            }
+            Column(
+                Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                feed.forEach { day ->
+                    Txt(
+                        dayLabel(day.dayIndex, todayIndex, day.rows.first().createdAt),
+                        color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold,
+                        letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 8.dp, bottom = 2.dp),
+                    )
+                    day.rows.forEach { row -> ActivityRow(row, mono) }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
@@ -1,0 +1,174 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.ui.design.HLine
+import app.skerry.ui.design.InitialsAvatar
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_col_last_seen
+import app.skerry.ui.generated.resources.lib_teams_col_member
+import app.skerry.ui.generated.resources.lib_teams_col_role
+import app.skerry.ui.generated.resources.lib_teams_scopes
+import app.skerry.ui.generated.resources.lib_teams_status_invited
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** Value cell with nothing to show — a member holding no scope, an unreported last-seen time. */
+internal const val NO_VALUE = "—"
+
+/** Value cell whose answer this device couldn't obtain — distinct from "there is nothing here". */
+internal const val UNKNOWN_VALUE = "?"
+
+private val ROLE_WIDTH = 104.dp
+private val SEEN_WIDTH = 150.dp
+private val ACTIONS_WIDTH = 28.dp
+
+/**
+ * The team's members as a table: who they are, what they may do, which share spaces they hold a key
+ * to, and when they were last around. The role badge is the role editor and the trailing cross
+ * removes — both only for a viewer the server would actually let do it ([TeamMemberRowUi.manageable]).
+ */
+@Composable
+internal fun TeamMemberTable(
+    rows: List<TeamMemberRowUi>,
+    now: Long,
+    /** True while the access lists are still being fetched — the scope column stays blank until then. */
+    scopesLoading: Boolean = false,
+    onChangeRole: (TeamMemberRowUi) -> Unit,
+    onRemove: (TeamMemberRowUi) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.fillMaxWidth()) {
+        MemberGridRow(Modifier.padding(vertical = 9.dp)) {
+            HeaderCell(stringResource(Res.string.lib_teams_col_member), Modifier.weight(1.6f))
+            HeaderCell(stringResource(Res.string.lib_teams_col_role), Modifier.width(ROLE_WIDTH))
+            HeaderCell(stringResource(Res.string.lib_teams_scopes), Modifier.weight(1.2f))
+            HeaderCell(stringResource(Res.string.lib_teams_col_last_seen), Modifier.width(SEEN_WIDTH))
+            Box(Modifier.width(ACTIONS_WIDTH))
+        }
+        HLine()
+        rows.forEach { row ->
+            MemberRow(row, now, scopesLoading, onChangeRole = { onChangeRole(row) }, onRemove = { onRemove(row) })
+            HLine()
+        }
+    }
+}
+
+@Composable
+private fun MemberRow(row: TeamMemberRowUi, now: Long, scopesLoading: Boolean, onChangeRole: () -> Unit, onRemove: () -> Unit) {
+    val mono = LocalFonts.current.mono
+    val member = row.member
+    val invited = member.status == TeamMemberStatus.INVITED
+    val (roleFg, roleBg) = roleBadgeColors(member.role)
+    MemberGridRow(Modifier.padding(vertical = 11.dp)) {
+        Row(
+            Modifier.weight(1.6f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            InitialsAvatar(member.accountId, size = 28.dp)
+            Txt(
+                member.accountId,
+                color = if (invited) Skerry.colors.dim else Skerry.colors.text,
+                size = 12.5.sp,
+                font = mono,
+                weight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Box(Modifier.width(ROLE_WIDTH)) {
+            if (invited) {
+                RoleBadge(stringResource(Res.string.lib_teams_status_invited), Skerry.colors.amber, Skerry.colors.amber.copy(alpha = 0.14f))
+            } else {
+                // Clicking the badge opens the role picker — the same affordance the old list had.
+                val editable = if (row.manageable) Modifier.clip(RoundedCornerShape(20.dp)).clickable(onClick = onChangeRole) else Modifier
+                RoleBadge(teamRoleLabel(member.role), roleFg, roleBg, modifier = editable)
+            }
+        }
+        Box(Modifier.weight(1.2f)) {
+            // An access list we failed to read is not the same answer as "holds nothing" — and a
+            // partial read is not a complete one, so the "?" follows whatever tags did load.
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                if (row.scopes.isEmpty() && row.scopesKnown && !scopesLoading) {
+                    Txt(NO_VALUE, color = Skerry.colors.faint, size = 11.5.sp, font = mono)
+                }
+                row.scopes.forEach { ScopeTag(it) }
+                if (!row.scopesKnown && !scopesLoading) {
+                    Txt(UNKNOWN_VALUE, color = Skerry.colors.amber, size = 11.5.sp, font = mono)
+                }
+            }
+        }
+        Txt(
+            lastSeenText(row.member.lastSeenAt, now),
+            color = Skerry.colors.dim,
+            size = 11.5.sp,
+            font = mono,
+            modifier = Modifier.width(SEEN_WIDTH),
+            maxLines = 1,
+        )
+        Box(Modifier.width(ACTIONS_WIDTH), contentAlignment = Alignment.CenterEnd) {
+            if (row.manageable) {
+                Box(Modifier.clip(CircleShape).clickable(onClick = onRemove).padding(4.dp)) {
+                    Sym("close", size = 15.sp, color = Skerry.colors.faint)
+                }
+            }
+        }
+    }
+}
+
+/** A share space a member holds, as a small tag — the "#prod" of the design. */
+@Composable
+private fun ScopeTag(name: String) {
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(Skerry.colors.overlayMed)
+            .border(1.dp, Skerry.colors.line, RoundedCornerShape(20.dp))
+            .padding(horizontal = 9.dp, vertical = 2.dp),
+    ) {
+        Txt("#$name", color = Skerry.colors.dim, size = 10.5.sp, font = LocalFonts.current.mono, maxLines = 1)
+    }
+}
+
+/** Shared geometry of the header and the rows — one place decides padding and column spacing. */
+@Composable
+private fun MemberGridRow(modifier: Modifier = Modifier, content: @Composable RowScope.() -> Unit) {
+    Row(
+        modifier.fillMaxWidth().padding(horizontal = 22.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        content = content,
+    )
+}
+
+@Composable
+private fun HeaderCell(text: String, modifier: Modifier = Modifier) {
+    Box(modifier, contentAlignment = Alignment.CenterStart) {
+        Txt(text.uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
@@ -37,6 +37,7 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_scope_access_hint
 import app.skerry.ui.generated.resources.lib_teams_scope_access_title
+import app.skerry.ui.generated.resources.lib_teams_scope_access_unknown
 import app.skerry.ui.generated.resources.lib_teams_scope_delete
 import app.skerry.ui.generated.resources.lib_teams_scope_no_key
 import app.skerry.ui.generated.resources.lib_teams_scope_access
@@ -174,6 +175,17 @@ internal fun CreateScopeDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit
 }
 
 /**
+ * One scope's access list as the dialog sees it. Loading and failed are separate states on purpose:
+ * telling the user "the server did not answer" while the request is still in flight is a lie that
+ * looks exactly like the truth.
+ */
+internal sealed interface ScopeAccess {
+    data object Loading : ScopeAccess
+    data class Known(val accounts: Set<String>) : ScopeAccess
+    data object Unavailable : ScopeAccess
+}
+
+/**
  * Who may read a scope. Granting seals the scope key to the member, so only someone who holds the
  * key can hand it out — a manager without a grant sees the list but can't add to it ([canGrant]).
  */
@@ -181,7 +193,7 @@ internal fun CreateScopeDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit
 internal fun ScopeAccessDialog(
     scopeName: String,
     members: List<TeamMember>,
-    granted: Set<String>,
+    granted: ScopeAccess,
     canGrant: Boolean,
     busy: Boolean,
     onGrant: (String) -> Unit,
@@ -201,7 +213,7 @@ internal fun ScopeAccessDialog(
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             members.forEach { member ->
-                val has = member.accountId in granted
+                val has = granted is ScopeAccess.Known && member.accountId in granted.accounts
                 Row(
                     Modifier
                         .fillMaxWidth()
@@ -219,16 +231,24 @@ internal fun ScopeAccessDialog(
                             fg = Skerry.colors.sunset,
                             border = Skerry.colors.sunset.copy(alpha = 0.3f),
                         )
-                    } else if (canGrant) {
+                    } else if (canGrant && granted is ScopeAccess.Known) {
                         GhostButton(stringResource(Res.string.lib_teams_scope_grant), onClick = { if (!busy) onGrant(member.accountId) })
                     }
                 }
             }
         }
-        Txt(
-            stringResource(Res.string.lib_teams_scope_members_count, granted.size),
-            color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.padding(top = 10.dp),
-        )
+        when (granted) {
+            is ScopeAccess.Known -> Txt(
+                stringResource(Res.string.lib_teams_scope_members_count, granted.accounts.size),
+                color = Skerry.colors.faint, size = 11.sp, modifier = Modifier.padding(top = 10.dp),
+            )
+            ScopeAccess.Unavailable -> Txt(
+                stringResource(Res.string.lib_teams_scope_access_unknown),
+                color = Skerry.colors.amber, size = 11.sp, modifier = Modifier.padding(top = 10.dp),
+            )
+            // Loading says nothing: the count and the failure line would both be guesses.
+            ScopeAccess.Loading -> Unit
+        }
         Row(
             Modifier.fillMaxWidth().padding(top = 16.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -1,0 +1,449 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.host.VaultHostStore
+import app.skerry.shared.runbook.VaultRunbookStore
+import app.skerry.shared.snippet.VaultSnippetStore
+import app.skerry.shared.team.HOST_SHARE_STRIP
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.terminal.epochMillis
+import app.skerry.shared.vault.RecordType
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.LocalRunbooks
+import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.design.AnchoredDropdown
+import app.skerry.ui.design.DropdownMenuColumn
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.SectionHeader
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_accept
+import app.skerry.ui.generated.resources.lib_teams_decline
+import app.skerry.ui.generated.resources.lib_teams_delete
+import app.skerry.ui.generated.resources.lib_teams_header_subtitle
+import app.skerry.ui.generated.resources.lib_teams_header_title
+import app.skerry.ui.generated.resources.lib_teams_invite
+import app.skerry.ui.generated.resources.lib_teams_invite_unverified
+import app.skerry.ui.generated.resources.lib_teams_invited_banner
+import app.skerry.ui.generated.resources.lib_teams_invited_by
+import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
+import app.skerry.ui.generated.resources.lib_teams_leave
+import app.skerry.ui.generated.resources.lib_teams_no_key
+import app.skerry.ui.generated.resources.lib_teams_scopes
+import app.skerry.ui.generated.resources.lib_teams_share_empty
+import app.skerry.ui.generated.resources.lib_teams_share_host
+import app.skerry.ui.generated.resources.lib_teams_share_host_title
+import app.skerry.ui.generated.resources.lib_teams_share_runbook
+import app.skerry.ui.generated.resources.lib_teams_share_runbook_title
+import app.skerry.ui.generated.resources.lib_teams_share_snippet
+import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
+import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
+import app.skerry.ui.generated.resources.lib_teams_shared_runbooks_count
+import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
+import app.skerry.ui.generated.resources.lib_teams_synced_never
+import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.theme.Skerry
+import kotlinx.coroutines.delay
+import org.jetbrains.compose.resources.stringResource
+
+/** How often the freshness pill re-reads the clock; a minute-grained label needs no finer tick. */
+private const val PILL_TICK_MS = 10_000L
+
+// The team's own screen: header, share-space strip, member table, summary cards and the lists they
+// open. TeamsView.kt keeps the state and the dialogs; everything that draws one team lives here.
+
+/**
+ * One team: the header with its freshness and its actions, the member table with the share spaces
+ * above it, the summary cards, and — for owner/admin — the activity column beside them.
+ */
+@Composable
+internal fun TeamScreen(
+    tc: TeamsCoordinator,
+    team: TeamUi,
+    scopeId: String,
+    tick: Int,
+    busy: Boolean,
+    onInvite: () -> Unit,
+    onConfirm: (TeamsConfirm) -> Unit,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onSync: () -> Unit,
+    onShowHistory: () -> Unit,
+    onChangeRole: (TeamMember) -> Unit,
+    onSelectScope: (String) -> Unit,
+    onNewScope: () -> Unit,
+    onScopeAccess: (TeamScopeUi) -> Unit,
+    onOpenShared: (TeamSharedView) -> Unit,
+) {
+    val invited = team.status == TeamMemberStatus.INVITED
+    val owner = team.role == TeamRole.OWNER && !invited
+    val canManage = team.role.canManageMembers && !invited
+    val canAudit = team.role.canViewAudit && !invited
+    val syncStamps by tc.lastSyncedAt.collectAsState()
+    val members by produceState(emptyList<TeamMember>(), team.id, team.memberCount, tick) {
+        value = tc.members(team.id)
+    }
+    val grants = scopeGrants(tc, team, tick, canManage)
+    val feed = teamFeed(tc, team, tick, canAudit)
+
+    TeamHeader(
+        team = team,
+        lastSyncedAt = syncStamps[team.id],
+        busy = busy,
+        owner = owner,
+        canManage = canManage,
+        invited = invited,
+        onSync = onSync,
+        onInvite = onInvite,
+        onLeave = { onConfirm(TeamsConfirm.Leave(team.id)) },
+        onDelete = { onConfirm(TeamsConfirm.Delete(team.id)) },
+    )
+    Row(Modifier.fillMaxSize()) {
+        Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())) {
+            if (invited) {
+                InviteBanner(tc, team, busy, onAccept = onAccept, onDecline = onDecline)
+                return@Column
+            }
+            if (!team.hasKey) {
+                Txt(
+                    stringResource(Res.string.lib_teams_no_key),
+                    color = Skerry.colors.amber, size = 12.sp,
+                    modifier = Modifier.padding(horizontal = 22.dp, vertical = 12.dp),
+                )
+            }
+            ScopeStrip(team, scopeId, canManage, onSelectScope, onNewScope, onScopeAccess, onDeleteScope = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) })
+            val rows = remember(team, members, grants, canManage) {
+                teamMemberRows(team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true)
+            }
+            // Read once per reread rather than per row, so every row of one paint agrees on "now".
+            val now = remember(tick, members) { epochMillis() }
+            TeamMemberTable(
+                rows = rows,
+                now = now,
+                scopesLoading = canManage && grants == null,
+                onChangeRole = { onChangeRole(it.member) },
+                onRemove = { onConfirm(TeamsConfirm.Remove(team.id, it.member.accountId)) },
+            )
+            TeamSummaryCards(
+                cards = teamCards(tc, team, scopeId, tick, feed),
+                onOpen = onOpenShared,
+                modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+            )
+        }
+        if (canAudit) TeamActivityPanel(feed, onOpenFull = onShowHistory)
+    }
+}
+
+/** Header strip: what team this is, how fresh it is, and the actions on the team as a whole. */
+@Composable
+private fun TeamHeader(
+    team: TeamUi,
+    lastSyncedAt: Long?,
+    busy: Boolean,
+    owner: Boolean,
+    canManage: Boolean,
+    invited: Boolean,
+    onSync: () -> Unit,
+    onInvite: () -> Unit,
+    onLeave: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    SectionHeader(
+        title = stringResource(Res.string.lib_teams_header_title),
+        subtitle = stringResource(Res.string.lib_teams_header_subtitle, team.name, team.memberCount),
+        actions = {
+            if (!invited) SyncPill(lastSyncedAt, onSync)
+            if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
+            if (!invited) TeamOverflowMenu(owner = owner, onLeave = onLeave, onDelete = onDelete)
+        },
+    )
+}
+
+/** "synced 12 s ago" — and the way to sync now, since the two are the same question. */
+@Composable
+internal fun SyncPill(lastSyncedAt: Long?, onSync: () -> Unit) {
+    // The pill's whole job is freshness, so it re-derives on a timer: without it the label would
+    // freeze at "synced 0 s ago" for as long as nothing else recomposes the screen.
+    var now by remember { mutableStateOf(epochMillis()) }
+    LaunchedEffect(lastSyncedAt) {
+        // Nothing to age while no sync has finished — the pill reads "not synced yet" either way.
+        while (lastSyncedAt != null) {
+            delay(PILL_TICK_MS)
+            now = epochMillis()
+        }
+    }
+    val ago = lastSyncedAt?.let { syncedAgoText((now - it).coerceAtLeast(0)) }
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(20.dp))
+            .background(Skerry.colors.moss.copy(alpha = 0.10f))
+            .border(1.dp, Skerry.colors.moss.copy(alpha = 0.25f), RoundedCornerShape(20.dp))
+            .clickable(onClick = onSync)
+            .padding(horizontal = 11.dp, vertical = 5.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Sym(if (ago == null) "cloud_off" else "cloud_done", size = 15.sp, color = Skerry.colors.moss)
+        Txt(
+            ago ?: stringResource(Res.string.lib_teams_synced_never),
+            color = Skerry.colors.moss, size = 11.sp, weight = FontWeight.Medium,
+        )
+    }
+}
+
+/** Leave/Delete — rare and destructive, so they sit behind the header's overflow rather than in it. */
+@Composable
+private fun TeamOverflowMenu(owner: Boolean, onLeave: () -> Unit, onDelete: () -> Unit) {
+    var open by remember { mutableStateOf(false) }
+    AnchoredDropdown(
+        expanded = open,
+        onDismiss = { open = false },
+        trigger = {
+            Box(
+                Modifier.clip(RoundedCornerShape(7.dp)).clickable { open = !open }.padding(6.dp),
+            ) {
+                Sym("more_vert", size = 18.sp, color = Skerry.colors.dim)
+            }
+        },
+        menu = {
+            DropdownMenuColumn(width = 190.dp) {
+                val label = if (owner) stringResource(Res.string.lib_teams_delete) else stringResource(Res.string.lib_teams_leave)
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { open = false; if (owner) onDelete() else onLeave() }
+                        .padding(horizontal = 12.dp, vertical = 9.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(9.dp),
+                ) {
+                    Sym(if (owner) "delete" else "logout", size = 16.sp, color = Skerry.colors.sunset)
+                    Txt(label, color = Skerry.colors.sunset, size = 12.5.sp)
+                }
+            }
+        },
+    )
+}
+
+/** Share spaces of the team, with the manager actions on the selected one. */
+@Composable
+private fun ScopeStrip(
+    team: TeamUi,
+    scopeId: String,
+    canManage: Boolean,
+    onSelect: (String) -> Unit,
+    onNew: () -> Unit,
+    onAccess: (TeamScopeUi) -> Unit,
+    onDeleteScope: (TeamScopeUi) -> Unit,
+) {
+    Column(Modifier.padding(horizontal = 22.dp, vertical = 14.dp)) {
+        Txt(
+            stringResource(Res.string.lib_teams_scopes).uppercase(),
+            color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp,
+            modifier = Modifier.padding(bottom = 10.dp),
+        )
+        ScopeSection(
+            scopes = team.scopes,
+            selected = scopeId,
+            canManage = canManage,
+            onSelect = onSelect,
+            onNew = onNew,
+            onAccess = onAccess,
+            onDelete = onDeleteScope,
+        )
+    }
+}
+
+/** The invite this account hasn't answered yet: who sent it, their fingerprint, accept or decline. */
+@Composable
+private fun InviteBanner(tc: TeamsCoordinator, team: TeamUi, busy: Boolean, onAccept: () -> Unit, onDecline: () -> Unit) {
+    val mono = LocalFonts.current.mono
+    // Verify the inviter's identity (signature + fingerprint) before offering Accept. Null = the
+    // invite couldn't be authenticated (forged/tampered) — warn and don't reveal a fingerprint.
+    val acceptPreview by produceState<InvitePreview?>(null, team.id) { value = tc.acceptPreview(team.id) }
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 22.dp, vertical = 18.dp)
+            .clip(RoundedCornerShape(9.dp))
+            .background(Skerry.colors.amber.copy(alpha = 0.08f))
+            .border(1.dp, Skerry.colors.amber.copy(alpha = 0.25f), RoundedCornerShape(9.dp))
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Sym("mail", size = 18.sp, color = Skerry.colors.amber)
+            Txt(stringResource(Res.string.lib_teams_invited_banner), color = Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
+            GhostButton(stringResource(Res.string.lib_teams_decline), onClick = onDecline, fg = Skerry.colors.dim)
+            PrimaryButton(stringResource(Res.string.lib_teams_accept), onClick = onAccept, enabled = !busy)
+        }
+        acceptPreview.let { p ->
+            if (p == null) {
+                Txt(stringResource(Res.string.lib_teams_invite_unverified), color = Skerry.colors.sunset, size = 11.5.sp)
+            } else {
+                Txt(stringResource(Res.string.lib_teams_invited_by, p.accountId), color = Skerry.colors.dim, size = 11.5.sp)
+                Txt(stringResource(Res.string.lib_teams_invited_fingerprint, p.fingerprint), color = Skerry.colors.cyanBright, size = 11.5.sp, font = mono)
+            }
+        }
+    }
+}
+
+/** The list behind a "Shared with the team" row: records of one kind, or the live session directory. */
+@Composable
+internal fun SharedRecordsView(
+    tc: TeamsCoordinator,
+    team: TeamUi,
+    scopeId: String,
+    view: TeamSharedView,
+    tick: Int,
+    onShare: (RecordType) -> Unit,
+    onUnshare: (String) -> Unit,
+    onRecordHistory: (HistoryTarget) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    if (view == TeamSharedView.LIVE) {
+        TeamLiveSessionsDialog(team.id, onDismiss)
+        return
+    }
+    val invited = team.status == TeamMemberStatus.INVITED
+    val activeScope = team.scopes.firstOrNull { it.id == scopeId }
+    val readable = !invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)
+    val canWrite = team.role.canWrite && readable
+    val canAudit = team.role.canViewAudit && !invited
+    val spaceVault = if (readable) tc.spaceVault(TeamScopeRef(team.id, scopeId)) else null
+    // Decrypting the space is the expensive part, so it stays in remember; the second line of a
+    // runbook row is localized text and has to be built in the composition.
+    val runbooks = remember(team.id, scopeId, tick, spaceVault, view) {
+        if (view == TeamSharedView.RUNBOOKS) spaceVault?.let { VaultRunbookStore(it).all() }.orEmpty() else emptyList()
+    }
+    val records = remember(team.id, scopeId, tick, spaceVault, view) {
+        when (view) {
+            TeamSharedView.HOSTS -> spaceVault?.let { vault ->
+                VaultHostStore(vault).all().map { SharedRecordUi(it.id, it.label, it.rowSubtitle()) }
+            }
+            TeamSharedView.SNIPPETS -> spaceVault?.let { vault ->
+                VaultSnippetStore(vault).all().map { SharedRecordUi(it.id, it.label, it.command) }
+            }
+            else -> null
+        } ?: emptyList()
+    }
+    val items = if (view == TeamSharedView.RUNBOOKS) {
+        runbooks.map { SharedRecordUi(it.id, it.label, runbookSummary(it.steps.size)) }
+    } else {
+        records
+    }
+    val kind = when (view) {
+        TeamSharedView.HOSTS -> RecordType.HOST
+        TeamSharedView.SNIPPETS -> RecordType.SNIPPET
+        else -> RecordType.RUNBOOK
+    }
+    TeamSharedRecordsDialog(
+        title = when (view) {
+            TeamSharedView.HOSTS -> stringResource(Res.string.lib_teams_shared_hosts_count, items.size)
+            TeamSharedView.SNIPPETS -> stringResource(Res.string.lib_teams_shared_snippets_count, items.size)
+            else -> stringResource(Res.string.lib_teams_shared_runbooks_count, items.size)
+        },
+        items = items,
+        shareLabel = if (canWrite) {
+            when (view) {
+                TeamSharedView.HOSTS -> stringResource(Res.string.lib_teams_share_host)
+                TeamSharedView.SNIPPETS -> stringResource(Res.string.lib_teams_share_snippet)
+                else -> stringResource(Res.string.lib_teams_share_runbook)
+            }
+        } else {
+            null
+        },
+        onShare = { onShare(kind) },
+        onUnshare = if (canWrite) {
+            { item -> onUnshare(item.id) }
+        } else {
+            null
+        },
+        onHistory = if (canAudit) {
+            { item -> onRecordHistory(HistoryTarget(item.id, item.label)) }
+        } else {
+            null
+        },
+        onDismiss = onDismiss,
+    )
+}
+
+/**
+ * "Share a record" picker: own hosts/snippets/runbooks minus those already shared with the team.
+ * Shared with the phone screen — a record type offered on one platform and not the other would be
+ * the kind of drift two copies of this function produced before.
+ */
+@Composable
+internal fun SharePicker(
+    tc: TeamsCoordinator,
+    ref: TeamScopeRef,
+    kind: RecordType,
+    tick: Int,
+    onDone: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val hosts = LocalHosts.current
+    val snippets = LocalSnippets.current
+    val runbooks = LocalRunbooks.current
+    // Across every space of the team, not just the selected one: a record lives in exactly one space.
+    val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
+    val items = when (kind) {
+        RecordType.HOST ->
+            (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
+        RecordType.SNIPPET ->
+            (snippets?.snippets ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.snippet.label, it.snippet.command) }
+        else ->
+            (runbooks?.runbooks ?: emptyList()).filter { it.id !in sharedIds }
+                .map { ShareItem(it.id, it.runbook.label, runbookSummary(it.runbook.steps.size)) }
+    }
+    SharePickerDialog(
+        title = when (kind) {
+            RecordType.HOST -> stringResource(Res.string.lib_teams_share_host_title)
+            RecordType.SNIPPET -> stringResource(Res.string.lib_teams_share_snippet_title)
+            else -> stringResource(Res.string.lib_teams_share_runbook_title)
+        },
+        items = items,
+        emptyText = stringResource(Res.string.lib_teams_share_empty),
+        onPick = { item ->
+            scope.launch2 {
+                tc.shareRecord(ref, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
+                onDone()
+            }
+        },
+        onDismiss = onDismiss,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSharedRecordsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSharedRecordsDialog.kt
@@ -1,0 +1,117 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalSharedSessions
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_nothing_shared
+import app.skerry.ui.generated.resources.share_live_sessions
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.share.SharedSessionsList
+import app.skerry.ui.share.rememberJoinSharedSession
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/** A record shared into the selected space: what the list row shows, plus the id its actions need. */
+internal data class SharedRecordUi(val id: String, val label: String, val detail: String)
+
+/**
+ * The records of one kind shared into the selected share space, with everything one can do to
+ * them: add another ([onShare]), take one out ([onUnshare]), or look at what happened to it
+ * ([onHistory], owner/admin only). Reached from the "Shared with the team" card.
+ */
+@Composable
+internal fun TeamSharedRecordsDialog(
+    title: String,
+    items: List<SharedRecordUi>,
+    shareLabel: String?,
+    onShare: () -> Unit,
+    onUnshare: ((SharedRecordUi) -> Unit)?,
+    onHistory: ((SharedRecordUi) -> Unit)?,
+    onDismiss: () -> Unit,
+) {
+    val mono = LocalFonts.current.mono
+    TeamsDialogCard(onDismiss) {
+        Txt(title, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp, modifier = Modifier.padding(bottom = 12.dp))
+        if (items.isEmpty()) {
+            Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.dim, size = 12.5.sp)
+        } else {
+            Column(
+                Modifier.fillMaxWidth().heightIn(max = 340.dp).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                items.forEach { item ->
+                    Row(
+                        Modifier.fillMaxWidth().padding(vertical = 7.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(9.dp),
+                    ) {
+                        Txt(item.label, color = Skerry.colors.textBright, size = 12.5.sp, font = mono)
+                        Txt(item.detail, color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.weight(1f), maxLines = 1)
+                        if (onHistory != null) {
+                            Box(Modifier.clip(CircleShape).clickable { onHistory(item) }.padding(3.dp)) {
+                                Sym("history", size = 14.sp, color = Skerry.colors.faint)
+                            }
+                        }
+                        if (onUnshare != null) {
+                            Box(Modifier.clip(CircleShape).clickable { onUnshare(item) }.padding(3.dp)) {
+                                Sym("close", size = 14.sp, color = Skerry.colors.faint)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Row(
+            Modifier.fillMaxWidth().padding(top = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (shareLabel != null) GhostButton(shareLabel, onClick = onShare, icon = "add")
+            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+        }
+    }
+}
+
+/**
+ * The team's live shared sessions — a directory that exists only while the sockets do, so it is a
+ * dialog over the live list rather than a stored count.
+ */
+@Composable
+internal fun TeamLiveSessionsDialog(teamId: String, onDismiss: () -> Unit) {
+    TeamsDialogCard(onDismiss) {
+        Txt(
+            stringResource(Res.string.share_live_sessions),
+            color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        SharedSessionsList(teamId, LocalSharedSessions.current, onJoin = rememberJoinSharedSession())
+        Row(
+            Modifier.fillMaxWidth().padding(top = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+        ) {
+            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSharedRecordsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSharedRecordsDialog.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.app.LocalSharedSessions
-import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
@@ -27,7 +26,6 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_nothing_shared
 import app.skerry.ui.generated.resources.share_live_sessions
-import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.share.SharedSessionsList
 import app.skerry.ui.share.rememberJoinSharedSession
 import app.skerry.ui.theme.Skerry
@@ -53,7 +51,7 @@ internal fun TeamSharedRecordsDialog(
 ) {
     val mono = LocalFonts.current.mono
     TeamsDialogCard(onDismiss) {
-        Txt(title, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp, modifier = Modifier.padding(bottom = 12.dp))
+        DialogTitleRow(title, onDismiss)
         if (items.isEmpty()) {
             Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.dim, size = 12.5.sp)
         } else {
@@ -83,13 +81,14 @@ internal fun TeamSharedRecordsDialog(
                 }
             }
         }
-        Row(
-            Modifier.fillMaxWidth().padding(top = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            if (shareLabel != null) GhostButton(shareLabel, onClick = onShare, icon = "add")
-            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+        if (shareLabel != null) {
+            Row(
+                Modifier.fillMaxWidth().padding(top = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                GhostButton(shareLabel, onClick = onShare, icon = "add")
+            }
         }
     }
 }
@@ -101,17 +100,30 @@ internal fun TeamSharedRecordsDialog(
 @Composable
 internal fun TeamLiveSessionsDialog(teamId: String, onDismiss: () -> Unit) {
     TeamsDialogCard(onDismiss) {
-        Txt(
-            stringResource(Res.string.share_live_sessions),
-            color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
-            modifier = Modifier.padding(bottom = 12.dp),
-        )
+        DialogTitleRow(stringResource(Res.string.share_live_sessions), onDismiss)
         SharedSessionsList(teamId, LocalSharedSessions.current, onJoin = rememberJoinSharedSession())
-        Row(
-            Modifier.fillMaxWidth().padding(top = 16.dp),
-            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
-        ) {
-            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss)
+    }
+}
+
+/**
+ * Title of a list dialog, with the way out on the same line. These dialogs show what is already
+ * shared rather than ask for a decision, so a bottom "Cancel" would offer to abandon something the
+ * user never started; closing belongs in the corner.
+ */
+@Composable
+private fun DialogTitleRow(title: String, onDismiss: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(bottom = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Txt(
+            title,
+            color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp,
+            modifier = Modifier.weight(1f),
+        )
+        Box(Modifier.clip(CircleShape).clickable(onClick = onDismiss).padding(4.dp)) {
+            Sym("close", size = 16.sp, color = Skerry.colors.dim)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSummaryCards.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSummaryCards.kt
@@ -1,0 +1,130 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.skerry.ui.design.Card
+import app.skerry.ui.design.KeyValueRow
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_card_devices
+import app.skerry.ui.generated.resources.lib_teams_card_devices_value
+import app.skerry.ui.generated.resources.lib_teams_card_encryption
+import app.skerry.ui.generated.resources.lib_teams_card_encryption_value
+import app.skerry.ui.generated.resources.lib_teams_card_endpoint
+import app.skerry.ui.generated.resources.lib_teams_card_hosts
+import app.skerry.ui.generated.resources.lib_teams_card_items
+import app.skerry.ui.generated.resources.lib_teams_card_last_rekey
+import app.skerry.ui.generated.resources.lib_teams_card_live
+import app.skerry.ui.generated.resources.lib_teams_card_live_value
+import app.skerry.ui.generated.resources.lib_teams_card_runbooks
+import app.skerry.ui.generated.resources.lib_teams_card_server
+import app.skerry.ui.generated.resources.lib_teams_card_shared
+import app.skerry.ui.generated.resources.lib_teams_card_snippets
+import app.skerry.ui.generated.resources.lib_teams_card_storage
+import app.skerry.ui.generated.resources.lib_teams_card_storage_value
+import app.skerry.ui.generated.resources.lib_teams_card_vault
+import app.skerry.ui.generated.resources.lib_teams_card_version
+import org.jetbrains.compose.resources.stringResource
+
+/** Which list a "Shared with the team" row opens. */
+internal enum class TeamSharedView { HOSTS, SNIPPETS, RUNBOOKS, LIVE }
+
+/**
+ * The three facts panels under the member table: what the shared vault holds, which server it lives
+ * on, and what the team has put in it. The counts are the way into the lists — the records
+ * themselves (with their share/unshare/history actions) open from these rows.
+ *
+ * Fields the server hasn't told us (an old instance, an unreachable one) show [NO_VALUE] rather than
+ * a plausible-looking zero.
+ */
+internal data class TeamCards(
+    val items: Int,
+    val lastRekeyAt: Long?,
+    val endpoint: String?,
+    val serverVersion: String?,
+    val devices: Int?,
+    val hosts: Int,
+    val snippets: Int,
+    val runbooks: Int,
+    val liveSessions: Int,
+)
+
+/** The three cards side by side — the desktop screen, where there is room for a row of them. */
+@Composable
+internal fun TeamSummaryCards(cards: TeamCards, onOpen: (TeamSharedView) -> Unit, modifier: Modifier = Modifier) {
+    Row(modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        VaultCard(cards, Modifier.weight(1f))
+        ServerCard(cards, Modifier.weight(1f))
+        SharedCard(cards, onOpen, Modifier.weight(1f))
+    }
+}
+
+/** The same three cards stacked — the phone, where a row of them would be unreadable. */
+@Composable
+internal fun TeamSummaryCardsStacked(cards: TeamCards, onOpen: ((TeamSharedView) -> Unit)? = null, modifier: Modifier = Modifier) {
+    Column(modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        VaultCard(cards, Modifier.fillMaxWidth())
+        ServerCard(cards, Modifier.fillMaxWidth())
+        SharedCard(cards, onOpen, Modifier.fillMaxWidth())
+    }
+}
+
+@Composable
+private fun VaultCard(cards: TeamCards, modifier: Modifier) {
+    Card(modifier, title = stringResource(Res.string.lib_teams_card_vault)) {
+        KeyValueRow(stringResource(Res.string.lib_teams_card_items), cards.items.toString())
+        KeyValueRow(stringResource(Res.string.lib_teams_card_encryption), stringResource(Res.string.lib_teams_card_encryption_value))
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_last_rekey),
+            cards.lastRekeyAt?.let { formatEpochUtc(it).substringBefore(' ') } ?: NO_VALUE,
+        )
+    }
+}
+
+@Composable
+private fun ServerCard(cards: TeamCards, modifier: Modifier) {
+    Card(modifier, title = stringResource(Res.string.lib_teams_card_server)) {
+        KeyValueRow(stringResource(Res.string.lib_teams_card_endpoint), cards.endpoint ?: NO_VALUE)
+        KeyValueRow(stringResource(Res.string.lib_teams_card_storage), stringResource(Res.string.lib_teams_card_storage_value))
+        KeyValueRow(stringResource(Res.string.lib_teams_card_version), cards.serverVersion?.takeIf { it.isNotBlank() } ?: NO_VALUE)
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_devices),
+            cards.devices?.let { stringResource(Res.string.lib_teams_card_devices_value, it) } ?: NO_VALUE,
+        )
+    }
+}
+
+@Composable
+private fun SharedCard(cards: TeamCards, onOpen: ((TeamSharedView) -> Unit)?, modifier: Modifier) {
+    Card(modifier, title = stringResource(Res.string.lib_teams_card_shared)) {
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_hosts),
+            cards.hosts.toString(),
+            modifier = openModifier(onOpen, TeamSharedView.HOSTS),
+        )
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_snippets),
+            cards.snippets.toString(),
+            modifier = openModifier(onOpen, TeamSharedView.SNIPPETS),
+        )
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_runbooks),
+            cards.runbooks.toString(),
+            modifier = openModifier(onOpen, TeamSharedView.RUNBOOKS),
+        )
+        KeyValueRow(
+            stringResource(Res.string.lib_teams_card_live),
+            stringResource(Res.string.lib_teams_card_live_value, cards.liveSessions),
+            modifier = openModifier(onOpen, TeamSharedView.LIVE),
+        )
+    }
+}
+
+/** A count is clickable only where clicking it opens something — see [TeamSummaryCardsStacked]. */
+private fun openModifier(onOpen: ((TeamSharedView) -> Unit)?, view: TeamSharedView): Modifier =
+    if (onOpen == null) Modifier else Modifier.clickable { onOpen(view) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -37,7 +37,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import app.skerry.shared.team.stripShareFields
+import app.skerry.shared.terminal.epochMillis
 import app.skerry.shared.host.VaultHostStore
+import app.skerry.shared.runbook.VaultRunbookStore
 import app.skerry.shared.snippet.VaultSnippetStore
 
 /** Typed cause of a Teams operation failure (text in the UI layer, syncFailureText style). */
@@ -147,6 +149,14 @@ class TeamsCoordinator(
 
     private val _busy = MutableStateFlow(false)
     val busy: StateFlow<Boolean> = _busy
+
+    /**
+     * When each team last completed a sync cycle, `teamId -> epoch millis`; absent until one does.
+     * Per team rather than one stamp for the account: [syncAll] runs every team, and one of them
+     * failing must not let the others' freshness vouch for it in the header pill.
+     */
+    private val _lastSyncedAt = MutableStateFlow<Map<String, Long>>(emptyMap())
+    val lastSyncedAt: StateFlow<Map<String, Long>> = _lastSyncedAt
 
     private val _lastError = MutableStateFlow<TeamsFailure?>(null)
     val lastError: StateFlow<TeamsFailure?> = _lastError
@@ -427,6 +437,7 @@ class TeamsCoordinator(
             val names = buildMap {
                 VaultHostStore(vault).all().forEach { put(it.id, it.label) }
                 VaultSnippetStore(vault).all().forEach { put(it.id, it.label) }
+                VaultRunbookStore(vault).all().forEach { put(it.id, it.label) }
             }
             if (names.isEmpty()) null else ref.scopeId to names
         }.toMap()
@@ -582,17 +593,22 @@ class TeamsCoordinator(
         }
     }
 
-    /** Accounts holding a grant on the scope (managers only); empty list plus [lastError] on failure. */
-    suspend fun scopeGrants(teamId: String, scopeId: String): List<String> {
-        val s = session() ?: return emptyList()
-        val c = client() ?: return emptyList()
+    /**
+     * Accounts holding a grant on the scope (managers only), or **null** when the list couldn't be
+     * read — the failure is also surfaced in [lastError]. Null rather than an empty list on purpose:
+     * "nobody has access" and "we don't know who has access" are different answers, and a screen that
+     * renders the second as the first tells a manager the scope is unshared when it may not be.
+     */
+    suspend fun scopeGrants(teamId: String, scopeId: String): List<String>? {
+        val s = session() ?: return null
+        val c = client() ?: return null
         return try {
             c.scopeGrants(s, teamId, scopeId).map { it.accountId }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             markError(e.toFailure())
-            emptyList()
+            null
         }
     }
 
@@ -668,6 +684,7 @@ class TeamsCoordinator(
                 // local share/unshare bump revision explicitly, and a push-all with no incoming delta
                 // doesn't change section contents.
                 if (outcome.pulled > 0) _revision.value++
+                _lastSyncedAt.update { it + (ref.teamId to epochMillis()) }
                 onTeamsChanged()
             } catch (e: CancellationException) {
                 throw e
@@ -706,6 +723,7 @@ class TeamsCoordinator(
         teamVaults.resetTeam(teamId) // the team's vault and every scope vault under it
         spaceKeys.forEach { teamState.setCursor(it, 0) }
         verifiedInvites.update { it - teamId } // decline/leave: drop any cached invite for this team
+        _lastSyncedAt.update { it - teamId }
     }
 
     /** refresh() without re-acquiring [opMutex] — for calls from inside op{} blocks. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsMock.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsMock.kt
@@ -1,9 +1,7 @@
 package app.skerry.ui.teams
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,10 +9,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -22,18 +18,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.lib_teams_invite
-import app.skerry.ui.generated.resources.lib_teams_members
-import app.skerry.ui.generated.resources.lib_teams_recent_activity
-import app.skerry.ui.generated.resources.lib_teams_sidebar
-import org.jetbrains.compose.resources.stringResource
-import app.skerry.ui.design.Dot
-import app.skerry.ui.design.LocalFonts
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.buildTeamActivityFeed
+import app.skerry.shared.terminal.epochMillis
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SIDEBAR_WIDTH
 import app.skerry.ui.design.SectionHeader
@@ -41,171 +33,117 @@ import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_header_subtitle
+import app.skerry.ui.generated.resources.lib_teams_header_title
+import app.skerry.ui.generated.resources.lib_teams_invite
+import app.skerry.ui.generated.resources.lib_teams_sidebar
 import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
 
-private data class Member(val initials: String, val avatar: Color, val name: String, val email: String, val role: String, val roleBg: Color, val roleFg: Color)
-private data class SharedHost(val name: String, val members: String, val online: Boolean)
-private data class Activity(val icon: String, val iconColor: Color, val prefix: String, val target: String, val time: String)
+// Preview path (LocalTeams == null): the same composables the live screen is built from, fed with
+// placeholder rows — so a layout change can't quietly apply to only one of the two.
 
-// Mock rows resolve their colors from the active theme, so they are built inside the composable.
-@Composable
-private fun mockMembers(): List<Member> {
-    val c = Skerry.colors
-    return listOf(
-        Member("MK", c.cyan, "Maya Kovac", "maya@skerry.dev", "OWNER", c.amberSoft, c.amber),
-        Member("TR", c.moss, "Theo Reyes", "theo@skerry.dev", "ADMIN", c.cyan.copy(alpha = 0.12f), c.cyanBright),
-        Member("JL", c.dim, "June Lin", "june@skerry.dev", "MEMBER", c.overlayMed, c.dim),
-    )
-}
+private const val MOCK_TEAM = "skerry-ops"
+private const val HOUR_MS = 3_600_000L
+private const val DAY_MS = 24 * HOUR_MS
 
-private val SHARED_HOSTS = listOf(
-    SharedHost("prod-web-01", "5 members", true),
-    SharedHost("prod-web-02", "5 members", true),
-    SharedHost("db-master", "3 members", true),
-    SharedHost("k3s-control", "2 members", false),
+private val MOCK_SCOPES = listOf(
+    TeamScopeUi(id = "s-prod", name = "prod", memberCount = 2, hasKey = true),
+    TeamScopeUi(id = "s-db", name = "db", memberCount = 2, hasKey = true),
 )
 
-@Composable
-private fun mockActivity(): List<Activity> {
-    val c = Skerry.colors
-    return listOf(
-        Activity("login", c.moss, "Theo connected to ", "prod-web-02", "3 min ago"),
-        Activity("add", c.cyan, "Maya shared host ", "k3s-control", "1 h ago"),
-        Activity("key", c.amber, "June rotated key ", "deploy_ci", "Yesterday"),
-    )
-}
+private fun mockTeam() = TeamUi(
+    id = "team-mock",
+    name = MOCK_TEAM,
+    ownerAccountId = "sergey@skerry.dev",
+    role = TeamRole.OWNER,
+    status = TeamMemberStatus.ACTIVE,
+    memberCount = 5,
+    hasKey = true,
+    scopes = MOCK_SCOPES,
+)
 
-/** Static Teams layout — mock/preview path (LocalTeams == null), renders placeholder data. */
+private fun mockMembers(now: Long) = listOf(
+    TeamMember("sergey@skerry.dev", TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0, now),
+    TeamMember("anna@skerry.dev", TeamRole.ADMIN, TeamMemberStatus.ACTIVE, 0, now - 3 * HOUR_MS),
+    TeamMember("dmitry@skerry.dev", TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0, now - DAY_MS),
+    TeamMember("marina@skerry.dev", TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0, now - 6 * DAY_MS),
+    TeamMember("pavel@skerry.dev", TeamRole.VIEWER, TeamMemberStatus.INVITED, 0, null),
+)
+
+private fun mockGrants() = mapOf(
+    "s-prod" to setOf("anna@skerry.dev"),
+    "s-db" to setOf("anna@skerry.dev", "marina@skerry.dev"),
+)
+
+private fun mockEntries(now: Long) = listOf(
+    TeamActivityEntry("anna@skerry.dev", "team.record_share", "", now - 2 * HOUR_MS, recordId = "h1", recordType = "HOST"),
+    TeamActivityEntry("sergey@skerry.dev", "team.rekey", "", now - DAY_MS),
+    TeamActivityEntry("sergey@skerry.dev", "team.invite", "pavel@skerry.dev", now - 2 * DAY_MS),
+)
+
+/** Static Teams layout — mock/preview path, rendered from the same building blocks as the live one. */
 @Composable
 internal fun TeamsMockView() {
-    val mono = LocalFonts.current.mono
+    val now = epochMillis()
+    val team = mockTeam()
+    val feed = buildTeamActivityFeed(mockEntries(now), selfAccountId = team.ownerAccountId)
     Row(Modifier.fillMaxSize()) {
         Column(Modifier.width(SIDEBAR_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).padding(horizontal = 8.dp, vertical = 14.dp)) {
             SidebarSectionTitle(stringResource(Res.string.lib_teams_sidebar), modifier = Modifier.padding(start = 10.dp, bottom = 10.dp))
-            TeamRow("rocket_launch", "Platform crew", active = true)
-            TeamRow("database", "Data team")
+            MockTeamRow(MOCK_TEAM, active = true)
+            MockTeamRow("data-team")
             Spacer(Modifier.weight(1f))
-            Row(
-                Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.moss.copy(alpha = 0.06f)).padding(horizontal = 10.dp, vertical = 9.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(7.dp),
-            ) {
-                Sym("sync", size = 15.sp, color = Skerry.colors.moss)
-                Txt("Synced 2 min ago", color = Skerry.colors.moss, size = 11.5.sp)
-            }
         }
         VLine(Skerry.colors.line)
-        Column(Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
+        Column(Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg)) {
             SectionHeader(
-                title = "Platform crew",
-                subtitle = "5 members · 9 shared hosts · 2 shared vaults",
-                actions = {
-                    PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = {}, icon = "person_add")
-                },
+                title = stringResource(Res.string.lib_teams_header_title),
+                subtitle = stringResource(Res.string.lib_teams_header_subtitle, team.name, team.memberCount),
+                actions = { PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = {}, icon = "person_add") },
             )
-            Column(Modifier.padding(horizontal = 24.dp, vertical = 20.dp)) {
-                SectionLabel(stringResource(Res.string.lib_teams_members))
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    mockMembers().forEach { MemberRow(it) }
+            Row(Modifier.fillMaxSize()) {
+                Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())) {
+                    TeamMemberTable(
+                        rows = teamMemberRows(team, mockMembers(now), mockGrants(), canManage = true),
+                        now = now,
+                        onChangeRole = {},
+                        onRemove = {},
+                    )
+                    TeamSummaryCards(
+                        cards = TeamCards(
+                            items = 33,
+                            lastRekeyAt = now - DAY_MS,
+                            endpoint = "sync.skerry.local",
+                            serverVersion = "0.2.1",
+                            devices = 9,
+                            hosts = 14,
+                            snippets = 18,
+                            runbooks = 4,
+                            liveSessions = 2,
+                        ),
+                        onOpen = {},
+                        modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
+                    )
                 }
-                Row(Modifier.padding(top = 24.dp), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
-                    Column(Modifier.weight(1f)) {
-                        SectionLabel("Shared hosts · 9")
-                        SHARED_HOSTS.forEach { SharedHostRow(it, mono) }
-                    }
-                    Column(Modifier.weight(1f)) {
-                        SectionLabel("Shared vaults · 2")
-                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            SharedVaultRow(Skerry.colors.cyanBright, "Production secrets", "12 items · read-only for members")
-                            SharedVaultRow(Skerry.colors.amber, "CI / deploy keys", "4 items · admins only")
-                        }
-                    }
-                }
-                Box(Modifier.padding(top = 24.dp))
-                SectionLabel(stringResource(Res.string.lib_teams_recent_activity))
-                mockActivity().forEach { ActivityRow(it, mono) }
+                TeamActivityPanel(feed, onOpenFull = {})
             }
         }
     }
 }
 
 @Composable
-private fun TeamRow(icon: String, name: String, active: Boolean = false) {
+private fun MockTeamRow(name: String, active: Boolean = false) {
+    val fg = if (active) Skerry.colors.cyanBright else Skerry.colors.dim
     Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(if (active) Skerry.colors.cyan10 else Color.Transparent).padding(horizontal = 10.dp, vertical = 8.dp),
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp))
+            .background(if (active) Skerry.colors.cyan10 else Color.Transparent)
+            .padding(horizontal = 10.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Sym(icon, size = 16.sp, color = if (active) Skerry.colors.cyanBright else Skerry.colors.dim)
-        Txt(name, color = if (active) Skerry.colors.cyanBright else Skerry.colors.dim, size = 12.5.sp)
-    }
-}
-
-@Composable
-private fun SectionLabel(text: String) {
-    Txt(text.uppercase(), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 12.dp))
-}
-
-@Composable
-private fun MemberRow(m: Member) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(9.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(9.dp)).padding(horizontal = 14.dp, vertical = 11.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Box(Modifier.size(32.dp).clip(CircleShape).background(m.avatar), contentAlignment = Alignment.Center) {
-            Txt(m.initials, color = Skerry.colors.ink, size = 13.sp, weight = FontWeight.SemiBold)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(m.name, color = Skerry.colors.text, size = 13.sp, weight = FontWeight.Medium)
-            Txt(m.email, color = Skerry.colors.faint, size = 11.5.sp)
-        }
-        Box(Modifier.clip(RoundedCornerShape(20.dp)).background(m.roleBg).padding(horizontal = 9.dp, vertical = 2.dp)) {
-            Txt(m.role, color = m.roleFg, size = 10.sp, weight = FontWeight.SemiBold)
-        }
-    }
-}
-
-@Composable
-private fun SharedHostRow(h: SharedHost, mono: FontFamily) {
-    Row(
-        Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(9.dp),
-    ) {
-        Dot(if (h.online) Skerry.colors.moss else Skerry.colors.faint)
-        Txt(h.name, color = Skerry.colors.textBright, size = 12.sp, font = mono, modifier = Modifier.weight(1f))
-        Txt(h.members, color = Skerry.colors.faint, size = 10.sp)
-    }
-}
-
-@Composable
-private fun SharedVaultRow(iconColor: Color, title: String, subtitle: String) {
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(9.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(9.dp)).padding(horizontal = 13.dp, vertical = 11.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Sym("folder_shared", size = 18.sp, color = iconColor)
-        Column(Modifier.weight(1f)) {
-            Txt(title, color = Skerry.colors.text, size = 12.5.sp, weight = FontWeight.Medium)
-            Txt(subtitle, color = Skerry.colors.faint, size = 10.5.sp)
-        }
-    }
-}
-
-@Composable
-private fun ActivityRow(a: Activity, mono: FontFamily) {
-    Row(
-        Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Sym(a.icon, size = 16.sp, color = a.iconColor)
-        Row(Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
-            Txt(a.prefix, color = Skerry.colors.textBright, size = 12.sp)
-            Txt(a.target, color = Skerry.colors.cyanBright, size = 12.sp, font = mono)
-        }
-        Txt(a.time, color = Skerry.colors.faint, size = 11.sp)
+        Sym("group", size = 16.sp, color = fg)
+        Txt(name, color = fg, size = 12.5.sp)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenData.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenData.kt
@@ -1,0 +1,111 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import app.skerry.shared.sync.AccountSummary
+import app.skerry.shared.team.TeamActivityDay
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.buildTeamActivityFeed
+import app.skerry.shared.vault.RecordType
+import app.skerry.ui.app.LocalSharedSessions
+import app.skerry.ui.app.LocalSync
+import app.skerry.ui.sync.serverHost
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+
+// What the desktop and the phone Teams screens both need to show: the activity feed and the numbers
+// behind the summary cards. Kept in one place so the two platforms can't drift into reporting
+// different counts for the same team.
+
+/**
+ * Who holds which scope, as far as this device could find out: [byScope] is `scopeId -> accounts`,
+ * and [complete] is false when at least one access list failed to load, so the member table can say
+ * "unknown" instead of "nobody".
+ */
+internal data class ScopeGrants(val byScope: Map<String, Set<String>>, val complete: Boolean)
+
+/**
+ * Scope access lists of the team. Manager-only on the server, so anyone else gets an empty (and
+ * complete) answer rather than a failed call and an error banner over a column they can't see.
+ */
+@Composable
+internal fun scopeGrants(tc: TeamsCoordinator, team: TeamUi, tick: Int, canManage: Boolean): ScopeGrants? {
+    // Null until the first answer arrives: during the load the table must claim neither "holds
+    // nothing" nor "unknown" — both would be a statement about access it hasn't read yet.
+    val grants by produceState<ScopeGrants?>(null, team.id, team.scopes, tick, canManage) {
+        value = if (!canManage) {
+            ScopeGrants(emptyMap(), true)
+        } else {
+            // One round-trip per scope, run together: sequentially, a team with five scopes would
+            // leave the member table's scope column five round-trips behind after every operation.
+            val read = coroutineScope {
+                team.scopes.map { scope -> async { scope.id to tc.scopeGrants(team.id, scope.id) } }.awaitAll()
+            }
+            ScopeGrants(
+                byScope = read.mapNotNull { (scopeId, accounts) -> accounts?.let { scopeId to it.toSet() } }.toMap(),
+                complete = read.none { (_, accounts) -> accounts == null },
+            )
+        }
+    }
+    return grants
+}
+
+/** The team's activity feed, for members allowed to read it; an empty list for everyone else. */
+@Composable
+internal fun teamFeed(tc: TeamsCoordinator, team: TeamUi, tick: Int, canAudit: Boolean): List<TeamActivityDay> {
+    val entries by produceState(emptyList<TeamActivityEntry>(), team.id, tick, canAudit) {
+        value = if (canAudit) tc.teamActivity(team.id) else emptyList()
+    }
+    val recordNames by produceState(emptyMap<String, Map<String, String>>(), team.id, tick, canAudit) {
+        value = if (canAudit) withContext(Dispatchers.Default) { tc.sharedRecordNames(team.id) } else emptyMap()
+    }
+    val scopeNames = remember(team.scopes) { team.scopes.associate { it.id to it.name } }
+    return remember(entries, recordNames, scopeNames) {
+        buildTeamActivityFeed(
+            entries = entries,
+            selfAccountId = tc.selfAccountId(),
+            resolveRecordName = { scope, recordId -> recordNames[scope]?.get(recordId) },
+            resolveScopeName = { scope -> scopeNames[scope] },
+        )
+    }
+}
+
+/** What the Server card knows: where this account syncs, and what the instance reports about itself. */
+private data class ServerFacts(val endpoint: String?, val summary: AccountSummary?)
+
+/** Counts and server facts behind the three summary cards. */
+@Composable
+internal fun teamCards(tc: TeamsCoordinator, team: TeamUi, scopeId: String, tick: Int, feed: List<TeamActivityDay>): TeamCards {
+    val sync = LocalSync.current
+    val shares = LocalSharedSessions.current
+    val counts = remember(team.id, scopeId, tick) {
+        listOf(RecordType.HOST, RecordType.SNIPPET, RecordType.RUNBOOK)
+            .associateWith { tc.sharedRecordIds(team.id, it).size }
+    }
+    // savedConfig re-reads the config file, so it belongs here beside the network call rather than
+    // in the composition — read straight from the body it would touch disk on every recomposition.
+    val server by produceState<ServerFacts?>(null, sync, tick) {
+        value = sync?.let { coordinator ->
+            ServerFacts(
+                endpoint = withContext(Dispatchers.Default) { serverHost(coordinator.savedConfig?.serverUrl) },
+                summary = coordinator.serverSummary(),
+            )
+        }
+    }
+    return TeamCards(
+        items = counts.values.sum(),
+        lastRekeyAt = lastRekeyAt(feed),
+        endpoint = server?.endpoint,
+        serverVersion = server?.summary?.serverVersion,
+        devices = server?.summary?.devices,
+        hosts = counts[RecordType.HOST] ?: 0,
+        snippets = counts[RecordType.SNIPPET] ?: 0,
+        runbooks = counts[RecordType.RUNBOOK] ?: 0,
+        liveSessions = shares?.shares?.count { it.teamId == team.id } ?: 0,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
@@ -1,0 +1,142 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.team.TeamActivityDay
+import app.skerry.shared.team.TeamActivityKind
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+
+/**
+ * One row of the member table: the member, the scopes they hold, and whether this viewer may act on
+ * them. Built away from the composables so the ordering and the permission rules can be tested.
+ */
+data class TeamMemberRowUi(
+    val member: TeamMember,
+    /** The team's owner — never removable, and their role can't be changed. */
+    val isOwner: Boolean,
+    /** Names of the share spaces this member holds a grant on, in the team's own scope order. */
+    val scopes: List<String>,
+    /**
+     * Whether [scopes] is the whole answer. False when an access list couldn't be read: an empty
+     * list then means "unknown", not "holds nothing", and the table must not present it as a fact.
+     */
+    val scopesKnown: Boolean,
+    /** The viewer may change this member's role or remove them (mirrors the server ACL). */
+    val manageable: Boolean,
+)
+
+/**
+ * Rows of the member table: active members first (owner, then admins, then editors, then viewers,
+ * alphabetically inside a rank), invitees last — an invite is a pending state, not a seat.
+ *
+ * [scopeGrants] is `scopeId -> accounts holding it`, as the scope access lists report it; a viewer
+ * who may not read those lists simply passes an empty map and the column stays empty.
+ * [grantsComplete] is false when at least one of those lists failed to load — see
+ * [TeamMemberRowUi.scopesKnown].
+ */
+fun teamMemberRows(
+    team: TeamUi,
+    members: List<TeamMember>,
+    scopeGrants: Map<String, Set<String>>,
+    canManage: Boolean,
+    grantsComplete: Boolean = true,
+): List<TeamMemberRowUi> {
+    val scopeNames = team.scopes.associate { it.id to it.name }
+    return members
+        .sortedWith(compareBy({ it.status == TeamMemberStatus.INVITED }, { it.role.rank }, { it.accountId }))
+        .map { member ->
+            TeamMemberRowUi(
+                member = member,
+                isOwner = member.accountId == team.ownerAccountId,
+                // Ordered by the team's scope list, not by the map: the same member must not get a
+                // different chip order on every reread.
+                scopes = team.scopes.mapNotNull { scope ->
+                    scopeNames[scope.id]?.takeIf { member.accountId in scopeGrants[scope.id].orEmpty() }
+                },
+                scopesKnown = grantsComplete,
+                manageable = canManage &&
+                    member.accountId != team.ownerAccountId &&
+                    canModifyMember(team.role, member.role),
+            )
+        }
+}
+
+/** Sort rank of a role, highest privilege first. */
+private val TeamRole.rank: Int
+    get() = when (this) {
+        TeamRole.OWNER -> 0
+        TeamRole.ADMIN -> 1
+        TeamRole.EDITOR -> 2
+        TeamRole.VIEWER -> 3
+    }
+
+/**
+ * How a member's last activity reads in the table. The words are localized by the view; this decides
+ * which of them applies and formats the time (UTC, like the rest of the Teams timestamps).
+ */
+sealed interface LastSeen {
+    /** The server doesn't report it, or the account has never signed in on any device. */
+    data object Never : LastSeen
+
+    /** Within the last minute — including a clock a few seconds ahead of ours. */
+    data object Now : LastSeen
+
+    data class Today(val time: String) : LastSeen
+    data class Yesterday(val time: String) : LastSeen
+
+    /** Anything older: the full stamp, since "5 days ago" answers no question a table row asks. */
+    data class Earlier(val stamp: String) : LastSeen
+}
+
+private const val JUST_NOW_MILLIS = 60_000L
+
+/** Classifies [at] (epoch millis, null = never seen) against [now]. */
+fun lastSeen(at: Long?, now: Long): LastSeen {
+    if (at == null) return LastSeen.Never
+    // A device clock ahead of ours is routine; a member "last seen in 4 seconds" is not a thing.
+    if (at >= now - JUST_NOW_MILLIS) return LastSeen.Now
+    val stamp = formatEpochUtc(at)
+    val time = stamp.substringAfter(' ')
+    return when (now.floorDiv(MILLIS_PER_DAY) - at.floorDiv(MILLIS_PER_DAY)) {
+        0L -> LastSeen.Today(time)
+        1L -> LastSeen.Yesterday(time)
+        else -> LastSeen.Earlier(stamp)
+    }
+}
+
+/**
+ * How long ago the team last finished a sync, bucketed for the header pill. A unit rather than a
+ * formatted string so the thresholds can be tested; the wording is [syncedAgoText]'s job.
+ */
+sealed interface SyncedAgo {
+    data class Seconds(val value: Long) : SyncedAgo
+    data class Minutes(val value: Long) : SyncedAgo
+    data class Hours(val value: Long) : SyncedAgo
+    data class Days(val value: Long) : SyncedAgo
+}
+
+private const val SECOND_MS = 1_000L
+private const val MINUTE_MS = 60 * SECOND_MS
+private const val HOUR_MS = 60 * MINUTE_MS
+private const val DAY_MS = 24 * HOUR_MS
+
+/** Buckets [elapsedMs]; a negative value (a server clock ahead of ours) reads as zero seconds. */
+fun syncedAgo(elapsedMs: Long): SyncedAgo {
+    val elapsed = elapsedMs.coerceAtLeast(0)
+    return when {
+        elapsed < MINUTE_MS -> SyncedAgo.Seconds(elapsed / SECOND_MS)
+        elapsed < HOUR_MS -> SyncedAgo.Minutes(elapsed / MINUTE_MS)
+        elapsed < DAY_MS -> SyncedAgo.Hours(elapsed / HOUR_MS)
+        else -> SyncedAgo.Days(elapsed / DAY_MS)
+    }
+}
+
+/**
+ * When the team's keys were last rotated, from the feed the screen already holds — a rotation is an
+ * audited event, so there is nothing to ask the server for. Null for a team that was never rekeyed
+ * (or whose feed this member may not read).
+ */
+fun lastRekeyAt(feed: List<TeamActivityDay>): Long? = feed
+    .flatMap { it.rows }
+    .filter { it.kind == TeamActivityKind.KEY_ROTATE || it.kind == TeamActivityKind.SCOPE_KEY_ROTATE }
+    .maxOfOrNull { it.createdAt }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsText.kt
@@ -1,0 +1,40 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_runbook_steps
+import app.skerry.ui.generated.resources.lib_teams_seen_never
+import app.skerry.ui.generated.resources.lib_teams_seen_now
+import app.skerry.ui.generated.resources.lib_teams_seen_today
+import app.skerry.ui.generated.resources.lib_teams_seen_yesterday
+import app.skerry.ui.generated.resources.lib_teams_synced_day
+import app.skerry.ui.generated.resources.lib_teams_synced_hour
+import app.skerry.ui.generated.resources.lib_teams_synced_min
+import app.skerry.ui.generated.resources.lib_teams_synced_sec
+import org.jetbrains.compose.resources.stringResource
+
+// Localized wording for the Teams screen's numbers. The rules that decide *which* wording applies
+// live in TeamsScreenModel (and are tested there); this file only puts words to them.
+
+/** "synced 12 s ago" for an elapsed time since the last completed team sync (see [syncedAgo]). */
+@Composable
+internal fun syncedAgoText(elapsedMs: Long): String = when (val ago = syncedAgo(elapsedMs)) {
+    is SyncedAgo.Seconds -> stringResource(Res.string.lib_teams_synced_sec, ago.value)
+    is SyncedAgo.Minutes -> stringResource(Res.string.lib_teams_synced_min, ago.value)
+    is SyncedAgo.Hours -> stringResource(Res.string.lib_teams_synced_hour, ago.value)
+    is SyncedAgo.Days -> stringResource(Res.string.lib_teams_synced_day, ago.value)
+}
+
+/** Second line of a runbook in the share lists — its length is what distinguishes two of them. */
+@Composable
+internal fun runbookSummary(steps: Int): String = stringResource(Res.string.lib_teams_runbook_steps, steps)
+
+/** Localized "last seen" cell for [at]; see [lastSeen] for how the case is chosen. */
+@Composable
+internal fun lastSeenText(at: Long?, now: Long): String = when (val seen = lastSeen(at, now)) {
+    LastSeen.Never -> stringResource(Res.string.lib_teams_seen_never)
+    LastSeen.Now -> stringResource(Res.string.lib_teams_seen_now)
+    is LastSeen.Today -> stringResource(Res.string.lib_teams_seen_today, seen.time)
+    is LastSeen.Yesterday -> stringResource(Res.string.lib_teams_seen_yesterday, seen.time)
+    is LastSeen.Earlier -> seen.stamp
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -232,7 +232,10 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
         SharePicker(tc, TeamScopeRef(shareTeam.id, scopeId), shareKind, tick, onDone = { sharePicker = null; afterOp() }, onDismiss = { sharePicker = null })
     }
     val sharedTeam = selected
-    val openShared = sharedView
+    // The picker opens from this list, so the list steps aside while it is up — two stacked cards
+    // would leave the one underneath visible and clickable through the gaps. It comes back on
+    // dismiss, showing whatever was just shared.
+    val openShared = sharedView.takeIf { shareKind == null }
     if (openShared != null && sharedTeam != null) {
         SharedRecordsView(
             tc = tc,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -12,10 +12,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -34,8 +32,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.ui.host.rowSubtitle
 import app.skerry.shared.host.VaultHostStore
+import app.skerry.shared.runbook.VaultRunbookStore
 import app.skerry.shared.snippet.VaultSnippetStore
 import app.skerry.shared.team.HOST_SHARE_STRIP
 import app.skerry.shared.team.TeamActivityEntry
@@ -43,20 +41,20 @@ import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
 import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.terminal.epochMillis
 import app.skerry.shared.vault.RecordType
 import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.LocalRunbooks
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTeams
+import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.ConfirmActionDialog
+import app.skerry.ui.design.DropdownMenuColumn
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SIDEBAR_WIDTH
-import app.skerry.ui.app.LocalSharedSessions
-import app.skerry.ui.generated.resources.share_live_sessions
-import app.skerry.ui.share.SharedSessionsList
-import app.skerry.ui.share.rememberJoinSharedSession
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
@@ -72,7 +70,6 @@ import app.skerry.ui.generated.resources.lib_teams_empty_subtitle
 import app.skerry.ui.generated.resources.lib_teams_empty_title
 import app.skerry.ui.generated.resources.lib_teams_err_already_invited
 import app.skerry.ui.generated.resources.lib_teams_err_already_shared
-import app.skerry.ui.generated.resources.lib_teams_err_scopes_unsupported
 import app.skerry.ui.generated.resources.lib_teams_err_forbidden
 import app.skerry.ui.generated.resources.lib_teams_err_key_missing
 import app.skerry.ui.generated.resources.lib_teams_err_network
@@ -80,46 +77,49 @@ import app.skerry.ui.generated.resources.lib_teams_err_no_recipient_key
 import app.skerry.ui.generated.resources.lib_teams_err_no_such_account
 import app.skerry.ui.generated.resources.lib_teams_err_not_connected
 import app.skerry.ui.generated.resources.lib_teams_err_protocol
+import app.skerry.ui.generated.resources.lib_teams_err_scopes_unsupported
 import app.skerry.ui.generated.resources.lib_teams_err_server_error
 import app.skerry.ui.generated.resources.lib_teams_err_too_many_requests
 import app.skerry.ui.generated.resources.lib_teams_err_vault_locked
 import app.skerry.ui.generated.resources.lib_teams_err_vault_unreadable
-import app.skerry.ui.generated.resources.lib_teams_history
+import app.skerry.ui.generated.resources.lib_teams_header_title
+import app.skerry.ui.generated.resources.lib_teams_header_subtitle
 import app.skerry.ui.generated.resources.lib_teams_invite
+import app.skerry.ui.generated.resources.lib_teams_invite_unverified
 import app.skerry.ui.generated.resources.lib_teams_invited_banner
 import app.skerry.ui.generated.resources.lib_teams_invited_by
 import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
-import app.skerry.ui.generated.resources.lib_teams_invite_unverified
 import app.skerry.ui.generated.resources.lib_teams_leave
 import app.skerry.ui.generated.resources.lib_teams_leave_message
-import app.skerry.ui.generated.resources.lib_teams_members
-import app.skerry.ui.generated.resources.lib_teams_members_count
 import app.skerry.ui.generated.resources.lib_teams_need_sync
 import app.skerry.ui.generated.resources.lib_teams_no_key
-import app.skerry.ui.generated.resources.lib_teams_nothing_shared
 import app.skerry.ui.generated.resources.lib_teams_remove_member_message
 import app.skerry.ui.generated.resources.lib_teams_remove_member_title
-import app.skerry.ui.generated.resources.lib_teams_share_empty
+import app.skerry.ui.generated.resources.lib_teams_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_scope_delete_message
+import app.skerry.ui.generated.resources.lib_teams_scopes
 import app.skerry.ui.generated.resources.lib_teams_share_host
 import app.skerry.ui.generated.resources.lib_teams_share_host_title
+import app.skerry.ui.generated.resources.lib_teams_share_runbook
+import app.skerry.ui.generated.resources.lib_teams_share_runbook_title
 import app.skerry.ui.generated.resources.lib_teams_share_snippet
 import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
+import app.skerry.ui.generated.resources.lib_teams_share_empty
 import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
+import app.skerry.ui.generated.resources.lib_teams_shared_runbooks_count
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
 import app.skerry.ui.generated.resources.lib_teams_sidebar
-import app.skerry.ui.generated.resources.lib_teams_scope_delete_message
-import app.skerry.ui.generated.resources.lib_teams_scope_delete
-import app.skerry.ui.generated.resources.lib_teams_scopes
-import app.skerry.ui.generated.resources.lib_teams_status_invited
-import app.skerry.ui.generated.resources.lib_teams_sync_now
+import app.skerry.ui.generated.resources.lib_teams_synced_never
+import app.skerry.ui.host.rowSubtitle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
-/** Teams: E2E sharing of hosts/snippets. Live data from [LocalTeams]; null — mock preview. */
+/** Teams: E2E sharing of hosts/snippets/runbooks. Live data from [LocalTeams]; null — mock preview. */
 @Composable
 fun TeamsView() {
     val coordinator = LocalTeams.current
@@ -127,7 +127,7 @@ fun TeamsView() {
 }
 
 /** Destructive Teams actions requiring [ConfirmActionDialog]. */
-private sealed interface TeamsConfirm {
+internal sealed interface TeamsConfirm {
     data class Leave(val teamId: String) : TeamsConfirm
     data class Delete(val teamId: String) : TeamsConfirm
     data class Remove(val teamId: String, val accountId: String) : TeamsConfirm
@@ -159,6 +159,8 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     var selectedScope by remember { mutableStateOf("") }
     var showCreateScope by remember { mutableStateOf(false) }
     var scopeAccess by remember { mutableStateOf<TeamScopeUi?>(null) }
+    // Which "Shared with the team" list is open, if any.
+    var sharedView by remember { mutableStateOf<TeamSharedView?>(null) }
 
     val selected = teams.firstOrNull { it.id == selectedId } ?: teams.firstOrNull()
     // A scope that vanished (revoked, deleted, or simply another team's) falls back to team-wide.
@@ -179,33 +181,27 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
             PrimaryButton(stringResource(Res.string.lib_teams_create), onClick = { showCreate = true }, icon = "group_add", modifier = Modifier.fillMaxWidth())
         }
         VLine(Skerry.colors.line)
-        Column(
-            Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg)
-                // Scroll only the team detail; the empty state needs the full height to center in it.
-                .then(if (selected != null) Modifier.verticalScroll(rememberScrollState()) else Modifier),
-        ) {
+        Column(Modifier.weight(1f).fillMaxHeight().background(Skerry.colors.bg)) {
             when {
                 selected == null && error == TeamsFailure.NotConnected -> TeamsEmptyState(stringResource(Res.string.lib_teams_need_sync))
                 selected == null -> TeamsEmptyState(stringResource(Res.string.lib_teams_empty_subtitle))
-                else -> TeamDetail(
+                else -> TeamScreen(
                     tc = tc,
                     team = selected,
                     scopeId = scopeId,
                     tick = tick,
                     busy = busy,
                     onInvite = { showInvite = true; invitePreview = null },
-                    onShare = { sharePicker = it },
                     onConfirm = { confirm = it },
                     onAccept = { scope.launch2 { tc.accept(selected.id); afterOp() } },
                     onDecline = { scope.launch2 { tc.decline(selected.id); afterOp() } },
                     onSync = { scope.launch2 { tc.refresh(); tc.syncTeam(selected.id); afterOp() } },
-                    onUnshare = { recordId -> scope.launch2 { tc.unshareRecord(TeamScopeRef(selected.id, scopeId), recordId); afterOp() } },
                     onShowHistory = { showHistory = true },
-                    onShowRecordHistory = { historyRecord = it },
                     onChangeRole = { member -> rolePicker = member },
                     onSelectScope = { selectedScope = it },
                     onNewScope = { showCreateScope = true },
                     onScopeAccess = { scopeAccess = it },
+                    onOpenShared = { sharedView = it },
                 )
             }
         }
@@ -234,6 +230,21 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     val shareKind = sharePicker
     if (shareKind != null && shareTeam != null) {
         SharePicker(tc, TeamScopeRef(shareTeam.id, scopeId), shareKind, tick, onDone = { sharePicker = null; afterOp() }, onDismiss = { sharePicker = null })
+    }
+    val sharedTeam = selected
+    val openShared = sharedView
+    if (openShared != null && sharedTeam != null) {
+        SharedRecordsView(
+            tc = tc,
+            team = sharedTeam,
+            scopeId = scopeId,
+            view = openShared,
+            tick = tick,
+            onShare = { sharePicker = it },
+            onUnshare = { recordId -> scope.launch2 { tc.unshareRecord(TeamScopeRef(sharedTeam.id, scopeId), recordId); afterOp() } },
+            onRecordHistory = { historyRecord = it },
+            onDismiss = { sharedView = null },
+        )
     }
     confirm?.let { c ->
         val (title, message) = when (c) {
@@ -297,8 +308,9 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     val accessScope = scopeAccess
     if (accessScope != null && scopeTeam != null) {
         val members by produceState(emptyList<TeamMember>(), scopeTeam.id, tick) { value = tc.members(scopeTeam.id) }
-        val granted by produceState(emptySet<String>(), scopeTeam.id, accessScope.id, tick) {
-            value = tc.scopeGrants(scopeTeam.id, accessScope.id).toSet()
+        val granted by produceState<ScopeAccess>(ScopeAccess.Loading, scopeTeam.id, accessScope.id, tick) {
+            value = tc.scopeGrants(scopeTeam.id, accessScope.id)
+                ?.let { ScopeAccess.Known(it.toSet()) } ?: ScopeAccess.Unavailable
         }
         ScopeAccessDialog(
             scopeName = accessScope.name,
@@ -326,204 +338,6 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     }
 }
 
-/** "Share a record" picker: own hosts/snippets minus those already shared with the team. */
-@Composable
-private fun SharePicker(
-    tc: TeamsCoordinator,
-    ref: TeamScopeRef,
-    kind: RecordType,
-    tick: Int,
-    onDone: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val scope = rememberCoroutineScope()
-    val hosts = LocalHosts.current
-    val snippets = LocalSnippets.current
-    // Across every space of the team, not just the selected one: a record lives in exactly one space.
-    val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
-    val items = if (kind == RecordType.HOST) {
-        (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
-    } else {
-        (snippets?.snippets ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.snippet.label, it.snippet.command) }
-    }
-    SharePickerDialog(
-        title = if (kind == RecordType.HOST) stringResource(Res.string.lib_teams_share_host_title) else stringResource(Res.string.lib_teams_share_snippet_title),
-        items = items,
-        emptyText = stringResource(Res.string.lib_teams_share_empty),
-        onPick = { item ->
-            scope.launch2 {
-                tc.shareRecord(ref, item.id, kind, if (kind == RecordType.HOST) HOST_SHARE_STRIP else emptySet())
-                onDone()
-            }
-        },
-        onDismiss = onDismiss,
-    )
-}
-
-@Composable
-private fun TeamDetail(
-    tc: TeamsCoordinator,
-    team: TeamUi,
-    scopeId: String,
-    tick: Int,
-    busy: Boolean,
-    onInvite: () -> Unit,
-    onShare: (RecordType) -> Unit,
-    onConfirm: (TeamsConfirm) -> Unit,
-    onAccept: () -> Unit,
-    onDecline: () -> Unit,
-    onSync: () -> Unit,
-    onUnshare: (String) -> Unit,
-    onShowHistory: () -> Unit,
-    onShowRecordHistory: (HistoryTarget) -> Unit,
-    onChangeRole: (TeamMember) -> Unit,
-    onSelectScope: (String) -> Unit,
-    onNewScope: () -> Unit,
-    onScopeAccess: (TeamScopeUi) -> Unit,
-) {
-    val mono = LocalFonts.current.mono
-    val invited = team.status == TeamMemberStatus.INVITED
-    val owner = team.role == TeamRole.OWNER && !invited
-    val canManage = team.role.canManageMembers && !invited
-    val activeScope = team.scopes.firstOrNull { it.id == scopeId }
-    val canWrite = team.role.canWrite && !invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)
-    val canAudit = team.role.canViewAudit && !invited
-    val members by produceState(emptyList<TeamMember>(), team.id, team.memberCount, tick) {
-        value = tc.members(team.id)
-    }
-    // Records of the selected space only. A scope we hold no key for has nothing readable to show.
-    val spaceVault = if (!invited && team.hasKey && (scopeId.isEmpty() || activeScope?.hasKey == true)) {
-        tc.spaceVault(TeamScopeRef(team.id, scopeId))
-    } else {
-        null
-    }
-    val sharedHosts = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultHostStore(it).all() } ?: emptyList() }
-    val sharedSnippets = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
-
-    SectionHeader(
-        title = team.name,
-        subtitle = stringResource(Res.string.lib_teams_members_count, team.memberCount),
-        actions = {
-            if (!invited) GhostButton(stringResource(Res.string.lib_teams_sync_now), onClick = onSync, icon = "sync")
-            if (canAudit) GhostButton(stringResource(Res.string.lib_teams_history), onClick = onShowHistory, icon = "history")
-            if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
-            if (owner) {
-                GhostButton(stringResource(Res.string.lib_teams_delete), onClick = { onConfirm(TeamsConfirm.Delete(team.id)) }, icon = "delete", fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f))
-            } else if (!invited) {
-                GhostButton(stringResource(Res.string.lib_teams_leave), onClick = { onConfirm(TeamsConfirm.Leave(team.id)) }, icon = "logout", fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f))
-            }
-        },
-    )
-    Column(Modifier.padding(horizontal = 24.dp, vertical = 20.dp)) {
-        if (invited) {
-            // Verify the inviter's identity (signature + fingerprint) before offering Accept. Null =
-            // the invite couldn't be authenticated (forged/tampered) — warn and don't reveal a fingerprint.
-            val acceptPreview by produceState<InvitePreview?>(null, team.id) { value = tc.acceptPreview(team.id) }
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(9.dp))
-                    .background(Skerry.colors.amber.copy(alpha = 0.08f))
-                    .border(1.dp, Skerry.colors.amber.copy(alpha = 0.25f), RoundedCornerShape(9.dp))
-                    .padding(horizontal = 14.dp, vertical = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    Sym("mail", size = 18.sp, color = Skerry.colors.amber)
-                    Txt(stringResource(Res.string.lib_teams_invited_banner), color = Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
-                    GhostButton(stringResource(Res.string.lib_teams_decline), onClick = onDecline, fg = Skerry.colors.dim)
-                    PrimaryButton(stringResource(Res.string.lib_teams_accept), onClick = onAccept, enabled = !busy)
-                }
-                acceptPreview.let { p ->
-                    if (p == null) {
-                        Txt(stringResource(Res.string.lib_teams_invite_unverified), color = Skerry.colors.sunset, size = 11.5.sp)
-                    } else {
-                        Txt(stringResource(Res.string.lib_teams_invited_by, p.accountId), color = Skerry.colors.dim, size = 11.5.sp)
-                        Txt(stringResource(Res.string.lib_teams_invited_fingerprint, p.fingerprint), color = Skerry.colors.cyanBright, size = 11.5.sp, font = mono)
-                    }
-                }
-            }
-            Box(Modifier.padding(top = 24.dp))
-        } else if (!team.hasKey) {
-            Txt(stringResource(Res.string.lib_teams_no_key), color = Skerry.colors.amber, size = 12.sp, modifier = Modifier.padding(bottom = 16.dp))
-        }
-        // Sessions the team is sharing right now (see [SharedSessionsList]) — a live directory, not
-        // a stored one: an entry lives exactly as long as its host's socket.
-        LiveSectionLabel(stringResource(Res.string.share_live_sessions))
-        SharedSessionsList(team.id, LocalSharedSessions.current, onJoin = rememberJoinSharedSession(), modifier = Modifier.padding(bottom = 18.dp))
-        LiveSectionLabel(stringResource(Res.string.lib_teams_members))
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            members.forEach { m ->
-                val modifiable = canManage && m.accountId != team.ownerAccountId && canModifyMember(team.role, m.role)
-                LiveMemberRow(
-                    m,
-                    isOwnerRow = m.accountId == team.ownerAccountId,
-                    canManageMember = modifiable,
-                    onChangeRole = { onChangeRole(m) },
-                    onRemove = { onConfirm(TeamsConfirm.Remove(team.id, m.accountId)) },
-                )
-            }
-        }
-        if (!invited) {
-            Column(Modifier.padding(top = 24.dp)) {
-                LiveSectionLabel(stringResource(Res.string.lib_teams_scopes))
-                ScopeSection(
-                    scopes = team.scopes,
-                    selected = scopeId,
-                    canManage = canManage,
-                    onSelect = onSelectScope,
-                    onNew = onNewScope,
-                    onAccess = onScopeAccess,
-                    onDelete = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) },
-                )
-            }
-            Row(Modifier.padding(top = 24.dp), horizontalArrangement = Arrangement.spacedBy(24.dp)) {
-                Column(Modifier.weight(1f)) {
-                    LiveSectionLabel(stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size))
-                    if (sharedHosts.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
-                    sharedHosts.forEach { host ->
-                        SharedRecordRow(
-                            host.label, host.rowSubtitle(), mono,
-                            canUnshare = canWrite,
-                            onHistory = if (canAudit) {
-                                { onShowRecordHistory(HistoryTarget(host.id, host.label)) }
-                            } else {
-                                null
-                            },
-                            onUnshare = { onUnshare(host.id) },
-                        )
-                    }
-                    if (canWrite) {
-                        GhostButton(stringResource(Res.string.lib_teams_share_host), onClick = { onShare(RecordType.HOST) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
-                    }
-                }
-                Column(Modifier.weight(1f)) {
-                    LiveSectionLabel(stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size))
-                    if (sharedSnippets.isEmpty()) Txt(stringResource(Res.string.lib_teams_nothing_shared), color = Skerry.colors.faint, size = 11.5.sp)
-                    sharedSnippets.forEach { snippet ->
-                        SharedRecordRow(
-                            snippet.label, snippet.command, mono,
-                            canUnshare = canWrite,
-                            onHistory = if (canAudit) {
-                                { onShowRecordHistory(HistoryTarget(snippet.id, snippet.label)) }
-                            } else {
-                                null
-                            },
-                            onUnshare = { onUnshare(snippet.id) },
-                        )
-                    }
-                    if (canWrite) {
-                        GhostButton(stringResource(Res.string.lib_teams_share_snippet), onClick = { onShare(RecordType.SNIPPET) }, icon = "add", modifier = Modifier.padding(top = 10.dp))
-                    }
-                }
-            }
-        }
-    }
-}
-
 @Composable
 private fun TeamsEmptyState(subtitle: String) {
     EmptyState(icon = "groups", title = stringResource(Res.string.lib_teams_empty_title), subtitle = subtitle)
@@ -547,78 +361,8 @@ private fun LiveTeamRow(team: TeamUi, active: Boolean, onClick: () -> Unit) {
     }
 }
 
-@Composable
-private fun LiveSectionLabel(text: String) {
-    Txt(text.uppercase(), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(bottom = 12.dp))
-}
-
-@Composable
-private fun LiveMemberRow(
-    m: TeamMember,
-    isOwnerRow: Boolean,
-    canManageMember: Boolean,
-    onChangeRole: () -> Unit,
-    onRemove: () -> Unit,
-) {
-    val mono = LocalFonts.current.mono
-    val initials = m.accountId.take(2).uppercase()
-    val invited = m.status == TeamMemberStatus.INVITED
-    val (roleFg, roleBg) = roleBadgeColors(m.role)
-    Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(9.dp)).border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(9.dp)).padding(horizontal = 14.dp, vertical = 11.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Box(Modifier.size(32.dp).clip(CircleShape).background(if (isOwnerRow) Skerry.colors.cyan else Skerry.colors.moss), contentAlignment = Alignment.Center) {
-            Txt(initials, color = Skerry.colors.ink, size = 13.sp, weight = FontWeight.SemiBold)
-        }
-        Txt(m.accountId, color = Skerry.colors.text, size = 13.sp, font = mono, weight = FontWeight.Medium, modifier = Modifier.weight(1f))
-        if (invited) {
-            RoleBadge(stringResource(Res.string.lib_teams_status_invited), Skerry.colors.cyanBright, Skerry.colors.cyan.copy(alpha = 0.12f))
-        }
-        // Clicking the role badge changes it (owner/admin within anti-escalation limits).
-        val badgeModifier = if (canManageMember) Modifier.clip(RoundedCornerShape(20.dp)).clickable(onClick = onChangeRole) else Modifier
-        RoleBadge(teamRoleLabel(m.role), roleFg, roleBg, modifier = badgeModifier)
-        if (canManageMember) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onRemove).padding(4.dp)) {
-                Sym("close", size = 15.sp, color = Skerry.colors.faint)
-            }
-        }
-    }
-}
-
 /** A record to show the history of: its id, plus the name to put in the dialog's title. */
 internal data class HistoryTarget(val recordId: String, val label: String)
-
-@Composable
-private fun SharedRecordRow(
-    label: String,
-    detail: String,
-    mono: androidx.compose.ui.text.font.FontFamily,
-    canUnshare: Boolean,
-    onHistory: (() -> Unit)? = null,
-    onUnshare: () -> Unit,
-) {
-    Row(
-        Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 7.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(9.dp),
-    ) {
-        Txt(label, color = Skerry.colors.textBright, size = 12.sp, font = mono)
-        Txt(detail, color = Skerry.colors.faint, size = 10.5.sp, modifier = Modifier.weight(1f))
-        // "What happened to this one" — only for readers who may see the audit log at all.
-        if (onHistory != null) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onHistory).padding(3.dp)) {
-                Sym("history", size = 14.sp, color = Skerry.colors.faint)
-            }
-        }
-        if (canUnshare) {
-            Box(Modifier.clip(CircleShape).clickable(onClick = onUnshare).padding(3.dp)) {
-                Sym("close", size = 14.sp, color = Skerry.colors.faint)
-            }
-        }
-    }
-}
 
 /** Text for a typed Teams error (analogous to syncFailureText). */
 @Composable
@@ -640,6 +384,6 @@ internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
 }
 
 /** launch from click handlers: a param-less suspend block, shorter than a lambda with CoroutineScope. */
-private fun CoroutineScope.launch2(block: suspend () -> Unit) {
+internal fun CoroutineScope.launch2(block: suspend () -> Unit) {
     launch { block() }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sync/SyncCoordinatorHealthTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.InMemorySyncStateStore
 import app.skerry.shared.sync.PairingResult
@@ -202,6 +203,7 @@ private class FakePingClient(@Volatile var reachable: Boolean) : SyncClient {
     override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
     override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+    override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
     override suspend fun refresh(session: SyncSession): SyncSession = nope()
     override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
@@ -1,0 +1,179 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.buildTeamActivityFeed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The Teams screen's own projection: who is listed in which order, which scopes each member holds,
+ * who the actor may act on, and how "last seen" reads. All of it is decided here rather than in the
+ * composables, so the table can be checked without a display.
+ */
+class TeamsScreenModelTest {
+
+    private val owner = "sergey@example.com"
+    private val admin = "anna@example.com"
+    private val editor = "dmitry@example.com"
+    private val invitee = "pavel@example.com"
+
+    private fun member(
+        id: String,
+        role: TeamRole,
+        status: TeamMemberStatus = TeamMemberStatus.ACTIVE,
+        lastSeenAt: Long? = null,
+    ) = TeamMember(id, role, status, createdAt = 0, lastSeenAt = lastSeenAt)
+
+    private fun team(role: TeamRole) = TeamUi(
+        id = "team-1",
+        name = "skerry-ops",
+        ownerAccountId = owner,
+        role = role,
+        status = TeamMemberStatus.ACTIVE,
+        memberCount = 4,
+        hasKey = true,
+        scopes = listOf(
+            TeamScopeUi(id = "s-prod", name = "prod", memberCount = 2, hasKey = true),
+            TeamScopeUi(id = "s-db", name = "db", memberCount = 1, hasKey = true),
+        ),
+    )
+
+    @Test
+    fun `the table lists active members by rank and keeps invitees last`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(
+                member(invitee, TeamRole.VIEWER, TeamMemberStatus.INVITED),
+                member(editor, TeamRole.EDITOR),
+                member(owner, TeamRole.OWNER),
+                member(admin, TeamRole.ADMIN),
+            ),
+            scopeGrants = emptyMap(),
+            canManage = true,
+        )
+
+        assertEquals(listOf(owner, admin, editor, invitee), rows.map { it.member.accountId })
+        assertTrue(rows.first().isOwner)
+        assertFalse(rows.last().isOwner)
+    }
+
+    @Test
+    fun `each member carries the scopes they hold a grant on`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            scopeGrants = mapOf("s-prod" to setOf(admin), "s-db" to setOf(admin, owner)),
+            canManage = true,
+        )
+
+        // Scope names, not ids: the id is a UUID nobody recognizes.
+        assertEquals(listOf("db"), rows.single { it.member.accountId == owner }.scopes)
+        assertEquals(listOf("prod", "db"), rows.single { it.member.accountId == admin }.scopes)
+    }
+
+    @Test
+    fun `a member whose access lists could not be read is marked unknown, not scope-less`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            // One scope answered, the other failed: what we know is partial, so no row may claim
+            // "this member holds nothing" — that would read as an access fact rather than a gap.
+            scopeGrants = mapOf("s-prod" to setOf(admin)),
+            canManage = true,
+            grantsComplete = false,
+        )
+
+        assertTrue(rows.none { it.scopesKnown })
+        assertTrue(teamMemberRows(team(TeamRole.OWNER), listOf(member(owner, TeamRole.OWNER)), emptyMap(), canManage = true).all { it.scopesKnown })
+    }
+
+    @Test
+    fun `the owner row and higher roles are not manageable`() {
+        val asAdmin = teamMemberRows(
+            team = team(TeamRole.ADMIN),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN), member(editor, TeamRole.EDITOR)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+        )
+
+        assertFalse(asAdmin.single { it.member.accountId == owner }.manageable, "the owner is never removable")
+        // An admin may not act on another admin — the server enforces it, and offering it would lie.
+        assertFalse(asAdmin.single { it.member.accountId == admin }.manageable)
+        assertTrue(asAdmin.single { it.member.accountId == editor }.manageable)
+    }
+
+    @Test
+    fun `a member without manage rights sees no row actions at all`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.VIEWER),
+            members = listOf(member(owner, TeamRole.OWNER), member(editor, TeamRole.EDITOR)),
+            scopeGrants = emptyMap(),
+            canManage = false,
+        )
+
+        assertTrue(rows.none { it.manageable })
+    }
+
+    @Test
+    fun `last seen reads as never, now, today, yesterday, or a stamp`() {
+        val now = 1_754_308_800_000L // 2025-08-04 12:00 UTC
+
+        assertEquals(LastSeen.Never, lastSeen(null, now))
+        assertEquals(LastSeen.Now, lastSeen(now - 30_000, now))
+        assertEquals(LastSeen.Today("09:41"), lastSeen(now - 2 * 3_600_000 - 19 * 60_000, now))
+        assertEquals(LastSeen.Yesterday("14:02"), lastSeen(now - 86_400_000 + 2 * 3_600_000 + 2 * 60_000, now))
+        assertEquals(LastSeen.Earlier("2025-07-29 10:18"), lastSeen(1_753_784_280_000L, now))
+    }
+
+    @Test
+    fun `a clock skewed into the future still reads as now, not as a future date`() {
+        val now = 1_754_308_800_000L
+        // Server and device clocks disagree by seconds routinely; "in 4 seconds" is not a thing to show.
+        assertEquals(LastSeen.Now, lastSeen(now + 4_000, now))
+    }
+
+    @Test
+    fun `the freshness pill buckets the elapsed time by seconds, minutes, hours and days`() {
+        assertEquals(SyncedAgo.Seconds(59), syncedAgo(59_999))
+        assertEquals(SyncedAgo.Minutes(1), syncedAgo(60_000))
+        assertEquals(SyncedAgo.Minutes(59), syncedAgo(3_599_999))
+        assertEquals(SyncedAgo.Hours(1), syncedAgo(3_600_000))
+        assertEquals(SyncedAgo.Hours(23), syncedAgo(86_399_999))
+        assertEquals(SyncedAgo.Days(1), syncedAgo(86_400_000))
+    }
+
+    @Test
+    fun `a sync stamped by a clock ahead of ours reads as zero, never as negative`() {
+        assertEquals(SyncedAgo.Seconds(0), syncedAgo(-5_000))
+    }
+
+    @Test
+    fun `the vault card takes its rekey date from the newest key rotation in the feed`() {
+        val feed = buildTeamActivityFeed(
+            entries = listOf(
+                entry("team.rekey", 1_753_000_000_000L),
+                entry("team.scope_rekey", 1_754_000_000_000L),
+                entry("team.record_share", 1_754_300_000_000L),
+            ),
+            selfAccountId = owner,
+        )
+
+        assertEquals(1_754_000_000_000L, lastRekeyAt(feed))
+    }
+
+    @Test
+    fun `a team that was never rekeyed reports no date`() {
+        val feed = buildTeamActivityFeed(listOf(entry("team.create", 1L)), selfAccountId = owner)
+
+        assertNull(lastRekeyAt(feed))
+    }
+
+    private fun entry(event: String, at: Long) =
+        TeamActivityEntry(actorAccountId = owner, event = event, detail = "", createdAt = at)
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLockPauseTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -81,6 +82,7 @@ class SyncCoordinatorLockPauseTest {
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
         override suspend fun refresh(session: SyncSession): SyncSession = nope()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -77,6 +78,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -128,6 +129,7 @@ class SyncCoordinatorPasswordReplaceTest {
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
         override suspend fun refresh(session: SyncSession): SyncSession = nope()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.InMemorySyncStateStore
 import app.skerry.shared.sync.PairingResult
@@ -91,6 +92,7 @@ class SyncCoordinatorReactivationTest {
         override suspend fun ping(): Boolean = true
         override suspend fun close() {}
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
         override suspend fun refresh(session: SyncSession): SyncSession = throw NotImplementedError()
         // The rotation itself isn't what these tests are about: they need the activation that follows it,

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -83,6 +84,7 @@ class SyncCoordinatorServerFailureTest {
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorTokenRefreshTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -88,6 +89,7 @@ class SyncCoordinatorTokenRefreshTest {
         override suspend fun ping(): Boolean = true
         override suspend fun close() { closeCalls.incrementAndGet() }
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
         override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = throw NotImplementedError()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorWebAccessTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorWebAccessTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sync
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -117,6 +118,7 @@ class SyncCoordinatorWebAccessTest {
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
         override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
         override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
@@ -187,6 +187,39 @@ class TeamsCoordinatorScopeTest {
         TeamKeyStore(f.vault).also { it.put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0) }
 
     @Test
+    fun `a finished sync stamps when the team was last in step with the server`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val coord = coordinator(f, FakeTeamClient(self, teamId), listOf("prod").iterator())
+        assertNull(coord.lastSyncedAt.value[teamId], "nothing has synced yet")
+
+        coord.syncTeam(teamId)
+
+        // The header's "synced N ago" pill reads this; without it the screen can only claim freshness.
+        assertNotNull(coord.lastSyncedAt.value[teamId])
+        // Per team, not per account: a team that never synced must not inherit another's freshness.
+        assertNull(coord.lastSyncedAt.value["other-team"])
+    }
+
+    @Test
+    fun `an access list that cannot be read is null, never an empty one`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val f = newFixture()
+        seedTeam(f)
+        val failing = object : TeamClient by FakeTeamClient(self, teamId) {
+            override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
+                throw SyncException(SyncException.Kind.NETWORK, "offline")
+        }
+        val coord = coordinator(f, failing, listOf("prod").iterator())
+
+        // "Nobody holds this scope" and "we couldn't find out" must not be the same answer — the
+        // member table renders the first as a fact and the second as unknown.
+        assertNull(coord.scopeGrants(teamId, "prod"))
+        assertEquals(TeamsFailure.Network, coord.lastError.value)
+    }
+
+    @Test
     fun `creating a scope stores its own key and lists it on the team`() = runBlocking {
         initializeVaultCrypto()
         val f = newFixture()

--- a/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
@@ -2,6 +2,7 @@ package app.skerry.server.db
 
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.statements.api.ExposedBlob
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -80,6 +81,19 @@ class TeamRepository(private val db: Database) {
 
     suspend fun members(teamId: String): List<TeamMemberRow> = dbTransaction(db) {
         TeamMembers.selectAll().where { TeamMembers.teamId eq teamId }.map { it.toMemberRow() }
+    }
+
+    /**
+     * Newest device activity of each of [accountIds] (epoch millis), for the members list. One query
+     * for the whole team rather than a lookup per member, and accounts with no device row are simply
+     * absent from the map — the endpoint reports them as never seen.
+     */
+    suspend fun lastSeenByAccount(accountIds: Collection<String>): Map<String, Long> = dbTransaction(db) {
+        if (accountIds.isEmpty()) return@dbTransaction emptyMap()
+        Devices.selectAll()
+            .where { Devices.accountId inList accountIds.toSet() }
+            .groupingBy { it[Devices.accountId] }
+            .fold(0L) { newest, row -> maxOf(newest, row[Devices.lastSeenAt]) }
     }
 
     suspend fun membership(teamId: String, accountId: String): TeamMemberRow? = dbTransaction(db) {

--- a/server/src/main/kotlin/app/skerry/server/model/Dto.kt
+++ b/server/src/main/kotlin/app/skerry/server/model/Dto.kt
@@ -95,23 +95,9 @@ data class AdminRecordsResponse(
 
 // --- account zone ---
 
-/**
- * `GET /account/summary`: the caller's own totals, the same aggregates `/admin/accounts` reports for
- * one row. [records] counts tombstones too ([tombstones] is how many of them are); [lastSeenAt] is
- * the most recent activity across the account's devices, null for an account that never synced.
- */
-@Serializable
-data class AccountSummaryResponse(
-    val accountId: String,
-    val createdAt: Long,
-    val syncSeq: Long,
-    val devices: Int,
-    val activeDevices: Int,
-    val records: Int,
-    val tombstones: Int,
-    val storageBytes: Long,
-    val lastSeenAt: Long?,
-)
+// `GET /account/summary` answers with [app.skerry.sync.wire.AccountSummaryResponse]: the app reads
+// the same endpoint for the Teams screen's Server card, so its shape belongs to the wire contract
+// rather than to the server's own admin DTOs.
 
 /** `GET /account/activity`: one row of the caller's own log. No accountId — every row is theirs. */
 @Serializable

--- a/server/src/main/kotlin/app/skerry/server/routes/AccountRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/AccountRoutes.kt
@@ -1,12 +1,13 @@
 package app.skerry.server.routes
 
+import app.skerry.server.SERVER_VERSION
 import app.skerry.server.Services
 import app.skerry.server.accountId
 import app.skerry.server.jwtPrincipal
 import app.skerry.server.model.AccountActivityDto
 import app.skerry.server.model.AccountActivityResponse
-import app.skerry.server.model.AccountSummaryResponse
 import app.skerry.server.model.ErrorResponse
+import app.skerry.sync.wire.AccountSummaryResponse
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -42,6 +43,7 @@ fun Route.accountRoutes(services: Services) {
                 tombstones = summary.tombstones,
                 storageBytes = summary.storageBytes,
                 lastSeenAt = summary.lastSeenAt,
+                serverVersion = SERVER_VERSION,
             ),
         )
     }

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -47,7 +47,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.put
 
 /** Types synced in team scope: secrets and structure, excluding SETTINGS/KNOWN_HOST (per-account). */
-private val TEAM_ALLOWED_TYPES = setOf("HOST", "GROUP", "IDENTITY", "CREDENTIAL", "SNIPPET", "TUNNEL")
+private val TEAM_ALLOWED_TYPES = setOf("HOST", "GROUP", "IDENTITY", "CREDENTIAL", "SNIPPET", "RUNBOOK", "TUNNEL")
 
 /** Public X25519 key is exactly 32 bytes; a crypto_box_seal envelope is 48 bytes overhead + payload. */
 private const val PUBLIC_KEY_BYTES = 32
@@ -134,8 +134,10 @@ fun Route.teamRoutes(services: Services) {
         val principal = call.jwtPrincipal()
         val teamId = call.requiredPathId("id") ?: return@get
         call.requireActiveMember(services, teamId, principal.accountId) ?: return@get
-        val members = services.teams.members(teamId).map {
-            TeamMemberDto(it.accountId, it.role, it.status, it.createdAt)
+        val rows = services.teams.members(teamId)
+        val lastSeen = services.teams.lastSeenByAccount(rows.map { it.accountId })
+        val members = rows.map {
+            TeamMemberDto(it.accountId, it.role, it.status, it.createdAt, lastSeen[it.accountId])
         }
         call.respond(TeamMembersResponse(members))
     }

--- a/server/src/test/kotlin/app/skerry/server/routes/AccountProjectionRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/AccountProjectionRoutesTest.kt
@@ -1,11 +1,12 @@
 package app.skerry.server.routes
 
+import app.skerry.server.SERVER_VERSION
 import app.skerry.server.configureServer
 import app.skerry.server.model.AccountActivityResponse
-import app.skerry.server.model.AccountSummaryResponse
 import app.skerry.server.model.HealthResponse
 import app.skerry.server.model.VaultEnvelopesResponse
 import app.skerry.server.model.b64
+import app.skerry.sync.wire.AccountSummaryResponse
 import app.skerry.sync.wire.RecordDto
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -52,6 +53,20 @@ class AccountProjectionRoutesTest {
         assertEquals(1, summary.devices)
         assertEquals(1, summary.activeDevices)
         assertNotNull(summary.lastSeenAt)
+    }
+
+    @Test
+    fun `the summary names the server version`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val tokens = client.registerAccount(account, password)
+
+        val summary: AccountSummaryResponse = client.get("/account/summary") { bearerAuth(tokens.accessToken) }.body()
+
+        // The client shows it in the Teams screen's Server card; /admin/health is admin-only, so
+        // this is the only place an ordinary member can learn which server they are talking to.
+        assertEquals(SERVER_VERSION, summary.serverVersion)
     }
 
     @Test

--- a/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
@@ -32,6 +32,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TeamRoutesTest {
 
@@ -164,6 +165,57 @@ class TeamRoutesTest {
         val members: TeamMembersResponse = client.get("/teams/$teamId/members") { bearerAuth(bobTokens.accessToken) }.body()
         assertEquals(setOf(alice, bob), members.members.map { it.accountId }.toSet())
         assertNotNull(members.members.single { it.role == "owner" && it.accountId == alice })
+    }
+
+    @Test
+    fun `a runbook is a shareable team record, an unknown type still is not`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val aliceTokens = client.registerAccount(alice, password)
+        client.createTeam(aliceTokens.accessToken)
+
+        suspend fun push(type: String) = client.put("/teams/$teamId/records") {
+            bearerAuth(aliceTokens.accessToken)
+            contentType(ContentType.Application.Json)
+            setBody(PushRequest(listOf(record("r-$type", type = type))))
+        }
+
+        // Runbooks are shared with a team like hosts and snippets; the client offers it, so the
+        // server has to accept it — otherwise the share writes a local copy nobody else ever sees.
+        assertEquals(HttpStatusCode.OK, push("RUNBOOK").status)
+        val delta: RecordsResponse = client.get("/teams/$teamId/records?since=0") { bearerAuth(aliceTokens.accessToken) }.body()
+        assertEquals("r-RUNBOOK", delta.records.single().id)
+        // The allowlist is still an allowlist: a type the team zone knows nothing about is refused.
+        assertEquals(HttpStatusCode.BadRequest, push("TERMINAL_HISTORY").status)
+    }
+
+    @Test
+    fun `members report when each account was last seen, across all of its devices`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val before = System.currentTimeMillis()
+        val aliceTokens = client.registerAccount(alice, password)
+        val bobTokens = client.registerAccount(bob, password, deviceId = "dev-bob")
+        client.createTeam(aliceTokens.accessToken)
+        client.invite(aliceTokens.accessToken, bob, byteArrayOf(1))
+        client.post("/teams/$teamId/accept") { bearerAuth(bobTokens.accessToken) }
+
+        // Bob signs in on a second device; the freshest of an account's devices is what the team sees.
+        val secondLogin = System.currentTimeMillis()
+        client.srpLogin(bob, password, deviceId = "dev-bob-2", deviceName = "Phone")
+
+        val members: TeamMembersResponse = client.get("/teams/$teamId/members") { bearerAuth(aliceTokens.accessToken) }.body()
+        val aliceSeen = members.members.single { it.accountId == alice }.lastSeenAt
+        val bobSeen = members.members.single { it.accountId == bob }.lastSeenAt
+
+        assertNotNull(aliceSeen)
+        assertTrue(aliceSeen >= before)
+        assertNotNull(bobSeen)
+        assertTrue(bobSeen >= secondLogin, "the newer device's activity must win: $bobSeen < $secondLogin")
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncClient.kt
@@ -55,6 +55,19 @@ data class RemoteDevice(
     val current: Boolean,
 )
 
+/**
+ * What the server holds for the signed-in account, as it sees it: counts, ciphertext size, and the
+ * version of the instance answering ([serverVersion] is empty on a server too old to report one).
+ * Metadata only — the server has nothing else to tell about an account.
+ */
+data class AccountSummary(
+    val devices: Int,
+    val activeDevices: Int,
+    val records: Int,
+    val storageBytes: Long,
+    val serverVersion: String,
+)
+
 /** Quick pairing ticket (variant B): a QR code and its expiry. */
 data class PairingTicket(val code: String, val expiresAt: Long)
 
@@ -109,6 +122,9 @@ interface SyncClient {
     suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage
 
     suspend fun listDevices(session: SyncSession): List<RemoteDevice>
+
+    /** The account's own totals as the server holds them (`GET /account/summary`). */
+    suspend fun accountSummary(session: SyncSession): AccountSummary
 
     suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
@@ -95,6 +95,11 @@ class TeamMember(
     val role: TeamRole,
     val status: TeamMemberStatus,
     val createdAt: Long,
+    /**
+     * When the account was last active on any of its devices (epoch millis), or null on a server
+     * that doesn't report it — the member table then shows nothing rather than inventing a time.
+     */
+    val lastSeenAt: Long? = null,
 )
 
 /** An account's published Teams identity keys (both public halves; see [TeamClient.fetchPublicKey]). */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamScopedSyncClient.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.team
 
+import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.PairingResult
 import app.skerry.shared.sync.PairingTicket
@@ -33,6 +34,7 @@ class TeamScopedSyncClient(
     override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = unsupported()
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = unsupported()
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = unsupported()
+    override suspend fun accountSummary(session: SyncSession): AccountSummary = unsupported()
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = unsupported()
     override suspend fun refresh(session: SyncSession): SyncSession = unsupported()
     override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = unsupported()

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/FakeSyncClient.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/FakeSyncClient.kt
@@ -20,6 +20,7 @@ internal open class FakeSyncClient(var serverRecords: List<RemoteRecord> = empty
     override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = error("unused")
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = error("unused")
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = error("unused")
+    override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = error("unused")
     override suspend fun refresh(session: SyncSession): SyncSession = error("unused")
     override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = error("unused")

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/KtorSyncClientServerInfoTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/KtorSyncClientServerInfoTest.kt
@@ -1,0 +1,81 @@
+package app.skerry.shared.sync
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * What the Teams screen's Server card and member table read off the wire. Both fields are optional
+ * on the server side (an instance older than them simply omits them), so the client's contract is
+ * that a missing field degrades to "unknown" rather than failing the whole call.
+ */
+class KtorSyncClientServerInfoTest {
+
+    private val requests = mutableListOf<HttpRequestData>()
+
+    private fun client(body: String): KtorSyncClient {
+        val engine = MockEngine { request ->
+            requests += request
+            respond(
+                content = body,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        return KtorSyncClient(
+            serverUrl = "https://sync.example.com",
+            http = HttpClient(engine) { install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) } },
+        )
+    }
+
+    private val session = SyncSession("a@example.com", "at", "rt")
+
+    @Test
+    fun `the account summary carries the instance version and its device count`() = runTest {
+        val summary = client(
+            """{"accountId":"a@example.com","createdAt":1,"syncSeq":7,"devices":9,"activeDevices":8,
+                "records":41,"tombstones":2,"storageBytes":4096,"lastSeenAt":1754300000000,"serverVersion":"0.2.1"}""",
+        ).accountSummary(session)
+
+        assertEquals("/account/summary", requests.single().url.encodedPath)
+        assertEquals(9, summary.devices)
+        assertEquals(8, summary.activeDevices)
+        assertEquals(4096L, summary.storageBytes)
+        assertEquals("0.2.1", summary.serverVersion)
+    }
+
+    @Test
+    fun `a server that reports no version yields an empty one instead of failing`() = runTest {
+        val summary = client(
+            """{"accountId":"a@example.com","createdAt":1,"syncSeq":0,"devices":1,"activeDevices":1,
+                "records":0,"tombstones":0,"storageBytes":0,"lastSeenAt":null}""",
+        ).accountSummary(session)
+
+        assertEquals("", summary.serverVersion)
+        assertEquals(1, summary.devices)
+    }
+
+    @Test
+    fun `members carry the last time each was seen, and null on a server that doesn't track it`() = runTest {
+        val members = client(
+            """{"members":[
+                {"accountId":"a@example.com","role":"owner","status":"active","createdAt":1,"lastSeenAt":1754300000000},
+                {"accountId":"b@example.com","role":"viewer","status":"invited","createdAt":2}]}""",
+        ).members(session, "team-1")
+
+        assertEquals(1754300000000L, members.first().lastSeenAt)
+        assertNull(members.last().lastSeenAt)
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.sync
 
+import app.skerry.sync.wire.AccountSummaryResponse
 import app.skerry.sync.wire.ChallengeRequest
 import app.skerry.sync.wire.ChallengeResponse
 import app.skerry.sync.wire.ChangePasswordRequest
@@ -239,6 +240,11 @@ class KtorSyncClient(
         return resp.devices.map { RemoteDevice(it.id, it.name, it.createdAt, it.lastSeenAt, it.revoked, it.current) }
     }
 
+    override suspend fun accountSummary(session: SyncSession): AccountSummary {
+        val resp: AccountSummaryResponse = get("/account/summary") { bearerAuth(session.accessToken) }.bodyChecked()
+        return AccountSummary(resp.devices, resp.activeDevices, resp.records, resp.storageBytes, resp.serverVersion)
+    }
+
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean {
         val resp = http.delete("$serverUrl/devices/$deviceId") { bearerAuth(session.accessToken) }
         return when (resp.status) {
@@ -358,7 +364,7 @@ class KtorSyncClient(
             bearerAuth(session.accessToken)
         }.bodyChecked()
         return resp.members.map {
-            TeamMember(it.accountId, TeamRole.fromWire(it.role), TeamMemberStatus.fromWire(it.status), it.createdAt)
+            TeamMember(it.accountId, TeamRole.fromWire(it.role), TeamMemberStatus.fromWire(it.status), it.createdAt, it.lastSeenAt)
         }
     }
 

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/AccountWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/AccountWireDto.kt
@@ -1,0 +1,26 @@
+package app.skerry.sync.wire
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The account zone's own view of itself (`GET /account/summary`) — read by the web console and by
+ * the app (Teams → Server card). Metadata only: counts, sizes and the instance version, never a
+ * record's content.
+ *
+ * [records] counts tombstones too ([tombstones] is how many of them are); [lastSeenAt] is the most
+ * recent activity across the account's devices, null for an account that never synced. An instance
+ * older than [serverVersion] omits it, and the client reads it as unknown.
+ */
+@Serializable
+data class AccountSummaryResponse(
+    val accountId: String,
+    val createdAt: Long,
+    val syncSeq: Long,
+    val devices: Int,
+    val activeDevices: Int,
+    val records: Int,
+    val tombstones: Int,
+    val storageBytes: Long,
+    val lastSeenAt: Long?,
+    val serverVersion: String = "",
+)

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
@@ -62,6 +62,13 @@ data class TeamMemberDto(
     val role: String,
     val status: String,
     val createdAt: Long,
+    /**
+     * Most recent activity across the member's devices (epoch millis), or null when the server
+     * predates the field or the account has no device rows. Metadata the team already implies —
+     * membership is public inside the team — and the only thing it says is whether a colleague is
+     * still around.
+     */
+    val lastSeenAt: Long? = null,
 )
 
 @Serializable


### PR DESCRIPTION
The Team screen follows the design mockup.

**Member table** — member, role, access scopes, last seen. The role badge opens the role picker and the trailing cross removes a member, both only where the server would allow it. An access list that failed to load is marked as unknown, never rendered as "holds nothing".

**Activity column** for owner and admin, beside the table, with the full history dialog one click away.

**Summary cards** — Shared vault (items, encryption, last rekey), Server (endpoint, storage, version, devices), Shared with the team (hosts, snippets, runbooks, live sessions). The counts open the record lists, where records are shared, unshared, and their history read.

**Share spaces** keep their strip above the table: select, create, manage access, delete. Leaving or deleting a team moved into the header's overflow menu.

**Freshness** — the header pill says how long ago this team last synced, and syncs on click.

## Runbooks are team records

Runbooks can now be shared with a team like hosts and snippets — picker, shared list, unshare, audit noun and count — on desktop and Android. The team zone accepts the `RUNBOOK` type.

## Server

- `GET /teams/{id}/members` reports `lastSeenAt` per member, aggregated over that account's devices in one query.
- `GET /account/summary` reports the instance version; its response type moved into the shared wire contract, so client and server share one type.
- The team zone accepts `RUNBOOK` records.

An older server omits both new fields and the screen shows dashes.

## Verification

`./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll` and `:androidApp:compileDebugKotlin` are green. The desktop app was launched on a clean profile and starts without errors; the screen itself has not been exercised against a live sync server, so per-member "last seen", the server version and the device count are untested end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
