### PR TITLE
Select the prefilled value when a form field takes focus

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
@@ -497,15 +497,18 @@ fun NumberStepper(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         StepButton("remove") { onValueChange(value - step); editing = null }
+        // Untouched, the field shows the setting's current number: select it on focus, so the next
+        // keystroke replaces the value instead of extending it into a nonsense one (13 -> 133).
+        val draft = rememberFieldDraft(shown, selectAllOnFocus = editing == null)
         BasicTextField(
-            value = shown,
-            onValueChange = { editing = it },
+            value = draft.textFieldValue(shown),
+            onValueChange = { next -> draft.accept(next, shown) { editing = it } },
             singleLine = true,
             textStyle = textStyle,
             cursorBrush = SolidColor(Skerry.colors.cyan),
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(onDone = { commit() }),
-            modifier = Modifier.width(fieldWidth).onFocusChanged { if (!it.isFocused) commit() },
+            modifier = Modifier.width(fieldWidth).fieldFocus(draft).onFocusChanged { if (!it.isFocused) commit() },
         )
         if (suffix.isNotEmpty()) Txt(suffix, color = Skerry.colors.faint, size = 12.sp)
         StepButton("add") { onValueChange(value + step); editing = null }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 
@@ -33,8 +35,25 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
     /** Whether the last [accept] handed the caller new text — see [caretIn]. */
     private var emitted by mutableStateOf(false)
 
+    /**
+     * Where the gesture that brought focus here put the caret, until the one write it still owes
+     * arrives. A mouse click reaches the field twice — the selection gesture places the caret on the
+     * press, `detectTapAndPress` places it again on the release — and a selection made on focus goes
+     * on between the two, so the release would undo it. Exactly one write is ignored, and the next
+     * one lands wherever it points. Not read during composition, so it stays a plain field.
+     *
+     * Only a gesture still holding the field owes anything, which is what a mouse press does and a
+     * finished tap does not. Focus arriving from the keyboard records nothing at all — `Home` and
+     * `Left` both collapse a full selection onto offset 0, the same shape a click there has, and
+     * `Left` is how a screen reader reads a field it has just landed on.
+     */
+    private var gestureCaret: Int? = null
+
     /** Written by [fieldFocus]; read by [rememberFieldDraft] to drive the select-on-focus rule. */
     internal var focused by mutableStateOf(false)
+
+    /** Written by [fieldFocus]: whether a pointer is on the field right now. See [gestureCaret]. */
+    internal var pressed = false
 
     /**
      * The value to hand to `BasicTextField`, built around the caller's [text].
@@ -84,6 +103,9 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
      * that from a caller refusing the edit.
      */
     fun accept(next: TextFieldValue, current: String, onText: (String) -> Unit) {
+        val owed = gestureCaret
+        gestureCaret = null
+        if (next.text == anchor && next.selection.collapsed && next.selection.end == owed) return
         // Compared against the last text this field produced, not against [current]: the field can
         // emit twice before the caller's state recomposes (batched IME edits), and the second
         // emission would be measured against a value already one edit stale — dropping the newer
@@ -111,6 +133,12 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
     fun focusGained(text: String, selectAll: Boolean) {
         val selectable = !masked && singleLine
         if (!selectAll || !selectable || text.isEmpty()) return
+        // The caret the focusing gesture already placed, and only while that gesture is still under
+        // a finger or a button — one that is over reports once, before this runs, and owes nothing.
+        // Its repeat on the release is ignored; a click anywhere else is the user asking to edit in
+        // place. With nothing on record the click landed on offset 0 — that is the caret an
+        // unfocused field is handed, and a gesture that does not move it is never reported at all.
+        gestureCaret = if (!pressed) null else if (anchor == text) selection?.end else 0
         anchor = text
         selection = TextRange(0, text.length)
         emitted = false
@@ -124,6 +152,7 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
         anchor = null
         lastCurrent = null
         emitted = false
+        gestureCaret = null
         selection = null
         composition = null
     }
@@ -167,5 +196,22 @@ internal fun rememberSeededDraft(text: String, vararg keys: Any?): FieldDraft {
 }
 
 /** Feeds focus changes into [draft]; goes on the `BasicTextField` itself, not on its decoration. */
-internal fun Modifier.fieldFocus(draft: FieldDraft): Modifier =
-    onFocusChanged { draft.focused = it.isFocused }
+internal fun Modifier.fieldFocus(draft: FieldDraft): Modifier = this
+    .onFocusChanged { draft.focused = it.isFocused }
+    // Watched in the initial pass and never consumed: the field's own handlers still see every
+    // event. This only tells focus that arrived under a finger or a mouse button from focus that
+    // arrived off the keyboard, which owes no caret write and must not have one taken.
+    .pointerInput(draft) {
+        // The gesture can end by being cancelled rather than released — the field leaving
+        // composition under a finger, a parent taking the stream over — and a flag left standing
+        // would make the next keyboard focus owe a write it never received.
+        try {
+            awaitPointerEventScope {
+                while (true) {
+                    draft.pressed = awaitPointerEvent(PointerEventPass.Initial).changes.any { it.pressed }
+                }
+            }
+        } finally {
+            draft.pressed = false
+        }
+    }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
@@ -1,0 +1,171 @@
+package app.skerry.ui.design
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+
+/**
+ * Caret state for a text field whose value lives outside it as a plain [String].
+ *
+ * `BasicTextField`'s String overload seeds its own caret at offset 0 and never moves it on focus,
+ * so a prefilled field typed into after Tab or an autofocus prepends instead of replacing. This
+ * holds the missing piece — selection and IME composition — next to the caller's string, and keeps
+ * the two in step: a caret only survives for the exact text it was measured against.
+ */
+@Stable
+internal class FieldDraft(private val masked: Boolean = false, private val singleLine: Boolean = true) {
+    /** The text [selection] was measured against; a value replaced from outside no longer matches. */
+    private var anchor by mutableStateOf<String?>(null)
+    private var selection by mutableStateOf<TextRange?>(null)
+    private var composition by mutableStateOf<TextRange?>(null)
+
+    /** The caller's value as of the last [accept]; a change means it was replaced from outside. */
+    private var lastCurrent by mutableStateOf<String?>(null)
+
+    /** Whether the last [accept] handed the caller new text — see [caretIn]. */
+    private var emitted by mutableStateOf(false)
+
+    /** Written by [fieldFocus]; read by [rememberFieldDraft] to drive the select-on-focus rule. */
+    internal var focused by mutableStateOf(false)
+
+    /**
+     * The value to hand to `BasicTextField`, built around the caller's [text].
+     *
+     * A single-line field taking focus with no caret of its own starts after the text, where an
+     * editor puts it, never at offset 0, which turns the first keystroke into a prepend. A
+     * multi-line one starts at the top the way a file opens in the editor — its content is read
+     * before it is edited, and the end of it may be several screens down.
+     *
+     * A [text] that no longer matches the caret's [anchor] changed while the field held it. A
+     * caller only ever takes away from what it was handed — `capNotes` truncates, a sanitizer
+     * strips — so a text no lengthier than the one emitted is that edit coming back, and the
+     * offset it was typed at survives, clamped. A text that grew came from somewhere else (the
+     * port refilled when the protocol changes) and starts at its end. Either way the range goes:
+     * one measured against text that is gone means nothing.
+     *
+     * An unfocused field keeps the caret at the start: the field scrolls to follow the caret
+     * whether it has focus or not (`TextFieldScroll`), and a value wider than its box would
+     * otherwise sit there showing its tail with the beginning clipped.
+     */
+    fun textFieldValue(text: String): TextFieldValue = when {
+        anchor == text -> TextFieldValue(text, selection ?: TextRange(text.length), composition)
+        anchor != null -> TextFieldValue(text, TextRange(caretIn(text)))
+        focused && singleLine -> TextFieldValue(text, TextRange(text.length))
+        else -> TextFieldValue(text)
+    }
+
+    /** Where the caret lands in a [text] the caller rewrote or replaced; see [textFieldValue]. */
+    private fun caretIn(text: String): Int {
+        // Both halves are needed. Without [emitted], a replacement that happens to be as wide as the
+        // value it replaces (RDP 3389 to VNC 5900) reads as a rewrite and keeps a caret from the
+        // middle of the old one; without the length, an edit still in flight when the value is
+        // replaced (the stepper's + button) reads as a rewrite of text the caller never saw.
+        val rewritten = emitted && text.length <= (anchor?.length ?: 0)
+        return if (rewritten) (selection?.end ?: text.length).coerceAtMost(text.length) else text.length
+    }
+
+    /**
+     * Take the caret back from the field after an edit, a click or a drag, and forward the text to
+     * [onText] — but only when it actually changed. The String overload of `BasicTextField` filters
+     * that call itself; every caret move reaching a caller's setter would re-run its side effects
+     * (clearing an error banner, committing a setting) on nothing more than a click. A caller free
+     * to store something other than what it was handed — a capped note, a sanitized parameter — is
+     * accounted for by [textFieldValue], which keeps the caret across the rewrite. What [onText]
+     * must not do is act on being called rather than on the text: an edit and a caret move landing
+     * in the same frame can hand it the same string twice, and no signal available here separates
+     * that from a caller refusing the edit.
+     */
+    fun accept(next: TextFieldValue, current: String, onText: (String) -> Unit) {
+        // Compared against the last text this field produced, not against [current]: the field can
+        // emit twice before the caller's state recomposes (batched IME edits), and the second
+        // emission would be measured against a value already one edit stale — dropping the newer
+        // text. Once [current] itself moves, though, the caller has replaced the value and its own
+        // string is the baseline again — otherwise a field whose value was set from outside would
+        // swallow an edit that happens to reproduce the text this field last emitted.
+        val previous = if (lastCurrent == current) anchor ?: current else current
+        lastCurrent = current
+        anchor = next.text
+        selection = next.selection
+        composition = next.composition
+        // Also when the field and the caller simply disagree: a caller free to refuse an edit (the
+        // web-access password ignores input while a save is in flight) leaves its own value where
+        // it was, so the retyped character would match the text this field last emitted and the key
+        // would go dead for good.
+        emitted = next.text != previous || next.text != current
+        if (emitted) onText(next.text)
+    }
+
+    /**
+     * Focus arrived: select the whole value when the caller says it is still a default. Masked
+     * input and multi-line areas never do, whatever they ask for — a selected password reveals its
+     * length, and a pasted key is edited, not replaced wholesale.
+     */
+    fun focusGained(text: String, selectAll: Boolean) {
+        val selectable = !masked && singleLine
+        if (!selectAll || !selectable || text.isEmpty()) return
+        anchor = text
+        selection = TextRange(0, text.length)
+        emitted = false
+        // A composing region under a full selection is about to be committed anyway; keeping it
+        // would restart the IME with a stale range.
+        composition = null
+    }
+
+    /** Focus left: forget the caret so the next visit starts from a known state. */
+    fun focusLost() {
+        anchor = null
+        lastCurrent = null
+        emitted = false
+        selection = null
+        composition = null
+    }
+}
+
+/**
+ * Remembers a [FieldDraft] for a field currently showing [text], selecting the whole value when the
+ * field takes focus and [selectAllOnFocus] holds (a still-default port, a name arriving prefilled
+ * for a rename). Everything else keeps the caret where it was put. [masked] and [singleLine]
+ * describe the shape of the field, are the same values its `BasicTextField` is given, and do not
+ * change over its life — the draft is rebuilt if they do, and a rebuilt one has no caret.
+ */
+@Composable
+internal fun rememberFieldDraft(
+    text: String,
+    selectAllOnFocus: Boolean = false,
+    masked: Boolean = false,
+    singleLine: Boolean = true,
+): FieldDraft {
+    val draft = remember(masked, singleLine) { FieldDraft(masked, singleLine) }
+    // An effect rather than the focus callback: a tap requests focus and then drops the caret at
+    // the tapped offset inside the same gesture, so a selection made while the focus is being
+    // granted is undone by the very click that asked for it. Applying it once the gesture is over
+    // — the effect runs after the recomposition it triggered — outlives both paths, click and Tab.
+    LaunchedEffect(draft.focused) {
+        if (draft.focused) draft.focusGained(text, selectAllOnFocus) else draft.focusLost()
+    }
+    return draft
+}
+
+/**
+ * A [FieldDraft] for a find or filter bar: [text] is selected on focus for as long as it is the
+ * value the bar opened with — reopened over a query carried in from the last time, the next
+ * keystroke starts a new search; once the user has typed over it, clicking back in refines instead
+ * of wiping. [keys] are what makes the bar a new one (the pane and path behind a file filter).
+ */
+@Composable
+internal fun rememberSeededDraft(text: String, vararg keys: Any?): FieldDraft {
+    val seeded = remember(*keys) { text }
+    return rememberFieldDraft(text, selectAllOnFocus = text == seeded && text.isNotEmpty())
+}
+
+/** Feeds focus changes into [draft]; goes on the `BasicTextField` itself, not on its decoration. */
+internal fun Modifier.fieldFocus(draft: FieldDraft): Modifier =
+    onFocusChanged { draft.focused = it.isFocused }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/SectionChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/SectionChrome.kt
@@ -124,13 +124,14 @@ fun SidebarSearchField(
     placeholder: String,
     modifier: Modifier = Modifier,
 ) {
+    val draft = rememberFieldDraft(value)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = true,
         textStyle = TextStyle(color = Skerry.colors.text, fontSize = 12.5.sp, fontFamily = LocalFonts.current.ui),
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = modifier,
+        modifier = modifier.fieldFocus(draft),
         decorationBox = { inner ->
             Row(
                 Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
@@ -42,6 +42,8 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberSeededDraft
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_fkey_edit
@@ -338,6 +340,7 @@ private fun EditorSearchBar(
 ) {
     val focus = remember { FocusRequester() }
     LaunchedEffect(Unit) { runCatching { focus.requestFocus() } }
+    val draft = rememberSeededDraft(query)
     Row(
         Modifier.fillMaxWidth().background(Skerry.colors.panel).padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -346,14 +349,15 @@ private fun EditorSearchBar(
         Sym("search", size = 15.sp, color = Skerry.colors.cyanBright)
         Txt(stringResource(Res.string.sftp_edit_find), color = Skerry.colors.faint, size = 11.5.sp)
         BasicTextField(
-            value = query,
-            onValueChange = onQueryChange,
+            value = draft.textFieldValue(query),
+            onValueChange = { draft.accept(it, query, onQueryChange) },
             singleLine = true,
             textStyle = TextStyle(color = Skerry.colors.textBright, fontSize = 12.sp, fontFamily = mono),
             cursorBrush = SolidColor(Skerry.colors.cyan),
             modifier = Modifier
                 .weight(1f)
                 .focusRequester(focus)
+                .fieldFocus(draft)
                 .onPreviewKeyEvent { event ->
                     if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                     when (event.key) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/GroupDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/GroupDialog.kt
@@ -44,6 +44,8 @@ import app.skerry.ui.generated.resources.shell_create
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Txt
@@ -66,6 +68,9 @@ fun GroupDialog(
     var name by remember { mutableStateOf(initialName) }
     val focus = remember { FocusRequester() }
     LaunchedEffect(Unit) { runCatching { focus.requestFocus() } }
+    // Renaming opens on the old name, autofocused: select it so typing replaces it instead of
+    // landing in front of it. Creating starts empty and has nothing to select.
+    val draft = rememberFieldDraft(name, selectAllOnFocus = editing && name == initialName)
     val canSave = name.trim().isNotEmpty()
     val save = { if (canSave) onSave(name) }
     ModalScrim(onDismiss = onDismiss) {
@@ -93,14 +98,14 @@ fun GroupDialog(
             // Border/placeholder live in decorationBox + fillMaxWidth so a click anywhere in the
             // field places the caret.
             BasicTextField(
-                value = name,
-                onValueChange = { name = it },
+                value = draft.textFieldValue(name),
+                onValueChange = { draft.accept(it, name) { name = it } },
                 singleLine = true,
                 textStyle = TextStyle(color = Skerry.colors.text, fontSize = 13.sp, fontFamily = LocalFonts.current.ui),
                 cursorBrush = SolidColor(Skerry.colors.cyan),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { save() }),
-                modifier = Modifier.fillMaxWidth().focusRequester(focus),
+                modifier = Modifier.fillMaxWidth().focusRequester(focus).fieldFocus(draft),
                 decorationBox = { inner ->
                     Row(
                         Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFields.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFields.kt
@@ -54,6 +54,8 @@ import app.skerry.ui.generated.resources.conn_test_rtt_ms
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.ai.PolicyOption
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
@@ -88,6 +90,11 @@ internal fun ModalTextField(
     singleLine: Boolean = true,
     mono: Boolean = false,
     minHeightDp: Int? = null,
+    /**
+     * Select the whole value when the field takes focus, so the next keystroke replaces it. For a
+     * value the form filled in itself (a still-default port) — never for one the user typed.
+     */
+    selectAllOnFocus: Boolean = false,
     /** Drawn at the right edge, inside the border — the serial device field hangs its menu arrow here. */
     trailing: (@Composable () -> Unit)? = null,
 ) {
@@ -98,16 +105,19 @@ internal fun ModalTextField(
     val textStyle = remember(family, fontSize, textColor) {
         TextStyle(color = textColor, fontSize = fontSize, fontFamily = family, lineHeight = if (mono) 16.sp else 18.sp)
     }
+    // Masked input and multi-line areas keep the plain caret: a selected password reveals its
+    // length, and replacing a whole pasted key wholesale is not what the field is for.
+    val draft = rememberFieldDraft(value, selectAllOnFocus, masked, singleLine)
     // Border/icon live in decorationBox so a click anywhere on the field places the caret.
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = singleLine,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         visualTransformation = if (masked) PasswordVisualTransformation() else VisualTransformation.None,
         keyboardOptions = KeyboardOptions(keyboardType = if (masked) KeyboardType.Password else keyboardType),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Row(
                 Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -86,13 +86,20 @@ class NewConnectionFormState {
      */
     fun chooseConnectionType(type: ConnectionType) {
         if (type == connectionType) return
-        if (port.trim() == defaultPortFor(connectionType).toString()) {
+        if (isDefaultPort) {
             port = defaultPortFor(type).toString()
         }
         if (!type.usesSshAuth) jumpHostId = null
         if (type.isVnc) dropNonVncAuth()
         connectionType = type
     }
+
+    /**
+     * True while [port] still holds the current transport's default — the value the form filled in
+     * itself, not one the user typed. Drives the port substitution in [chooseConnectionType] and
+     * the select-on-focus rule of the port field.
+     */
+    val isDefaultPort: Boolean get() = port.trim() == defaultPortFor(connectionType).toString()
 
     /**
      * VNC auth is password-only: leftover key state — or an already-picked saved secret, possibly

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -267,7 +267,13 @@ fun NewConnectionModal(state: DesktopDesignState, editHost: Host? = null, duplic
                         }
                     }
                     Field(if (serial) stringResource(Res.string.conn_field_baud) else stringResource(Res.string.conn_field_port), Modifier.width(110.dp)) {
-                        ModalTextField(form.port, { form.port = it }, if (serial) "9600" else "22", keyboardType = KeyboardType.Number)
+                        // Still the transport's own default (22 / 23 / 3389 / 5900 / 9600 baud) —
+                        // select it on focus so typing replaces it. A port the user set stays put.
+                        ModalTextField(
+                            form.port, { form.port = it }, if (serial) "9600" else "22",
+                            keyboardType = KeyboardType.Number,
+                            selectAllOnFocus = form.isDefaultPort,
+                        )
                     }
                 }
                 // Auth follows the SSH path (SSH and Mosh): Telnet enters login/password in the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
@@ -45,6 +45,8 @@ import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberSeededDraft
 import app.skerry.ui.theme.Skerry
 
 /**
@@ -157,23 +159,26 @@ internal fun MobileFilesBreadcrumbRow(
 internal fun MobileFilterRow(pane: FilePaneController, mono: FontFamily, onClose: () -> Unit) {
     var text by remember(pane, pane.path) { mutableStateOf(pane.nameFilter) }
     // Focus the field the moment the row appears (funnel tap), so typing starts immediately.
-    val fieldFocus = remember { FocusRequester() }
-    LaunchedEffect(Unit) { fieldFocus.requestFocus() }
+    val focus = remember { FocusRequester() }
+    val draft = rememberSeededDraft(text, pane, pane.path)
+    LaunchedEffect(Unit) { focus.requestFocus() }
     Row(
         Modifier.fillMaxWidth().padding(start = 22.dp, end = 16.dp, top = 6.dp, bottom = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         BasicTextField(
-            value = text,
+            value = draft.textFieldValue(text),
             onValueChange = {
-                text = it
-                pane.setNameFilter(it)
+                draft.accept(it, text) { changed ->
+                    text = changed
+                    pane.setNameFilter(changed)
+                }
             },
             singleLine = true,
             textStyle = TextStyle(color = Skerry.colors.text, fontSize = 13.sp, fontFamily = mono),
             cursorBrush = SolidColor(Skerry.colors.cyan),
-            modifier = Modifier.weight(1f).focusRequester(fieldFocus),
+            modifier = Modifier.weight(1f).focusRequester(focus).fieldFocus(draft),
             decorationBox = { inner ->
                 Box(
                     Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 
 /**
@@ -68,6 +70,8 @@ internal fun MobileFormInput(
     background: Color = Skerry.colors.bg,
     minHeightDp: Int? = null,
     imeAction: ImeAction = ImeAction.Default,
+    /** See `ModalTextField`: select the prefilled value on focus so the next keystroke replaces it. */
+    selectAllOnFocus: Boolean = false,
     onSubmit: (() -> Unit)? = null,
 ) {
     val fonts = LocalFonts.current
@@ -77,10 +81,11 @@ internal fun MobileFormInput(
     val textStyle = remember(family, fontSize, textColor) {
         TextStyle(color = textColor, fontSize = fontSize, fontFamily = family, lineHeight = if (mono) 17.sp else 20.sp)
     }
+    val draft = rememberFieldDraft(value, selectAllOnFocus, masked, singleLine)
     // Border/padding live in decorationBox so a click anywhere in the field places the caret.
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = singleLine,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
@@ -91,7 +96,7 @@ internal fun MobileFormInput(
         } else {
             KeyboardActions.Default
         },
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(
                 Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileGroupDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileGroupDialogs.kt
@@ -135,7 +135,8 @@ internal fun MobileGroupRenameDialog(
         Spacer(Modifier.height(6.dp))
         Txt(stringResource(Res.string.conn_group_rename_hint), color = Skerry.colors.dim, size = 12.5.sp)
         Spacer(Modifier.height(14.dp))
-        MobileFormInput(name, { name = it }, "Production")
+        // Prefilled with the old name: selected on focus, so a tap and a keystroke replace it.
+        MobileFormInput(name, { name = it }, "Production", selectAllOnFocus = name == initialName)
         Spacer(Modifier.height(18.dp))
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             Box(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -240,7 +240,7 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                         MobileFormInput(form.username, { form.username = it }, "root")
                     }
                     MobileFormField(stringResource(Res.string.conn_field_port), Modifier.width(84.dp)) {
-                        MobileFormInput(form.port, { form.port = it }, "22", keyboardType = KeyboardType.Number)
+                        MobileFormInput(form.port, { form.port = it }, "22", keyboardType = KeyboardType.Number, selectAllOnFocus = form.isDefaultPort)
                     }
                 }
                 Spacer(Modifier.height(14.dp))
@@ -264,7 +264,7 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
                         MobileFormInput(form.username, { form.username = it }, "Administrator")
                     }
                     MobileFormField(stringResource(Res.string.conn_field_port), Modifier.width(84.dp)) {
-                        MobileFormInput(form.port, { form.port = it }, "3389", keyboardType = KeyboardType.Number)
+                        MobileFormInput(form.port, { form.port = it }, "3389", keyboardType = KeyboardType.Number, selectAllOnFocus = form.isDefaultPort)
                     }
                 }
                 Spacer(Modifier.height(14.dp))
@@ -287,7 +287,7 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
             } else if (form.connectionType.isVnc) {
                 // VNC: a password (no username), plus the RFB port. No jump host / keep-alive.
                 MobileFormField(stringResource(Res.string.conn_field_port), Modifier.width(120.dp)) {
-                    MobileFormInput(form.port, { form.port = it }, "5900", keyboardType = KeyboardType.Number)
+                    MobileFormInput(form.port, { form.port = it }, "5900", keyboardType = KeyboardType.Number, selectAllOnFocus = form.isDefaultPort)
                 }
                 Spacer(Modifier.height(14.dp))
                 MobileFormField(stringResource(Res.string.conn_field_authentication)) { MobileAuthPicker(form, allowKey = false) }
@@ -295,7 +295,7 @@ fun MobileNewConnectionSheet(state: MobileDesignState) {
             } else {
                 // Telnet/Serial: no authentication; show only port/baud.
                 MobileFormField(if (serial) stringResource(Res.string.conn_field_baud) else stringResource(Res.string.conn_field_port), Modifier.width(120.dp)) {
-                    MobileFormInput(form.port, { form.port = it }, if (serial) "9600" else "23", keyboardType = KeyboardType.Number)
+                    MobileFormInput(form.port, { form.port = it }, if (serial) "9600" else "23", keyboardType = KeyboardType.Number, selectAllOnFocus = form.isDefaultPort)
                 }
                 Spacer(Modifier.height(14.dp))
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -113,6 +113,8 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 
 /**
@@ -375,7 +377,7 @@ private fun MobileTunnelEditorSheet(
             MobileFormField(stringResource(Res.string.ports_field_via_host)) { MobileHostPicker(hostName, hostList.map { it.id to it.label }) { form.hostId = it } }
             Spacer(Modifier.height(14.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                MobileFormField(stringResource(Res.string.ports_field_bind_address), Modifier.weight(1f)) { PortInput(form.bindHost, { form.bindHost = it }, "127.0.0.1", mono) }
+                MobileFormField(stringResource(Res.string.ports_field_bind_address), Modifier.weight(1f)) { PortInput(form.bindHost, { form.bindHost = it }, TunnelFormState.DEFAULT_BIND_HOST, mono, selectAllOnFocus = form.isDefaultBindHost) }
                 MobileFormField(stringResource(Res.string.ports_field_port), Modifier.width(96.dp)) { PortInput(form.bindPort, { form.bindPort = it }, "8080", mono, KeyboardType.Number) }
             }
             BindExposureWarning(form.bindHost)
@@ -607,18 +609,27 @@ private fun MobileHostPicker(current: String, options: List<Pair<String, String>
 
 /** Field label + content, matching the New connection sheet's field idiom. */
 @Composable
-private fun PortInput(value: String, onValueChange: (String) -> Unit, placeholder: String, mono: FontFamily, keyboardType: KeyboardType = KeyboardType.Text) {
+private fun PortInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    mono: FontFamily,
+    keyboardType: KeyboardType = KeyboardType.Text,
+    /** See `ModalTextField`: select the prefilled value on focus so the next keystroke replaces it. */
+    selectAllOnFocus: Boolean = false,
+) {
     val textColor = Skerry.colors.text
     val textStyle = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 15.sp, fontFamily = mono) }
+    val draft = rememberFieldDraft(value, selectAllOnFocus)
     // Border lives in decorationBox so a click anywhere in the field places the caret.
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = true,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(11.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(11.dp)).padding(horizontal = 14.dp, vertical = 13.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -347,6 +347,8 @@ private fun MobileRenameTagSheet(oldTag: String, onDismiss: () -> Unit, onSave: 
                 { name = it },
                 stringResource(Res.string.lib_snippets_rename_tag_placeholder),
                 imeAction = ImeAction.Done,
+                // The old tag arrives prefilled: select it so typing replaces the name.
+                selectAllOnFocus = name == oldTag,
                 onSubmit = save,
             )
             MobileSheetButton(stringResource(Res.string.shell_save), onClick = save, modifier = Modifier.fillMaxWidth())

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookEditorFields.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookEditorFields.kt
@@ -32,6 +32,8 @@ import app.skerry.ui.design.Chip
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.labelUppercase
@@ -283,13 +285,14 @@ private fun RunbookLineField(
 ) {
     val textColor = Skerry.colors.text
     val style = remember(font, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = font) }
+    val draft = rememberFieldDraft(value, singleLine = singleLine)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = singleLine,
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg)
@@ -307,12 +310,13 @@ private fun RunbookLineField(
 private fun RunbookCommandField(value: String, onValueChange: (String) -> Unit, placeholder: String, mono: FontFamily) {
     val textColor = Skerry.colors.textBright
     val style = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = mono) }
+    val draft = rememberFieldDraft(value, singleLine = false)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(
                 Modifier.fillMaxWidth().heightIn(min = 44.dp).clip(RoundedCornerShape(8.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/TerminalSection.kt
@@ -30,6 +30,8 @@ import app.skerry.ui.design.Badge
 import app.skerry.ui.design.DropdownField
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.NumberStepper
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
@@ -241,13 +243,14 @@ private fun LocalShellField(value: String, onChange: (String) -> Unit) {
     val textColor = Skerry.colors.text
     val textStyle = remember(fonts.ui, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = fonts.ui) }
     val placeholder = stringResource(Res.string.conn_field_shell_placeholder)
+    val draft = rememberFieldDraft(value)
     BasicTextField(
-        value = value,
-        onValueChange = onChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onChange) },
         singleLine = true,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Row(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpDialogs.kt
@@ -61,6 +61,8 @@ import app.skerry.ui.generated.resources.sftp_what_single
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
@@ -94,21 +96,25 @@ internal fun NameDialog(
     val ok = valid && !conflict
     val submit = { if (ok) onConfirm(trimmed) }
     // Autofocus: the field should be ready for input the moment the dialog opens, without a click.
-    val fieldFocus = remember { FocusRequester() }
-    LaunchedEffect(Unit) { fieldFocus.requestFocus() }
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focus.requestFocus() }
+    // Rename opens on the current name, autofocused: select all of it — extension included, since
+    // renaming report.log to notes.txt replaces both halves. "New folder" opens empty.
+    val draft = rememberFieldDraft(name, selectAllOnFocus = name == initial)
     SftpDialogFrame(onDismiss = onDismiss) {
             Txt(title, color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
             // Border in decorationBox so a click anywhere in the field places the caret.
             BasicTextField(
-                value = name,
-                onValueChange = { name = it },
+                value = draft.textFieldValue(name),
+                onValueChange = { draft.accept(it, name) { name = it } },
                 singleLine = true,
                 textStyle = TextStyle(color = Skerry.colors.text, fontSize = 13.sp, fontFamily = mono),
                 cursorBrush = SolidColor(Skerry.colors.cyan),
                 // Enter confirms (if the name is valid), Esc closes — handler before the focusable field.
                 modifier = Modifier
                     .fillMaxWidth()
-                    .focusRequester(fieldFocus)
+                    .focusRequester(focus)
+                    .fieldFocus(draft)
                     .onPreviewKeyEvent { event ->
                         if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
                         when (event.key) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
@@ -62,6 +62,8 @@ import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberSeededDraft
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.design.Badge
 
@@ -208,14 +210,15 @@ private fun PaneFilterField(
     restoreFocus: () -> Unit,
 ) {
     var text by remember(pane, pane.path) { mutableStateOf(pane.nameFilter) }
-    val fieldFocus = remember { FocusRequester() }
+    val focus = remember { FocusRequester() }
+    val draft = rememberSeededDraft(text, pane, pane.path)
     val clearAndClose = {
         pane.setNameFilter("")
         onClose()
         restoreFocus()
     }
     // Each Ctrl+F press (tick increment) refocuses the field, including when the row is already open.
-    LaunchedEffect(focusTick) { if (focusTick > 0) fieldFocus.requestFocus() }
+    LaunchedEffect(focusTick) { if (focusTick > 0) focus.requestFocus() }
     // The row can leave composition while focused (Esc path, listing reload) — release the standdown.
     DisposableEffect(Unit) { onDispose { onEditing(false) } }
     Row(
@@ -225,17 +228,20 @@ private fun PaneFilterField(
     ) {
         Sym("filter_alt", size = 14.sp, color = Skerry.colors.faint)
         BasicTextField(
-            value = text,
+            value = draft.textFieldValue(text),
             onValueChange = {
-                text = it
-                pane.setNameFilter(it)
+                draft.accept(it, text) { changed ->
+                    text = changed
+                    pane.setNameFilter(changed)
+                }
             },
             singleLine = true,
             textStyle = TextStyle(color = Skerry.colors.textBright, fontSize = 11.5.sp, fontFamily = mono),
             cursorBrush = SolidColor(Skerry.colors.cyan),
             modifier = Modifier
                 .weight(1f)
-                .focusRequester(fieldFocus)
+                .focusRequester(focus)
+                .fieldFocus(draft)
                 .onFocusChanged { onEditing(it.isFocused) }
                 .onPreviewKeyEvent { event ->
                     if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
@@ -55,6 +55,8 @@ import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.FieldLabel
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
@@ -298,13 +300,14 @@ private fun ShortcutField(value: String?, mono: FontFamily, conflictText: String
 private fun EditField(value: String, onValueChange: (String) -> Unit, placeholder: String, font: FontFamily) {
     val textColor = Skerry.colors.text
     val textStyle = remember(font, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = font) }
+    val draft = rememberFieldDraft(value)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = true,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp)) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = font)
@@ -319,12 +322,13 @@ private fun EditField(value: String, onValueChange: (String) -> Unit, placeholde
 private fun CommandField(value: String, onValueChange: (String) -> Unit, placeholder: String, mono: FontFamily) {
     val textColor = Skerry.colors.textBright
     val textStyle = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = mono) }
+    val draft = rememberFieldDraft(value, singleLine = false)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).padding(horizontal = 16.dp, vertical = 14.dp)) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = mono)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
@@ -40,6 +40,8 @@ import app.skerry.ui.design.Chip
 import app.skerry.ui.design.FilterChipRow
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
@@ -171,6 +173,8 @@ private fun RenameTagDialog(initialName: String, onDismiss: () -> Unit, onSave: 
     var name by remember { mutableStateOf(initialName) }
     val focus = remember { FocusRequester() }
     LaunchedEffect(Unit) { runCatching { focus.requestFocus() } }
+    // The old tag arrives prefilled and autofocused: select it so typing replaces the name.
+    val draft = rememberFieldDraft(name, selectAllOnFocus = name == initialName)
     val canSave = name.trim().isNotEmpty()
     val save = { if (canSave) onSave(name) }
     ModalScrim(onDismiss = onDismiss) {
@@ -195,14 +199,14 @@ private fun RenameTagDialog(initialName: String, onDismiss: () -> Unit, onSave: 
                 modifier = Modifier.padding(top = 4.dp, bottom = 16.dp),
             )
             BasicTextField(
-                value = name,
-                onValueChange = { name = it },
+                value = draft.textFieldValue(name),
+                onValueChange = { draft.accept(it, name) { name = it } },
                 singleLine = true,
                 textStyle = TextStyle(color = Skerry.colors.text, fontSize = 13.sp, fontFamily = LocalFonts.current.ui),
                 cursorBrush = SolidColor(Skerry.colors.cyan),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
                 keyboardActions = KeyboardActions(onDone = { save() }),
-                modifier = Modifier.fillMaxWidth().focusRequester(focus),
+                modifier = Modifier.fillMaxWidth().focusRequester(focus).fieldFocus(draft),
                 decorationBox = { inner ->
                     Row(
                         Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
@@ -44,7 +44,9 @@ import app.skerry.ui.design.KeyValueRow
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_clipboard_ref
 import app.skerry.ui.generated.resources.lib_snippets_copied
@@ -262,13 +264,16 @@ private fun VariableRow(
 private fun ParamInput(value: String, onValueChange: (String) -> Unit, mono: FontFamily, modifier: Modifier = Modifier) {
     val textColor = Skerry.colors.text
     val style = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 11.5.sp, fontFamily = mono) }
+    // The caller sanitizes what it stores, so the caret has to survive a value coming back
+    // rewritten — see FieldDraft.
+    val draft = rememberFieldDraft(value)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = true,
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = modifier,
+        modifier = modifier.fieldFocus(draft),
         decorationBox = { inner ->
             Box(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(Skerry.colors.bg)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
@@ -37,6 +37,8 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.design.FieldLabel
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippet_vars_clipboard
@@ -83,6 +85,12 @@ class TemplateVariableValues internal constructor(
     internal val vaultResolutions: Map<String, VaultRef>,
     internal val params: SnapshotStateMap<String, String>,
 ) {
+    /** What each parameter was seeded with — the template's default, or the previous run's value. */
+    private val seeded: Map<String, String> = params.toMap()
+
+    /** True while [name] still holds what the form put there, so its field may select on focus. */
+    internal fun isSeeded(name: String): Boolean = params[name] == seeded[name]
+
     /** Clipboard contents; `null` while still being read. */
     internal var clipboard: String? by mutableStateOf(null)
 
@@ -159,6 +167,9 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
                 value = values.params[name].orEmpty(),
                 onChange = { values.params[name] = sanitizeSnippetValue(it) },
                 modifier = if (index == 0) Modifier.focusRequester(firstFieldFocus) else Modifier,
+                // The default from the template (or the previous run) is a suggestion: select it, so
+                // the autofocused first field takes a replacement rather than a prefix.
+                selectAllOnFocus = values.isSeeded(name),
             )
         }
     }
@@ -200,18 +211,19 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
 }
 
 @Composable
-private fun ParamField(value: String, onChange: (String) -> Unit, modifier: Modifier = Modifier) {
+private fun ParamField(value: String, onChange: (String) -> Unit, modifier: Modifier = Modifier, selectAllOnFocus: Boolean = false) {
     val mono = LocalFonts.current.mono
     val textColor = Skerry.colors.text
     val style = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 12.5.sp, fontFamily = mono) }
+    val draft = rememberFieldDraft(value, selectAllOnFocus)
     Box(
         Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg)
             .border(1.dp, Skerry.colors.line, RoundedCornerShape(7.dp)).padding(horizontal = 9.dp, vertical = 7.dp),
     ) {
         BasicTextField(
-            value, onChange, singleLine = true, textStyle = style,
+            draft.textFieldValue(value), { draft.accept(it, value, onChange) }, singleLine = true, textStyle = style,
             cursorBrush = SolidColor(Skerry.colors.cyan),
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth().fieldFocus(draft),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
@@ -44,6 +44,8 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sync_back
@@ -528,15 +530,18 @@ internal fun SyncTextField(
     val ui = LocalFonts.current.ui
     val textColor = Skerry.colors.text
     val style = remember(ui, textColor) { TextStyle(color = textColor, fontSize = 15.sp, fontFamily = ui, lineHeight = 20.sp) }
+    // No select-on-focus: a saved server URL is edited, not replaced. [masked] is passed anyway,
+    // so the rule holds if this field is ever armed.
+    val draft = rememberFieldDraft(value, masked = masked)
     BasicTextField(
-        value = value,
-        onValueChange = onChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onChange) },
         singleLine = true,
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         visualTransformation = if (masked) PasswordVisualTransformation() else VisualTransformation.None,
         keyboardOptions = KeyboardOptions(keyboardType = if (masked) KeyboardType.Password else keyboardType),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Row(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(11.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(11.dp)).padding(horizontal = 14.dp, vertical = 13.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
@@ -62,6 +62,8 @@ import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 
 /**
@@ -226,17 +228,20 @@ internal fun SyncField(
     val ui = LocalFonts.current.ui
     val textColor = Skerry.colors.text
     val style = remember(ui, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = ui) }
+    // No select-on-focus: a saved server URL is edited, not replaced. The draft is still here for
+    // the caret, which otherwise starts at offset 0 on a prefilled field.
+    val draft = rememberFieldDraft(value, masked = secret)
     // Capsule/padding/icon live in decorationBox so a click anywhere in the field places the caret.
     BasicTextField(
-        value = value,
-        onValueChange = onChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onChange) },
         singleLine = true,
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         visualTransformation = if (secret) PasswordVisualTransformation() else VisualTransformation.None,
         keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = keyboardType),
         keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }, onSend = { onSubmit() }),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Row(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 10.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFields.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFields.kt
@@ -39,6 +39,8 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ports_no_saved_hosts
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 
@@ -53,17 +55,20 @@ internal fun EditField(
     placeholder: String,
     mono: FontFamily,
     keyboardType: KeyboardType = KeyboardType.Text,
+    /** See `ModalTextField`: select the prefilled value on focus so the next keystroke replaces it. */
+    selectAllOnFocus: Boolean = false,
 ) {
     val textColor = Skerry.colors.text
     val textStyle = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 12.5.sp, fontFamily = mono) }
+    val draft = rememberFieldDraft(value, selectAllOnFocus)
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
         singleLine = true,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft),
         decorationBox = { inner ->
             Box(fieldBox()) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, font = mono)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFormState.kt
@@ -22,11 +22,17 @@ class TunnelFormState private constructor(private val editingId: String?) {
     var label: String by mutableStateOf("")
     var direction: TunnelDirection by mutableStateOf(TunnelDirection.Local)
     var hostId: String? by mutableStateOf(null)
-    var bindHost: String by mutableStateOf("127.0.0.1")
+    var bindHost: String by mutableStateOf(DEFAULT_BIND_HOST)
     var bindPort: String by mutableStateOf("")
     var destHost: String by mutableStateOf("")
     var destPort: String by mutableStateOf("")
     var autostart: Boolean by mutableStateOf(false)
+
+    /**
+     * True while [bindHost] still holds the loopback the form filled in itself — the field selects
+     * it on focus so retyping it as `0.0.0.0` replaces the value instead of appending to it.
+     */
+    val isDefaultBindHost: Boolean get() = bindHost.trim() == DEFAULT_BIND_HOST
 
     /** SOCKS (`-D`) has no destination; the form hides the destination fields. */
     val isDynamic: Boolean get() = direction == TunnelDirection.Dynamic
@@ -41,6 +47,9 @@ class TunnelFormState private constructor(private val editingId: String?) {
             ?.copy(autostart = autostart)
 
     companion object {
+        /** Loopback: the bind address a tunnel gets unless the user widens it. */
+        const val DEFAULT_BIND_HOST = "127.0.0.1"
+
         /**
          * Form pre-filled from [entry] (edit), or empty with defaults (create, `entry == null`):
          * type `-L`, loopback bind host, empty ports.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
@@ -130,7 +130,7 @@ internal fun TunnelEditor(
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Column(Modifier.weight(1f)) {
                 FieldLabel(labelUppercase(stringResource(Res.string.ports_field_bind_address)), top = 0.dp)
-                EditField(form.bindHost, { form.bindHost = it }, "127.0.0.1", mono)
+                EditField(form.bindHost, { form.bindHost = it }, TunnelFormState.DEFAULT_BIND_HOST, mono, selectAllOnFocus = form.isDefaultBindHost)
             }
             Column(Modifier.width(70.dp)) {
                 FieldLabel(labelUppercase(stringResource(Res.string.ports_field_port)), top = 0.dp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
@@ -110,6 +110,8 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.shared.ssh.keyFileSiblingRef
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 
 @Composable
@@ -283,7 +285,8 @@ internal fun RenameSecretDialog(currentLabel: String, onDismiss: () -> Unit, onC
     val trimmed = name.trim()
     val valid = trimmed.isNotEmpty() && trimmed != currentLabel
     VaultDialogScaffold(stringResource(Res.string.vault_rename_title, currentLabel), null, onDismiss) {
-        DialogField(stringResource(Res.string.vault_field_name), name, { name = it }, placeholder = currentLabel)
+        // The old label arrives prefilled: select it so typing replaces the name outright.
+        DialogField(stringResource(Res.string.vault_field_name), name, { name = it }, placeholder = currentLabel, selectAllOnFocus = name == currentLabel)
         DialogButtons(confirmLabel = stringResource(Res.string.vault_rename), confirmEnabled = valid, onDismiss = onDismiss, onConfirm = { onConfirm(trimmed) })
     }
 }
@@ -351,6 +354,8 @@ internal fun DialogField(
     // Explicit keyboard type override: for visible but sensitive fields (PEM key) set
     // KeyboardType.Password — disables IME autocorrect/dictionary without visually masking input.
     keyboardType: KeyboardType? = null,
+    /** See `ModalTextField`: select the prefilled value on focus so the next keystroke replaces it. */
+    selectAllOnFocus: Boolean = false,
 ) {
     val ui = LocalFonts.current.ui
     val mono = LocalFonts.current.mono
@@ -383,14 +388,15 @@ internal fun DialogField(
             now = withFrameNanos { it }
         }
     }
+    val draft = rememberFieldDraft(value, selectAllOnFocus, masked = password, singleLine = singleLine)
     Column {
         Txt(label, color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 5.dp))
         // Capsule/padding live in decorationBox so a click anywhere in the field (incl. the empty area
         // below the caret in multi-line PEM/certificate fields) places the caret.
         BasicTextField(
-            value = value,
-            onValueChange = onValueChange,
-            modifier = Modifier.fillMaxWidth().onFocusChanged { focused = it.isFocused },
+            value = draft.textFieldValue(value),
+            onValueChange = { draft.accept(it, value, onValueChange) },
+            modifier = Modifier.fillMaxWidth().fieldFocus(draft).onFocusChanged { focused = it.isFocused },
             singleLine = singleLine,
             textStyle = style,
             cursorBrush = SolidColor(Skerry.colors.cyan),

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
@@ -48,6 +48,98 @@ class FieldDraftTest {
     }
 
     @Test
+    fun the_click_that_brought_focus_does_not_collapse_the_selection() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.pressed = true
+        // A mouse click reaches the field twice: the selection gesture drops the caret on the press,
+        // and `detectTapAndPress` drops it again at the same offset on the release. The selection
+        // goes on in between, so without this the whole value flashes selected and dies on release.
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        draft.focusGained("127.0.0.1", selectAll = true)
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        assertEquals(TextRange(0, 9), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun the_next_click_at_the_same_place_places_the_caret() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.pressed = true
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        draft.focusGained("127.0.0.1", selectAll = true)
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        // One write is ignored, not every write at that offset: the click after it is the user
+        // asking for the caret and must land.
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        assertEquals(TextRange(5), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun a_key_that_collapses_the_selection_after_keyboard_focus_lands() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // Tab, or a dialog autofocusing itself: no gesture, so nothing is owed. Home and Left both
+        // collapse a full selection onto offset 0 — the same shape a click there has — and Left is
+        // how a screen reader reads a field it has just landed on.
+        draft.focusGained("127.0.0.1", selectAll = true)
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(0)), "127.0.0.1") {}
+        assertEquals(TextRange(0), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun a_click_on_the_start_of_the_value_does_not_collapse_the_selection() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.pressed = true
+        // An unfocused field is handed a caret at offset 0, so a click landing there leaves the
+        // selection unchanged and the press is never reported — only the release arrives, and with
+        // nothing on record it would collapse the selection the focus had just made.
+        draft.focusGained("127.0.0.1", selectAll = true)
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(0)), "127.0.0.1") {}
+        assertEquals(TextRange(0, 9), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun a_tap_that_reported_once_leaves_nothing_owed() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // Touch reports a tap once, on the release, and the finger is up by the time the selection
+        // is made — so nothing is owed, and the next tap on the same character places the caret
+        // instead of being spent.
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        draft.focusGained("127.0.0.1", selectAll = true)
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        assertEquals(TextRange(5), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun a_drag_ending_where_the_press_began_still_selects() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.pressed = true
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        draft.focusGained("127.0.0.1", selectAll = true)
+        // Only a collapsed caret is ever spent. A range the user dragged out by hand is theirs,
+        // wherever it ends.
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(2, 5)), "127.0.0.1") {}
+        assertEquals(TextRange(2, 5), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
+    fun a_click_somewhere_else_still_places_the_caret() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.pressed = true
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(5)), "127.0.0.1") {}
+        draft.focusGained("127.0.0.1", selectAll = true)
+        // Only the offset the focusing gesture put the caret at is ignored. Clicking into the value
+        // afterwards means the user wants to edit it in place.
+        draft.accept(TextFieldValue("127.0.0.1", TextRange(2)), "127.0.0.1") {}
+        assertEquals(TextRange(2), draft.textFieldValue("127.0.0.1").selection)
+    }
+
+    @Test
     fun a_click_after_the_selection_collapses_it() {
         val draft = FieldDraft()
         draft.focusGained("22", selectAll = true)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
@@ -1,0 +1,228 @@
+package app.skerry.ui.design
+
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FieldDraftTest {
+
+    /** Records what a call site's `onValueChange` received, in order. */
+    private class Sink {
+        val texts = mutableListOf<String>()
+        val take: (String) -> Unit = { texts += it }
+    }
+
+    @Test
+    fun untouched_field_puts_the_caret_after_the_prefilled_text() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // The String overload of BasicTextField seeds TextRange.Zero, so typing into an autofocused
+        // rename dialog used to prepend: "report.log" + "x" -> "xreport.log".
+        assertEquals(TextRange(10), draft.textFieldValue("report.log").selection)
+    }
+
+    @Test
+    fun focus_selects_the_whole_value_when_armed() {
+        val draft = FieldDraft()
+        draft.focusGained("report.log", selectAll = true)
+        // The extension is part of the selection: renaming report.log to notes.txt replaces both.
+        assertEquals(TextRange(0, 10), draft.textFieldValue("report.log").selection)
+    }
+
+    @Test
+    fun focus_leaves_the_caret_alone_when_not_armed() {
+        val draft = FieldDraft()
+        draft.accept(TextFieldValue("2222", TextRange(2)), "2222") {}
+        draft.focusGained("2222", selectAll = false)
+        assertEquals(TextRange(2), draft.textFieldValue("2222").selection)
+    }
+
+    @Test
+    fun an_empty_value_is_not_selected() {
+        val draft = FieldDraft()
+        draft.focusGained("", selectAll = true)
+        assertTrue(draft.textFieldValue("").selection.collapsed)
+    }
+
+    @Test
+    fun a_click_after_the_selection_collapses_it() {
+        val draft = FieldDraft()
+        draft.focusGained("22", selectAll = true)
+        draft.accept(TextFieldValue("22", TextRange(1)), "22") {}
+        assertEquals(TextRange(1), draft.textFieldValue("22").selection)
+    }
+
+    @Test
+    fun a_caret_move_is_not_reported_as_an_edit() {
+        val draft = FieldDraft()
+        val sink = Sink()
+        // A click moves the caret and nothing else. The String overload of BasicTextField filters
+        // this out; forwarding it would re-run the caller's setter — clearing an error banner or
+        // committing a setting — on a bare click.
+        draft.accept(TextFieldValue("22", TextRange(1)), "22", sink.take)
+        assertEquals(emptyList(), sink.texts)
+        draft.accept(TextFieldValue("223", TextRange(3)), "22", sink.take)
+        assertEquals(listOf("223"), sink.texts)
+    }
+
+    @Test
+    fun the_ime_composition_survives_a_round_trip() {
+        val draft = FieldDraft()
+        // Dropping the composition makes EditProcessor commit it and restart the input session on
+        // every keystroke, which breaks composing input (pinyin, predictive text).
+        draft.accept(TextFieldValue("ni", TextRange(2), composition = TextRange(0, 2)), "") {}
+        assertEquals(TextRange(0, 2), draft.textFieldValue("ni").composition)
+    }
+
+    @Test
+    fun selecting_all_drops_a_stale_composition() {
+        val draft = FieldDraft()
+        draft.accept(TextFieldValue("ni", TextRange(2), composition = TextRange(0, 2)), "") {}
+        draft.focusGained("ni", selectAll = true)
+        assertNull(draft.textFieldValue("ni").composition)
+    }
+
+    @Test
+    fun blur_forgets_the_caret() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.focusGained("3389", selectAll = true)
+        assertEquals(TextRange(0, 4), draft.textFieldValue("3389").selection)
+        draft.focusLost()
+        draft.focused = false
+        // Same text, so only the reset can explain the collapsed caret.
+        assertTrue(draft.textFieldValue("3389").selection.collapsed)
+    }
+
+    @Test
+    fun an_unfocused_field_keeps_the_caret_at_the_start() {
+        val draft = FieldDraft()
+        // The field scrolls to follow the caret even unfocused, so a value wider than its box would
+        // open showing its tail. Only a focused field gets the caret moved to the end.
+        assertEquals(TextRange(0), draft.textFieldValue("https://sync.example.com:8443").selection)
+        draft.focused = true
+        assertEquals(TextRange(29), draft.textFieldValue("https://sync.example.com:8443").selection)
+    }
+
+    @Test
+    fun a_second_edit_before_the_caller_recomposes_is_still_reported() {
+        val draft = FieldDraft()
+        val sink = Sink()
+        // Two emissions inside one frame: the caller's `current` is still the pre-edit value for
+        // both, so comparing against it would drop the second one and lose the retyped character.
+        draft.accept(TextFieldValue("lo", TextRange(2)), "log", sink.take)
+        draft.accept(TextFieldValue("log", TextRange(3)), "log", sink.take)
+        assertEquals(listOf("lo", "log"), sink.texts)
+    }
+
+    @Test
+    fun an_edit_reproducing_the_last_emitted_text_survives_an_outside_replacement() {
+        val draft = FieldDraft()
+        val sink = Sink()
+        // NumberStepper: the field holds "13", the user types "1", then the +/- button replaces the
+        // value with "14" without taking focus. Backspace re-emits "1" — the text this field last
+        // produced — and comparing against it would drop the keystroke, leaving the key dead.
+        draft.accept(TextFieldValue("1", TextRange(1)), "13", sink.take)
+        draft.accept(TextFieldValue("1", TextRange(1)), "14", sink.take)
+        assertEquals(listOf("1", "1"), sink.texts)
+    }
+
+    @Test
+    fun a_value_the_caller_rewrote_keeps_the_caret_where_it_was() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // Notes are capped at their limit on the way in (`capNotes`), snippet parameters are
+        // sanitized. Typing in the middle of such a value emits one string and the caller stores
+        // another, so the caret belongs to no text at all — sending it to the end would push every
+        // following keystroke there too.
+        draft.accept(TextFieldValue("abcXdef", TextRange(4)), "abcdef") {}
+        assertEquals(TextRange(4), draft.textFieldValue("abcXde").selection)
+    }
+
+    @Test
+    fun a_multi_line_field_opens_at_its_beginning() {
+        val draft = FieldDraft(singleLine = false)
+        draft.focused = true
+        // A snippet command or a note is read before it is edited, so it opens the way a file does
+        // in the editor — at the top, not scrolled to its last line.
+        assertEquals(TextRange(0), draft.textFieldValue("cd /var/log\ntail -f syslog").selection)
+    }
+
+    @Test
+    fun a_shorter_value_from_outside_keeps_the_caret_inside_it() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.focusGained("3389", selectAll = true)
+        // Switching the protocol refills the port while the field keeps focus. Constraining the old
+        // range would highlight "33" out of "22"; what survives is the offset, and only inside the
+        // new text.
+        assertEquals(TextRange(2), draft.textFieldValue("22").selection)
+    }
+
+    @Test
+    fun a_longer_value_from_outside_starts_at_its_end() {
+        val draft = FieldDraft()
+        draft.focused = true
+        draft.focusGained("22", selectAll = true)
+        // SSH to RDP with the port field still focused. A caller only ever takes away from what it
+        // was handed, so a value that grew came from somewhere else and is not the text this caret
+        // was measured against: keeping offset 2 would leave "33|89" and turn a keystroke into 33589.
+        assertEquals(TextRange(4), draft.textFieldValue("3389").selection)
+    }
+
+    @Test
+    fun a_value_of_the_same_length_from_outside_starts_at_its_end() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // A tap places the caret and changes nothing else; whatever arrives after that came from
+        // elsewhere. RDP to VNC refills 3389 with 5900 — the same width, so length alone would read
+        // it as the field's own text coming back and leave the caret at "59|00".
+        draft.accept(TextFieldValue("3389", TextRange(2)), "3389") {}
+        assertEquals(TextRange(4), draft.textFieldValue("5900").selection)
+    }
+
+    @Test
+    fun a_value_replaced_while_an_edit_was_in_flight_starts_at_its_end() {
+        val draft = FieldDraft()
+        draft.focused = true
+        // The stepper: the field holds "13", the user types "1", and the + button replaces the value
+        // with "14" without taking focus. The field did emit, but a value longer than what it emitted
+        // cannot be that emission coming back.
+        draft.accept(TextFieldValue("1", TextRange(1)), "13") {}
+        assertEquals(TextRange(2), draft.textFieldValue("14").selection)
+    }
+
+    @Test
+    fun an_edit_the_caller_refused_is_reported_again() {
+        val draft = FieldDraft()
+        val sink = Sink()
+        // A caller may drop what it is handed instead of storing it — the web-access password field
+        // ignores input while a save is in flight. Its value never moves, so measuring against the
+        // text this field last emitted would make the retyped character equal to "no change" and
+        // the key would stay dead for as long as the field lives.
+        draft.accept(TextFieldValue("x", TextRange(1)), "", sink.take)
+        draft.accept(TextFieldValue("x", TextRange(1)), "", sink.take)
+        assertEquals(listOf("x", "x"), sink.texts)
+    }
+
+    @Test
+    fun a_masked_field_never_selects_on_focus() {
+        val draft = FieldDraft(masked = true)
+        draft.focused = true
+        // A selected password reveals its length to anyone looking at the screen.
+        draft.focusGained("hunter2", selectAll = true)
+        assertTrue(draft.textFieldValue("hunter2").selection.collapsed)
+    }
+
+    @Test
+    fun a_multi_line_field_never_selects_on_focus() {
+        val draft = FieldDraft(singleLine = false)
+        draft.focused = true
+        // A pasted key or a note is edited, not replaced wholesale.
+        draft.focusGained("-----BEGIN OPENSSH PRIVATE KEY-----", selectAll = true)
+        assertTrue(draft.textFieldValue("-----BEGIN OPENSSH PRIVATE KEY-----").selection.collapsed)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -111,6 +111,21 @@ class NewConnectionFormStateTest {
     }
 
     @Test
+    fun default_port_is_recognized_per_transport() {
+        val f = NewConnectionFormState()
+        assertTrue(f.isDefaultPort) // untouched SSH form
+        f.port = " 22 "
+        assertTrue(f.isDefaultPort) // the field is trimmed on the way into the draft
+        f.port = "2222"
+        assertFalse(f.isDefaultPort)
+        f.chooseConnectionType(app.skerry.shared.ssh.ConnectionType.RDP)
+        assertEquals("2222", f.port) // a customized port survives the switch
+        assertFalse(f.isDefaultPort)
+        f.port = "3389"
+        assertTrue(f.isDefaultPort) // RDP's own default, not SSH's
+    }
+
+    @Test
     fun switching_away_from_ssh_drops_the_jump_host() {
         val f = NewConnectionFormState().apply { jumpHostId = "bastion-1" }
         f.chooseConnectionType(app.skerry.shared.ssh.ConnectionType.TELNET)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
@@ -1,0 +1,43 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.mutableStateMapOf
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TemplateVariableValuesTest {
+
+    private fun values(params: Map<String, String>) = TemplateVariableValues(
+        paramNames = params.keys.toList(),
+        vaultRefs = emptyList(),
+        needsClipboard = false,
+        vaultResolutions = emptyMap(),
+        params = mutableStateMapOf<String, String>().apply { putAll(params) },
+    )
+
+    @Test
+    fun a_parameter_is_seeded_until_it_is_edited() {
+        val v = values(mapOf("host" to "prod-01"))
+        assertTrue(v.isSeeded("host")) // the template's default — the field may select it on focus
+        v.params["host"] = "prod-02"
+        assertFalse(v.isSeeded("host"))
+    }
+
+    @Test
+    fun typing_the_seeded_value_back_re_arms_the_field() {
+        val v = values(mapOf("host" to "prod-01"))
+        v.params["host"] = "prod-02"
+        v.params["host"] = "prod-01"
+        // Deliberate: the rule is "the value the form put there", by content — not an edited flag.
+        // A parameter typed back to the default is indistinguishable from an untouched one.
+        assertTrue(v.isSeeded("host"))
+    }
+
+    @Test
+    fun a_parameter_with_no_default_is_seeded_while_still_empty() {
+        val v = values(mapOf("port" to ""))
+        assertTrue(v.isSeeded("port"))
+        v.params["port"] = "8080"
+        assertFalse(v.isSeeded("port"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelFormTest.kt
@@ -17,6 +17,16 @@ import kotlin.test.assertTrue
 class TunnelFormTest {
 
     @Test
+    fun `the loopback bind host counts as a default until the user changes it`() {
+        val form = TunnelFormState.fromEntry(null)
+        assertTrue(form.isDefaultBindHost) // seeded by the form, so its field selects on focus
+        form.bindHost = " 127.0.0.1 "
+        assertTrue(form.isDefaultBindHost)
+        form.bindHost = "0.0.0.0"
+        assertFalse(form.isDefaultBindHost)
+    }
+
+    @Test
     fun `builds a local draft from valid fields`() {
         val draft = buildTunnelDraft(
             id = null, label = "web", hostId = "h1", direction = TunnelDirection.Local,

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -79,6 +79,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Field labels, caps, avatars | `FieldLabel`, `LabelCase.labelUppercase`, `InitialsAvatar` |
 | Mobile chrome | `MobilePushHeader`, `MobileScreenTitle`, `MobileFabButton`, `MobileTagsEditor` |
 | Mobile form fields (label caps + input) | `ui/mobile/MobileForm.kt`: `MobileFormField` / `MobileFormInput` |
+| Caret and select-on-focus for a field whose value is a caller-owned `String` | `ui/design/FieldDraft`: `rememberFieldDraft` + `Modifier.fieldFocus`, told whether the field is masked and single-line so it applies the never-select rules itself; `rememberSeededDraft` for a find or filter bar, which selects its query only while it is the one the bar opened with. A field that owns its own `TextFieldValue` and selects on *open* (`PathJumpField`, `TerminalSearchBar`) is the other, deliberate shape — don't hand-roll a third |
 | Tunnel/snippet form state (desktop and mobile) | `TunnelFormState`, `SnippetFormState` |
 | Secret display | `VaultPresentation.secretStyle` |
 | Terminal screen state (incl. scrollback search) | `ui/terminal/TerminalScreenState` |

--- a/tools/harness/gate.py
+++ b/tools/harness/gate.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """The gate runner — the only thing that can mark a stage green.
 
 The previous recorder inferred a green build from the *text* of a Bash command and the tool's


### PR DESCRIPTION
Closes #181.

A field whose value lives outside it as a `String` went through the `String` overload of `BasicTextField`, which seeds its caret at offset 0 and never moves it on focus. Typing into an autofocused rename dialog prepended instead of replacing: `report.log` + `x` became `xreport.log`.

## What changes

- A single-line field taking focus puts the caret after its text. A multi-line one starts at the top, the way a file opens in the editor.
- A value the app prefilled, and the user has not touched, is selected whole when the field takes focus, so the next keystroke replaces it:
  - the default port for the transport (22, 23, 3389, 5900, 9600) — a port typed by the user is not selected;
  - the current name in a rename dialog — file or folder (extension included), host group, snippet tag, vault secret;
  - the loopback bind host of a tunnel;
  - a snippet parameter still holding its template default;
  - the query a find or filter bar was reopened over.
- Masked input and multi-line areas never select: a highlighted password reveals its length, and a pasted key is edited rather than replaced.

The selection is applied one frame after focus, because the tap that grants focus places the caret inside the same gesture and would otherwise undo it.

`ui/design/FieldDraft` is the shared primitive: `rememberFieldDraft` for a form field, `rememberSeededDraft` for a find bar, `Modifier.fieldFocus` for the focus edge. A field that owns its own `TextFieldValue` and selects on open (`PathJumpField`, `TerminalSearchBar`) stays as it is — both shapes are recorded in the abstraction catalogue.

Desktop and Android carry the same behaviour, through shared composables or matched pairs at every call site.

## Verifying by hand

- SFTP, F2 on a file: the whole name is selected, extension included; typing replaces both halves.
- New connection, click the port field on an untouched form: the default port is selected. Type 2222, leave, come back: it is not.
- Any rename dialog opened with autofocus: the first character replaces the name instead of landing in front of it.
- Settings → Terminal, the font-size field: a click selects the number; the +/- buttons do not kill the next keystroke.
- Sync settings with a long saved URL: the field opens showing the start of the value, not its tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)