### PR TITLE
Join soft-wrapped rows when detecting terminal URLs

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
@@ -115,6 +115,10 @@ private fun rowHasPathMarker(row: List<TermCell>): Boolean {
  * Same detection as [detectFilePaths] over a grid row, returning spans in **column** coordinates
  * (see [rowTextSpans]). Spans touching a cell that already carries an OSC 8 hyperlink are dropped —
  * the hyperlink owns those cells.
+ *
+ * Unlike URLs ([linkSpansByRow]), a path is detected within one row only: the affordance is the
+ * Ctrl+hover underline, which is painted on the pointed row, so joining a soft-wrap chain here would
+ * underline part of a path and open the whole of it. A path cut by a wrap stays unclickable.
  */
 internal fun rowFilePathSpans(row: List<TermCell>): List<TextLinkSpan> {
     // Runs per visible row on every Canvas draw — bail out with zero allocation on rows that cannot

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.terminal
 
 import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.wrapsToNextRow
 
 /**
  * Whether an OSC 8 hyperlink is safe to open on Ctrl+click. The URI comes from an untrusted ssh
@@ -40,31 +41,127 @@ internal fun detectPlainTextLinks(text: String): List<TextLinkSpan> {
     return out ?: emptyList()
 }
 
-/** Cheap allocation-free scan for a `://` scheme separator anywhere in the row (across cell borders). */
-private fun rowHasSchemeMarker(row: List<TermCell>): Boolean {
-    var p2 = ' '
-    var p1 = ' '
-    for (cell in row) {
-        for (ch in cell.text) {
+/**
+ * Cheap allocation-free scan for a `://` scheme separator across rows [rows] of [screen] — the
+ * two-character lookbehind carries over row boundaries, because auto-wrap can cut the separator
+ * itself in half (a row ending in `https:` continued by `//host/…`).
+ */
+private fun hasSchemeMarker(screen: List<List<TermCell>>, rows: IntRange): Boolean {
+    val scan = SchemeMarkerScan()
+    for (r in rows) if (scan.accept(screen[r])) return true
+    return false
+}
+
+/** Two-character lookbehind for `://`, kept alive across rows and cells by [hasSchemeMarker]. */
+private class SchemeMarkerScan {
+    private var p2 = ' '
+    private var p1 = ' '
+
+    /** Feeds one row; true as soon as the separator completes (possibly from the previous row). */
+    fun accept(row: List<TermCell>): Boolean {
+        for (cell in row) for (ch in cell.text) {
             if (p2 == ':' && p1 == '/' && ch == '/') return true
             p2 = p1
             p1 = ch
         }
+        return false
     }
-    return false
 }
 
 /**
- * Same detection as [detectPlainTextLinks], but over a grid row, returning spans in **column**
- * coordinates (see [rowTextSpans]).
+ * Rows joined at once out of a soft-wrapped logical line. Bounds the text work: a logical line can be
+ * thousands of rows (a one-line JSON dump), and joining it whole would cost O(line) per frame. At any
+ * sane terminal width a block still holds a URL several times over.
  */
-internal fun rowLinkSpans(row: List<TermCell>): List<TextLinkSpan> {
-    // Runs per visible row on every Canvas draw (scroll, cursor blink, PTY output) — so bail out with
-    // zero allocation on the overwhelmingly common URL-free row before touching StringBuilder/regex.
-    if (!rowHasSchemeMarker(row)) return emptyList()
-    return rowTextSpans(row, ::detectPlainTextLinks)
+private const val WRAP_BLOCK_ROWS = 9
+
+/**
+ * The block of a soft-wrap chain that row [r] belongs to. Blocks are counted from the line's real
+ * start, so every row of a block answers with the same rows — the draw pass (which asks per visible
+ * window) and the pointer (which asks per row) must not disagree about the same cell.
+ *
+ * [startClipped]/[endClipped] mean the block ended mid-line: the text beyond that edge is not in the
+ * join, so a match touching it may be a fragment of a longer one.
+ */
+private class WrapChain(val rows: IntRange, val startClipped: Boolean, val endClipped: Boolean)
+
+private fun wrapChain(screen: List<List<TermCell>>, r: Int, lineStart: Int): WrapChain {
+    val first = lineStart + (r - lineStart) / WRAP_BLOCK_ROWS * WRAP_BLOCK_ROWS
+    var last = first
+    while (last < screen.lastIndex && last - first < WRAP_BLOCK_ROWS - 1 && screen[last].wrapsToNextRow()) last++
+    val endClipped = last < screen.lastIndex && screen[last].wrapsToNextRow()
+    return WrapChain(first..last, startClipped = first > lineStart, endClipped = endClipped)
 }
 
-/** The plain-text URL under column [col] in [row], or `null`. Used for Ctrl+click hit-testing. */
-internal fun linkAt(row: List<TermCell>, col: Int): String? =
-    rowLinkSpans(row).firstOrNull { col >= it.start && col < it.endExclusive }?.uri
+/**
+ * First row of the logical line row [r] belongs to. Reads wrap flags only (O(1) per row, no text), so
+ * a very long line costs a pointer chase here rather than the joining that the block size bounds —
+ * and callers walking several blocks of one line reuse the answer instead of re-walking per block.
+ */
+private fun lineStartOf(screen: List<List<TermCell>>, r: Int): Int {
+    var start = r
+    while (start > 0 && screen[start - 1].wrapsToNextRow()) start--
+    return start
+}
+
+/**
+ * URL spans per grid row for rows [window] of [screen], in column coordinates. A row that auto-wrap
+ * cut out of a longer logical line is detected together with its neighbours, so a URL split at the
+ * right margin is one link: underlined on every row it crosses, and opening the whole URL wherever it
+ * is clicked. Rows with no URL are absent from the map.
+ *
+ * Each chain is flattened and matched once, not once per row it covers — the draw pass asks for the
+ * whole visible window, and re-joining the same chain for every one of its rows was the cost this
+ * grouping exists to avoid.
+ *
+ * A match touching either edge of a clipped block (see [WrapChain]) is dropped rather than reported:
+ * past the edge the text is unknown, and a click must never open a truncated address. On a line
+ * longer than [WRAP_BLOCK_ROWS] rows that also costs the rare URL that merely starts or ends flush
+ * with a block edge without crossing it.
+ */
+internal fun linkSpansByRow(screen: List<List<TermCell>>, window: IntRange): Map<Int, List<TextLinkSpan>> {
+    var out: MutableMap<Int, List<TextLinkSpan>>? = null
+    var r = window.first.coerceAtLeast(0)
+    val last = window.last.coerceAtMost(screen.lastIndex)
+    // Carried across blocks: a clipped end means the same logical line continues into the next block,
+    // so its start is already known and the walk back is not repeated.
+    var lineStart = -1
+    while (r <= last) {
+        if (lineStart < 0) lineStart = lineStartOf(screen, r)
+        val chain = wrapChain(screen, r, lineStart)
+        for ((row, spans) in chainLinkSpans(screen, chain, r..minOf(chain.rows.last, last))) {
+            (out ?: HashMap<Int, List<TextLinkSpan>>().also { out = it })[row] = spans
+        }
+        if (!chain.endClipped) lineStart = -1
+        r = chain.rows.last + 1
+    }
+    return out ?: emptyMap()
+}
+
+/** Spans of one [chain], reported for rows [wanted] only (the rest of the chain is off-window). */
+private fun chainLinkSpans(
+    screen: List<List<TermCell>>,
+    chain: WrapChain,
+    wanted: IntRange,
+): Map<Int, List<TextLinkSpan>> {
+    if (!hasSchemeMarker(screen, chain.rows)) return emptyMap()
+    val flat = rowsText(screen, chain.rows) ?: return emptyMap()
+    val found = detectPlainTextLinks(flat.text).filterNot { span ->
+        (chain.startClipped && span.start == 0) || (chain.endClipped && span.endExclusive == flat.text.length)
+    }
+    if (found.isEmpty()) return emptyMap()
+    var out: MutableMap<Int, List<TextLinkSpan>>? = null
+    for (row in wanted) {
+        val spans = flat.spansOn(row, found)
+        if (spans.isNotEmpty()) (out ?: HashMap<Int, List<TextLinkSpan>>().also { out = it })[row] = spans
+    }
+    return out ?: emptyMap()
+}
+
+/** URL spans on row [r] alone — hit-testing a single pointer position, not the draw pass. */
+internal fun rowLinkSpans(screen: List<List<TermCell>>, r: Int): List<TextLinkSpan> =
+    linkSpansByRow(screen, r..r)[r] ?: emptyList()
+
+/** The plain-text URL under row [r], column [col] of [screen], or `null`. Ctrl+click hit-testing. */
+internal fun linkAt(screen: List<List<TermCell>>, r: Int, col: Int): String? =
+    rowLinkSpans(screen, r).firstOrNull { col >= it.start && col < it.endExclusive }?.uri

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
@@ -34,41 +34,92 @@ internal fun trimTrailingPunct(token: String, punct: String): String {
 }
 
 /**
- * A grid row flattened to plain [text], with [colOf] mapping each string index back to the column it
- * came from. The two diverge because a wide glyph occupies two columns (its continuation cell has
- * empty text) and a cell may hold a combining sequence — without the map, matches would land a
- * column or two off.
+ * Grid rows flattened to plain [text], with every character mapped back to the grid row and column it
+ * was drawn at. String indices and columns diverge because a wide glyph occupies two columns (its
+ * continuation cell has empty text) and a cell may hold a combining sequence — without the map,
+ * matches would land a column or two off.
+ *
+ * More than one row at a time because auto-wrap cuts a logical line at the right margin: a URL split
+ * there is still one URL, so it must be detected over the joined text and painted per row.
  */
-internal class RowText(val text: String, private val colOf: IntArray) {
+internal class RowText(val text: String, private val rowOf: IntArray?, private val colOf: IntArray) {
 
-    /** Column the character at string index [index] was drawn in. */
+    /** Column the character at string index [index] was drawn in (single-row callers). */
     fun column(index: Int): Int = colOf[index]
 
-    /** Converts a string-index span into the column span `[start, endExclusive)` it covers. */
-    fun columns(start: Int, endExclusive: Int): IntRange = colOf[start]..colOf[endExclusive - 1]
+    /**
+     * The part of the string span `[start, endExclusive)` that landed on grid [row], as a column
+     * range, or `null` when the span does not touch that row. Columns are contiguous within a row —
+     * the span is a substring of one logical line.
+     */
+    fun columnsOn(row: Int, start: Int, endExclusive: Int): IntRange? {
+        // A single-row flatten keeps no row map — every character came from the one row it was built from.
+        if (rowOf == null) return if (row != 0) null else colOf[start]..colOf[endExclusive - 1]
+        var from = -1
+        var to = -1
+        for (i in start until endExclusive) {
+            if (rowOf[i] != row) continue
+            if (from < 0) from = colOf[i]
+            to = colOf[i]
+        }
+        return if (from < 0) null else from..to
+    }
 }
 
 /**
- * Flattens a grid row for text-level detectors, or `null` when the row holds no characters at all.
- * Callers do their own allocation-free "could this row match at all" prescan first — this builds a
- * StringBuilder, and on a draw pass most rows can't match anything.
+ * Flattens a single grid row for text-level detectors, or `null` when it holds no characters at all.
+ * Its only row is numbered 0. Callers do their own allocation-free "could this row match at all"
+ * prescan first — this builds a StringBuilder, and on a draw pass most rows can't match anything.
  */
 internal fun rowText(row: List<TermCell>): RowText? {
-    val sb = StringBuilder(row.size)
-    // IntArray with a counter rather than ArrayList<Int>: this runs for every visible row of every
-    // snapshot, and boxing one Integer per character showed up as steady GC pressure while output
-    // streams. A row can hold combining sequences, so the array is grown rather than sized once.
-    var colOf = IntArray(row.size)
-    var n = 0
-    for (c in row.indices) {
-        for (ch in row[c].text) {
-            if (n == colOf.size) colOf = colOf.copyOf(n * 2 + 1)
-            sb.append(ch)
-            colOf[n++] = c
-        }
+    val builder = RowTextBuilder(row.size, trackRows = false)
+    builder.append(row, 0)
+    return builder.build()
+}
+
+/**
+ * Flattens grid rows [rows] of [screen] (a soft-wrap chain) into one text, or `null` when they hold
+ * no characters at all. Rows are joined with nothing between them: a soft wrap is not a character, so
+ * the logical line reads exactly as the server printed it.
+ */
+internal fun rowsText(screen: List<List<TermCell>>, rows: IntRange): RowText? {
+    var capacity = 0
+    for (r in rows) capacity += screen[r].size
+    val builder = RowTextBuilder(capacity, trackRows = true)
+    for (r in rows) builder.append(screen[r], r)
+    return builder.build()
+}
+
+/**
+ * Accumulator behind [rowText] and [rowsText]: text plus the index maps, grown together. IntArray with a
+ * counter rather than ArrayList<Int> — this runs for every visible row of every snapshot, and boxing
+ * one Integer per character showed up as steady GC pressure while output streams. A row can hold
+ * combining sequences, so the arrays are grown rather than sized once.
+ */
+private class RowTextBuilder(capacity: Int, trackRows: Boolean) {
+    private val text = StringBuilder(capacity)
+    // Only a multi-row flatten needs the row map; single-row callers (highlighting, prompt scan) run
+    // per visible row per frame, and a second array of the same size there is pure waste.
+    private var rowOf = if (trackRows) IntArray(capacity) else null
+    private var colOf = IntArray(capacity)
+    private var n = 0
+
+    fun append(row: List<TermCell>, r: Int) {
+        for (c in row.indices) for (ch in row[c].text) add(ch, r, c)
     }
-    if (n == 0) return null
-    return RowText(sb.toString(), if (n == colOf.size) colOf else colOf.copyOf(n))
+
+    fun build(): RowText? = if (n == 0) null else RowText(text.toString(), rowOf, colOf)
+
+    private fun add(ch: Char, r: Int, c: Int) {
+        if (n == colOf.size) {
+            colOf = colOf.copyOf(n * 2 + 1)
+            rowOf = rowOf?.copyOf(n * 2 + 1)
+        }
+        text.append(ch)
+        rowOf?.set(n, r)
+        colOf[n] = c
+        n++
+    }
 }
 
 /**
@@ -77,10 +128,16 @@ internal fun rowText(row: List<TermCell>): RowText? {
  */
 internal fun rowTextSpans(row: List<TermCell>, detect: (String) -> List<TextLinkSpan>): List<TextLinkSpan> {
     val flat = rowText(row) ?: return emptyList()
-    val found = detect(flat.text)
+    return flat.spansOn(0, detect(flat.text))
+}
+
+/**
+ * Maps string-index spans onto the columns they cover on grid [row], dropping those that miss it.
+ * The URI travels unchanged, so a match split across rows opens whole from any of its parts.
+ */
+internal fun RowText.spansOn(row: Int, found: List<TextLinkSpan>): List<TextLinkSpan> {
     if (found.isEmpty()) return emptyList()
-    return found.map { s ->
-        val cols = flat.columns(s.start, s.endExclusive)
-        TextLinkSpan(cols.first, cols.last + 1, s.uri)
+    return found.mapNotNull { s ->
+        columnsOn(row, s.start, s.endExclusive)?.let { TextLinkSpan(it.first, it.last + 1, s.uri) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -447,8 +447,9 @@ fun TerminalScreen(
     // Is there an openable link (OSC 8 or bare text URL) under this cell? Mirrors the Ctrl+click
     // resolution so the hand cursor appears exactly where a click would open something.
     fun linkUnderPos(pos: TerminalPos): Boolean {
-        val row = state.screen.getOrNull(pos.row) ?: return false
-        val uri = row.getOrNull(pos.col)?.hyperlink ?: linkAt(row, pos.col)
+        // One snapshot for both lookups: the cell's own OSC 8 URI and the wrap-chain text around it.
+        val snap = state.screen
+        val uri = snap.getOrNull(pos.row)?.getOrNull(pos.col)?.hyperlink ?: linkAt(snap, pos.row, pos.col)
         return uri != null && isSafeLinkUri(uri)
     }
 
@@ -627,7 +628,11 @@ fun TerminalScreen(
               // spill): walking all of scrollback per repaint is O(history) of wasted work
               // whenever output streams while the user sits scrolled up in history. The search
               // highlight above derives its window from the same helper.
-              for (r in visibleRowWindow(scrollPx, size.height, chh, screen.size)) {
+              val drawWindow = visibleRowWindow(scrollPx, size.height, chh, screen.size)
+              // Plain-text URLs for the whole window at once (pass 5 below): a URL cut by a soft wrap
+              // spans several rows, and its chain is joined and matched once rather than per row.
+              val linksByRow = linkSpansByRow(screen, drawWindow)
+              for (r in drawWindow) {
                   val top = r * chh - scrollPx
                   val row = screen[r]
                   // 1) Cell backgrounds — collapse same-color runs; stretch the trailing run to the viewport edge.
@@ -698,7 +703,9 @@ fun TerminalScreen(
                   // 5) Plain-text URLs (no OSC 8) — http(s)/ftp printed as bare text (MOTD, curl output)
                   // are underlined like hyperlinks so Ctrl+click can open them; skip cells already
                   // carrying an OSC 8 URI (pass 4) or an app underline (pass 3) to avoid a double line.
-                  for (link in rowLinkSpans(row)) {
+                  // Spans come from the whole soft-wrap chain, so a URL cut at the right margin keeps
+                  // its underline on the row it continues on.
+                  for (link in linksByRow[r].orEmpty()) {
                       var k = link.start
                       while (k < link.endExclusive) {
                           if (row[k].hyperlink != null || row[k].style.underline) { k++; continue }
@@ -1012,9 +1019,9 @@ fun TerminalScreen(
                         // row text. The URI comes from an untrusted server — open only safe web schemes,
                         // blocking file:/javascript:/anything else that could harm locally.
                         if (mods.isCtrlPressed) {
-                            val cellRow = state.screen.getOrNull(pos.row)
-                            val uri = cellRow?.getOrNull(pos.col)?.hyperlink
-                                ?: cellRow?.let { linkAt(it, pos.col) }
+                            val snap = state.screen
+                            val uri = snap.getOrNull(pos.row)?.getOrNull(pos.col)?.hyperlink
+                                ?: linkAt(snap, pos.row, pos.col)
                             if (uri != null && isSafeLinkUri(uri)) {
                                 runCatching { uriHandler.openUri(uri) }
                                 down.consume()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.terminal
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.SnapshotMutationPolicy
 import androidx.compose.runtime.setValue
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.AutocompleteEngine
@@ -27,6 +28,7 @@ import app.skerry.shared.terminal.bracketedPasteWrap
 import app.skerry.shared.terminal.encodeMouseReport
 import app.skerry.shared.terminal.lineSelectionAt
 import app.skerry.shared.terminal.wordSelectionAt
+import app.skerry.shared.terminal.wrapsToNextRow
 import kotlin.concurrent.Volatile
 import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
@@ -100,7 +102,7 @@ class TerminalScreenState(
     )
 
     /** Screen snapshot (rows top to bottom) for rendering. */
-    var screen: List<List<TermCell>> by mutableStateOf(emptyList())
+    var screen: List<List<TermCell>> by mutableStateOf(emptyList(), SCREEN_SNAPSHOT_POLICY)
         private set
 
     /**
@@ -1097,3 +1099,18 @@ internal fun lastCommandBlocks(text: String, count: Int): List<String> {
 }
 
 internal fun lastCommandBlock(text: String): String? = lastCommandBlocks(text, 1).firstOrNull()
+
+/**
+ * Whether two screen snapshots are the same as far as the UI is concerned — cell content **and** the
+ * soft-wrap flags. Compose skips a state write whose new value is equivalent to the old one, and list
+ * equality only compares cells: a row can drop its wrap without any cell changing (`ESC[K` over an
+ * already-blank tail), and publishing that as "no change" would leave [TerminalScreen]'s link joining
+ * reading wrap flags that no longer hold.
+ */
+internal fun sameScreen(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean =
+    a == b && a.indices.all { a[it].wrapsToNextRow() == b[it].wrapsToNextRow() }
+
+/** [sameScreen] as the equivalence Compose uses to decide whether publishing a snapshot is a no-op. */
+private val SCREEN_SNAPSHOT_POLICY = object : SnapshotMutationPolicy<List<List<TermCell>>> {
+    override fun equivalent(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean = sameScreen(a, b)
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalLinksTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalLinksTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.terminal
 
 import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermSnapshotRow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -97,8 +98,8 @@ class TerminalLinksTest {
 
     @Test
     fun `maps a url onto its grid columns`() {
-        val cells = row("x https://a.test y")
-        val span = rowLinkSpans(cells).single()
+        val screen = listOf(row("x https://a.test y"))
+        val span = rowLinkSpans(screen, 0).single()
         assertEquals(2, span.start)                 // 'h' column
         assertEquals(2 + "https://a.test".length, span.endExclusive)
         assertEquals("https://a.test", span.uri)
@@ -106,10 +107,10 @@ class TerminalLinksTest {
 
     @Test
     fun `linkAt returns the uri only under the url columns`() {
-        val cells = row("go https://a.test")
-        assertNull(linkAt(cells, 0))                // 'g'
-        assertEquals("https://a.test", linkAt(cells, 3))  // 'h'
-        assertEquals("https://a.test", linkAt(cells, cells.lastIndex))
+        val screen = listOf(row("go https://a.test"))
+        assertNull(linkAt(screen, 0, 0))                        // 'g'
+        assertEquals("https://a.test", linkAt(screen, 0, 3))    // 'h'
+        assertEquals("https://a.test", linkAt(screen, 0, screen[0].lastIndex))
     }
 
     @Test
@@ -117,12 +118,164 @@ class TerminalLinksTest {
         // A cell may already carry an OSC 8 URI; rowLinkSpans still reports the bare text URL. Which one
         // wins (and the no-double-underline skip) is decided by the renderer/click layer, not here.
         val cells = "https://a.test".map { TermCell(it.toString(), hyperlink = "https://osc8.test") }
-        assertEquals("https://a.test", rowLinkSpans(cells).single().uri)
+        assertEquals("https://a.test", rowLinkSpans(listOf(cells), 0).single().uri)
     }
 
     @Test
     fun `plain rows without a scheme allocate nothing and yield no spans`() {
-        assertTrue(rowLinkSpans(row("total 42  drwxr-xr-x  root:root  10:30")).isEmpty())
+        assertTrue(rowLinkSpans(listOf(row("total 42  drwxr-xr-x  root:root  10:30")), 0).isEmpty())
+    }
+
+    // --- URLs split by a soft wrap: detection runs over the joined logical line ---
+
+    /** A row the emulator marked as soft-wrapped (the logical line continues on the next row). */
+    private fun wrapped(text: String): List<TermCell> = TermSnapshotRow(text.map { TermCell(it) }, wrapped = true)
+
+    @Test
+    fun `a url split by a soft wrap is one link on both rows`() {
+        val screen = listOf(wrapped("see https://a.test/docs/rate-li"), row("mits#new-certs and more"))
+        val uri = "https://a.test/docs/rate-limits#new-certs"
+        val top = rowLinkSpans(screen, 0).single()
+        assertEquals(uri, top.uri)
+        assertEquals(4, top.start)
+        assertEquals(screen[0].size, top.endExclusive) // underlined to the wrap point
+        val bottom = rowLinkSpans(screen, 1).single()
+        assertEquals(uri, bottom.uri)
+        assertEquals(0, bottom.start)
+        assertEquals("mits#new-certs".length, bottom.endExclusive)
+        // Ctrl+click on the tail opens the whole URL, not the fragment under the pointer.
+        assertEquals(uri, linkAt(screen, 1, 2))
+        assertEquals(uri, linkAt(screen, 0, 4))
+        assertNull(linkAt(screen, 1, "mits#new-certs".length + 1))
+    }
+
+    @Test
+    fun `a url spanning three wrapped rows is linked on the middle row too`() {
+        val screen = listOf(wrapped("https://a.test/aaaa"), wrapped("bbbb"), row("cccc end"))
+        val uri = "https://a.test/aaaabbbbcccc"
+        assertEquals(uri, rowLinkSpans(screen, 1).single().uri)
+        assertEquals(0, rowLinkSpans(screen, 1).single().start)
+        assertEquals(4, rowLinkSpans(screen, 1).single().endExclusive)
+        assertEquals(uri, linkAt(screen, 2, 0))
+    }
+
+    @Test
+    fun `a hard line break keeps the two rows apart`() {
+        val screen = listOf(row("see https://a.test/docs/rate-li"), row("mits#new-certs"))
+        assertEquals("https://a.test/docs/rate-li", rowLinkSpans(screen, 0).single().uri)
+        assertTrue(rowLinkSpans(screen, 1).isEmpty())
+        assertNull(linkAt(screen, 1, 2))
+    }
+
+    @Test
+    fun `a url whose scheme separator straddles the wrap is still linked`() {
+        // The `://` itself lands on the row boundary — a per-row scan sees no scheme on either row.
+        val screen = listOf(wrapped("see https:"), row("//a.test/x rest"))
+        assertEquals("https://a.test/x", rowLinkSpans(screen, 0).single().uri)
+        assertEquals("https://a.test/x", linkAt(screen, 1, 0))
+    }
+
+    @Test
+    fun `a url running past the chain cap is dropped, not opened truncated`() {
+        // 12 wrapped rows: from the head the join stops at the clamp, so the URL's tail is unknown —
+        // reporting the joined prefix would open an address the server never printed.
+        val screen = buildList {
+            add(wrapped("https://a.test/aaaaa"))
+            repeat(11) { add(wrapped("bbbbbbbbbbbbbbbbbbbb")) }
+            add(row("tail"))
+        }
+        assertTrue(rowLinkSpans(screen, 0).isEmpty())
+        assertNull(linkAt(screen, 0, 3))
+        assertTrue(rowLinkSpans(screen, 12).isEmpty())
+    }
+
+    @Test
+    fun `a url spanning exactly the chain cap is still linked`() {
+        // 8 wraps = 9 rows, the longest chain the clamp lets through whole.
+        val screen = buildList {
+            add(wrapped("https://a.test/aaaaa"))
+            repeat(7) { add(wrapped("bbbbbbbbbbbbbbbbbbbb")) }
+            add(row("cccc"))
+        }
+        val uri = "https://a.test/aaaaa" + "bbbbbbbbbbbbbbbbbbbb".repeat(7) + "cccc"
+        assertEquals(uri, rowLinkSpans(screen, 0).single().uri)
+        assertEquals(uri, linkAt(screen, 8, 0))
+    }
+
+    @Test
+    fun `a draw window reports the wrapped url on every row it crosses`() {
+        val screen = listOf(wrapped("see https://a.test/docs/rate-li"), row("mits#new-certs"), row("plain row"))
+        assertEquals(setOf(0, 1), linkSpansByRow(screen, 0..2).keys)
+    }
+
+    @Test
+    fun `a long chain resolves the same from a draw window and from a single row`() {
+        // 13 rows of one logical line: the underline (computed for the whole window) and the hand
+        // cursor (computed for the pointed row) must agree on every cell, whatever the scroll offset.
+        val screen = buildList {
+            add(wrapped("https://a.test/aaaaa"))          // runs past the first block's edge — unlinkable
+            repeat(8) { add(wrapped("bbbbbbbbbbbbbbbbbbbb")) }
+            add(wrapped("x https://a.test/q y"))          // wholly inside the second block — linkable
+            repeat(2) { add(wrapped("cccccccccccccccccccc")) }
+            add(row("tail"))
+        }
+        val whole = linkSpansByRow(screen, 0..12)
+        val scrolled = linkSpansByRow(screen, 4..12)
+        // Not a vacuous comparison: the second block really does carry a link.
+        assertEquals("https://a.test/q", whole.getValue(9).single().uri)
+        for (r in 0..12) {
+            assertEquals(whole[r].orEmpty(), rowLinkSpans(screen, r), "row $r")
+            if (r >= 4) assertEquals(whole[r].orEmpty(), scrolled[r].orEmpty(), "row $r scrolled")
+        }
+    }
+
+    @Test
+    fun `a scheme marker on the last row of a chain is found from any row`() {
+        val screen = listOf(wrapped("plain text here"), wrapped("still plain"), row("go https://a.test"))
+        assertTrue(rowLinkSpans(screen, 0).isEmpty())
+        assertEquals("https://a.test", rowLinkSpans(screen, 2).single().uri)
+    }
+
+    @Test
+    fun `an out-of-range row yields nothing`() {
+        val screen = listOf(row("go https://a.test"))
+        assertTrue(rowLinkSpans(screen, 5).isEmpty())
+        assertNull(linkAt(screen, 5, 0))
+    }
+
+    @Test
+    fun `a wide glyph before the wrap keeps the columns aligned on both rows`() {
+        // 世 occupies columns 0-1, so the URL on the first row starts at column 2, not 1.
+        val head = TermSnapshotRow(
+            buildList {
+                add(TermCell("世", width = app.skerry.shared.terminal.CellWidth.Wide))
+                add(TermCell("", width = app.skerry.shared.terminal.CellWidth.Continuation))
+                "https://a.test/pa".forEach { add(TermCell(it)) }
+            },
+            wrapped = true,
+        )
+        val screen = listOf(head, row("th x"))
+        val top = rowLinkSpans(screen, 0).single()
+        assertEquals(2, top.start)
+        assertEquals(head.size, top.endExclusive)
+        assertEquals("https://a.test/path", top.uri)
+        assertEquals("https://a.test/path", linkAt(screen, 1, 1))
+    }
+
+    @Test
+    fun `a url wrapped by a real emulator is one link end to end`() {
+        val emu = app.skerry.shared.terminal.TerminalEmulator(cols = 20, rows = 4)
+        emu.feed("see https://a.test/docs/rate-limits done".encodeToByteArray())
+        val screen = emu.lines
+        assertEquals("https://a.test/docs/rate-limits", rowLinkSpans(screen, 0).single().uri)
+        assertEquals("https://a.test/docs/rate-limits", linkAt(screen, 1, 0))
+    }
+
+    @Test
+    fun `a url wholly inside a wrapped row is reported on that row only`() {
+        val screen = listOf(wrapped("go https://a.test now padding"), row("tail of the line"))
+        assertEquals("https://a.test", rowLinkSpans(screen, 0).single().uri)
+        assertTrue(rowLinkSpans(screen, 1).isEmpty())
     }
 
     @Test
@@ -134,8 +287,8 @@ class TerminalLinksTest {
             add(TermCell(' '))
             "https://a.test".forEach { add(TermCell(it)) }
         }
-        val span = rowLinkSpans(cells).single()
+        val span = rowLinkSpans(listOf(cells), 0).single()
         assertEquals(3, span.start)                 // url starts after wide glyph (cols 0,1) + space (col 2)
-        assertEquals("https://a.test", linkAt(cells, 3))
+        assertEquals("https://a.test", linkAt(listOf(cells), 0, 3))
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -6,7 +6,10 @@ import app.skerry.shared.terminal.CursorShape
 import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermSnapshotRow
 import app.skerry.shared.terminal.TerminalPos
+import app.skerry.shared.terminal.wrapsToNextRow
 import app.skerry.shared.terminal.TerminalSearchError
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
@@ -1921,6 +1924,39 @@ class TerminalScreenStateTest {
 
         assertEquals(null, state.selectedText())
         scope.cancel()
+    }
+
+    @Test
+    fun `clearing a soft wrap republishes the screen even when no cell changes`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+        state.resize(PtySize(cols = 4, rows = 4))
+
+        // 中 does not fit in the last column: row 0 is marked wrapped and its column 3 stays blank.
+        session.emit("ABC中".encodeToByteArray())
+        assertTrue(state.screen[0].wrapsToNextRow())
+
+        // ESC[1;4H ESC[K erases from that blank column — every cell keeps its value, only the wrap
+        // goes away. A snapshot compared on cells alone would look unchanged and never be published.
+        session.emit("${27.toChar()}[1;4H${27.toChar()}[K".encodeToByteArray())
+        assertFalse(state.screen[0].wrapsToNextRow())
+        scope.cancel()
+    }
+
+    @Test
+    fun `a snapshot differing only in the soft-wrap flag is not treated as unchanged`() {
+        // Compose skips a state write when the new value is equivalent to the old one, and list
+        // equality only sees cells. A row can lose its wrap (EL over an already-blank tail) without a
+        // single cell changing — publishing that as "no change" would leave link joining on stale flags.
+        val cells = listOf(TermCell('a'), TermCell('b'))
+        val wrapped = listOf<List<TermCell>>(TermSnapshotRow(cells, wrapped = true))
+        val plain = listOf<List<TermCell>>(TermSnapshotRow(cells, wrapped = false))
+
+        assertTrue(sameScreen(wrapped, listOf(TermSnapshotRow(cells, wrapped = true))))
+        assertFalse(sameScreen(wrapped, plain))
+        assertFalse(sameScreen(plain, listOf<List<TermCell>>(listOf(TermCell('a')))))
     }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
@@ -101,6 +101,25 @@ class TermRow(
     var wrapped: Boolean = false,
 ) : MutableList<TermCell> by cells
 
+/**
+ * A row as published in a render snapshot ([TerminalEmulator.lines]): immutable cells plus the
+ * [wrapped] flag copied off the [TermRow] it came from. Extends [AbstractList] rather than
+ * delegating, so a snapshot row still compares element-wise with a plain list — snapshot equality is
+ * what lets an unchanged screen skip recomposition.
+ */
+class TermSnapshotRow(private val cells: List<TermCell>, val wrapped: Boolean) : AbstractList<TermCell>() {
+    override val size: Int get() = cells.size
+
+    override fun get(index: Int): TermCell = cells[index]
+}
+
+/**
+ * Whether this row soft-wraps into the next one — an auto-wrap (DECAWM) cut the logical line here,
+ * an honest `\n` did not (see [TermRow]). Rows outside a render snapshot (hand-built lists in tests,
+ * selection fragments) carry no flag and answer `false`.
+ */
+fun List<TermCell>.wrapsToNextRow(): Boolean = this is TermSnapshotRow && wrapped
+
 /** Mouse reporting mode to the application (DEC private modes). Encoding is chosen by [TerminalEmulator.mouseSgr]. */
 enum class MouseTracking { Off, X10, Normal, ButtonEvent, AnyEvent }
 
@@ -205,7 +224,8 @@ class TerminalEmulator(
      */
     val lines: List<List<TermCell>>
         get() {
-            val screenRows = ArrayList<List<TermCell>>(grid.size).apply { grid.forEach { add(it.toList()) } }
+            val screenRows = ArrayList<List<TermCell>>(grid.size)
+                .apply { grid.forEach { add(TermSnapshotRow(it.toList(), it.wrapped)) } }
             return if (altScreen) screenRows else SnapshotLines(scrollback.frozen(), screenRows)
         }
 
@@ -1321,7 +1341,7 @@ private class ScrollbackBuffer {
 
     fun push(row: TermRow) {
         rows.addLast(row)
-        tail.add(row.toList())
+        tail.add(TermSnapshotRow(row.toList(), row.wrapped))
         if (tail.size == SCROLLBACK_CHUNK) {
             sealed.addLast(tail)
             tail = ArrayList(SCROLLBACK_CHUNK)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSearch.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSearch.kt
@@ -61,8 +61,10 @@ data class TerminalSearchResult(
  * Finds [query] in the terminal buffer [screen] (scrollback + screen rows, as published by
  * [TerminalEmulator.lines]).
  *
- * Each row is searched on its own: rows are physical, so a hit spanning a soft wrap is not found —
- * the render snapshot carries no `wrapped` flag (see [TermRow]) and joining rows would need it.
+ * Each row is searched on its own: rows are physical, so a hit spanning a soft wrap is not found.
+ * The snapshot does carry the flag ([wrapsToNextRow]) — joining rows here is possible and simply out
+ * of scope: the hit list is a row/column range the render highlights, and a match crossing a wrap
+ * would have to become several of them.
  * Trailing blank cells are ignored, as when copying a selection: grid rows are padded to the
  * terminal width, and searching the padding would match spaces on every row.
  *

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
@@ -1160,6 +1160,41 @@ class TerminalEmulatorTest {
     }
 
     @Test
+    fun `snapshot rows expose the soft-wrap flag`() {
+        // cols=4: "ABCDEF" autowraps — the render snapshot must say so, or the UI cannot tell a soft
+        // wrap from a hard newline (a URL split by the wrap would be two unrelated fragments).
+        val emu = emulate(cols = 4, rows = 6, chunks = arrayOf("ABCDEF"))
+        assertTrue(emu.lines[0].wrapsToNextRow())
+        assertFalse(emu.lines[1].wrapsToNextRow())
+        assertFalse(emulate(cols = 10, rows = 6, chunks = arrayOf("AB\r\nCD")).lines[0].wrapsToNextRow())
+    }
+
+    @Test
+    fun `a wide glyph pushed off the margin also marks the row wrapped`() {
+        // cols=4: 中 doesn't fit in the last column, so it moves to the next row — a soft wrap set by
+        // a different code path than the ordinary end-of-row one.
+        val emu = emulate(cols = 4, rows = 4, chunks = arrayOf("ABC中"))
+        assertTrue(emu.lines[0].wrapsToNextRow())
+    }
+
+    @Test
+    fun `the alt screen publishes the soft-wrap flag too`() {
+        val emu = emulate(cols = 4, rows = 4, chunks = arrayOf("$esc[?1049h", "ABCDEF"))
+        assertTrue(emu.lines[0].wrapsToNextRow())
+        assertFalse(emu.lines[1].wrapsToNextRow())
+    }
+
+    @Test
+    fun `the soft-wrap flag survives into scrollback`() {
+        // rows=2: the wrapped row is pushed to history, where the snapshot reads a frozen copy of it.
+        val emu = TerminalEmulator(cols = 4, rows = 2, maxScrollback = 100)
+        emu.feed("ABCDEF\r\nX".encodeToByteArray())
+        assertEquals(3, emu.lines.size)
+        assertTrue(emu.lines[0].wrapsToNextRow())
+        assertFalse(emu.lines[1].wrapsToNextRow())
+    }
+
+    @Test
     fun `widening does not merge across a hard newline`() {
         val emu = emulate(cols = 10, rows = 6, chunks = arrayOf("AB\r\nCD"))
         emu.resize(40, 6)


### PR DESCRIPTION
A URL cut at the right margin was detected per physical row: the first half was underlined and clickable, the continuation was neither, and a click opened the truncated address.

## What changed

- Render snapshots carry the emulator's soft-wrap flag (`TermSnapshotRow`, `wrapsToNextRow`) — previously the flag existed only inside the emulator's mutable grid.
- Plain-text URL detection joins a soft-wrapped line into one logical text before matching, and returns spans per row. The underline follows the URL across the wrap, and Ctrl+click anywhere on it opens the whole address.
- The scheme scan carries its lookbehind across rows, so a `://` split by the wrap is still found.
- Joining is bounded to blocks of nine rows counted from the line's start, so the draw pass (which resolves a whole viewport) and the pointer (which resolves one row) always agree about a cell. A match touching a clipped block edge is dropped rather than reported truncated.
- The draw pass resolves the whole visible window at once instead of re-joining a chain per row.
- Screen snapshots now compare on wrap flags as well as cells, so a line that stops wrapping without any cell changing is still published to the UI.
- One flattener (`RowText`) serves both the single-row and the multi-row case; the row map is built only when more than one row is joined.

File paths stay single-row on purpose: their affordance is the Ctrl+hover underline painted on the pointed row, so joining would underline part of a path and open the whole of it.

## Verifying

Connect to a host and print output where a URL wraps at the window edge, e.g. `grep -r "https://" /var/log/letsencrypt/`. The link is underlined on both rows, and Ctrl+click on either half opens the full address.

## Tests

`TerminalLinksTest`: wrap join across two and three rows, `://` straddling the wrap, block cap (9 rows joined whole, 13 rows drops the clipped match), draw-window vs single-row agreement, wide glyph before the wrap, scheme marker on the last row, out-of-range row, end-to-end through a real `TerminalEmulator`. `TerminalEmulatorTest`: the flag on the ordinary wrap, the wide-glyph wrap, the alt screen and scrollback. `TerminalScreenStateTest`: a wrap cleared without any cell change is still published.

Not verified: live Android device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)