### PR TITLE
Fix libsodium init crash on non-ASCII install paths (override resource-loader 2.1.0)

### DIFF
--- a/composeApp/flatpak/flatpak-sources.json
+++ b/composeApp/flatpak/flatpak-sources.json
@@ -1660,24 +1660,24 @@
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.0.2/resource-loader-2.0.2.jar",
-    "sha512": "92d65330989744888360265fb8f8f5d010f8193b4ddbc06dc68dc72d3ebf753257e2a3f7c15c917264377d7ba7019dd471fd38fe40fe534ee0d250923f5ee69c",
-    "dest": "offline-repository/com/goterl/resource-loader/2.0.2",
-    "dest-filename": "resource-loader-2.0.2.jar"
+    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.1.0/resource-loader-2.1.0.jar",
+    "sha512": "896ddeab1f25ac5038076975230c7c88bc9ca17a62772cab85a676b58fdbefa668dd41d397be0f093599a490ca076b393cb9e17cafaf491434ba29c6717db5f7",
+    "dest": "offline-repository/com/goterl/resource-loader/2.1.0",
+    "dest-filename": "resource-loader-2.1.0.jar"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.0.2/resource-loader-2.0.2.module",
-    "sha512": "e8b6b0484d0106d0bb6b9d1da079e5c8fbd69174e419a072513c8952d45b7b7117562283e50394b3042310a580cc5fc50c0d5887ba26fe39f5c76969aed7fabf",
-    "dest": "offline-repository/com/goterl/resource-loader/2.0.2",
-    "dest-filename": "resource-loader-2.0.2.module"
+    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.1.0/resource-loader-2.1.0.module",
+    "sha512": "d51cf6001b1c57e8e337571c7a430c1086e7230e9ed03552714bb966122bee22147fa0f393b48a382d325e86d7d12fac8220aeb352c6ff0dd39d2c1d04119513",
+    "dest": "offline-repository/com/goterl/resource-loader/2.1.0",
+    "dest-filename": "resource-loader-2.1.0.module"
   },
   {
     "type": "file",
-    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.0.2/resource-loader-2.0.2.pom",
-    "sha512": "b82d0fc5a3401031d89593c73486aad92f224394c358fb424aa5fb2b413c9e775fb19088e27f3763a9c48b87113caec9e9290c1f573aee331e7f08b36c579205",
-    "dest": "offline-repository/com/goterl/resource-loader/2.0.2",
-    "dest-filename": "resource-loader-2.0.2.pom"
+    "url": "https://repo.maven.apache.org/maven2/com/goterl/resource-loader/2.1.0/resource-loader-2.1.0.pom",
+    "sha512": "1297ba7ec9c7a7b3ef24c0985f5699e3c3daf4507173dd3c50b2bdadd27091e2d1b090ce48fff126961c453bbb0f05dc0eb6571c07d64f67d1d481c1f09fbb84",
+    "dest": "offline-repository/com/goterl/resource-loader/2.1.0",
+    "dest-filename": "resource-loader-2.1.0.pom"
   },
   {
     "type": "file",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,10 @@ bouncycastle = "1.85"
 sshd = "2.19.0"
 # multiplatform libsodium binding (KMP, Argon2id + XChaCha20-Poly1305) for a single VaultCrypto
 ionspin-libsodium = "0.9.5"
+# goterl resource-loader: ionspin's transitive pin (2.0.2) feeds percent-encoded URL paths into
+# new JarFile() — crashes libsodium init on Chinese/space install paths (isJarFile bug). v2.1.0
+# fixed it (URL→URI decoding); ionspin 0.9.5 still pins 2.0.2, so we override here. Desktop only.
+goterl-resource-loader = "2.1.0"
 # okio — cross-platform file I/O behind FileSystem (FileVault in commonMain, FakeFileSystem in tests)
 okio = "3.18.0"
 # atomicfu — multiplatform locks (kotlinx.atomicfu.locks) instead of JVM-only @Synchronized
@@ -147,6 +151,7 @@ bouncycastle-pkix = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = 
 sshd-core = { module = "org.apache.sshd:sshd-core", version.ref = "sshd" }
 sshd-sftp = { module = "org.apache.sshd:sshd-sftp", version.ref = "sshd" }
 ionspin-libsodium = { module = "com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings", version.ref = "ionspin-libsodium" }
+goterl-resource-loader = { module = "com.goterl:resource-loader", version.ref = "goterl-resource-loader" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -112,6 +112,12 @@ kotlin {
                 // size, raw mode on Linux/macOS/Windows. Bundles its own natives + JNA (compatible
                 // with the JNA already on the classpath). Desktop only — Android uses a native helper.
                 implementation(libs.pty4j)
+                // Desktop libsodium loads its native library through goterl resource-loader
+                // (ionspin transitive). Its pinned 2.0.2 breaks on non-ASCII install paths (Chinese
+                // dirs/usernames, spaces) — isJarFile() passes percent-encoded URLs to new JarFile().
+                // Override to 2.1.0 which decodes via URI; otherwise libsodium init crashes at
+                // startup on Chinese paths. Android loads libsodium via JNA directly, unaffected.
+                implementation(libs.goterl.resource.loader)
             }
         }
         androidMain.dependencies {


### PR DESCRIPTION
## Problem

The desktop app crashes at startup when the install path contains non-ASCII bytes — Chinese characters, spaces, or any other non-ASCII characters. libsodium fails to initialize (JNA throws), so the app never reaches the window. This is not a bug in the app code; it comes from a broken dependency in the load chain.

## Root cause

`com.ionspin.kotlin:multiplatform-crypto-libsodium-bindings` 0.9.5 pulls in `com.goterl:resource-loader` 2.0.2 transitively. In resource-loader 2.0.2, `isJarFile()` feeds a percent-encoded URL path straight into `new JarFile()` — a Chinese path becomes something like `file:/tmp/%E4%B8%AD%E6%96%87/...` and `new JarFile()` cannot resolve it, so libsodium's native library load crashes. Paths containing spaces hit the same issue.

## Fix

resource-loader fixed this in 2.1.0 (the URL is decoded through `URI` before being passed to `JarFile`). Since ionspin 0.9.5 still pins 2.0.2, this PR overrides the transitive dependency to 2.1.0:

1. `gradle/libs.versions.toml` — add `goterl-resource-loader = "2.1.0"` and the library alias.
2. `shared/build.gradle.kts` — add `implementation(libs.goterl.resource.loader)` to desktopMain.
3. `composeApp/flatpak/flatpak-sources.json` — bump the offline-repository manifest entries from 2.0.2 to 2.1.0 (jar/module/pom, urls + sha512), keeping the flatpak hermetic build resolvable.

## Scope

Desktop targets only. Android loads libsodium through JNA directly and does not use resource-loader, so it is unaffected. A pure dependency override — no application code changes.
