### PR TITLE
Record the reactivation reconcile intent as soon as the server reports it (#168)

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -97,6 +97,12 @@ class SyncCoordinator(
     val biometricResetNeeded: StateFlow<Boolean> = _biometricResetNeeded.asStateFlow()
 
     /**
+     * One server link — what a reconcile debt belongs to. [SyncConfig] pairs the two for the saved link;
+     * this is the same pair for the debts that have no saved link to sit on ([unsavedReactivations]).
+     */
+    private data class ServerAccount(val serverUrl: String, val accountId: String)
+
+    /**
      * Connect paused on [SyncStatus.NeedsPasswordReplaceConfirm]: the params to re-run the connect once the
      * user confirms replacing the vault unlock password. Holds an owned password copy — wiped on confirm
      * (handed to the re-run, wiped in its finally), cancel, a superseding connect, and [close].
@@ -211,6 +217,21 @@ class SyncCoordinator(
     // nothing was cleared. Every read and write is under [syncMutex].
     @Volatile
     private var reconcileArmed = false
+
+    // Links a login reported as reactivated while [rememberReactivation] had nowhere durable to put the
+    // intent: this device has no saved link for them (nothing to mark, and a connect that never reached a
+    // session must not create one), or the config write was refused. The server never repeats the signal,
+    // so the debt is held here for the lifetime of the process — a later connect to the same link still
+    // owes the rebuild. A debt whose marker gets overwritten has nothing else either: [SyncConfig] holds
+    // ONE link, so connecting to another one saves a config without the previous link's marker. An entry is dropped only by the reconcile that discharges it ([reconcileLocked], after
+    // the records are actually gone) — [disconnect] deliberately leaves it, because erasing a link
+    // rebuilds nothing. A LINK, not an account id: the same id names different accounts on two servers, and
+    // rebuilding the wrong one throws away records nobody purged. Replaced whole rather than mutated; every
+    // write is under [syncMutex], which is also what serializes the read in [reconcileOwed] (reached from
+    // sync cycles that hold no [opMutex]). The [doConnect]/[restoreSession] reads run under [opMutex] alone,
+    // and @Volatile is what publishes the field across those coroutines.
+    @Volatile
+    private var unsavedReactivations: Set<ServerAccount> = emptySet()
 
     // Set by [pauseForLock], cleared by [resumeAfterUnlock]: which of the two the coordinator should end
     // up obeying when they queue up behind a long operation holding [opMutex], regardless of the order
@@ -341,6 +362,7 @@ class SyncCoordinator(
             // and whether the unlock password changes (issue #28). verifyPassword runs Argon2id over the
             // vault salt; a rare user-initiated connect, so the extra derivation is acceptable.
             val matchesVault = vault.verifyPassword(masterPassword.copyOf())
+            val link = ServerAccount(serverUrl, accountId)
             var adoptedKey = false
             // Set when the server reports this device was revoked and this login reactivated it: the vault
             // may still hold records the server purged while we were locked out, so we must re-mirror the
@@ -380,6 +402,7 @@ class SyncCoordinator(
                         throw failure
                     }
                     reactivated = s.reactivated
+                    if (reactivated) rememberReactivation(link)
                     // Same password on both sides: nothing to re-wrap, only a possible key change.
                     when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
                         KeyAdoption.Adopted -> adoptedKey = true
@@ -420,6 +443,12 @@ class SyncCoordinator(
                 // Verified only — close this client; the confirmed re-run opens its own. Stash the connect
                 // params + password and ask the UI to confirm (finally still wipes mk/authKey/dataKey/password).
                 runCatching { syncClient.close() }
+                // The verify above is a full SRP login: it reactivates a revoked device server-side and
+                // consumes the one-shot signal, so the confirmed re-run's login reports an ordinary live
+                // device and only what is recorded here reaches it. Nothing is written for a link this
+                // device doesn't have — the user has merely typed a password and may still take it back.
+                // After the close, not before: a refused write throws, and it must not strand the client.
+                if (s.reactivated) rememberReactivation(link)
                 stashPendingReplace(PendingReplace(serverUrl, accountId, masterPassword.copyOf(), keepConnected))
                 _status.value = SyncStatus.NeedsPasswordReplaceConfirm(serverUrl, accountId)
                 return
@@ -427,7 +456,11 @@ class SyncCoordinator(
                 // Confirmed ([confirmPasswordReplace]): log into the existing account and adopt its key,
                 // re-keying this vault to the account password (the intended, consented password change).
                 val s = syncClient.login(accountId, ak, device)
-                reactivated = s.reactivated
+                // Normally the reactivation was reported to the paused connect's verify login and cleared
+                // server-side there, so it reaches this second login only as a debt in memory. This session
+                // is read too — a device revoked again while the confirmation was on screen.
+                reactivated = s.reactivated || link in unsavedReactivations
+                if (reactivated) rememberReactivation(link)
                 when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
                     KeyAdoption.Adopted -> adoptedKey = true
                     // The account key already IS ours (registered here, then the vault password was changed
@@ -467,10 +500,15 @@ class SyncCoordinator(
             // A reactivated (formerly revoked) device forces a full re-pull like an adopted key, and first
             // discards its pre-revocation records so a stale live copy can't re-push a server-purged record.
             // The server reports `reactivated` only once (it clears revocation on this verify), so we also
-            // honor a durable pendingReconcile from a previously interrupted reconcile — otherwise a crash
-            // mid-reconcile would drop the signal and let the stale records push on the next connect.
-            val pendingReconcile = configStore.load()?.takeIf { it.accountId == accountId }?.pendingReconcile == true
-            val mustReconcile = reactivated || pendingReconcile
+            // honor a durable pendingReconcile — raised by [rememberReactivation] the moment the login
+            // reported it, or left up by a reconcile that was interrupted before its first sync succeeded.
+            // The live `reactivated` still counts on its own, and so does a debt from an earlier connect
+            // this process that had nowhere to write it ([unsavedReactivations]).
+            // Matched on the whole link, like the write: a marker raised for this account on another server
+            // says nothing about this one, and honoring it would rebuild a vault nobody purged records from.
+            val pendingReconcile = configStore.load()
+                ?.takeIf { it.serverUrl == serverUrl && it.accountId == accountId }?.pendingReconcile == true
+            val mustReconcile = reactivated || pendingReconcile || link in unsavedReactivations
             activateSession(
                 syncClient,
                 newSession,
@@ -573,6 +611,47 @@ class SyncCoordinator(
     }
 
     /**
+     * Persist the reactivation reconcile intent the moment the server reports it, before anything that can
+     * still fail.
+     *
+     * The server clears the revocation on the SRP verify that reports `reactivated` and never reports it
+     * again, while the intent used to be written only by [reconcileLocked], at the end of a connect that
+     * reached its session. Everything in between dropped the signal for good: an account wrap that doesn't
+     * open, a failed local re-key, a dropped connection while adopting the key. The next connect then looked
+     * like an ordinary incremental reconnect — the vault was never rebuilt and the records the account
+     * purged while this device was revoked were pushed back (issue #168; issue #142 through another door).
+     *
+     * The marker goes onto the saved link when this device has one for [link], and nowhere else: a connect
+     * that never reached a session must not leave a link behind (the password-replace pause is the sharp
+     * case — the user can still decline it), and a link to another server or account belongs to a device
+     * that is fine. Everything the marker cannot reach is held in [unsavedReactivations] instead, which is
+     * why that is set first and unconditionally: the write below can also be refused outright.
+     *
+     * A store that refuses the write fails the connect (uncaught, like [reconcileLocked]'s): a device that
+     * cannot record what it owes must not go on to sync as if it owed nothing.
+     *
+     * The cost of the earlier write is a longer wait between "the rebuild is owed" and "the rebuild runs":
+     * the marker can now sit through a failed connect and everything the user does after it, and the clear
+     * that eventually discharges it takes every sync-capable record with it, including ones created since
+     * (they were never pushed — the connect failed). The alternative is worse and silent: records the
+     * account purged coming back on every device.
+     *
+     * Under [syncMutex] like every other config write — a cycle of the session this connect is about to
+     * supersede rewrites the same config ([clearPendingReconcile], [refreshSessionLocked]). Called from
+     * [doConnect] under [opMutex], which [syncMutex] nests inside.
+     */
+    private suspend fun rememberReactivation(link: ServerAccount) {
+        syncMutex.withLock {
+            // In memory first, and whatever happens below: the write can be refused (a full disk) or have
+            // nowhere to go, and there is no second chance to learn this from the server.
+            unsavedReactivations = unsavedReactivations + link
+            val saved = configStore.load()?.takeIf { it.serverUrl == link.serverUrl && it.accountId == link.accountId }
+                ?: return@withLock
+            configStore.save(saved.copy(pendingReconcile = true))
+        }
+    }
+
+    /**
      * The reactivation reconcile itself: drop the local records BEFORE resetting the cursor and running the
      * first sync, so the following full re-pull rebuilds them from the server snapshot and the subsequent
      * push can't resurrect a record the server purged while this device was revoked.
@@ -599,6 +678,10 @@ class SyncCoordinator(
         configStore.save(config.copy(pendingReconcile = true))
         val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
         vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
+        // Discharged only once the records are actually gone, and only for the link being reconciled: a
+        // clear that threw leaves the debt owed (the durable marker alone would not survive a [disconnect]),
+        // and a debt held for another link is not this reconcile's to retire.
+        unsavedReactivations = unsavedReactivations - ServerAccount(config.serverUrl, config.accountId)
         syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
         reconcileArmed = true // only now — see [clearPendingReconcile]
     }
@@ -662,6 +745,11 @@ class SyncCoordinator(
      * Decline replacing the vault unlock password (status [SyncStatus.NeedsPasswordReplaceConfirm]): wipe the
      * kept password and return to the prior state (Configured if a link is saved, else Disabled). The account
      * is untouched and the local vault keeps its current password. No-op if nothing is pending.
+     *
+     * What the decline does NOT undo is a reactivation the verify login reported ([unsavedReactivations]):
+     * the server cleared the revocation on that login and won't mention it again, so this device still owes
+     * that account a rebuild whenever it does connect. Declining is an answer about the password, not about
+     * the revocation.
      */
     fun cancelPasswordReplace() {
         val pending = pendingReplace ?: return
@@ -1129,13 +1217,18 @@ class SyncCoordinator(
      * any activation that doesn't reconcile at all ([doChangeAccountPassword]) while the marker is up.
      * Issue #142.
      *
+     * A debt this process could not write down ([unsavedReactivations]) counts exactly like the marker: it
+     * is the same obligation, and without it a store that refused the write would leave the guard blind —
+     * every cycle would run over the un-rebuilt vault.
+     *
      * Read under [syncMutex] like [reconcileArmed] itself, and matched on [accountId] — a marker saved
      * for another account says nothing about this session.
      */
     private fun reconcileOwed(accountId: String): Boolean {
         if (reconcileArmed) return false
         val cfg = configStore.load() ?: return false
-        return cfg.accountId == accountId && cfg.pendingReconcile
+        if (cfg.accountId != accountId) return false
+        return cfg.pendingReconcile || ServerAccount(cfg.serverUrl, cfg.accountId) in unsavedReactivations
     }
 
     /** Park the status on Configured (the vault-locked resting state); Disabled without a link. */
@@ -1551,6 +1644,8 @@ class SyncCoordinator(
                 // cursor write failure (disk full) must not leave configStore/healthTarget/status in a
                 // half-detached state ("Disconnect ran but the device is linked again").
                 runCatching { configStore.load()?.let { syncState.setCursor(it.accountId, 0) } }
+                // [unsavedReactivations] survives on purpose: erasing the link rebuilds nothing, so a debt
+                // the reconcile never paid is still owed — and the durable marker goes with the config here.
                 configStore.clear()
                 health.setTarget(null) // detached — stop the health ping (poller closes the client, status → UNKNOWN)
                 _status.value = SyncStatus.Disabled
@@ -1700,9 +1795,12 @@ class SyncCoordinator(
                     val syncClient = clientFactory(cfg.serverUrl)
                     val newSession = syncClient.refresh(SyncSession(cfg.accountId, "", refreshToken))
                     // A reconcile interrupted before it finished (pendingReconcile) must still run on this
-                    // silent restore — refresh carries no `reactivated` signal, so the durable marker is the
-                    // only thing that redoes it before the first push.
-                    val reconcile = cfg.pendingReconcile
+                    // silent restore — refresh carries no `reactivated` signal, so the marker is the only
+                    // thing that redoes it before the first push. A debt this process could not write down
+                    // counts the same: the connect that learned of it failed, and this restore is what
+                    // brings the device back.
+                    val reconcile = cfg.pendingReconcile ||
+                        ServerAccount(cfg.serverUrl, cfg.accountId) in unsavedReactivations
                     // refresh rotates the token — re-save it sealed under the dataKey (inside activation).
                     activateSession(
                         syncClient,

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.sync.SyncSignal
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.flow.Flow
@@ -23,6 +24,7 @@ import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -65,6 +67,8 @@ class SyncCoordinatorPasswordReplaceTest {
         accountDataKey: DataKey? = null,
         /** Serve a wrap that can't be unwrapped, modelling a corrupted/mismatched server record. */
         private val corruptWrap: Boolean = false,
+        /** This device is revoked on the account: the first successful login reactivates it and says so once. */
+        revoked: Boolean = false,
     ) : SyncClient {
         // var: a password rotation ([changePassword]) swaps both to the new password's material.
         private var expectedAuthKey: ByteArray?
@@ -87,6 +91,10 @@ class SyncCoordinatorPasswordReplaceTest {
 
         var registered = false; private set
 
+        // Cleared by the verify that reports it, exactly as the server does it (re-authentication
+        // reactivates the device), so a later login of the same device carries nothing.
+        private val revoked = AtomicBoolean(revoked)
+
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
             if (expectedAuthKey != null) throw SyncException(SyncException.Kind.CONFLICT, "account exists")
             registered = true
@@ -95,7 +103,7 @@ class SyncCoordinatorPasswordReplaceTest {
 
         override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
             if (expectedAuthKey != null && authKey.contentEquals(expectedAuthKey)) {
-                return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+                return SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
             }
             throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong password") // server hides "no such account"
         }
@@ -334,6 +342,154 @@ class SyncCoordinatorPasswordReplaceTest {
             // Opened by this connect and adopted by nothing downstream: left behind it leaks a Ktor pool
             // per attempt.
             assertEquals(1, client.closeCalls, "the client must be closed on the way out")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #168 on the replace path. The login that only VERIFIES the typed password is a full SRP
+     * verify: it reactivates this revoked device server-side and consumes the one-shot signal, and then
+     * the connect pauses for the user's confirmation. By the time the confirmed re-run logs in again the
+     * server sees an ordinary live device and reports nothing — so unless the paused connect carries the
+     * signal across the confirmation, the rebuild the reactivation owes never happens and this device
+     * pushes back the records the account purged while it was locked out.
+     */
+    @Test
+    fun `a reactivation reported by the verify-only login survives the confirmation`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        // Held LIVE through the revocation — the server purged it in the meantime.
+        vault.put("r1", RecordType.HOST, "stale".encodeToByteArray())
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val store = InMemorySyncConfigStore()
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            // A password the user has only typed is not a link: nothing may be saved before they confirm.
+            assertEquals(null, store.load(), "a paused connect must not save a link the user hasn't confirmed")
+
+            sut.confirmPasswordReplace()
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the reactivated device must rebuild from the server before it pushes")
+            assertEquals(false, store.load()?.pendingReconcile, "the completed reconcile retires the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The other half of the same pause. Declining must leave the device exactly as it was — the verify
+     * login was a password probe, not a link — so the reactivation carried across the pause has to live
+     * with the paused connect and die with it, not on disk. Otherwise Cancel leaves the app "Configured"
+     * for an account the user refused to join, and armed to wipe the vault whenever it does connect.
+     */
+    @Test
+    fun `declining the confirmation leaves no link behind after a reactivating verify`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val store = InMemorySyncConfigStore()
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.cancelPasswordReplace()
+            sut.status.awaitStatus("the status to come Disabled") { it is SyncStatus.Disabled }
+            assertEquals(null, store.load(), "a declined connect must not leave a saved link")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The pause is not a reason to withhold the marker from a link this device ALREADY has: recording it
+     * there creates no new state and takes nothing back from the user, and the device owes the rebuild
+     * whatever it decides about the password. Only the fields the reactivation is about may change —
+     * the deviceId and the keep-connected token belong to a link that is still valid.
+     */
+    @Test
+    fun `a reactivating verify marks the link this device already has`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val linked = SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed")
+        val store = InMemorySyncConfigStore().apply { save(linked) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            assertEquals(
+                linked.copy(pendingReconcile = true),
+                store.load(),
+                "the marker goes onto the existing link, and nothing else about it changes",
+            )
+        } finally {
+            sut.close()
+        }
+    }
+
+    /** A vault that refuses the re-wrap the confirmed replace needs (`VaultRekeyFailed`). */
+    private class RewrapUnderFailingVault(private val delegate: Vault) : Vault by delegate {
+        override fun rewrapUnder(password: CharArray): Boolean {
+            password.fill(' ')
+            return false
+        }
+    }
+
+    /**
+     * The third early return of issue #168: the confirmed replace logs in, the account key turns out to
+     * already be ours, and re-wrapping the vault under the account password fails. The connect stops
+     * there — but the reactivation the paused connect carried is already the server's last word on the
+     * subject, so it must be on the device's link by then rather than die with the failed re-key. (The
+     * device is linked here, which is what a rotation from another device leaves behind: the account
+     * password moved on and this vault still holds the old one.)
+     */
+    @Test
+    fun `a confirmed replace that fails on the re-key keeps the reactivation`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, accountDataKey = vault.exportDataKey(), revoked = true)
+        val store = configuredStore()
+        val sut = coordinator(RewrapUnderFailingVault(vault), client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.confirmPasswordReplace()
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertEquals(
+                SyncFailureReason.VaultRekeyFailed,
+                (sut.status.value as? SyncStatus.Failed)?.reason,
+                "was ${sut.status.value}",
+            )
+            assertEquals(true, store.load()?.pendingReconcile, "the rebuild is owed even though the re-key failed")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Recording the reactivation can fail — the config file is on a full disk — and that failure travels
+     * out through the catch-all rather than a return of its own. The client the verify opened must not go
+     * with it: nothing else holds a reference, so every retry would strand another socket pool.
+     */
+    @Test
+    fun `a refused reactivation write still closes the client the verify opened`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        // The link is already there, so the reactivation has somewhere to be written — and that write fails.
+        val linked = InMemorySyncConfigStore().apply { save(SyncConfig(serverUrl, account, deviceId = "dev-local")) }
+        val store = object : SyncConfigStore by linked {
+            override fun save(config: SyncConfig): Unit = error("config write failed")
+        }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
+            assertEquals(1, client.closeCalls, "the verify's client must be closed even when the write throws")
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -62,9 +63,13 @@ class SyncCoordinatorReactivationTest {
      */
     private inner class ReactivatingClient(
         private val ownWrappedKey: ByteArray,
-        private val reactivated: Boolean = true,
+        reactivated: Boolean = true,
         /** Makes the reconcile's own first cycle fail, leaving the rebuild to a later sync. */
         private val failFirstPull: Boolean = false,
+        /** How many key fetches serve an unopenable wrap — a connect that fails AFTER the login. */
+        private val corruptWraps: Int = 0,
+        /** The first key fetch dies on the network — a connect that THROWS after the login. */
+        private val throwOnFirstFetch: Boolean = false,
     ) : SyncClient {
         val pushed = mutableListOf<RemoteRecord>()
 
@@ -72,11 +77,20 @@ class SyncCoordinatorReactivationTest {
         val pulledSince = mutableListOf<Long>()
         private val pulls = AtomicInteger(0)
 
+        // The reactivation is reported exactly once, like the server does it: the verify that reports it
+        // is the one that clears the revocation, so every later login of this device is an ordinary one.
+        private val revoked = AtomicBoolean(reactivated)
+        private val fetches = AtomicInteger(0)
+
         override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
             throw SyncException(SyncException.Kind.CONFLICT, "account exists")
         override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = reactivated)
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray = ownWrappedKey.copyOf()
+            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
+        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
+            val n = fetches.getAndIncrement()
+            if (throwOnFirstFetch && n == 0) throw SyncException(SyncException.Kind.NETWORK, "unreachable")
+            return if (n < corruptWraps) ByteArray(ownWrappedKey.size) else ownWrappedKey.copyOf()
+        }
         override suspend fun pull(session: SyncSession, since: Long): RecordPage {
             pulledSince += since
             // Not a SyncException(NETWORK): that one arms the backoff retry loop, and the test wants the
@@ -89,12 +103,18 @@ class SyncCoordinatorReactivationTest {
             return RecordPage(emptyList(), 1)
         }
         override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
-        override suspend fun ping(): Boolean = true
+
+        // Unreachable on purpose: a health ping that comes up drives the coordinator's own self-heal
+        // ([SyncCoordinator]'s init — no session, so `restoreSession`), which would race the connects these
+        // tests drive and re-save the config from under the assertions. Reachability is covered elsewhere.
+        override suspend fun ping(): Boolean = false
         override suspend fun close() {}
         override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
         override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
         override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
-        override suspend fun refresh(session: SyncSession): SyncSession = throw NotImplementedError()
+        // The silent restore of a keep-connected device: a token exchange, with no `reactivated` in it.
+        override suspend fun refresh(session: SyncSession): SyncSession =
+            SyncSession(session.accountId, accessToken = "access2", refreshToken = "refresh2")
         // The rotation itself isn't what these tests are about: they need the activation that follows it,
         // which re-publishes the session WITHOUT reconciling. Accepts any current password.
         override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
@@ -119,6 +139,20 @@ class SyncCoordinatorReactivationTest {
             if (attempts.getAndIncrement() < failures) error("vault is locked")
             delegate.clearRecords(types)
         }
+    }
+
+    /** Config store that refuses exactly the write RAISING the reconcile marker (a full disk). */
+    private class MarkerRaiseFailingStore(private val delegate: SyncConfigStore) : SyncConfigStore {
+        /** Cleared once the test wants the disk to have room again. */
+        @Volatile
+        var refuse = true
+
+        override fun load(): SyncConfig? = delegate.load()
+        override fun save(config: SyncConfig) {
+            if (refuse && config.pendingReconcile && delegate.load()?.pendingReconcile != true) error("config write failed")
+            delegate.save(config)
+        }
+        override fun clear() = delegate.clear()
     }
 
     /** Config store that refuses exactly the write retiring the reconcile marker (a full disk). */
@@ -193,6 +227,301 @@ class SyncCoordinatorReactivationTest {
             assertFalse(vault.records().any { it.id == "r1" }, "a pending reconcile must still rebuild the vault")
             assertFalse(client.pushed.any { it.id == "r1" }, "a pending reconcile must not let the stale record push")
             assertEquals(false, config.load()?.pendingReconcile, "the redone reconcile clears the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #168: the login succeeds and reports the reactivation, then the connect fails on its way to
+     * the session — here on an account wrap that doesn't open (issue #133's refusal). The server already
+     * cleared the revocation on that verify and will never report it again, so an intent persisted only
+     * by a connect that reaches the end is no intent at all: the next connect would look like an ordinary
+     * incremental reconnect and push the pre-revocation records straight back.
+     */
+    @Test
+    fun `a connect that fails after the login keeps the reactivation it was told about`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        // The first connect's key fetch serves an unopenable wrap; the second one is served the real key.
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertEquals(
+                SyncFailureReason.AccountKeyNotAdopted,
+                (sut.status.value as? SyncStatus.Failed)?.reason,
+                "was ${sut.status.value}",
+            )
+            assertEquals(null, config.load(), "a connect that never reached a session must not save a link")
+
+            // The repaired server state, and a login that reports nothing: the connect that failed is the
+            // only thing that still knows a rebuild is owed.
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the repaired connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the deferred reconcile must still drop the pre-revocation record")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The device that gets reactivated normally still HAS its link — that is the production shape of the
+     * write, and the one the fresh-store tests never take. Only the reconcile marker may change: the
+     * deviceId identifies this device to the account, and the keep-connected token is what lets the next
+     * launch restore without a password. Rebuilding the config from the connect's own parameters instead
+     * of marking the saved one would drop both and no other test would notice.
+     */
+    @Test
+    fun `marking a reactivation preserves the link it is written onto`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+
+        val linked = SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = "sealed")
+        val config = InMemorySyncConfigStore().also { it.save(linked) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertEquals(linked.copy(pendingReconcile = true), config.load(), "only the marker may change")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The connect need not fail with a status of its own to lose the signal: a network error while
+     * fetching the account key throws straight past every early return into the catch-all. The marker
+     * has to be down on disk before that fetch, not after it.
+     */
+    @Test
+    fun `a connect that throws after the login keeps the reactivation`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, throwOnFirstFetch = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the key fetch") { it is SyncStatus.Failed }
+            assertEquals(true, config.load()?.pendingReconcile, "a throw after the login must not take the reactivation with it")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A keep-connected device recovers without a password: the next launch refreshes its saved token
+     * instead of logging in, and `refresh` carries no `reactivated` signal at all. The marker raised by
+     * the failed connect is the only thing that can make that silent restore rebuild the vault first —
+     * which is the whole reason the intent is durable rather than kept in memory.
+     */
+    @Test
+    fun `a keep-connected restore finishes the reconcile a failed connect left owed`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        // The link a keep-connected device already has — the failed connect below never reaches a session,
+        // so it seals no token of its own.
+        val dataKey = vault.exportDataKey()!!
+        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
+        val config = InMemorySyncConfigStore().also {
+            it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
+        }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val failed = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            failed.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            failed.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+        } finally {
+            failed.close()
+        }
+        assertEquals(true, config.load()?.pendingReconcile, "the failed connect left the rebuild owed")
+
+        // A new process: no coordinator state survives, only the config file and the vault.
+        val restored = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            restored.restoreSession()
+            restored.status.awaitStatus("the silent restore to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(restored.status.value is SyncStatus.Online, "was ${restored.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the restore must run the reconcile the connect never got to")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+        } finally {
+            restored.close()
+        }
+    }
+
+    /**
+     * The marker is written onto the saved link, and a connect that hasn't succeeded yet has not earned
+     * one: a failed connect to another account must leave the link — its deviceId and its keep-connected
+     * token — exactly as it was, rather than trade a device that is still fine for a reconcile intent that
+     * cannot even be read for that account. The signal is carried live instead (`reactivated`), and the
+     * connect that succeeds writes its own link with the marker.
+     */
+    @Test
+    fun `a failed connect does not overwrite the link to another account`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+
+        val linked = SyncConfig(serverUrl, "other-account", deviceId = "devOther", keepConnected = true, sealedRefreshToken = "sealed")
+        val config = InMemorySyncConfigStore().also { it.save(linked) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertEquals(linked, config.load(), "a failed connect must leave the saved link untouched")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Disconnect erases the link, and with it the durable marker — but it rebuilds nothing: the records
+     * the reconcile was supposed to drop are still in the vault. A debt that was never actually paid must
+     * therefore survive it, or the reconnect after a disconnect is the ordinary incremental one and pushes
+     * the purged records straight back. (Here the reconcile's clear failed, which is exactly the state in
+     * which a user reaches for Disconnect.)
+     */
+    @Test
+    fun `a disconnect does not pay a rebuild that never ran`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault, failures = 1),
+            configStore = config,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+
+            sut.disconnect()
+            sut.status.awaitStatus("the link to be erased") { it is SyncStatus.Disabled }
+            assertEquals(null, config.load(), "disconnect erases the link — and the durable marker with it")
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the reconnect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the rebuild is still owed — disconnect ran no reconcile")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The account id is chosen by the user and says nothing about which server it belongs to — the same
+     * one names two accounts on a home and a work instance. A rebuild owed to one of them must not be
+     * charged to the other: the vault would be wiped of records the other server never purged, and they
+     * were never pushed to it either.
+     */
+    @Test
+    fun `a rebuild owed to one server is not charged to another`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        // Linked to the home instance, so the failed connect below marks THAT link — the marker and the
+        // in-memory debt both have to stay charged to it.
+        val config = InMemorySyncConfigStore()
+            .also { it.save(SyncConfig("https://home.test", account, deviceId = "devA")) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            // The home instance: this device was revoked there, and the connect fails after the login.
+            sut.connect("https://home.test", account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+
+            // The work instance, same account id: an ordinary connect that owes nothing.
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the second connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertTrue(vault.records().any { it.id == "r1" }, "another server's reactivation must not clear this vault")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The reactivation is reported, the marker write is refused (a full disk), and the connect fails
+     * loudly — but the device is keep-connected, so what happens next is a silent restore that never
+     * logs in again. It has to see the rebuild is owed from the only place it was recorded: this
+     * process's memory. Otherwise the session comes Online and pushes the purged records back.
+     */
+    @Test
+    fun `a restore honors a rebuild whose marker could not be written`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val dataKey = vault.exportDataKey()!!
+        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
+        val config = MarkerRaiseFailingStore(
+            InMemorySyncConfigStore().also {
+                it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
+            },
+        )
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
+            assertEquals(false, config.load()?.pendingReconcile, "the marker never made it to disk")
+
+            config.refuse = false // the disk has room again by the time the restore runs
+            sut.restoreSession()
+            sut.status.awaitStatus("the silent restore to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the restore must rebuild — the debt is still owed")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Standing down from the write is not the same as forgetting: the server said this device was
+     * reactivated and will never say it again, so the retry that finally connects must still rebuild —
+     * even though the intent had nowhere on disk to wait (the saved link is another account's, and a
+     * refused write leaves the same nothing behind).
+     */
+    @Test
+    fun `a reactivation with nowhere to be saved still reconciles on the next connect`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+            .also { it.save(SyncConfig(serverUrl, "other-account", deviceId = "devOther")) }
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the retry to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the retry must rebuild — the signal is gone from the server")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
         } finally {
             sut.close()
         }
@@ -533,6 +862,42 @@ class SyncCoordinatorReactivationTest {
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+
+            assertEquals(
+                AccountPasswordChange.Success,
+                sut.changeAccountPassword(password.toCharArray(), "vault-B".toCharArray()),
+            )
+            assertEquals(
+                SyncStatus.Failed(SyncFailureReason.ReconcileRequired),
+                sut.status.value,
+                "an activation that doesn't reconcile must not sync a vault that still owes one",
+            )
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The refusal guard reads the durable marker, so a debt that never reached disk must be visible to it
+     * too. A password rotation re-publishes the session without reconciling: with nothing to see, its first
+     * cycle would push the pre-revocation records the failed connect never got to drop.
+     */
+    @Test
+    fun `a rotation cannot sync over a rebuild whose marker could not be written`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = MarkerRaiseFailingStore(
+            InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) },
+        )
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
+            assertEquals(false, config.load()?.pendingReconcile, "the marker never made it to disk")
 
             assertEquals(
                 AccountPasswordChange.Success,


### PR DESCRIPTION
Fixes #168.

## What it does

A device that was revoked and then reactivated must rebuild its vault from the server before it pushes, or it re-uploads records the account purged while it was locked out. The server reports that reactivation exactly once — the SRP verify that reports it also clears the revocation — and the client persisted the resulting reconcile intent only when the connect went on to reach a session.

Everything between the login and the session dropped the signal: an account wrap that doesn't open, a failed local re-key, a dropped connection while adopting the key. So did the pause for the password-replace confirmation, whose verify login is a full SRP login and consumes the signal, leaving the confirmed re-run to log in to an ordinary live device. Any of those, and the next connect ran as an ordinary incremental reconnect and pushed the pre-revocation records back.

The intent is now recorded the moment a login reports it:

- onto the saved link, when the device has one for that server and account;
- in memory for the lifetime of the process, when it has none or the config write is refused.

A connect that never reaches a session still saves no link, so declining the password-replace confirmation leaves nothing on disk. The debt is keyed by the link — the same account id names different accounts on two servers, and rebuilding the wrong one throws away records nobody purged — is retired only once the records are actually dropped, and is honored by `reconcileOwed` and by the silent keep-connected restore, which sees no `reactivated` of its own.

## Verification

`./gradlew test allTests detektAll build` and `:androidApp:compileDebugKotlin` are green. Twelve tests cover the paths that used to lose the signal: the two typed refusals (`AccountKeyNotAdopted`, `VaultRekeyFailed`), a throw after the login, the confirmation pause and its decline, a refused marker write, the keep-connected restore, a disconnect between the failed connect and the retry, and the two non-interference cases (another account, another server).

Not verified against a live server or on an Android device: reproducing it needs a device row in `revoked` state plus a connect that fails after the login.