### PR TITLE
Terminal syntax highlighting for the command line and output

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -181,6 +181,10 @@ class MainActivity : FragmentActivity() {
                     onReportTeamSessionsChange = { writeReportTeamSessions(dir, it) },
                     initialOpenFilePathsInSftp = readOpenFilePaths(dir),
                     onOpenFilePathsInSftpChange = { writeOpenFilePaths(dir, it) },
+                    initialHighlightCommandLine = readHighlightInput(dir),
+                    onHighlightCommandLineChange = { writeHighlightInput(dir, it) },
+                    initialHighlightOutput = readHighlightOutput(dir),
+                    onHighlightOutputChange = { writeHighlightOutput(dir, it) },
                     initialConfirmProductionWarnings = readProdWarnings(dir),
                     onConfirmProductionWarningsChange = { writeProdWarnings(dir, it) },
                     initialUiLanguage = currentUiLanguage.value,
@@ -307,6 +311,28 @@ class MainActivity : FragmentActivity() {
     private fun writeOpenFilePaths(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_open_paths").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Command-line syntax highlighting: `terminal_highlight_input`, default on. */
+    private fun readHighlightInput(dir: File): Boolean = runCatching {
+        File(dir, "terminal_highlight_input").readText().trim().toBoolean()
+    }.getOrDefault(true)
+
+    private fun writeHighlightInput(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_highlight_input").writeText(enabled.toString()) }
+        }
+    }
+
+    /** Log-level highlighting in output: `terminal_highlight_output`, default off. */
+    private fun readHighlightOutput(dir: File): Boolean = runCatching {
+        File(dir, "terminal_highlight_output").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeHighlightOutput(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "terminal_highlight_output").writeText(enabled.toString()) }
         }
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -87,6 +87,10 @@
     <string name="settings_terminal_open_paths">Открытие файловых путей в SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+клик по пути в выводе открывает его в файловой панели.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Долгое нажатие на путь в выводе, затем «Открыть в Файлах».</string>
+    <string name="settings_terminal_highlight_input">Подсветка командной строки</string>
+    <string name="settings_terminal_highlight_input_desc">Раскрашивает команды, флаги, строки в кавычках, пути и операторы при вводе.</string>
+    <string name="settings_terminal_highlight_output">Подсветка уровней логов в выводе</string>
+    <string name="settings_terminal_highlight_output_desc">Отмечает ERROR/WARN/INFO, IP-адреса и метки времени в выводе, который сервер не раскрасил сам.</string>
     <string name="settings_terminal_host_connect">Подключение к хосту</string>
     <string name="settings_terminal_host_connect_single">Одинарный клик</string>
     <string name="settings_terminal_host_connect_double">Двойной клик (клик выделяет)</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -87,6 +87,10 @@
     <string name="settings_terminal_open_paths">在 SFTP 中打开文件路径</string>
     <string name="settings_terminal_open_paths_desc">按住 Ctrl 点击输出中的路径，即可在文件面板中定位。</string>
     <string name="settings_terminal_open_paths_desc_mobile">长按输出中的路径，然后点按“在文件中打开”。</string>
+    <string name="settings_terminal_highlight_input">命令行语法高亮</string>
+    <string name="settings_terminal_highlight_input_desc">输入时为命令、参数、引号字符串、路径和操作符着色。</string>
+    <string name="settings_terminal_highlight_output">高亮输出中的日志级别</string>
+    <string name="settings_terminal_highlight_output_desc">标记服务器未着色输出中的 ERROR/WARN/INFO、IP 地址和时间戳。</string>
     <string name="settings_terminal_host_connect">连接主机方式</string>
     <string name="settings_terminal_host_connect_single">单击</string>
     <string name="settings_terminal_host_connect_double">双击（单击选中）</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -87,6 +87,10 @@
     <string name="settings_terminal_open_paths">Open file paths in SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+click a file path in the output to reveal it in the file panel.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap "Open in Files".</string>
+    <string name="settings_terminal_highlight_input">Highlight the command line</string>
+    <string name="settings_terminal_highlight_input_desc">Colors commands, flags, quoted strings, paths and operators as you type.</string>
+    <string name="settings_terminal_highlight_output">Highlight log levels in output</string>
+    <string name="settings_terminal_highlight_output_desc">Marks ERROR/WARN/INFO, IP addresses and timestamps in output the server left uncolored.</string>
     <string name="settings_terminal_host_connect">Connect to host on</string>
     <string name="settings_terminal_host_connect_single">Single click</string>
     <string name="settings_terminal_host_connect_double">Double click (click selects)</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopSettingsState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/DesktopSettingsState.kt
@@ -59,6 +59,10 @@ class DesktopSettingsState(
     private val onReportTeamSessionsChange: (Boolean) -> Unit = {},
     initialOpenFilePathsInSftp: Boolean = true,
     private val onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
+    initialHighlightCommandLine: Boolean = true,
+    private val onHighlightCommandLineChange: (Boolean) -> Unit = {},
+    initialHighlightOutput: Boolean = false,
+    private val onHighlightOutputChange: (Boolean) -> Unit = {},
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
     initialTerminalTheme: TerminalTheme = TerminalThemes.DEFAULT,
@@ -135,6 +139,20 @@ class DesktopSettingsState(
      * output makes the Ctrl+hover highlight a distraction.
      */
     var openFilePathsInSftp: Boolean by mutableStateOf(initialOpenFilePathsInSftp); private set
+
+    /**
+     * Whether the client colors the command line being typed (Terminal → Highlight the command
+     * line). On by default: it only ever paints the user's own input, and only where the server
+     * left the cells uncolored.
+     */
+    var highlightCommandLine: Boolean by mutableStateOf(initialHighlightCommandLine); private set
+
+    /**
+     * Whether the client marks log levels, addresses and timestamps in output (Terminal → Highlight
+     * log levels in output). Off by default — unlike the command line, this repaints text the
+     * server printed, which is an opinion the user should ask for.
+     */
+    var highlightOutput: Boolean by mutableStateOf(initialHighlightOutput); private set
 
     /**
      * Whether the production guard also confirms [app.skerry.shared.ai.CommandRisk.Warn] commands
@@ -267,6 +285,18 @@ class DesktopSettingsState(
     fun toggleOpenFilePathsInSftp() {
         openFilePathsInSftp = !openFilePathsInSftp
         onOpenFilePathsInSftpChange(openFilePathsInSftp)
+    }
+
+    /** Toggle command-line syntax highlighting and report outward (for persistence). */
+    fun toggleHighlightCommandLine() {
+        highlightCommandLine = !highlightCommandLine
+        onHighlightCommandLineChange(highlightCommandLine)
+    }
+
+    /** Toggle log-level highlighting in output and report outward (for persistence). */
+    fun toggleHighlightOutput() {
+        highlightOutput = !highlightOutput
+        onHighlightOutputChange(highlightOutput)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -122,6 +122,11 @@ class MobileDesignState(
     // Desktop parity (Ctrl+click there). On by default; persisted on Android.
     initialOpenFilePathsInSftp: Boolean = true,
     private val onOpenFilePathsInSftpChange: (Boolean) -> Unit = {},
+    // Client-side syntax highlighting (More → Terminal). Desktop parity; persisted on Android.
+    initialHighlightCommandLine: Boolean = true,
+    private val onHighlightCommandLineChange: (Boolean) -> Unit = {},
+    initialHighlightOutput: Boolean = false,
+    private val onHighlightOutputChange: (Boolean) -> Unit = {},
     // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
@@ -355,6 +360,18 @@ class MobileDesignState(
     var openFilePathsInSftp: Boolean by mutableStateOf(initialOpenFilePathsInSftp); private set
 
     /**
+     * Whether the client colors the command line being typed (More → Terminal). On by default;
+     * desktop parity, see [app.skerry.ui.app.DesktopDesignState.highlightCommandLine].
+     */
+    var highlightCommandLine: Boolean by mutableStateOf(initialHighlightCommandLine); private set
+
+    /**
+     * Whether the client marks log levels in output (More → Terminal). Off by default; desktop
+     * parity, see [app.skerry.ui.app.DesktopDesignState.highlightOutput].
+     */
+    var highlightOutput: Boolean by mutableStateOf(initialHighlightOutput); private set
+
+    /**
      * Whether the production guard also confirms Warn-level commands (More → Terminal). Off by
      * default — desktop parity, see [app.skerry.ui.app.DesktopDesignState.confirmProductionWarnings].
      */
@@ -416,6 +433,18 @@ class MobileDesignState(
     fun toggleOpenFilePathsInSftp() {
         openFilePathsInSftp = !openFilePathsInSftp
         onOpenFilePathsInSftpChange(openFilePathsInSftp)
+    }
+
+    /** Toggle command-line syntax highlighting and report outward (for persistence). */
+    fun toggleHighlightCommandLine() {
+        highlightCommandLine = !highlightCommandLine
+        onHighlightCommandLineChange(highlightCommandLine)
+    }
+
+    /** Toggle log-level highlighting in output and report outward (for persistence). */
+    fun toggleHighlightOutput() {
+        highlightOutput = !highlightOutput
+        onHighlightOutputChange(highlightOutput)
     }
 
     /** Toggle honoring server OSC 52 clipboard writes and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -36,6 +36,8 @@ import app.skerry.ui.runbook.RunbookRunner
 import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.terminal.LocalTerminalAppearance
+import app.skerry.ui.terminal.LocalTerminalHighlight
+import app.skerry.ui.terminal.TerminalHighlight
 import app.skerry.ui.terminal.LocalTerminalTheme
 import app.skerry.ui.terminal.TerminalAppearance
 import app.skerry.ui.theme.ThemeMode
@@ -370,6 +372,11 @@ fun DesktopDesignApp(
         LocalSftpPrefs provides sftpPrefs,
         // Terminal appearance from settings: font + size, read by [app.skerry.ui.terminal.TerminalScreen].
         LocalTerminalAppearance provides terminalAppearance,
+        // Client-side syntax highlighting (Settings → Terminal), read by TerminalScreen's draw layer.
+        LocalTerminalHighlight provides TerminalHighlight(
+            commandLine = state.settings.highlightCommandLine,
+            output = state.settings.highlightOutput,
+        ),
         // Terminal color theme: the app theme's twin, or the separately-picked one (Appearance → cards).
         LocalTerminalTheme provides effectiveTerminalTheme,
         // The open vault + biometrics behind the gate — needed for re-authentication before copying

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
@@ -50,6 +50,10 @@ import app.skerry.ui.generated.resources.appearance_custom_term_theme_desc
 import app.skerry.ui.generated.resources.appearance_section_terminal
 import app.skerry.ui.generated.resources.settings_terminal_open_paths
 import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc_mobile
+import app.skerry.ui.generated.resources.settings_terminal_highlight_input
+import app.skerry.ui.generated.resources.settings_terminal_highlight_input_desc
+import app.skerry.ui.generated.resources.settings_terminal_highlight_output
+import app.skerry.ui.generated.resources.settings_terminal_highlight_output_desc
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_cursor_style
@@ -161,45 +165,45 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
             // Clickable file paths in output (desktop parity): here the affordance is a chip over a
             // selected path rather than Ctrl+click, and this switch governs both.
             HLine()
-            Row(
-                Modifier.fillMaxWidth().padding(vertical = 11.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Txt(stringResource(Res.string.settings_terminal_open_paths), color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
-                    Txt(stringResource(Res.string.settings_terminal_open_paths_desc_mobile), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
-                }
-                Toggle(on = state.openFilePathsInSftp, onToggle = state::toggleOpenFilePathsInSftp)
-            }
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_open_paths),
+                desc = stringResource(Res.string.settings_terminal_open_paths_desc_mobile),
+                on = state.openFilePathsInSftp,
+                onToggle = state::toggleOpenFilePathsInSftp,
+            )
+            // Client-side syntax highlighting (desktop parity): input on by default, output off.
+            HLine()
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_highlight_input),
+                desc = stringResource(Res.string.settings_terminal_highlight_input_desc),
+                on = state.highlightCommandLine,
+                onToggle = state::toggleHighlightCommandLine,
+            )
+            HLine()
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_highlight_output),
+                desc = stringResource(Res.string.settings_terminal_highlight_output_desc),
+                on = state.highlightOutput,
+                onToggle = state::toggleHighlightOutput,
+            )
             // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host
             // from silently overwriting the system clipboard. Applies to new and already-open sessions.
             HLine()
-            Row(
-                Modifier.fillMaxWidth().padding(vertical = 11.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Txt(stringResource(Res.string.settings_terminal_clipboard_write), color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
-                    Txt(stringResource(Res.string.settings_terminal_clipboard_write_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
-                }
-                Toggle(on = state.allowServerClipboardWrite, onToggle = state::toggleAllowServerClipboardWrite)
-            }
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_clipboard_write),
+                desc = stringResource(Res.string.settings_terminal_clipboard_write_desc),
+                on = state.allowServerClipboardWrite,
+                onToggle = state::toggleAllowServerClipboardWrite,
+            )
             // Production guard threshold (desktop parity): dangerous commands always confirm, the
             // warnings on top of them are opt-in.
             HLine()
-            Row(
-                Modifier.fillMaxWidth().padding(vertical = 11.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                Column(Modifier.weight(1f)) {
-                    Txt(stringResource(Res.string.settings_terminal_prod_warnings), color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
-                    Txt(stringResource(Res.string.settings_terminal_prod_warnings_desc), color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
-                }
-                Toggle(on = state.confirmProductionWarnings, onToggle = state::toggleConfirmProductionWarnings)
-            }
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_terminal_prod_warnings),
+                desc = stringResource(Res.string.settings_terminal_prod_warnings_desc),
+                on = state.confirmProductionWarnings,
+                onToggle = state::toggleConfirmProductionWarnings,
+            )
             Txt(stringResource(Res.string.appearance_section_interface), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 18.dp, bottom = 6.dp))
             FontSettingRow(stringResource(Res.string.appearance_language)) {
                 MobileLanguagePicker(state.uiLanguage, onPick = state::chooseUiLanguage)
@@ -433,4 +437,24 @@ private fun MobileCursorStylePicker(current: TerminalCursorStyle, onPick: (Termi
             }
         },
     )
+}
+
+/**
+ * One settings switch on mobile: title, secondary line, toggle. The same row shape appears for every
+ * behaviour setting on this screen, so it lives here once — the desktop twin is
+ * [app.skerry.ui.settings.SettingToggleRow], which differs only in its type scale.
+ */
+@Composable
+private fun MobileToggleRow(title: String, desc: String, on: Boolean, onToggle: () -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 11.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(title, color = Skerry.colors.text, size = 13.5.sp, weight = FontWeight.Medium)
+            Txt(desc, color = Skerry.colors.faint, size = 11.5.sp, modifier = Modifier.padding(top = 2.dp))
+        }
+        Toggle(on = on, onToggle = onToggle)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -24,6 +24,8 @@ import app.skerry.ui.session.SessionsController
 import app.skerry.ui.sync.SyncStatus
 import app.skerry.ui.sync.SyncOnboardingScreen
 import app.skerry.ui.terminal.LocalTerminalAppearance
+import app.skerry.ui.terminal.LocalTerminalHighlight
+import app.skerry.ui.terminal.TerminalHighlight
 import app.skerry.ui.terminal.LocalTerminalTheme
 import app.skerry.ui.terminal.TerminalAppearance
 import app.skerry.ui.terminal.TerminalSessionPrefs
@@ -253,6 +255,11 @@ fun MobileDesignApp(
         LocalFonts provides fonts,
         // Terminal appearance from settings (More → Appearance): font + size read by TerminalScreen.
         LocalTerminalAppearance provides terminalAppearance,
+        // Client-side syntax highlighting (More → Terminal), read by TerminalScreen's draw layer.
+        LocalTerminalHighlight provides TerminalHighlight(
+            commandLine = state.highlightCommandLine,
+            output = state.highlightOutput,
+        ),
         // Terminal color theme: the app theme's twin, or the separately-picked one (More → Appearance → cards).
         LocalTerminalTheme provides effectiveTerminalTheme,
         LocalHosts provides deps.hosts,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -51,6 +51,10 @@ import app.skerry.ui.generated.resources.settings_terminal_cursor_underline_blin
 import app.skerry.ui.generated.resources.settings_terminal_cursor_underline_steady
 import app.skerry.ui.generated.resources.settings_terminal_open_paths
 import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc
+import app.skerry.ui.generated.resources.settings_terminal_highlight_input
+import app.skerry.ui.generated.resources.settings_terminal_highlight_input_desc
+import app.skerry.ui.generated.resources.settings_terminal_highlight_output
+import app.skerry.ui.generated.resources.settings_terminal_highlight_output_desc
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write
 import app.skerry.ui.generated.resources.settings_terminal_clipboard_write_desc
 import app.skerry.ui.generated.resources.settings_terminal_scrollback
@@ -192,6 +196,22 @@ internal fun TerminalSection(state: DesktopDesignState) {
         stringResource(Res.string.settings_terminal_open_paths_desc),
         on = state.settings.openFilePathsInSftp,
         onToggle = state.settings::toggleOpenFilePathsInSftp,
+    )
+    HLine()
+    // Client-side syntax highlighting. Two switches, not one: the first colors what the user types,
+    // the second repaints what the server printed — and only cells the server left uncolored.
+    SettingToggleRow(
+        stringResource(Res.string.settings_terminal_highlight_input),
+        stringResource(Res.string.settings_terminal_highlight_input_desc),
+        on = state.settings.highlightCommandLine,
+        onToggle = state.settings::toggleHighlightCommandLine,
+    )
+    HLine()
+    SettingToggleRow(
+        stringResource(Res.string.settings_terminal_highlight_output),
+        stringResource(Res.string.settings_terminal_highlight_output_desc),
+        on = state.settings.highlightOutput,
+        onToggle = state.settings::toggleHighlightOutput,
     )
     HLine()
     // OSC 52 clipboard-write gate (default off, like xterm/kitty): keeps an untrusted host from

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
@@ -41,6 +41,7 @@ import app.skerry.shared.terminal.TermColor
 import app.skerry.shared.terminal.TermStyle
 import app.skerry.shared.terminal.UnderlineStyle
 import app.skerry.shared.terminal.TerminalSelection
+import app.skerry.shared.terminal.highlight.HighlightKind
 import kotlin.math.roundToInt
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
@@ -182,9 +183,18 @@ internal fun cellBgColor(style: TermStyle, palette: Palette, theme: TerminalThem
 
 /**
  * One glyph run to draw: text, start column [col], number of columns occupied [span] (for underline:
- * Wide=2, ASCII run = cell count), and style.
+ * Wide=2, ASCII run = cell count), style, and the client-side highlight category over it ([kind]).
+ *
+ * [kind] stays separate from [style] so the run keeps the server's own attributes for the underline
+ * pass — the highlight recolors the glyph, not the line under it.
  */
-internal data class GlyphRun(val col: Int, val text: String, val span: Int, val style: TermStyle)
+internal data class GlyphRun(
+    val col: Int,
+    val text: String,
+    val span: Int,
+    val style: TermStyle,
+    val kind: HighlightKind = HighlightKind.None,
+)
 
 /**
  * Printable ASCII (a single BMP char 0x20..0x7e) — in JetBrains Mono guaranteed a cellWidth advance.
@@ -199,28 +209,38 @@ private fun TermCell.isPlainAscii(): Boolean = text.length == 1 && text[0].code 
  * run that accumulates drift (ragged box horizontals, colored rows sliding by a column). A wide cell — a
  * separate two-column run; a Continuation carries no glyph. The run's column is the physical cell index,
  * so a Continuation "hole" doesn't shift the next run.
+ *
+ * [highlight] adds the client's own syntax categories: a run also breaks where the category changes,
+ * so a token boundary inside otherwise identical cells becomes a boundary between runs.
  */
-internal fun glyphRuns(row: List<TermCell>): List<GlyphRun> {
+internal fun glyphRuns(row: List<TermCell>, highlight: RowHighlight? = null): List<GlyphRun> {
     val runs = ArrayList<GlyphRun>()
+    fun kindAt(col: Int) = highlight?.kindAt(col) ?: HighlightKind.None
     var g = 0
     while (g < row.size) {
         val cell = row[g]
         when {
             cell.width == CellWidth.Continuation -> g++
             cell.width == CellWidth.Wide -> {
-                runs.add(GlyphRun(g, cell.text, 2, cell.style)); g++
+                runs.add(GlyphRun(g, cell.text, 2, cell.style, kindAt(g))); g++
             }
             !cell.isPlainAscii() -> {
-                runs.add(GlyphRun(g, cell.text, 1, cell.style)); g++
+                runs.add(GlyphRun(g, cell.text, 1, cell.style, kindAt(g))); g++
             }
             else -> {
                 val st = cell.style
+                val kind = kindAt(g)
                 val start = g
                 val sb = StringBuilder()
-                while (g < row.size && row[g].width == CellWidth.Single && row[g].style == st && row[g].isPlainAscii()) {
+                fun continuesRun(at: Int): Boolean {
+                    if (at >= row.size) return false
+                    val c = row[at]
+                    return c.width == CellWidth.Single && c.style == st && c.isPlainAscii() && kindAt(at) == kind
+                }
+                while (continuesRun(g)) {
                     sb.append(row[g].text); g++
                 }
-                runs.add(GlyphRun(start, sb.toString(), g - start, st))
+                runs.add(GlyphRun(start, sb.toString(), g - start, st, kind))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
@@ -1,0 +1,212 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermColor
+import app.skerry.shared.terminal.TermStyle
+import app.skerry.shared.terminal.highlight.CommandVocabulary
+import app.skerry.shared.terminal.highlight.HighlightKind
+import app.skerry.shared.terminal.highlight.MAX_OUTPUT_SCAN
+import app.skerry.shared.terminal.highlight.highlightOutputLine
+import app.skerry.shared.terminal.TerminalPos
+import app.skerry.shared.terminal.highlight.tokenizeCommandLine
+
+/**
+ * Highlight categories of one grid row, by column. Built once per snapshot and read in the draw
+ * phase, so lookups must not allocate — hence a sorted array pair and a binary search rather than a
+ * map.
+ */
+internal class RowHighlight private constructor(
+    private val starts: IntArray,
+    private val ends: IntArray,
+    private val kinds: Array<HighlightKind>,
+) {
+    fun kindAt(col: Int): HighlightKind {
+        var low = 0
+        var high = starts.size - 1
+        while (low <= high) {
+            val mid = (low + high) ushr 1
+            when {
+                col < starts[mid] -> high = mid - 1
+                col >= ends[mid] -> low = mid + 1
+                else -> return kinds[mid]
+            }
+        }
+        return HighlightKind.None
+    }
+
+    companion object {
+        val Empty = RowHighlight(IntArray(0), IntArray(0), emptyArray())
+
+        /** Builds from column spans; [spans] must be sorted by start and non-overlapping. */
+        fun of(spans: List<ColumnSpan>): RowHighlight {
+            if (spans.isEmpty()) return Empty
+            return RowHighlight(
+                starts = IntArray(spans.size) { spans[it].startCol },
+                ends = IntArray(spans.size) { spans[it].endColExclusive },
+                kinds = Array(spans.size) { spans[it].kind },
+            )
+        }
+    }
+}
+
+/** A highlight category over grid columns `[startCol, endColExclusive)` of one row. */
+internal data class ColumnSpan(val startCol: Int, val endColExclusive: Int, val kind: HighlightKind)
+
+/**
+ * Whether this cell's color is the client's to choose. A cell the server already styled is left
+ * alone: `ls --color`, `git`, compiler diagnostics and TUI chrome picked their colors deliberately,
+ * and overpainting them would destroy information rather than add it.
+ *
+ * `inverse` is excluded because reverse-video makes the foreground paint the *background* (mc's
+ * selected row), and `hidden` because a hidden cell is password echo that must stay invisible.
+ *
+ * This gate doubles as the damage limiter for the prompt heuristic: a colored prompt (oh-my-zsh,
+ * powerline) fails it, so even a mis-cut prompt is never recolored.
+ */
+internal fun TermStyle.acceptsHighlight(): Boolean =
+    fg == TermColor.Default && bg == TermColor.Default && !inverse && !hidden
+
+/**
+ * Highlight categories for the rows in [window], keyed by row index. Rows with nothing to highlight
+ * are absent, and both features off yields an empty map — the renderer then walks its old path.
+ *
+ * The command line (rows around the cursor) and output (everything else) never overlap: the cursor's
+ * own chain of rows is excluded from the output pass, so a typed `ERROR` isn't recolored as a log
+ * level while it is still being typed.
+ */
+internal fun highlightRows(
+    source: HighlightSource,
+    window: IntRange,
+    settings: TerminalHighlight,
+    vocabulary: CommandVocabulary,
+): Map<Int, RowHighlight> {
+    if (!settings.commandLine && !settings.output) return emptyMap()
+    val screen = source.screen
+    val out = HashMap<Int, RowHighlight>()
+    val commandRows = HashSet<Int>()
+    if (settings.commandLine) {
+        commandRows += tokenizeSlices(source, commandLineSlices(source), vocabulary, out)
+        // Commands already run keep their colors: the cursor has moved to the next prompt, and
+        // without this pass a command would go plain the moment it is executed.
+        for (r in window) {
+            if (r in commandRows) continue
+            commandRows += tokenizeSlices(source, executedCommandSlices(source, r), vocabulary, out)
+        }
+    }
+    if (settings.output && !source.altScreen) {
+        for (r in window) {
+            if (r in commandRows || r !in screen.indices) continue
+            outputHighlight(screen[r])?.let { out[r] = it }
+        }
+    }
+    return out
+}
+
+/**
+ * Tokenizes one command line ([slices], from either the cursor or a line already run) and fills
+ * [out] with its rows. Returns the rows it claimed, so the output pass can skip them — a typed
+ * `ERROR` must read as an argument, not as a log level.
+ */
+private fun tokenizeSlices(
+    source: HighlightSource,
+    slices: List<CommandLineSlice>,
+    vocabulary: CommandVocabulary,
+    out: MutableMap<Int, RowHighlight>,
+): Set<Int> {
+    val screen = source.screen
+    if (slices.isEmpty()) return emptySet()
+    val flat = commandLineText(screen, slices)
+    if (flat.text.isBlank()) return slices.mapTo(HashSet()) { it.row }
+
+    val perRow = HashMap<Int, MutableList<ColumnSpan>>()
+    for (span in tokenizeCommandLine(flat.text, vocabulary)) {
+        for (i in span.start until span.endExclusive) {
+            val row = flat.rowAt(i)
+            val col = flat.colAt(i)
+            if (screen[row].getOrNull(col)?.style?.acceptsHighlight() != true) continue
+            perRow.getOrPut(row) { ArrayList() }.appendColumn(col, span.kind)
+        }
+    }
+    perRow.forEach { (row, spans) -> out[row] = RowHighlight.of(spans) }
+    return slices.mapTo(HashSet()) { it.row }
+}
+
+/** Log levels, addresses and timestamps in one output row, or `null` when it holds none. */
+private fun outputHighlight(row: List<TermCell>): RowHighlight? {
+    if (!rowHasOutputMarker(row)) return null
+    val flat = rowText(row) ?: return null
+    val spans = highlightOutputLine(flat.text)
+    if (spans.isEmpty()) return null
+    val columns = ArrayList<ColumnSpan>(spans.size)
+    for (span in spans) {
+        for (i in span.start until span.endExclusive) {
+            val col = flat.column(i)
+            if (row.getOrNull(col)?.style?.acceptsHighlight() != true) continue
+            columns.appendColumn(col, span.kind)
+        }
+    }
+    return if (columns.isEmpty()) null else RowHighlight.of(columns)
+}
+
+/**
+ * Appends column [col] to the last span when it continues it, otherwise starts a new one. Building
+ * per column (rather than per token) is what lets a span be cut around cells the server colored.
+ */
+private fun MutableList<ColumnSpan>.appendColumn(col: Int, kind: HighlightKind) {
+    val last = lastOrNull()
+    if (last != null && last.kind == kind && last.endColExclusive == col) {
+        this[lastIndex] = last.copy(endColExclusive = col + 1)
+    } else {
+        add(ColumnSpan(col, col + 1, kind))
+    }
+}
+
+/**
+ * Allocation-free prescan: every rule needs a digit (addresses, timestamps), an uppercase letter (a
+ * bare `ERROR`) or a colon (`error:`, `10:11:12`). Output rows are scanned per snapshot, and prose
+ * — the bulk of them — carries none of the three.
+ */
+private fun rowHasOutputMarker(row: List<TermCell>): Boolean {
+    var scanned = 0
+    for (cell in row) {
+        for (ch in cell.text) {
+            if (ch.isDigit() || ch.isUpperCase() || ch == ':') return true
+            if (++scanned >= MAX_OUTPUT_SCAN) return false
+        }
+    }
+    return false
+}
+
+/**
+ * Highlight categories for [window], recomputed only when something they depend on changes.
+ *
+ * Deliberately in composition rather than in the draw phase: the terminal Canvas repaints on every
+ * cursor blink and on every pixel of a selection drag, and tokenizing there would redo identical
+ * work dozens of times a second.
+ */
+@Composable
+internal fun rememberRowHighlights(
+    state: TerminalScreenState,
+    screen: List<List<TermCell>>,
+    window: IntRange,
+): Map<Int, RowHighlight> {
+    val settings = LocalTerminalHighlight.current
+    return remember(
+        screen, window, settings, state.vocabulary, state.executedCommands,
+        state.cursorRow, state.cursorCol, state.altScreen,
+    ) {
+        highlightRows(
+            source = HighlightSource(
+                screen = screen,
+                cursor = TerminalPos(state.cursorRow, state.cursorCol),
+                altScreen = state.altScreen,
+                executedCommands = state.executedCommands,
+            ),
+            window = window,
+            settings = settings,
+            vocabulary = state.vocabulary,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightSettings.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightSettings.kt
@@ -1,0 +1,32 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import app.skerry.shared.terminal.highlight.HighlightKind
+
+/**
+ * Which client-side highlighting the terminal applies. Two switches rather than one because the two
+ * halves differ in whose text they touch: [commandLine] colors what the user types (on by default),
+ * while [output] repaints what the server printed — an opinion about someone else's output, so it
+ * stays off until asked for.
+ */
+@Immutable
+data class TerminalHighlight(
+    val commandLine: Boolean = true,
+    val output: Boolean = false,
+) {
+    val enabled: Boolean get() = commandLine || output
+}
+
+/**
+ * Highlighting settings for the terminal subtree. A composition local (like
+ * [LocalTerminalAppearance]) so the setting reaches every terminal surface — panes, the mobile view,
+ * the recording player — without threading two more parameters through their signatures.
+ */
+val LocalTerminalHighlight = staticCompositionLocalOf { TerminalHighlight() }
+
+/** Number of highlight categories — the width of the per-style glyph cache in the render layer. */
+internal val HIGHLIGHT_KIND_COUNT = HighlightKind.entries.size
+
+/** Longest a session's executed-command set may grow; mirrors the cap on command history. */
+internal const val MAX_EXECUTED_COMMANDS = 500

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPromptScan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPromptScan.kt
@@ -1,0 +1,189 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.guard.ProductionGuard
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TerminalPos
+
+/** Longest chain of soft-wrapped rows treated as one command line. Beyond this it isn't a command. */
+private const val MAX_COMMAND_ROWS = 8
+
+/**
+ * The part of the typed command line living on grid row [row]: columns `[startCol, endColExclusive)`.
+ */
+internal data class CommandLineSlice(val row: Int, val startCol: Int, val endColExclusive: Int)
+
+/**
+ * The screen state highlighting is derived from: the grid, where the cursor is, whether a
+ * full-screen app owns the screen, and what this session has already run. Travels together because
+ * no rule reads one without the others.
+ *
+ * [executedCommands] is what keeps a command colored after Enter: the cursor has moved on to the
+ * next prompt, so the line above is no longer "the command line", and matching it against commands
+ * this session actually ran is the one signal that cannot mistake output for input.
+ */
+internal data class HighlightSource(
+    val screen: List<List<TermCell>>,
+    val cursor: TerminalPos,
+    val altScreen: Boolean,
+    val executedCommands: Set<String> = emptySet(),
+)
+
+/**
+ * The typed command line as one string, with each character mapped back to the grid cell it was read
+ * from — a wide glyph spans two columns and a continuation cell carries no character at all, so
+ * string index and column diverge and spans would land beside their text.
+ */
+internal class CommandLineText(val text: String, private val rows: IntArray, private val cols: IntArray) {
+    fun rowAt(index: Int): Int = rows[index]
+    fun colAt(index: Int): Int = cols[index]
+}
+
+/**
+ * Finds the command line the user is typing, as grid slices with the prompt cut off, or an empty
+ * list when nothing on screen reads as one.
+ *
+ * Only the cursor row and its soft-wrap continuations are considered — never a row of past output.
+ * That is what makes a `$ ` printed inside output harmless: it isn't where the cursor is, so it is
+ * never examined. Where the prompt ends is [ProductionGuard.promptEnd], the same heuristic the
+ * production guard uses to decide what was typed.
+ *
+ * There is no semantic prompt marking (OSC 133) to lean on, and the snapshot doesn't carry
+ * [app.skerry.shared.terminal.TermRow.wrapped], so a soft wrap is inferred from a row being filled
+ * to its last column. A row that happens to end exactly at the edge therefore joins the next one —
+ * the cost is a highlight reaching one row too far, on a line the user is editing anyway.
+ */
+internal fun commandLineSlices(source: HighlightSource): List<CommandLineSlice> {
+    val screen = source.screen
+    val cursor = source.cursor
+    // A full-screen app (vim, htop, mc) has no shell line: whatever the cursor sits on is the app's.
+    if (source.altScreen) return emptyList()
+    if (cursor.row !in screen.indices) return emptyList()
+
+    val first = chainStart(screen, cursor.row)
+    val startCol = promptEndColumn(screen[first])
+    // No prompt terminator: output, or an app's own prompt — not a shell line we can cut.
+    if (startCol < 0) return emptyList()
+    // The cursor sits inside the prompt itself — `read -p`, a password, an app asking a question.
+    if (cursor.row == first && cursor.col < startCol) return emptyList()
+    return chainSlices(screen, first, startCol)
+}
+
+/**
+ * Slices of a command line the session already ran, starting at grid row [row], or an empty list
+ * when that row doesn't begin one.
+ *
+ * A past line has no cursor to anchor on, so the anchor is [HighlightSource.executedCommands]: the
+ * text after the prompt must equal a command this session executed. Output that merely contains a
+ * `$ ` never matches, because it would have to be character-for-character a command that ran.
+ */
+internal fun executedCommandSlices(source: HighlightSource, row: Int): List<CommandLineSlice> {
+    val screen = source.screen
+    if (source.altScreen || source.executedCommands.isEmpty()) return emptyList()
+    if (row !in screen.indices || source.cursor.row !in screen.indices) return emptyList()
+    // Only the first row of a wrapped chain starts a command; the rest are handled with it.
+    if (row > 0 && isFilledToEdge(screen[row - 1])) return emptyList()
+    // The line under the cursor is the live command line and is highlighted by its own path.
+    if (row == chainStart(screen, source.cursor.row)) return emptyList()
+    if (!rowHasPromptMarker(screen[row])) return emptyList()
+
+    val startCol = promptEndColumn(screen[row])
+    if (startCol < 0) return emptyList()
+    val slices = chainSlices(screen, row, startCol)
+    if (slices.isEmpty()) return emptyList()
+    val text = commandLineText(screen, slices).text
+    return if (text in source.executedCommands) slices else emptyList()
+}
+
+/** Slices of the soft-wrap chain starting at [first], with the prompt cut at [startCol]. */
+private fun chainSlices(
+    screen: List<List<TermCell>>,
+    first: Int,
+    startCol: Int,
+): List<CommandLineSlice> {
+    val last = chainEnd(screen, first)
+    val slices = ArrayList<CommandLineSlice>(last - first + 1)
+    for (r in first..last) {
+        val from = if (r == first) startCol else 0
+        // The text ends where the row does, not at the cursor: editing mid-line must not drop the
+        // colors from everything to the right of it.
+        val to = lastUsedColumn(screen[r]) + 1
+        if (to > from) slices.add(CommandLineSlice(r, from, to))
+    }
+    return slices
+}
+
+/**
+ * Allocation-free scan for a prompt terminator followed by whitespace. Runs for every visible row of
+ * every snapshot, ahead of the StringBuilder and the regex behind [ProductionGuard.promptEnd].
+ */
+private fun rowHasPromptMarker(row: List<TermCell>): Boolean {
+    var prev = ' '
+    var scanned = 0
+    for (cell in row) {
+        for (ch in cell.text) {
+            if (prev in ProductionGuard.PROMPT_TERMINATORS && ch.isWhitespace()) return true
+            // A prompt lives at the start of the line; scanning the whole row would only find the
+            // `>` of a diff or the `%` of a progress bar and pay for flattening the row for nothing.
+            if (++scanned > MAX_PROMPT_SCAN) return false
+            prev = ch
+        }
+    }
+    return false
+}
+
+/** Columns a prompt may occupy. Past this, a terminator belongs to output, not to a prompt. */
+private const val MAX_PROMPT_SCAN = 96
+
+/**
+ * Flattens [slices] into the string the tokenizer sees, keeping the grid position of every
+ * character. A soft wrap continues the same word, so rows are concatenated without a separator.
+ */
+internal fun commandLineText(screen: List<List<TermCell>>, slices: List<CommandLineSlice>): CommandLineText {
+    val sb = StringBuilder()
+    val rows = ArrayList<Int>()
+    val cols = ArrayList<Int>()
+    for (slice in slices) {
+        val row = screen[slice.row]
+        for (c in slice.startCol until slice.endColExclusive) {
+            val cell = row.getOrNull(c) ?: continue
+            // A continuation cell has empty text: it adds a column but no character.
+            for (ch in cell.text) { sb.append(ch); rows.add(slice.row); cols.add(c) }
+        }
+    }
+    return CommandLineText(sb.toString(), rows.toIntArray(), cols.toIntArray())
+}
+
+/**
+ * Column where the typed text starts on a prompt row, or -1 when the row doesn't look like a prompt.
+ * Works in columns rather than string indices so a wide glyph in the prompt doesn't shift the cut.
+ */
+private fun promptEndColumn(row: List<TermCell>): Int {
+    val flat = rowText(row) ?: return -1
+    val end = ProductionGuard.promptEnd(flat.text)
+    if (end == 0) return -1
+    // promptEnd points just past the terminator's trailing space; that space's column + 1 is the cut.
+    return flat.column(end - 1) + 1
+}
+
+/** First row of the soft-wrap chain containing [row]. */
+private fun chainStart(screen: List<List<TermCell>>, row: Int): Int {
+    var first = row
+    while (first > 0 && row - first < MAX_COMMAND_ROWS && isFilledToEdge(screen[first - 1])) first--
+    return first
+}
+
+/** Last row of the soft-wrap chain containing [row]. */
+private fun chainEnd(screen: List<List<TermCell>>, row: Int): Int {
+    var last = row
+    while (last < screen.lastIndex && last - row < MAX_COMMAND_ROWS && isFilledToEdge(screen[last])) last++
+    return last
+}
+
+/** Whether the row runs to its last column — the only available hint that the line wrapped. */
+private fun isFilledToEdge(row: List<TermCell>): Boolean = row.lastOrNull()?.text?.isNotBlank() == true
+
+/** Index of the last non-blank column, or -1 for a blank row. */
+private fun lastUsedColumn(row: List<TermCell>): Int {
+    for (c in row.indices.reversed()) if (row[c].text.isNotBlank()) return c
+    return -1
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
@@ -34,20 +34,53 @@ internal fun trimTrailingPunct(token: String, punct: String): String {
 }
 
 /**
- * Runs [detect] over a grid row's text and returns its spans in **column** coordinates: a wide glyph
- * occupies two columns (its continuation cell has empty text), so string index and column diverge,
- * and clicks would otherwise miss the match. Callers do their own allocation-free "could this row
- * match at all" prescan first — this builds a StringBuilder, and on a draw pass most rows can't
- * match anything.
+ * A grid row flattened to plain [text], with [colOf] mapping each string index back to the column it
+ * came from. The two diverge because a wide glyph occupies two columns (its continuation cell has
+ * empty text) and a cell may hold a combining sequence — without the map, matches would land a
+ * column or two off.
+ */
+internal class RowText(val text: String, private val colOf: IntArray) {
+
+    /** Column the character at string index [index] was drawn in. */
+    fun column(index: Int): Int = colOf[index]
+
+    /** Converts a string-index span into the column span `[start, endExclusive)` it covers. */
+    fun columns(start: Int, endExclusive: Int): IntRange = colOf[start]..colOf[endExclusive - 1]
+}
+
+/**
+ * Flattens a grid row for text-level detectors, or `null` when the row holds no characters at all.
+ * Callers do their own allocation-free "could this row match at all" prescan first — this builds a
+ * StringBuilder, and on a draw pass most rows can't match anything.
+ */
+internal fun rowText(row: List<TermCell>): RowText? {
+    val sb = StringBuilder(row.size)
+    // IntArray with a counter rather than ArrayList<Int>: this runs for every visible row of every
+    // snapshot, and boxing one Integer per character showed up as steady GC pressure while output
+    // streams. A row can hold combining sequences, so the array is grown rather than sized once.
+    var colOf = IntArray(row.size)
+    var n = 0
+    for (c in row.indices) {
+        for (ch in row[c].text) {
+            if (n == colOf.size) colOf = colOf.copyOf(n * 2 + 1)
+            sb.append(ch)
+            colOf[n++] = c
+        }
+    }
+    if (n == 0) return null
+    return RowText(sb.toString(), if (n == colOf.size) colOf else colOf.copyOf(n))
+}
+
+/**
+ * Runs [detect] over a grid row's text and returns its spans in **column** coordinates (see
+ * [RowText]), so a click lands on the match rather than beside it.
  */
 internal fun rowTextSpans(row: List<TermCell>, detect: (String) -> List<TextLinkSpan>): List<TextLinkSpan> {
-    val sb = StringBuilder(row.size)
-    val colOf = ArrayList<Int>(row.size)
-    for (c in row.indices) {
-        for (ch in row[c].text) { sb.append(ch); colOf.add(c) }
-    }
-    if (colOf.isEmpty()) return emptyList()
-    val found = detect(sb.toString())
+    val flat = rowText(row) ?: return emptyList()
+    val found = detect(flat.text)
     if (found.isEmpty()) return emptyList()
-    return found.map { s -> TextLinkSpan(colOf[s.start], colOf[s.endExclusive - 1] + 1, s.uri) }
+    return found.map { s ->
+        val cols = flat.columns(s.start, s.endExclusive)
+        TextLinkSpan(cols.first, cols.last + 1, s.uri)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -91,6 +91,8 @@ import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
 import app.skerry.shared.terminal.TermStyle
+import app.skerry.shared.terminal.highlight.HighlightKind
+import app.skerry.shared.terminal.highlight.applyTo
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.searchTerminal
 import app.skerry.shared.terminal.TerminalState
@@ -405,7 +407,9 @@ fun TerminalScreen(
     // Glyph TextStyle cache keyed by TermStyle: toGlyphStyle does merge() (SpanStyle+TextStyle
     // allocation) per run. There are hundreds of rows/runs per frame but few distinct styles, so
     // memoize. Reset on a base style or palette (OSC 4/104) change — the result depends on them.
-    val glyphStyleCache = remember(textStyle, state.palette, termTheme) { HashMap<TermStyle, TextStyle>() }
+    // Keyed by TermStyle, then by highlight category: looking up a highlighted run must not build a
+    // derived TermStyle first, or every frame of a drag would allocate one per run just to hit the cache.
+    val glyphStyleCache = remember(textStyle, state.palette, termTheme) { HashMap<TermStyle, Array<TextStyle?>>() }
 
     // textStyle-derived styles are computed once per font/theme change, not in the draw phase: the
     // cursor overlay repaints every blink half-period, where copy() would allocate a new TextStyle per
@@ -611,6 +615,7 @@ fun TerminalScreen(
                   ).matches.groupBy { it.row }
               }
           }
+          val highlightByRow = rememberRowHighlights(state, screen, searchWindow)
           // clipToBounds after padding: the scrollback row at the scroll boundary is drawn at top=-chh and
           // would otherwise spill into the top padding zone (desktop has no default clip, unlike Android)
           // — after `clear` the command row would peek there. The clip cuts it at the content edge.
@@ -661,10 +666,13 @@ fun TerminalScreen(
                   // (mc box-drawing, CJK, symbols) is drawn at its own column separately: a fallback font
                   // gives a non-cellWidth advance, and a long run would accumulate drift (ragged box
                   // horizontals, colored rows sliding). A wide cell — span=2.
-                  for (run in glyphRuns(row)) {
+                  for (run in glyphRuns(row, highlightByRow[r])) {
                       val x = run.col * cw
                       if (run.text.isNotBlank()) {
-                          val style = glyphStyleCache.getOrPut(run.style) { run.style.toGlyphStyle(textStyle, palette, termTheme) }
+                          val byKind = glyphStyleCache.getOrPut(run.style) { arrayOfNulls(HIGHLIGHT_KIND_COUNT) }
+                          val style = byKind[run.kind.ordinal]
+                              ?: run.kind.applyTo(run.style).toGlyphStyle(textStyle, palette, termTheme)
+                                  .also { byKind[run.kind.ordinal] = it }
                           drawGlyphText(measurer, run.text, Offset(x, top), style)
                       }
                       // Draw the underline across the full run width, including under spaces (like xterm).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.setValue
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.AutocompleteEngine
 import app.skerry.shared.terminal.CommandHistory
+import app.skerry.shared.terminal.highlight.CommandVocabulary
+import app.skerry.shared.terminal.highlight.SessionVocabulary
 import app.skerry.shared.terminal.CursorShape
 import app.skerry.shared.terminal.DEFAULT_MAX_SCROLLBACK
 import app.skerry.shared.terminal.MouseButton
@@ -313,47 +315,6 @@ class TerminalScreenState(
         onForget = { forgetHistoryCommand(it) },
     )
 
-    init {
-        // Sole collector of PTY output; forwards chunks into the command queue. Closes the queue
-        // when output ends (EOF/session close), otherwise the owner loop below would hang forever
-        // in `for (cmd in commands)`.
-        scope.launch {
-            try {
-                session.output.collect { chunk -> commands.send(TerminalCommand.Feed(chunk)) }
-            } finally {
-                commands.close()
-            }
-        }
-        // Sole owner of the emulator: feed and resize run strictly in order. Publishes one snapshot
-        // per batch of immediately-available commands: under heavy output (build, cat) the PTY
-        // delivers many chunks in a row, and publishSnapshot copies the whole scrollback, so doing
-        // it per chunk is expensive (freezes/GC, especially on Android). When the queue is empty,
-        // behavior is unchanged (snapshot right away), so interactive latency does not grow.
-        scope.launch {
-            try {
-                for (cmd in commands) {
-                    applyCommand(cmd)
-                    while (true) {
-                        val next = commands.tryReceive().getOrNull() ?: break
-                        applyCommand(next)
-                    }
-                    publishSnapshot()
-                }
-            } finally {
-                // Cancellation can leave a stop-recording queued with nobody to answer it; hand the
-                // take over here rather than leave the exporting caller awaiting forever.
-                while (true) {
-                    val left = commands.tryReceive().getOrNull() ?: break
-                    if (left is TerminalCommand.StopRecording) left.cast.complete(recorder?.finish())
-                }
-            }
-        }
-        // Sole consumer of outbound bytes: guarantees FIFO write order to the PTY regardless of how
-        // many coroutines call send/sendBytes. All sends go through [outbound].
-        scope.launch {
-            for (bytes in outbound) session.send(bytes)
-        }
-    }
 
     /** Apply one command to the emulator (does not publish a snapshot; the caller batches that). */
     private suspend fun applyCommand(cmd: TerminalCommand) {
@@ -518,6 +479,26 @@ class TerminalScreenState(
     )
 
     /**
+     * What the syntax highlighter is allowed to call a command. Rebuilt when a command is committed,
+     * not per keystroke: it is a set built off the whole history, and the answer can only change
+     * once a new command has actually run.
+     */
+    var vocabulary: CommandVocabulary by mutableStateOf(SessionVocabulary(initialHistory))
+        private set
+
+    /**
+     * Commands this session has run, for keeping an executed command colored after Enter. A set of
+     * exact command texts, not a heuristic: matching a scrollback line against it is what stops
+     * output that merely contains a `$ ` from being colored as input.
+     */
+    var executedCommands: Set<String> by mutableStateOf(emptySet())
+        private set
+
+    // Insertion-ordered so the oldest entry can be dropped once the cap is reached; only commands
+    // still on screen can ever match, so keeping every command of a week-old session buys nothing.
+    private val executed = LinkedHashSet<String>()
+
+    /**
      * What to draw in gray at the cursor of the published snapshot: the rest of the suggested command
      * after the part the host has echoed back. `null` when there is nothing to continue there — the
      * echo has not started, the line wrapped onto the next row, or the shell redrew it. The
@@ -596,7 +577,18 @@ class TerminalScreenState(
         // other panes only once it is confirmed (this runs again on confirm), never on the hold.
         if (mirror) inputMirror?.invoke(text, MirroredInput.Typed)
         // Command was committed with Enter (and was echoed): persist the history snapshot for this host.
-        if (committed != null) onHistoryChanged?.invoke(autocomplete.commandHistory.commands)
+        if (committed != null) {
+            val commands = autocomplete.commandHistory.commands
+            onHistoryChanged?.invoke(commands)
+            // The host's own tooling becomes a known command after its first run.
+            vocabulary = SessionVocabulary(commands)
+            // Only commands run *here* count: a preloaded history belongs to earlier sessions whose
+            // lines are not on this screen, and matching against them could color unrelated output.
+            executed.remove(committed)
+            executed.add(committed)
+            while (executed.size > MAX_EXECUTED_COMMANDS) executed.remove(executed.first())
+            executedCommands = executed.toSet()
+        }
     }
 
     // --- Production guard ---
@@ -959,6 +951,54 @@ class TerminalScreenState(
      */
     fun applyClipboardWriteEnabled(enabled: Boolean) {
         commands.trySend(TerminalCommand.SetClipboardWriteEnabled(enabled))
+    }
+
+    // The init block sits at the very END of the class body on purpose: it starts coroutines
+    // that call publishSnapshot -> refreshSuggestion, which writes state properties declared
+    // further down. Kotlin runs initializers in declaration order, so an init block placed above
+    // them would let the first PTY chunk land before their `by mutableStateOf` delegates exist —
+    // a NullPointerException inside setValue, which is what happened when a property whose
+    // initializer took a moment was added between the two.
+    init {
+        // Sole collector of PTY output; forwards chunks into the command queue. Closes the queue
+        // when output ends (EOF/session close), otherwise the owner loop below would hang forever
+        // in `for (cmd in commands)`.
+        scope.launch {
+            try {
+                session.output.collect { chunk -> commands.send(TerminalCommand.Feed(chunk)) }
+            } finally {
+                commands.close()
+            }
+        }
+        // Sole owner of the emulator: feed and resize run strictly in order. Publishes one snapshot
+        // per batch of immediately-available commands: under heavy output (build, cat) the PTY
+        // delivers many chunks in a row, and publishSnapshot copies the whole scrollback, so doing
+        // it per chunk is expensive (freezes/GC, especially on Android). When the queue is empty,
+        // behavior is unchanged (snapshot right away), so interactive latency does not grow.
+        scope.launch {
+            try {
+                for (cmd in commands) {
+                    applyCommand(cmd)
+                    while (true) {
+                        val next = commands.tryReceive().getOrNull() ?: break
+                        applyCommand(next)
+                    }
+                    publishSnapshot()
+                }
+            } finally {
+                // Cancellation can leave a stop-recording queued with nobody to answer it; hand the
+                // take over here rather than leave the exporting caller awaiting forever.
+                while (true) {
+                    val left = commands.tryReceive().getOrNull() ?: break
+                    if (left is TerminalCommand.StopRecording) left.cast.complete(recorder?.finish())
+                }
+            }
+        }
+        // Sole consumer of outbound bytes: guarantees FIFO write order to the PTY regardless of how
+        // many coroutines call send/sendBytes. All sends go through [outbound].
+        scope.launch {
+            for (bytes in outbound) session.send(bytes)
+        }
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopSettingsStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/DesktopSettingsStateTest.kt
@@ -39,6 +39,31 @@ class DesktopSettingsStateTest {
     }
 
     @Test
+    fun toggleHighlightCommandLine_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = DesktopSettingsState(onHighlightCommandLineChange = { seen += it })
+        assertEquals(true, s.highlightCommandLine) // on by default: it only paints the user's own input
+        s.toggleHighlightCommandLine()
+        assertEquals(false, s.highlightCommandLine)
+        s.toggleHighlightCommandLine()
+        assertEquals(true, s.highlightCommandLine)
+        assertEquals(listOf(false, true), seen)
+    }
+
+    @Test
+    fun toggleHighlightOutput_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = DesktopSettingsState(onHighlightOutputChange = { seen += it })
+        // Off by default: it repaints what the server printed, so it is opt-in.
+        assertEquals(false, s.highlightOutput)
+        s.toggleHighlightOutput()
+        assertEquals(true, s.highlightOutput)
+        s.toggleHighlightOutput()
+        assertEquals(false, s.highlightOutput)
+        assertEquals(listOf(true, false), seen)
+    }
+
+    @Test
     fun toggleConfirmProductionWarnings_flips_and_reports() {
         val seen = mutableListOf<Boolean>()
         val s = DesktopSettingsState(onConfirmProductionWarningsChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -48,6 +48,26 @@ class MobileDesignStateTest {
     }
 
     @Test
+    fun toggleHighlightCommandLine_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onHighlightCommandLineChange = { seen += it })
+        assertEquals(true, s.highlightCommandLine) // on by default (desktop parity)
+        s.toggleHighlightCommandLine()
+        assertEquals(false, s.highlightCommandLine)
+        assertEquals(listOf(false), seen)
+    }
+
+    @Test
+    fun toggleHighlightOutput_flips_and_reports() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(onHighlightOutputChange = { seen += it })
+        assertEquals(false, s.highlightOutput) // off by default (desktop parity)
+        s.toggleHighlightOutput()
+        assertEquals(true, s.highlightOutput)
+        assertEquals(listOf(true), seen)
+    }
+
+    @Test
     fun toggleOpenFilePathsInSftp_flips_and_reports() {
         val seen = mutableListOf<Boolean>()
         val s = MobileDesignState(onOpenFilePathsInSftpChange = { seen += it })

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGlyphRunsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalGlyphRunsTest.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.terminal
 import app.skerry.shared.terminal.CellWidth
 import app.skerry.shared.terminal.TermCell
 import app.skerry.shared.terminal.TermStyle
+import app.skerry.shared.terminal.highlight.HighlightKind
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -76,5 +77,34 @@ class TerminalGlyphRunsTest {
         assertEquals(GlyphRun(0, "a", 1, TermStyle()), runs[0])
         assertEquals(GlyphRun(1, "中", 2, TermStyle()), runs[1])
         assertEquals(GlyphRun(3, "b", 1, TermStyle()), runs[2])
+    }
+
+    @Test
+    fun `a highlight category breaks the run at the token boundary`() {
+        val cells = row(TermCell('l'), TermCell('s'), TermCell(' '), TermCell('x'))
+        val highlight = RowHighlight.of(listOf(ColumnSpan(0, 2, HighlightKind.Command)))
+        val runs = glyphRuns(cells, highlight)
+        assertEquals(listOf("ls", " x"), runs.map { it.text })
+        assertEquals(HighlightKind.Command, runs[0].kind)
+        assertEquals(HighlightKind.None, runs[1].kind)
+    }
+
+    @Test
+    fun `without a highlight the segmentation is unchanged`() {
+        val cells = row(TermCell('l'), TermCell('s'), TermCell(' '), TermCell('x'))
+        assertEquals(glyphRuns(cells), glyphRuns(cells, null))
+        assertEquals(1, glyphRuns(cells).size)
+        assertEquals(HighlightKind.None, glyphRuns(cells).single().kind)
+    }
+
+    @Test
+    fun `a wide glyph carries its category`() {
+        val cells = row(
+            TermCell("\u4f60", TermStyle(), CellWidth.Wide),
+            TermCell("", TermStyle(), CellWidth.Continuation),
+        )
+        val runs = glyphRuns(cells, RowHighlight.of(listOf(ColumnSpan(0, 1, HighlightKind.StringLit))))
+        assertEquals(1, runs.size)
+        assertEquals(HighlightKind.StringLit, runs.single().kind)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRowsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRowsTest.kt
@@ -1,0 +1,282 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.CellWidth
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermColor
+import app.skerry.shared.terminal.TermStyle
+import app.skerry.shared.terminal.TerminalPos
+import app.skerry.shared.terminal.highlight.HighlightKind
+import app.skerry.shared.terminal.highlight.SessionVocabulary
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TerminalHighlightRowsTest {
+
+    private val vocabulary = SessionVocabulary()
+
+    private fun row(text: String, style: TermStyle = TermStyle(), width: Int = 40): List<TermCell> {
+        val cells = ArrayList<TermCell>(width)
+        for (ch in text) cells.add(TermCell(ch.toString(), style))
+        while (cells.size < width) cells.add(TermCell(' '))
+        return cells
+    }
+
+    private fun highlight(
+        screen: List<List<TermCell>>,
+        cursorRow: Int = 0,
+        cursorCol: Int = 0,
+        altScreen: Boolean = false,
+        settings: TerminalHighlight = TerminalHighlight(commandLine = true, output = true),
+        executed: Set<String> = emptySet(),
+    ) = highlightRows(
+        HighlightSource(screen, TerminalPos(cursorRow, cursorCol), altScreen, executed),
+        screen.indices,
+        settings,
+        vocabulary,
+    )
+
+    /** Categories of [text]'s columns in row 0, as a string per category for readable assertions. */
+    private fun kindsOf(screen: List<List<TermCell>>, rowIndex: Int, map: Map<Int, RowHighlight>): String {
+        val rh = map[rowIndex] ?: return ""
+        val row = screen[rowIndex]
+        return row.indices.joinToString("") { col ->
+            when (rh.kindAt(col)) {
+                HighlightKind.None -> "."
+                HighlightKind.Command -> "C"
+                HighlightKind.Subcommand -> "s"
+                HighlightKind.Option -> "o"
+                HighlightKind.PathLit -> "p"
+                HighlightKind.LevelError -> "E"
+                else -> "?"
+            }
+        }.trimEnd('.')
+    }
+
+    @Test
+    fun `command line is highlighted around the cursor`() {
+        val screen = listOf(row("user@host:~$ git status"))
+        val map = highlight(screen, cursorCol = 23)
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+        assertEquals(HighlightKind.Subcommand, map.getValue(0).kindAt(17))
+        // The prompt itself is never touched.
+        assertEquals(HighlightKind.None, map.getValue(0).kindAt(0))
+    }
+
+    @Test
+    fun `cells the server already colored are left alone`() {
+        val colored = TermStyle(fg = TermColor.Indexed(1))
+        val screen = listOf(row("user@host:~$ git status", style = colored))
+        assertTrue(highlight(screen, cursorCol = 23).isEmpty())
+    }
+
+    @Test
+    fun `a colored background is respected too`() {
+        val screen = listOf(row("user@host:~$ git status", style = TermStyle(bg = TermColor.Indexed(4))))
+        assertTrue(highlight(screen, cursorCol = 23).isEmpty())
+    }
+
+    @Test
+    fun `reverse video is respected`() {
+        val screen = listOf(row("user@host:~$ git status", style = TermStyle(inverse = true)))
+        assertTrue(highlight(screen, cursorCol = 23).isEmpty())
+    }
+
+    @Test
+    fun `hidden cells stay hidden`() {
+        val screen = listOf(row("user@host:~$ git status", style = TermStyle(hidden = true)))
+        assertTrue(highlight(screen, cursorCol = 23).isEmpty())
+    }
+
+    @Test
+    fun `a partly colored command keeps highlighting on its plain cells`() {
+        val cells = ArrayList<TermCell>()
+        for (ch in "user@host:~$ ") cells.add(TermCell(ch.toString(), TermStyle(fg = TermColor.Indexed(6))))
+        for (ch in "git status") cells.add(TermCell(ch))
+        while (cells.size < 40) cells.add(TermCell(' '))
+        val map = highlight(listOf(cells), cursorCol = 23)
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+    }
+
+    @Test
+    fun `output levels are highlighted`() {
+        val screen = listOf(row("user@host:~$ x"), row("ERROR failed to bind"))
+        val map = highlight(screen, cursorRow = 0, cursorCol = 14)
+        assertEquals(HighlightKind.LevelError, map.getValue(1).kindAt(0))
+        assertEquals(HighlightKind.None, map.getValue(1).kindAt(6))
+    }
+
+    @Test
+    fun `the command row is not scanned as output`() {
+        // "ERROR" typed at the prompt must read as a command-line token, not as a log level.
+        val screen = listOf(row("user@host:~$ grep ERROR /var/log/syslog"))
+        val map = highlight(screen, cursorCol = 38)
+        assertEquals(HighlightKind.None, map.getValue(0).kindAt(18))
+        assertEquals(HighlightKind.PathLit, map.getValue(0).kindAt(24))
+    }
+
+    @Test
+    fun `both switches off means no work at all`() {
+        val screen = listOf(row("user@host:~$ git status"), row("ERROR failed"))
+        val settings = TerminalHighlight(commandLine = false, output = false)
+        assertTrue(highlight(screen, cursorCol = 23, settings = settings).isEmpty())
+    }
+
+    @Test
+    fun `output switch alone leaves the command line plain`() {
+        val screen = listOf(row("user@host:~$ git status"), row("ERROR failed"))
+        val map = highlight(screen, cursorCol = 23, settings = TerminalHighlight(commandLine = false, output = true))
+        assertNull(map[0])
+        assertEquals(HighlightKind.LevelError, map.getValue(1).kindAt(0))
+    }
+
+    @Test
+    fun `command switch alone leaves output plain`() {
+        val screen = listOf(row("user@host:~$ git status"), row("ERROR failed"))
+        val map = highlight(screen, cursorCol = 23, settings = TerminalHighlight(commandLine = true, output = false))
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+        assertNull(map[1])
+    }
+
+    @Test
+    fun `alt screen is left entirely alone`() {
+        val screen = listOf(row("user@host:~$ git status"), row("ERROR failed"))
+        assertTrue(highlight(screen, cursorCol = 23, altScreen = true).isEmpty())
+    }
+
+    @Test
+    fun `only rows of the window are scanned for output`() {
+        val screen = listOf(row("user@host:~$ x"), row("ERROR one"), row("ERROR two"))
+        val map = highlightRows(
+            HighlightSource(screen, TerminalPos(0, 14), altScreen = false, executedCommands = emptySet()),
+            window = 0..1,
+            settings = TerminalHighlight(commandLine = true, output = true),
+            vocabulary = vocabulary,
+        )
+        assertTrue(1 in map)
+        assertNull(map[2])
+    }
+
+    @Test
+    fun `a continuation cell carries no category`() {
+        val cells = ArrayList<TermCell>()
+        for (ch in "user@host:~$ ") cells.add(TermCell(ch))
+        cells.add(TermCell("你", width = CellWidth.Wide))
+        cells.add(TermCell("", width = CellWidth.Continuation))
+        while (cells.size < 40) cells.add(TermCell(' '))
+        val map = highlight(listOf(cells), cursorCol = 15)
+        // Nothing recognizable was typed, so no span may cover the continuation column either.
+        assertEquals(HighlightKind.None, (map[0] ?: RowHighlight.Empty).kindAt(14))
+    }
+
+    @Test
+    fun `lookup outside every span is None`() {
+        val screen = listOf(row("user@host:~$ git status"))
+        val rh = highlight(screen, cursorCol = 23).getValue(0)
+        assertEquals(HighlightKind.None, rh.kindAt(0))
+        assertEquals(HighlightKind.None, rh.kindAt(39))
+        assertEquals(HighlightKind.None, RowHighlight.Empty.kindAt(3))
+    }
+
+    @Test
+    fun `adjacent columns of one token form a single span`() {
+        val screen = listOf(row("user@host:~$ ls -la /var"))
+        val map = highlight(screen, cursorCol = 24)
+        assertEquals("CC.ooo.pppp", kindsOf(screen, 0, map).drop(13))
+    }
+
+    @Test
+    fun `a command that already ran keeps its colors`() {
+        // The regression this exists for: after Enter the cursor moves to the next prompt, and the
+        // command just executed must not go plain.
+        val screen = listOf(row("user@host:~$ git status"), row("user@host:~$ "))
+        val map = highlight(screen, cursorRow = 1, cursorCol = 13, executed = setOf("git status"))
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+        assertEquals(HighlightKind.Subcommand, map.getValue(0).kindAt(17))
+    }
+
+    @Test
+    fun `a past line is not colored unless this session ran it`() {
+        val screen = listOf(row("user@host:~$ git status"), row("user@host:~$ "))
+        assertNull(highlight(screen, cursorRow = 1, cursorCol = 13, executed = emptySet())[0])
+    }
+
+    @Test
+    fun `output that merely looks like a prompt is never colored`() {
+        // The command text is in history, but the output line is not equal to it — no match, no color.
+        val screen = listOf(row("echo '$ git status' >> notes"), row("user@host:~$ "))
+        assertNull(highlight(screen, cursorRow = 1, cursorCol = 13, executed = setOf("git status"))[0])
+    }
+
+    @Test
+    fun `a wrapped executed command is colored across both rows`() {
+        val width = 20
+        val screen = listOf(
+            row("user@host:~$ grep -rn", width = width),
+            row("pattern /var/log", width = width),
+            row("user@host:~$ ", width = width),
+        )
+        val map = highlight(
+            screen, cursorRow = 2, cursorCol = 13,
+            executed = setOf("grep -rnpattern /var/log"),
+        )
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+        assertEquals(HighlightKind.PathLit, map.getValue(1).kindAt(8))
+    }
+
+    @Test
+    fun `executed commands follow the command-line switch, not the output one`() {
+        val screen = listOf(row("user@host:~$ git status"), row("user@host:~$ "))
+        val map = highlight(
+            screen, cursorRow = 1, cursorCol = 13,
+            settings = TerminalHighlight(commandLine = false, output = true),
+            executed = setOf("git status"),
+        )
+        assertNull(map[0])
+    }
+
+    @Test
+    fun `a token is split around cells the server colored mid-word`() {
+        // grep --color paints only the match inside a word: the client must color what is left of
+        // the token on either side and leave the server's cells alone, not give up on the token.
+        val cells = ArrayList<TermCell>()
+        for (ch in "user@host:~$ ") cells.add(TermCell(ch))
+        for (ch in "/var/") cells.add(TermCell(ch))
+        for (ch in "lo") cells.add(TermCell(ch.toString(), TermStyle(fg = TermColor.Indexed(1))))
+        for (ch in "g") cells.add(TermCell(ch))
+        while (cells.size < 40) cells.add(TermCell(' '))
+
+        val rh = highlight(listOf(cells), cursorCol = 22).getValue(0)
+        assertEquals(HighlightKind.PathLit, rh.kindAt(13))
+        assertEquals(HighlightKind.None, rh.kindAt(18), "the server's cell keeps its own color")
+        assertEquals(HighlightKind.None, rh.kindAt(19))
+        assertEquals(HighlightKind.PathLit, rh.kindAt(20), "the token resumes after the hole")
+    }
+
+    @Test
+    fun `a wide glyph inside an argument keeps the grid aligned`() {
+        val cells = ArrayList<TermCell>()
+        for (ch in "user@host:~$ ") cells.add(TermCell(ch))
+        for (ch in "echo \"a") cells.add(TermCell(ch))
+        cells.add(TermCell("好", width = CellWidth.Wide))
+        cells.add(TermCell("", width = CellWidth.Continuation))
+        cells.add(TermCell('"'))
+        while (cells.size < 40) cells.add(TermCell(' '))
+
+        val rh = highlight(listOf(cells), cursorCol = 24).getValue(0)
+        assertEquals(HighlightKind.Command, rh.kindAt(13), "echo")
+        assertEquals(HighlightKind.StringLit, rh.kindAt(18), "the opening quote")
+        assertEquals(HighlightKind.StringLit, rh.kindAt(20), "the wide glyph's own column")
+        assertEquals(HighlightKind.StringLit, rh.kindAt(22), "the closing quote after the continuation")
+    }
+
+    @Test
+    fun `a recalled command is colored as the live line, not as a past one`() {
+        // Arrow-up puts an earlier command back on the prompt. It is where the cursor is, so the
+        // live path owns it; the executed-command matcher must not shadow that.
+        val screen = listOf(row("user@host:~$ git status"))
+        val map = highlight(screen, cursorCol = 23, executed = setOf("git status"))
+        assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalPromptScanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalPromptScanTest.kt
@@ -1,0 +1,124 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.CellWidth
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TerminalPos
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TerminalPromptScanTest {
+
+    /** A grid row of [width] columns holding [text], padded with blanks like the emulator's own. */
+    private fun row(text: String, width: Int = 40): List<TermCell> {
+        val cells = ArrayList<TermCell>(width)
+        for (ch in text) cells.add(TermCell(ch))
+        while (cells.size < width) cells.add(TermCell(' '))
+        return cells
+    }
+
+    private fun screenOf(vararg lines: String, width: Int = 40) = lines.map { row(it, width) }
+
+    private fun sliceText(screen: List<List<TermCell>>, slices: List<CommandLineSlice>) =
+        commandLineText(screen, slices).text
+
+    @Test
+    fun `cuts the prompt off the cursor row`() {
+        val screen = screenOf("user@host:~$ git status")
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(0, 23), altScreen = false))
+        assertEquals("git status", sliceText(screen, slices))
+    }
+
+    @Test
+    fun `root prompt is cut too`() {
+        val screen = screenOf("root@pve:~# systemctl restart nginx")
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(0, 35), altScreen = false))
+        assertEquals("systemctl restart nginx", sliceText(screen, slices))
+    }
+
+    @Test
+    fun `alt screen has no shell line`() {
+        val screen = screenOf("user@host:~$ vim")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 16), altScreen = true)).isEmpty())
+    }
+
+    @Test
+    fun `a row without a prompt terminator is not a command line`() {
+        val screen = screenOf("total 48")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 8), altScreen = false)).isEmpty())
+    }
+
+    @Test
+    fun `output containing a prompt-like dollar is ignored when the cursor is elsewhere`() {
+        val screen = screenOf(
+            "echo '$ rm -rf /' >> notes.txt",
+            "user@host:~$ ls",
+        )
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(1, 15), altScreen = false))
+        assertEquals("ls", sliceText(screen, slices))
+        assertEquals(listOf(1), slices.map { it.row })
+    }
+
+    @Test
+    fun `a row filled to the edge joins the next one`() {
+        val width = 20
+        val screen = listOf(
+            row("user@host:~$ grep -rn", width),
+            row("pattern /var/log", width),
+        )
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(1, 16), altScreen = false))
+        assertEquals(listOf(0, 1), slices.map { it.row })
+        assertEquals("grep -rnpattern /var/log", sliceText(screen, slices))
+    }
+
+    @Test
+    fun `the cursor inside the prompt yields nothing`() {
+        val screen = screenOf("Password for user: ")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 5), altScreen = false)).isEmpty())
+    }
+
+    @Test
+    fun `an empty prompt has no command line`() {
+        val screen = screenOf("user@host:~$ ")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 13), altScreen = false)).isEmpty())
+    }
+
+    @Test
+    fun `the slice runs to the end of the row, not to the cursor`() {
+        val screen = screenOf("user@host:~$ git status --short")
+        // Cursor parked mid-line (the user pressed Home / arrowed left).
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(0, 16), altScreen = false))
+        assertEquals("git status --short", sliceText(screen, slices))
+    }
+
+    @Test
+    fun `a cursor row outside the screen yields nothing`() {
+        val screen = screenOf("user@host:~$ ls")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(5, 0), altScreen = false)).isEmpty())
+        assertTrue(commandLineSlices(HighlightSource(emptyList(), TerminalPos(0, 0), altScreen = false)).isEmpty())
+    }
+
+    @Test
+    fun `a wide glyph in the prompt does not shift the cut`() {
+        val cells = ArrayList<TermCell>()
+        cells.add(TermCell("你", width = CellWidth.Wide))
+        cells.add(TermCell("", width = CellWidth.Continuation))
+        for (ch in "$ ls -la") cells.add(TermCell(ch))
+        while (cells.size < 40) cells.add(TermCell(' '))
+        val screen = listOf(cells)
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(0, 12), altScreen = false))
+        assertEquals("ls -la", sliceText(screen, slices))
+        assertEquals(4, slices.single().startCol)
+    }
+
+    @Test
+    fun `character positions map back to their columns`() {
+        val screen = screenOf("user@host:~$ ls")
+        val slices = commandLineSlices(HighlightSource(screen, TerminalPos(0, 15), altScreen = false))
+        val flat = commandLineText(screen, slices)
+        assertEquals("ls", flat.text)
+        assertEquals(13, flat.colAt(0))
+        assertEquals(14, flat.colAt(1))
+        assertEquals(0, flat.rowAt(0))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -955,6 +956,70 @@ class TerminalScreenStateTest {
 
         assertEquals("hit", state.search.query)
         assertEquals(1, state.search.matches.size)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a committed command joins the vocabulary and the executed set`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        assertFalse(state.vocabulary.isCommand("pveversion"), "unknown before it is ever run")
+        state.typeInput("pveversion -v")
+        state.typeInput("\r")
+
+        assertEquals(setOf("pveversion -v"), state.executedCommands)
+        assertTrue(state.vocabulary.isCommand("pveversion"), "the host's own tool is known after one run")
+        scope.cancel()
+    }
+
+    @Test
+    fun `input typed at a password prompt never reaches the executed set`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        session.echoOff = true
+        state.typeInput("hunter2")
+        state.typeInput("\r")
+
+        assertEquals(emptySet(), state.executedCommands)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the executed set stays bounded over a long session`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        repeat(MAX_EXECUTED_COMMANDS + 50) { i ->
+            state.typeInput("cmd$i")
+            state.typeInput("\r")
+        }
+
+        assertEquals(MAX_EXECUTED_COMMANDS, state.executedCommands.size)
+        assertTrue("cmd0" !in state.executedCommands, "the oldest command is dropped, not kept forever")
+        assertTrue("cmd${MAX_EXECUTED_COMMANDS + 49}" in state.executedCommands, "the newest is kept")
+        scope.cancel()
+    }
+
+    /**
+     * Construction must survive output arriving before the constructor returns. The session below
+     * emits at collection time, and with an unconfined dispatcher the init coroutine runs straight
+     * through publishSnapshot -> refreshSuggestion — which writes state properties. If the init
+     * block is ever moved above them, their `by mutableStateOf` delegates do not exist yet and this
+     * throws a NullPointerException inside setValue.
+     */
+    @Test
+    fun `a chunk arriving during construction does not break initialization`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = EagerOutputSession("hello\r\n".encodeToByteArray())
+        val state = TerminalScreenState(session, scope)
+
+        assertTrue(state.screen.isNotEmpty(), "the eager chunk was applied")
+        assertFalse(state.hasSuggestion)
         scope.cancel()
     }
 
