### PR TITLE
Drop the stale space-path warning and force a fresh flatpak source list

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -257,8 +257,9 @@ compose.desktop {
             linux { iconFile.set(project.file("icons/skerry.png")) }
             windows {
                 iconFile.set(project.file("icons/skerry.ico"))
-                // Space-free install path (%LOCALAPPDATA%\Skerry): goterl/ionspin's isJarFile()
-                // throws on the space in "C:\Program Files" and then crashes libsodium init.
+                // Per-user install (%LOCALAPPDATA%\Skerry): no admin rights needed to install or
+                // update. It also predates the resource-loader 2.1.0 bump, which is what actually
+                // fixed libsodium init from paths with spaces or non-ASCII characters.
                 perUserInstall = true
                 menu = true
                 shortcut = true
@@ -309,8 +310,7 @@ tasks.register<Exec>("packageAppImage") {
 
 // Portable build: zip the jpackage app-image (createDistributable) as-is — no installer, the
 // user extracts and runs Skerry.exe. Used by the release workflow for the Windows portable
-// asset (the arch suffix is appended there, like for the msi). The bundled README warns about
-// paths with spaces — libsodium's loader (goterl) fails to initialize from them.
+// asset (the arch suffix is appended there, like for the msi).
 tasks.register<Zip>("packagePortableZip") {
     group = "compose desktop"
     description = "Build a portable .zip from the jpackage app-image"

--- a/composeApp/flatpak/regenerate-sources.sh
+++ b/composeApp/flatpak/regenerate-sources.sh
@@ -6,6 +6,10 @@
 #
 # It drives the flatpak-gradle-generator plugin via an init script so the production build files
 # stay untouched. -PdesktopOnly matches exactly what the sandbox build resolves.
+#
+# --rerun-tasks is mandatory: the generator task declares no inputs, so Gradle calls it up-to-date
+# and the merge silently reuses a months-old artifact list — reverting dependency bumps and
+# resurrecting versions that were deliberately held back.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -13,7 +17,7 @@ FLATPAK_DIR="$REPO_ROOT/composeApp/flatpak"
 cd "$REPO_ROOT"
 
 echo "==> Resolving dependencies with flatpak-gradle-generator"
-./gradlew --no-configuration-cache -PdesktopOnly \
+./gradlew --no-configuration-cache -PdesktopOnly --rerun-tasks \
   --init-script "$FLATPAK_DIR/tools/flatpak-gen.init.gradle.kts" \
   :sync-wire:flatpakGradleGenerator \
   :shared:flatpakGradleGenerator \

--- a/composeApp/portable/README.txt
+++ b/composeApp/portable/README.txt
@@ -2,8 +2,3 @@ Skerry — portable Windows build
 
 Extract this archive anywhere and run Skerry\Skerry.exe.
 Nothing is installed; settings are stored in your user profile as usual.
-
-IMPORTANT: pick a folder whose full path contains NO spaces
-(e.g. C:\Tools\Skerry — not C:\Program Files\Skerry). The bundled
-libsodium loader fails to initialize from a path with spaces, and the
-app will not start.


### PR DESCRIPTION
Follow-up to #164.

- `composeApp/portable/README.txt`: removes the instruction to pick an install folder without spaces. resource-loader 2.1.0 loads libsodium from paths with spaces and non-ASCII characters, verified against both cases.
- `composeApp/build.gradle.kts`: the Windows `perUserInstall` and the portable-zip task carried the same obsolete reason; they now state what still holds (no admin rights for install/update).
- `composeApp/flatpak/regenerate-sources.sh`: passes `--rerun-tasks`. The `flatpakGradleGenerator` task declares no inputs, so Gradle reports it up-to-date and the merge step reuses whatever artifact list is left in `*/build/` — silently reverting dependency bumps.

Comments, shell, and packaging text only; no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)