### PR TITLE
Keep the reactivation reconcile debt in a store of its own (#170)

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidReconcileDebtStore.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidReconcileDebtStore.kt
@@ -1,0 +1,50 @@
+package app.skerry.android
+
+import app.skerry.shared.io.PrivateConfig
+import app.skerry.ui.sync.ReconcileDebtStore
+import app.skerry.ui.sync.ServerLink
+import java.io.File
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.file.Files
+
+/**
+ * File-backed reconcile-debt store (Android): `sync-reconcile` in the app's private files dir. One line
+ * per owed link, `urlencoded(serverUrl)=urlencoded(accountId)` — mirrors desktop `FileReconcileDebtStore`,
+ * down to the write primitive: [PrivateConfig.atomicWrite] never rewrites the file in place, so a process
+ * kill (the norm on Android) cannot leave a truncated file that reads as "this device owes nothing".
+ *
+ * Its own file rather than a key in `sync.json`: the config is erased by a disconnect and overwritten by
+ * a connect to another server, and a debt must outlive both (issue #170).
+ */
+class AndroidReconcileDebtStore(private val file: File) : ReconcileDebtStore {
+
+    override fun load(): Set<ServerLink> {
+        if (!file.exists()) return emptySet()
+        return runCatching {
+            // Per line, so one unparseable entry (a truncated percent escape) costs its own debt and no
+            // more. Losing that one is already a silent resurrection for its link; letting it take every
+            // intact line with it is the same failure on every link at once.
+            file.readLines().mapNotNull { line -> runCatching { parse(line) }.getOrNull() }.toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    override fun save(debts: Set<ServerLink>) {
+        if (debts.isEmpty()) {
+            Files.deleteIfExists(file.toPath()) // throws on a real I/O failure — a retired debt must land
+            return
+        }
+        val text = debts.joinToString(separator = "") {
+            "${URLEncoder.encode(it.serverUrl, "UTF-8")}=${URLEncoder.encode(it.accountId, "UTF-8")}\n"
+        }
+        PrivateConfig.atomicWrite(file.toPath(), text.encodeToByteArray())
+    }
+
+    private fun parse(line: String): ServerLink? {
+        val i = line.indexOf('=')
+        if (i <= 0) return null
+        val url = URLDecoder.decode(line.substring(0, i), "UTF-8")
+        val account = URLDecoder.decode(line.substring(i + 1), "UTF-8")
+        return if (url.isEmpty() || account.isEmpty()) null else ServerLink(url, account)
+    }
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidSyncConfigStore.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidSyncConfigStore.kt
@@ -31,7 +31,9 @@ class AndroidSyncConfigStore(private val file: File) : SyncConfigStore {
                 deviceId = device,
                 keepConnected = map["keepConnected"] == "true",
                 sealedRefreshToken = map["sealedRefreshToken"]?.takeIf { it.isNotEmpty() },
-                pendingReconcile = map["pendingReconcile"] == "true", // absent in older files → false
+                // Written by 0.2.1 and earlier; migrated into [AndroidReconcileDebtStore] at startup and
+                // dropped by the next save. Absent in every other file → false.
+                legacyPendingReconcile = map["pendingReconcile"] == "true",
             )
         }.getOrNull()
     }
@@ -43,7 +45,6 @@ class AndroidSyncConfigStore(private val file: File) : SyncConfigStore {
             appendLine("deviceId=${URLEncoder.encode(config.deviceId, "UTF-8")}")
             appendLine("keepConnected=${config.keepConnected}")
             config.sealedRefreshToken?.let { appendLine("sealedRefreshToken=${URLEncoder.encode(it, "UTF-8")}") }
-            if (config.pendingReconcile) appendLine("pendingReconcile=true")
         }
         // Atomic write: write to a temp file then rename, so a process kill mid-write can't leave a truncated sync.json.
         val tmp = File(file.parentFile, "${file.name}.tmp")

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -618,6 +618,9 @@ class MainActivity : FragmentActivity() {
             crypto = crypto,
             vault = vault,
             configStore = AndroidSyncConfigStore(File(dir, "sync.json")),
+            // Reactivation rebuilds this device still owes — beside the link, not on it: a disconnect or a
+            // connect to another server must not take a debt the reconcile never paid (issue #170).
+            debtStore = AndroidReconcileDebtStore(File(dir, "sync-reconcile")),
             // Persistent delta-sync cursor: survives restart, otherwise every start would be a full re-pull since 0.
             syncState = FileSyncStateStore(File(dir, "sync-cursor.json").toPath()),
             deviceIdProvider = { deviceId(dir) },

--- a/androidApp/src/test/kotlin/app/skerry/android/AndroidSyncStoresTest.kt
+++ b/androidApp/src/test/kotlin/app/skerry/android/AndroidSyncStoresTest.kt
@@ -1,0 +1,76 @@
+package app.skerry.android
+
+import app.skerry.ui.sync.ServerLink
+import app.skerry.ui.sync.SyncConfig
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Android halves of the two sync stores. Both are plain JVM file code (no Android framework), and both
+ * carry state that decides whether this device rebuilds its vault before it pushes — a divergence from the
+ * desktop twins ([app.skerry.ui.sync.FileReconcileDebtStore], `FileSyncConfigStore`) is silent and costs
+ * records the account purged, so the same behaviours are pinned here.
+ */
+class AndroidSyncStoresTest {
+
+    private fun tempFile(name: String): File =
+        Files.createTempDirectory("skerry-android-stores").resolve(name).toFile()
+
+    @Test
+    fun `debts survive a round trip, separators and all`() {
+        val file = tempFile("sync-reconcile")
+        val store = AndroidReconcileDebtStore(file)
+        val debts = setOf(
+            ServerLink("https://home.test", "maya"),
+            ServerLink("https://host.test/path?a=b\nnot-a-line", "acc=ount"),
+        )
+        store.save(debts)
+        assertEquals(debts, store.load(), "url-encoding must keep every link on one parseable line")
+    }
+
+    @Test
+    fun `an empty set leaves no file behind`() {
+        val file = tempFile("sync-reconcile")
+        val store = AndroidReconcileDebtStore(file)
+        store.save(setOf(ServerLink("https://home.test", "maya")))
+        assertTrue(file.exists())
+
+        store.save(emptySet())
+        assertFalse(file.exists(), "a device that owes nothing carries no file")
+        assertEquals(emptySet(), store.load(), "and reads as owing nothing")
+    }
+
+    @Test
+    fun `a line with a broken escape costs its own line and not the file`() {
+        val file = tempFile("sync-reconcile")
+        val intact = ServerLink("https://home.test", "maya")
+        AndroidReconcileDebtStore(file).save(setOf(intact))
+        file.appendText("https%3A%2F%2Fwork.te%ZZ=maya\n")
+
+        assertEquals(setOf(intact), AndroidReconcileDebtStore(file).load(), "the intact debt must survive")
+    }
+
+    /**
+     * The 0.2.1 config file carried the reconcile intent as `pendingReconcile=true`. It has to be read
+     * back as [SyncConfig.legacyPendingReconcile] — that flag is the only thing the migration in
+     * `SyncCoordinator`'s init has to go on — and it must not be written again, or the debt would be
+     * re-imported after the reconcile that discharged it.
+     */
+    @Test
+    fun `the legacy reconcile marker is read once and never written back`() {
+        val file = tempFile("sync.json")
+        file.writeText("serverUrl=https%3A%2F%2Fsync.test\naccountId=maya\ndeviceId=devA\npendingReconcile=true\n")
+        val store = AndroidSyncConfigStore(file)
+
+        val loaded = store.load()!!
+        assertTrue(loaded.legacyPendingReconcile, "the old marker must reach the migration")
+
+        store.save(loaded.copy(legacyPendingReconcile = false))
+        assertFalse(file.readText().contains("pendingReconcile"), "and must not be written again")
+        assertFalse(store.load()!!.legacyPendingReconcile)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncContracts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncContracts.kt
@@ -26,14 +26,48 @@ data class SyncConfig(
     val keepConnected: Boolean = false,
     val sealedRefreshToken: String? = null,
     /**
-     * Durable "this device must rebuild from the server before pushing" marker for the revoked→reactivated
-     * flow. The server clears revocation on the SRP verify that reports `reactivated`, so it never reports
-     * it again; persisting the intent here (set before the vault is cleared, cleared only after the first
-     * sync succeeds) means an interrupted reconcile is retried on the next connect/restore — or on the
-     * unlock that lets a failed clear through — instead of silently resurrecting a purged record. Default `false`; older config files without the key load as `false`.
+     * The reactivation reconcile marker as versions up to 0.2.1 wrote it, when the intent lived on the
+     * saved link itself. Read from an older config file and migrated into [ReconcileDebtStore] once, at
+     * startup ([SyncCoordinator]'s init); never written again. A config holds ONE link, so a connect to
+     * another server saved a config without the previous link's marker and the debt died with the
+     * process — issue #170.
      */
-    val pendingReconcile: Boolean = false,
+    val legacyPendingReconcile: Boolean = false,
 )
+
+/**
+ * One server link — what a reactivation reconcile debt belongs to. A LINK, not an account id: the same
+ * user-chosen id names different accounts on a home and a work instance, and rebuilding the wrong one
+ * throws away records nobody purged.
+ */
+data class ServerLink(val serverUrl: String, val accountId: String)
+
+/**
+ * Durable set of links this device owes a reactivation rebuild to — records dropped and re-pulled from
+ * the server before it may push again.
+ *
+ * Separate from [SyncConfigStore] because the debt outlives the link it was learned on: the server
+ * reports `reactivated` exactly once (the SRP verify that reports it is what clears the revocation), the
+ * connect that heard it may fail before it reaches a session, and the config holds a single link — so a
+ * connect to another server, or a [SyncCoordinator.disconnect], must not take the debt with it.
+ */
+interface ReconcileDebtStore {
+    /**
+     * The debts recorded on this device. Best-effort like [SyncConfigStore.load]: an unreadable store
+     * yields an empty set. That direction is deliberate — the alternative (refuse to sync until the file
+     * reads) is a dead end the user cannot resolve, since nothing but a reconcile retires a debt.
+     */
+    fun load(): Set<ServerLink>
+
+    /** Replace the recorded debts. Throws if the write is refused — the caller must not go on as if it landed. */
+    fun save(debts: Set<ServerLink>)
+}
+
+class InMemoryReconcileDebtStore : ReconcileDebtStore {
+    private var debts: Set<ServerLink> = emptySet()
+    override fun load(): Set<ServerLink> = debts
+    override fun save(debts: Set<ServerLink>) { this.debts = debts }
+}
 
 class InMemorySyncConfigStore : SyncConfigStore {
     private var config: SyncConfig? = null
@@ -149,7 +183,7 @@ enum class SyncFailureReason {
     RegistrationRefusedSignInFailed,
     TooManyRequests,       // the server's rate limiter turned the request away — retrying later works
     ServerError,           // the server (or the proxy in front of it) is broken or restarting
-    // This device still owes the reactivation rebuild ([SyncConfig.pendingReconcile]) and its vault was
+    // This device still owes the reactivation rebuild ([ReconcileDebtStore]) and its vault was
     // never cleared, so every sync cycle is refused rather than push records the account purged. Redoing
     // the reconcile takes a reconnect, a keep-connected restore, or the unlock of a vault that was locked
     // when the clear ran — hence a named reason and not the silent Configured that reads as "vault locked".

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -53,6 +53,8 @@ class SyncCoordinator(
     private val crypto: VaultCrypto,
     private val vault: Vault,
     private val configStore: SyncConfigStore = InMemorySyncConfigStore(),
+    /** Where the reactivation rebuilds this device still owes are persisted (see [ReconcileDebtStore]). */
+    private val debtStore: ReconcileDebtStore = InMemoryReconcileDebtStore(),
     private val syncState: SyncStateStore = InMemorySyncStateStore(),
     private val deviceIdProvider: () -> String = { randomDeviceId(crypto) },
     private val deviceName: String = "Skerry device",
@@ -95,12 +97,6 @@ class SyncCoordinator(
      */
     private val _biometricResetNeeded = MutableStateFlow(false)
     val biometricResetNeeded: StateFlow<Boolean> = _biometricResetNeeded.asStateFlow()
-
-    /**
-     * One server link — what a reconcile debt belongs to. [SyncConfig] pairs the two for the saved link;
-     * this is the same pair for the debts that have no saved link to sit on ([unsavedReactivations]).
-     */
-    private data class ServerAccount(val serverUrl: String, val accountId: String)
 
     /**
      * Connect paused on [SyncStatus.NeedsPasswordReplaceConfirm]: the params to re-run the connect once the
@@ -212,26 +208,25 @@ class SyncCoordinator(
     private var retryJob: Job? = null
 
     // Whether THIS coordinator has actually started a reactivation reconcile (records dropped, cursor
-    // reset) — the permission [clearPendingReconcile] needs before it may retire the durable marker.
-    // The marker alone isn't enough: it is persisted before the vault is touched, so it can be up while
+    // reset) — the permission [retireDischargedDebt] needs before it may retire a recorded debt.
+    // The debt alone isn't enough: it is recorded before the vault is touched, so it can stand while
     // nothing was cleared. Every read and write is under [syncMutex].
     @Volatile
     private var reconcileArmed = false
 
-    // Links a login reported as reactivated while [rememberReactivation] had nowhere durable to put the
-    // intent: this device has no saved link for them (nothing to mark, and a connect that never reached a
-    // session must not create one), or the config write was refused. The server never repeats the signal,
-    // so the debt is held here for the lifetime of the process — a later connect to the same link still
-    // owes the rebuild. A debt whose marker gets overwritten has nothing else either: [SyncConfig] holds
-    // ONE link, so connecting to another one saves a config without the previous link's marker. An entry is dropped only by the reconcile that discharges it ([reconcileLocked], after
-    // the records are actually gone) — [disconnect] deliberately leaves it, because erasing a link
-    // rebuilds nothing. A LINK, not an account id: the same id names different accounts on two servers, and
-    // rebuilding the wrong one throws away records nobody purged. Replaced whole rather than mutated; every
-    // write is under [syncMutex], which is also what serializes the read in [reconcileOwed] (reached from
-    // sync cycles that hold no [opMutex]). The [doConnect]/[restoreSession] reads run under [opMutex] alone,
-    // and @Volatile is what publishes the field across those coroutines.
+    // Links this device owes a reactivation rebuild to — the in-memory half of [debtStore], which holds the
+    // same set across restarts. A login that reports `reactivated` records the debt here and on disk before
+    // anything that can still fail ([rememberReactivation]); it is dropped only by the reconcile that
+    // discharges it, once a sync cycle over the rebuilt vault has actually succeeded ([retireDischargedDebt]).
+    // Neither a connect to another link nor a [disconnect] may take it: the first saves a config that has no
+    // room for it and the second rebuilds nothing, while the server reports the reactivation exactly once
+    // (issues #168, #170). Memory is written first and unconditionally — a refused disk write must not also
+    // lose the signal for this process. Replaced whole rather than mutated; every write is under [syncMutex],
+    // which is also what serializes the read in [reconcileOwed] (reached from sync cycles that hold no
+    // [opMutex]). The [doConnect]/[restoreSession] reads run under [opMutex] alone, and @Volatile is what
+    // publishes the field across those coroutines.
     @Volatile
-    private var unsavedReactivations: Set<ServerAccount> = emptySet()
+    private var reconcileDebts: Set<ServerLink> = debtStore.load()
 
     // Set by [pauseForLock], cleared by [resumeAfterUnlock]: which of the two the coordinator should end
     // up obeying when they queue up behind a long operation holding [opMutex], regardless of the order
@@ -259,6 +254,7 @@ class SyncCoordinator(
     private val pairMutex = Mutex()
 
     init {
+        migrateLegacyReconcileMarker()
         // Restore the link after a restart: no session/tokens in memory, but show the saved
         // server/account as Configured — the UI offers "reconnect" with one password, no retyping.
         // Disconnect erases the config → back to Disabled.
@@ -362,7 +358,7 @@ class SyncCoordinator(
             // and whether the unlock password changes (issue #28). verifyPassword runs Argon2id over the
             // vault salt; a rare user-initiated connect, so the extra derivation is acceptable.
             val matchesVault = vault.verifyPassword(masterPassword.copyOf())
-            val link = ServerAccount(serverUrl, accountId)
+            val link = ServerLink(serverUrl, accountId)
             var adoptedKey = false
             // Set when the server reports this device was revoked and this login reactivated it: the vault
             // may still hold records the server purged while we were locked out, so we must re-mirror the
@@ -445,8 +441,9 @@ class SyncCoordinator(
                 runCatching { syncClient.close() }
                 // The verify above is a full SRP login: it reactivates a revoked device server-side and
                 // consumes the one-shot signal, so the confirmed re-run's login reports an ordinary live
-                // device and only what is recorded here reaches it. Nothing is written for a link this
-                // device doesn't have — the user has merely typed a password and may still take it back.
+                // device and only what is recorded here reaches it. The debt is recorded whether or not
+                // this device is linked — it belongs to the link, not to the config, and declining the
+                // password is an answer about the password, not about the revocation ([cancelPasswordReplace]).
                 // After the close, not before: a refused write throws, and it must not strand the client.
                 if (s.reactivated) rememberReactivation(link)
                 stashPendingReplace(PendingReplace(serverUrl, accountId, masterPassword.copyOf(), keepConnected))
@@ -459,7 +456,7 @@ class SyncCoordinator(
                 // Normally the reactivation was reported to the paused connect's verify login and cleared
                 // server-side there, so it reaches this second login only as a debt in memory. This session
                 // is read too — a device revoked again while the confirmation was on screen.
-                reactivated = s.reactivated || link in unsavedReactivations
+                reactivated = s.reactivated || link in reconcileDebts
                 if (reactivated) rememberReactivation(link)
                 when (adoptAccountDataKey(syncClient, s, mk, masterPassword.copyOf())) {
                     KeyAdoption.Adopted -> adoptedKey = true
@@ -499,16 +496,13 @@ class SyncCoordinator(
             // (onVaultReset) and adoptedKey.
             // A reactivated (formerly revoked) device forces a full re-pull like an adopted key, and first
             // discards its pre-revocation records so a stale live copy can't re-push a server-purged record.
-            // The server reports `reactivated` only once (it clears revocation on this verify), so we also
-            // honor a durable pendingReconcile — raised by [rememberReactivation] the moment the login
-            // reported it, or left up by a reconcile that was interrupted before its first sync succeeded.
-            // The live `reactivated` still counts on its own, and so does a debt from an earlier connect
-            // this process that had nowhere to write it ([unsavedReactivations]).
-            // Matched on the whole link, like the write: a marker raised for this account on another server
-            // says nothing about this one, and honoring it would rebuild a vault nobody purged records from.
-            val pendingReconcile = configStore.load()
-                ?.takeIf { it.serverUrl == serverUrl && it.accountId == accountId }?.pendingReconcile == true
-            val mustReconcile = reactivated || pendingReconcile || link in unsavedReactivations
+            // The server reports `reactivated` only once (it clears revocation on this verify), so a debt
+            // recorded earlier counts the same: raised by [rememberReactivation] the moment a login reported
+            // it — this launch or any before it — or left standing by a reconcile that was interrupted
+            // before its first sync succeeded. Matched on the whole link, like the write: a debt owed for
+            // this account on another server says nothing about this one, and paying it here would rebuild
+            // a vault nobody purged records from.
+            val mustReconcile = reactivated || link in reconcileDebts
             activateSession(
                 syncClient,
                 newSession,
@@ -556,14 +550,14 @@ class SyncCoordinator(
         // and the reconcile below is what makes it safe to sync: split into two sections, the mutex is
         // free in between, and any cycle that wins it there (the previous session's watch/push, a manual
         // syncNow, a retry tick — all of which read the live [client]/[session] fields) runs over the
-        // just-published session with the vault not yet cleared and the marker not yet persisted, so even
+        // just-published session with the vault not yet cleared and the debt not yet recorded, so even
         // [reconcileOwed] cannot see that it must stand down. That cycle pushes the pre-revocation
         // records: issue #142 again, through a narrower window.
         //
         // Sharing the lock with the 401 recovery ([refreshSessionLocked]) is the other reason it is held
         // here at all: that path rotates/nulls the session and rewrites the config under syncMutex only,
         // and a refresh in flight would otherwise resolve after this activation and clobber the session
-        // and config it just published (including the pendingReconcile marker).
+        // and config it just published.
         //
         // Lock order holds: we're under opMutex, syncMutex nests inside it.
         val superseded: SyncClient?
@@ -582,16 +576,16 @@ class SyncCoordinator(
             } else {
                 if (resetCursor) syncState.setCursor(config.accountId, 0)
                 configStore.save(config)
-                // Disarm only if the config just saved carries no marker for this account. A re-activation
-                // that doesn't reconcile ([doChangeAccountPassword]) can still carry one — a reconcile that
-                // ran here but whose marker write was refused — and the records it dropped stay dropped.
-                // Disarming there would make [reconcileOwed] refuse every later cycle, including the one
-                // that would finally retire the marker.
-                reconcileArmed = reconcileArmed && config.pendingReconcile
+                // Disarm only if this link owes nothing. A re-activation that doesn't reconcile
+                // ([doChangeAccountPassword]) can still land on a debt — a reconcile that ran here but whose
+                // retiring write was refused — and the records it dropped stay dropped. Disarming there
+                // would make [reconcileOwed] refuse every later cycle, including the one that would finally
+                // retire the debt.
+                reconcileArmed = reconcileArmed && ServerLink(config.serverUrl, config.accountId) in reconcileDebts
             }
         }
         health.setTarget(config.serverUrl)
-        // The marker raised above is dropped by the sync cycle itself ([clearPendingReconcile]) — not
+        // The debt recorded above is retired by the sync cycle itself ([retireDischargedDebt]) — not
         // here, because a first cycle that fails leaves it to a later retry to finish the reconcile.
         runSync()
         startWatch()
@@ -621,33 +615,70 @@ class SyncCoordinator(
      * like an ordinary incremental reconnect — the vault was never rebuilt and the records the account
      * purged while this device was revoked were pushed back (issue #168; issue #142 through another door).
      *
-     * The marker goes onto the saved link when this device has one for [link], and nowhere else: a connect
-     * that never reached a session must not leave a link behind (the password-replace pause is the sharp
-     * case — the user can still decline it), and a link to another server or account belongs to a device
-     * that is fine. Everything the marker cannot reach is held in [unsavedReactivations] instead, which is
-     * why that is set first and unconditionally: the write below can also be refused outright.
+     * The debt is charged to the LINK and kept beside the config rather than on it ([ReconcileDebtStore]):
+     * a connect that never reached a session must not leave a link behind (the password-replace pause is
+     * the sharp case — the user can still decline it), and the one saved link cannot hold the intent of
+     * another one, which is how a later connect to a different server used to drop it (issue #170).
      *
      * A store that refuses the write fails the connect (uncaught, like [reconcileLocked]'s): a device that
      * cannot record what it owes must not go on to sync as if it owed nothing.
      *
      * The cost of the earlier write is a longer wait between "the rebuild is owed" and "the rebuild runs":
-     * the marker can now sit through a failed connect and everything the user does after it, and the clear
+     * the debt can now sit through a failed connect and everything the user does after it, and the clear
      * that eventually discharges it takes every sync-capable record with it, including ones created since
      * (they were never pushed — the connect failed). The alternative is worse and silent: records the
      * account purged coming back on every device.
      *
-     * Under [syncMutex] like every other config write — a cycle of the session this connect is about to
-     * supersede rewrites the same config ([clearPendingReconcile], [refreshSessionLocked]). Called from
-     * [doConnect] under [opMutex], which [syncMutex] nests inside.
+     * Under [syncMutex] like every other debt write — a cycle of the session this connect is about to
+     * supersede retires the same debt ([retireDischargedDebt]). Called from [doConnect] under [opMutex],
+     * which [syncMutex] nests inside.
      */
-    private suspend fun rememberReactivation(link: ServerAccount) {
-        syncMutex.withLock {
-            // In memory first, and whatever happens below: the write can be refused (a full disk) or have
-            // nowhere to go, and there is no second chance to learn this from the server.
-            unsavedReactivations = unsavedReactivations + link
-            val saved = configStore.load()?.takeIf { it.serverUrl == link.serverUrl && it.accountId == link.accountId }
-                ?: return@withLock
-            configStore.save(saved.copy(pendingReconcile = true))
+    private suspend fun rememberReactivation(link: ServerLink) {
+        syncMutex.withLock { recordDebt(link) }
+    }
+
+    /**
+     * Record a reconcile debt: in memory first and whatever happens next, because the disk write can be
+     * refused (a full disk) and the server never reports the reactivation twice — a debt this process knows
+     * about still stops the cycle that would push purged records back ([reconcileOwed]).
+     *
+     * Throws whatever the store throws: every caller treats a refused write as a failure of the operation
+     * it is part of, never as a debt that quietly went away. Call under [syncMutex] — or from `init`, where
+     * no cycle exists yet to race it.
+     */
+    private fun recordDebt(link: ServerLink) {
+        reconcileDebts = reconcileDebts + link
+        debtStore.save(reconcileDebts)
+    }
+
+    /**
+     * Retire a discharged debt — disk FIRST, the mirror image of [recordDebt]: both keep the debt when the
+     * write is refused. Dropping it from memory first would leave the store the only place that still knows,
+     * and nothing reads it again until the next launch: the retry [retireDischargedDebt] arms would find
+     * nothing to retire and the debt would sit on disk for good, rebuilding the vault on every later connect.
+     * Call under [syncMutex].
+     */
+    private fun retireDebt(link: ServerLink) {
+        val next = reconcileDebts - link
+        debtStore.save(next)
+        reconcileDebts = next
+    }
+
+    /**
+     * Move a reconcile marker written by an older version (0.2.1 and earlier kept it on the saved link, see
+     * [SyncConfig.legacyPendingReconcile]) into [debtStore], once, at startup — an upgrade in the middle of
+     * an owed rebuild must not drop it.
+     *
+     * The debt is written before the config so a failure in between only repeats the migration on the next
+     * launch; clearing the flag on the config is what stops the marker from being re-imported after the debt
+     * is discharged. Best-effort: an unwritable store must not keep the app from starting, and the marker
+     * stays on the link for the next attempt.
+     */
+    private fun migrateLegacyReconcileMarker() {
+        val cfg = configStore.load()?.takeIf { it.legacyPendingReconcile } ?: return
+        runCatching {
+            recordDebt(ServerLink(cfg.serverUrl, cfg.accountId))
+            configStore.save(cfg.copy(legacyPendingReconcile = false))
         }
     }
 
@@ -665,7 +696,7 @@ class SyncCoordinator(
      * history) are kept.
      *
      * Throws whatever the clear throws — a vault locked at this moment ([Vault.clearRecords] needs an
-     * unlocked one) leaves the marker up over an un-cleared vault, which is what [reconcileOwed] reads.
+     * unlocked one) leaves the debt standing over an un-cleared vault, which is what [reconcileOwed] reads.
      *
      * Call with [syncMutex] held (kotlinx [Mutex] is not reentrant): both callers — [activateSession] and
      * the redo in [resumeAfterUnlock] — take it themselves, and every [reconcileArmed]/cursor/config write
@@ -674,16 +705,16 @@ class SyncCoordinator(
     private fun reconcileLocked(config: SyncConfig) {
         // Persist the reconcile intent BEFORE mutating the vault: the server clears revocation on the
         // verify that reported `reactivated` and never reports it again, so a crash between here and
-        // the first successful sync would otherwise lose the signal and let the stale records push.
-        configStore.save(config.copy(pendingReconcile = true))
+        // the first successful sync would otherwise lose the signal and let the stale records push. The
+        // debt is usually already recorded ([rememberReactivation]) — a set write, so re-recording it is
+        // free; the paths that reach a reconcile without one (a restore driven by an older launch's debt)
+        // get it written here.
+        recordDebt(ServerLink(config.serverUrl, config.accountId))
+        configStore.save(config)
         val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
         vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
-        // Discharged only once the records are actually gone, and only for the link being reconciled: a
-        // clear that threw leaves the debt owed (the durable marker alone would not survive a [disconnect]),
-        // and a debt held for another link is not this reconcile's to retire.
-        unsavedReactivations = unsavedReactivations - ServerAccount(config.serverUrl, config.accountId)
         syncState.setCursor(config.accountId, 0) // reactivation always full-pulls to rebuild from the server
-        reconcileArmed = true // only now — see [clearPendingReconcile]
+        reconcileArmed = true // only now — see [retireDischargedDebt]
     }
 
     /**
@@ -746,7 +777,7 @@ class SyncCoordinator(
      * kept password and return to the prior state (Configured if a link is saved, else Disabled). The account
      * is untouched and the local vault keeps its current password. No-op if nothing is pending.
      *
-     * What the decline does NOT undo is a reactivation the verify login reported ([unsavedReactivations]):
+     * What the decline does NOT undo is a reactivation the verify login reported ([reconcileDebts]):
      * the server cleared the revocation on that login and won't mention it again, so this device still owes
      * that account a rebuild whenever it does connect. Declining is an answer about the password, not about
      * the revocation.
@@ -1130,7 +1161,7 @@ class SyncCoordinator(
         }
         // This device owes a reconcile it never performed (see [reconcileOwed]): its vault still holds
         // the records the server purged while it was revoked, and pushing them is exactly the
-        // resurrection the marker exists to prevent — silently, under an Online status. Refuse the cycle
+        // resurrection the debt exists to prevent — silently, under an Online status. Refuse the cycle
         // and name the reason: nothing but a connect/restore/unlock redoes the reconcile, so the user has
         // to act, and a bare Configured would render as "vault locked" over a vault that is open. The session stays
         // published (tearing it down needs [opMutex], which nests outside this lock) but is inert —
@@ -1207,28 +1238,28 @@ class SyncCoordinator(
     }
 
     /**
-     * Whether a reactivation reconcile is owed on this account but was never performed here: the durable
-     * marker ([SyncConfig.pendingReconcile]) is up while [reconcileArmed] is down.
+     * Whether a reactivation reconcile is owed on this account but was never performed here: a debt for the
+     * saved link stands ([reconcileDebts]) while [reconcileArmed] is down.
      *
      * [activateSession] publishes the session and reconciles in one locked section, so a cycle can no
      * longer slip in mid-reconcile — but the clear itself can throw (an auto-lock landing inside the
-     * connect: [Vault.clearRecords] needs an unlocked vault), and the marker is persisted before the
+     * connect: [Vault.clearRecords] needs an unlocked vault), and the debt is persisted before the
      * vault is touched. That leaves a live session over a vault full of pre-revocation records, as does
-     * any activation that doesn't reconcile at all ([doChangeAccountPassword]) while the marker is up.
+     * any activation that doesn't reconcile at all ([doChangeAccountPassword]) while a debt stands.
      * Issue #142.
      *
-     * A debt this process could not write down ([unsavedReactivations]) counts exactly like the marker: it
-     * is the same obligation, and without it a store that refused the write would leave the guard blind —
-     * every cycle would run over the un-rebuilt vault.
+     * A debt whose disk write was refused counts exactly the same — it is the same obligation, held in
+     * memory — which is why [reconcileDebts] and not the store is what this reads: otherwise a full disk
+     * would leave the guard blind and every cycle would run over the un-rebuilt vault.
      *
-     * Read under [syncMutex] like [reconcileArmed] itself, and matched on [accountId] — a marker saved
-     * for another account says nothing about this session.
+     * Read under [syncMutex] like [reconcileArmed] itself, and matched on the saved link — a debt owed by
+     * this device to another server, or another account, says nothing about this session.
      */
     private fun reconcileOwed(accountId: String): Boolean {
         if (reconcileArmed) return false
         val cfg = configStore.load() ?: return false
         if (cfg.accountId != accountId) return false
-        return cfg.pendingReconcile || ServerAccount(cfg.serverUrl, cfg.accountId) in unsavedReactivations
+        return ServerLink(cfg.serverUrl, cfg.accountId) in reconcileDebts
     }
 
     /** Park the status on Configured (the vault-locked resting state); Disabled without a link. */
@@ -1270,7 +1301,7 @@ class SyncCoordinator(
     // One sync attempt + the Online bookkeeping; exceptions propagate to runSyncLocked.
     private suspend fun runSyncAttempt(c: SyncClient, s: SyncSession) {
         val outcome = engineFactory(c).sync(s)
-        clearPendingReconcile(s.accountId)
+        retireDischargedDebt(s.accountId)
         _status.value = SyncStatus.Online(s.accountId, outcome.pushed, outcome.pulled)
         // Pulled records from the server → refresh list managers, else synced data isn't visible until reopen.
         if (outcome.pulled > 0) {
@@ -1280,35 +1311,40 @@ class SyncCoordinator(
     }
 
     /**
-     * Drop the durable reactivation marker ([SyncConfig.pendingReconcile]) once a sync cycle for that
-     * account has actually succeeded. [reconcileArmed] says this coordinator dropped the local records
-     * and reset the cursor, so the cycle that just finished IS the full re-pull the marker is waiting
+     * Retire the reactivation debt for the saved link once a sync cycle for that account has actually
+     * succeeded. [reconcileArmed] says this coordinator dropped the local records
+     * and reset the cursor, so the cycle that just finished IS the full re-pull the debt is waiting
      * for — including one reached by a later retry (backoff loop, reachability trigger, manual sync)
      * after the reconcile's own first cycle failed.
      *
-     * The marker on its own would be the wrong permission: [activateSession] persists it BEFORE it
-     * touches the vault (a crash in between must not lose the signal), so a clear that threw — an
-     * auto-lock landing inside the connect — leaves it up over a vault nothing was dropped from, on a
-     * session that is already published. Retiring it there would strand the pre-revocation records; that
-     * session's cycles are refused ([reconcileOwed]) and the reconcile is redone instead — by the next
-     * connect/restore, or by the unlock that hands the clear the vault it needed
-     * ([redoOwedReconcileLocked]).
+     * The debt on its own would be the wrong permission: it is recorded BEFORE the vault is touched (a
+     * crash in between must not lose the signal), so a clear that threw — an auto-lock landing inside the
+     * connect — leaves it standing over a vault nothing was dropped from, on a session that is already
+     * published. Retiring it there would strand the pre-revocation records; that session's cycles are
+     * refused ([reconcileOwed]) and the reconcile is redone instead — by the next connect/restore, or by
+     * the unlock that hands the clear the vault it needed ([redoOwedReconcileLocked]).
      *
      * Called before the status is published: [SyncStatus.Online] is what every observer reacts to, and
-     * clearing the marker afterwards leaves a window in which Online is on screen while the saved config
-     * still says a reconcile is pending. Reads the live config rather than a captured copy — the cycle
-     * that just ran may have rotated a fresh sealed refresh token into it.
+     * retiring the debt afterwards leaves a window in which Online is on screen while the device still
+     * owes a rebuild. Reads the live config rather than a captured copy — the link is what the debt is
+     * keyed on, and a connect that ran in between may have changed it.
      *
-     * Best-effort like [resealRefreshToken]: a config store that fails must not turn a sync that
-     * succeeded into a failure — [reconcileArmed] stays up so the next cycle retries the clear.
+     * Best-effort like [resealRefreshToken]: a store that fails must not turn a sync that succeeded into a
+     * failure — [reconcileArmed] stays up so the next cycle retries the write.
      */
-    private fun clearPendingReconcile(accountId: String) {
+    private fun retireDischargedDebt(accountId: String) {
         if (!reconcileArmed) return
         runCatching {
             val cfg = configStore.load()
             if (cfg != null && cfg.accountId == accountId) {
-                if (cfg.pendingReconcile) configStore.save(cfg.copy(pendingReconcile = false))
-                reconcileArmed = false // also when the marker was already down: nothing left to retry
+                val link = ServerLink(cfg.serverUrl, cfg.accountId)
+                if (link in reconcileDebts) retireDebt(link)
+                // Also when this link owes nothing: there is nothing left for a later cycle to retire.
+                // [reconcileArmed] is a plain flag rather than the link it was armed for, so a reconcile
+                // whose link was replaced before its first cycle succeeded (two servers under the same
+                // account id, switched in that window) leaves its debt standing and pays for it with one
+                // extra rebuild on the next connect back — never with a record the server purged.
+                reconcileArmed = false
             }
         }
     }
@@ -1644,8 +1680,8 @@ class SyncCoordinator(
                 // cursor write failure (disk full) must not leave configStore/healthTarget/status in a
                 // half-detached state ("Disconnect ran but the device is linked again").
                 runCatching { configStore.load()?.let { syncState.setCursor(it.accountId, 0) } }
-                // [unsavedReactivations] survives on purpose: erasing the link rebuilds nothing, so a debt
-                // the reconcile never paid is still owed — and the durable marker goes with the config here.
+                // The recorded debts survive on purpose ([debtStore] is not the config): erasing the link
+                // rebuilds nothing, so a debt the reconcile never paid is still owed on the next connect.
                 configStore.clear()
                 health.setTarget(null) // detached — stop the health ping (poller closes the client, status → UNKNOWN)
                 _status.value = SyncStatus.Disabled
@@ -1718,13 +1754,13 @@ class SyncCoordinator(
     /**
      * Finish a reactivation reconcile this live session owes ([reconcileOwed]) now that the vault is
      * unlocked. The situation is an auto-lock landing inside a reactivating connect or silent restore: the session was
-     * published, [Vault.clearRecords] threw, and the durable marker stayed up over an un-cleared vault, so
+     * published, [Vault.clearRecords] threw, and the recorded debt stayed standing over an un-cleared vault, so
      * every cycle is refused with [SyncFailureReason.ReconcileRequired]. Only a connect/restore used to
      * redo the reconcile, which asked the user for the master password — for a rebuild that needs none
      * (drop the records, reset the cursor, arm the flag). Issue #147.
      *
-     * A reconcile that fails again — the vault re-locked between the unlock and here, or the marker write
-     * was refused — is not a new failure: it leaves the marker up and the session owing the same
+     * A reconcile that fails again — the vault re-locked between the unlock and here, or the debt write
+     * was refused — is not a new failure: it leaves the debt standing and the session owing the same
      * reconcile, and the cycle right after this call republishes [SyncFailureReason.ReconcileRequired] —
      * the state the user already sees, with the same recovery. Any cause lands there; naming them apart
      * would only rename a stop whose exit is the same.
@@ -1735,11 +1771,11 @@ class SyncCoordinator(
     private fun redoOwedReconcileLocked() {
         val accountId = session?.accountId ?: return
         // Matched on the account before anything is dropped: reconciling under a config saved for another
-        // account would clear this vault against a marker that says nothing about it. ([reconcileOwed]
+        // account would clear this vault against a debt that says nothing about it. ([reconcileOwed]
         // matches the same way on its own read — the two agree because nothing suspends in between.)
         val cfg = configStore.load()?.takeIf { it.accountId == accountId } ?: return
         if (!reconcileOwed(accountId)) return
-        // Not swallowed silently: the cycle the caller runs next reads the same marker this clear failed to
+        // Not swallowed silently: the cycle the caller runs next reads the same debt this clear failed to
         // retire and publishes the refusal, so the failure keeps its own status — see the KDoc above.
         // runCatching is safe here: [reconcileLocked] has no suspension point, so there is no
         // CancellationException for it to absorb.
@@ -1794,13 +1830,11 @@ class SyncCoordinator(
                     }
                     val syncClient = clientFactory(cfg.serverUrl)
                     val newSession = syncClient.refresh(SyncSession(cfg.accountId, "", refreshToken))
-                    // A reconcile interrupted before it finished (pendingReconcile) must still run on this
-                    // silent restore — refresh carries no `reactivated` signal, so the marker is the only
-                    // thing that redoes it before the first push. A debt this process could not write down
-                    // counts the same: the connect that learned of it failed, and this restore is what
-                    // brings the device back.
-                    val reconcile = cfg.pendingReconcile ||
-                        ServerAccount(cfg.serverUrl, cfg.accountId) in unsavedReactivations
+                    // A reconcile interrupted before it finished must still run on this silent restore —
+                    // refresh carries no `reactivated` signal, so a standing debt is the only thing that
+                    // redoes it before the first push, whether it was recorded by this launch or an
+                    // earlier one.
+                    val reconcile = ServerLink(cfg.serverUrl, cfg.accountId) in reconcileDebts
                     // refresh rotates the token — re-save it sealed under the dataKey (inside activation).
                     activateSession(
                         syncClient,

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -48,6 +48,7 @@ import app.skerry.shared.snippet.VaultSnippetStore
 import app.skerry.shared.sync.FileSyncStateStore
 import app.skerry.shared.sync.KtorSyncClient
 import app.skerry.shared.tunnel.VaultTunnelStore
+import app.skerry.ui.sync.FileReconcileDebtStore
 import app.skerry.ui.sync.FileSyncConfigStore
 import app.skerry.shared.ai.AiSettingsStore
 import app.skerry.shared.ai.local.IsolatedLlmRuntime
@@ -274,6 +275,9 @@ private fun buildDesktopGraph(dir: Path, prefs: FilePrefs): DesktopGraph {
         crypto = IonspinVaultCrypto(),
         vault = vault,
         configStore = FileSyncConfigStore(dir.resolve("sync.json")),
+        // Reactivation rebuilds this device still owes — beside the link, not on it: a disconnect or a
+        // connect to another server must not take a debt the reconcile never paid (issue #170).
+        debtStore = FileReconcileDebtStore(dir.resolve("sync-reconcile")),
         // Persistent delta-sync cursor: survives restarts, otherwise every start would be a full re-pull since 0.
         syncState = FileSyncStateStore(dir.resolve("sync-cursor.json")),
         deviceIdProvider = { deviceId(dir) },

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileReconcileDebtStore.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileReconcileDebtStore.kt
@@ -1,0 +1,52 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.io.PrivateConfig
+import java.net.URLDecoder
+import java.net.URLEncoder
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * File-backed reconcile-debt store (desktop): `sync-reconcile` alongside `sync.json`, mode 0600 via
+ * [PrivateConfig]. One line per owed link, `urlencoded(serverUrl)=urlencoded(accountId)` — the same
+ * line-based, dependency-free shape as [FileSyncConfigStore], and URL-encoding keeps a server URL with
+ * an `=` or a newline in it on one parseable line.
+ *
+ * Its own file rather than a key in `sync.json` on purpose: the config is erased by a disconnect and
+ * overwritten by a connect to another server, and a debt must outlive both (issue #170).
+ *
+ * Reads are best-effort ([ReconcileDebtStore.load]); an empty set is written as a deleted file, so a
+ * device that owes nothing carries no file at all.
+ */
+class FileReconcileDebtStore(private val path: Path) : ReconcileDebtStore {
+
+    override fun load(): Set<ServerLink> {
+        if (!Files.exists(path)) return emptySet()
+        return runCatching {
+            // Per line, so one unparseable entry (a truncated percent escape, which [decode] throws on)
+            // costs its own debt and no more. Losing that one is already a silent resurrection for its
+            // link; letting it take every intact line with it is the same failure on every link at once.
+            Files.readAllLines(path).mapNotNull { line -> runCatching { parse(line) }.getOrNull() }.toSet()
+        }.getOrDefault(emptySet())
+    }
+
+    private fun parse(line: String): ServerLink? {
+        val i = line.indexOf('=')
+        if (i <= 0) return null
+        val url = decode(line.substring(0, i))
+        val account = decode(line.substring(i + 1))
+        return if (url.isEmpty() || account.isEmpty()) null else ServerLink(url, account)
+    }
+
+    override fun save(debts: Set<ServerLink>) {
+        if (debts.isEmpty()) {
+            Files.deleteIfExists(path)
+            return
+        }
+        val text = debts.joinToString(separator = "") { "${encode(it.serverUrl)}=${encode(it.accountId)}\n" }
+        PrivateConfig.atomicWrite(path, text.encodeToByteArray())
+    }
+
+    private fun encode(s: String): String = URLEncoder.encode(s, Charsets.UTF_8)
+    private fun decode(s: String): String = URLDecoder.decode(s, Charsets.UTF_8)
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileSyncConfigStore.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/sync/FileSyncConfigStore.kt
@@ -33,7 +33,9 @@ class FileSyncConfigStore(private val path: Path) : SyncConfigStore {
                 deviceId = device,
                 keepConnected = map["keepConnected"] == "true",
                 sealedRefreshToken = map["sealedRefreshToken"]?.takeIf { it.isNotEmpty() },
-                pendingReconcile = map["pendingReconcile"] == "true", // absent in older files → false
+                // Written by 0.2.1 and earlier; migrated into [FileReconcileDebtStore] at startup and
+                // dropped by the next save. Absent in every other file → false.
+                legacyPendingReconcile = map["pendingReconcile"] == "true",
             )
         }.getOrNull()
     }
@@ -45,7 +47,6 @@ class FileSyncConfigStore(private val path: Path) : SyncConfigStore {
             appendLine("deviceId=${encode(config.deviceId)}")
             appendLine("keepConnected=${config.keepConnected}")
             config.sealedRefreshToken?.let { appendLine("sealedRefreshToken=${encode(it)}") }
-            if (config.pendingReconcile) appendLine("pendingReconcile=true")
         }
         PrivateConfig.atomicWrite(path, text.encodeToByteArray())
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/FileReconcileDebtStoreTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/FileReconcileDebtStoreTest.kt
@@ -1,0 +1,69 @@
+package app.skerry.ui.sync
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The debt file is what carries a reactivation rebuild across restarts, so what it can and cannot hold is
+ * the whole point: a server URL is user-typed and may contain the separator, and an unreadable file must
+ * not take the app down with it.
+ */
+class FileReconcileDebtStoreTest {
+
+    private fun store() = FileReconcileDebtStore(
+        Files.createTempDirectory("skerry-debts").resolve("sync-reconcile"),
+    )
+
+    @Test
+    fun `debts survive a round trip through the file`() {
+        val store = store()
+        val debts = setOf(ServerLink("https://home.test", "maya"), ServerLink("https://work.test", "maya"))
+        store.save(debts)
+        assertEquals(debts, store.load(), "both links must come back")
+    }
+
+    @Test
+    fun `a server URL carrying the separator or a newline stays one parseable link`() {
+        val store = store()
+        val awkward = ServerLink("https://host.test/path?a=b&c=d\nnot-a-line", "acc=ount")
+        store.save(setOf(awkward))
+        assertEquals(setOf(awkward), store.load(), "url-encoding must keep it on one line")
+    }
+
+    @Test
+    fun `an empty set leaves no file behind`() {
+        val path = Files.createTempDirectory("skerry-debts").resolve("sync-reconcile")
+        val store = FileReconcileDebtStore(path)
+        store.save(setOf(ServerLink("https://home.test", "maya")))
+        assertTrue(Files.exists(path))
+
+        store.save(emptySet())
+        assertFalse(Files.exists(path), "a device that owes nothing carries no file")
+        assertEquals(emptySet(), store.load(), "and reads as owing nothing")
+    }
+
+    @Test
+    fun `a garbled file reads as no debts rather than throwing`() {
+        val path = Files.createTempDirectory("skerry-debts").resolve("sync-reconcile")
+        Files.writeString(path, "no-separator-here\n=leading\ntrailing=\n")
+        assertEquals(emptySet(), FileReconcileDebtStore(path).load(), "unparseable lines are dropped, not thrown")
+    }
+
+    /**
+     * One line truncated mid percent-escape (a kill during a write on a store that isn't atomic, or a
+     * damaged filesystem) makes `URLDecoder` throw. That must cost that line only: taking the rest of the
+     * file with it would read as "this device owes nothing" and push back every record the account purged.
+     */
+    @Test
+    fun `a line with a broken escape costs its own line and not the file`() {
+        val path = Files.createTempDirectory("skerry-debts").resolve("sync-reconcile")
+        val intact = ServerLink("https://home.test", "maya")
+        FileReconcileDebtStore(path).save(setOf(intact))
+        Files.writeString(path, Files.readString(path) + "https%3A%2F%2Fwork.te%ZZ=maya\n")
+
+        assertEquals(setOf(intact), FileReconcileDebtStore(path).load(), "the intact debt must survive")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/FileSyncConfigStoreLegacyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/FileSyncConfigStoreLegacyTest.kt
@@ -1,0 +1,29 @@
+package app.skerry.ui.sync
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The on-disk half of the #170 migration. Up to 0.2.1 the reconcile intent was the key
+ * `pendingReconcile=true` inside `sync.json`; the flag it now loads as
+ * ([SyncConfig.legacyPendingReconcile]) is the only thing [SyncCoordinator]'s startup migration has to go
+ * on, and a device that upgrades mid-rebuild would otherwise lose it silently.
+ */
+class FileSyncConfigStoreLegacyTest {
+
+    @Test
+    fun `the legacy reconcile marker is read once and never written back`() {
+        val path = Files.createTempDirectory("skerry-config").resolve("sync.json")
+        Files.writeString(path, "serverUrl=https%3A%2F%2Fsync.test\naccountId=maya\ndeviceId=devA\npendingReconcile=true\n")
+        val store = FileSyncConfigStore(path)
+
+        val loaded = store.load()!!
+        assertTrue(loaded.legacyPendingReconcile, "the old marker must reach the migration")
+
+        store.save(loaded.copy(legacyPendingReconcile = false))
+        assertFalse(Files.readString(path).contains("pendingReconcile"), "and must not be written again")
+        assertFalse(store.load()!!.legacyPendingReconcile)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
@@ -1,0 +1,158 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.AccountSummary
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultCrypto
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Shared doubles for the reactivation/reconcile tests ([SyncCoordinatorReactivationTest] and
+ * [SyncCoordinatorReconcileDebtTest]): a server that reactivates a revoked device, a vault whose clear
+ * fails, and debt stores that refuse one direction of the write.
+ */
+
+/**
+ * This device's own account after a server-side purge: `register` collides (account exists), `login`
+ * reports [reactivated], the served wrap is the vault's OWN key (so the connect adopts nothing — isolating
+ * the reactivation path), and the server no longer holds the purged record, so `pull` returns nothing.
+ * `push` records exactly what the client sent.
+ */
+internal class ReactivatingClient(
+    private val ownWrappedKey: ByteArray,
+    reactivated: Boolean = true,
+    /** Makes the reconcile's own first cycle fail, leaving the rebuild to a later sync. */
+    private val failFirstPull: Boolean = false,
+    /** How many key fetches serve an unopenable wrap — a connect that fails AFTER the login. */
+    private val corruptWraps: Int = 0,
+    /** The first key fetch dies on the network — a connect that THROWS after the login. */
+    private val throwOnFirstFetch: Boolean = false,
+) : SyncClient {
+    val pushed = mutableListOf<RemoteRecord>()
+
+    /** What each pull asked for — `0` is the full re-pull a reconcile's cursor reset forces. */
+    val pulledSince = mutableListOf<Long>()
+    private val pulls = AtomicInteger(0)
+
+    // The reactivation is reported exactly once, like the server does it: the verify that reports it is the
+    // one that clears the revocation, so every later login of this device is an ordinary one.
+    private val revoked = AtomicBoolean(reactivated)
+    private val fetches = AtomicInteger(0)
+
+    override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+        throw SyncException(SyncException.Kind.CONFLICT, "account exists")
+    override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
+        SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
+    override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
+        val n = fetches.getAndIncrement()
+        if (throwOnFirstFetch && n == 0) throw SyncException(SyncException.Kind.NETWORK, "unreachable")
+        return if (n < corruptWraps) ByteArray(ownWrappedKey.size) else ownWrappedKey.copyOf()
+    }
+    override suspend fun pull(session: SyncSession, since: Long): RecordPage {
+        pulledSince += since
+        // Not a SyncException(NETWORK): that one arms the backoff retry loop, and the tests want the next
+        // cycle to be the one they trigger themselves.
+        if (failFirstPull && pulls.getAndIncrement() == 0) error("pull unreachable")
+        return RecordPage(emptyList(), 1)
+    }
+    override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
+        pushed += records
+        return RecordPage(emptyList(), 1)
+    }
+    override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
+
+    // Unreachable on purpose: a health ping that comes up drives the coordinator's own self-heal
+    // ([SyncCoordinator]'s init — no session, so `restoreSession`), which would race the connects these
+    // tests drive and re-save the config from under the assertions. Reachability is covered elsewhere.
+    override suspend fun ping(): Boolean = false
+    override suspend fun close() {}
+    override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
+    override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
+    override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
+    // The silent restore of a keep-connected device: a token exchange, with no `reactivated` in it.
+    override suspend fun refresh(session: SyncSession): SyncSession =
+        SyncSession(session.accountId, accessToken = "access2", refreshToken = "refresh2")
+    // The rotation itself isn't what these tests are about: they need the activation that follows it, which
+    // re-publishes the session WITHOUT reconciling. Accepts any current password.
+    override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
+        SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
+    override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()
+    override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
+}
+
+/**
+ * A real vault whose reconcile-time clear fails — what an auto-lock landing inside the connect does
+ * (`clearRecords` requires an unlocked vault), leaving the debt standing with nothing cleared. [failures]
+ * bounds how many clears fail, so a test can also drive the recovery: the lock is gone by the next connect
+ * and the reconcile finally runs.
+ */
+internal class ClearFailingVault(private val delegate: Vault, private val failures: Int = Int.MAX_VALUE) : Vault by delegate {
+    private val attempts = AtomicInteger(0)
+
+    /** How many clears were tried — the observable "the reconcile ran again" for a retry that fails too. */
+    val clearAttempts: Int get() = attempts.get()
+
+    override fun clearRecords(types: Set<RecordType>) {
+        if (attempts.getAndIncrement() < failures) error("vault is locked")
+        delegate.clearRecords(types)
+    }
+}
+
+/** Debt store that refuses exactly the write RECORDING a debt (a full disk). */
+internal class DebtRaiseFailingStore(private val delegate: ReconcileDebtStore) : ReconcileDebtStore {
+    /** Cleared once the test wants the disk to have room again. */
+    @Volatile
+    var refuse = true
+
+    override fun load(): Set<ServerLink> = delegate.load()
+    override fun save(debts: Set<ServerLink>) {
+        if (refuse && debts.size > delegate.load().size) error("debt write failed")
+        delegate.save(debts)
+    }
+}
+
+/** Debt store that refuses exactly the write retiring a debt (a full disk). */
+internal class DebtClearFailingStore(private val delegate: ReconcileDebtStore) : ReconcileDebtStore {
+    @Volatile
+    var refuseClear = true
+
+    override fun load(): Set<ServerLink> = delegate.load()
+    override fun save(debts: Set<ServerLink>) {
+        if (refuseClear && debts.size < delegate.load().size) error("debt write failed")
+        delegate.save(debts)
+    }
+}
+
+/** Whether the store records a rebuild owed to [url]/[id]. */
+internal fun ReconcileDebtStore.owes(url: String, id: String): Boolean = ServerLink(url, id) in load()
+
+/** A fresh unlocked account vault under [password], with its own random dataKey. */
+internal fun newAccountVault(crypto: VaultCrypto, password: String): Vault {
+    val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()
+    FileSystem.SYSTEM.delete(file) // FileVault creates it
+    return FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-22T00:00:00Z" })
+        .also { it.create(password.toCharArray()) }
+}
+
+/** The vault's own dataKey wrapped under the account (= vault) password, so a connect adopts nothing. */
+internal fun wrapOwnKey(vault: Vault, crypto: VaultCrypto, password: String, account: String): ByteArray {
+    val dk = vault.exportDataKey()!!
+    return crypto.wrapDataKey(syncAccountKey(crypto, password, account), dk).also { dk.zeroize() }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -164,14 +164,17 @@ class SyncCoordinatorPasswordReplaceTest {
         vault: Vault,
         client: SyncClient,
         configStore: SyncConfigStore = InMemorySyncConfigStore(),
+        debtStore: ReconcileDebtStore = InMemoryReconcileDebtStore(),
     ): SyncCoordinator = SyncCoordinator(
         clientFactory = { client },
         crypto = crypto,
         vault = vault,
         configStore = configStore,
+        debtStore = debtStore,
         deviceIdProvider = { "dev-local" },
         engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
     )
+
 
     /** Sync already configured for [account] on [serverUrl] (so [SyncCoordinator.changeAccountPassword] runs). */
     private fun configuredStore(): SyncConfigStore = InMemorySyncConfigStore().apply {
@@ -363,7 +366,8 @@ class SyncCoordinatorPasswordReplaceTest {
         vault.put("r1", RecordType.HOST, "stale".encodeToByteArray())
         val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
         val store = InMemorySyncConfigStore()
-        val sut = coordinator(vault, client, store)
+        val debts = InMemoryReconcileDebtStore()
+        val sut = coordinator(vault, client, store, debts)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
@@ -374,7 +378,7 @@ class SyncCoordinatorPasswordReplaceTest {
             sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
             assertFalse(vault.records().any { it.id == "r1" }, "the reactivated device must rebuild from the server before it pushes")
-            assertEquals(false, store.load()?.pendingReconcile, "the completed reconcile retires the marker")
+            assertFalse(debts.owes(serverUrl, account), "the completed reconcile retires the debt")
         } finally {
             sut.close()
         }
@@ -405,27 +409,25 @@ class SyncCoordinatorPasswordReplaceTest {
     }
 
     /**
-     * The pause is not a reason to withhold the marker from a link this device ALREADY has: recording it
-     * there creates no new state and takes nothing back from the user, and the device owes the rebuild
-     * whatever it decides about the password. Only the fields the reactivation is about may change —
-     * the deviceId and the keep-connected token belong to a link that is still valid.
+     * The pause is not a reason to withhold the debt: recording it takes nothing back from the user, and
+     * the device owes the rebuild whatever it decides about the password. The link this device already has
+     * must come through untouched — the deviceId and the keep-connected token belong to a link that is
+     * still valid, and the debt is not kept on it.
      */
     @Test
-    fun `a reactivating verify marks the link this device already has`() = runBlocking {
+    fun `a reactivating verify records the debt without touching the saved link`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
         val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
         val linked = SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed")
         val store = InMemorySyncConfigStore().apply { save(linked) }
-        val sut = coordinator(vault, client, store)
+        val debts = InMemoryReconcileDebtStore()
+        val sut = coordinator(vault, client, store, debts)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
-            assertEquals(
-                linked.copy(pendingReconcile = true),
-                store.load(),
-                "the marker goes onto the existing link, and nothing else about it changes",
-            )
+            assertEquals(linked, store.load(), "nothing about the existing link changes")
+            assertTrue(debts.owes(serverUrl, account), "and the rebuild it owes is recorded beside it")
         } finally {
             sut.close()
         }
@@ -443,9 +445,9 @@ class SyncCoordinatorPasswordReplaceTest {
      * The third early return of issue #168: the confirmed replace logs in, the account key turns out to
      * already be ours, and re-wrapping the vault under the account password fails. The connect stops
      * there — but the reactivation the paused connect carried is already the server's last word on the
-     * subject, so it must be on the device's link by then rather than die with the failed re-key. (The
-     * device is linked here, which is what a rotation from another device leaves behind: the account
-     * password moved on and this vault still holds the old one.)
+     * subject, so it must be recorded by then rather than die with the failed re-key. (The device is
+     * linked here, which is what a rotation from another device leaves behind: the account password moved
+     * on and this vault still holds the old one.)
      */
     @Test
     fun `a confirmed replace that fails on the re-key keeps the reactivation`() = runBlocking {
@@ -453,7 +455,8 @@ class SyncCoordinatorPasswordReplaceTest {
         val vault = localVault()
         val client = FakeAccountClient(existingAccountPassword = accountPassword, accountDataKey = vault.exportDataKey(), revoked = true)
         val store = configuredStore()
-        val sut = coordinator(RewrapUnderFailingVault(vault), client, store)
+        val debts = InMemoryReconcileDebtStore()
+        val sut = coordinator(RewrapUnderFailingVault(vault), client, store, debts)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
@@ -464,28 +467,28 @@ class SyncCoordinatorPasswordReplaceTest {
                 (sut.status.value as? SyncStatus.Failed)?.reason,
                 "was ${sut.status.value}",
             )
-            assertEquals(true, store.load()?.pendingReconcile, "the rebuild is owed even though the re-key failed")
+            assertTrue(debts.owes(serverUrl, account), "the rebuild is owed even though the re-key failed")
         } finally {
             sut.close()
         }
     }
 
     /**
-     * Recording the reactivation can fail — the config file is on a full disk — and that failure travels
-     * out through the catch-all rather than a return of its own. The client the verify opened must not go
-     * with it: nothing else holds a reference, so every retry would strand another socket pool.
+     * Recording the reactivation can fail — the debt file is on a full disk — and that failure travels out
+     * through the catch-all rather than a return of its own. The client the verify opened must not go with
+     * it: nothing else holds a reference, so every retry would strand another socket pool.
      */
     @Test
     fun `a refused reactivation write still closes the client the verify opened`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
         val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
-        // The link is already there, so the reactivation has somewhere to be written — and that write fails.
         val linked = InMemorySyncConfigStore().apply { save(SyncConfig(serverUrl, account, deviceId = "dev-local")) }
-        val store = object : SyncConfigStore by linked {
-            override fun save(config: SyncConfig): Unit = error("config write failed")
+        val debts = object : ReconcileDebtStore {
+            override fun load(): Set<ServerLink> = emptySet()
+            override fun save(debts: Set<ServerLink>): Unit = error("debt write failed")
         }
-        val sut = coordinator(vault, client, store)
+        val sut = coordinator(vault, client, linked, debts)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -1,20 +1,8 @@
 package app.skerry.ui.sync
 
-import app.skerry.shared.sync.AccountSummary
-import app.skerry.shared.sync.DeviceInfo
 import app.skerry.shared.sync.InMemorySyncStateStore
-import app.skerry.shared.sync.PairingResult
-import app.skerry.shared.sync.PairingTicket
-import app.skerry.shared.sync.RecordPage
-import app.skerry.shared.sync.RemoteDevice
-import app.skerry.shared.sync.RemoteRecord
-import app.skerry.shared.sync.SyncClient
-import app.skerry.shared.sync.SyncException
-import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.sync.SyncSettings
 import app.skerry.shared.sync.SyncSettingsStore
-import app.skerry.shared.sync.SyncSignal
-import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.UnlockResult
@@ -22,16 +10,8 @@ import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import okio.FileSystem
-import okio.Path.Companion.toPath
-import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -42,11 +22,14 @@ import kotlin.test.assertTrue
  * tombstone while a revoked device still holds the record LIVE (it never pulled the tombstone). On
  * reactivation that device's full push would re-upload the record (the server has no row for it → resurrected)
  * and it would spread back to every peer. The coordinator closes this window: when the login reports the
- * device was reactivated — or a previously interrupted reconcile is still pending — it rebuilds the vault
- * from the server snapshot before the first push.
+ * device was reactivated — or a rebuild recorded earlier is still owed — it rebuilds the vault from the
+ * server snapshot before the first push.
  *
- * Real [FileVault] + real [IonspinVaultCrypto] (the reconcile is the whole point) and the REAL [SyncEngine]
- * runs so the push path is genuinely exercised; only the network is stubbed.
+ * What the debt itself must survive (a link overwritten, a disconnect, a restart) is
+ * [SyncCoordinatorReconcileDebtTest]; the doubles both use live in `ReactivationFixtures.kt`.
+ *
+ * Real [Vault] + real [IonspinVaultCrypto] (the reconcile is the whole point) and the REAL sync engine runs
+ * so the push path is genuinely exercised; only the network is stubbed.
  */
 class SyncCoordinatorReactivationTest {
 
@@ -55,178 +38,60 @@ class SyncCoordinatorReactivationTest {
     private val account = "maya"
     private val password = "vault-A"
 
-    /**
-     * This device's own account after a server-side purge: `register` collides (account exists), `login`
-     * reports [reactivated], the served wrap is this vault's OWN key (so the connect adopts nothing —
-     * isolating the reactivation path), and the server no longer holds `r1` (purged), so `pull` returns
-     * nothing. `push` records exactly what the client sent.
-     */
-    private inner class ReactivatingClient(
-        private val ownWrappedKey: ByteArray,
-        reactivated: Boolean = true,
-        /** Makes the reconcile's own first cycle fail, leaving the rebuild to a later sync. */
-        private val failFirstPull: Boolean = false,
-        /** How many key fetches serve an unopenable wrap — a connect that fails AFTER the login. */
-        private val corruptWraps: Int = 0,
-        /** The first key fetch dies on the network — a connect that THROWS after the login. */
-        private val throwOnFirstFetch: Boolean = false,
-    ) : SyncClient {
-        val pushed = mutableListOf<RemoteRecord>()
+    private fun freshVault(): Vault = newAccountVault(crypto, password)
+    private fun ownWrap(vault: Vault): ByteArray = wrapOwnKey(vault, crypto, password, account)
 
-        /** What each pull asked for — `0` is the full re-pull a reconcile's cursor reset forces. */
-        val pulledSince = mutableListOf<Long>()
-        private val pulls = AtomicInteger(0)
-
-        // The reactivation is reported exactly once, like the server does it: the verify that reports it
-        // is the one that clears the revocation, so every later login of this device is an ordinary one.
-        private val revoked = AtomicBoolean(reactivated)
-        private val fetches = AtomicInteger(0)
-
-        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
-            throw SyncException(SyncException.Kind.CONFLICT, "account exists")
-        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
-            val n = fetches.getAndIncrement()
-            if (throwOnFirstFetch && n == 0) throw SyncException(SyncException.Kind.NETWORK, "unreachable")
-            return if (n < corruptWraps) ByteArray(ownWrappedKey.size) else ownWrappedKey.copyOf()
-        }
-        override suspend fun pull(session: SyncSession, since: Long): RecordPage {
-            pulledSince += since
-            // Not a SyncException(NETWORK): that one arms the backoff retry loop, and the test wants the
-            // next cycle to be the one it triggers itself.
-            if (failFirstPull && pulls.getAndIncrement() == 0) error("pull unreachable")
-            return RecordPage(emptyList(), 1)
-        }
-        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
-            pushed += records
-            return RecordPage(emptyList(), 1)
-        }
-        override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
-
-        // Unreachable on purpose: a health ping that comes up drives the coordinator's own self-heal
-        // ([SyncCoordinator]'s init — no session, so `restoreSession`), which would race the connects these
-        // tests drive and re-save the config from under the assertions. Reachability is covered elsewhere.
-        override suspend fun ping(): Boolean = false
-        override suspend fun close() {}
-        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()
-        override suspend fun accountSummary(session: SyncSession): AccountSummary = error("unused")
-        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = false
-        // The silent restore of a keep-connected device: a token exchange, with no `reactivated` in it.
-        override suspend fun refresh(session: SyncSession): SyncSession =
-            SyncSession(session.accountId, accessToken = "access2", refreshToken = "refresh2")
-        // The rotation itself isn't what these tests are about: they need the activation that follows it,
-        // which re-publishes the session WITHOUT reconciling. Accepts any current password.
-        override suspend fun changePassword(accountId: String, currentAuthKey: ByteArray, newAuthKey: ByteArray, newWrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
-            SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
-        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = throw NotImplementedError()
-        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = throw NotImplementedError()
-    }
-
-    /**
-     * A real vault whose reconcile-time clear fails — what an auto-lock landing inside the connect does
-     * (`clearRecords` requires an unlocked vault), leaving the durable marker up with nothing cleared.
-     * [failures] bounds how many clears fail, so a test can also drive the recovery: the lock is gone by
-     * the next connect and the reconcile finally runs.
-     */
-    private class ClearFailingVault(private val delegate: Vault, private val failures: Int = Int.MAX_VALUE) : Vault by delegate {
-        private val attempts = AtomicInteger(0)
-
-        /** How many clears were tried — the observable "the reconcile ran again" for a retry that fails too. */
-        val clearAttempts: Int get() = attempts.get()
-
-        override fun clearRecords(types: Set<RecordType>) {
-            if (attempts.getAndIncrement() < failures) error("vault is locked")
-            delegate.clearRecords(types)
-        }
-    }
-
-    /** Config store that refuses exactly the write RAISING the reconcile marker (a full disk). */
-    private class MarkerRaiseFailingStore(private val delegate: SyncConfigStore) : SyncConfigStore {
-        /** Cleared once the test wants the disk to have room again. */
-        @Volatile
-        var refuse = true
-
-        override fun load(): SyncConfig? = delegate.load()
-        override fun save(config: SyncConfig) {
-            if (refuse && config.pendingReconcile && delegate.load()?.pendingReconcile != true) error("config write failed")
-            delegate.save(config)
-        }
-        override fun clear() = delegate.clear()
-    }
-
-    /** Config store that refuses exactly the write retiring the reconcile marker (a full disk). */
-    private class MarkerClearFailingStore(private val delegate: SyncConfigStore) : SyncConfigStore {
-        @Volatile
-        var refuseClear = true
-
-        override fun load(): SyncConfig? = delegate.load()
-        override fun save(config: SyncConfig) {
-            if (refuseClear && !config.pendingReconcile && delegate.load()?.pendingReconcile == true) {
-                error("config write failed")
-            }
-            delegate.save(config)
-        }
-        override fun clear() = delegate.clear()
-    }
-
-    /** A fresh unlocked account vault under [password], with its own random dataKey. */
-    private fun freshVault(): Vault {
-        val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()
-        FileSystem.SYSTEM.delete(file) // FileVault creates it
-        return FileVault(file, crypto, deviceId = "devA", fileSystem = FileSystem.SYSTEM, now = { "2026-07-22T00:00:00Z" })
-            .also { it.create(password.toCharArray()) }
-    }
-
-    /** This vault's own dataKey wrapped under the account (= vault) password, so the connect adopts nothing. */
-    private fun ownWrap(vault: Vault): ByteArray {
-        val dk = vault.exportDataKey()!!
-        return crypto.wrapDataKey(syncAccountKey(crypto, password, account), dk).also { dk.zeroize() }
-    }
 
     @Test
-    fun `reactivated device drops its stale record, does not re-push it, and clears the pending marker`() = runBlocking {
+    fun `reactivated device drops its stale record, does not re-push it, and retires the debt`() = runBlocking {
         initializeVaultCrypto()
         val vault = freshVault()
         // The device still holds r1 LIVE — it was revoked before it could pull the tombstone.
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val config = InMemorySyncConfigStore()
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val debts = InMemoryReconcileDebtStore()
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
             assertFalse(vault.records().any { it.id == "r1" }, "a reactivated device must discard its pre-revocation records")
             assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
-            // The durable marker is cleared once the reconcile's first sync succeeded.
-            assertEquals(false, config.load()?.pendingReconcile, "a completed reconcile clears the pending marker")
+            // The debt is retired once the reconcile's first sync succeeded.
+            assertFalse(debts.owes(serverUrl, account), "a completed reconcile retires the debt")
         } finally {
             sut.close()
         }
     }
 
     @Test
-    fun `a pending reconcile from an interrupted run is redone even when the login is not a reactivation`() = runBlocking {
+    fun `a debt from an interrupted run is redone even when the login is not a reactivation`() = runBlocking {
         initializeVaultCrypto()
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
         // A previous reactivation was interrupted after the server cleared revocation but before the vault
-        // was rebuilt: the durable marker survived. This login is NOT a reactivation (server already sees
-        // the device as live), so only the marker can drive the reconcile.
+        // was rebuilt: the recorded debt survived. This login is NOT a reactivation (server already sees
+        // the device as live), so only the debt can drive the reconcile.
         val config = InMemorySyncConfigStore()
-        config.save(SyncConfig(serverUrl, account, deviceId = "devA", pendingReconcile = true))
+        config.save(SyncConfig(serverUrl, account, deviceId = "devA"))
+        val debts = InMemoryReconcileDebtStore().also { it.save(setOf(ServerLink(serverUrl, account))) }
         val client = ReactivatingClient(ownWrap(vault), reactivated = false)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "reconnect should come Online")
-            assertFalse(vault.records().any { it.id == "r1" }, "a pending reconcile must still rebuild the vault")
-            assertFalse(client.pushed.any { it.id == "r1" }, "a pending reconcile must not let the stale record push")
-            assertEquals(false, config.load()?.pendingReconcile, "the redone reconcile clears the marker")
+            assertFalse(vault.records().any { it.id == "r1" }, "an owed rebuild must still rebuild the vault")
+            assertFalse(client.pushed.any { it.id == "r1" }, "an owed rebuild must not let the stale record push")
+            assertFalse(debts.owes(serverUrl, account), "the redone reconcile retires the debt")
         } finally {
             sut.close()
         }
@@ -246,9 +111,16 @@ class SyncCoordinatorReactivationTest {
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
         val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         // The first connect's key fetch serves an unopenable wrap; the second one is served the real key.
         val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
@@ -258,40 +130,16 @@ class SyncCoordinatorReactivationTest {
                 "was ${sut.status.value}",
             )
             assertEquals(null, config.load(), "a connect that never reached a session must not save a link")
+            assertTrue(debts.owes(serverUrl, account), "and it records the rebuild it was told about, link or no link")
 
-            // The repaired server state, and a login that reports nothing: the connect that failed is the
-            // only thing that still knows a rebuild is owed.
+            // The repaired server state, and a login that reports nothing: the debt the failed connect
+            // recorded is the only thing that still knows a rebuild is owed.
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the repaired connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
             assertFalse(vault.records().any { it.id == "r1" }, "the deferred reconcile must still drop the pre-revocation record")
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
-            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * The device that gets reactivated normally still HAS its link — that is the production shape of the
-     * write, and the one the fresh-store tests never take. Only the reconcile marker may change: the
-     * deviceId identifies this device to the account, and the keep-connected token is what lets the next
-     * launch restore without a password. Rebuilding the config from the connect's own parameters instead
-     * of marking the saved one would drop both and no other test would notice.
-     */
-    @Test
-    fun `marking a reactivation preserves the link it is written onto`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-
-        val linked = SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = "sealed")
-        val config = InMemorySyncConfigStore().also { it.save(linked) }
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
-            assertEquals(linked.copy(pendingReconcile = true), config.load(), "only the marker may change")
+            assertFalse(debts.owes(serverUrl, account), "the completed reconcile retires the debt")
         } finally {
             sut.close()
         }
@@ -299,8 +147,8 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * The connect need not fail with a status of its own to lose the signal: a network error while
-     * fetching the account key throws straight past every early return into the catch-all. The marker
-     * has to be down on disk before that fetch, not after it.
+     * fetching the account key throws straight past every early return into the catch-all. The debt has
+     * to be on disk before that fetch, not after it.
      */
     @Test
     fun `a connect that throws after the login keeps the reactivation`() = runBlocking {
@@ -309,12 +157,19 @@ class SyncCoordinatorReactivationTest {
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
         val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true, throwOnFirstFetch = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to fail on the key fetch") { it is SyncStatus.Failed }
-            assertEquals(true, config.load()?.pendingReconcile, "a throw after the login must not take the reactivation with it")
+            assertTrue(debts.owes(serverUrl, account), "a throw after the login must not take the reactivation with it")
         } finally {
             sut.close()
         }
@@ -322,7 +177,7 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * A keep-connected device recovers without a password: the next launch refreshes its saved token
-     * instead of logging in, and `refresh` carries no `reactivated` signal at all. The marker raised by
+     * instead of logging in, and `refresh` carries no `reactivated` signal at all. The debt recorded by
      * the failed connect is the only thing that can make that silent restore rebuild the vault first —
      * which is the whole reason the intent is durable rather than kept in memory.
      */
@@ -339,219 +194,68 @@ class SyncCoordinatorReactivationTest {
         val config = InMemorySyncConfigStore().also {
             it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
         }
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val failed = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val failed = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
         try {
             failed.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
             failed.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
         } finally {
             failed.close()
         }
-        assertEquals(true, config.load()?.pendingReconcile, "the failed connect left the rebuild owed")
+        assertTrue(debts.owes(serverUrl, account), "the failed connect left the rebuild owed")
 
-        // A new process: no coordinator state survives, only the config file and the vault.
-        val restored = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        // A new process: no coordinator state survives, only the stores and the vault.
+        val restored = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
         try {
             restored.restoreSession()
             restored.status.awaitStatus("the silent restore to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
             assertTrue(restored.status.value is SyncStatus.Online, "was ${restored.status.value}")
             assertFalse(vault.records().any { it.id == "r1" }, "the restore must run the reconcile the connect never got to")
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
-            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+            assertFalse(debts.owes(serverUrl, account), "the completed reconcile retires the debt")
         } finally {
             restored.close()
         }
     }
 
     /**
-     * The marker is written onto the saved link, and a connect that hasn't succeeded yet has not earned
-     * one: a failed connect to another account must leave the link — its deviceId and its keep-connected
-     * token — exactly as it was, rather than trade a device that is still fine for a reconcile intent that
-     * cannot even be read for that account. The signal is carried live instead (`reactivated`), and the
-     * connect that succeeds writes its own link with the marker.
-     */
-    @Test
-    fun `a failed connect does not overwrite the link to another account`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-
-        val linked = SyncConfig(serverUrl, "other-account", deviceId = "devOther", keepConnected = true, sealedRefreshToken = "sealed")
-        val config = InMemorySyncConfigStore().also { it.save(linked) }
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
-            assertEquals(linked, config.load(), "a failed connect must leave the saved link untouched")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * Disconnect erases the link, and with it the durable marker — but it rebuilds nothing: the records
-     * the reconcile was supposed to drop are still in the vault. A debt that was never actually paid must
-     * therefore survive it, or the reconnect after a disconnect is the ordinary incremental one and pushes
-     * the purged records straight back. (Here the reconcile's clear failed, which is exactly the state in
-     * which a user reaches for Disconnect.)
-     */
-    @Test
-    fun `a disconnect does not pay a rebuild that never ran`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(
-            clientFactory = { client },
-            crypto = crypto,
-            vault = ClearFailingVault(vault, failures = 1),
-            configStore = config,
-        )
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
-
-            sut.disconnect()
-            sut.status.awaitStatus("the link to be erased") { it is SyncStatus.Disabled }
-            assertEquals(null, config.load(), "disconnect erases the link — and the durable marker with it")
-
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the reconnect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
-            assertFalse(vault.records().any { it.id == "r1" }, "the rebuild is still owed — disconnect ran no reconcile")
-            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * The account id is chosen by the user and says nothing about which server it belongs to — the same
-     * one names two accounts on a home and a work instance. A rebuild owed to one of them must not be
-     * charged to the other: the vault would be wiped of records the other server never purged, and they
-     * were never pushed to it either.
-     */
-    @Test
-    fun `a rebuild owed to one server is not charged to another`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        // Linked to the home instance, so the failed connect below marks THAT link — the marker and the
-        // in-memory debt both have to stay charged to it.
-        val config = InMemorySyncConfigStore()
-            .also { it.save(SyncConfig("https://home.test", account, deviceId = "devA")) }
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            // The home instance: this device was revoked there, and the connect fails after the login.
-            sut.connect("https://home.test", account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
-
-            // The work instance, same account id: an ordinary connect that owes nothing.
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the second connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
-            assertTrue(vault.records().any { it.id == "r1" }, "another server's reactivation must not clear this vault")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * The reactivation is reported, the marker write is refused (a full disk), and the connect fails
-     * loudly — but the device is keep-connected, so what happens next is a silent restore that never
-     * logs in again. It has to see the rebuild is owed from the only place it was recorded: this
-     * process's memory. Otherwise the session comes Online and pushes the purged records back.
-     */
-    @Test
-    fun `a restore honors a rebuild whose marker could not be written`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        val dataKey = vault.exportDataKey()!!
-        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
-        val config = MarkerRaiseFailingStore(
-            InMemorySyncConfigStore().also {
-                it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
-            },
-        )
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
-            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
-            assertEquals(false, config.load()?.pendingReconcile, "the marker never made it to disk")
-
-            config.refuse = false // the disk has room again by the time the restore runs
-            sut.restoreSession()
-            sut.status.awaitStatus("the silent restore to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
-            assertFalse(vault.records().any { it.id == "r1" }, "the restore must rebuild — the debt is still owed")
-            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * Standing down from the write is not the same as forgetting: the server said this device was
-     * reactivated and will never say it again, so the retry that finally connects must still rebuild —
-     * even though the intent had nowhere on disk to wait (the saved link is another account's, and a
-     * refused write leaves the same nothing behind).
-     */
-    @Test
-    fun `a reactivation with nowhere to be saved still reconciles on the next connect`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        val config = InMemorySyncConfigStore()
-            .also { it.save(SyncConfig(serverUrl, "other-account", deviceId = "devOther")) }
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
-
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the retry to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
-            assertFalse(vault.records().any { it.id == "r1" }, "the retry must rebuild — the signal is gone from the server")
-            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
      * [SyncStatus.Online] is what the UI and every other observer react to, so it must not arrive while the
-     * reconcile marker is still up: an observer would read a config the reconcile has already left behind.
-     * The sample is taken by an unconfined collector, i.e. inside the emission itself, so it sees exactly
-     * what the coordinator published rather than what it got around to writing afterwards.
+     * debt still stands: an observer would read a state the reconcile has already left behind. The sample is
+     * taken by an unconfined collector, i.e. inside the emission itself, so it sees exactly what the
+     * coordinator published rather than what it got around to writing afterwards.
      */
     @Test
-    fun `the reconcile marker is already down when the connect publishes Online`() = runBlocking {
+    fun `the reconcile debt is already retired when the connect publishes Online`() = runBlocking {
         initializeVaultCrypto()
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
         val markerAtOnline = CompletableDeferred<Boolean?>()
         val observer = launch(Dispatchers.Unconfined) {
-            sut.status.collect { if (it is SyncStatus.Online) markerAtOnline.complete(config.load()?.pendingReconcile) }
+            sut.status.collect { if (it is SyncStatus.Online) markerAtOnline.complete(debts.owes(serverUrl, account)) }
         }
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             assertEquals(
                 false,
                 awaitSync("the reactivation connect to publish Online") { markerAtOnline.await() },
-                "Online must not be published while the reconcile marker is still up",
+                "Online must not be published while the rebuild is still owed",
             )
         } finally {
             observer.cancel()
@@ -562,8 +266,8 @@ class SyncCoordinatorReactivationTest {
     /**
      * The reconcile is finished by whichever cycle first succeeds, not only by the one the connect
      * starts: a first cycle that fails leaves the vault cleared and the cursor at 0, so the next sync is
-     * still the full re-pull the marker is waiting for. Clearing it only in the connect's own cycle would
-     * leave the marker up for good and redo the reconcile on every later connect.
+     * still the full re-pull the debt is waiting for. Retiring it only in the connect's own cycle would
+     * leave the debt standing for good and redo the reconcile on every later connect.
      */
     @Test
     fun `a reconcile whose first cycle failed is completed by the next sync that succeeds`() = runBlocking {
@@ -571,29 +275,29 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true, failFirstPull = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the reconcile's first cycle to fail") { it is SyncStatus.Failed }
-            assertEquals(true, config.load()?.pendingReconcile, "a failed cycle must leave the marker up")
+            assertTrue(debts.owes(serverUrl, account), "a failed cycle must leave the debt standing")
 
             sut.syncNow()
             sut.status.awaitStatus("the status to come Online") { it is SyncStatus.Online }
-            assertEquals(false, config.load()?.pendingReconcile, "the cycle that succeeded completes the reconcile")
+            assertFalse(debts.owes(serverUrl, account), "the cycle that succeeded completes the reconcile")
         } finally {
             sut.close()
         }
     }
 
     /**
-     * The marker is persisted BEFORE the vault is cleared (a crash in between must not lose the signal),
-     * so it can be up on a device whose reconcile never actually ran — the clear threw and the session
-     * published a moment earlier is still live. That session must not sync: its vault still holds the
-     * pre-revocation records the server purged, and a cycle would push them straight back and report
-     * Online while doing it (issue #142). The cycle is refused and the status parks on the link state;
-     * the rebuild is left to the next connect/restore, which redoes the reconcile.
+     * The debt is recorded BEFORE the vault is cleared (a crash in between must not lose the signal), so it
+     * can stand on a device whose reconcile never actually ran — the clear threw and the session published
+     * a moment earlier is still live. That session must not sync: its vault still holds the pre-revocation
+     * records the server purged, and a cycle would push them straight back and report Online while doing it
+     * (issue #142). The cycle is refused and the status parks on the link state; the rebuild is left to the
+     * next connect/restore, which redoes the reconcile.
      */
     @Test
     fun `a session whose reconcile never cleared the vault refuses to sync`() = runBlocking {
@@ -601,18 +305,18 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         val sut = SyncCoordinator(
             clientFactory = { client },
             crypto = crypto,
             vault = ClearFailingVault(vault),
-            configStore = config,
+            debtStore = debts,
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
-            assertEquals(true, config.load()?.pendingReconcile, "a reconcile that could not clear the vault keeps the marker")
+            assertTrue(debts.owes(serverUrl, account), "a reconcile that could not clear the vault keeps the debt")
 
             sut.syncNow()
             val settled = sut.status.awaitStatus("the manual sync to settle") {
@@ -627,7 +331,7 @@ class SyncCoordinatorReactivationTest {
                 client.pushed.any { it.id == "r1" },
                 "a refused cycle must not push the records the reconcile was supposed to drop",
             )
-            assertEquals(true, config.load()?.pendingReconcile, "only a reconcile that actually ran may retire the marker")
+            assertTrue(debts.owes(serverUrl, account), "only a reconcile that actually ran may retire the debt")
             assertTrue(vault.records().any { it.id == "r1" }, "the stale record is still there — the reconcile never ran")
         } finally {
             sut.close()
@@ -635,10 +339,10 @@ class SyncCoordinatorReactivationTest {
     }
 
     /**
-     * The refusal is a stop, not a dead end: the marker is still on disk, so the next connect on the SAME
+     * The refusal is a stop, not a dead end: the debt is still recorded, so the next connect on the SAME
      * coordinator redoes the reconcile — this time over a vault that lets the clear through — and the
      * device comes back Online with its records rebuilt from the server. Recovery through a fresh
-     * coordinator (an app restart) is a different path and is covered by the pending-marker test above.
+     * coordinator (an app restart) is a different path and is covered by the interrupted-run test above.
      */
     @Test
     fun `a reconnect finishes the reconcile the refused cycle was waiting for`() = runBlocking {
@@ -646,13 +350,13 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         val sut = SyncCoordinator(
             clientFactory = { client },
             crypto = crypto,
             vault = ClearFailingVault(vault, failures = 1),
-            configStore = config,
+            debtStore = debts,
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
@@ -666,7 +370,7 @@ class SyncCoordinatorReactivationTest {
             sut.status.awaitStatus("the reconnect to settle") { it is SyncStatus.Online }
             assertFalse(vault.records().any { it.id == "r1" }, "the redone reconcile must drop the pre-revocation record")
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never have been pushed")
-            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+            assertFalse(debts.owes(serverUrl, account), "the completed reconcile retires the debt")
         } finally {
             sut.close()
         }
@@ -684,7 +388,7 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         // A cursor from before the revocation: the reconcile has to reset it, or the re-pull that rebuilds
         // the vault would ask for changes since the tip and get nothing back.
@@ -693,7 +397,7 @@ class SyncCoordinatorReactivationTest {
             clientFactory = { client },
             crypto = crypto,
             vault = ClearFailingVault(vault, failures = 1),
-            configStore = config,
+            debtStore = debts,
             syncState = state,
         )
         try {
@@ -714,7 +418,7 @@ class SyncCoordinatorReactivationTest {
             sut.status.awaitStatus("the unlock to finish the reconcile") { it is SyncStatus.Online }
             assertFalse(vault.records().any { it.id == "r1" }, "the redone reconcile must drop the pre-revocation record")
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never have been pushed")
-            assertEquals(false, config.load()?.pendingReconcile, "the completed reconcile retires the marker")
+            assertFalse(debts.owes(serverUrl, account), "the completed reconcile retires the debt")
             // The cycle the connect would have run never happened (the clear threw first), so the first
             // pull of the whole test is the one the redo armed.
             assertEquals(0L, client.pulledSince.firstOrNull(), "the rebuild must be a full re-pull, not one from the stale cursor")
@@ -725,7 +429,7 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * The redone reconcile can fail too — the vault re-locked between the unlock and the clear. That must
-     * stay the same stop as before (the marker up, the cycle refused), not turn the unlock into a new
+     * stay the same stop as before (the debt standing, the cycle refused), not turn the unlock into a new
      * failure that hides the recovery the status names.
      *
      * The lock is real here (`pauseForLock` parks the status on Configured), so the refusal after the
@@ -739,10 +443,10 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
+        val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         val clearFailing = ClearFailingVault(vault)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = clearFailing, configStore = config)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = clearFailing, debtStore = debts)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
@@ -761,7 +465,7 @@ class SyncCoordinatorReactivationTest {
                 (it as? SyncStatus.Failed)?.reason == SyncFailureReason.ReconcileRequired
             }
             assertEquals(2, clearFailing.clearAttempts, "the unlock must have retried the reconcile exactly once")
-            assertEquals(true, config.load()?.pendingReconcile, "a reconcile that failed again keeps the marker")
+            assertTrue(debts.owes(serverUrl, account), "a reconcile that failed again keeps the debt")
             assertTrue(vault.records().any { it.id == "r1" }, "nothing was cleared — the record is still there")
             assertFalse(client.pushed.any { it.id == "r1" }, "and it must not have been pushed")
         } finally {
@@ -771,8 +475,8 @@ class SyncCoordinatorReactivationTest {
 
     /**
      * The other branch of the same guard, and the one with teeth: an unlock on a session that owes nothing
-     * must not reconcile. Without the [SyncCoordinator] check, every ordinary unlock would raise a fresh
-     * marker and wipe every host and snippet in the vault — the mirror image of the bug this path fixes.
+     * must not reconcile. Without the [SyncCoordinator] check, every ordinary unlock would record a fresh
+     * debt and wipe every host and snippet in the vault — the mirror image of the bug this path fixes.
      */
     @Test
     fun `an unlock with no reconcile owed leaves the vault alone`() = runBlocking {
@@ -780,10 +484,10 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
-        // Not a reactivation and no pending marker: an ordinary connected device.
+        val debts = InMemoryReconcileDebtStore()
+        // Not a reactivation and nothing owed: an ordinary connected device.
         val client = ReactivatingClient(ownWrap(vault), reactivated = false)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to come Online") { it is SyncStatus.Online }
@@ -796,18 +500,18 @@ class SyncCoordinatorReactivationTest {
             sut.status.awaitStatus("the unlock to bring sync back") { it is SyncStatus.Online }
 
             assertTrue(vault.records().any { it.id == "r1" }, "an unlock that owes no reconcile must not clear the vault")
-            assertEquals(false, config.load()?.pendingReconcile, "and must not raise a reconcile marker of its own")
+            assertFalse(debts.owes(serverUrl, account), "and must not record a debt of its own")
         } finally {
             sut.close()
         }
     }
 
     /**
-     * A password rotation re-activates the session without reconciling, and the config it saves still
-     * carries the marker. When the reconcile it belongs to already ran here (records dropped, only the
-     * marker write refused), that re-activation must not disarm the coordinator: doing so would make
-     * every later cycle refuse — including the one that would finally retire the marker — and the device
-     * would sit blocked until a reconnect for a rebuild that already happened.
+     * A password rotation re-activates the session without reconciling, and the debt it lands on is still
+     * standing. When the reconcile it belongs to already ran here (records dropped, only the retiring write
+     * refused), that re-activation must not disarm the coordinator: doing so would make every later cycle
+     * refuse — including the one that would finally retire the debt — and the device would sit blocked
+     * until a reconnect for a rebuild that already happened.
      */
     @Test
     fun `a password rotation over a reconcile that already ran keeps syncing`() = runBlocking {
@@ -815,14 +519,14 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = MarkerClearFailingStore(InMemorySyncConfigStore())
+        val debts = DebtClearFailingStore(InMemoryReconcileDebtStore())
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
         try {
             sut.connect(serverUrl, account, password.toCharArray())
             sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "the reconcile itself succeeded — only its marker write was refused")
-            assertEquals(true, config.load()?.pendingReconcile, "the refused write leaves the marker up")
+            assertTrue(sut.status.value is SyncStatus.Online, "the reconcile itself succeeded — only its retiring write was refused")
+            assertTrue(debts.owes(serverUrl, account), "the refused write leaves the debt standing")
 
             // changeAccountPassword awaits the activation it triggers, so the cycle has already run here.
             assertEquals(
@@ -831,7 +535,7 @@ class SyncCoordinatorReactivationTest {
             )
             assertTrue(
                 sut.status.value is SyncStatus.Online,
-                "a re-activation carrying a marker whose reconcile already ran must keep syncing",
+                "a re-activation landing on a debt whose reconcile already ran must keep syncing",
             )
         } finally {
             sut.close()
@@ -843,7 +547,7 @@ class SyncCoordinatorReactivationTest {
      * the session without reconciling either. The rotation itself succeeds — the server did change the
      * password — but the vault it re-publishes still holds the purged records, so the cycle is refused
      * instead of pushing them. The activation path is not the reactivation one, which is the point:
-     * the refusal is keyed on the marker, not on who published the session.
+     * the refusal is keyed on the debt, not on who published the session.
      */
     @Test
     fun `a password rotation cannot sync a vault whose reconcile never ran`() = runBlocking {
@@ -851,13 +555,11 @@ class SyncCoordinatorReactivationTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val config = InMemorySyncConfigStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)
         val sut = SyncCoordinator(
             clientFactory = { client },
             crypto = crypto,
             vault = ClearFailingVault(vault),
-            configStore = config,
         )
         try {
             sut.connect(serverUrl, account, password.toCharArray())
@@ -873,70 +575,6 @@ class SyncCoordinatorReactivationTest {
                 "an activation that doesn't reconcile must not sync a vault that still owes one",
             )
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * The refusal guard reads the durable marker, so a debt that never reached disk must be visible to it
-     * too. A password rotation re-publishes the session without reconciling: with nothing to see, its first
-     * cycle would push the pre-revocation records the failed connect never got to drop.
-     */
-    @Test
-    fun `a rotation cannot sync over a rebuild whose marker could not be written`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        val config = MarkerRaiseFailingStore(
-            InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) },
-        )
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
-            assertEquals(false, config.load()?.pendingReconcile, "the marker never made it to disk")
-
-            assertEquals(
-                AccountPasswordChange.Success,
-                sut.changeAccountPassword(password.toCharArray(), "vault-B".toCharArray()),
-            )
-            assertEquals(
-                SyncStatus.Failed(SyncFailureReason.ReconcileRequired),
-                sut.status.value,
-                "an activation that doesn't reconcile must not sync a vault that still owes one",
-            )
-            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
-        } finally {
-            sut.close()
-        }
-    }
-
-    /**
-     * Retiring the marker is a config write, and a config write can fail. It must not turn a sync that
-     * actually succeeded into a reported failure — the marker simply stays up, and the next cycle retires
-     * it, the same fallback an interrupted reconcile relies on.
-     */
-    @Test
-    fun `a refused marker write keeps the sync green and is retried by the next cycle`() = runBlocking {
-        initializeVaultCrypto()
-        val vault = freshVault()
-        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
-
-        val config = MarkerClearFailingStore(InMemorySyncConfigStore())
-        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
-        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, configStore = config)
-        try {
-            sut.connect(serverUrl, account, password.toCharArray())
-            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
-            assertTrue(sut.status.value is SyncStatus.Online, "a refused marker write must not fail a sync that succeeded")
-            assertEquals(true, config.load()?.pendingReconcile, "a refused write leaves the marker up")
-
-            config.refuseClear = false
-            sut.syncNow()
-            awaitSync("the retried clear to land") { while (config.load()?.pendingReconcile != false) delay(20) }
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReconcileDebtTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReconcileDebtTest.kt
@@ -1,0 +1,465 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The reactivation debt as a durable fact of its own: what must survive a link being overwritten by a
+ * connect to another server, a disconnect, a restart, and a store that refuses the write (issues #168 and
+ * #170). The reconcile it drives is exercised in [SyncCoordinatorReactivationTest]; the doubles both use
+ * live in `ReactivationFixtures.kt`.
+ */
+class SyncCoordinatorReconcileDebtTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val password = "vault-A"
+
+    private fun freshVault(): Vault = newAccountVault(crypto, password)
+    private fun ownWrap(vault: Vault): ByteArray = wrapOwnKey(vault, crypto, password, account)
+
+
+    /**
+     * The upgrade path: 0.2.1 and earlier kept the intent on the saved link ([SyncConfig.legacyPendingReconcile]).
+     * A device that upgrades mid-rebuild must not lose it — the server said `reactivated` once, and the
+     * marker on the old config file is the only record of it.
+     */
+    @Test
+    fun `a marker written by an older version is migrated into the debt store`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+        config.save(SyncConfig(serverUrl, account, deviceId = "devA", legacyPendingReconcile = true))
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = false)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            assertTrue(debts.owes(serverUrl, account), "the marker on the old config is a debt now")
+            assertFalse(config.load()!!.legacyPendingReconcile, "and it is cleared off the link, so it migrates once")
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the migrated debt must still rebuild the vault")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A migration the debt store refuses must not keep the app from starting, and must not be the end of
+     * the intent either: the legacy marker stays on the link, so the next launch tries again.
+     */
+    @Test
+    fun `a refused migration leaves the legacy marker for the next launch`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+
+        val legacy = SyncConfig(serverUrl, account, deviceId = "devA", legacyPendingReconcile = true)
+        val config = InMemorySyncConfigStore().also { it.save(legacy) }
+        val debts = DebtRaiseFailingStore(InMemoryReconcileDebtStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = false)
+        val first = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        first.close()
+        assertFalse(debts.owes(serverUrl, account), "the refused write recorded nothing")
+        assertTrue(config.load()!!.legacyPendingReconcile, "so the marker must still be on the link")
+
+        debts.refuse = false // the disk has room again on the next launch
+        val second = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            assertTrue(debts.owes(serverUrl, account), "the retried migration records the debt")
+            assertFalse(config.load()!!.legacyPendingReconcile, "and retires the marker it came from")
+        } finally {
+            second.close()
+        }
+    }
+
+    /**
+     * The device that gets reactivated normally still HAS its link — that is the production shape, and the
+     * one the fresh-store tests never take. The link must come through the connect untouched: the deviceId
+     * identifies this device to the account, and the keep-connected token is what lets the next launch
+     * restore without a password. Recording the debt on the config instead of beside it would put both at
+     * the mercy of a connect that has not succeeded.
+     */
+    @Test
+    fun `recording a reactivation leaves the saved link untouched`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+
+        val linked = SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = "sealed")
+        val config = InMemorySyncConfigStore().also { it.save(linked) }
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertEquals(linked, config.load(), "the link must survive the failed connect as it was")
+            assertTrue(debts.owes(serverUrl, account), "the rebuild is recorded beside it")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A connect that hasn't succeeded has earned no link: a failed connect to another account must leave
+     * the saved one — its deviceId and its keep-connected token — exactly as it was, rather than trade a
+     * device that is still fine for the reconcile intent of an account it isn't linked to. The debt goes
+     * to its own store instead, where it belongs to the link it was learned on.
+     */
+    @Test
+    fun `a failed connect does not overwrite the link to another account`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+
+        val linked = SyncConfig(serverUrl, "other-account", deviceId = "devOther", keepConnected = true, sealedRefreshToken = "sealed")
+        val config = InMemorySyncConfigStore().also { it.save(linked) }
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertEquals(linked, config.load(), "a failed connect must leave the saved link untouched")
+            assertTrue(debts.owes(serverUrl, account), "the rebuild is owed by the account that was reactivated")
+            assertFalse(debts.owes(serverUrl, "other-account"), "and by no other")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Disconnect erases the link, but it rebuilds nothing: the records the reconcile was supposed to drop
+     * are still in the vault. A debt that was never actually paid must therefore survive it, or the
+     * reconnect after a disconnect is the ordinary incremental one and pushes the purged records straight
+     * back. (Here the reconcile's clear failed, which is exactly the state in which a user reaches for
+     * Disconnect.)
+     */
+    @Test
+    fun `a disconnect does not pay a rebuild that never ran`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = ClearFailingVault(vault, failures = 1),
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the clear") { it is SyncStatus.Failed }
+
+            sut.disconnect()
+            sut.status.awaitStatus("the link to be erased") { it is SyncStatus.Disabled }
+            assertEquals(null, config.load(), "disconnect erases the link")
+            assertTrue(debts.owes(serverUrl, account), "but not a rebuild it did not run")
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the reconnect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the rebuild is still owed — disconnect ran no reconcile")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #170: the debt belongs to a link and the saved config holds exactly one, so an ordinary
+     * successful connect to ANOTHER server saves a config with no room for the previous link's marker.
+     * The debt has to be recorded somewhere the config cannot overwrite — otherwise it lives only in
+     * process memory, and the restart after that connect loses it: reconnecting to the server that
+     * reactivated this device is then an ordinary incremental reconnect that pushes back every record
+     * the account purged while it was revoked.
+     */
+    @Test
+    fun `a debt survives a connect to another link and the restart that follows`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val homeUrl = "https://home.test"
+        // Home revoked this device: the login reports the reactivation, and the connect then fails on an
+        // unopenable wrap — the recorded debt is all that is left of a signal the server never repeats.
+        val home = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val work = ReactivatingClient(ownWrap(vault), reactivated = false)
+        val factory = { url: String -> if (url == homeUrl) home else work }
+        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(homeUrl, account, deviceId = "devA")) }
+        val debts = InMemoryReconcileDebtStore()
+
+        val before = SyncCoordinator(
+            clientFactory = factory,
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            before.connect(homeUrl, account, password.toCharArray())
+            before.status.awaitStatus("the home connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+
+            // Nothing wrong with this connect — it is another server, it succeeds, and it saves its own link.
+            before.connect(serverUrl, account, password.toCharArray())
+            before.status.awaitStatus("the work connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(before.status.value is SyncStatus.Online, "was ${before.status.value}")
+            assertEquals(serverUrl, config.load()?.serverUrl, "the saved link is the work one now")
+        } finally {
+            before.close()
+        }
+
+        // The restart: only the stores and the vault survive it.
+        val after = SyncCoordinator(
+            clientFactory = factory,
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            after.connect(homeUrl, account, password.toCharArray())
+            after.status.awaitStatus("the home reconnect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(after.status.value is SyncStatus.Online, "was ${after.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the rebuild owed to home survives the link that was overwritten")
+            assertFalse(home.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            after.close()
+        }
+    }
+
+    /**
+     * The account id is chosen by the user and says nothing about which server it belongs to — the same
+     * one names two accounts on a home and a work instance. A rebuild owed to one of them must not be
+     * charged to the other: the vault would be wiped of records the other server never purged, and they
+     * were never pushed to it either.
+     */
+    @Test
+    fun `a rebuild owed to one server is not charged to another`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        // Linked to the home instance, so the failed connect below records a debt charged to THAT link.
+        val config = InMemorySyncConfigStore()
+            .also { it.save(SyncConfig("https://home.test", account, deviceId = "devA")) }
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            // The home instance: this device was revoked there, and the connect fails after the login.
+            sut.connect("https://home.test", account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+
+            // The work instance, same account id: an ordinary connect that owes nothing.
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the second connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertTrue(vault.records().any { it.id == "r1" }, "another server's reactivation must not clear this vault")
+            assertTrue(debts.owes("https://home.test", account), "and the home rebuild is still owed")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The reactivation is reported, the debt write is refused (a full disk), and the connect fails
+     * loudly — but the device is keep-connected, so what happens next is a silent restore that never
+     * logs in again. It has to see the rebuild is owed from the only place it was recorded: this
+     * process's memory. Otherwise the session comes Online and pushes the purged records back.
+     */
+    @Test
+    fun `a restore honors a rebuild that could not be written down`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val dataKey = vault.exportDataKey()!!
+        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
+        val config = InMemorySyncConfigStore().also {
+            it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
+        }
+        val debts = DebtRaiseFailingStore(InMemoryReconcileDebtStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray(), keepConnected = true)
+            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
+            assertFalse(debts.owes(serverUrl, account), "the debt never made it to disk")
+
+            debts.refuse = false // the disk has room again by the time the restore runs
+            sut.restoreSession()
+            sut.status.awaitStatus("the silent restore to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the restore must rebuild — the debt is still owed")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The debt outlives the connect that learned of it even when this device is linked somewhere else
+     * entirely: the server said it was reactivated on THIS link and will never say it again, so the retry
+     * that finally connects must still rebuild. Under the old design there was nowhere to put it — the
+     * saved link was another account's, and the config holds one — which is how the intent used to die.
+     */
+    @Test
+    fun `a reactivation on a link this device is not on still reconciles on the next connect`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore()
+            .also { it.save(SyncConfig(serverUrl, "other-account", deviceId = "devOther")) }
+        val debts = InMemoryReconcileDebtStore()
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the unopenable wrap") { it is SyncStatus.Failed }
+            assertTrue(debts.owes(serverUrl, account), "the debt is charged to the link that reactivated it")
+
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the retry to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "was ${sut.status.value}")
+            assertFalse(vault.records().any { it.id == "r1" }, "the retry must rebuild — the signal is gone from the server")
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must never be pushed back")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The refusal guard reads the debts this process knows about, so one that never reached disk must be
+     * visible to it too. A password rotation re-publishes the session without reconciling: with nothing to
+     * see, its first cycle would push the pre-revocation records the failed connect never got to drop.
+     */
+    @Test
+    fun `a rotation cannot sync over a rebuild that could not be written down`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val config = InMemorySyncConfigStore().also { it.save(SyncConfig(serverUrl, account, deviceId = "devA")) }
+        val debts = DebtRaiseFailingStore(InMemoryReconcileDebtStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client },
+            crypto = crypto,
+            vault = vault,
+            configStore = config,
+            debtStore = debts,
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to fail on the refused write") { it is SyncStatus.Failed }
+            assertFalse(debts.owes(serverUrl, account), "the debt never made it to disk")
+
+            assertEquals(
+                AccountPasswordChange.Success,
+                sut.changeAccountPassword(password.toCharArray(), "vault-B".toCharArray()),
+            )
+            assertEquals(
+                SyncStatus.Failed(SyncFailureReason.ReconcileRequired),
+                sut.status.value,
+                "an activation that doesn't reconcile must not sync a vault that still owes one",
+            )
+            assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Retiring a debt is a store write, and a store write can fail. It must not turn a sync that actually
+     * succeeded into a reported failure — the debt simply stays standing, and the next cycle retires it,
+     * the same fallback an interrupted reconcile relies on.
+     */
+    @Test
+    fun `a refused retiring write keeps the sync green and is retried by the next cycle`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
+
+        val debts = DebtClearFailingStore(InMemoryReconcileDebtStore())
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "a refused debt write must not fail a sync that succeeded")
+            assertTrue(debts.owes(serverUrl, account), "a refused write leaves the debt standing")
+
+            debts.refuseClear = false
+            sut.syncNow()
+            awaitSync("the retried write to land") { while (debts.owes(serverUrl, account)) delay(20) }
+        } finally {
+            sut.close()
+        }
+    }
+}


### PR DESCRIPTION
Closes #170.

A device that was revoked and then reactivated must rebuild its vault from the server before it pushes again, or it puts back every record the account purged while it was locked out. The server reports `reactivated` exactly once, so that intent has to be persisted — and until now it was persisted as a flag on the saved link, of which a device holds exactly one. An ordinary successful connect to another server saved a config with no room for the previous link's flag, leaving the intent only in process memory; the next restart lost it, and reconnecting to the first server was an ordinary incremental reconnect that pushed the purged records straight back.

## What changed

- `ReconcileDebtStore` holds a durable set of `ServerLink(serverUrl, accountId)` beside the config — `sync-reconcile` next to `sync.json`, one line per owed link, mode 0600 on desktop and the app's private files dir on Android. Neither a connect to another server nor a disconnect touches it.
- A debt is recorded the moment a login reports the reactivation and retired only once a sync cycle over the rebuilt vault has actually succeeded. Recording writes memory first, retiring writes disk first: a refused write always leaves the debt standing rather than dropping it.
- Reconcile markers written by 0.2.1 and earlier (`pendingReconcile` in `sync.json`) are migrated into the store once, at startup, and cleared off the link.
- Both stores parse the file per line, so a truncated percent-escape costs its own debt instead of every intact one in the file.

## Tests

`SyncCoordinatorReconcileDebtTest` (11) covers the issue's own scenario — a connect that fails after a reactivating login, a successful connect to another server, a restart, and the reconnect that must still rebuild — plus the legacy migration and its refused-write path. `FileReconcileDebtStoreTest` (5) and `AndroidSyncStoresTest` (4) pin the on-disk format on both platforms, including a server URL containing `=` and a newline, and a line with a broken escape. `FileSyncConfigStoreLegacyTest` pins that the 0.2.1 key is read once and never written again.

Verified live: nothing — reproducing the path needs a device revoked on a live server and a connect that fails after its login. The Android side compiles but was not run on a device.