@@ -1896,4 +1961,17 @@ private class FakeTerminalSession : TerminalSession {
         _state.value = TerminalState.Closed()
         emissions.close()
     }
+}
+
+/**
+ * A session whose output is already available the moment it is collected — the shape that makes a
+ * PTY chunk land while [TerminalScreenState] is still being constructed.
+ */
+private class EagerOutputSession(private vararg val chunks: ByteArray) : TerminalSession {
+    private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+    override val state: StateFlow<TerminalState> = _state
+    override val output: Flow<ByteArray> = flow { chunks.forEach { emit(it) } }
+    override suspend fun send(data: ByteArray) {}
+    override suspend fun resize(size: PtySize) {}
+    override suspend fun close() {}
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -455,6 +455,8 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
             prefs.set("terminal_show_title", false)
             prefs.set("terminal_clipboard_write", false)
             prefs.set("terminal_prod_warnings", false)
+            prefs.set("terminal_highlight_input", true)
+            prefs.set("terminal_highlight_output", false)
             prefs.set("auto_lock", AutoLockDuration.DEFAULT.id)
         }
         hosts.reload()
@@ -636,6 +638,10 @@ fun main(args: Array<String>) {
                             onReportTeamSessionsChange = { prefs.set("teams_report_sessions", it) },
                             initialOpenFilePathsInSftp = prefs.bool("terminal_open_paths", true),
                             onOpenFilePathsInSftpChange = { prefs.set("terminal_open_paths", it) },
+                            initialHighlightCommandLine = prefs.bool("terminal_highlight_input", true),
+                            onHighlightCommandLineChange = { prefs.set("terminal_highlight_input", it) },
+                            initialHighlightOutput = prefs.bool("terminal_highlight_output", false),
+                            onHighlightOutputChange = { prefs.set("terminal_highlight_output", it) },
                             initialConfirmProductionWarnings = prefs.bool("terminal_prod_warnings", false),
                             onConfirmProductionWarningsChange = { prefs.set("terminal_prod_warnings", it) },
                             initialAutoLock = prefs.id("auto_lock", AutoLockDuration.DEFAULT, AutoLockDuration::fromId),

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -1,0 +1,212 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.use
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Renders a live [TerminalScreen] offscreen and checks that syntax highlighting reaches the glyphs:
+ * a typed command turns the theme's green, the switch actually turns it off, and a color the server
+ * chose itself is never overpainted. The categorization is covered by the tokenizer's own tests;
+ * this is the draw path.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+class TerminalHighlightRenderTest {
+
+    /** Fake PTY session: output only, input/resize are no-ops. */
+    private class FakeSession : TerminalSession {
+        private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+        override val state: StateFlow<TerminalState> = _state.asStateFlow()
+        private val _output = MutableSharedFlow<ByteArray>(extraBufferCapacity = 64)
+        override val output: Flow<ByteArray> = _output.asSharedFlow()
+        override suspend fun send(data: ByteArray) {}
+        override suspend fun resize(size: PtySize) {}
+        override suspend fun close() {}
+        fun emit(text: String) {
+            check(_output.tryEmit(text.encodeToByteArray())) { "output buffer overflow" }
+        }
+    }
+
+    private val theme = TerminalThemes.NightSea
+
+    /** Runs [body] against a rendered terminal with the given highlight settings. */
+    private fun withScreen(
+        highlight: TerminalHighlight,
+        body: (session: FakeSession, frame: () -> PixelMap) -> Unit,
+    ) {
+        // Unconfined: feed/resize run synchronously at the emit point, making frames deterministic.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides highlight,
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                // Let layout settle (resize -> sized=true) before emitting.
+                repeat(3) { frame() }
+                body(session, ::frame)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** Renders a few frames and reports whether [color] ended up on screen. */
+    private fun settle(frame: () -> PixelMap, color: Color): Boolean {
+        var pixels = frame()
+        repeat(4) { pixels = frame() }
+        return pixels.hasColorNear(color.toArgb())
+    }
+
+    @Test
+    fun typedCommandIsPaintedInTheThemeGreen() {
+        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frame ->
+            session.emit("user@host:~$ git status")
+            assertTrue(settle(frame, theme.ansi[2]), "a known command should be drawn in the theme's green")
+        }
+    }
+
+    @Test
+    fun theSwitchTurnsHighlightingOff() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            session.emit("user@host:~$ git status")
+            assertFalse(settle(frame, theme.ansi[2]), "nothing may be recolored while the switch is off")
+        }
+    }
+
+    @Test
+    fun outputLevelsArePaintedOnlyWhenAskedFor() {
+        withScreen(TerminalHighlight(commandLine = false, output = true)) { session, frame ->
+            session.emit("\r\nERROR failed to bind\r\n")
+            assertTrue(settle(frame, theme.ansi[1]), "a log level should be drawn in the theme's red")
+        }
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            session.emit("\r\nERROR failed to bind\r\n")
+            assertFalse(settle(frame, theme.ansi[1]), "output stays plain while the switch is off")
+        }
+    }
+
+    @Test
+    fun theServerWinsTheArgumentAboutColor() {
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+            // The server prints ERROR in its own green; the client's rule would make it red.
+            session.emit("\r\n\u001b[32mERROR failed to bind\u001b[0m\r\n")
+            var pixels = frame()
+            repeat(4) { pixels = frame() }
+            assertTrue(pixels.hasColorNear(theme.ansi[2].toArgb()), "the server's green must survive")
+            assertFalse(pixels.hasColorNear(theme.ansi[1].toArgb()), "an already-colored cell must not be repainted")
+        }
+    }
+
+    @Test
+    fun anExecutedCommandKeepsItsColorAfterEnter() {
+        // The regression a user hit: the command went plain the moment it ran. The state is driven
+        // through typeInput so the executed-command set is populated the way it is in a session.
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides TerminalHighlight(commandLine = true, output = false),
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                repeat(3) { frame() }
+
+                session.emit("user@host:~$ ")
+                state.typeInput("git status")
+                session.emit("git status")
+                state.typeInput("\r")
+                // The shell echoes the newline and draws the next prompt; the command is now history.
+                session.emit("\r\nuser@host:~$ ")
+
+                var pixels = frame()
+                repeat(5) { pixels = frame() }
+                assertTrue(
+                    pixels.hasColorNear(theme.ansi[2].toArgb()),
+                    "the executed command must stay green once the cursor moves to the next prompt",
+                )
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** Whether opaque pixel [argb] matches [target] within [tolerance] on every channel. */
+    private fun matches(argb: Int, target: Int, tolerance: Int): Boolean {
+        if ((argb ushr 24) != 0xFF) return false
+        for (shift in intArrayOf(16, 8, 0)) {
+            if (abs((argb shr shift and 0xFF) - (target shr shift and 0xFF)) > tolerance) return false
+        }
+        return true
+    }
+
+    /** Whether any pixel is within [tolerance] per channel of [argb] (antialiasing shifts edges). */
+    private fun PixelMap.hasColorNear(argb: Int, tolerance: Int = 2): Boolean {
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                if (matches(this[x, y].toArgb(), argb, tolerance)) return true
+            }
+        }
+        return false
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
@@ -66,7 +66,24 @@ object ProductionGuard {
      * Prompt terminator: the `$`/`#`/`%`/`>` (and the usual powerline/starship arrows) followed by a
      * space that separates a shell prompt from what was typed after it.
      */
-    private val PROMPT_TERMINATOR = Regex("""[$#%>❯➜»›]\s""")
+    /**
+     * Characters that end a shell prompt. Exposed because the syntax highlighter needs the same set
+     * for its allocation-free prescan: a second hand-written copy would silently drift from this one
+     * the day a prompt glyph is added, and rows the guard cuts would stop being highlighted.
+     */
+    const val PROMPT_TERMINATORS = "$#%>❯➜»›"
+
+    private val PROMPT_TERMINATOR = Regex("[$PROMPT_TERMINATORS]\\s")
+
+    /**
+     * Index just past the prompt in [line], or 0 when it doesn't look like a prompt at all. Shared
+     * with the syntax highlighter, which needs the *position* of the cut rather than the text after
+     * it — one heuristic, so the guard and the highlighter never disagree on where a command starts.
+     *
+     * The cut is at the FIRST terminator, not the last: `cat img > /dev/sda` contains a `>` of its
+     * own, and cutting there would leave `/dev/sda` and lose the very command worth stopping.
+     */
+    fun promptEnd(line: String): Int = PROMPT_TERMINATOR.find(line)?.let { it.range.last + 1 } ?: 0
 
     /** Whether [tags] make a host production (carries [PROD_TAG]). */
     fun isProduction(tags: List<String>): Boolean = PROD_TAG in tags
@@ -131,17 +148,15 @@ object ProductionGuard {
 
     /**
      * Command candidates from a raw screen line: the line itself plus, when it looks like a prompt,
-     * the tail after the prompt. Both are kept — cutting is a guess, and the uncut line still holds
-     * the command.
-     *
-     * The cut is at the FIRST prompt terminator, not the last: `cat img > /dev/sda` contains a `>`
-     * of its own, and cutting there would leave `/dev/sda` and lose the very command worth stopping.
+     * the tail after the prompt ([promptEnd]). Both are kept — cutting is a guess, and the uncut
+     * line still holds the command.
      */
     fun promptCandidates(rawLine: String): List<String> {
         val line = rawLine.trim().take(MAX_GUARDED_COMMAND_LENGTH)
         if (line.isEmpty()) return emptyList()
-        val match = PROMPT_TERMINATOR.find(line) ?: return listOf(line)
-        val tail = line.substring(match.range.last + 1).trim()
+        val cut = promptEnd(line)
+        if (cut == 0) return listOf(line)
+        val tail = line.substring(cut).trim()
         return if (tail.isEmpty() || tail == line) listOf(line) else listOf(line, tail)
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/CommandLineTokenizer.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/CommandLineTokenizer.kt
@@ -1,0 +1,204 @@
+package app.skerry.shared.terminal.highlight
+
+/** Beyond this a "command line" is pasted data, not something worth tokenizing per keystroke. */
+const val MAX_HIGHLIGHT_LENGTH = 4096
+
+/** Characters that end a word and start an operator. Braces are left out — `{a,b}` is expansion, not control. */
+private const val OPERATOR_CHARS = "|&;<>()"
+
+/** Quotes that open a string literal. Backquote is treated as one too: close enough, and it never nests here. */
+private const val QUOTE_CHARS = "\"'`"
+
+/** Single-character variables the shell defines itself: `$?`, `$$`, `$!`, `$#`, `$@`, `$*`, `$-`, `$0`..`$9`. */
+private const val SPECIAL_VARS = "?$!#@*-"
+
+/**
+ * Splits a shell command line into highlight spans (fish-style: command green, options cyan, quoted
+ * strings yellow, paths blue, operators magenta).
+ *
+ * One left-to-right scan, no regex — this runs on every screen snapshot while the user types.
+ * Returned spans are sorted, non-overlapping and within `[0, line.length)`.
+ *
+ * Deliberately not a shell parser: quoted text is one span (a `$VAR` inside `"…"` is not resolved),
+ * `2>&1` reads as digits plus an operator, and an unknown command is simply left uncolored — see
+ * [CommandVocabulary] for why nothing is ever marked as wrong.
+ */
+fun tokenizeCommandLine(line: String, vocabulary: CommandVocabulary): List<HighlightSpan> {
+    val text = if (line.length > MAX_HIGHLIGHT_LENGTH) line.substring(0, MAX_HIGHLIGHT_LENGTH) else line
+    return Tokenizer(text, vocabulary).run()
+}
+
+private class Tokenizer(private val text: String, private val vocabulary: CommandVocabulary) {
+
+    private val out = ArrayList<HighlightSpan>()
+
+    /** Whether the next word sits where a command name goes (line start, after `|`, `;`, `&&`, `sudo`). */
+    private var commandPosition = true
+
+    /** The command whose subcommand the next word could be, or `null`. */
+    private var pendingCommand: String? = null
+
+    fun run(): List<HighlightSpan> {
+        var i = 0
+        while (i < text.length) {
+            val ch = text[i]
+            i = when {
+                ch == ' ' || ch == '\t' -> i + 1
+                ch == '#' && startsToken(i) -> {
+                    add(i, text.length, HighlightKind.Comment)
+                    text.length
+                }
+                ch in OPERATOR_CHARS -> operator(i)
+                else -> word(i)
+            }
+        }
+        return out
+    }
+
+    private fun add(start: Int, endExclusive: Int, kind: HighlightKind) {
+        if (start < endExclusive) out.add(HighlightSpan(start, endExclusive, kind))
+    }
+
+    private fun startsToken(at: Int): Boolean = at == 0 || text[at - 1].isWhitespace()
+
+    /**
+     * Consumes a run of operator characters as one span (`&&`, `||`, `>>`). A pure redirect keeps the
+     * argument position — the word after `>` is a file, not a command; everything else (`|`, `;`, `&`,
+     * `(`) starts a new command.
+     */
+    private fun operator(start: Int): Int {
+        var end = start
+        while (end < text.length && text[end] in OPERATOR_CHARS) end++
+        add(start, end, HighlightKind.Operator)
+        val redirectOnly = (start until end).all { text[it] == '<' || text[it] == '>' }
+        commandPosition = !redirectOnly
+        pendingCommand = null
+        return end
+    }
+
+    /**
+     * Consumes one word — everything up to whitespace or an operator, with quoted sections and
+     * variables taken as they come. A word made only of plain characters is classified as a whole
+     * (command / option / path); one carrying quotes or variables keeps those inner spans, plus an
+     * option prefix when it starts with a dash (`--message="…"`).
+     */
+    private fun word(start: Int): Int {
+        val inner = ArrayList<HighlightSpan>()
+        var i = start
+        while (i < text.length) {
+            val ch = text[i]
+            when {
+                ch == ' ' || ch == '\t' || ch in OPERATOR_CHARS -> return finishWord(start, i, inner)
+                ch in QUOTE_CHARS -> {
+                    val end = quoteEnd(i)
+                    inner.add(HighlightSpan(i, end, HighlightKind.StringLit))
+                    i = end
+                }
+                ch == '$' -> {
+                    val end = variableEnd(i)
+                    if (end > i) inner.add(HighlightSpan(i, end, HighlightKind.Variable))
+                    i = if (end > i) end else i + 1
+                }
+                else -> i++
+            }
+        }
+        return finishWord(start, i, inner)
+    }
+
+    /** End (exclusive) of the string literal opened at [start]; an unterminated quote runs to end of line. */
+    private fun quoteEnd(start: Int): Int {
+        val quote = text[start]
+        var i = start + 1
+        while (i < text.length) {
+            // A backslash escapes inside "…" and `…`, but is literal inside '…' (POSIX).
+            if (quote != '\'' && text[i] == '\\' && i + 1 < text.length) { i += 2; continue }
+            if (text[i] == quote) return i + 1
+            i++
+        }
+        return text.length
+    }
+
+    /** End (exclusive) of the variable reference at [start] (`$NAME`, `${…}`, `$1`, `$?`), or [start] if it isn't one. */
+    private fun variableEnd(start: Int): Int {
+        val next = text.getOrNull(start + 1) ?: return start
+        if (next == '{') {
+            var i = start + 2
+            while (i < text.length && text[i] != '}') i++
+            return if (i < text.length) i + 1 else text.length
+        }
+        if (next in SPECIAL_VARS) return start + 2
+        if (!next.isLetterOrDigit() && next != '_') return start
+        var i = start + 1
+        while (i < text.length && (text[i].isLetterOrDigit() || text[i] == '_')) i++
+        return i
+    }
+
+    private fun finishWord(start: Int, end: Int, inner: List<HighlightSpan>): Int {
+        if (end <= start) return end + 1
+        if (inner.isEmpty()) classifyPlainWord(start, end) else classifyMixedWord(start, inner)
+        return end
+    }
+
+    private fun classifyPlainWord(start: Int, end: Int) {
+        val word = text.substring(start, end)
+        val assignment = assignmentEnd(word)
+        when {
+            // `FOO=1 make build`: the assignment is a prefix of the command, not the command itself.
+            commandPosition && assignment > 0 -> {
+                add(start, start + assignment, HighlightKind.Variable)
+                if (isPathWord(word.substring(assignment))) {
+                    add(start + assignment, end, HighlightKind.PathLit)
+                }
+                return // command position and pending command both survive an assignment prefix
+            }
+            isOptionWord(word) -> {
+                add(start, end, HighlightKind.Option)
+                return // an option never fills the command or argument slot
+            }
+            // A path is checked before the vocabulary: `/usr/bin/git` is a path that happens to end in a name.
+            isPathWord(word) -> add(start, end, HighlightKind.PathLit)
+            commandPosition && vocabulary.isCommand(word) -> {
+                add(start, end, HighlightKind.Command)
+                pendingCommand = word
+                commandPosition = word in COMMAND_PREFIXES
+                return
+            }
+            pendingCommand?.let { vocabulary.isSubcommand(it, word) } == true ->
+                add(start, end, HighlightKind.Subcommand)
+        }
+        commandPosition = false
+        pendingCommand = null
+    }
+
+    private fun classifyMixedWord(start: Int, inner: List<HighlightSpan>) {
+        val first = inner.first()
+        if (first.start > start && text[start] == '-') {
+            add(start, first.start, HighlightKind.Option)
+            out.addAll(inner)
+            return // still an option: `--message="fix"` doesn't consume the command slot
+        }
+        out.addAll(inner)
+        commandPosition = false
+        pendingCommand = null
+    }
+
+    /** Length of a `NAME=` prefix (including the `=`), or 0 when [word] isn't an assignment. */
+    private fun assignmentEnd(word: String): Int {
+        val eq = word.indexOf('=')
+        if (eq <= 0) return 0
+        if (!word[0].isLetter() && word[0] != '_') return 0
+        for (i in 0 until eq) if (!word[i].isLetterOrDigit() && word[i] != '_') return 0
+        return eq + 1
+    }
+
+    private fun isOptionWord(word: String): Boolean =
+        word.length > 1 && word[0] == '-' && (word[1].isLetter() || word[1] == '-')
+
+    /** A word that names a filesystem location: absolute, home- or dot-relative, or simply containing a separator. */
+    private fun isPathWord(word: String): Boolean = when {
+        word.isEmpty() -> false
+        word == "~" || word.startsWith("~/") -> true
+        word[0] == '-' -> false
+        else -> word.contains('/')
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/HighlightKind.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/HighlightKind.kt
@@ -1,0 +1,62 @@
+package app.skerry.shared.terminal.highlight
+
+import app.skerry.shared.terminal.TermColor
+import app.skerry.shared.terminal.TermStyle
+
+/**
+ * Category a piece of terminal text was recognized as, by the client's own highlighting (the shell
+ * and the commands themselves know nothing about it). Two families:
+ *  - command line: [Command]..[Comment] — what the user is typing at the prompt;
+ *  - output: [LevelError]..[Timestamp] — what a command printed without colors of its own.
+ *
+ * A category carries no color: it maps into a [TermStyle] via [applyTo], which uses palette indices
+ * only, so the result follows the active terminal theme (including light ones) and any OSC 4 override.
+ */
+enum class HighlightKind(
+    /** Palette index for the text, or `null` to keep the cell's own color. */
+    internal val paletteIndex: Int?,
+    internal val bold: Boolean = false,
+    internal val dim: Boolean = false,
+) {
+    None(null),
+
+    // Command line. Colors follow fish/zsh-syntax-highlighting so the mapping is already familiar.
+    Command(2, bold = true),
+    Subcommand(2),
+    Option(6),
+    StringLit(3),
+    PathLit(4),
+    Operator(5, bold = true),
+    Variable(13),
+    Comment(null, dim = true),
+
+    // Output.
+    LevelError(1, bold = true),
+    LevelWarn(3, bold = true),
+    LevelInfo(4),
+    LevelDebug(null, dim = true),
+    LevelOk(2),
+    Address(6),
+    Timestamp(null, dim = true),
+}
+
+/** A [kind] recognized over `[start, endExclusive)` of a line — string indices, never columns. */
+data class HighlightSpan(val start: Int, val endExclusive: Int, val kind: HighlightKind)
+
+/**
+ * The style a cell gets under this category: [base] with the palette color (and weight) of the
+ * category laid over it. [None] returns [base] itself — the no-highlight path allocates nothing.
+ *
+ * Colors are palette indices, never literals: on a light theme index 2 is that theme's green, the
+ * same one `ls --color` is already read against there, so contrast is the theme's property and not
+ * something guessed here. [Comment], [LevelDebug] and [Timestamp] only dim, which is safe on any
+ * background.
+ */
+fun HighlightKind.applyTo(base: TermStyle): TermStyle {
+    if (this == HighlightKind.None) return base
+    return base.copy(
+        fg = paletteIndex?.let { TermColor.Indexed(it) } ?: base.fg,
+        bold = base.bold || bold,
+        dim = base.dim || dim,
+    )
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/KnownCommands.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/KnownCommands.kt
@@ -1,0 +1,101 @@
+package app.skerry.shared.terminal.highlight
+
+import app.skerry.shared.terminal.COMMON_COMMANDS
+import app.skerry.shared.terminal.SUBCOMMANDS
+
+/**
+ * What the tokenizer is allowed to call a command. Deliberately a lookup and not a check against the
+ * host: asking the shell (`command -v`) would cost a round-trip per keystroke and pollute the user's
+ * own history, so the vocabulary is local and necessarily incomplete. An unknown word is therefore
+ * left uncolored rather than marked as wrong — the failure mode is "less green", not a false alarm.
+ */
+interface CommandVocabulary {
+    fun isCommand(word: String): Boolean
+    fun isSubcommand(command: String, word: String): Boolean
+
+    /** Knows nothing — every word stays uncolored. For tests and for the highlight-off path. */
+    object Empty : CommandVocabulary {
+        override fun isCommand(word: String): Boolean = false
+        override fun isSubcommand(command: String, word: String): Boolean = false
+    }
+}
+
+/** Shell keywords and builtins: no binary behind them, but they open a command position all the same. */
+val SHELL_KEYWORDS: Set<String> = setOf(
+    "if", "then", "elif", "else", "fi", "for", "while", "until", "do", "done",
+    "case", "esac", "select", "function", "in",
+    "cd", "echo", "export", "source", "alias", "unalias", "set", "unset", "read",
+    "return", "exit", "shift", "test", "eval", "trap", "wait", "jobs", "kill",
+    "pushd", "popd", "dirs", "local", "declare", "typeset", "readonly", "printf",
+)
+
+/**
+ * Words that keep the command position open: what follows them is still a command, not an argument
+ * (`sudo systemctl restart nginx` — both `sudo` and `systemctl` are commands).
+ */
+val COMMAND_PREFIXES: Set<String> = setOf(
+    "sudo", "doas", "env", "time", "nohup", "command", "exec", "watch", "nice", "ionice", "stdbuf",
+)
+
+/**
+ * Base userland present on any Unix host. [COMMON_COMMANDS] is a list of ready-made *lines* for
+ * autocomplete, not a command inventory, so the everyday binaries are enumerated here.
+ */
+val BASE_COMMANDS: Set<String> = setOf(
+    "ls", "cat", "less", "more", "head", "tail", "grep", "egrep", "fgrep", "rg", "ag",
+    "find", "locate", "which", "whereis", "file", "stat", "du", "df", "mount", "umount",
+    "cp", "mv", "rm", "mkdir", "rmdir", "ln", "touch", "chmod", "chown", "chgrp", "install",
+    "tar", "gzip", "gunzip", "zip", "unzip", "xz", "zstd",
+    "ps", "top", "htop", "btop", "kill", "pkill", "pgrep", "nice", "renice", "lsof", "strace",
+    "free", "uptime", "uname", "hostname", "whoami", "id", "who", "w", "last", "groups",
+    "man", "info", "history", "date", "cal", "sleep", "seq", "yes", "tee", "xargs",
+    "sed", "awk", "sort", "uniq", "wc", "cut", "paste", "tr", "diff", "patch", "jq", "yq",
+    "curl", "wget", "ssh", "scp", "sftp", "rsync", "ping", "traceroute", "dig", "nslookup",
+    "netstat", "ss", "ip", "ifconfig", "iptables", "nft", "nc", "tcpdump", "openssl",
+    "vim", "vi", "nvim", "nano", "emacs", "tmux", "screen", "make", "cmake", "gcc", "g++",
+    "python", "python3", "pip", "pip3", "node", "npx", "yarn", "pnpm", "java", "javac",
+    "go", "rustc", "ruby", "perl", "php", "psql", "mysql", "redis-cli", "sqlite3",
+    "adb", "gradle", "gradlew", "mvn", "podman", "helm", "terraform", "ansible", "zfs", "btrfs",
+    "useradd", "usermod", "userdel", "groupadd", "passwd", "su", "crontab", "dmesg", "lsblk",
+    "fdisk", "mkfs", "swapon", "sync", "shutdown", "reboot", "systemd-analyze", "journalctl",
+    "apt-get", "dpkg", "yum", "dnf", "pacman", "zypper", "snap", "flatpak", "rpm",
+)
+
+/**
+ * Vocabulary for one session: the built-in catalogue ([BASE_COMMANDS], [COMMON_COMMANDS],
+ * [SUBCOMMANDS]), shell keywords, and the first word of everything this session ran ([history],
+ * newest first) — so a host's own tooling turns green after its first use.
+ */
+class SessionVocabulary(private val history: List<String> = emptyList()) : CommandVocabulary {
+
+    // Built lazily: this is constructed while a terminal session is being set up, and folding a few
+    // hundred names into a set there would only add latency to the moment the screen first appears.
+    private val commands: Set<String> by lazy { buildCommands() }
+
+    private fun buildCommands(): Set<String> = buildSet {
+        addAll(SHELL_KEYWORDS)
+        addAll(COMMAND_PREFIXES)
+        addAll(BASE_COMMANDS)
+        addAll(SUBCOMMANDS.keys)
+        // COMMON_COMMANDS holds ready-made lines ("ls -la", "git status"), not bare command names.
+        COMMON_COMMANDS.forEach { line -> firstWord(line)?.let { add(it) } }
+        history.forEach { line -> firstWord(line)?.let { add(it) } }
+    }
+
+    override fun isCommand(word: String): Boolean = word in commands
+
+    override fun isSubcommand(command: String, word: String): Boolean =
+        SUBCOMMANDS[command]?.contains(word) == true
+}
+
+/**
+ * The command name a history line starts with, or `null` when it doesn't start with one — a path
+ * (`./deploy.sh`), an assignment (`FOO=1`) or an option is not a name worth learning.
+ */
+private fun firstWord(line: String): String? {
+    val word = line.trimStart().substringBefore(' ').trim()
+    if (word.isEmpty()) return null
+    if (word.any { it == '/' || it == '=' || it == '$' }) return null
+    if (!word[0].isLetter() && word[0] != '_') return null
+    return word
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/OutputHighlighter.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/highlight/OutputHighlighter.kt
@@ -1,0 +1,180 @@
+package app.skerry.shared.terminal.highlight
+
+/** Columns past which a line is noise, not a log record — scanning further buys nothing. */
+const val MAX_OUTPUT_SCAN = 512
+
+/** Level words, upper-cased. Matched only when the token also *looks* like a label — see [levelAt]. */
+private val LEVEL_WORDS: Map<String, HighlightKind> = mapOf(
+    "ERROR" to HighlightKind.LevelError,
+    "ERR" to HighlightKind.LevelError,
+    "FATAL" to HighlightKind.LevelError,
+    "CRITICAL" to HighlightKind.LevelError,
+    "CRIT" to HighlightKind.LevelError,
+    "PANIC" to HighlightKind.LevelError,
+    "FAIL" to HighlightKind.LevelError,
+    "FAILED" to HighlightKind.LevelError,
+    "WARN" to HighlightKind.LevelWarn,
+    "WARNING" to HighlightKind.LevelWarn,
+    "INFO" to HighlightKind.LevelInfo,
+    "NOTICE" to HighlightKind.LevelInfo,
+    "DEBUG" to HighlightKind.LevelDebug,
+    "TRACE" to HighlightKind.LevelDebug,
+    "OK" to HighlightKind.LevelOk,
+    "SUCCESS" to HighlightKind.LevelOk,
+    "PASS" to HighlightKind.LevelOk,
+    "PASSED" to HighlightKind.LevelOk,
+)
+
+/** Longest key in [LEVEL_WORDS] — the scan reads no further before giving up on a token. */
+private const val MAX_LEVEL_LENGTH = 8
+
+/** Characters that may sit directly before a level word: a bracket, a quote, or a field separator. */
+private const val LABEL_OPENERS = "[(<{\"'|,"
+
+/** Characters that may sit directly after a level word for it to still read as a label. */
+private const val LABEL_CLOSERS = "])>}\"'|,:="
+
+/**
+ * Characters that end a numeric token. Unlike [LABEL_CLOSERS] this excludes `:` — a colon is part of
+ * both a clock (`10:11:12`) and a `host:port`, and cutting there would leave a bare `10`.
+ */
+private const val NUMERIC_CLOSERS = "])>}\"',|"
+
+/**
+ * Marks the few things worth spotting in output a command printed without colors of its own: log
+ * levels, IPv4 addresses and timestamps.
+ *
+ * Level words match only on a token boundary and only when they look like a label — all caps
+ * (`ERROR failed to bind`), followed by a colon (`error: no such file`), or bracketed (`[warn]`).
+ * That keeps prose ("an error occurred while parsing") out of the results.
+ *
+ * One left-to-right scan, no regex: this runs for every visible row of every snapshot.
+ */
+fun highlightOutputLine(text: String, limit: Int = MAX_OUTPUT_SCAN): List<HighlightSpan> {
+    val end = minOf(text.length, limit)
+    var out: MutableList<HighlightSpan>? = null
+    var i = 0
+    while (i < end) {
+        val ch = text[i]
+        val span = when {
+            !isTokenStart(text, i) -> null
+            ch.isDigit() -> numericAt(text, i, end)
+            ch.isLetter() -> levelAt(text, i, end)
+            else -> null
+        }
+        if (span == null) { i++; continue }
+        (out ?: ArrayList<HighlightSpan>(4).also { out = it }).add(span)
+        i = span.endExclusive
+    }
+    return out ?: emptyList()
+}
+
+/** Whether position [at] begins a token: start of line, whitespace, or a label opener before it. */
+private fun isTokenStart(text: String, at: Int): Boolean {
+    if (at == 0) return true
+    val prev = text[at - 1]
+    return prev.isWhitespace() || prev in LABEL_OPENERS
+}
+
+/**
+ * A level word starting at [from], or `null`. Requires both a token boundary at the end and one of
+ * the label shapes: all-caps, a trailing `:`/bracket, or a bracket right before it.
+ */
+private fun levelAt(text: String, from: Int, end: Int): HighlightSpan? {
+    var wordEnd = from
+    while (wordEnd < end && text[wordEnd].isLetter()) {
+        // Bail out early rather than uppercase a whole English sentence word by word.
+        if (wordEnd - from > MAX_LEVEL_LENGTH) return null
+        wordEnd++
+    }
+    val word = text.substring(from, wordEnd)
+    val kind = LEVEL_WORDS[word.uppercase()] ?: return null
+    val after = text.getOrNull(wordEnd)
+    val closer = after != null && after in LABEL_CLOSERS
+    if (!(after == null || after.isWhitespace() || closer)) return null
+    val labelled = word.all { it.isUpperCase() } ||
+        closer ||
+        (from > 0 && text[from - 1] in LABEL_OPENERS)
+    return if (labelled) HighlightSpan(from, wordEnd, kind) else null
+}
+
+/** An IPv4 address (optionally `:port`), a clock time or an ISO date starting at [from], or `null`. */
+private fun numericAt(text: String, from: Int, end: Int): HighlightSpan? {
+    var tokenEnd = from
+    while (tokenEnd < end && !text[tokenEnd].isWhitespace() && text[tokenEnd] !in NUMERIC_CLOSERS) tokenEnd++
+    val token = text.substring(from, tokenEnd)
+    ipv4Length(token)?.let { return HighlightSpan(from, from + it, HighlightKind.Address) }
+    timestampLength(token)?.let { return HighlightSpan(from, from + it, HighlightKind.Timestamp) }
+    return null
+}
+
+/**
+ * Length of the IPv4 address (plus an optional `:port`) [token] starts with, or `null`. Exactly four
+ * octets of 0..255 and nothing but a port after them: `1.2.3.4.5` and `999.1.1.1` are not addresses,
+ * and neither is a version number.
+ */
+internal fun ipv4Length(token: String): Int? {
+    var i = 0
+    repeat(4) { octet ->
+        if (octet > 0) {
+            if (token.getOrNull(i) != '.') return null
+            i++
+        }
+        i = octetEnd(token, i) ?: return null
+    }
+    val afterHost = i
+    i = portEnd(token, i) ?: afterHost
+    // A trailing '.' is sentence punctuation; anything else means the token wasn't an address.
+    val tail = token.getOrNull(i) ?: return i
+    return if (tail == '.' && i == token.length - 1) i else null
+}
+
+/** End of a 1..3 digit octet of value 0..255 starting at [from], or `null` if there isn't one. */
+private fun octetEnd(token: String, from: Int): Int? {
+    var i = from
+    while (i < token.length && token[i].isDigit()) i++
+    val digits = i - from
+    if (digits == 0 || digits > 3) return null
+    return if (token.substring(from, i).toInt() <= 255) i else null
+}
+
+/** End of a `:port` suffix starting at [from], or `null` when there is no complete one. */
+private fun portEnd(token: String, from: Int): Int? {
+    if (token.getOrNull(from) != ':') return null
+    var i = from + 1
+    while (i < token.length && token[i].isDigit()) i++
+    return if (i > from + 1) i else null
+}
+
+/**
+ * Length of the timestamp [token] starts with, or `null`: `HH:MM:SS` with an optional `.mmm`
+ * fraction, or an ISO `YYYY-MM-DD` date.
+ */
+internal fun timestampLength(token: String): Int? {
+    clockLength(token)?.let { return it }
+    return isoDateLength(token)
+}
+
+private fun clockLength(token: String): Int? {
+    if (token.length < 8) return null
+    for (i in intArrayOf(0, 1, 3, 4, 6, 7)) if (!token[i].isDigit()) return null
+    if (token[2] != ':' || token[5] != ':') return null
+    if (token[0].digitToInt() > 2 || token[3].digitToInt() > 5 || token[6].digitToInt() > 5) return null
+    var end = 8
+    if (end < token.length && token[end] == '.') {
+        var i = end + 1
+        while (i < token.length && token[i].isDigit()) i++
+        if (i > end + 1) end = i
+    }
+    return end
+}
+
+private fun isoDateLength(token: String): Int? {
+    if (token.length < 10) return null
+    for (i in intArrayOf(0, 1, 2, 3, 5, 6, 8, 9)) if (!token[i].isDigit()) return null
+    if (token[4] != '-' || token[7] != '-') return null
+    val month = token.substring(5, 7).toInt()
+    val day = token.substring(8, 10).toInt()
+    if (month !in 1..12 || day !in 1..31) return null
+    return 10
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/CommandLineTokenizerTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/CommandLineTokenizerTest.kt
@@ -1,0 +1,194 @@
+package app.skerry.shared.terminal.highlight
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CommandLineTokenizerTest {
+
+    private val vocab = SessionVocabulary()
+
+    private fun tokens(line: String): List<HighlightSpan> {
+        val spans = tokenizeCommandLine(line, vocab)
+        assertSpansSane(line, spans)
+        return spans
+    }
+
+    /** Every caller maps spans onto grid columns, so overlap or an out-of-range end corrupts the row. */
+    private fun assertSpansSane(line: String, spans: List<HighlightSpan>) {
+        var prevEnd = 0
+        for (span in spans) {
+            assertTrue(span.start >= prevEnd, "spans overlap or unsorted in `$line`: $spans")
+            assertTrue(span.start < span.endExclusive, "empty span in `$line`: $span")
+            assertTrue(span.endExclusive <= line.length, "span past end in `$line`: $span")
+            prevEnd = span.endExclusive
+        }
+    }
+
+    private fun textOf(line: String, span: HighlightSpan) = line.substring(span.start, span.endExclusive)
+
+    private fun kindOf(line: String, text: String): HighlightKind? =
+        tokens(line).firstOrNull { textOf(line, it) == text }?.kind
+
+    @Test
+    fun `known command and its subcommand`() {
+        val line = "git status"
+        assertEquals(HighlightKind.Command, kindOf(line, "git"))
+        assertEquals(HighlightKind.Subcommand, kindOf(line, "status"))
+    }
+
+    @Test
+    fun `unknown command is left alone`() {
+        assertTrue(tokens("frobnicate bar").isEmpty())
+    }
+
+    @Test
+    fun `subcommand of another command is not highlighted`() {
+        assertEquals(null, kindOf("git restart", "restart"))
+    }
+
+    @Test
+    fun `options and absolute paths`() {
+        val line = "ls -la /var/log"
+        assertEquals(HighlightKind.Command, kindOf(line, "ls"))
+        assertEquals(HighlightKind.Option, kindOf(line, "-la"))
+        assertEquals(HighlightKind.PathLit, kindOf(line, "/var/log"))
+    }
+
+    @Test
+    fun `long options and home-relative paths`() {
+        val line = "cat --number ~/.ssh/config ./local.txt"
+        assertEquals(HighlightKind.Option, kindOf(line, "--number"))
+        assertEquals(HighlightKind.PathLit, kindOf(line, "~/.ssh/config"))
+        assertEquals(HighlightKind.PathLit, kindOf(line, "./local.txt"))
+    }
+
+    @Test
+    fun `a lone dash is not an option`() {
+        assertEquals(null, kindOf("cat -", "-"))
+    }
+
+    @Test
+    fun `pipe reopens the command position`() {
+        val line = "echo hello | grep -i x"
+        assertEquals(HighlightKind.Command, kindOf(line, "echo"))
+        assertEquals(HighlightKind.Operator, kindOf(line, "|"))
+        assertEquals(HighlightKind.Command, kindOf(line, "grep"))
+        assertEquals(HighlightKind.Option, kindOf(line, "-i"))
+    }
+
+    @Test
+    fun `quoted string includes its quotes`() {
+        val line = "echo \"hello world\""
+        assertEquals(HighlightKind.StringLit, kindOf(line, "\"hello world\""))
+    }
+
+    @Test
+    fun `an operator inside quotes is text`() {
+        val line = "echo 'a | b'"
+        assertEquals(HighlightKind.StringLit, kindOf(line, "'a | b'"))
+        assertTrue(tokens(line).none { it.kind == HighlightKind.Operator })
+    }
+
+    @Test
+    fun `escaped quote does not close the string`() {
+        val line = "echo \"a \\\" b\" tail"
+        assertEquals(HighlightKind.StringLit, kindOf(line, "\"a \\\" b\""))
+    }
+
+    @Test
+    fun `unterminated quote runs to end of line`() {
+        val line = "echo \"unfinished"
+        val string = tokens(line).single { it.kind == HighlightKind.StringLit }
+        assertEquals(line.length, string.endExclusive)
+    }
+
+    @Test
+    fun `variables in their three forms`() {
+        val line = "echo \$HOME \${XDG_DIR} \$1"
+        val vars = tokens(line).filter { it.kind == HighlightKind.Variable }.map { textOf(line, it) }
+        assertEquals(listOf("\$HOME", "\${XDG_DIR}", "\$1"), vars)
+    }
+
+    @Test
+    fun `an assignment prefix keeps the command position`() {
+        val line = "FOO=1 make build"
+        assertEquals(HighlightKind.Variable, kindOf(line, "FOO="))
+        assertEquals(HighlightKind.Command, kindOf(line, "make"))
+    }
+
+    @Test
+    fun `sudo keeps the command position open`() {
+        val line = "sudo systemctl restart nginx"
+        assertEquals(HighlightKind.Command, kindOf(line, "sudo"))
+        assertEquals(HighlightKind.Command, kindOf(line, "systemctl"))
+        assertEquals(HighlightKind.Subcommand, kindOf(line, "restart"))
+        assertEquals(null, kindOf(line, "nginx"))
+    }
+
+    @Test
+    fun `redirect is an operator and its target stays a path`() {
+        val line = "cat img > /dev/sda"
+        assertEquals(HighlightKind.Operator, kindOf(line, ">"))
+        assertEquals(HighlightKind.PathLit, kindOf(line, "/dev/sda"))
+    }
+
+    @Test
+    fun `boolean operators`() {
+        val line = "make && echo ok || echo fail"
+        val ops = tokens(line).filter { it.kind == HighlightKind.Operator }.map { textOf(line, it) }
+        assertEquals(listOf("&&", "||"), ops)
+    }
+
+    @Test
+    fun `semicolon separates and reopens`() {
+        val line = "cd /tmp; ls"
+        assertEquals(HighlightKind.Operator, kindOf(line, ";"))
+        assertEquals(HighlightKind.Command, kindOf(line, "ls"))
+    }
+
+    @Test
+    fun `comment runs to end of line`() {
+        val line = "make build # rebuild everything"
+        val comment = tokens(line).single { it.kind == HighlightKind.Comment }
+        assertEquals("# rebuild everything", textOf(line, comment))
+    }
+
+    @Test
+    fun `a hash inside a word is not a comment`() {
+        val line = "echo \"#1\""
+        assertTrue(tokens(line).none { it.kind == HighlightKind.Comment })
+    }
+
+    @Test
+    fun `an executable path is a path, not a command`() {
+        assertEquals(HighlightKind.PathLit, kindOf("./deploy.sh prod", "./deploy.sh"))
+        assertEquals(HighlightKind.PathLit, kindOf("/usr/bin/git status", "/usr/bin/git"))
+    }
+
+    @Test
+    fun `blank input yields nothing`() {
+        assertTrue(tokens("").isEmpty())
+        assertTrue(tokens("     ").isEmpty())
+    }
+
+    @Test
+    fun `a partially typed command is not green yet`() {
+        assertEquals(null, kindOf("gi", "gi"))
+        assertEquals(HighlightKind.Command, kindOf("git", "git"))
+    }
+
+    @Test
+    fun `overlong input is truncated instead of scanned whole`() {
+        val line = "echo " + "x".repeat(MAX_HIGHLIGHT_LENGTH * 2)
+        val spans = tokenizeCommandLine(line, vocab)
+        assertTrue(spans.all { it.endExclusive <= MAX_HIGHLIGHT_LENGTH })
+    }
+
+    @Test
+    fun `option carrying a quoted value keeps both parts`() {
+        val line = "git commit --message=\"fix bug\""
+        assertEquals(HighlightKind.Option, kindOf(line, "--message="))
+        assertEquals(HighlightKind.StringLit, kindOf(line, "\"fix bug\""))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/HighlightKindTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/HighlightKindTest.kt
@@ -1,0 +1,83 @@
+package app.skerry.shared.terminal.highlight
+
+import app.skerry.shared.terminal.TermColor
+import app.skerry.shared.terminal.TermStyle
+import app.skerry.shared.terminal.UnderlineStyle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class HighlightKindTest {
+
+    @Test
+    fun `none returns the very same style`() {
+        val style = TermStyle(bold = true)
+        assertSame(style, HighlightKind.None.applyTo(style))
+    }
+
+    @Test
+    fun `command is green and bold`() {
+        val style = HighlightKind.Command.applyTo(TermStyle())
+        assertEquals(TermColor.Indexed(2), style.fg)
+        assertTrue(style.bold)
+    }
+
+    @Test
+    fun `subcommand is green without bold`() {
+        val style = HighlightKind.Subcommand.applyTo(TermStyle())
+        assertEquals(TermColor.Indexed(2), style.fg)
+        assertFalse(style.bold)
+    }
+
+    @Test
+    fun `every command-line category maps to a palette color or dim`() {
+        val kinds = listOf(
+            HighlightKind.Command, HighlightKind.Subcommand, HighlightKind.Option,
+            HighlightKind.StringLit, HighlightKind.PathLit, HighlightKind.Operator,
+            HighlightKind.Variable, HighlightKind.Comment,
+        )
+        for (kind in kinds) {
+            val style = kind.applyTo(TermStyle())
+            val changed = style.fg != TermColor.Default || style.dim
+            assertTrue(changed, "$kind changed nothing")
+            // Only palette indices — an Rgb literal would ignore the active theme.
+            assertTrue(style.fg is TermColor.Indexed || style.fg == TermColor.Default, "$kind used a literal color")
+        }
+    }
+
+    @Test
+    fun `comment dims without recoloring`() {
+        val style = HighlightKind.Comment.applyTo(TermStyle())
+        assertTrue(style.dim)
+        assertEquals(TermColor.Default, style.fg)
+    }
+
+    @Test
+    fun `base attributes survive`() {
+        val base = TermStyle(
+            bg = TermColor.Indexed(4),
+            italic = true,
+            underlineStyle = UnderlineStyle.Curly,
+            strikethrough = true,
+        )
+        val style = HighlightKind.Option.applyTo(base)
+        assertEquals(TermColor.Indexed(4), style.bg)
+        assertTrue(style.italic)
+        assertEquals(UnderlineStyle.Curly, style.underlineStyle)
+        assertTrue(style.strikethrough)
+    }
+
+    @Test
+    fun `error level is red and bold`() {
+        val style = HighlightKind.LevelError.applyTo(TermStyle())
+        assertEquals(TermColor.Indexed(1), style.fg)
+        assertTrue(style.bold)
+    }
+
+    @Test
+    fun `timestamp is dimmed`() {
+        assertTrue(HighlightKind.Timestamp.applyTo(TermStyle()).dim)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/KnownCommandsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/KnownCommandsTest.kt
@@ -1,0 +1,61 @@
+package app.skerry.shared.terminal.highlight
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class KnownCommandsTest {
+
+    @Test
+    fun `built-in catalogue is known without any history`() {
+        val vocab = SessionVocabulary()
+        assertTrue(vocab.isCommand("git"))
+        assertTrue(vocab.isCommand("systemctl"))
+        assertTrue(vocab.isCommand("ls"))
+        assertTrue(vocab.isCommand("sudo"))
+    }
+
+    @Test
+    fun `shell keywords are commands`() {
+        val vocab = SessionVocabulary()
+        assertTrue(vocab.isCommand("if"))
+        assertTrue(vocab.isCommand("done"))
+        assertTrue(vocab.isCommand("echo"))
+    }
+
+    @Test
+    fun `history teaches the host's own tooling`() {
+        val vocab = SessionVocabulary(listOf("pveversion -v", "zfs list"))
+        assertTrue(vocab.isCommand("pveversion"))
+        assertTrue(vocab.isCommand("zfs"))
+    }
+
+    @Test
+    fun `history entries that are not command names are not learned`() {
+        val vocab = SessionVocabulary(listOf("./deploy.sh prod", "FOO=1 make", "-n 5"))
+        assertFalse(vocab.isCommand("./deploy.sh"))
+        assertFalse(vocab.isCommand("FOO=1"))
+        assertFalse(vocab.isCommand("-n"))
+        assertFalse(vocab.isCommand("deploy.sh"))
+    }
+
+    @Test
+    fun `unknown word stays unknown`() {
+        assertFalse(SessionVocabulary().isCommand("frobnicate"))
+    }
+
+    @Test
+    fun `subcommands are scoped to their command`() {
+        val vocab = SessionVocabulary()
+        assertTrue(vocab.isSubcommand("git", "status"))
+        assertTrue(vocab.isSubcommand("systemctl", "restart"))
+        assertFalse(vocab.isSubcommand("git", "restart"))
+        assertFalse(vocab.isSubcommand("frobnicate", "status"))
+    }
+
+    @Test
+    fun `empty vocabulary knows nothing`() {
+        assertFalse(CommandVocabulary.Empty.isCommand("git"))
+        assertFalse(CommandVocabulary.Empty.isSubcommand("git", "status"))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/OutputHighlighterTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/highlight/OutputHighlighterTest.kt
@@ -1,0 +1,102 @@
+package app.skerry.shared.terminal.highlight
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class OutputHighlighterTest {
+
+    private fun spans(text: String): List<HighlightSpan> {
+        val found = highlightOutputLine(text)
+        var prevEnd = 0
+        for (span in found) {
+            assertTrue(span.start >= prevEnd, "spans overlap or unsorted in `$text`: $found")
+            assertTrue(span.start < span.endExclusive && span.endExclusive <= text.length, "bad span in `$text`: $span")
+            prevEnd = span.endExclusive
+        }
+        return found
+    }
+
+    private fun textOf(text: String, span: HighlightSpan) = text.substring(span.start, span.endExclusive)
+
+    private fun kindOf(text: String, token: String): HighlightKind? =
+        spans(text).firstOrNull { textOf(text, it) == token }?.kind
+
+    @Test
+    fun `syslog line gets timestamp and level`() {
+        val line = "2026-08-04 10:11:12 ERROR failed to bind"
+        assertEquals(HighlightKind.Timestamp, kindOf(line, "2026-08-04"))
+        assertEquals(HighlightKind.Timestamp, kindOf(line, "10:11:12"))
+        assertEquals(HighlightKind.LevelError, kindOf(line, "ERROR"))
+    }
+
+    @Test
+    fun `bracketed level marks the word only`() {
+        val line = "[WARN] disk 82%"
+        assertEquals(HighlightKind.LevelWarn, kindOf(line, "WARN"))
+    }
+
+    @Test
+    fun `lowercase level with a colon counts`() {
+        assertEquals(HighlightKind.LevelError, kindOf("error: no such file", "error"))
+    }
+
+    @Test
+    fun `level word in prose is ignored`() {
+        assertTrue(spans("an error occurred while parsing").isEmpty())
+    }
+
+    @Test
+    fun `level word must stand on a token boundary`() {
+        assertTrue(spans("terror strikes").isEmpty())
+        assertTrue(spans("ERRORS everywhere").isEmpty())
+    }
+
+    @Test
+    fun `all level families are recognized`() {
+        assertEquals(HighlightKind.LevelError, kindOf("FATAL boom", "FATAL"))
+        assertEquals(HighlightKind.LevelWarn, kindOf("WARNING low space", "WARNING"))
+        assertEquals(HighlightKind.LevelInfo, kindOf("INFO started", "INFO"))
+        assertEquals(HighlightKind.LevelDebug, kindOf("DEBUG payload", "DEBUG"))
+        assertEquals(HighlightKind.LevelOk, kindOf("OK ready", "OK"))
+    }
+
+    @Test
+    fun `ipv4 with a port`() {
+        assertEquals(HighlightKind.Address, kindOf("connect to 10.0.0.14:8080 now", "10.0.0.14:8080"))
+    }
+
+    @Test
+    fun `bare ipv4`() {
+        assertEquals(HighlightKind.Address, kindOf("from 192.168.1.1", "192.168.1.1"))
+    }
+
+    @Test
+    fun `things that only look like addresses are skipped`() {
+        assertTrue(spans("build 1.2.3.4.5 tag").isEmpty())
+        assertTrue(spans("host 999.1.1.1 down").isEmpty())
+        assertTrue(spans("version 1.2.3").isEmpty())
+    }
+
+    @Test
+    fun `clock time with milliseconds`() {
+        assertEquals(HighlightKind.Timestamp, kindOf("at 23:59:59.123 done", "23:59:59.123"))
+    }
+
+    @Test
+    fun `plain text yields nothing`() {
+        assertTrue(spans("total 48").isEmpty())
+        assertTrue(spans("drwxr-xr-x 2 root root 4096 Aug  4 10:00 etc").isEmpty())
+    }
+
+    @Test
+    fun `scanning stops at the limit`() {
+        val line = "x".repeat(600) + " ERROR here"
+        assertTrue(highlightOutputLine(line, limit = 512).isEmpty())
+    }
+
+    @Test
+    fun `empty line yields nothing`() {
+        assertTrue(spans("").isEmpty())
+    }
+}


### PR DESCRIPTION
Colors what the shell leaves plain.

**Command line** — as it is typed: command and subcommand green, flags cyan, quoted strings yellow, paths blue, operators magenta, variables bright magenta, comments dimmed. An unknown command is left uncolored rather than marked as wrong, so the vocabulary being incomplete costs a color, not a false alarm. A command keeps its colors after Enter.

**Output** — log levels (`ERROR`/`WARN`/`INFO`/`DEBUG`/`OK` and their families), IPv4 addresses with an optional port, and timestamps. A level word matches only where it reads as a label — all caps, followed by a colon, or bracketed — so prose like "an error occurred" stays plain.

Two switches in **Settings → Terminal**: the command line is on by default; output highlighting is off, since it repaints text the server printed.

## How it stays out of the way

A category maps to a **palette index**, never a literal color, so it follows the active terminal theme (including the light ones) and any OSC 4 override from the host.

A cell the server already styled is never repainted — the gate is `fg == Default && bg == Default && !inverse && !hidden`. That keeps `ls --color`, TUI chrome and compiler diagnostics intact, keeps reverse-video cells readable, and keeps password echo hidden. Spans are built per column, so a token the server colored only partly (a `grep --color` match inside a word) keeps its remaining columns highlighted instead of being dropped whole.

Where a command starts comes from the prompt heuristic the production guard already uses (`ProductionGuard.promptEnd`), applied to the cursor row and its soft-wrap chain. A line further up in the scrollback is colored only when its text matches, character for character, a command this session ran — which is what keeps output containing a `$ ` from being colored as input. Nothing is highlighted on the alternate screen.

## Also in this change

`TerminalScreenState`'s init block moves to the end of the class. It starts coroutines that reach state properties declared below it, so a PTY chunk arriving during construction wrote to a `by mutableStateOf` delegate that did not exist yet — a NullPointerException inside `setValue`. A test constructs the state against a session that emits at collection time and reproduces it deterministically.

## Known limitation

A hostile host can print output shaped like a prompt and have it colored like a shell line. This is cosmetic — the text is not trusted, executed or fed to the production guard differently — and is the same class as ANSI-based prompt spoofing that already works against any terminal emulator.

## Verifying

Type `sudo systemctl restart nginx` — `sudo` and `systemctl` green, `restart` green without bold, the argument plain. Press Enter: the line keeps its colors. Run `ls --color=always /` — nothing recolored. Enable the second switch and run `journalctl -n 50 --no-pager`. Open `htop` — no highlighting at all. Switch to a light theme and confirm the colors still read.

Tests: `./gradlew test allTests`, `./gradlew build`, `./gradlew detektAll`, `:androidApp:compileDebugKotlin` — all green. Verified by hand on desktop against a live host; Android was not run on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)