### PR TITLE
Vault: "Export" hands out the private key, behind re-authentication

### DIFF
--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -136,13 +136,12 @@ class MainActivity : FragmentActivity() {
 
         // SFTP SAF pickers: launchers are registered in onCreate (ActivityResult API requires
         // registration before STARTED) and handed to SafBridge as launch lambdas so the shared UI code
-        // stays Activity-independent. octet-stream for arbitrary binary downloads; text/plain for
-        // key/certificate .pub export; "*/*" for any upload.
+        // stays Activity-independent. octet-stream for every created document — SAF keeps the caller's
+        // extension only when it maps back to the requested MIME, and neither `.pem` nor `.cast` maps
+        // to text/plain, so a text launcher would file an exported key as `id_ed25519.pem.txt`.
+        // "*/*" for any upload.
         val createDocument = registerForActivityResult(
             ActivityResultContracts.CreateDocument("application/octet-stream"),
-        ) { uri -> SafBridge.onCreateResult(uri) }
-        val createTextDocument = registerForActivityResult(
-            ActivityResultContracts.CreateDocument("text/plain"),
         ) { uri -> SafBridge.onCreateResult(uri) }
         val openDocument = registerForActivityResult(
             ActivityResultContracts.OpenDocument(),
@@ -150,7 +149,6 @@ class MainActivity : FragmentActivity() {
         SafBridge.install(
             applicationContext,
             launchCreate = { name -> createDocument.launch(name) },
-            launchCreateText = { name -> createTextDocument.launch(name) },
             launchOpen = { openDocument.launch(arrayOf("*/*")) },
         )
 

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/sftp/FilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/sftp/FilePicker.android.kt
@@ -141,27 +141,24 @@ object SafBridge {
     private var launchCreate: ((String) -> Unit)? = null
 
     @Volatile
-    private var launchCreateText: ((String) -> Unit)? = null
-
-    @Volatile
     private var launchOpen: (() -> Unit)? = null
 
     @Volatile
     private var pending: CompletableDeferred<Uri?>? = null
 
     /**
-     * Called from `MainActivity.onCreate`: [launchCreate] (octet-stream, binary SFTP download) and
-     * [launchCreateText] (text/plain, key/certificate .pub export) take a filename; [launchOpen] takes
-     * none. The two create launchers differ only by MIME (fixed at contract registration), giving the
-     * file manager the right icon/handler for text .pub exports.
+     * Called from `MainActivity.onCreate`: [launchCreate] (octet-stream) takes a filename, [launchOpen]
+     * takes none. Everything created goes through the one octet-stream contract — a MIME-specific
+     * launcher would make SAF rewrite extensions it can't map back (`id_ed25519.pem` → `…pem.txt`),
+     * and what travels here is an SFTP download, a session recording, or a private key, none of which
+     * the file manager should open as text.
      */
-    fun install(context: Context, launchCreate: (String) -> Unit, launchCreateText: (String) -> Unit, launchOpen: () -> Unit) {
+    fun install(context: Context, launchCreate: (String) -> Unit, launchOpen: () -> Unit) {
         // Release a pick started by the previous (destroyed) Activity, or its await would hang forever.
         pending?.complete(null)
         pending = null
         appContext = context.applicationContext
         this.launchCreate = launchCreate
-        this.launchCreateText = launchCreateText
         this.launchOpen = launchOpen
     }
 
@@ -169,9 +166,6 @@ object SafBridge {
 
     /** Launch CreateDocument (octet-stream) with [suggestedName], await the chosen Uri (null on cancel). */
     suspend fun createDocument(suggestedName: String): Uri? = createVia(launchCreate, suggestedName)
-
-    /** Launch CreateDocument (text/plain) with [suggestedName], for key/certificate text export. */
-    suspend fun createTextDocument(suggestedName: String): Uri? = createVia(launchCreateText, suggestedName)
 
     private suspend fun createVia(launch: ((String) -> Unit)?, suggestedName: String): Uri? = lock.withLock {
         val fire = launch ?: return null

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ExportFile.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ExportFile.android.kt
@@ -6,25 +6,36 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * Exports a public key/certificate via Storage Access Framework, reusing [SafBridge]: `CreateDocument`
- * yields a `content://` Uri, then [content] is written there as UTF-8. Only public material is
- * exported; private keys never leave the app.
+ * Writes an exported file via Storage Access Framework, reusing [SafBridge]: `CreateDocument` yields
+ * a `content://` Uri, then [content] is written there as UTF-8. The user picks where it lands, which
+ * is the point — an exported private key is meant to be moved to another device — and also the limit
+ * of what this can promise: a document in Downloads is readable by anything holding that Uri. The
+ * decision to hand the key over is re-authenticated at the call site, not here.
  *
- * Returns `false` if the user cancels the picker (Uri == null) or the write fails; any IO/Uri
- * failure is swallowed rather than thrown. On write failure the partially created document is
- * deleted to avoid leaving an empty file behind.
+ * A closed picker is [ExportOutcome.Cancelled]; an IO/Uri failure is reported as
+ * [ExportOutcome.Failed] rather than thrown, and the partially created document is deleted so a
+ * truncated key is not left behind looking like a whole one. That delete is best-effort: SAF hands
+ * back the final Uri up front, so unlike the desktop writer there is no temp file to discard, and if
+ * the delete fails too a partial document can survive at the name the user picked.
  */
-actual suspend fun exportTextFile(suggestedName: String, content: String): Boolean {
-    val ctx = SafBridge.context() ?: return false
-    val uri = SafBridge.createTextDocument(suggestedName) ?: return false
+internal actual suspend fun exportTextFile(suggestedName: String, content: String): ExportOutcome {
+    val ctx = SafBridge.context() ?: return ExportOutcome.Failed
+    val uri = SafBridge.createDocument(suggestedName) ?: return ExportOutcome.Cancelled
     return withContext(Dispatchers.IO) {
-        runCatching {
-            ctx.contentResolver.openOutputStream(uri)?.use { it.write(content.toByteArray(Charsets.UTF_8)) }
-                ?: error("no output stream for $uri")
-            true
-        }.getOrElse {
-            runCatching { DocumentsContract.deleteDocument(ctx.contentResolver, uri) }
-            false
+        // Zeroed after the write, as on desktop: the String behind it can't be, but this copy can,
+        // and a phone is the likelier of the two to have its heap dumped.
+        val bytes = content.toByteArray(Charsets.UTF_8)
+        try {
+            runCatching {
+                ctx.contentResolver.openOutputStream(uri)?.use { it.write(bytes) }
+                    ?: error("no output stream for $uri")
+                ExportOutcome.Saved
+            }.getOrElse {
+                runCatching { DocumentsContract.deleteDocument(ctx.contentResolver, uri) }
+                ExportOutcome.Failed
+            }
+        } finally {
+            bytes.fill(0)
         }
     }
 }

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -82,6 +82,7 @@
     <string name="term_record_truncated">Запись остановлена: достигнут предел размера</string>
     <string name="term_record_empty">Записывать было нечего</string>
     <string name="term_record_saved">Запись сохранена</string>
+    <string name="term_record_failed">Запись не удалось сохранить</string>
     <string name="term_player_open">Воспроизвести запись</string>
     <string name="term_player_title">Запись сессии</string>
     <string name="term_player_invalid">Это не запись в формате asciicast v2</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -29,6 +29,11 @@
     <string name="vault_copy_public_key">Скопировать открытый ключ</string>
     <string name="vault_copy_password">Скопировать пароль</string>
     <string name="vault_export">Экспорт</string>
+    <string name="vault_export_key">Экспорт ключа</string>
+    <string name="vault_export_certificate">Экспорт сертификата</string>
+    <string name="vault_export_failed_title">Экспорт не удался</string>
+    <string name="vault_export_failed_message">Файл не записан.</string>
+    <string name="vault_export_dismiss">Закрыть</string>
     <string name="vault_delete">Удалить</string>
     <string name="vault_rename">Переименовать</string>
     <string name="vault_cancel">Отмена</string>
@@ -75,6 +80,7 @@
     <!-- Подтверждение мастер-пароля перед копированием секрета. -->
     <string name="vault_confirm_master_title">Подтвердите мастер-пароль</string>
     <string name="vault_confirm_master_subtitle">Введите мастер-пароль, чтобы скопировать секрет в буфер обмена.</string>
+    <string name="vault_confirm_master_subtitle_export">Введите мастер-пароль, чтобы записать приватный ключ в файл.</string>
     <string name="vault_field_master_password">МАСТЕР-ПАРОЛЬ</string>
     <string name="vault_placeholder_master_password">мастер-пароль</string>
     <string name="vault_password_mismatch_retry">Пароль не подошёл — попробуйте ещё раз.</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
@@ -13,6 +13,7 @@
     <string name="vtail_bio_copy_title">Подтвердите личность</string>
     <string name="vtail_bio_copy_cancel">Отмена</string>
     <string name="vtail_bio_copy_subtitle">Подтвердите биометрию, чтобы скопировать секрет в буфер обмена.</string>
+    <string name="vtail_bio_export_subtitle">Подтвердите биометрию, чтобы записать приватный ключ в файл.</string>
 
     <!-- Пикер аутентификации: типы секретов keychain. -->
     <string name="vtail_picker_type_password">Пароль</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -82,6 +82,7 @@
     <string name="term_record_truncated">录制已停止：已达大小上限</string>
     <string name="term_record_empty">没有录制到内容</string>
     <string name="term_record_saved">录制已保存</string>
+    <string name="term_record_failed">录制无法写入</string>
     <string name="term_player_open">播放录制</string>
     <string name="term_player_title">会话录制</string>
     <string name="term_player_invalid">该文件不是 asciicast v2 录制</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -29,6 +29,11 @@
     <string name="vault_copy_public_key">复制公钥</string>
     <string name="vault_copy_password">复制密码</string>
     <string name="vault_export">导出</string>
+    <string name="vault_export_key">导出密钥</string>
+    <string name="vault_export_certificate">导出证书</string>
+    <string name="vault_export_failed_title">导出失败</string>
+    <string name="vault_export_failed_message">文件未写入。</string>
+    <string name="vault_export_dismiss">关闭</string>
     <string name="vault_delete">删除</string>
     <string name="vault_rename">重命名</string>
     <string name="vault_cancel">取消</string>
@@ -75,6 +80,7 @@
     <!-- 复制密钥前确认主密码 -->
     <string name="vault_confirm_master_title">确认主密码</string>
     <string name="vault_confirm_master_subtitle">请输入主密码以将此密钥复制到剪贴板。</string>
+    <string name="vault_confirm_master_subtitle_export">请输入主密码以将此私钥写入文件。</string>
     <string name="vault_field_master_password">主密码</string>
     <string name="vault_placeholder_master_password">主密码</string>
     <string name="vault_password_mismatch_retry">密码不匹配——请重试。</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -13,6 +13,7 @@
     <string name="vtail_bio_copy_title">确认身份</string>
     <string name="vtail_bio_copy_cancel">取消</string>
     <string name="vtail_bio_copy_subtitle">验证你的生物识别以将此密钥复制到剪贴板。</string>
+    <string name="vtail_bio_export_subtitle">验证你的生物识别以将此私钥写入文件。</string>
 
     <!-- 认证选择器：密钥链凭据类型标签。 -->
     <string name="vtail_picker_type_password">密码</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -82,6 +82,7 @@
     <string name="term_record_truncated">Recording stopped: size limit reached</string>
     <string name="term_record_empty">Nothing was recorded</string>
     <string name="term_record_saved">Recording saved</string>
+    <string name="term_record_failed">Recording could not be written</string>
     <string name="term_player_open">Play a recording</string>
     <string name="term_player_title">Recording</string>
     <string name="term_player_invalid">This file is not an asciicast v2 recording</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -29,6 +29,11 @@
     <string name="vault_copy_public_key">Copy public key</string>
     <string name="vault_copy_password">Copy password</string>
     <string name="vault_export">Export</string>
+    <string name="vault_export_key">Export key</string>
+    <string name="vault_export_certificate">Export certificate</string>
+    <string name="vault_export_failed_title">Export failed</string>
+    <string name="vault_export_failed_message">The file was not written.</string>
+    <string name="vault_export_dismiss">Close</string>
     <string name="vault_delete">Delete</string>
     <string name="vault_rename">Rename</string>
     <string name="vault_cancel">Cancel</string>
@@ -72,9 +77,10 @@
     <string name="vault_cert_valid_summary">%1$s · %2$s · valid until %3$s</string>
     <string name="vault_import">Import</string>
 
-    <!-- Confirm master password before copying a secret. -->
+    <!-- Confirm master password before a secret leaves the vault (clipboard copy or key export). -->
     <string name="vault_confirm_master_title">Confirm master password</string>
     <string name="vault_confirm_master_subtitle">Enter your master password to copy this secret to the clipboard.</string>
+    <string name="vault_confirm_master_subtitle_export">Enter your master password to write this private key to a file.</string>
     <string name="vault_field_master_password">MASTER PASSWORD</string>
     <string name="vault_placeholder_master_password">master password</string>
     <string name="vault_password_mismatch_retry">That password didn't match — try again.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
@@ -13,6 +13,7 @@
     <string name="vtail_bio_copy_title">Confirm it's you</string>
     <string name="vtail_bio_copy_cancel">Cancel</string>
     <string name="vtail_bio_copy_subtitle">Verify your biometrics to copy this secret to the clipboard.</string>
+    <string name="vtail_bio_export_subtitle">Verify your biometrics to write this private key to a file.</string>
 
     <!-- Auth picker: keychain credential type labels. -->
     <string name="vtail_picker_type_password">Password</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -77,7 +77,8 @@ import app.skerry.ui.session.broadcastTargets
 import kotlinx.coroutines.launch
 import app.skerry.shared.terminal.castFileName
 import app.skerry.shared.terminal.recordingStamp
-import app.skerry.ui.vault.exportTextFile
+import app.skerry.ui.vault.ExportOutcome
+import app.skerry.ui.vault.exportFileGuarded
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.host.isProdHostId
 import app.skerry.ui.host.prodOutline
@@ -407,14 +408,15 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                                         } else {
                                             val name = castFileName(active?.displayTitle.orEmpty().ifBlank { active?.subtitle.orEmpty() }, recordingStamp())
                                             val seconds = activeTerminal.recordingSeconds
-                                            val saved = exportTextFile(name, cast)
+                                            val outcome = exportFileGuarded(name, cast)
                                             // Desktop parity: report a saved recording of a shared
                                             // host to its team. A cancelled Save-As kept nothing.
-                                            if (saved) active.hostId?.let { teams?.reportSessionRecorded(it, seconds) }
-                                            recordingNotice = when {
-                                                !saved -> null
-                                                truncated -> RecordingOutcome.SavedTruncated
-                                                else -> RecordingOutcome.Saved
+                                            if (outcome == ExportOutcome.Saved) active.hostId?.let { teams?.reportSessionRecorded(it, seconds) }
+                                            recordingNotice = when (outcome) {
+                                                ExportOutcome.Cancelled -> null
+                                                ExportOutcome.Failed -> RecordingOutcome.Failed
+                                                ExportOutcome.Saved ->
+                                                    if (truncated) RecordingOutcome.SavedTruncated else RecordingOutcome.Saved
                                             }
                                         }
                                     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -54,7 +54,11 @@ import app.skerry.ui.generated.resources.vault_empty_passwords_hint
 import app.skerry.ui.generated.resources.vault_empty_passwords_title
 import app.skerry.ui.generated.resources.vault_empty_ssh_hint
 import app.skerry.ui.generated.resources.vault_empty_ssh_title
-import app.skerry.ui.generated.resources.vault_export
+import app.skerry.ui.generated.resources.vault_export_key
+import app.skerry.ui.generated.resources.vault_export_certificate
+import app.skerry.ui.generated.resources.vault_export_failed_title
+import app.skerry.ui.generated.resources.vault_export_failed_message
+import app.skerry.ui.generated.resources.vault_export_dismiss
 import app.skerry.ui.generated.resources.vault_generate_key
 import app.skerry.ui.generated.resources.vault_header_summary
 import app.skerry.ui.generated.resources.vault_item_count
@@ -76,12 +80,18 @@ import app.skerry.ui.identity.CredentialKind
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.known.shortFingerprint
 import app.skerry.ui.vault.SecretCopyAuthorizer
+import app.skerry.ui.vault.SecretExport
+import app.skerry.ui.vault.privateKeyExport
+import app.skerry.ui.vault.certificateExport
+import app.skerry.ui.vault.SecretActions
+import app.skerry.ui.vault.secretActions
+import app.skerry.ui.vault.exportPrivateKey
+import app.skerry.ui.vault.exportPublic
 import app.skerry.ui.vault.VaultCategoryKind
 import app.skerry.ui.vault.VaultPresentation
 import app.skerry.ui.vault.title
 import app.skerry.ui.vault.copyPasswordToClipboard
 import app.skerry.ui.vault.copyTextToClipboard
-import app.skerry.ui.vault.exportTextFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -96,6 +106,8 @@ import app.skerry.ui.vault.GenerateKeyDialog
 import app.skerry.ui.vault.ImportCertificateDialog
 import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.NoticeDialog
+import app.skerry.ui.nav.PlatformBackHandler
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSnippets
@@ -165,6 +177,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     val vault = LocalVault.current
     val biometrics = LocalVaultBiometrics.current
     val copyAuth = remember(vault, biometrics, scope) { SecretCopyAuthorizer(vault, biometrics, scope) }
+    var exportFailed by remember { mutableStateOf(false) }
 
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
     var selectedId by remember { mutableStateOf<String?>(null) }
@@ -186,7 +199,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     // writes the flag only on value change (not every list recomposition); DisposableEffect clears it
     // on leaving the tab so the tab bar isn't left hidden.
     val modalOpen = showGenerate || showAddPassword || showImportCert || showLinkKeyFile || pendingRename != null || pendingDelete != null ||
-        selectedCred != null || copyAuth.passwordPromptVisible
+        selectedCred != null || copyAuth.passwordPromptVisible || exportFailed
     LaunchedEffect(modalOpen) { state.modalOverlay(modalOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
 
@@ -339,7 +352,9 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onCopyPassword = { pwd ->
                     copyAuth.authorize { credentials.recordCopied(credential.id); copyPasswordToClipboard(pwd) }
                 },
-                onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
+                // Private key material: re-authenticated like a password copy; see VaultView.
+                onExportKey = { export -> exportPrivateKey(copyAuth, export, scope) { exportFailed = it.worthReporting } },
+                onExportPublic = { export -> exportPublic(export, scope) { exportFailed = it.worthReporting } },
                 // Close the detail sheet before showing a centered dialog (rename/delete): otherwise the
                 // sheet, drawn on top, would cover it and leave only its edge visible.
                 onRename = {
@@ -353,10 +368,22 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onDismiss = { selectedId = null },
             )
         }
+        if (exportFailed) {
+            // The sheet underneath registers its own back handler, so without this one Back would
+            // close the sheet and leave the notice stranded over the tab bar.
+            PlatformBackHandler(onBack = { exportFailed = false })
+            NoticeDialog(
+                title = stringResource(Res.string.vault_export_failed_title),
+                message = stringResource(Res.string.vault_export_failed_message),
+                buttonLabel = stringResource(Res.string.vault_export_dismiss),
+                onDismiss = { exportFailed = false },
+            )
+        }
         if (copyAuth.passwordPromptVisible) {
             PasswordConfirmDialog(
                 error = copyAuth.passwordError,
                 busy = copyAuth.verifying,
+                access = copyAuth.access,
                 onDismiss = { copyAuth.dismiss() },
                 onConfirm = { copyAuth.submitPassword(it) },
             )
@@ -514,8 +541,9 @@ private fun MobileVaultEmpty(category: VaultCategoryKind) {
 
 /**
  * Bottom detail sheet for the selected secret: header (icon/name/subtype), public key + fingerprint
- * (key) or certificate body, used-by hosts, Copy/Export/Delete buttons. Only public material (public
- * key/cert) is exposed; the private key/password only via Copy/Export on an explicit user action.
+ * (key) or certificate body, used-by hosts, Copy/Export/Delete buttons. What the sheet *draws* is
+ * public material only (public key/cert); the private key and the password leave the vault solely
+ * through Copy/Export, each behind re-authentication.
  */
 @Composable
 private fun MobileSecretDetailSheet(
@@ -527,11 +555,14 @@ private fun MobileSecretDetailSheet(
     mono: FontFamily,
     onCopy: (String) -> Unit,
     onCopyPassword: (String) -> Unit,
-    onExport: (name: String, content: String) -> Unit,
+    onExportKey: (SecretExport.PrivateKey) -> Unit,
+    onExportPublic: (SecretExport.Public) -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val keyExport = remember(credential) { privateKeyExport(credential) }
+    val certExport = remember(credential) { certificateExport(credential) }
     val generator = LocalSshKeyGenerator.current
     val inspector = LocalSshCertificateInspector.current
     val secret = credential.secret
@@ -598,17 +629,23 @@ private fun MobileSecretDetailSheet(
                         is CredentialSecret.KeyFile -> Unit
                     }
                     MobileSheetButton(stringResource(Res.string.vault_rename), onClick = onRename, filled = false, modifier = Modifier.fillMaxWidth())
-                    when (secret) {
-                        is CredentialSecret.Certificate -> Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                            MobileSheetButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, filled = false, modifier = Modifier.weight(1f))
-                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
+                    // Export hands out the private key; see the desktop panel.
+                    val deleteButton: @Composable (Modifier) -> Unit = { modifier ->
+                        MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = modifier)
+                    }
+                    when (secretActions(credential)) {
+                        SecretActions.KeyAndCertificate -> {
+                            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                                MobileSheetButton(stringResource(Res.string.vault_export_key), onClick = { keyExport?.let(onExportKey) }, filled = false, modifier = Modifier.weight(1f))
+                                MobileSheetButton(stringResource(Res.string.vault_export_certificate), onClick = { certExport?.let(onExportPublic) }, filled = false, modifier = Modifier.weight(1f))
+                            }
+                            deleteButton(Modifier.fillMaxWidth())
                         }
-                        is CredentialSecret.PrivateKey -> Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                            MobileSheetButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, filled = false, modifier = Modifier.weight(1f))
-                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.weight(1f))
+                        SecretActions.KeyAndDelete -> Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                            MobileSheetButton(stringResource(Res.string.vault_export_key), onClick = { keyExport?.let(onExportKey) }, filled = false, modifier = Modifier.weight(1f))
+                            deleteButton(Modifier.weight(1f))
                         }
-                        is CredentialSecret.Password, is CredentialSecret.KeyFile ->
-                            MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = Modifier.fillMaxWidth())
+                        SecretActions.DeleteOnly -> deleteButton(Modifier.fillMaxWidth())
                     }
                 }
                 SecretSectionLabel(encryptionSectionTitle())

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/remote/RemoteScreenshot.kt
@@ -1,6 +1,7 @@
 package app.skerry.ui.remote
 
 import androidx.compose.ui.graphics.ImageBitmap
+import app.skerry.shared.io.safeFileStem
 
 /**
  * Writes the current remote frame to a PNG the user can find outside the app: the pictures folder on
@@ -11,18 +12,9 @@ import androidx.compose.ui.graphics.ImageBitmap
  */
 expect suspend fun saveRemoteScreenshot(image: ImageBitmap, baseName: String): String?
 
-/** A file name that is safe on every platform: a host name can carry anything a URL can. */
-internal fun screenshotFileName(baseName: String, stamp: String): String {
-    // Dots are kept — a host name is mostly dots — but never two in a row, which is the one spelling
-    // that means a directory above this one.
-    val safe = baseName.map { if (it.isLetterOrDigit() || it == '-' || it == '_' || it == '.') it else '-' }
-        .joinToString("")
-        .replace("..", "-")
-        .replace(Regex("-+"), "-")
-        .trim('-', '.')
-        .take(48)
-        // Trimmed again: the cut can land on a separator and leave one dangling before the stamp.
-        .trim('-', '.')
-        .ifEmpty { "desktop" }
-    return "skerry-$safe-$stamp.png"
-}
+/**
+ * A file name that is safe on every platform: a host name can carry anything a URL can. Dots are
+ * kept — a host name is mostly dots — and [safeFileStem] answers for the rest.
+ */
+internal fun screenshotFileName(baseName: String, stamp: String): String =
+    "skerry-${safeFileStem(baseName, fallback = "desktop", keepDots = true)}-$stamp.png"

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -14,7 +14,8 @@ import app.skerry.ui.generated.resources.shell_tip_record_stop
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.session.Session
 import app.skerry.ui.connection.ConnectionUiState
-import app.skerry.ui.vault.exportTextFile
+import app.skerry.ui.vault.ExportOutcome
+import app.skerry.ui.vault.exportFileGuarded
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import app.skerry.ui.theme.Skerry
@@ -60,15 +61,15 @@ fun RecordSessionButton(
                 }
                 val name = castFileName(session.displayTitle.ifBlank { session.subtitle }, recordingStamp())
                 val seconds = live.recordingSeconds
-                val saved = exportTextFile(name, cast)
+                val outcome = exportFileGuarded(name, cast)
                 // Only an actually exported recording is reported: a cancelled Save-As wrote nothing,
                 // and announcing a recording nobody kept would be a plain falsehood in the feed.
-                if (saved) session.hostId?.let { onSaved(it, seconds) }
+                if (outcome == ExportOutcome.Saved) session.hostId?.let { onSaved(it, seconds) }
                 onDone(
-                    when {
-                        !saved -> RecordingOutcome.Cancelled
-                        truncated -> RecordingOutcome.SavedTruncated
-                        else -> RecordingOutcome.Saved
+                    when (outcome) {
+                        ExportOutcome.Cancelled -> RecordingOutcome.Cancelled
+                        ExportOutcome.Failed -> RecordingOutcome.Failed
+                        ExportOutcome.Saved -> if (truncated) RecordingOutcome.SavedTruncated else RecordingOutcome.Saved
                     },
                 )
             }
@@ -91,6 +92,7 @@ enum class RecordingOutcome {
     Saved,
     SavedTruncated,
     Empty,
+    Failed,
     Cancelled;
 
     /** A cancelled Save-As is the user's own choice — nothing to tell them about it. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordingOutcomeText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordingOutcomeText.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.terminal
 import androidx.compose.runtime.Composable
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_record_empty
+import app.skerry.ui.generated.resources.term_record_failed
 import app.skerry.ui.generated.resources.term_record_saved
 import app.skerry.ui.generated.resources.term_record_truncated
 import org.jetbrains.compose.resources.stringResource
@@ -16,6 +17,7 @@ fun recordingOutcomeMessage(outcome: RecordingOutcome): String = when (outcome) 
     RecordingOutcome.Saved -> stringResource(Res.string.term_record_saved)
     RecordingOutcome.SavedTruncated -> stringResource(Res.string.term_record_truncated)
     RecordingOutcome.Empty -> stringResource(Res.string.term_record_empty)
+    RecordingOutcome.Failed -> stringResource(Res.string.term_record_failed)
     // Never shown (see RecordingOutcome.worthReporting), but the mapping stays total.
     RecordingOutcome.Cancelled -> ""
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ExportFile.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/ExportFile.kt
@@ -1,8 +1,46 @@
 package app.skerry.ui.vault
 
+import kotlinx.coroutines.CancellationException
+
+/**
+ * How an export ended. A `Boolean` cannot separate the two ways nothing was written — the user
+ * closing the Save-As dialog, and the write itself failing — and the caller has to, because one of
+ * them is worth interrupting them over and the other is not.
+ */
+enum class ExportOutcome {
+    Saved,
+    Cancelled,
+    Failed;
+
+    /** A cancelled Save-As is the user's own choice; a failed write is not, and silence reads as success. */
+    val worthReporting: Boolean get() = this == Failed
+}
+
 /**
  * Saves [content] to a file chosen via the native "Save As" dialog with [suggestedName]. Used to
- * export a key from the vault (public key / private PEM). Returns `true` if the file was written,
- * `false` on cancel or an unsupported platform.
+ * export a private key from the vault and to save a session recording. The content is secret in both
+ * cases, so implementations write it as a private file (0600 where the platform has permissions).
  */
-expect suspend fun exportTextFile(suggestedName: String, content: String): Boolean
+internal expect suspend fun exportTextFile(suggestedName: String, content: String): ExportOutcome
+
+/**
+ * [exportTextFile] with anything it throws collapsed to [ExportOutcome.Failed]. The platform writers
+ * guard their own IO, but the step before it — opening the picker — is not theirs: `launch()` on an
+ * Android document contract throws when no provider handles the intent, and that exception would
+ * escape into the calling screen's `rememberCoroutineScope()`, cancel it, and leave every later
+ * action on that screen silently doing nothing.
+ *
+ * [CancellationException] is rethrown rather than reported: a cancelled export is the composition
+ * going away, not a failure to tell the user about.
+ */
+internal suspend fun exportFileGuarded(suggestedName: String, content: String): ExportOutcome =
+    guardedExport { exportTextFile(suggestedName, content) }
+
+/**
+ * Runs [write] and collapses anything it throws to [ExportOutcome.Failed], rethrowing
+ * [CancellationException]. Shared by [exportFileGuarded] and the vault's export actions, which have
+ * to guard an injected writer rather than this one.
+ */
+internal suspend fun guardedExport(write: suspend () -> ExportOutcome): ExportOutcome =
+    runCatching { write() }
+        .getOrElse { if (it is CancellationException) throw it else ExportOutcome.Failed }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretCopyAuthorizer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretCopyAuthorizer.kt
@@ -12,6 +12,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vtail_bio_copy_cancel
 import app.skerry.ui.generated.resources.vtail_bio_copy_subtitle
 import app.skerry.ui.generated.resources.vtail_bio_copy_title
+import app.skerry.ui.generated.resources.vtail_bio_export_subtitle
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -21,10 +22,18 @@ import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.getString
 
 /**
- * Re-authenticates before copying a sensitive secret (password) to the clipboard: an unlocked
- * vault alone shouldn't let anyone copy a password from an unattended screen. If biometrics are
- * enabled and available, uses the system biometric prompt ([VaultBiometrics.confirm]); otherwise
- * falls back to the master password ([Vault.verifyPassword]). The action runs only after success.
+ * What the vault is being asked to hand over. It selects the prompt's wording — the check itself is
+ * the same — so a biometric sheet or a password dialog never says "copy to the clipboard" over an
+ * action that writes a private key to disk.
+ */
+internal enum class SecretAccess { COPY, EXPORT }
+
+/**
+ * Re-authenticates before a sensitive secret leaves the vault — a password to the clipboard, a
+ * private key to a file: an unlocked vault alone shouldn't let anyone take either off an unattended
+ * screen. If biometrics are enabled and available, uses the system biometric prompt
+ * ([VaultBiometrics.confirm]); otherwise falls back to the master password ([Vault.verifyPassword]).
+ * The action runs only after success.
  *
  * Shared by desktop ([app.skerry.ui.vault.VaultView]) and mobile ([app.skerry.ui.mobile.MobileVaultView])
  * keychains; desktop has no biometrics (`biometrics == null`), so it always falls back to password.
@@ -52,6 +61,10 @@ internal class SecretCopyAuthorizer(
     var verifying by mutableStateOf(false)
         private set
 
+    /** What the open prompt is asking for; the dialog words itself from it. */
+    var access by mutableStateOf(SecretAccess.COPY)
+        private set
+
     // Deferred action (copy) waiting on password confirmation; unused on the biometric path.
     private var pending: (() -> Unit)? = null
 
@@ -59,15 +72,20 @@ internal class SecretCopyAuthorizer(
     private var biometricInFlight = false
 
     /**
-     * Requests authorization before [onAuthorized] (the copy action). Uses biometrics if enabled
-     * and available; cancel/failure there aborts without falling back to the password form. Any
-     * other biometric outcome (not enabled/unavailable/invalidated/hardware error) falls back to
-     * the password form. Repeat calls while a prompt is in flight are ignored.
+     * Requests authorization before [onAuthorized] (the copy or export action). Uses biometrics if
+     * enabled and available; cancel/failure there aborts without falling back to the password form.
+     * Any other biometric outcome (not enabled/unavailable/invalidated/hardware error) falls back to
+     * the password form. Repeat calls while a prompt is in flight are ignored. [access] only words
+     * the prompt.
      */
-    fun authorize(onAuthorized: () -> Unit) {
+    fun authorize(access: SecretAccess = SecretAccess.COPY, onAuthorized: () -> Unit) {
         val bio = biometrics
         if (bio != null && bio.isEnabled() && bio.availability() == BiometricAvailability.Available) {
+            // Assigned only past this guard: a second tap while a prompt is in flight is dropped, and
+            // re-wording the open prompt for a request that was never started would put "Export" over
+            // a pending clipboard copy.
             if (biometricInFlight) return
+            this.access = access
             biometricInFlight = true
             scope.launch {
                 // Reset in finally: coroutine cancellation (screen left/vault locked mid-prompt) would
@@ -76,7 +94,12 @@ internal class SecretCopyAuthorizer(
                     val prompt = BiometricPrompt(
                         title = getString(Res.string.vtail_bio_copy_title),
                         cancelLabel = getString(Res.string.vtail_bio_copy_cancel),
-                        subtitle = getString(Res.string.vtail_bio_copy_subtitle),
+                        subtitle = getString(
+                            when (access) {
+                                SecretAccess.COPY -> Res.string.vtail_bio_copy_subtitle
+                                SecretAccess.EXPORT -> Res.string.vtail_bio_export_subtitle
+                            },
+                        ),
                     )
                     // confirm() may throw on some devices; fall back to password instead of crashing.
                     // CancellationException is rethrown rather than swallowed, so cancellation doesn't
@@ -95,15 +118,16 @@ internal class SecretCopyAuthorizer(
                     BiometricConfirmResult.Confirmed -> onAuthorized()
                     BiometricConfirmResult.Cancelled, BiometricConfirmResult.Failed -> Unit
                     // NotEnabled/Unavailable/Invalidated, and exceptions (null): fall back to password.
-                    else -> requirePassword(onAuthorized)
+                    else -> requirePassword(access, onAuthorized)
                 }
             }
         } else {
-            requirePassword(onAuthorized)
+            requirePassword(access, onAuthorized)
         }
     }
 
-    private fun requirePassword(onAuthorized: () -> Unit) {
+    private fun requirePassword(access: SecretAccess, onAuthorized: () -> Unit) {
+        this.access = access
         pending = onAuthorized
         passwordError = false
         passwordPromptVisible = true

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretExport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretExport.kt
@@ -1,0 +1,135 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.io.safeFileStem
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * One file "Export" writes: the [fileName] offered in the Save-As dialog and the [content] written
+ * into it.
+ *
+ * Split by sensitivity rather than carrying a boolean, because the two halves take different paths
+ * out of the vault: [exportPublic] accepts a [Public] and nothing else, so a private key cannot be
+ * handed to the ungated writer by mistake — that mistake, made once, is issue #218. The split stops
+ * the accident, not a determined caller: `Public(name, pem)` still compiles, and what actually keeps
+ * the two apart is that [privateKeyExport] and [certificateExport] are the only producers.
+ *
+ * `toString` redacts everything — the rule every secret-carrying type in the app follows
+ * ([CredentialSecret], `CredentialDraft`): one `"$export"` in a log line would otherwise print a
+ * whole private key. The file name goes too, because it is built from the vault label, and
+ * `Credential.toString` redacts that for its own reason: `root@customer-bastion` is information
+ * even without the key beside it.
+ */
+sealed interface SecretExport {
+    val fileName: String
+    val content: String
+
+    /** Key material. Leaves the vault only through [exportPrivateKey], behind re-authentication. */
+    data class PrivateKey(override val fileName: String, override val content: String) : SecretExport {
+        override fun toString(): String = "SecretExport.PrivateKey(redacted)"
+    }
+
+    /** Public half (a certificate) — no gate, the same as the Copy button beside it. */
+    data class Public(override val fileName: String, override val content: String) : SecretExport {
+        override fun toString(): String = "SecretExport.Public(redacted)"
+    }
+}
+
+/**
+ * The private key of a keychain secret as a file, or `null` when there is none to write: a password
+ * is not a file, and a file-backed secret already *is* one — its material never entered the vault.
+ * This is the half a user cannot get out of the vault any other way, so it leaves only behind
+ * re-authentication ([exportPrivateKey]).
+ *
+ * The PEM is written exactly as stored, encrypted or not. A key imported under a passphrase stays
+ * encrypted in the file and the passphrase is not written next to it — it is the user's own.
+ */
+fun privateKeyExport(credential: Credential): SecretExport.PrivateKey? {
+    val pem = when (val secret = credential.secret) {
+        is CredentialSecret.PrivateKey -> secret.privateKeyPem
+        is CredentialSecret.Certificate -> secret.privateKeyPem
+        is CredentialSecret.Password, is CredentialSecret.KeyFile -> return null
+    }
+    // ".pem" over the OpenSSH convention of no extension at all: a Save-As dialog with no extension
+    // is where a file goes missing, and both formats the vault holds (openssh-key-v1 and PKCS#1)
+    // are PEM-armoured.
+    return SecretExport.PrivateKey("${fileStem(credential)}.pem", pem)
+}
+
+/**
+ * The CA-signed certificate as a file, or `null` for a secret that has none. Authenticating with a
+ * certificate takes both files (`id` and `id-cert.pub`), so exporting the key alone would hand over
+ * an unusable half — and on a phone there is nowhere to paste "Copy certificate" into a file.
+ *
+ * Deliberately a second button rather than a second file written by the same one: two Save-As
+ * dialogs behind one authorization can end half-done, and "the export failed" would then be a lie
+ * told over a private key already lying on disk. One button writes one file and reports on it.
+ *
+ * Public material, so no re-authentication — the same as the "Copy certificate" beside it.
+ */
+fun certificateExport(credential: Credential): SecretExport.Public? {
+    val secret = credential.secret as? CredentialSecret.Certificate ?: return null
+    return SecretExport.Public("${fileStem(credential)}-cert.pub", secret.certificate)
+}
+
+private fun fileStem(credential: Credential): String = safeFileStem(credential.label, fallback = "key")
+
+/**
+ * Which buttons the detail panel's bottom row carries. Decided here, once, because both screens draw
+ * the same three layouts out of their own platform primitives — and a chain of ifs that got the
+ * pairing right by accident would drift between them the first time someone edited one of the two.
+ */
+enum class SecretActions {
+    /** Export key · Export certificate, with Delete on its own row below. */
+    KeyAndCertificate,
+
+    /** Export key · Delete. */
+    KeyAndDelete,
+
+    /** Delete only — a password or a file-backed secret has nothing to write out. */
+    DeleteOnly,
+}
+
+/** The row layout for [credential]; see [SecretActions]. */
+fun secretActions(credential: Credential): SecretActions = when {
+    certificateExport(credential) != null -> SecretActions.KeyAndCertificate
+    privateKeyExport(credential) != null -> SecretActions.KeyAndDelete
+    else -> SecretActions.DeleteOnly
+}
+
+/**
+ * The Export action for private key material, shared by the desktop panel and the mobile sheet:
+ * re-authenticate, then write. The two must not drift — this is the gate issue #218 was missing, and
+ * a screen calling [exportTextFile] directly would hand out a private key from an unattended
+ * unlocked screen.
+ *
+ * [onOutcome] is told how it ended so the caller can surface a failure (see
+ * [ExportOutcome.worthReporting]); it never runs when authorization is refused, which is the
+ * behaviour `SecretExportGateTest` pins down. [write] is [exportTextFile] in the app and a fake in
+ * tests — the only way to exercise this without a native file dialog.
+ */
+internal fun exportPrivateKey(
+    auth: SecretCopyAuthorizer,
+    export: SecretExport.PrivateKey,
+    scope: CoroutineScope,
+    write: suspend (SecretExport) -> ExportOutcome = { exportTextFile(it.fileName, it.content) },
+    onOutcome: (ExportOutcome) -> Unit,
+) {
+    auth.authorize(SecretAccess.EXPORT) {
+        scope.launch { onOutcome(guardedExport { write(export) }) }
+    }
+}
+
+/** Writes public material (the certificate) — no gate, the same as copying it to the clipboard. */
+internal fun exportPublic(
+    export: SecretExport.Public,
+    scope: CoroutineScope,
+    write: suspend (SecretExport) -> ExportOutcome = { exportTextFile(it.fileName, it.content) },
+    onOutcome: (ExportOutcome) -> Unit,
+) {
+    scope.launch { onOutcome(guardedExport { write(export) }) }
+}
+
+

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
@@ -61,6 +61,8 @@ import app.skerry.ui.generated.resources.vault_cancel
 import app.skerry.ui.generated.resources.vault_cert_read_error
 import app.skerry.ui.generated.resources.vault_cert_valid_summary
 import app.skerry.ui.generated.resources.vault_confirm_master_subtitle
+import app.skerry.ui.generated.resources.vault_confirm_master_subtitle_export
+import app.skerry.ui.generated.resources.vault_export
 import app.skerry.ui.generated.resources.vault_confirm_master_title
 import app.skerry.ui.generated.resources.vault_copy
 import app.skerry.ui.generated.resources.vault_delete
@@ -263,13 +265,29 @@ private fun RefField(label: String, value: String, onValueChange: (String) -> Un
  * open for another attempt. The field clears when the dialog is recreated.
  */
 @Composable
-internal fun PasswordConfirmDialog(error: Boolean, busy: Boolean, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+internal fun PasswordConfirmDialog(
+    error: Boolean,
+    busy: Boolean,
+    access: SecretAccess,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
     var password by remember { mutableStateOf("") }
-    VaultDialogScaffold(stringResource(Res.string.vault_confirm_master_title), stringResource(Res.string.vault_confirm_master_subtitle), onDismiss) {
+    // The dialog names the action it is gating: a master password typed for "Copy" must not be the
+    // one that writes a private key to disk.
+    val subtitle = when (access) {
+        SecretAccess.COPY -> stringResource(Res.string.vault_confirm_master_subtitle)
+        SecretAccess.EXPORT -> stringResource(Res.string.vault_confirm_master_subtitle_export)
+    }
+    val confirmLabel = when (access) {
+        SecretAccess.COPY -> stringResource(Res.string.vault_copy)
+        SecretAccess.EXPORT -> stringResource(Res.string.vault_export)
+    }
+    VaultDialogScaffold(stringResource(Res.string.vault_confirm_master_title), subtitle, onDismiss) {
         DialogField(stringResource(Res.string.vault_field_master_password), password, { password = it }, placeholder = stringResource(Res.string.vault_placeholder_master_password), password = true)
         if (error) Txt(stringResource(Res.string.vault_password_mismatch_retry), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(top = 12.dp))
         // confirmEnabled is disabled while verifying (Argon2id) — otherwise a double-tap would run it twice.
-        DialogButtons(confirmLabel = stringResource(Res.string.vault_copy), confirmEnabled = password.isNotEmpty() && !busy, onDismiss = onDismiss, onConfirm = { onConfirm(password) })
+        DialogButtons(confirmLabel = confirmLabel, confirmEnabled = password.isNotEmpty() && !busy, onDismiss = onDismiss, onConfirm = { onConfirm(password) })
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
@@ -32,7 +32,7 @@ import app.skerry.ui.generated.resources.vault_copy_public_key
 import app.skerry.ui.generated.resources.vault_delete
 import app.skerry.ui.generated.resources.vault_e2e_description
 import app.skerry.ui.generated.resources.vault_e2e_encrypted
-import app.skerry.ui.generated.resources.vault_export
+import app.skerry.ui.generated.resources.vault_export_key
 import app.skerry.ui.generated.resources.vault_header_summary
 import app.skerry.ui.generated.resources.vault_item_count
 import app.skerry.ui.generated.resources.vault_title
@@ -142,7 +142,7 @@ private fun MockSecretDetail(credential: Credential, mono: FontFamily) {
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             PrimaryButton(stringResource(Res.string.vault_copy_public_key), onClick = {}, icon = "content_copy", modifier = Modifier.fillMaxWidth())
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                GhostButton(stringResource(Res.string.vault_export), onClick = {}, modifier = Modifier.weight(1f))
+                GhostButton(stringResource(Res.string.vault_export_key), onClick = {}, modifier = Modifier.weight(1f))
                 GhostButton(stringResource(Res.string.vault_delete), onClick = {}, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -49,7 +49,8 @@ import app.skerry.ui.generated.resources.vault_copy_certificate
 import app.skerry.ui.generated.resources.vault_copy_password
 import app.skerry.ui.generated.resources.vault_copy_public_key
 import app.skerry.ui.generated.resources.vault_delete
-import app.skerry.ui.generated.resources.vault_export
+import app.skerry.ui.generated.resources.vault_export_key
+import app.skerry.ui.generated.resources.vault_export_certificate
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_cert_path
 import app.skerry.ui.generated.resources.vault_label_key_path
@@ -136,11 +137,14 @@ internal fun LiveSecretDetail(
     mono: FontFamily,
     onCopy: (String) -> Unit,
     onCopyPassword: (String) -> Unit,
-    onExport: (name: String, content: String) -> Unit,
+    onExportKey: (SecretExport.PrivateKey) -> Unit,
+    onExportPublic: (SecretExport.Public) -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val secret = credential.secret
+    val keyExport = remember(credential) { privateKeyExport(credential) }
+    val certExport = remember(credential) { certificateExport(credential) }
     val keyInfo = rememberKeyInfo(credential, generator)
     val certInfo = rememberCertInfo(credential, inspector)
     val keyFileState = (secret as? CredentialSecret.KeyFile)?.let { rememberKeyFileState(it, LocalSecretFileReader.current, inspector) }
@@ -195,23 +199,33 @@ internal fun LiveSecretDetail(
                 is CredentialSecret.KeyFile -> Unit
             }
             GhostButton(stringResource(Res.string.vault_rename), onClick = onRename, modifier = Modifier.fillMaxWidth())
-            when (secret) {
-                is CredentialSecret.Certificate -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    GhostButton(stringResource(Res.string.vault_export), onClick = { onExport("${credential.label}-cert.pub", secret.certificate) }, modifier = Modifier.weight(1f))
-                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
+            // Export writes the private key — the half of a key or a certificate that is otherwise
+            // trapped in the vault; it is labelled for what it hands out, and the host
+            // re-authenticates first. A certificate's public half gets its own button rather than a
+            // second file from this one: one button, one file, one outcome to report.
+            val deleteButton: @Composable (Modifier) -> Unit = { modifier ->
+                GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = modifier)
+            }
+            when (secretActions(credential)) {
+                SecretActions.KeyAndCertificate -> {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        GhostButton(stringResource(Res.string.vault_export_key), onClick = { keyExport?.let(onExportKey) }, modifier = Modifier.weight(1f))
+                        GhostButton(stringResource(Res.string.vault_export_certificate), onClick = { certExport?.let(onExportPublic) }, modifier = Modifier.weight(1f))
+                    }
+                    deleteButton(Modifier.fillMaxWidth())
                 }
-                is CredentialSecret.PrivateKey -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    GhostButton(stringResource(Res.string.vault_export), onClick = { keyInfo?.let { onExport("${credential.label}.pub", it.publicKeyOpenSsh) } }, modifier = Modifier.weight(1f))
-                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.weight(1f))
+                SecretActions.KeyAndDelete -> Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    GhostButton(stringResource(Res.string.vault_export_key), onClick = { keyExport?.let(onExportKey) }, modifier = Modifier.weight(1f))
+                    deleteButton(Modifier.weight(1f))
                 }
-                is CredentialSecret.Password, is CredentialSecret.KeyFile ->
-                    GhostButton(stringResource(Res.string.vault_delete), onClick = onDelete, fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f), modifier = Modifier.fillMaxWidth())
+                SecretActions.DeleteOnly -> deleteButton(Modifier.fillMaxWidth())
             }
         }
         SecretSectionLabel(encryptionSectionTitle())
         SecretEncryptionRows(syncing)
         // Audit counts clipboard copies, and only a password ever leaves the vault that way: for a
         // key or a certificate the copy button hands over the public half, which is not a secret.
+        // (An exported key is not a copy and is not counted — the log records clipboard events.)
         if (secret is CredentialSecret.Password) {
             SecretSectionLabel(auditSectionTitle())
             SecretAuditRows(usage)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -39,6 +39,9 @@ import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vault_export_dismiss
+import app.skerry.ui.generated.resources.vault_export_failed_message
+import app.skerry.ui.generated.resources.vault_export_failed_title
 import app.skerry.ui.generated.resources.vault_add_password
 import app.skerry.ui.generated.resources.vault_badge_expired
 import app.skerry.ui.generated.resources.vault_e2e_description
@@ -66,7 +69,6 @@ import app.skerry.ui.vault.VaultPresentation
 import app.skerry.ui.vault.title
 import app.skerry.ui.vault.copyPasswordToClipboard
 import app.skerry.ui.vault.copyTextToClipboard
-import app.skerry.ui.vault.exportTextFile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -74,6 +76,7 @@ import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.LocalSync
 import app.skerry.ui.sync.SyncStatus
+import app.skerry.ui.design.NoticeDialog
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.design.GhostButton
@@ -130,10 +133,12 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     val inspector = LocalSshCertificateInspector.current
     val scope = rememberCoroutineScope()
     val allCreds = credentials.credentials
-    // Re-authentication before copying a password (no biometrics on desktop — master password instead).
+    // Re-authentication before copying a password or exporting a key (no biometrics on desktop —
+    // master password instead).
     val vault = LocalVault.current
     val biometrics = LocalVaultBiometrics.current
     val copyAuth = remember(vault, biometrics, scope) { SecretCopyAuthorizer(vault, biometrics, scope) }
+    var exportFailed by remember { mutableStateOf(false) }
 
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
     var selectedId by remember { mutableStateOf<String?>(null) }
@@ -204,7 +209,17 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                             onCopyPassword = { pwd ->
                                 copyAuth.authorize { credentials.recordCopied(credential.id); copyPasswordToClipboard(pwd) }
                             },
-                            onExport = { name, content -> scope.launch { exportTextFile(name, content) } },
+                            // Private key material: the same re-authentication a password copy takes,
+                            // for the same reason — an unlocked vault on an unattended screen. A
+                            // cancelled Save-As stays silent; a failed write must not, or the user
+                            // walks away believing they have a backup.
+                            onExportKey = { export ->
+                                exportPrivateKey(copyAuth, export, scope) { exportFailed = it.worthReporting }
+                            },
+                            // The certificate is public — no gate, like the Copy button next to it.
+                            onExportPublic = { export ->
+                                exportPublic(export, scope) { exportFailed = it.worthReporting }
+                            },
                             onRename = { pendingRenameCred = credential },
                             onDelete = { pendingDeleteCred = credential },
                         )
@@ -314,10 +329,19 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                 },
             )
         }
+        if (exportFailed) {
+            NoticeDialog(
+                title = stringResource(Res.string.vault_export_failed_title),
+                message = stringResource(Res.string.vault_export_failed_message),
+                buttonLabel = stringResource(Res.string.vault_export_dismiss),
+                onDismiss = { exportFailed = false },
+            )
+        }
         if (copyAuth.passwordPromptVisible) {
             PasswordConfirmDialog(
                 error = copyAuth.passwordError,
                 busy = copyAuth.verifying,
+                access = copyAuth.access,
                 onDismiss = { copyAuth.dismiss() },
                 onConfirm = { copyAuth.submitPassword(it) },
             )

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/ExportOutcomeTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/ExportOutcomeTest.kt
@@ -1,0 +1,31 @@
+package app.skerry.ui.vault
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The one decision [ExportOutcome] encodes: which endings the user has to be told about. It exists
+ * because a single `Boolean` cannot tell "you cancelled the dialog" apart from "the write failed",
+ * and silence after a failed write reads as success — for a private key export, that is the user
+ * believing they have a backup they do not have.
+ */
+class ExportOutcomeTest {
+
+    @Test
+    fun a_cancelled_save_as_is_the_users_own_choice() {
+        assertFalse(ExportOutcome.Cancelled.worthReporting)
+    }
+
+    @Test
+    fun a_failed_write_is_reported() {
+        assertTrue(ExportOutcome.Failed.worthReporting)
+    }
+
+    @Test
+    fun a_written_file_speaks_for_itself() {
+        // The user chose the path in the dialog and can see the file there; a "saved!" box on top of
+        // that is the reassuring second sentence this UI does not write.
+        assertFalse(ExportOutcome.Saved.worthReporting)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/FakeUnlockedVault.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/FakeUnlockedVault.kt
@@ -1,0 +1,37 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.MergeResult
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SyncMeta
+import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+
+/**
+ * Unlocked vault that accepts exactly one master password — everything the re-authentication tests
+ * need and nothing else. Shared by [SecretCopyAuthorizerTest] and [SecretExportGateTest]: eighteen
+ * identical overrides copied into both would drift the first time [Vault] grows a member.
+ * (`VaultGateControllerTest` has its own, file-private fake — that one models a *locked* vault and
+ * its unlock outcomes, which is a different thing to fake.)
+ */
+internal class FakeUnlockedVault(private val correct: String) : Vault {
+    override fun verifyPassword(password: CharArray): Boolean = password.concatToString() == correct
+
+    override fun exists(): Boolean = true
+    override val isUnlocked: Boolean = true
+    override fun create(password: CharArray) = Unit
+    override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
+    override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Success
+    override fun exportDataKey(): DataKey? = null
+    override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
+    override fun lock() = Unit
+    override fun reset() = Unit
+    override fun records(): List<VaultRecord> = emptyList()
+    override fun syncMeta(): SyncMeta? = null
+    override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
+    override fun openPayload(id: String): ByteArray? = null
+    override fun put(id: String, type: RecordType, payload: ByteArray) = Unit
+    override fun remove(id: String) = Unit
+    override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretCopyAuthorizerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretCopyAuthorizerTest.kt
@@ -1,17 +1,11 @@
 package app.skerry.ui.vault
 
-import app.skerry.shared.vault.DataKey
-import app.skerry.shared.vault.MergeResult
-import app.skerry.shared.vault.RecordType
-import app.skerry.shared.vault.SyncMeta
-import app.skerry.shared.vault.UnlockResult
-import app.skerry.shared.vault.Vault
-import app.skerry.shared.vault.VaultRecord
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -25,32 +19,11 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class SecretCopyAuthorizerTest {
 
-    private class FakeVault(private val correct: String) : Vault {
-        override fun verifyPassword(password: CharArray): Boolean = password.concatToString() == correct
-
-        override fun exists(): Boolean = true
-        override val isUnlocked: Boolean = true
-        override fun create(password: CharArray) = Unit
-        override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
-        override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Success
-        override fun exportDataKey(): DataKey? = null
-        override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
-        override fun lock() = Unit
-        override fun reset() = Unit
-        override fun records(): List<VaultRecord> = emptyList()
-        override fun syncMeta(): SyncMeta? = null
-        override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
-        override fun openPayload(id: String): ByteArray? = null
-        override fun put(id: String, type: RecordType, payload: ByteArray) = Unit
-        override fun remove(id: String) = Unit
-        override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
-    }
-
     @Test
     fun `authorize without biometrics opens the password form and defers the action`() = runTest {
         var copied = false
         val auth = SecretCopyAuthorizer(
-            FakeVault("master"), biometrics = null, scope = this,
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
@@ -65,7 +38,7 @@ class SecretCopyAuthorizerTest {
     fun `correct password runs the deferred copy and closes the form`() = runTest {
         var copied = false
         val auth = SecretCopyAuthorizer(
-            FakeVault("master"), biometrics = null, scope = this,
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
         auth.authorize { copied = true }
@@ -83,7 +56,7 @@ class SecretCopyAuthorizerTest {
     fun `wrong password flags an error and keeps the action pending`() = runTest {
         var copied = false
         val auth = SecretCopyAuthorizer(
-            FakeVault("master"), biometrics = null, scope = this,
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
         auth.authorize { copied = true }
@@ -103,10 +76,43 @@ class SecretCopyAuthorizerTest {
     }
 
     @Test
+    fun `an export is gated by the same check and words the prompt for itself`() = runTest {
+        var exported = false
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        auth.authorize(SecretAccess.EXPORT) { exported = true }
+
+        assertEquals(SecretAccess.EXPORT, auth.access, "the dialog reads this to name the action")
+        assertTrue(auth.passwordPromptVisible)
+        assertFalse(exported, "a private key leaves the vault only after the password check")
+
+        auth.submitPassword("master")
+        advanceUntilIdle()
+        assertTrue(exported)
+    }
+
+    @Test
+    fun `a copy after an export words the prompt back for a copy`() = runTest {
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+        auth.authorize(SecretAccess.EXPORT) {}
+        auth.dismiss()
+
+        auth.authorize { }
+
+        assertEquals(SecretAccess.COPY, auth.access)
+    }
+
+    @Test
     fun `dismiss drops the pending action`() = runTest {
         var copied = false
         val auth = SecretCopyAuthorizer(
-            FakeVault("master"), biometrics = null, scope = this,
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
         auth.authorize { copied = true }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
@@ -3,10 +3,12 @@ package app.skerry.ui.vault
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -90,6 +92,26 @@ class SecretExportGateTest {
         launch { laterWorkRan = true }
         advanceUntilIdle()
         assertTrue(laterWorkRan, "the scope was cancelled — later actions on this screen are dead")
+    }
+
+    @Test
+    fun `a cancelled export is not reported as a failure`() = runTest {
+        // The composition going away is not something to interrupt the user about. Pinned at the
+        // action, not at guardedExport: an inline runCatching here would collapse cancellation into
+        // "Export failed" and pop that dialog every time the sheet closed mid-write.
+        var reported: ExportOutcome? = null
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { throw CancellationException("screen left") }) {
+            reported = it
+        }
+        auth.submitPassword("master")
+        runCatching { advanceUntilIdle() }
+
+        assertNull(reported, "a cancelled export must not be reported as an outcome")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
@@ -1,0 +1,137 @@
+package app.skerry.ui.vault
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The join issue #218 was missing: a private key must not reach the disk until the user has
+ * re-authenticated. `privateKeyExport` being correct and `SecretCopyAuthorizer` being correct prove
+ * nothing on their own — the bug was in the wiring between them, so the wiring is what this pins.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecretExportGateTest {
+
+    private val key = SecretExport.PrivateKey("id_ed25519.pem", "-----BEGIN OPENSSH PRIVATE KEY-----")
+    private val cert = SecretExport.Public("id_ed25519-cert.pub", "ssh-ed25519-cert-v01@openssh.com AAAA")
+
+    @Test
+    fun `nothing is written until the master password is confirmed`() = runTest {
+        val written = mutableListOf<String>()
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }) {}
+        advanceUntilIdle()
+
+        assertTrue(written.isEmpty(), "the key reached disk without authorization: $written")
+
+        auth.submitPassword("master")
+        advanceUntilIdle()
+        assertEquals(listOf("id_ed25519.pem"), written)
+    }
+
+    @Test
+    fun `a refused authorization writes nothing at all`() = runTest {
+        val written = mutableListOf<String>()
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }) {}
+        auth.dismiss()
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertTrue(written.isEmpty(), "a dismissed prompt still exported: $written")
+    }
+
+    @Test
+    fun `the certificate is written without a password check`() = runTest {
+        // Public material, like the Copy button beside it. If this ever starts demanding the master
+        // password, the two actions have been wired to the wrong helper.
+        val written = mutableListOf<String>()
+
+        var reported: ExportOutcome? = null
+        exportPublic(cert, scope = this, write = { written += it.fileName; ExportOutcome.Saved }) { reported = it }
+        advanceUntilIdle()
+
+        assertEquals(listOf("id_ed25519-cert.pub"), written)
+        assertEquals(ExportOutcome.Saved, reported)
+    }
+
+    @Test
+    fun `a write that throws is reported as failed and does not kill the screen's scope`() = runTest {
+        // The picker itself can throw before any byte is written — ActivityNotFoundException when no
+        // document provider handles the intent, and worse on some OEM ROMs. Escaping into the shared
+        // scope would cancel it, and every later action on that screen (copy password, generate key)
+        // would then be dropped in silence.
+        var reported: ExportOutcome? = null
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { error("no document provider") }) { reported = it }
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(ExportOutcome.Failed, reported)
+
+        var laterWorkRan = false
+        launch { laterWorkRan = true }
+        advanceUntilIdle()
+        assertTrue(laterWorkRan, "the scope was cancelled — later actions on this screen are dead")
+    }
+
+    @Test
+    fun `a failed certificate write is reported too`() = runTest {
+        var reported: ExportOutcome? = null
+
+        exportPublic(cert, scope = this, write = { ExportOutcome.Failed }) { reported = it }
+        advanceUntilIdle()
+
+        assertEquals(ExportOutcome.Failed, reported)
+    }
+
+    @Test
+    fun `a failed write is reported to the caller`() = runTest {
+        var reported: ExportOutcome? = null
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Failed }) { reported = it }
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(ExportOutcome.Failed, reported)
+        assertTrue(reported!!.worthReporting)
+    }
+
+    @Test
+    fun `a cancelled save-as is reported but not worth a dialog`() = runTest {
+        var reported: ExportOutcome? = null
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Cancelled }) { reported = it }
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(ExportOutcome.Cancelled, reported)
+        assertTrue(!reported!!.worthReporting)
+    }
+
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportTest.kt
@@ -1,0 +1,120 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val PEM = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE=\n-----END OPENSSH PRIVATE KEY-----\n"
+private const val CERT = "ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1 deploy@ci"
+
+class SecretExportTest {
+
+    @Test
+    fun a_private_key_exports_the_private_key() {
+        val export = privateKeyExport(Credential("k1", "id_ed25519", CredentialSecret.PrivateKey(PEM)))
+        assertEquals(PEM, export?.content)
+        assertEquals("id_ed25519.pem", export?.fileName)
+    }
+
+    @Test
+    fun a_private_key_never_exports_its_public_half() {
+        // The bug this test was written for: Export handed out `<label>.pub` with the OpenSSH public
+        // key in it — the one half already covered by "Copy public key", and the one the user can
+        // regenerate from the key anyway.
+        val export = privateKeyExport(Credential("k1", "id_ed25519", CredentialSecret.PrivateKey(PEM)))!!
+        assertTrue(!export.fileName.endsWith(".pub"), export.fileName)
+        assertTrue(export.content.startsWith("-----BEGIN"))
+    }
+
+    @Test
+    fun a_certificate_offers_the_key_and_the_certificate_as_two_separate_files() {
+        // Authenticating with a certificate needs both files; exporting only the public one (the old
+        // behaviour) left the credential unusable on the target machine. They are two actions, not
+        // one action writing two files — see certificateExport.
+        val credential = Credential("c1", "prod-ca", CredentialSecret.Certificate(PEM, CERT))
+        assertEquals(SecretExport.PrivateKey("prod-ca.pem", PEM), privateKeyExport(credential))
+        assertEquals(SecretExport.Public("prod-ca-cert.pub", CERT), certificateExport(credential))
+    }
+
+    @Test
+    fun only_a_certificate_has_a_certificate_to_export() {
+        assertEquals(null, certificateExport(Credential("k1", "id_ed25519", CredentialSecret.PrivateKey(PEM))))
+        assertEquals(null, certificateExport(Credential("p1", "root", CredentialSecret.Password("x"))))
+    }
+
+    @Test
+    fun a_passphrase_protected_key_is_exported_as_stored_without_its_passphrase() {
+        val export = privateKeyExport(Credential("k1", "id_rsa", CredentialSecret.PrivateKey(PEM, passphrase = "s3cret")))!!
+        assertEquals(PEM, export.content)
+        assertTrue("s3cret" !in export.content)
+    }
+
+    @Test
+    fun a_password_has_nothing_to_export() {
+        assertEquals(null, privateKeyExport(Credential("p1", "root", CredentialSecret.Password("hunter2"))))
+    }
+
+    @Test
+    fun a_file_backed_secret_has_nothing_to_export() {
+        assertEquals(null, privateKeyExport(Credential("f1", "teleport", CredentialSecret.KeyFile("/home/me/.ssh/id_ecdsa"))))
+    }
+
+    @Test
+    fun a_label_cannot_turn_into_a_path() {
+        // Labels are user data and travel straight into a Save-As dialog.
+        val export = privateKeyExport(Credential("k1", "../../etc/id_rsa", CredentialSecret.PrivateKey(PEM)))
+        assertEquals("etc-id_rsa.pem", export?.fileName)
+    }
+
+    @Test
+    fun a_nameless_secret_still_gets_a_file_name() {
+        assertEquals("key.pem", privateKeyExport(Credential("k1", "///", CredentialSecret.PrivateKey(PEM)))?.fileName)
+    }
+
+    @Test
+    fun a_label_that_names_a_windows_device_does_not_become_one() {
+        // On Windows `aux.pem` resolves to the AUX device, not a file: the write reports success and
+        // nothing appears on disk — after the user has spent a re-authentication on it.
+        val export = privateKeyExport(Credential("k1", "aux", CredentialSecret.PrivateKey(PEM)))
+        assertEquals("aux-key.pem", export?.fileName)
+    }
+
+    @Test
+    fun each_secret_kind_gets_its_own_button_row() {
+        // Decided once for both screens: a chain of ifs that happened to pair up correctly would
+        // drift the first time one platform was edited and the other wasn't.
+        assertEquals(
+            SecretActions.KeyAndCertificate,
+            secretActions(Credential("c1", "prod-ca", CredentialSecret.Certificate(PEM, CERT))),
+        )
+        assertEquals(
+            SecretActions.KeyAndDelete,
+            secretActions(Credential("k1", "id_ed25519", CredentialSecret.PrivateKey(PEM))),
+        )
+        assertEquals(
+            SecretActions.DeleteOnly,
+            secretActions(Credential("p1", "root", CredentialSecret.Password("x"))),
+        )
+        assertEquals(
+            SecretActions.DeleteOnly,
+            secretActions(Credential("f1", "teleport", CredentialSecret.KeyFile("/home/me/.ssh/id_ecdsa"))),
+        )
+    }
+
+    @Test
+    fun the_certificate_export_hides_the_label_too() {
+        val export = certificateExport(Credential("c1", "root@customer-bastion", CredentialSecret.Certificate(PEM, CERT)))!!
+        assertTrue("customer-bastion" !in export.toString(), export.toString())
+    }
+
+    @Test
+    fun the_export_never_prints_the_key_material() {
+        val export = privateKeyExport(Credential("k1", "id_ed25519", CredentialSecret.PrivateKey(PEM)))!!
+        // Neither the key nor the label it was named after: Credential.toString redacts the label
+        // for the same reason.
+        assertTrue("BEGIN" !in export.toString(), export.toString())
+        assertTrue("id_ed25519" !in export.toString(), export.toString())
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
@@ -14,9 +14,9 @@ import org.jetbrains.compose.resources.getString
 /**
  * Desktop export via the native AWT [FileDialog] (like [app.skerry.ui.sftp.pickDownloadTarget]).
  * The modal dialog runs a nested EDT event loop, so it's shown on [Dispatchers.Swing]; the write
- * happens on the IO dispatcher. Cancellation (directory/name null) returns `false`.
+ * happens on the IO dispatcher. Cancellation (directory/name null) returns [ExportOutcome.Cancelled].
  */
-actual suspend fun exportTextFile(suggestedName: String, content: String): Boolean {
+internal actual suspend fun exportTextFile(suggestedName: String, content: String): ExportOutcome {
     // Same dialog title as the SFTP download picker, so the shared key is reused.
     val title = getString(Res.string.sftp_dialog_save_as)
     val path = withContext(Dispatchers.Swing) {
@@ -27,14 +27,24 @@ actual suspend fun exportTextFile(suggestedName: String, content: String): Boole
         val dir = dialog.directory ?: return@withContext null
         val name = dialog.file ?: return@withContext null
         File(dir, name).absolutePath
-    } ?: return false
-    withContext(Dispatchers.IO) {
-        val file = File(path)
-        file.writeText(content)
-        // A session recording holds whatever the server printed — tokens, key material echoed by a
-        // careless command. Default umask leaves it 0644, readable by every local account, so it
-        // gets the same 0600 as every other private file Skerry writes.
-        PrivateConfig.harden(file.toPath())
+    } ?: return ExportOutcome.Cancelled
+    return withContext(Dispatchers.IO) {
+        // What travels through here is secret: a session recording holds whatever the server printed,
+        // and a keychain export is the private key itself. writePrivateFile attaches 0600 as the file
+        // is created (where the platform has permissions) — writing first and hardening after would
+        // leave the key world-readable for the width of that gap, and ssh(1) refuses a key at 0644
+        // anyway. Not atomicWrite: that one also forces 0700 on the parent, which here is the
+        // directory the user picked in the dialog — their Downloads folder is not ours to
+        // re-permission. A failed write is reported rather than swallowed: the user re-authenticated
+        // for this and would otherwise believe they have a backup they don't.
+        // The String behind the key can't be zeroed (accepted, see Credential's KDoc), but this copy
+        // of it can be, and is — no reason to leave a second one for a heap dump or swap to find.
+        val bytes = content.toByteArray()
+        try {
+            runCatching { PrivateConfig.writePrivateFile(File(path).toPath(), bytes) }
+                .fold(onSuccess = { ExportOutcome.Saved }, onFailure = { ExportOutcome.Failed })
+        } finally {
+            bytes.fill(0)
+        }
     }
-    return true
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/io/FileNames.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/io/FileNames.kt
@@ -1,0 +1,46 @@
+package app.skerry.shared.io
+
+/**
+ * Turns user data — a host label, a secret's name — into the stem of a file name a Save-As dialog
+ * can be handed on any platform. A label may hold anything a person can type, including the two
+ * spellings that stop being a name and start being a location: a separator and `..`.
+ *
+ * Everything that isn't a letter, digit, dash or underscore collapses to a dash; dots survive only
+ * when [keepDots] (a host name is mostly dots), and never two in a row. The result is trimmed of
+ * leading/trailing separators, cut to [maxLength], trimmed again — the cut can land on a separator —
+ * lowercased when [lowercase], and falls back to [fallback] when nothing printable is left.
+ */
+fun safeFileStem(
+    raw: String,
+    fallback: String,
+    keepDots: Boolean = false,
+    lowercase: Boolean = false,
+    maxLength: Int = 48,
+): String {
+    val mapped = raw.map { ch ->
+        when {
+            ch.isLetterOrDigit() || ch == '-' || ch == '_' -> ch
+            keepDots && ch == '.' -> ch
+            else -> '-'
+        }
+    }.joinToString("")
+    val stem = mapped
+        .replace("..", "-")
+        .replace(DASH_RUN, "-")
+        .trim('-', '.')
+        .take(maxLength)
+        .trim('-', '.')
+        .let { if (lowercase) it.lowercase() else it }
+        .ifEmpty { fallback }
+    // On Windows these are devices, not names: writing to "aux.pem" succeeds and produces no file.
+    return if (stem.substringBefore('.').lowercase() in WINDOWS_DEVICES) "$stem-$fallback" else stem
+}
+
+private val DASH_RUN = Regex("-+")
+
+/** Reserved DOS device names, still special in every Windows path today. */
+private val WINDOWS_DEVICES = setOf(
+    "con", "prn", "aux", "nul",
+    "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8", "com9",
+    "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+)

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SessionRecorder.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SessionRecorder.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.terminal
 
+import app.skerry.shared.io.safeFileStem
 import kotlinx.serialization.json.JsonPrimitive
 
 /**
@@ -166,14 +167,9 @@ private fun completeUtf8Length(data: ByteArray): Int {
 
 /**
  * File name suggested when exporting a recording: `skerry-<host>-<stamp>.cast`. The host label comes
- * from user data and travels into a Save-As dialog, so anything that isn't a letter, digit or dash
- * is collapsed — a label with a slash must not read as a path.
+ * from user data and travels into a Save-As dialog, so it goes through [safeFileStem] — a label with
+ * a slash must not read as a path. Dots are dropped rather than kept: a recording is filed by
+ * session, and `web-01.lan` gaining a second extension in front of `.cast` reads as the wrong format.
  */
-fun castFileName(hostLabel: String, stamp: String): String {
-    val safe = hostLabel.map { if (it.isLetterOrDigit()) it else '-' }
-        .joinToString("")
-        .split('-').filter { it.isNotEmpty() }.joinToString("-")
-        .lowercase()
-        .ifBlank { "session" }
-    return "skerry-$safe-$stamp.cast"
-}
+fun castFileName(hostLabel: String, stamp: String): String =
+    "skerry-${safeFileStem(hostLabel, fallback = "session", lowercase = true)}-$stamp.cast"

--- a/shared/src/commonTest/kotlin/app/skerry/shared/io/FileNamesTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/io/FileNamesTest.kt
@@ -1,0 +1,53 @@
+package app.skerry.shared.io
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FileNamesTest {
+
+    @Test
+    fun separators_and_traversal_collapse_to_dashes() {
+        assertEquals("etc-passwd", safeFileStem("../../etc/passwd", fallback = "x"))
+        assertEquals("a-b-c", safeFileStem("a/b\\c", fallback = "x"))
+    }
+
+    @Test
+    fun dots_survive_only_when_asked_for_and_never_two_in_a_row() {
+        assertEquals("web-01-lan", safeFileStem("web-01.lan", fallback = "x"))
+        assertEquals("web-01.lan", safeFileStem("web-01.lan", fallback = "x", keepDots = true))
+        assertEquals("a-b", safeFileStem("a..b", fallback = "x", keepDots = true))
+    }
+
+    @Test
+    fun a_stem_with_nothing_printable_falls_back() {
+        assertEquals("session", safeFileStem("   ", fallback = "session"))
+        assertEquals("session", safeFileStem("///", fallback = "session"))
+        assertEquals("session", safeFileStem("", fallback = "session"))
+    }
+
+    @Test
+    fun the_cut_never_leaves_a_dangling_separator() {
+        val stem = safeFileStem("host" + "-x".repeat(40), fallback = "x")
+        assertEquals(48, stem.length)
+        assertEquals(stem.trim('-', '.'), stem)
+    }
+
+    @Test
+    fun lowercasing_and_dots_compose() {
+        assertEquals("web-01.lan", safeFileStem("WEB-01.LAN", fallback = "x", keepDots = true, lowercase = true))
+    }
+
+    @Test
+    fun underscores_are_part_of_a_name_not_a_separator() {
+        assertEquals("deploy_box", safeFileStem("deploy_box", fallback = "x"))
+    }
+
+    @Test
+    fun a_windows_device_name_is_pushed_out_of_the_way() {
+        // "aux.pem" is the AUX device on Windows, whatever the extension.
+        assertEquals("aux-key", safeFileStem("AUX", fallback = "key", lowercase = true))
+        assertEquals("com1-key", safeFileStem("com1", fallback = "key"))
+        // Only the stem before the first dot decides; "auxiliary" is an ordinary name.
+        assertEquals("auxiliary", safeFileStem("auxiliary", fallback = "key"))
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SessionRecorderTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SessionRecorderTest.kt
@@ -172,5 +172,10 @@ class SessionRecorderTest {
         assertEquals("skerry-root-alpha-20251009-114640.cast", castFileName("root@alpha", "20251009-114640"))
         assertEquals("skerry-session-20251009-114640.cast", castFileName("   ", "20251009-114640"))
         assertEquals("skerry-a-b-c-20251009-114640.cast", castFileName("a/b\\c", "20251009-114640"))
+        // Dots would read as a second extension in front of .cast, underscores are a normal part of
+        // a host name, and a label long enough to bother a Save-As dialog is cut before the stamp.
+        assertEquals("skerry-web-01-lan-1.cast", castFileName("web-01.lan", "1"))
+        assertEquals("skerry-deploy_box-1.cast", castFileName("deploy_box", "1"))
+        assertEquals("skerry-${"h".repeat(48)}-1.cast", castFileName("h".repeat(80), "1"))
     }
 }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/io/PrivateConfigTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/io/PrivateConfigTest.kt
@@ -5,7 +5,9 @@ import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PrivateConfigTest {
@@ -78,6 +80,110 @@ class PrivateConfigTest {
             stream.map { it.fileName.toString() }.filter { it.endsWith(".tmp") }.toList()
         }
         assertTrue(leftovers.isEmpty(), "unexpected temp files: $leftovers")
+    }
+
+    @Test
+    fun `writePrivateFile stores the bytes owner-only`() {
+        val file = tempDir.resolve("id_ed25519.pem")
+
+        PrivateConfig.writePrivateFile(file, "-----BEGIN-----".toByteArray())
+
+        assertEquals("-----BEGIN-----", Files.readAllBytes(file).decodeToString())
+        assertEquals(
+            setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            Files.getPosixFilePermissions(file),
+        )
+    }
+
+    @Test
+    fun `writePrivateFile leaves the directory the user chose alone`() {
+        // The target here is a Save-As destination — Downloads, a USB stick — not Skerry's own
+        // config dir. Narrowing someone's Downloads folder to 0700 as a side effect of exporting a
+        // key is the reason this exists next to atomicWrite instead of reusing it.
+        val downloads = tempDir.resolve("downloads")
+        Files.createDirectories(downloads)
+        val before = java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x")
+        Files.setPosixFilePermissions(downloads, before)
+
+        PrivateConfig.writePrivateFile(downloads.resolve("key.pem"), "x".toByteArray())
+
+        assertEquals(before, Files.getPosixFilePermissions(downloads))
+    }
+
+    @Test
+    fun `writePrivateFile narrows an existing world-readable target before writing into it`() {
+        val file = tempDir.resolve("stale.pem")
+        Files.write(file, "old".toByteArray())
+        Files.setPosixFilePermissions(file, java.nio.file.attribute.PosixFilePermissions.fromString("rw-r--r--"))
+
+        PrivateConfig.writePrivateFile(file, "secret".toByteArray())
+
+        assertEquals("secret", Files.readAllBytes(file).decodeToString())
+        assertEquals(
+            setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            Files.getPosixFilePermissions(file),
+        )
+    }
+
+    @Test
+    fun `writePrivateFile writes every byte of a large secret`() {
+        // A single channel write may be short; a truncated private key that still reported success
+        // is the failure this guards.
+        val file = tempDir.resolve("big.pem")
+        val bytes = ByteArray(4 * 1024 * 1024) { (it % 251).toByte() }
+
+        PrivateConfig.writePrivateFile(file, bytes)
+
+        assertContentEquals(bytes, Files.readAllBytes(file))
+    }
+
+    @Test
+    fun `writePrivateFile replaces a symlink planted at the target name instead of following it`() {
+        // The export name is predictable, so in a shared directory the target may be someone else's
+        // symlink. Following it would write the key wherever it points; the move replaces the link.
+        val real = tempDir.resolve("attacker-owned")
+        Files.write(real, "old".toByteArray())
+        val link = tempDir.resolve("link.pem")
+        Files.createSymbolicLink(link, real)
+
+        PrivateConfig.writePrivateFile(link, "secret".toByteArray())
+
+        assertEquals("old", Files.readAllBytes(real).decodeToString(), "the key followed the symlink")
+        assertTrue(!Files.isSymbolicLink(link))
+        assertEquals("secret", Files.readAllBytes(link).decodeToString())
+        assertEquals(
+            setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+            Files.getPosixFilePermissions(link),
+        )
+    }
+
+    @Test
+    fun `writePrivateFile leaves no temp file behind`() {
+        val file = tempDir.resolve("id.pem")
+
+        PrivateConfig.writePrivateFile(file, "x".toByteArray())
+
+        val leftovers = Files.list(tempDir).use { s ->
+            s.map { it.fileName.toString() }.filter { it.endsWith(".tmp") }.toList()
+        }
+        assertTrue(leftovers.isEmpty(), "unexpected temp files: $leftovers")
+    }
+
+    @Test
+    fun `a failed write leaves no half-written secret behind`() {
+        // The move into place is what can fail here (the target is a directory, so neither ATOMIC_MOVE
+        // nor REPLACE_EXISTING can land). What must not survive is the temp file: it holds the whole
+        // private key, and the caller has just been told the export failed.
+        val target = tempDir.resolve("occupied")
+        Files.createDirectories(target)
+        Files.write(target.resolve("child"), "x".toByteArray())
+
+        assertFailsWith<java.io.IOException> { PrivateConfig.writePrivateFile(target, "secret".toByteArray()) }
+
+        val leftovers = Files.list(tempDir).use { s ->
+            s.map { it.fileName.toString() }.filter { it.endsWith(".tmp") }.toList()
+        }
+        assertTrue(leftovers.isEmpty(), "the key was left in a temp file: $leftovers")
     }
 
     @Test

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/io/PrivateConfig.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/io/PrivateConfig.kt
@@ -94,12 +94,21 @@ object PrivateConfig {
             // short (an ENOSPC boundary, a FUSE or network mount) and return normally, leaving a
             // truncated secret behind.
             channel.use { sink ->
-                Channels.newOutputStream(sink).use { it.write(bytes) }
+                // The stream is deliberately not closed: closing it closes `sink`, and force() on a
+                // closed channel throws — the flush below would be a no-op wearing a comment that
+                // says otherwise. It buffers nothing, so there is nothing to lose by leaving the
+                // single close to `use`.
+                Channels.newOutputStream(sink).write(bytes)
                 // Flushed before the rename: without it the move can land while the data does not
                 // (ext4 data=writeback, most network mounts), leaving a zero-length file where a
-                // host-key mismatch record or a private key was supposed to be. Best-effort — a
-                // filesystem may reject force(), and only a FileChannel offers it at all.
-                runCatching { (sink as? FileChannel)?.force(true) }
+                // host-key mismatch record or a private key was supposed to be. A failure here is
+                // *not* swallowed — under delayed allocation ENOSPC surfaces at fsync rather than at
+                // write, so this is the call that knows the bytes did not reach the medium, and
+                // reporting a private key as exported when they did not is the failure this whole
+                // path exists to avoid. Only the cast is tolerated: force() belongs to FileChannel.
+                // The directory entry itself is still not fsynced, so the window is narrowed rather
+                // than closed.
+                (sink as? FileChannel)?.force(true)
             }
             // No-op where the create attribute already applied, and a no-op on non-POSIX too — there
             // the mount's mask or the profile ACL is what decides, as the KDoc says.

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/io/PrivateConfig.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/io/PrivateConfig.kt
@@ -1,10 +1,14 @@
 package app.skerry.shared.io
 
+import java.nio.channels.Channels
+import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
+import java.util.UUID
 
 /**
  * Helpers for Skerry private config files: directory set to 0700, files to 0600 so local data
@@ -16,6 +20,7 @@ object PrivateConfig {
     private val DIR_PERMS_SET = PosixFilePermissions.fromString("rwx------")
     private val DIR_PERMS = PosixFilePermissions.asFileAttribute(DIR_PERMS_SET)
     private val FILE_PERMS = setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+    private val FILE_ATTR = PosixFilePermissions.asFileAttribute(FILE_PERMS)
 
     /**
      * Ensures [dir] exists with 0700 perms. Created with parents when missing; an existing directory
@@ -37,22 +42,68 @@ object PrivateConfig {
     }
 
     /**
-     * Atomically writes [bytes] to [path] as a private file (0600). Writes to a unique adjacent temp
-     * file (0600 on POSIX via `createTempFile`), then moves it into place ([ATOMIC_MOVE], falling back
-     * to [REPLACE_EXISTING]). The unique name (not a fixed `.tmp`) avoids a race between two processes
-     * over the same temp. Failures are rethrown and the partial temp is cleaned up.
+     * Writes [bytes] to [path] as a private file (0600) **without touching the parent directory** —
+     * the difference from [atomicWrite], whose target is always Skerry's own config dir. This one
+     * writes where a Save-As dialog pointed: Downloads, a USB stick, a shared project folder.
+     * Narrowing that directory to 0700 as a side effect of exporting one key would be Skerry
+     * re-permissioning the user's filesystem.
+     *
+     * Written through a private temp file and moved into place, so the bytes never sit at the umask
+     * default even briefly, a failed write never leaves a truncated key where the user will later
+     * mistake it for a backup, and a file pre-created at this (predictable) name by someone else is
+     * replaced rather than written into. Permissions are best-effort on filesystems that have none
+     * (Windows, FAT), where the profile ACL or the mount's mask applies instead. Failures are
+     * rethrown — the caller decides whether to report them.
+     */
+    fun writePrivateFile(path: Path, bytes: ByteArray) = writeThroughTemp(path, bytes)
+
+    /**
+     * Atomically writes [bytes] to [path] as a private file (0600), creating the parent directory
+     * (0700) if it is missing — the difference from [writePrivateFile], which must not touch a
+     * directory the user chose. Both share [writeThroughTemp]: a unique adjacent temp file created
+     * 0600, then moved into place. Failures are rethrown and the partial temp is cleaned up.
      */
     fun atomicWrite(path: Path, bytes: ByteArray) {
-        val parent = path.parent
-        if (parent != null) ensureDir(parent)
-        val tmp = if (parent != null) {
-            Files.createTempFile(parent, "${path.fileName}.", ".tmp")
-        } else {
-            path.resolveSibling("${path.fileName}.tmp").also { Files.deleteIfExists(it) }
-        }
+        path.parent?.let { ensureDir(it) }
+        writeThroughTemp(path, bytes)
+    }
+
+    /**
+     * Writes [bytes] into a private temp file beside [path] and moves it into place. Shared by
+     * [atomicWrite] and [writePrivateFile]; the only difference between the two is whether the
+     * parent directory is created and hardened first.
+     *
+     * The move is what makes every failure mode safe: a write that dies half-way leaves the temp
+     * file (deleted here), never a truncated target, and the target is *replaced* rather than opened
+     * — so a file someone else pre-created at the predictable export name, or a symlink planted
+     * there, is swapped out for our own 0600 file instead of being written into or followed.
+     */
+    private fun writeThroughTemp(path: Path, bytes: ByteArray) {
+        val posix = path.fileSystem.supportedFileAttributeViews().contains("posix")
+        // A unique name (not a fixed `.tmp`) avoids a race between two processes over the same temp.
+        val tmp = path.resolveSibling("${path.fileName}.${UUID.randomUUID()}.tmp")
         try {
-            Files.write(tmp, bytes)
-            harden(tmp) // createTempFile does not set 0600 on non-POSIX filesystems; enforce it (no-op on POSIX)
+            // Created and opened in one step, with CREATE_NEW: `createTempFile` followed by a write
+            // *by name* leaves a window in which someone who can write to this directory — it is the
+            // one the user picked in Save-As, not ours — swaps the temp for their own file or a
+            // symlink and receives the private key. O_EXCL closes it.
+            val options = setOf(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE)
+            val channel =
+                if (posix) Files.newByteChannel(tmp, options, FILE_ATTR) else Files.newByteChannel(tmp, options)
+            // Channels.newOutputStream loops until everything is written; a bare channel write may be
+            // short (an ENOSPC boundary, a FUSE or network mount) and return normally, leaving a
+            // truncated secret behind.
+            channel.use { sink ->
+                Channels.newOutputStream(sink).use { it.write(bytes) }
+                // Flushed before the rename: without it the move can land while the data does not
+                // (ext4 data=writeback, most network mounts), leaving a zero-length file where a
+                // host-key mismatch record or a private key was supposed to be. Best-effort — a
+                // filesystem may reject force(), and only a FileChannel offers it at all.
+                runCatching { (sink as? FileChannel)?.force(true) }
+            }
+            // No-op where the create attribute already applied, and a no-op on non-POSIX too — there
+            // the mount's mask or the profile ACL is what decides, as the KDoc says.
+            harden(tmp)
             runCatching { Files.move(tmp, path, StandardCopyOption.ATOMIC_MOVE) }
                 .onFailure { Files.move(tmp, path, StandardCopyOption.REPLACE_EXISTING) }
         } catch (t: Throwable) {


### PR DESCRIPTION
Fixes #218.

## Export hands out the private key

"Export" on a keychain secret wrote the *public* half — an OpenSSH public key under `<label>.pub` for a private key, the certificate for a certificate credential. Both are already available through their Copy buttons, and neither is what an export is for: a key generated in Skerry could not be taken out of the vault at all.

Export now writes the private key as `<label>.pem`, and a certificate credential gets a second button for its `-cert.pub`, because authenticating with a certificate takes both files and a phone has nowhere to paste a clipboard into one.

| Secret | Actions |
|---|---|
| Private key | Export key · Delete |
| Certificate | Export key · Export certificate, Delete below |
| Password, linked key file | Delete |

One button writes one file and reports on it. A cancelled Save-As is silent; a failed write says so.

## Export is re-authenticated

Handing out a private key now takes biometrics or the master password, the same gate "Copy password" uses, on desktop and Android. The prompt words itself for the action — a dialog that says "copy to the clipboard" over a write to disk is not a prompt the user can act on.

## Writing a secret to a user-chosen path

The exported file is written through a private temp file created `CREATE_NEW` with 0600 attached, flushed, and moved into place:

- The key never sits at the umask default, not even briefly.
- A failed write leaves no truncated PEM behind to be mistaken for a backup.
- A file or symlink pre-created at the (predictable) export name is replaced, not written into.
- The parent directory is left alone — `atomicWrite`, which serves Skerry's own config dir, forces it to 0700, and that is not a thing to do to someone's Downloads folder.

`atomicWrite` shares the same body and gains the flush, so a rename can no longer land without its data.

## Also in this change

- `exportTextFile` reports `Saved` / `Cancelled` / `Failed` instead of a `Boolean`, so the two ways nothing was written can be told apart. Session recordings use the same distinction and gained a "could not be written" notice.
- Any exception from the writer — including one thrown by the Android document picker before a byte is written — is reported as a failure instead of escaping into the screen's coroutine scope, where it would cancel it and leave every later action on that screen silently doing nothing.
- Android creates documents through the octet-stream contract; the `text/plain` one filed `id_ed25519.pem` as `id_ed25519.pem.txt`.
- `safeFileStem` replaces the two hand-rolled file-name sanitizers (session recordings, screenshots) and refuses Windows device names, so a secret labelled `aux` does not produce a file that silently isn't one. Recording file names change slightly as a result: underscores in a host label survive (`skerry-db_primary-…​.cast`, previously `db-primary`) and a label longer than 48 characters is cut.

## Verifying it

Vault → an SSH key → **Export key** → confirm with biometrics or the master password → save. The file is the PEM (`-----BEGIN … PRIVATE KEY-----`), mode 0600, usable as `ssh -i`. Cancel the Save-As: nothing is said. For a certificate, **Export certificate** writes `<label>-cert.pub` with no prompt — it is public.

Not verified: Android on a device (the SAF file name and the write itself), and Windows/macOS.
