### PR TITLE
Refuse the connect when the account dataKey doesn't open

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncContracts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncContracts.kt
@@ -137,7 +137,7 @@ enum class SyncFailureReason {
     LocalVaultCorrupted,
     PairingFailed,         // other pairing failures (no detail: don't expose crypto/Ktor internals)
     VaultRekeyFailed,      // vault couldn't be re-wrapped under the account password
-    AccountKeyNotAdopted,  // the account key didn't open, so the confirmed replace didn't happen
+    AccountKeyNotAdopted,  // the account's wrap didn't open under the account password — we'd sync unreadable records
     SaveSettingsFailed,    // sync settings didn't save (detail: cause)
     SyncFailed,            // sync cycle failure (detail: cause)
     RevokeFailed,          // device revoke failed (detail: cause)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -381,7 +381,22 @@ class SyncCoordinator(
                     }
                     reactivated = s.reactivated
                     // Same password on both sides: nothing to re-wrap, only a possible key change.
-                    adoptedKey = adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf()) == KeyAdoption.Adopted
+                    when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
+                        KeyAdoption.Adopted -> adoptedKey = true
+                        KeyAdoption.AlreadyOurs -> Unit // our own key came back — an ordinary reconnect
+                        // The login above already proved the typed password IS the account password, so
+                        // the account's wrap must open under it. One that doesn't means the account's
+                        // records are encrypted under a dataKey this device doesn't have (the wrap and
+                        // the verifier disagree — corrupted or partially restored server state; a
+                        // rotation can't do it, the server writes both in one transaction). Connecting
+                        // would pull records we can't decrypt and push records no other device can, with
+                        // nothing on screen to say so — issue #133.
+                        KeyAdoption.Undecryptable -> {
+                            runCatching { syncClient.close() }
+                            _status.value = SyncStatus.Failed(SyncFailureReason.AccountKeyNotAdopted)
+                            return
+                        }
+                    }
                     s
                 }
             } else if (!allowPasswordReplace) {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -38,6 +38,9 @@ import kotlin.test.assertTrue
  *  - connecting with the password of an EXISTING account (different from the vault's) re-keys this
  *    device to the account password — but only after the user confirms it.
  *
+ * Either way the device must end up holding the ACCOUNT's dataKey: a wrap that doesn't open under the
+ * password the server just accepted fails the connect on both paths (issue #133).
+ *
  * The account vault is a real [FileVault] over the system filesystem and crypto is real
  * [IonspinVaultCrypto] (Argon2id) — the whole point is password/key wrapping, so nothing is faked
  * there; only the network ([SyncClient]) is stubbed to model the server's account state.
@@ -123,9 +126,13 @@ class SyncCoordinatorPasswordReplaceTest {
             return SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
         }
 
+        var closeCalls = 0; private set
+
         override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
         override suspend fun ping(): Boolean = true
-        override suspend fun close() {}
+        override suspend fun close() {
+            closeCalls++
+        }
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
@@ -291,8 +298,42 @@ class SyncCoordinatorPasswordReplaceTest {
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
             sut.confirmPasswordReplace()
             sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Failed, "must not report success on a replace that didn't happen")
+            assertEquals(
+                SyncFailureReason.AccountKeyNotAdopted,
+                (sut.status.value as? SyncStatus.Failed)?.reason,
+                "must not report success on a replace that didn't happen, was ${sut.status.value}",
+            )
             assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is left as it was")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #133, the same refusal on the ordinary reconnect path (vault password == account password,
+     * register → CONFLICT → login). The SRP login already proved the typed password IS the account
+     * password, so a wrap that doesn't open means the account's records live under a dataKey this device
+     * doesn't have (a corrupted or partially restored server record). Syncing anyway pulls records we
+     * can't decrypt and pushes records the other devices can't — silently. Fail the connect instead.
+     */
+    @Test
+    fun `reconnecting fails loudly when the account key cannot be adopted`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = vaultPassword, corruptWrap = true)
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, vaultPassword.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertEquals(
+                SyncFailureReason.AccountKeyNotAdopted,
+                (sut.status.value as? SyncStatus.Failed)?.reason,
+                "must not sync under a key that isn't the account's, was ${sut.status.value}",
+            )
+            assertTrue(vault.verifyPassword(vaultPassword.toCharArray()), "the vault password is left as it was")
+            // Opened by this connect and adopted by nothing downstream: left behind it leaks a Ktor pool
+            // per attempt.
+            assertEquals(1, client.closeCalls, "the client must be closed on the way out")
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorServerFailureTest.kt
@@ -51,6 +51,8 @@ class SyncCoordinatorServerFailureTest {
         private val kind: SyncException.Kind,
         private val loginSession: SyncSession? = null,
         private val loginFailure: SyncException? = null,
+        /** The account's wrapped dataKey — only a login that succeeds ever gets this far. */
+        private val wrappedDataKey: ByteArray = ByteArray(0),
     ) : SyncClient {
         @Volatile
         var loginCalls = 0
@@ -76,11 +78,7 @@ class SyncCoordinatorServerFailureTest {
             return loginSession ?: nope()
         }
         override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession = nope()
-        // An empty wrap can't be unwrapped, so adoptAccountDataKey returns Undecryptable — which the
-        // matchesVault branch treats as "key not ours to adopt" and connects anyway. That is the only
-        // reason this stub reaches Online; the tests here are about the register/login handshake, not
-        // about key adoption.
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ByteArray(0)
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = wrappedDataKey.copyOf()
         override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
@@ -211,11 +209,21 @@ class SyncCoordinatorServerFailureTest {
     fun `a closed instance still lets existing accounts log in via the login fallback`() {
         val result = runBlocking {
             initializeVaultCrypto()
+            val vault = localVault()
             val session = SyncSession(accountId = account, accessToken = "at", refreshToken = "rt")
+            // The account publishes THIS vault's key, wrapped under the account master key: a wrap that
+            // doesn't open is a refusal of its own (issue #133) and would mask the handshake under test.
+            val wrap = vault.exportDataKey()!!.let { key ->
+                try {
+                    crypto.wrapDataKey(syncAccountKey(crypto, password, account), key)
+                } finally {
+                    key.zeroize()
+                }
+            }
             val sut = SyncCoordinator(
-                clientFactory = { RejectingClient(SyncException.Kind.FORBIDDEN, loginSession = session) },
+                clientFactory = { RejectingClient(SyncException.Kind.FORBIDDEN, loginSession = session, wrappedDataKey = wrap) },
                 crypto = crypto,
-                vault = localVault(),
+                vault = vault,
                 engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
             )
             try {


### PR DESCRIPTION
Closes #133.

`SyncCoordinator.adoptAccountDataKey` reports one of `Adopted`, `AlreadyOurs`, `Undecryptable`. On the ordinary reconnect path — vault password equals the account password, `register` → CONFLICT/FORBIDDEN → `login` — the outcome was collapsed into a boolean, so `Undecryptable` was indistinguishable from `AlreadyOurs`: the device went Online, pulled records it could not decrypt and pushed records no other device could, with no status, no message and no log line.

The login has already proven the typed password is the account password, so a wrap that fails to open means the wrap and the SRP verifier disagree on the server (a rotation cannot cause it — the server writes both in one transaction; database corruption or a partial restore can). That branch now closes the client and fails with `AccountKeyNotAdopted`, the same way the confirmed password-replace branch already did.

## Tests

- `reconnecting fails loudly when the account key cannot be adopted` — asserts the failure reason, an untouched vault password and a closed client. Verified to report `Online` before the fix.
- `confirming fails loudly when the account key cannot be adopted` — tightened from `is Failed` to the exact reason.
- `SyncCoordinatorServerFailureTest`'s stub served an empty wrap and reached Online only through this bug; it now serves the vault's own key wrapped under the account master key.

## Verifying by hand

The state cannot occur through normal use. In the sync server's database, replace an account's `wrapped_data_key` with garbage while leaving its SRP verifier intact, then connect an existing device: it must report "Couldn't adopt the account key" instead of going Online.

🤖 Generated with [Claude Code](https://claude.com/claude-code)