### PR TITLE
Mobile redesign: Sessions tab, flat catalog rows, template terminal

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -187,6 +187,8 @@ class MainActivity : FragmentActivity() {
                     onHighlightOutputChange = { writeHighlightOutput(dir, it) },
                     initialConfirmProductionWarnings = readProdWarnings(dir),
                     onConfirmProductionWarningsChange = { writeProdWarnings(dir, it) },
+                    initialHideSessionSystemBars = readHideSystemBars(dir),
+                    onHideSessionSystemBarsChange = { writeHideSystemBars(dir, it) },
                     initialUiLanguage = currentUiLanguage.value,
                     onUiLanguageChange = { currentUiLanguage.value = it; writeUiLanguage(dir, it) },
                     initialAutoLock = readAutoLock(dir),
@@ -344,6 +346,20 @@ class MainActivity : FragmentActivity() {
     private fun writeProdWarnings(dir: File, enabled: Boolean) {
         lifecycleScope.launch(Dispatchers.IO) {
             runCatching { File(dir, "terminal_prod_warnings").writeText(enabled.toString()) }
+        }
+    }
+
+    /**
+     * Hiding the phone's system bars inside a session (More → Appearance → Interface):
+     * `hide_system_bars`, default off — the bars belong to the phone.
+     */
+    private fun readHideSystemBars(dir: File): Boolean = runCatching {
+        File(dir, "hide_system_bars").readText().trim().toBoolean()
+    }.getOrDefault(false)
+
+    private fun writeHideSystemBars(dir: File, enabled: Boolean) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            runCatching { File(dir, "hide_system_bars").writeText(enabled.toString()) }
         }
     }
 
@@ -725,6 +741,7 @@ class MainActivity : FragmentActivity() {
                 writeClipboardWrite(dir, false)
                 writeReportTeamSessions(dir, true)
                 writeProdWarnings(dir, false)
+                writeHideSystemBars(dir, false)
                 writeUiLanguage(dir, UiLanguage.DEFAULT)
                 writeAutoLock(dir, AutoLockDuration.DEFAULT)
             }

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -34,7 +34,7 @@
 
     <!-- Нижняя навигация (mobile): подписи корневых табов. -->
     <string name="nav_tab_hosts">Хосты</string>
-    <string name="nav_tab_vault">Хранилище</string>
+    <string name="nav_tab_sessions">Сессии</string>
     <string name="nav_tab_more">Ещё</string>
 
     <!-- Левый icon-rail desktop-оболочки: подписи пунктов. -->

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -84,6 +84,8 @@
     <string name="settings_terminal_show_title">Показывать заголовок терминала на вкладках</string>
     <string name="settings_terminal_show_title_desc">Шелл может переименовывать вкладку (OSC-заголовок). Выкл — показывается имя хоста.</string>
     <string name="settings_terminal_clipboard_write">Разрешить серверу писать в буфер обмена (OSC 52)</string>
+    <string name="settings_hide_system_bars">Скрывать системные панели в сессии</string>
+    <string name="settings_hide_system_bars_desc">Терминал и удалённый рабочий стол занимают весь экран. Панели возвращаются свайпом от края.</string>
     <string name="settings_terminal_open_paths">Открытие файловых путей в SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+клик по пути в выводе открывает его в файловой панели.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Долгое нажатие на путь в выводе, затем «Открыть в Файлах».</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -80,7 +80,7 @@
 
     <!-- Mobile hosts list (MobileHostsView.kt) -->
     <string name="shell_hosts">Хосты</string>
-    <string name="shell_search_hosts">Поиск хостов, тегов…</string>
+    <string name="shell_search_hosts">Поиск хостов, тегов, IP…</string>
 
     <!-- Mobile route placeholder (MobileDesignApp.kt) -->
     <string name="shell_route_team">Команды</string>
@@ -117,4 +117,11 @@
     <string name="shell_kbdint_jump">Запрашивает промежуточный хост</string>
     <string name="shell_kbdint_continue">Продолжить</string>
     <string name="shell_kbdint_asks">Запрос от сервера:</string>
+
+    <!-- Корневой таб «Сессии» (MobileSessionsView.kt): что открыто сейчас -->
+    <string name="shell_sessions_title">Сессии</string>
+    <string name="shell_sessions_count">Открыто: %1$d</string>
+    <string name="shell_sessions_none">Открытых сессий нет</string>
+    <string name="shell_sessions_none_hint">Подключитесь из каталога — сессия останется здесь, пока вы её не закроете.</string>
+    <string name="shell_sessions_close">Закрыть сессию</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -117,4 +117,11 @@
     <string name="term_pane_menu">Действия панели</string>
     <string name="term_pane_change_host">Сменить хост</string>
     <string name="term_pane_close">Закрыть панель</string>
+
+    <!-- Иконки шапки терминала (MobileTerminalChrome.kt): озвучиваемые имена для голых глифов -->
+    <string name="term_header_back">Назад</string>
+    <string name="term_header_files">Файлы</string>
+    <string name="term_header_monitor">Мониторинг хоста</string>
+    <string name="term_header_menu">Меню сессии</string>
+    <string name="term_session_new">Новая сессия</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -34,7 +34,7 @@
 
     <!-- 底部导航（移动端） -->
     <string name="nav_tab_hosts">主机</string>
-    <string name="nav_tab_vault">保险库</string>
+    <string name="nav_tab_sessions">会话</string>
     <string name="nav_tab_more">更多</string>
 
     <!-- 桌面端左侧图标栏 -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -84,6 +84,8 @@
     <string name="settings_terminal_show_title">在标签页上显示终端标题</string>
     <string name="settings_terminal_show_title_desc">允许 shell 重命名标签页（OSC 标题）。关闭时显示主机名。</string>
     <string name="settings_terminal_clipboard_write">允许服务器写入剪贴板 (OSC 52)</string>
+    <string name="settings_hide_system_bars">会话中隐藏系统栏</string>
+    <string name="settings_hide_system_bars_desc">终端和远程桌面将占满整个屏幕。从屏幕边缘滑动即可让系统栏返回。</string>
     <string name="settings_terminal_open_paths">在 SFTP 中打开文件路径</string>
     <string name="settings_terminal_open_paths_desc">按住 Ctrl 点击输出中的路径，即可在文件面板中定位。</string>
     <string name="settings_terminal_open_paths_desc_mobile">长按输出中的路径，然后点按“在文件中打开”。</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -80,7 +80,7 @@
 
     <!-- 移动端主机列表 (MobileHostsView.kt) -->
     <string name="shell_hosts">主机</string>
-    <string name="shell_search_hosts">搜索主机、标签…</string>
+    <string name="shell_search_hosts">搜索主机、标签、IP…</string>
 
     <!-- 移动端路由占位 (MobileDesignApp.kt) -->
     <string name="shell_route_team">团队</string>
@@ -117,4 +117,11 @@
     <string name="shell_kbdint_jump">由跳板主机请求</string>
     <string name="shell_kbdint_continue">继续</string>
     <string name="shell_kbdint_asks">服务器请求：</string>
+
+    <!-- 会话根标签页（MobileSessionsView.kt） -->
+    <string name="shell_sessions_title">会话</string>
+    <string name="shell_sessions_count">已打开 %1$d 个</string>
+    <string name="shell_sessions_none">没有打开的会话</string>
+    <string name="shell_sessions_none_hint">从目录中连接 — 会话会保留在这里，直到你关闭它。</string>
+    <string name="shell_sessions_close">关闭会话</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -114,4 +114,11 @@
     <string name="term_pane_menu">面板操作</string>
     <string name="term_pane_change_host">更换主机</string>
     <string name="term_pane_close">关闭面板</string>
+
+    <!-- 终端标题栏图标（MobileTerminalChrome.kt） -->
+    <string name="term_header_back">返回</string>
+    <string name="term_header_files">文件</string>
+    <string name="term_header_monitor">主机监控</string>
+    <string name="term_header_menu">会话菜单</string>
+    <string name="term_session_new">新建会话</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -35,7 +35,7 @@
 
     <!-- Нижняя навигация (mobile): подписи корневых табов. -->
     <string name="nav_tab_hosts">Hosts</string>
-    <string name="nav_tab_vault">Vault</string>
+    <string name="nav_tab_sessions">Sessions</string>
     <string name="nav_tab_more">More</string>
 
     <!-- Левый icon-rail desktop-оболочки: подписи пунктов. -->

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -84,6 +84,8 @@
     <string name="settings_terminal_show_title">Show terminal title on tabs</string>
     <string name="settings_terminal_show_title_desc">The shell may rename the tab (OSC title). Off: tabs show the host name.</string>
     <string name="settings_terminal_clipboard_write">Allow server clipboard writes (OSC 52)</string>
+    <string name="settings_hide_system_bars">Hide system bars in a session</string>
+    <string name="settings_hide_system_bars_desc">The terminal and the remote desktop take the whole display. The bars come back on a swipe from the edge.</string>
     <string name="settings_terminal_open_paths">Open file paths in SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+click a file path in the output to reveal it in the file panel.</string>
     <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap "Open in Files".</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -80,7 +80,7 @@
 
     <!-- Mobile hosts list (MobileHostsView.kt) -->
     <string name="shell_hosts">Hosts</string>
-    <string name="shell_search_hosts">Search hosts, tags…</string>
+    <string name="shell_search_hosts">Search hosts, tags, IPs…</string>
 
     <!-- Mobile route placeholder (MobileDesignApp.kt) -->
     <string name="shell_route_team">Team</string>
@@ -117,4 +117,11 @@
     <string name="shell_kbdint_jump">Requested by the jump host</string>
     <string name="shell_kbdint_continue">Continue</string>
     <string name="shell_kbdint_asks">The server is asking:</string>
+
+    <!-- Sessions root tab (MobileSessionsView.kt): what is open right now -->
+    <string name="shell_sessions_title">Sessions</string>
+    <string name="shell_sessions_count">%1$d open</string>
+    <string name="shell_sessions_none">No open sessions</string>
+    <string name="shell_sessions_none_hint">Connect from a catalog — the session stays here until you close it.</string>
+    <string name="shell_sessions_close">Close session</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -115,4 +115,11 @@
     <string name="term_pane_menu">Pane actions</string>
     <string name="term_pane_change_host">Change host</string>
     <string name="term_pane_close">Close pane</string>
+
+    <!-- Terminal header icons (MobileTerminalChrome.kt): spoken names for bare glyphs -->
+    <string name="term_header_back">Back</string>
+    <string name="term_header_files">Files</string>
+    <string name="term_header_monitor">Host monitor</string>
+    <string name="term_header_menu">Session menu</string>
+    <string name="term_session_new">New session</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/MobileDesignState.kt
@@ -29,28 +29,72 @@ import app.skerry.ui.terminal.TerminalThemes
 
 /**
  * Bottom navigation — exactly 4 root tabs ([showTabs]=true). [icon] is a Material Symbols ligature
- * (see [Sym]), aligned with the desktop rail ([RAIL]) where the section matches (Hosts/Desktops/Vault).
+ * (see [Sym]), aligned with the desktop rail ([RAIL]) where the section matches (Hosts/Desktops).
  * No Files tab: SFTP opens as a push screen ([MobileRoute.Files]) from a host card's SFTP button —
  * a separate root tab would duplicate the terminal.
  *
- * Snippets is not a root tab either: the bar holds four, and the two catalogs (hosts and remote
- * desktops) come first — the library is reached from More ([MobileRoute.Snippets]) and, in the
- * moment it is actually needed, from the terminal's snippet palette.
+ * The two catalogs come first, then [Sessions] — what is already open, which on a phone is otherwise
+ * only reachable by tapping the host that opened it. The vault and the snippet library are not root
+ * tabs: they are push screens off the More hub ([MobileRoute.Vault]/[MobileRoute.Snippets]), and the
+ * library is also reached mid-session from the terminal's snippet palette.
  */
 // Labels are not part of the enum: they are localized in the tab bar (nav_tab_* resources).
 enum class MobileTab(val icon: String) {
     Hosts("dns"),
     Desktops("desktop_windows"),
-    Vault("vpn_key"),
+    Sessions("terminal"),
     More("more_horiz"),
 }
 
 /**
  * Full-screen push screens over the tab navigation (tab bar hidden): terminal and host detail open
- * from Hosts, the framebuffer from Desktops, SFTP (Files) via the host card's SFTP button, and
- * Snippets/Ports/Known/Team from the More tab.
+ * from Hosts, the framebuffer from Desktops or Sessions, SFTP (Files) via the host card's SFTP
+ * button, and Vault/Snippets/Ports/Known/Team from the More tab.
  */
-enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
+enum class MobileRoute { Terminal, Vnc, Files, HostDetail, Vault, Snippets, Runbooks, Ports, Known, Team, Appearance, Sync, Ai, Security, Trash, About }
+
+/**
+ * Push screens that keep the bottom navigation up. The terminal is one: per the template it is a
+ * place you work in and step out of, not a mode you have to escape — leaving for the catalog is one
+ * tap. The remote desktop is not: its picture wants the whole display and it carries its own
+ * floating bar.
+ */
+fun mobileRouteKeepsTabBar(route: MobileRoute?): Boolean = route == MobileRoute.Terminal
+
+/**
+ * Whether the bottom navigation is actually laid out under [route] right now. It disappears while a
+ * modal is up (it would float over the dialog) and while the soft keyboard is up (it would sit as a
+ * second bar above it), so "the terminal keeps the bar" is not the same as "the bar is there".
+ *
+ * The distinction matters beyond drawing: whatever is bottom-most owns the system navigation-bar
+ * inset. With the bar present that is the bar; without it, the terminal's key panel — and in
+ * immersive mode ([mobileSessionFullBleed]) nothing else reserves that space, so a swipe that
+ * transiently reveals the system bars would land on top of the keys.
+ */
+fun mobileTabBarUnderRoute(route: MobileRoute?, modalOpen: Boolean, keyboardVisible: Boolean): Boolean =
+    mobileRouteKeepsTabBar(route) && !modalOpen && !keyboardVisible
+
+/**
+ * Bottom-nav item drawn as active, or `null` when none is. A session screen highlights
+ * [MobileTab.Sessions] — it is what the user is inside of, and leaving the bar unlit while the
+ * terminal is up reads as having fallen out of the app's navigation. Any other push screen lights
+ * nothing: it belongs to the tab underneath, which the user can no longer see.
+ */
+fun mobileActiveTab(tab: MobileTab, route: MobileRoute?): MobileTab? = when (route) {
+    null -> tab
+    MobileRoute.Terminal, MobileRoute.Vnc -> MobileTab.Sessions
+    else -> null
+}
+
+/**
+ * Whether a screen runs edge to edge, giving up the safe area to the session on it. Only the two
+ * session screens ever do, and only when the user asked for it (More → Appearance → Interface):
+ * a catalog under the phone's status bar is unreadable, and a terminal under it was the bug the
+ * setting exists to fix. Read by the shell for its root inset padding, and mirrored by the screens
+ * themselves through [app.skerry.ui.immersive.ImmersiveScreen].
+ */
+fun mobileSessionFullBleed(hideSessionSystemBars: Boolean, route: MobileRoute?): Boolean =
+    hideSessionSystemBars && (route == MobileRoute.Terminal || route == MobileRoute.Vnc)
 
 /** What the system back gesture should do in the mobile shell. */
 enum class MobileBackAction {
@@ -130,6 +174,12 @@ class MobileDesignState(
     // Production guard: also confirm Warn-level commands (Settings → Terminal). Off by default.
     initialConfirmProductionWarnings: Boolean = false,
     private val onConfirmProductionWarningsChange: (Boolean) -> Unit = {},
+    // Whether a session screen hides the phone's status/navigation bars (More → Appearance →
+    // Interface). Off by default: the bars belong to the phone, and a session that swallows the
+    // clock and the battery gets them back only by a swipe the user has to know about. Opting in
+    // buys the pixels back. Persisted on Android; no-op default for previews/tests.
+    initialHideSessionSystemBars: Boolean = false,
+    private val onHideSessionSystemBarsChange: (Boolean) -> Unit = {},
     // UI language (More -> Appearance -> Language). Initial value is read from persistence at
     // startup, the callback writes it back — the choice survives restart. Defaults (System, no-op)
     // auto-detect from the OS locale for previews/tests.
@@ -377,6 +427,13 @@ class MobileDesignState(
      */
     var confirmProductionWarnings: Boolean by mutableStateOf(initialConfirmProductionWarnings); private set
 
+    /**
+     * Whether a session screen (terminal, remote desktop) hides the phone's system bars (More →
+     * Appearance → Interface). Off by default; read by the mobile shell to decide both the immersive
+     * request ([app.skerry.ui.immersive.ImmersiveScreen]) and whether those screens run edge to edge.
+     */
+    var hideSessionSystemBars: Boolean by mutableStateOf(initialHideSessionSystemBars); private set
+
     /** UI language (More -> Appearance -> Language). Threaded to the root via [app.skerry.ui.i18n.AppLocaleProvider]. */
     var uiLanguage: UiLanguage by mutableStateOf(initialUiLanguage); private set
 
@@ -427,6 +484,12 @@ class MobileDesignState(
     fun toggleConfirmProductionWarnings() {
         confirmProductionWarnings = !confirmProductionWarnings
         onConfirmProductionWarningsChange(confirmProductionWarnings)
+    }
+
+    /** Toggle hiding the phone's system bars inside a session and report outward (for persistence). */
+    fun toggleHideSessionSystemBars() {
+        hideSessionSystemBars = !hideSessionSystemBars
+        onHideSessionSystemBarsChange(hideSessionSystemBars)
     }
 
     /** Toggle offering "Open in Files" for a selected file path and report outward (for persistence). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionTypeIcon.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ConnectionTypeIcon.kt
@@ -9,7 +9,9 @@ import app.skerry.shared.ssh.ConnectionType
  */
 val ConnectionType.icon: String
     get() = when (this) {
-        ConnectionType.SSH -> "lan"
+        // Server rack, the same mark the mobile Hosts tab carries: "lan" drew a network topology,
+        // which named the wire rather than the machine at the end of it.
+        ConnectionType.SSH -> "dns"
         ConnectionType.MOSH -> "bolt"
         ConnectionType.TELNET -> "terminal"
         ConnectionType.SERIAL -> "cable"

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
@@ -29,6 +29,9 @@ fun List<Host>.inSection(section: HostSection): List<Host> = filter { it.section
  * the suffix, leaving just the shell path (blank for the system default).
  */
 fun Host.rowSubtitle(): String = when {
+    // The port belongs to the address a row identifies a profile by: two profiles on the same
+    // machine (a jump host and a container gateway, 22 and 2222) are otherwise the same line.
+    username.isNotBlank() && port > 0 -> "$username@$address:$port"
     username.isNotBlank() -> "$username@$address"
     port > 0 -> "$address:$port"
     else -> address

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/immersive/ImmersiveScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/immersive/ImmersiveScreen.kt
@@ -30,15 +30,21 @@ expect fun Modifier.hiddenSystemBarsPadding(top: Boolean = true, bottom: Boolean
 private val immersiveController = SecureFlagController(::applyPlatformImmersive)
 
 /**
- * Marks a screen as full-bleed: while this composable is in composition the system bars are hidden,
- * and they return when it leaves. Used by the session screens (VNC, terminal), where content shown
- * at anything less than the whole display wastes the scarcest thing on a phone — pixels — and where
- * the status bar sat on top of the picture in landscape.
+ * Marks a screen as full-bleed: while this composable is in composition with [enabled] the system
+ * bars are hidden, and they return when it leaves or the flag goes false. Used by the session
+ * screens (VNC, terminal), where content shown at anything less than the whole display wastes the
+ * scarcest thing on a phone — pixels — and where the status bar sat on top of the picture in
+ * landscape.
+ *
+ * [enabled] is the user's setting (More → Appearance → Interface), off by default: the bars are the
+ * phone's, and swallowing the clock and the battery is worth doing only on request. `false` claims
+ * nothing from the reference count, so a screen that opts out cannot hold the bars down for a later
+ * one that did opt in.
  */
 @Composable
-fun ImmersiveScreen() {
-    DisposableEffect(Unit) {
-        immersiveController.acquire()
-        onDispose { immersiveController.release() }
+fun ImmersiveScreen(enabled: Boolean = true) {
+    DisposableEffect(enabled) {
+        if (enabled) immersiveController.acquire()
+        onDispose { if (enabled) immersiveController.release() }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
@@ -3,8 +3,10 @@ package app.skerry.ui.mobile
 import app.skerry.ui.connection.toRdpPassword
 import app.skerry.shared.ssh.isRdp
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.windowInsetsPadding
@@ -61,6 +63,8 @@ import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.MobileRoute
 import app.skerry.ui.app.MobileTab
 import app.skerry.ui.app.mobileBackAction
+import app.skerry.ui.app.mobileSessionFullBleed
+import app.skerry.ui.app.mobileTabBarUnderRoute
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.host.ProdConnectDialog
 import app.skerry.ui.host.ProdConnectRequest
@@ -234,19 +238,29 @@ internal fun MobileChrome(
         // lifts all content above the keyboard, and the tab bar (BottomCenter) would otherwise float
         // as a bar right above it.
         val keyboardVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0
-        // Session screens run full-bleed: they hide the system bars and use the whole display (a phone
-        // has no pixels to spare for chrome, and in landscape the status bar sat on top of the remote
-        // picture). Their own floating chrome keeps clear of the insets, and they handle the keyboard
-        // inset themselves — see ImmersiveScreen / hiddenSystemBarsPadding.
-        val fullBleed = state.route == MobileRoute.Vnc || state.route == MobileRoute.Terminal
+        // Session screens run full-bleed only when the user asked for it (More → Appearance →
+        // Interface): then they hide the system bars and use the whole display, their own floating
+        // chrome keeps clear of the insets, and they handle the keyboard inset themselves — see
+        // ImmersiveScreen / hiddenSystemBarsPadding. With the setting off (the default) the bars
+        // stay up and this screen stays inside the safe area, or terminal output would run under
+        // the phone's clock.
+        val fullBleed = mobileSessionFullBleed(state.hideSessionSystemBars, state.route)
         Box(Modifier.fillMaxSize().then(if (fullBleed) Modifier else Modifier.windowInsetsPadding(WindowInsets.safeDrawing))) {
             val route = state.route
-            Box(Modifier.fillMaxSize()) {
-                if (route != null) {
-                    MobileRoutePane(state, route)
-                } else {
-                    MobileTabPane(state, onLock)
+            // The terminal keeps the bar ([mobileRouteKeepsTabBar]) and gets it as a sibling below
+            // the screen, not floating over it: a translucent strip works over a scrolling list, but
+            // over terminal output it would hide the last lines. Root tabs keep the overlay they
+            // were laid out for (their content reserves the space at the end).
+            val tabsUnderRoute = mobileTabBarUnderRoute(route, state.modalOpen, keyboardVisible)
+            Column(Modifier.fillMaxSize()) {
+                Box(Modifier.weight(1f).fillMaxWidth()) {
+                    if (route != null) {
+                        MobileRoutePane(state, route)
+                    } else {
+                        MobileTabPane(state, onLock)
+                    }
                 }
+                if (tabsUnderRoute) MobileTabBar(state)
             }
             if (state.showTabs && !keyboardVisible) {
                 MobileTabBar(state, Modifier.align(Alignment.BottomCenter))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppearanceScreen.kt
@@ -48,6 +48,8 @@ import app.skerry.ui.generated.resources.appearance_section_theme
 import app.skerry.ui.generated.resources.appearance_custom_term_theme
 import app.skerry.ui.generated.resources.appearance_custom_term_theme_desc
 import app.skerry.ui.generated.resources.appearance_section_terminal
+import app.skerry.ui.generated.resources.settings_hide_system_bars
+import app.skerry.ui.generated.resources.settings_hide_system_bars_desc
 import app.skerry.ui.generated.resources.settings_terminal_open_paths
 import app.skerry.ui.generated.resources.settings_terminal_open_paths_desc_mobile
 import app.skerry.ui.generated.resources.settings_terminal_highlight_input
@@ -208,6 +210,15 @@ fun MobileAppearanceScreen(state: MobileDesignState) {
             FontSettingRow(stringResource(Res.string.appearance_language)) {
                 MobileLanguagePicker(state.uiLanguage, onPick = state::chooseUiLanguage)
             }
+            HLine()
+            // Whether a session takes the phone's status/navigation bars with it. Off by default —
+            // they are the phone's, not ours; on, a swipe from the edge brings them back.
+            MobileToggleRow(
+                title = stringResource(Res.string.settings_hide_system_bars),
+                desc = stringResource(Res.string.settings_hide_system_bars_desc),
+                on = state.hideSessionSystemBars,
+                onToggle = state::toggleHideSessionSystemBars,
+            )
             HLine()
             // App theme cards in a 2xN grid — the chrome counterpart of the terminal cards above.
             Txt(stringResource(Res.string.appearance_section_theme), color = Skerry.colors.faint, size = 11.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 18.dp, bottom = 6.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileChrome.kt
@@ -5,20 +5,32 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
@@ -52,7 +64,107 @@ internal fun MobilePushHeader(title: String, onBack: () -> Unit, plainBack: Bool
     }
 }
 
-/** Root-tab title (28sp Bold, letterSpacing -0.5) — Hosts/Snippets/Vault/More/Files. */
+/**
+ * One catalog line of the mobile template — a saved profile or an open session. Flat by design:
+ * page background, no border, only the icon tile is filled, and the rows are told apart by
+ * whitespace and by the mono type of the address. [badge] rides beside the label (the production
+ * marking), [trailing] sits after the status dot (closing a session). [statusText] is what the dot
+ * says out loud — colour alone reaches neither a screen reader nor a colourblind eye.
+ *
+ * Shared by the two catalogs and the Sessions list so one change of the row shape reaches all of
+ * them; the parent supplies the horizontal gutter, which is why this row pads vertically only.
+ */
+@Composable
+internal fun MobileCatalogRow(
+    icon: String,
+    label: String,
+    subtitle: String,
+    dotColor: Color,
+    statusText: String,
+    onClick: () -> Unit,
+    badge: (@Composable () -> Unit)? = null,
+    trailing: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(13.dp),
+    ) {
+        Box(
+            Modifier.size(42.dp).clip(RoundedCornerShape(11.dp)).background(Skerry.colors.card),
+            contentAlignment = Alignment.Center,
+        ) {
+            Sym(icon, size = 21.sp, color = Skerry.colors.dim)
+        }
+        Column(Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Txt(
+                    label,
+                    color = Skerry.colors.text,
+                    size = 15.sp,
+                    weight = FontWeight.SemiBold,
+                    font = LocalFonts.current.mono,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                badge?.invoke()
+            }
+            Spacer(Modifier.height(3.dp))
+            Txt(
+                subtitle,
+                color = Skerry.colors.dim,
+                size = 12.sp,
+                font = LocalFonts.current.mono,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        // Not independently clickable, so the description merges into the row's announcement.
+        Box(Modifier.size(8.dp).clip(CircleShape).background(dotColor).semantics { contentDescription = statusText })
+        trailing?.invoke()
+    }
+}
+
+/**
+ * "Nothing here yet" for a mobile screen: glyph, what is empty, and why — centered, one look for
+ * every list. [content] is an optional slot under the text for whatever gets the user out of the
+ * empty state (the Sessions screen puts the two catalogs there).
+ *
+ * Extracted because the shell had grown three near-identical private copies (tunnels, known hosts,
+ * sessions) drifting in icon size and alignment. The host catalog keeps its own note: it is a
+ * left-aligned two-liner under the search field, not a centered placeholder for a blank screen.
+ */
+@Composable
+internal fun MobileEmptyNote(
+    icon: String,
+    title: String,
+    subtitle: String,
+    topPadding: Dp = 50.dp,
+    content: (@Composable ColumnScope.() -> Unit)? = null,
+) {
+    Box(Modifier.fillMaxWidth().padding(top = topPadding, start = 22.dp, end = 22.dp), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Sym(icon, size = 28.sp, color = Skerry.colors.faint)
+            Txt(title, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.Medium)
+            Txt(subtitle, color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp, align = TextAlign.Center)
+            content?.invoke(this)
+        }
+    }
+}
+
+/** Root-tab title (28sp Bold, letterSpacing -0.5) — Hosts/Desktops/Sessions/More. */
 @Composable
 internal fun MobileScreenTitle(text: String) {
     Txt(text, color = Skerry.colors.text, size = 28.sp, weight = FontWeight.Bold, letterSpacing = (-0.5).sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
@@ -36,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -79,6 +77,7 @@ import app.skerry.ui.host.hostChipLabel
 import app.skerry.ui.host.icon
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
+import app.skerry.ui.session.sessionStatusText
 import app.skerry.ui.host.draggableFolderHeader
 import app.skerry.ui.host.draggableHostRow
 import app.skerry.ui.theme.Skerry
@@ -217,7 +216,7 @@ private fun MobileHostFolder(
         }
         // A collapsed folder shows only its header; the host list (and its drag targets) is hidden.
         if (!collapsed) {
-            Column(Modifier.padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(9.dp)) {
+            Column(Modifier.padding(horizontal = 22.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
                 folder.hosts.forEach { host ->
                     key(host.id) {
                         if (host.id == lineBeforeId) MobileDropLine(horizontal = 0.dp)
@@ -414,7 +413,7 @@ private fun MobileFolderHeader(
     onEdit: (() -> Unit)?,
 ) {
     Row(
-        Modifier.fillMaxWidth().padding(start = 18.dp, end = 22.dp, top = 14.dp, bottom = 6.dp),
+        Modifier.fillMaxWidth().padding(start = 18.dp, end = 22.dp, top = 16.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
@@ -431,8 +430,10 @@ private fun MobileFolderHeader(
         ) {
             Sym(if (collapsed) "chevron_right" else "expand_more", size = 16.sp, color = Skerry.colors.faint)
         }
+        // Template form: "PRODUCTION · 3" — the count rides with the name instead of sitting on the
+        // far right, where it read as a column of unrelated numbers down the screen.
         Txt(
-            name.uppercase(),
+            "${name.uppercase()} · $count",
             color = if (dropTarget) Skerry.colors.cyanBright else Skerry.colors.faint,
             size = 12.sp,
             weight = FontWeight.SemiBold,
@@ -454,61 +455,35 @@ private fun MobileFolderHeader(
             }
         }
         Spacer(Modifier.weight(1f))
-        Txt(count.toString(), color = Skerry.colors.faint, size = 11.sp)
     }
 }
 
 /**
- * Host row: icon tile + name + monospace `user@address` + status dot. The tile carries the
- * profile's protocol ([app.skerry.ui.host.icon], same symbol as the desktop sidebar and the
- * connection form); the dot color is live, taken from the host's latest session status
- * ([SessionsController.sessionStatusFor]) via the desktop-shared [sessionDotColor] (live → green,
- * connecting → amber, error/dropped → sunset, no session → dim). Reading uiState inside the
+ * Host row, per the mobile template: a flat line — icon tile, monospace label over a monospace
+ * `user@address:port`, status dot at the right edge. No card and no border; the list is separated by
+ * whitespace, and the tile is the only filled shape (a frame around every profile turned the
+ * catalog into a stack of boxes and left the eye nothing to follow).
+ *
+ * The tile carries the profile's protocol ([app.skerry.ui.host.icon], same symbol as the desktop
+ * sidebar and the connection form); the dot color is live, taken from the host's latest session
+ * status ([SessionsController.sessionStatusFor]) via the desktop-shared [sessionDotColor] (live →
+ * green, connecting → amber, error/dropped → sunset, no session → dim). Reading uiState inside the
  * composition subscribes the row to status changes so the dot updates on connect.
+ *
+ * A production host keeps its [ProdBadge] beside the label: the template models no such host, and
+ * the badge is the marking that survives losing the frame the red outline used to live on.
  */
 @Composable
 private fun MobileHostRow(host: Host, onClick: () -> Unit) {
-    val dotColor = sessionDotColor(LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle)
-    val prod = isProdHost(host)
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
-            .background(Skerry.colors.card)
-            .border(1.dp, if (prod) Skerry.colors.sunset else Skerry.colors.cyan08, RoundedCornerShape(14.dp))
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onClick,
-            )
-            .padding(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(13.dp),
-    ) {
-        Box(
-            Modifier.size(40.dp).clip(RoundedCornerShape(11.dp)).background(Skerry.colors.cyan.copy(alpha = 0.1f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Sym(host.connectionType.icon, size = 21.sp, color = Skerry.colors.cyanBright)
-        }
-        Column(Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                Txt(
-                    host.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold,
-                    maxLines = 1, modifier = Modifier.weight(1f, fill = false),
-                )
-                if (prod) ProdBadge()
-            }
-            Spacer(Modifier.height(2.dp))
-            Txt(
-                host.rowSubtitle(),
-                color = Skerry.colors.dim,
-                size = 11.5.sp,
-                font = LocalFonts.current.mono,
-                maxLines = 1,
-            )
-        }
-        Box(Modifier.size(8.dp).clip(CircleShape).background(dotColor))
-    }
+    val status = LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle
+    MobileCatalogRow(
+        icon = host.connectionType.icon,
+        label = host.label,
+        subtitle = host.rowSubtitle(),
+        dotColor = sessionDotColor(status),
+        statusText = sessionStatusText(status),
+        onClick = onClick,
+        badge = if (isProdHost(host)) ({ ProdBadge() }) else null,
+    )
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKnownView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileKnownView.kt
@@ -234,15 +234,12 @@ private fun LiveKnownRow(entry: KnownHostEntry, mono: FontFamily, onForget: () -
 
 /** Empty state: no trusted keys yet (the first connect will record one via TOFU). */
 @Composable
-private fun MobileEmptyKnown() {
-    Box(Modifier.fillMaxWidth().padding(top = 60.dp), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Sym("fingerprint", size = 28.sp, color = Skerry.colors.faint)
-            Txt(stringResource(Res.string.lib_known_empty_title), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.Medium)
-            Txt(stringResource(Res.string.lib_known_empty_desc_mobile), color = Skerry.colors.faint, size = 12.sp)
-        }
-    }
-}
+private fun MobileEmptyKnown() = MobileEmptyNote(
+    icon = "fingerprint",
+    title = stringResource(Res.string.lib_known_empty_title),
+    subtitle = stringResource(Res.string.lib_known_empty_desc_mobile),
+    topPadding = 60.dp,
+)
 
 // Shared layout pieces.
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileMoreView.kt
@@ -42,7 +42,11 @@ import app.skerry.ui.generated.resources.more_trash
 import app.skerry.ui.generated.resources.more_title
 import app.skerry.ui.generated.resources.settings_security_title
 import app.skerry.ui.generated.resources.settings_update_status
+import app.skerry.ui.generated.resources.vault_item_count
+import app.skerry.ui.generated.resources.vault_title
+import app.skerry.ui.app.LocalCredentials
 import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.generated.resources.term_player_open
 import app.skerry.ui.generated.resources.conn_import_action
@@ -87,6 +91,18 @@ fun MobileMoreScreen(state: MobileDesignState, onLock: (() -> Unit)?) {
             val known = if (preview) mobileMoreKnownSubtitle(1) else knownSubtitle()
             val knownWarn = if (preview) true else knownChanged() > 0
 
+            // Keychain: it lost its root tab to Sessions and lives here now. Subtitle is the number
+            // of secrets in the open vault; without one (preview/locked) the row still opens the
+            // screen, which says the same thing in full.
+            val vaultCount = LocalCredentials.current?.credentials?.size
+            val vaultSubtitle = if (vaultCount == null) null else {
+                pluralStringResource(Res.plurals.vault_item_count, vaultCount, vaultCount)
+            }
+            MoreRow(
+                "vpn_key", Skerry.colors.cyanBright, stringResource(Res.string.vault_title),
+                vaultSubtitle, Skerry.colors.dim,
+                onClick = { state.push(MobileRoute.Vault) },
+            )
             // Snippet library: it lost its root tab to the remote-desktops one, so this is its home
             // in the shell (the terminal's snippet palette still reaches it mid-session).
             MoreRow("code_blocks", Skerry.colors.cyanBright, stringResource(Res.string.lib_snippets_screen_title), null, Skerry.colors.dim, onClick = { state.push(MobileRoute.Snippets) })

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -312,15 +312,11 @@ private fun TunnelStatusControl(entry: TunnelEntry, onToggle: () -> Unit) {
 
 /** Empty state (no tunnels yet); added via the New tunnel button below. */
 @Composable
-private fun MobileEmptyTunnels() {
-    Box(Modifier.fillMaxWidth().padding(top = 50.dp), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Sym("lan", size = 28.sp, color = Skerry.colors.faint)
-            Txt(stringResource(Res.string.ports_no_tunnels_yet), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.Medium)
-            Txt(stringResource(Res.string.ports_add_tunnel_below), color = Skerry.colors.faint, size = 12.sp)
-        }
-    }
-}
+private fun MobileEmptyTunnels() = MobileEmptyNote(
+    icon = "lan",
+    title = stringResource(Res.string.ports_no_tunnels_yet),
+    subtitle = stringResource(Res.string.ports_add_tunnel_below),
+)
 
 // Tunnel editor (sheet).
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
@@ -99,7 +99,7 @@ internal fun MobileTabPane(state: MobileDesignState, onLock: (() -> Unit)?) {
     when (state.tab) {
         MobileTab.Hosts -> MobileHostsScreen(state)
         MobileTab.Desktops -> MobileDesktopsScreen(state)
-        MobileTab.Vault -> MobileVaultScreen(state)
+        MobileTab.Sessions -> MobileSessionsScreen(state)
         MobileTab.More -> MobileMoreScreen(state, onLock)
     }
 }
@@ -115,6 +115,7 @@ internal fun MobileRoutePane(state: MobileDesignState, route: MobileRoute) {
         MobileRoute.Terminal -> MobileTerminalScreen(state)
         MobileRoute.Vnc -> MobileVncScreen(state)
         MobileRoute.Files -> MobileFilesScreen(onBack = state::pop)
+        MobileRoute.Vault -> MobileVaultScreen(state)
         MobileRoute.Snippets -> MobileSnippetsScreen(state)
         MobileRoute.Runbooks -> MobileRunbooksScreen(state)
         MobileRoute.Ports -> MobilePortsScreen(state)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessions.kt
@@ -1,0 +1,87 @@
+package app.skerry.ui.mobile
+
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.session.SessionStatus
+import app.skerry.ui.session.Tab
+
+// Pure list model behind the Sessions root tab; the composables live in MobileSessionsView.kt.
+
+/**
+ * What the Sessions list needs to know about one open [Tab], flattened off the live controller so
+ * the list logic is decided in one place and testable without a transport.
+ */
+internal data class MobileSessionInfo(
+    val tabId: String,
+    val title: String,
+    val subtitle: String,
+    val isVnc: Boolean,
+    val isPlayer: Boolean,
+    val isBlank: Boolean,
+    val status: SessionStatus,
+)
+
+/** One row of the Sessions list: what it shows and which push screen a tap opens. */
+internal data class MobileSessionRow(
+    val tabId: String,
+    val title: String,
+    val subtitle: String,
+    val icon: String,
+    val status: SessionStatus,
+    val route: MobileRoute,
+)
+
+/** Flatten a live tab into what the list reads. */
+internal fun Tab.toSessionInfo(): MobileSessionInfo = MobileSessionInfo(
+    tabId = id,
+    title = displayTitle,
+    subtitle = focusedPane.subtitle,
+    isVnc = isVnc,
+    isPlayer = isPlayer,
+    isBlank = isBlank,
+    status = focusedPane.status,
+)
+
+/** One chip of the terminal screen's session strip. */
+internal data class MobileStripChip(
+    val tabId: String,
+    val label: String,
+    val status: SessionStatus,
+    val active: Boolean,
+)
+
+/**
+ * Chips for the terminal screen's session strip: the open shells, in the order they were opened,
+ * with [activeId] marked. Remote desktops are left out — they render on their own screen, and a chip
+ * that swapped the terminal for a framebuffer would be a trapdoor rather than a tab. So is a blank
+ * tab: nothing is connected in it, so its chip would carry an empty label and lead to an empty
+ * screen (see [MobileSessionStrip], where "+" is the way to a new session instead).
+ */
+internal fun mobileTerminalStrip(
+    sessions: List<MobileSessionInfo>,
+    activeId: String?,
+): List<MobileStripChip> =
+    sessions.filterNot { it.isVnc || it.isBlank }.map {
+        MobileStripChip(tabId = it.tabId, label = it.title, status = it.status, active = it.tabId == activeId)
+    }
+
+/**
+ * Rows for the open sessions, in the order they were opened. A blank tab is left out: it holds no
+ * connection, so a row for it would open an empty terminal screen and read as a session that died.
+ * A failed or dropped session keeps its row — that is what the user comes here to find.
+ */
+internal fun mobileSessionRows(sessions: List<MobileSessionInfo>): List<MobileSessionRow> =
+    sessions.filterNot { it.isBlank }.map { s ->
+        MobileSessionRow(
+            tabId = s.tabId,
+            title = s.title,
+            subtitle = s.subtitle,
+            icon = when {
+                s.isVnc -> "desktop_windows"
+                s.isPlayer -> "play_circle"
+                else -> "terminal"
+            },
+            status = s.status,
+            // A recording replays in the terminal work area, so it opens the same screen a shell does.
+            route = if (s.isVnc) MobileRoute.Vnc else MobileRoute.Terminal,
+        )
+    }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionsView.kt
@@ -1,0 +1,190 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalSessions
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.app.MobileTab
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.rd_screen_title
+import app.skerry.ui.generated.resources.shell_hosts
+import app.skerry.ui.generated.resources.shell_sessions_close
+import app.skerry.ui.generated.resources.shell_sessions_count
+import app.skerry.ui.generated.resources.shell_sessions_none
+import app.skerry.ui.generated.resources.shell_sessions_none_hint
+import app.skerry.ui.generated.resources.shell_sessions_title
+import app.skerry.ui.session.SessionsController
+import app.skerry.ui.session.sessionDotColor
+import app.skerry.ui.session.sessionStatusText
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Root screen of the Sessions tab: everything currently open, terminals and remote desktops in one
+ * list. A phone shows one session at a time and has no tab row to switch them, so without this
+ * screen a live session is only reachable through the host that opened it — and a session opened on
+ * an ad-hoc target, or on a host since deleted, not at all.
+ *
+ * Tapping a row activates that session and opens its screen ([MobileSessionRow.route]); the cross
+ * closes it. With nothing open the screen explains itself and points at the two catalogs instead of
+ * showing an empty list.
+ */
+@Composable
+fun MobileSessionsScreen(state: MobileDesignState) {
+    val sessions = LocalSessions.current
+    // Read inside composition so opening, dropping or closing a session repaints the list.
+    val rows = mobileSessionRows(sessions?.tabs.orEmpty().map { it.toSessionInfo() })
+
+    Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
+        SessionsHeader(rows.size)
+        if (rows.isEmpty()) {
+            MobileSessionsEmpty(state)
+        } else {
+            Column(
+                Modifier.fillMaxWidth().padding(horizontal = 22.dp, vertical = 2.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) {
+                rows.forEach { row ->
+                    key(row.tabId) {
+                        MobileSessionRowCard(
+                            row = row,
+                            onOpen = { activateMobileSession(sessions, state, row) },
+                            onClose = sessions?.let { c -> { c.close(row.tabId) } },
+                        )
+                    }
+                }
+            }
+        }
+        // Clears the tab bar (see MobileCatalogScreen for the same reserve).
+        Spacer(Modifier.height(120.dp))
+    }
+}
+
+/** Activate [row]'s session and open the screen it belongs to. */
+private fun activateMobileSession(sessions: SessionsController?, state: MobileDesignState, row: MobileSessionRow) {
+    // Without a controller (preview/offscreen) there is nothing to activate, and pushing the screen
+    // would land on an empty terminal.
+    val controller = sessions ?: return
+    controller.activate(row.tabId)
+    state.push(row.route)
+}
+
+/** Header: screen title + how many sessions are open. */
+@Composable
+private fun SessionsHeader(count: Int) {
+    Row(
+        Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        MobileScreenTitle(stringResource(Res.string.shell_sessions_title))
+        if (count > 0) Txt(stringResource(Res.string.shell_sessions_count, count), color = Skerry.colors.dim, size = 12.sp)
+    }
+}
+
+/**
+ * Session line: the shared catalog row ([MobileCatalogRow]) so an open session reads like the host
+ * that opened it, with a close cross after the status dot. [onClose] == null (no controller) hides
+ * the cross.
+ */
+@Composable
+private fun MobileSessionRowCard(row: MobileSessionRow, onOpen: () -> Unit, onClose: (() -> Unit)?) {
+    MobileCatalogRow(
+        icon = row.icon,
+        label = row.title,
+        subtitle = row.subtitle,
+        dotColor = sessionDotColor(row.status),
+        statusText = sessionStatusText(row.status),
+        onClick = onOpen,
+        trailing = onClose?.let { close ->
+            {
+                // The cross is a bare glyph — without a label a screen reader announces the ligature
+                // name ("close") from the symbols font, so the action is spelled out here.
+                val closeLabel = stringResource(Res.string.shell_sessions_close)
+                Box(
+                    Modifier
+                        .size(44.dp)
+                        .clip(RoundedCornerShape(9.dp))
+                        .semantics { contentDescription = closeLabel }
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = close,
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Sym("close", size = 18.sp, color = Skerry.colors.faint)
+                }
+            }
+        },
+    )
+}
+
+/**
+ * Nothing open: says so, then offers the two places a session starts from. A bare "no sessions" on
+ * a tab the user just pressed leaves them to find the catalogs on their own.
+ */
+@Composable
+private fun MobileSessionsEmpty(state: MobileDesignState) {
+    MobileEmptyNote(
+        icon = "terminal",
+        title = stringResource(Res.string.shell_sessions_none),
+        subtitle = stringResource(Res.string.shell_sessions_none_hint),
+    ) {
+        Spacer(Modifier.height(6.dp))
+        SessionsEmptyTarget("dns", stringResource(Res.string.shell_hosts)) { state.select(MobileTab.Hosts) }
+        SessionsEmptyTarget("desktop_windows", stringResource(Res.string.rd_screen_title)) { state.select(MobileTab.Desktops) }
+    }
+}
+
+/** One "go to a catalog" card of the empty state. */
+@Composable
+private fun SessionsEmptyTarget(icon: String, label: String, onClick: () -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Skerry.colors.card)
+            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(12.dp))
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            )
+            .padding(horizontal = 14.dp, vertical = 13.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Sym(icon, size = 20.sp, color = Skerry.colors.cyanBright)
+        Txt(label, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.Medium, modifier = Modifier.weight(1f))
+        Sym("chevron_right", size = 20.sp, color = Skerry.colors.faint)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTabBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTabBar.kt
@@ -7,12 +7,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -23,13 +20,15 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.MobileTab
+import app.skerry.ui.app.mobileActiveTab
+import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.nav_tab_desktops
 import app.skerry.ui.generated.resources.nav_tab_hosts
 import app.skerry.ui.generated.resources.nav_tab_more
-import app.skerry.ui.generated.resources.nav_tab_vault
+import app.skerry.ui.generated.resources.nav_tab_sessions
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 
@@ -38,6 +37,10 @@ import app.skerry.ui.theme.Skerry
 /**
  * Bottom tab bar: translucent dark background + top cyan line; active tab cyanBright, others faint.
  * Content height ~64dp, with padding below for the system navigation (home indicator).
+ *
+ * It is the bottom-most element wherever it appears — over a root tab, and below the terminal
+ * ([mobileRouteKeepsTabBar]) — so it owns the navigation-bar inset for the screen. Nothing above it
+ * reserves that space again; the terminal's key panel used to, and did so from its own edge.
  */
 @Composable
 internal fun MobileTabBar(state: MobileDesignState, modifier: Modifier = Modifier) {
@@ -51,11 +54,15 @@ internal fun MobileTabBar(state: MobileDesignState, modifier: Modifier = Modifie
             Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 8.dp, vertical = 9.dp)
-                .windowInsetsPadding(WindowInsets.navigationBars),
+                // *IgnoringVisibility (see hiddenSystemBarsPadding): in immersive mode the live
+                // navigation-bar inset is zero, and a swipe that transiently brings the bar back
+                // would otherwise land on the tab labels.
+                .hiddenSystemBarsPadding(top = false, bottom = true),
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
+            val activeTab = mobileActiveTab(state.tab, state.route)
             MobileTab.entries.forEach { tab ->
-                MobileTabItem(tab, active = state.tab == tab && state.route == null) { state.select(tab) }
+                MobileTabItem(tab, active = tab == activeTab) { state.select(tab) }
             }
         }
     }
@@ -74,7 +81,7 @@ private fun MobileTabItem(tab: MobileTab, active: Boolean, onClick: () -> Unit) 
         val label = when (tab) {
             MobileTab.Hosts -> stringResource(Res.string.nav_tab_hosts)
             MobileTab.Desktops -> stringResource(Res.string.nav_tab_desktops)
-            MobileTab.Vault -> stringResource(Res.string.nav_tab_vault)
+            MobileTab.Sessions -> stringResource(Res.string.nav_tab_sessions)
             MobileTab.More -> stringResource(Res.string.nav_tab_more)
         }
         Txt(label, color = color, size = 10.sp, weight = if (active) FontWeight.SemiBold else FontWeight.Normal)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -32,7 +31,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -67,6 +65,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
+import app.skerry.ui.session.sessionStatusText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_accept
 import app.skerry.ui.generated.resources.lib_teams_create
@@ -597,56 +596,40 @@ internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>, section: HostSec
     )
     sections.forEach { (name, shared) ->
         Row(
-            Modifier.fillMaxWidth().padding(start = 18.dp, end = 22.dp, top = 14.dp, bottom = 6.dp),
+            Modifier.fillMaxWidth().padding(start = 18.dp, end = 22.dp, top = 16.dp, bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Sym("group", size = 15.sp, color = Skerry.colors.cyanBright)
+            // Same "NAME · N" form as a personal folder header (see MobileFolderHeader).
             Txt(
-                name.uppercase(),
+                "${name.uppercase()} · ${shared.size}",
                 color = Skerry.colors.faint, size = 12.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp,
                 maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f),
             )
-            Txt(shared.size.toString(), color = Skerry.colors.faint, size = 11.sp)
         }
-        Column(Modifier.padding(horizontal = 18.dp), verticalArrangement = Arrangement.spacedBy(9.dp)) {
+        Column(Modifier.padding(horizontal = 22.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             shared.forEach { host ->
-                key("team-${host.id}") { MobileTeamHostRow(host, mono, onClick = { connect(host) }) }
+                key("team-${host.id}") { MobileTeamHostRow(host, onClick = { connect(host) }) }
             }
         }
     }
 }
 
 /**
- * A team shared-host row — a card modeled on the personal [MobileHostRow] (panel, border,
- * `user@address` monospaced, status dot) but with a `group` icon instead of `dns` to mark its
- * team-vault origin. Tap connects via [LocalConnectHost].
+ * A team shared-host row — the shared catalog line ([MobileCatalogRow]) so it reads like a personal
+ * profile, with a `group` icon instead of the protocol's to mark its team-vault origin. Tap connects
+ * via [LocalConnectHost].
  */
 @Composable
-private fun MobileTeamHostRow(host: Host, mono: androidx.compose.ui.text.font.FontFamily, onClick: () -> Unit) {
-    val dotColor = sessionDotColor(LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle)
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(14.dp))
-            .background(Skerry.colors.card)
-            .border(1.dp, Skerry.colors.cyan08, RoundedCornerShape(14.dp))
-            .clickable(onClick = onClick)
-            .padding(14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(13.dp),
-    ) {
-        Box(
-            Modifier.size(40.dp).clip(RoundedCornerShape(11.dp)).background(Skerry.colors.cyan.copy(alpha = 0.1f)),
-            contentAlignment = Alignment.Center,
-        ) {
-            Sym("group", size = 21.sp, color = Skerry.colors.cyanBright)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(host.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            Spacer(Modifier.height(2.dp))
-            Txt(host.rowSubtitle(), color = Skerry.colors.dim, size = 11.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
-        }
-        Box(Modifier.size(8.dp).clip(CircleShape).background(dotColor))
-    }
+private fun MobileTeamHostRow(host: Host, onClick: () -> Unit) {
+    val status = LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle
+    MobileCatalogRow(
+        icon = "group",
+        label = host.label,
+        subtitle = host.rowSubtitle(),
+        dotColor = sessionDotColor(status),
+        statusText = sessionStatusText(status),
+        onClick = onClick,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalChrome.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.mobile
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -25,44 +26,63 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.ConnectionUiState
-import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.terminal.TerminalScreen
 import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.terminal.ArrowKey
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_header_back
+import app.skerry.ui.generated.resources.term_header_files
+import app.skerry.ui.generated.resources.term_header_menu
+import app.skerry.ui.generated.resources.term_header_monitor
+import app.skerry.ui.generated.resources.term_session_new
+import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.design.Dot
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.terminal.arrowSequence
 import app.skerry.ui.session.sessionDotColor
+import app.skerry.ui.session.sessionStatusText
 import app.skerry.ui.theme.Skerry
 
 /**
- * Terminal header (`#0B1A26` + bottom cyan line): back chevron, host name + status line with live
- * metrics (RTT/throughput), `more_horiz` icon (menu with Disconnect). [onDisconnect]==null — no active
- * session, the Disconnect item is hidden. The split icon is removed on phone (split not needed).
+ * Terminal header, per the mobile template: back chevron, host label over its `user@address:port`,
+ * then the three things a session is worked with from here — files (SFTP), the host monitor, and the
+ * overflow menu. Pinned, not auto-hiding: the address is what tells two shells apart, and a header
+ * that slides away hid it exactly while the user was reading output to decide where they are.
  *
- * Metrics come from [controller] via the same pollers as the desktop status bar: the keep-alive/RTT
- * poller ([openPing], null with the profile's keep-alive off) and channel throughput
- * ([openThroughput]). The remember is unconditional — keys (controller + connected flag) recreate it
- * on session/connection change; both methods are idempotent (cached in the controller). Before the
- * first sample / off-connection the metric is "—"; a narrow line scrolls horizontally.
+ * The second line carries more than the address when there is more to say: a session that is not
+ * connected appends its status in the status colour, a connected one appends live metrics
+ * (RTT/throughput) from the same pollers as the desktop status bar — the keep-alive/RTT poller
+ * ([openPing], null with the profile's keep-alive off) and channel throughput ([openThroughput]).
+ * The remember is unconditional — keys (controller + connected flag) recreate it on session/connection
+ * change; both methods are idempotent (cached in the controller). Before the first sample the metric
+ * is "—"; the line scrolls horizontally rather than truncating the address.
+ *
+ * [onFiles]/[onMonitor] == null hide their icons: a session with no SFTP channel (Telnet, serial,
+ * a watched share) has nothing to open, and a watched share has no connection to poll.
  */
 @Composable
 internal fun MobileTerminalHeader(
     title: String,
+    subtitle: String,
     status: ConnectionUiState?,
     controller: ConnectionController?,
     onBack: () -> Unit,
+    onFiles: (() -> Unit)?,
+    onMonitor: (() -> Unit)?,
     onMenu: () -> Unit,
-    onSnippets: (() -> Unit)?,
 ) {
     val mono = LocalFonts.current.mono
     val connected = status is ConnectionUiState.Connected
@@ -74,66 +94,138 @@ internal fun MobileTerminalHeader(
     }
     Column(Modifier.fillMaxWidth().background(Skerry.colors.surface2)) {
         Row(
-            Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 10.dp),
+            Modifier.fillMaxWidth().padding(start = 12.dp, end = 16.dp, top = 6.dp, bottom = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Sym(
-                "chevron_left",
-                size = 24.sp,
-                color = Skerry.colors.cyanBright,
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onBack,
-                ),
-            )
+            HeaderIcon("arrow_back", stringResource(Res.string.term_header_back), size = 22.sp, color = Skerry.colors.cyanBright, onClick = onBack)
             Column(Modifier.weight(1f)) {
-                Txt(title, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold, font = mono)
+                Txt(title, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.Bold, font = mono, maxLines = 1)
                 Row(
                     Modifier.horizontalScroll(rememberScrollState()),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    ) {
-                        Dot(sessionDotColor(status))
-                        Txt(mobileTerminalStatusText(mobileTerminalStatus(status)), color = sessionDotColor(status), size = 10.5.sp)
-                    }
-                    // Live metrics of the active session (desktop status-bar parity) — only when connected.
-                    if (connected) {
+                    Txt(subtitle, color = Skerry.colors.dim, size = 11.5.sp, font = mono)
+                    // Connected is the quiet case: the prompt below already says so. Anything else
+                    // is spelled out, in its colour.
+                    if (!connected) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        ) {
+                            Dot(sessionDotColor(status))
+                            Txt(mobileTerminalStatusText(mobileTerminalStatus(status)), color = sessionDotColor(status), size = 10.5.sp)
+                        }
+                    } else {
                         MobileTerminalMetric("network_ping", mobileRttLabel(ping?.rttMs), mono)
                         MobileTerminalMetric("arrow_upward", mobileRateLabel(throughput?.upRate), mono)
                         MobileTerminalMetric("arrow_downward", mobileRateLabel(throughput?.downRate), mono)
                     }
                 }
             }
-            if (onSnippets != null) {
-                Sym(
-                    "bolt",
-                    size = 21.sp,
-                    color = Skerry.colors.dim,
-                    modifier = Modifier.clickable(
-                        interactionSource = remember { MutableInteractionSource() },
-                        indication = null,
-                        onClick = onSnippets,
-                    ),
-                )
-            }
-            Sym(
-                "more_horiz",
-                size = 21.sp,
-                color = Skerry.colors.dim,
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onMenu,
-                ),
-            )
+            if (onFiles != null) HeaderIcon("folder", stringResource(Res.string.term_header_files), onClick = onFiles)
+            if (onMonitor != null) HeaderIcon("monitoring", stringResource(Res.string.term_header_monitor), onClick = onMonitor)
+            HeaderIcon("more_vert", stringResource(Res.string.term_header_menu), onClick = onMenu)
         }
         Box(Modifier.fillMaxWidth().height(1.dp).background(Skerry.colors.cyan08))
+    }
+}
+
+/**
+ * One tappable header glyph. The target is a 40dp box rather than the glyph itself — a 21sp symbol
+ * measures about 21dp, and these four are the only way into files, the monitor and the whole
+ * overflow menu. [label] is what it is called out loud: a bare [Sym] otherwise announces the Material
+ * Symbols ligature ("more_vert"), which names the shape and not the action.
+ */
+@Composable
+private fun HeaderIcon(
+    icon: String,
+    label: String,
+    size: TextUnit = 21.sp,
+    color: Color = Skerry.colors.dim,
+    onClick: () -> Unit,
+) {
+    Box(
+        Modifier
+            .size(40.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .semantics { contentDescription = label }
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym(icon, size = size, color = color)
+    }
+}
+
+/**
+ * Session strip under the header: one chip per open shell plus a "+" that goes to the catalog.
+ * The phone shows one session at a time, so this is the only way to cross between them without
+ * leaving the screen. A blank chip is not offered — an empty terminal on a phone does nothing, so
+ * "+" leads to where a session actually starts.
+ */
+@Composable
+internal fun MobileSessionStrip(
+    chips: List<MobileStripChip>,
+    onSelect: (String) -> Unit,
+    onNew: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(Skerry.colors.surface2)
+            .horizontalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        chips.forEach { chip ->
+            key(chip.tabId) {
+                StripChip(chip, onClick = { onSelect(chip.tabId) })
+            }
+        }
+        val newLabel = stringResource(Res.string.term_session_new)
+        Box(
+            Modifier
+                .clip(RoundedCornerShape(10.dp))
+                .background(Skerry.colors.overlayMed)
+                .semantics { contentDescription = newLabel }
+                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onNew)
+                .padding(horizontal = 16.dp, vertical = 10.dp),
+        ) {
+            Sym("add", size = 17.sp, color = Skerry.colors.dim)
+        }
+    }
+}
+
+/** One session chip: status dot + label; the one on screen is outlined cyan. */
+@Composable
+private fun StripChip(chip: MobileStripChip, onClick: () -> Unit) {
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(if (chip.active) Skerry.colors.cyan14 else Skerry.colors.overlayMed)
+            .border(1.dp, if (chip.active) Skerry.colors.cyan else Color.Transparent, RoundedCornerShape(10.dp))
+            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+    ) {
+        // Hoisted: stringResource is composable and cannot be called inside the semantics lambda.
+        val statusText = sessionStatusText(chip.status)
+        Dot(sessionDotColor(chip.status), modifier = Modifier.semantics { contentDescription = statusText })
+        Txt(
+            chip.label,
+            color = if (chip.active) Skerry.colors.cyanBright else Skerry.colors.dim,
+            size = 12.5.sp,
+            weight = if (chip.active) FontWeight.SemiBold else FontWeight.Normal,
+            font = LocalFonts.current.mono,
+            maxLines = 1,
+        )
     }
 }
 
@@ -182,6 +274,10 @@ internal fun MobileKeybar(
     onCtrlArmedChange: (Boolean) -> Unit,
     aiOpen: Boolean = false,
     onToggleAi: (() -> Unit)? = null,
+    // True when the tab bar is not laid out below this panel (a modal is up, or the keyboard is).
+    // Whatever is bottom-most owns the navigation-bar inset, and in immersive mode the live inset
+    // is zero — so a swipe that transiently reveals the bars would land on the keys.
+    reserveSystemBars: Boolean = false,
 ) {
     val plain = { seq: String -> terminal.sendUserInput(seq); onCtrlArmedChange(false) }
     val char = { c: String ->
@@ -204,8 +300,7 @@ internal fun MobileKeybar(
         Modifier
             .fillMaxWidth()
             .background(Skerry.colors.surface2)
-            // The screen runs edge to edge, so the panel keeps itself off the navigation bar.
-            .hiddenSystemBarsPadding(top = false, bottom = true)
+            .then(if (reserveSystemBars) Modifier.hiddenSystemBarsPadding(top = false, bottom = true) else Modifier)
             .horizontalScroll(rememberScrollState())
             .padding(horizontal = 12.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -1,8 +1,5 @@
 package app.skerry.ui.mobile
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -10,9 +7,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
@@ -24,9 +22,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -47,10 +44,10 @@ import app.skerry.ui.share.shareableTeams
 import app.skerry.ui.share.viewersMayOnlyWatch
 import app.skerry.ui.terminal.recordingOutcomeMessage
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_screen_title
 import app.skerry.ui.generated.resources.term_mobile_title_fallback
 import app.skerry.ui.generated.resources.runbook_section
 import app.skerry.ui.generated.resources.term_broadcast_title
-import app.skerry.ui.generated.resources.term_monitor_title
 import app.skerry.ui.generated.resources.term_record_start
 import app.skerry.ui.generated.resources.term_record_stop
 import app.skerry.ui.generated.resources.term_palette_title
@@ -72,10 +69,11 @@ import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalTerminalHistory
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.app.MobileTab
+import app.skerry.ui.app.mobileTabBarUnderRoute
 import app.skerry.ui.design.Txt
 import app.skerry.ui.terminal.filePathFromSelection
 import app.skerry.ui.session.broadcastTargets
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import app.skerry.shared.terminal.castFileName
 import app.skerry.shared.terminal.recordingStamp
@@ -88,10 +86,6 @@ import app.skerry.ui.host.rememberProductionLookup
 /** ESC (0x1B) — prefix of arrow CSI sequences and the esc key itself. */
 internal const val ESC = "\u001b"
 
-private const val HEADER_AUTO_HIDE_MS = 3000L
-// Where the header's reveal strip starts and how tall it is: clear of the system's edge-swipe zone.
-private val SYSTEM_EDGE_GESTURE = 40.dp
-private val TOP_EDGE_STRIP = 72.dp
 
 /**
  * Full-screen mobile terminal push-screen (a live SSH session over the PTY core). Header with host name
@@ -133,11 +127,6 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     // The AI input is off by default and raised by the sparkle key: on a phone it is a whole row of
     // screen that most sessions never use, and the terminal wants every line it can get.
     var aiOpen by remember(active?.id) { mutableStateOf(false) }
-    // Session chrome auto-hides like the VNC screen's bar; a swipe down near the top brings it back.
-    var headerVisible by remember(active?.id) { mutableStateOf(true) }
-    // See MobileVncScreen: keyed into the auto-hide effect so a swipe restarts the timer even when
-    // the header is already up.
-    var revealNonce by remember(active?.id) { mutableStateOf(0) }
     // Callbacks are stabilized by remember (keyed on session), else a fresh lambda per PTY chunk would
     // repaint the key panel/terminal for nothing. `ctrlArmed` is compose-state, so the lambda body sees
     // its live value even through remember.
@@ -176,22 +165,46 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     val activeTerminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     val canRunSnippet = snippets != null && activeTerminal != null
 
-    ImmersiveScreen()
-    // Held open while a sheet launched from it is up: the header is where they were opened from, and
-    // hiding it under an open menu reads as the app losing its place.
-    LaunchedEffect(headerVisible, menuOpen, paletteOpen, revealNonce) {
-        if (headerVisible && !menuOpen && !paletteOpen) {
-            delay(HEADER_AUTO_HIDE_MS)
-            headerVisible = false
-        }
-    }
-
+    // Full-bleed only on request (More → Appearance → Interface); off, the phone keeps its bars
+    // and the shell keeps this screen inside the safe area (see MobileChrome.fullBleed).
+    ImmersiveScreen(state.hideSessionSystemBars)
+    // Whether the bottom navigation is laid out under this screen right now — the same predicate the
+    // shell uses, so the key panel and the bar never both claim (or both skip) the system inset.
+    // Outside full-bleed the root padding already consumed the keyboard inset, so this reads false
+    // and the panel reserves nothing; that is correct, the root reserved it for the whole screen.
+    val tabBarBelow = mobileTabBarUnderRoute(
+        state.route,
+        state.modalOpen,
+        keyboardVisible = WindowInsets.ime.getBottom(LocalDensity.current) > 0,
+    )
     // Red frame around a production session (desktop parity): the phone has no tab row to carry the
     // marker, so the screen edge is the only always-visible place for it.
     Box(Modifier.fillMaxSize().background(Skerry.colors.terminalBg).prodOutline(isProdHostId(active?.hostId))) {
-        // imePadding here, not at the app root: this screen opts out of the root safeDrawing padding
-        // to run edge to edge, so lifting the content above the soft keyboard is its own job now.
+        // imePadding here, not at the app root: with "hide system bars" on this screen opts out of
+        // the root safeDrawing padding to run edge to edge, so lifting the content above the soft
+        // keyboard becomes its own job. With the setting off the root padding already consumed the
+        // keyboard inset and this is a no-op.
         Column(Modifier.fillMaxSize().imePadding()) {
+            MobileTerminalHeader(
+                title = active?.displayTitle ?: stringResource(Res.string.term_mobile_title_fallback),
+                subtitle = active?.subtitle.orEmpty(),
+                status = active?.controller?.uiState,
+                controller = active?.controller,
+                onBack = state::pop,
+                // Same rule as the path chip in output: a session with no SFTP channel (Telnet,
+                // serial, container, a watched share) has no files to open.
+                onFiles = if (active?.controller?.supportsSftp == true) ({ state.push(MobileRoute.Files) }) else null,
+                // Desktop parity ([monitorAvailable]): a pane watching a colleague's session has no
+                // connection of its own to poll.
+                onMonitor = if (activeTerminal != null && active?.controller?.isWatched != true) ({ monitorOpen = true }) else null,
+                onMenu = { menuOpen = true },
+            )
+            MobileSessionStrip(
+                chips = mobileTerminalStrip(sessions?.tabs.orEmpty().map { it.toSessionInfo() }, sessions?.activeId),
+                onSelect = { id -> sessions?.activate(id) },
+                // A blank terminal is useless on a phone, so "+" leads to where a session starts.
+                onNew = { state.select(MobileTab.Hosts) },
+            )
             when (val st = active?.controller?.uiState) {
                 null, ConnectionUiState.Form ->
                     MobileTerminalNotice("terminal", stringResource(Res.string.term_no_active_session), stringResource(Res.string.term_mobile_open_host_connect))
@@ -248,6 +261,8 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                         onCtrlArmedChange = setCtrlArmed,
                         aiOpen = aiOpen,
                         onToggleAi = if (aiController != null) ({ aiOpen = !aiOpen }) else null,
+                        // The tab bar below owns the navigation-bar inset whenever it is there.
+                        reserveSystemBars = !tabBarBelow,
                     )
                 }
                 is ConnectionUiState.Error ->
@@ -257,32 +272,6 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                 is ConnectionUiState.Disconnected ->
                     TerminalScreen(st.terminal, Modifier.weight(1f).fillMaxWidth())
             }
-        }
-        // Swipe down near the top brings the header back. Starts below the edge: a swipe from the very
-        // edge is the system's own gesture for restoring the hidden bars and never reaches us.
-        Box(
-            Modifier.align(Alignment.TopCenter).fillMaxWidth()
-                .padding(top = SYSTEM_EDGE_GESTURE).height(TOP_EDGE_STRIP)
-                .pointerInput(Unit) {
-                    detectVerticalDragGestures { _, dy ->
-                        if (dy > 0f) { headerVisible = true; revealNonce++ }
-                    }
-                },
-        )
-        AnimatedVisibility(
-            visible = headerVisible,
-            modifier = Modifier.align(Alignment.TopCenter),
-            enter = slideInVertically { -it },
-            exit = slideOutVertically { -it },
-        ) {
-            MobileTerminalHeader(
-                title = active?.displayTitle ?: stringResource(Res.string.term_mobile_title_fallback),
-                status = active?.controller?.uiState,
-                controller = active?.controller,
-                onBack = state::pop,
-                onMenu = { menuOpen = true },
-                onSnippets = if (canRunSnippet) ({ paletteOpen = true }) else null,
-            )
         }
         if (paletteOpen && snippets != null && activeTerminal != null) {
             MobileSnippetRunSheet(
@@ -326,22 +315,20 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                 Spacer(Modifier.height(14.dp))
                 Column(Modifier.fillMaxWidth().padding(bottom = 8.dp)) {
                     if (activeTerminal != null) {
-                        // Desktop parity ([monitorAvailable]): a pane watching a colleague's shared
-                        // session has no connection to poll, so the monitor isn't offered at all.
-                        if (active?.controller?.isWatched != true) {
-                            MobileSheetButton(
-                                label = stringResource(Res.string.term_monitor_title),
-                                onClick = { menuOpen = false; monitorOpen = true },
-                                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                                icon = "monitoring",
-                                filled = false,
-                            )
-                        }
                         MobileSheetButton(
                             label = stringResource(Res.string.term_palette_title),
                             onClick = { menuOpen = false; historyOpen = true },
                             modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
                             icon = "history",
+                            filled = false,
+                        )
+                    }
+                    if (canRunSnippet) {
+                        MobileSheetButton(
+                            label = stringResource(Res.string.lib_snippets_screen_title),
+                            onClick = { menuOpen = false; paletteOpen = true },
+                            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                            icon = "bolt",
                             filled = false,
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -133,7 +133,7 @@ import app.skerry.ui.vault.unbindCredential
 import app.skerry.ui.theme.Skerry
 
 /**
- * Vault root tab: three keychain categories (SSH keys/Passwords/Certificates) switched by pills, plus
+ * Vault push screen (More → Vault): three keychain categories (SSH keys/Passwords/Certificates) switched by pills, plus
  * key generation / add password / import certificate. Tapping a secret opens a detail sheet (public
  * key/fingerprint/principals, used-by hosts) with Copy/Export/Delete.
  *
@@ -143,7 +143,7 @@ import app.skerry.ui.theme.Skerry
 @Composable
 fun MobileVaultScreen(state: MobileDesignState) {
     when (val credentials = LocalCredentials.current) {
-        null -> MobileVaultMock()
+        null -> MobileVaultMock(onBack = state::pop)
         else -> MobileVaultLive(state, credentials)
     }
 }
@@ -196,9 +196,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
-            Box(Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp)) {
-                MobileScreenTitle(stringResource(Res.string.vault_title))
-            }
+            MobilePushHeader(stringResource(Res.string.vault_title), onBack = state::pop, plainBack = true)
             MobileVaultSummary(allCreds.size)
             MobileCategoryPills(category, allCreds) { category = it; selectedId = null }
             MobileVaultAction(
@@ -627,14 +625,12 @@ private fun MobileSecretDetailSheet(
 
 // Preview (mock).
 
-/** Static mock of the Vault tab (offscreen/preview without an unlocked keychain). */
+/** Static mock of the Vault screen (offscreen/preview without an unlocked keychain). */
 @Composable
-private fun MobileVaultMock() {
+private fun MobileVaultMock(onBack: () -> Unit) {
     val mono = LocalFonts.current.mono
     Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
-        Box(Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 6.dp, bottom = 10.dp)) {
-            MobileScreenTitle(stringResource(Res.string.vault_title))
-        }
+        MobilePushHeader(stringResource(Res.string.vault_title), onBack = onBack, plainBack = true)
         MobileVaultSummary(itemCount = mockSecrets().size)
         Column(Modifier.fillMaxWidth().padding(top = 8.dp)) {
             mockSecrets().forEach { (credential, meta) ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -87,7 +87,9 @@ fun MobileVncScreen(state: MobileDesignState) {
     // schedule — a swipe would then be answered by the bar vanishing a moment later.
     var revealNonce by remember { mutableStateOf(0) }
 
-    ImmersiveScreen()
+    // Full-bleed only on request (More → Appearance → Interface); off, the phone keeps its bars
+    // and the shell keeps this screen inside the safe area (see MobileChrome.fullBleed).
+    ImmersiveScreen(state.hideSessionSystemBars)
 
     // Auto-hide, restarted by every reveal. Held open while the keyboard is up: the button that puts
     // it away lives on the bar, and hiding the bar under the user's hands would strand them.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionVisuals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionVisuals.kt
@@ -4,7 +4,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_status_connected
+import app.skerry.ui.generated.resources.term_status_connecting
+import app.skerry.ui.generated.resources.term_status_disconnected
+import app.skerry.ui.generated.resources.term_status_no_session
 import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Session status-dot color (titlebar tab, sidebar host row): live - green, connecting - amber,
@@ -23,3 +29,20 @@ fun sessionDotColor(status: SessionStatus): Color = when (status) {
 @Composable
 @ReadOnlyComposable
 fun sessionDotColor(state: ConnectionUiState?): Color = sessionDotColor(state.asSessionStatus())
+
+/**
+ * The same status in words. The dot says it in colour alone, which is nothing to a screen reader and
+ * little to a red-green colourblind eye comparing "live" against "failed" down a list; attaching
+ * this as the dot's content description folds the state into the row's own announcement without
+ * adding a focus stop. Reuses the terminal header's vocabulary so one session never reads as two
+ * different things in two places.
+ */
+@Composable
+fun sessionStatusText(status: SessionStatus): String = stringResource(
+    when (status) {
+        SessionStatus.Live -> Res.string.term_status_connected
+        SessionStatus.Connecting -> Res.string.term_status_connecting
+        SessionStatus.Failed -> Res.string.term_status_disconnected
+        SessionStatus.Idle -> Res.string.term_status_no_session
+    },
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/TrashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/TrashScreen.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.vault
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -18,6 +19,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.vault.RecordType
@@ -165,9 +168,21 @@ private fun EmptyTrash() {
     }
 }
 
+/**
+ * Width a trash row needs before Restore / Delete forever fit beside the label. Not a breakpoint
+ * system — a guard: the two buttons are unweighted children of the row, so below this they eat the
+ * whole line and the weighted label is measured at ~zero (it rendered one character per line).
+ * Generous on purpose, and generous in the safe direction: too high only stacks a row that could
+ * have stayed inline.
+ */
+internal val TRASH_ROW_INLINE_MIN_WIDTH = 480.dp
+
+/** Whether a trash row of [rowWidth] must move its actions to a line of their own. */
+internal fun trashActionsStacked(rowWidth: Dp): Boolean = rowWidth < TRASH_ROW_INLINE_MIN_WIDTH
+
 @Composable
 private fun TrashRow(item: TrashItem, onRestore: () -> Unit, onForget: () -> Unit) {
-    Row(
+    BoxWithConstraints(
         Modifier
             .fillMaxWidth()
             .padding(bottom = 8.dp)
@@ -175,27 +190,56 @@ private fun TrashRow(item: TrashItem, onRestore: () -> Unit, onForget: () -> Uni
             .background(Skerry.colors.card)
             .border(1.dp, Skerry.colors.line, RoundedCornerShape(8.dp))
             .padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Sym(item.type.trashIcon(), size = 17.sp, color = Skerry.colors.cyanBright)
-        Column(Modifier.weight(1f)) {
-            Txt(item.label, color = Skerry.colors.text, size = 13.sp, maxLines = 1)
-            val daysLeft = stringResource(Res.string.settings_trash_days_left, item.daysLeft)
-            val kind = item.type.trashKind()
-            Txt(
-                if (kind.isEmpty()) daysLeft else "$kind · $daysLeft",
-                color = Skerry.colors.dim,
-                size = 11.5.sp,
-                modifier = Modifier.padding(top = 2.dp),
+        val actions: @Composable () -> Unit = {
+            GhostButton(stringResource(Res.string.settings_trash_restore), onClick = onRestore, icon = "restart_alt")
+            GhostButton(
+                stringResource(Res.string.settings_trash_forget),
+                onClick = onForget,
+                icon = "delete",
+                fg = Skerry.colors.sunset,
             )
         }
-        GhostButton(stringResource(Res.string.settings_trash_restore), onClick = onRestore, icon = "restart_alt")
-        GhostButton(
-            stringResource(Res.string.settings_trash_forget),
-            onClick = onForget,
-            icon = "delete",
-            fg = Skerry.colors.sunset,
+        if (trashActionsStacked(maxWidth)) {
+            Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Row(
+                    Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    Sym(item.type.trashIcon(), size = 17.sp, color = Skerry.colors.cyanBright)
+                    TrashRowLabel(item, Modifier.weight(1f))
+                }
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) { actions() }
+            }
+        } else {
+            Row(
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                Sym(item.type.trashIcon(), size = 17.sp, color = Skerry.colors.cyanBright)
+                TrashRowLabel(item, Modifier.weight(1f))
+                actions()
+            }
+        }
+    }
+}
+
+/** Name of the deleted record over its kind and how long it has left. */
+@Composable
+private fun TrashRowLabel(item: TrashItem, modifier: Modifier = Modifier) {
+    Column(modifier) {
+        Txt(item.label, color = Skerry.colors.text, size = 13.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        val daysLeft = stringResource(Res.string.settings_trash_days_left, item.daysLeft)
+        val kind = item.type.trashKind()
+        Txt(
+            if (kind.isEmpty()) daysLeft else "$kind · $daysLeft",
+            color = Skerry.colors.dim,
+            size = 11.5.sp,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = 2.dp),
         )
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/app/MobileDesignStateTest.kt
@@ -195,14 +195,14 @@ class MobileDesignStateTest {
 
     @Test
     fun four_tabs_in_template_order() {
-        // Bottom navigation: 4 root tabs in this order — the two catalogs first, then the vault and
-        // the More hub. Files isn't in the bar (SFTP is a push screen from the host card), and
-        // neither is the snippet library ([MobileRoute.Snippets], reached from More).
+        // Bottom navigation: 4 root tabs in this order — the two catalogs, then what is already
+        // open, then the More hub. The vault is not in the bar (it is a push screen from More,
+        // [MobileRoute.Vault]), and neither is the snippet library or SFTP.
         assertEquals(
             listOf(
                 MobileTab.Hosts,
                 MobileTab.Desktops,
-                MobileTab.Vault,
+                MobileTab.Sessions,
                 MobileTab.More,
             ),
             MobileTab.entries.toList(),
@@ -233,8 +233,8 @@ class MobileDesignStateTest {
     @Test
     fun select_switches_tab() {
         val s = MobileDesignState()
-        s.select(MobileTab.Vault)
-        assertEquals(MobileTab.Vault, s.tab)
+        s.select(MobileTab.Sessions)
+        assertEquals(MobileTab.Sessions, s.tab)
     }
 
     @Test
@@ -263,9 +263,21 @@ class MobileDesignStateTest {
     fun select_tab_clears_any_open_route() {
         val s = MobileDesignState()
         s.push(MobileRoute.HostDetail)
-        s.select(MobileTab.Vault)
-        assertEquals(MobileTab.Vault, s.tab)
+        s.select(MobileTab.Sessions)
+        assertEquals(MobileTab.Sessions, s.tab)
         assertNull(s.route)
+    }
+
+    @Test
+    fun the_vault_is_a_push_screen_of_the_more_hub() {
+        // It lost its root tab to Sessions: opened from More, back returns there and not to Hosts.
+        val s = MobileDesignState()
+        s.select(MobileTab.More)
+        s.push(MobileRoute.Vault)
+        assertFalse(s.showTabs)
+        assertEquals(MobileBackAction.PopRoute, mobileBackAction(s.route, s.tab))
+        s.pop()
+        assertEquals(MobileTab.More, s.tab)
     }
 
     @Test
@@ -456,6 +468,103 @@ class MobileDesignStateTest {
         assertTrue(seen.isEmpty())
     }
 
+    // Hiding the phone's system bars inside a session (More → Appearance → Interface)
+
+    @Test
+    fun session_system_bars_are_visible_by_default() {
+        // The status bar is the phone's, not ours: the clock and the battery stay readable inside a
+        // session unless the user asks for the pixels back.
+        assertFalse(MobileDesignState().hideSessionSystemBars)
+    }
+
+    @Test
+    fun toggling_the_system_bars_reports_every_change_outward() {
+        val seen = mutableListOf<Boolean>()
+        val s = MobileDesignState(
+            initialHideSessionSystemBars = false,
+            onHideSessionSystemBarsChange = { seen += it },
+        )
+        s.toggleHideSessionSystemBars()
+        assertTrue(s.hideSessionSystemBars)
+        s.toggleHideSessionSystemBars()
+        assertFalse(s.hideSessionSystemBars)
+        assertEquals(listOf(true, false), seen)
+    }
+
+    @Test
+    fun a_persisted_choice_to_hide_the_bars_is_honored_at_startup() {
+        assertTrue(MobileDesignState(initialHideSessionSystemBars = true).hideSessionSystemBars)
+    }
+
+    // Bottom navigation over a push screen (mobileRouteKeepsTabBar / mobileActiveTab)
+
+    @Test
+    fun the_terminal_keeps_the_bottom_navigation_and_the_remote_desktop_does_not() {
+        // Template: the terminal is a place you step out of in one tap. A framebuffer wants the
+        // whole display and carries its own floating bar.
+        assertTrue(mobileRouteKeepsTabBar(MobileRoute.Terminal))
+        assertFalse(mobileRouteKeepsTabBar(MobileRoute.Vnc))
+        assertFalse(mobileRouteKeepsTabBar(MobileRoute.Files))
+        assertFalse(mobileRouteKeepsTabBar(null))
+    }
+
+    @Test
+    fun the_bar_steps_aside_for_the_keyboard_and_for_a_modal() {
+        // "The terminal keeps the bar" is not "the bar is there": it would sit as a second bar above
+        // the keyboard, or float over a dialog. Whatever is bottom-most owns the navigation-bar
+        // inset, so this also decides whether the terminal's key panel reserves it.
+        assertTrue(mobileTabBarUnderRoute(MobileRoute.Terminal, modalOpen = false, keyboardVisible = false))
+        assertFalse(mobileTabBarUnderRoute(MobileRoute.Terminal, modalOpen = false, keyboardVisible = true))
+        assertFalse(mobileTabBarUnderRoute(MobileRoute.Terminal, modalOpen = true, keyboardVisible = false))
+        assertFalse(mobileTabBarUnderRoute(MobileRoute.Vnc, modalOpen = false, keyboardVisible = false))
+    }
+
+    @Test
+    fun a_session_screen_lights_the_sessions_tab() {
+        // Whatever tab it was opened from: the user is inside a session, and an unlit bar reads as
+        // having fallen out of the app's navigation.
+        assertEquals(MobileTab.Sessions, mobileActiveTab(MobileTab.Hosts, MobileRoute.Terminal))
+        assertEquals(MobileTab.Sessions, mobileActiveTab(MobileTab.Desktops, MobileRoute.Vnc))
+    }
+
+    @Test
+    fun a_root_screen_lights_its_own_tab() {
+        assertEquals(MobileTab.Hosts, mobileActiveTab(MobileTab.Hosts, route = null))
+        assertEquals(MobileTab.More, mobileActiveTab(MobileTab.More, route = null))
+    }
+
+    @Test
+    fun any_other_push_screen_lights_nothing() {
+        // It belongs to the tab underneath, which is no longer on screen.
+        assertNull(mobileActiveTab(MobileTab.More, MobileRoute.Vault))
+        assertNull(mobileActiveTab(MobileTab.Hosts, MobileRoute.Files))
+    }
+
+    // Which screens run edge to edge (mobileSessionFullBleed)
+
+    @Test
+    fun no_screen_runs_edge_to_edge_while_the_setting_is_off() {
+        // The default. Dropping the setting from this decision would put terminal output back under
+        // the phone's clock, which is the bug the setting exists to fix.
+        assertFalse(mobileSessionFullBleed(hideSessionSystemBars = false, route = MobileRoute.Terminal))
+        assertFalse(mobileSessionFullBleed(hideSessionSystemBars = false, route = MobileRoute.Vnc))
+    }
+
+    @Test
+    fun the_setting_makes_session_screens_edge_to_edge() {
+        assertTrue(mobileSessionFullBleed(hideSessionSystemBars = true, route = MobileRoute.Terminal))
+        assertTrue(mobileSessionFullBleed(hideSessionSystemBars = true, route = MobileRoute.Vnc))
+    }
+
+    @Test
+    fun the_setting_does_not_touch_screens_that_are_not_sessions() {
+        // It buys pixels back for a session, not for a list — a host list under the status bar is
+        // unreadable and was never what was asked for.
+        assertFalse(mobileSessionFullBleed(hideSessionSystemBars = true, route = null))
+        assertFalse(mobileSessionFullBleed(hideSessionSystemBars = true, route = MobileRoute.Files))
+        assertFalse(mobileSessionFullBleed(hideSessionSystemBars = true, route = MobileRoute.Vault))
+    }
+
     // System back: where it leads based on navigation state (mobileBackAction)
 
     @Test
@@ -474,9 +583,9 @@ class MobileDesignStateTest {
 
     @Test
     fun back_on_non_hosts_tab_goes_home() {
-        // From a non-root tab (Desktops/Vault/More), back returns to Hosts instead of exiting the app.
+        // From a non-root tab (Desktops/Sessions/More), back returns to Hosts instead of exiting the app.
         assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Desktops))
-        assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Vault))
+        assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.Sessions))
         assertEquals(MobileBackAction.GoHome, mobileBackAction(route = null, tab = MobileTab.More))
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ConnectionTypeIconTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/ConnectionTypeIconTest.kt
@@ -13,7 +13,8 @@ class ConnectionTypeIconTest {
 
     @Test
     fun every_connection_type_maps_to_its_symbol() {
-        assertEquals("lan", ConnectionType.SSH.icon)
+        // Server rack, matching the mobile Hosts tab: the row names the machine, not the wire.
+        assertEquals("dns", ConnectionType.SSH.icon)
         assertEquals("bolt", ConnectionType.MOSH.icon)
         assertEquals("terminal", ConnectionType.TELNET.icon)
         assertEquals("cable", ConnectionType.SERIAL.icon)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
@@ -155,8 +155,17 @@ class HostSectionTest {
 class HostRowSubtitleTest {
 
     @Test
-    fun a_profile_with_a_user_shows_user_at_host() {
-        val h = host("a", type = ConnectionType.SSH).copy(username = "root", address = "10.0.0.1")
+    fun a_profile_with_a_user_shows_user_at_host_and_port() {
+        // The port is part of the address the row identifies a profile by: two hosts on the same
+        // machine differ only by it, and the list would show them as the same line.
+        val h = host("a", type = ConnectionType.SSH).copy(username = "root", address = "10.0.0.1", port = 22)
+        assertEquals("root@10.0.0.1:22", h.rowSubtitle())
+    }
+
+    @Test
+    fun a_profile_with_no_port_at_all_shows_just_user_at_host() {
+        // A local shell or an imported profile can carry port 0 — ":0" would be a lie.
+        val h = host("a2", type = ConnectionType.SSH).copy(username = "root", address = "10.0.0.1", port = 0)
         assertEquals("root@10.0.0.1", h.rowSubtitle())
     }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileSessionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileSessionsTest.kt
@@ -1,0 +1,122 @@
+package app.skerry.ui.mobile
+
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.session.SessionStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Rows of the Sessions root tab: what it lists, what a tap opens, and what it leaves out. */
+class MobileSessionsTest {
+
+    private fun info(
+        id: String,
+        title: String = "prod-web-01",
+        subtitle: String = "root@10.0.0.1:22",
+        isVnc: Boolean = false,
+        isPlayer: Boolean = false,
+        isBlank: Boolean = false,
+        status: SessionStatus = SessionStatus.Live,
+    ) = MobileSessionInfo(id, title, subtitle, isVnc, isPlayer, isBlank, status)
+
+    @Test
+    fun a_terminal_session_opens_the_terminal_screen() {
+        val rows = mobileSessionRows(listOf(info("t1")))
+        assertEquals(1, rows.size)
+        assertEquals("t1", rows[0].tabId)
+        assertEquals("prod-web-01", rows[0].title)
+        assertEquals("root@10.0.0.1:22", rows[0].subtitle)
+        assertEquals(MobileRoute.Terminal, rows[0].route)
+        assertEquals(SessionStatus.Live, rows[0].status)
+    }
+
+    @Test
+    fun a_remote_desktop_session_opens_the_framebuffer_screen() {
+        val rows = mobileSessionRows(listOf(info("d1", isVnc = true)))
+        assertEquals(MobileRoute.Vnc, rows[0].route)
+        // The list mixes both kinds and the icon is the only place that says which.
+        assertEquals("desktop_windows", rows[0].icon)
+    }
+
+    @Test
+    fun a_recording_being_replayed_opens_the_terminal_screen() {
+        // A player holds no connection but replays into the same work area.
+        val rows = mobileSessionRows(listOf(info("p1", isPlayer = true)))
+        assertEquals(MobileRoute.Terminal, rows[0].route)
+        // ...and must not read as a live shell: same screen, different thing entirely.
+        assertEquals("play_circle", rows[0].icon)
+    }
+
+    @Test
+    fun a_shell_carries_the_terminal_icon() {
+        assertEquals("terminal", mobileSessionRows(listOf(info("t1")))[0].icon)
+    }
+
+    @Test
+    fun blank_tabs_are_not_listed() {
+        // A tab with nothing connected has no session to return to: listing it would offer a row
+        // that opens an empty terminal screen.
+        val rows = mobileSessionRows(listOf(info("b1", isBlank = true), info("t1")))
+        assertEquals(listOf("t1"), rows.map { it.tabId })
+    }
+
+    @Test
+    fun order_follows_the_open_order() {
+        val rows = mobileSessionRows(listOf(info("t1"), info("d1", isVnc = true), info("t2")))
+        assertEquals(listOf("t1", "d1", "t2"), rows.map { it.tabId })
+    }
+
+    @Test
+    fun nothing_open_means_no_rows() {
+        assertTrue(mobileSessionRows(emptyList()).isEmpty())
+        // A shell that is only ever a blank tab still leaves the screen on its empty state.
+        assertTrue(mobileSessionRows(listOf(info("b1", isBlank = true))).isEmpty())
+    }
+
+    @Test
+    fun a_failed_session_keeps_its_row_with_its_status() {
+        // A dropped session is exactly what the user comes to this screen to find; hiding it would
+        // leave the failure invisible until the host row is tapped again.
+        val rows = mobileSessionRows(listOf(info("t1", status = SessionStatus.Failed)))
+        assertEquals(SessionStatus.Failed, rows[0].status)
+    }
+
+    // Session strip on the terminal screen
+
+    @Test
+    fun the_strip_lists_shells_and_marks_the_one_on_screen() {
+        val chips = mobileTerminalStrip(listOf(info("t1"), info("t2", title = "db-master")), activeId = "t2")
+        assertEquals(listOf("t1", "t2"), chips.map { it.tabId })
+        assertEquals(listOf("prod-web-01", "db-master"), chips.map { it.label })
+        assertEquals(listOf(false, true), chips.map { it.active })
+    }
+
+    @Test
+    fun a_remote_desktop_is_not_a_terminal_strip_chip() {
+        // Tapping it would swap the terminal for a framebuffer without saying so.
+        val chips = mobileTerminalStrip(listOf(info("t1"), info("d1", isVnc = true)), activeId = "t1")
+        assertEquals(listOf("t1"), chips.map { it.tabId })
+    }
+
+    @Test
+    fun an_unknown_active_id_marks_nothing_instead_of_guessing() {
+        // The active tab is a remote desktop, or was just closed: no chip claims to be on screen.
+        val chips = mobileTerminalStrip(listOf(info("t1"), info("t2")), activeId = "gone")
+        assertTrue(chips.none { it.active })
+    }
+
+    @Test
+    fun a_blank_tab_is_not_a_strip_chip() {
+        // Nothing is connected in it, so its chip would carry an empty label and switch to an empty
+        // screen. "+" is the way to a new session, not a placeholder tab.
+        val chips = mobileTerminalStrip(listOf(info("b1", isBlank = true), info("t1")), activeId = "t1")
+        assertEquals(listOf("t1"), chips.map { it.tabId })
+    }
+
+    @Test
+    fun the_strip_keeps_a_failed_shell() {
+        // Its chip is how the user gets back to the screen that says what went wrong.
+        val chips = mobileTerminalStrip(listOf(info("t1", status = SessionStatus.Failed)), activeId = "t1")
+        assertEquals(SessionStatus.Failed, chips.single().status)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/TrashRowLayoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/TrashRowLayoutTest.kt
@@ -1,0 +1,38 @@
+package app.skerry.ui.vault
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Where a trash row puts Restore / Delete forever. Inline they are unweighted children of the row,
+ * so on a narrow screen they take the whole width and leave the label none — which rendered the
+ * label one character per line.
+ */
+class TrashRowLayoutTest {
+
+    @Test
+    fun a_phone_row_stacks_the_actions_under_the_label() {
+        // 390dp screen − 18dp gutters − 12dp card padding ≈ 330dp of row.
+        assertTrue(trashActionsStacked(330.dp))
+    }
+
+    @Test
+    fun a_desktop_settings_panel_keeps_them_on_one_line() {
+        assertFalse(trashActionsStacked(720.dp))
+    }
+
+    @Test
+    fun the_threshold_leaves_the_label_a_readable_column() {
+        // Just under the limit still stacks; at it, the label has room beside both buttons.
+        assertTrue(trashActionsStacked(TRASH_ROW_INLINE_MIN_WIDTH - 1.dp))
+        assertFalse(trashActionsStacked(TRASH_ROW_INLINE_MIN_WIDTH))
+    }
+
+    @Test
+    fun a_degenerate_width_stacks_rather_than_squeezing() {
+        // A row measured at zero (first frame of a subcomposition) must not pick the inline layout.
+        assertTrue(trashActionsStacked(0.dp))
+    }
+}


### PR DESCRIPTION
## Navigation

Bottom navigation is **Hosts · Desktops · Sessions · More**. The vault lost its root tab and is now a push screen off the More hub, listed there with its secret count.

**Sessions** is new: everything currently open, terminals and remote desktops in one list, each row carrying a live status dot and a close cross. Tapping a row activates that session and opens its screen. A blank tab is never listed — it holds no connection. With nothing open the screen says so and offers the two catalogs.

The Sessions tab stays lit while a session screen is up, so the bar never reads as unrelated to what is on screen.

## Catalog rows

Rows follow the mobile template: flat lines with no card and no border, a monospace label over `user@address:port`, and a muted protocol tile. Folder headers carry their count inline (`PRODUCTION · 3`). SSH profiles take the server-rack glyph.

One shared row (`MobileCatalogRow`) backs the host list, the remote-desktop list, team shared hosts and the Sessions list. A shared empty-state note (`MobileEmptyNote`) replaces three near-identical private copies.

## Terminal

- Bottom navigation stays visible; leaving for a catalog is one tap and the session stays alive.
- The header is pinned instead of sliding away after three seconds: host label over the address, with files (SFTP), the host monitor, and the overflow menu. Snippets moved into that menu.
- A session chip strip crosses between open shells without leaving the screen; `+` leads to the host catalog, since a blank terminal does nothing on a phone.

## System bars

A session no longer hides the phone's status and navigation bars. Hiding them is a setting — More → Appearance → Interface — off by default, persisted per device. Whichever element is bottom-most reserves the navigation-bar inset for the screen, so nothing double-pads and nothing is left under a transiently revealed bar.

## Also

- Trash rows stack their actions on a narrow screen. Inline, the two unweighted buttons took the whole line and left the weighted label roughly zero width, which rendered it one character per line.
- `Host.rowSubtitle()` includes the port, so two profiles on the same machine are no longer the same line. This reaches the desktop sidebar too.
- Status dots and bare-glyph controls (session close, terminal header icons, the strip's `+`) carry spoken names; the header icons get real touch targets.

## Verify

Install on a phone and check:

1. Four items in the bottom bar, third is Sessions. Empty → placeholder with links to both catalogs.
2. Connect to a host, go back: the session is in the list; the row reopens it, the cross closes it.
3. More → Vault opens the keychain; back returns to More.
4. In a terminal: the header stays put, chips switch between shells, `+` goes to Hosts, the bottom bar is there and hides while typing.
5. Open a terminal — the clock and battery are visible and output is not under them. Turn on More → Appearance → Interface → *Hide system bars in a session*: the terminal takes the whole display and a swipe from the edge brings the bars back.
6. More → Trash: rows are two lines, name and retention above, buttons below.

Not verified: iOS (deferred), and the immersive-mode edge swipe on a device other than the one this was built against.