### PR TITLE
AI assistant: select and copy text

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -78,6 +78,22 @@ kotlin {
                 implementation(libs.jna.platform)
             }
         }
+        val desktopTest by getting {
+            dependencies {
+                // Compose UI tests run on the desktop target only: gestures the UI is built around
+                // (mouse drag-to-select) have no headless equivalent on the Android unit-test JVM.
+                // Needs a display — CI wraps the run in xvfb.
+                //
+                // JUnit 4 and Truth come with it transitively, and this source set runs on the JUnit 5
+                // platform with no vintage engine: a test written with `org.junit.Test` would compile,
+                // report nothing, and pass. Excluded so that import cannot resolve in the first place.
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest) {
+                    exclude(group = "junit")
+                    exclude(group = "com.google.truth")
+                }
+            }
+        }
     }
 }
 

--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/design/TextContextMenu.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/design/TextContextMenu.android.kt
@@ -1,0 +1,9 @@
+package app.skerry.ui.design
+
+import androidx.compose.runtime.Composable
+
+/** Android draws the system's own floating selection toolbar; nothing to restyle. */
+@Composable
+actual fun SkerryTextContextMenu(content: @Composable () -> Unit) {
+    content()
+}

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -207,6 +207,7 @@
     <string name="settings_kb_open_assistant">Открыть ассистента</string>
     <string name="settings_kb_open_sftp">Открыть SFTP</string>
     <string name="settings_kb_lock">Заблокировать Skerry</string>
+    <string name="settings_kb_copy_text">Копировать выделенный текст (ассистент, диалоги)</string>
     <string name="settings_kb_accept_autocomplete">Принять подсказку автодополнения</string>
     <string name="settings_kb_cycle_suggestions">Перебрать подсказки</string>
     <string name="settings_kb_search_history">Поиск по истории команд</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -207,6 +207,7 @@
     <string name="settings_kb_open_assistant">打开助手</string>
     <string name="settings_kb_open_sftp">打开 SFTP</string>
     <string name="settings_kb_lock">锁定 Skerry</string>
+    <string name="settings_kb_copy_text">复制选中的文本（助手、对话框）</string>
     <string name="settings_kb_accept_autocomplete">接受自动补全建议</string>
     <string name="settings_kb_cycle_suggestions">循环切换建议</string>
     <string name="settings_kb_search_history">搜索命令历史</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -207,6 +207,7 @@
     <string name="settings_kb_open_assistant">Open assistant</string>
     <string name="settings_kb_open_sftp">Open SFTP</string>
     <string name="settings_kb_lock">Lock Skerry</string>
+    <string name="settings_kb_copy_text">Copy selected text (assistant, dialogs)</string>
     <string name="settings_kb_accept_autocomplete">Accept autocomplete suggestion</string>
     <string name="settings_kb_cycle_suggestions">Cycle suggestions</string>
     <string name="settings_kb_search_history">Search command history</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiChatBubble.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiChatBubble.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.ai.AiRole
 import app.skerry.ui.design.Sym
@@ -44,14 +47,42 @@ internal fun AiQuickChatHeader(title: String, desc: String, open: Boolean, onTog
 @Composable
 internal fun AiChatBubble(role: AiRole, text: String) {
     val mine = role == AiRole.USER
+    // The quick chat does no fence parsing — a reply arrives as one string, commands and all — so
+    // this is the only place its text can be filtered before it is shown and, now, copied. The
+    // user's own turn goes through the same call for one code path; it costs nothing.
+    val shown = remember(text) { AssistantAnswer.safeText(text) }
     Row(Modifier.fillMaxWidth().padding(vertical = 3.dp), horizontalArrangement = if (mine) Arrangement.End else Arrangement.Start) {
-        Box(
-            Modifier.clip(RoundedCornerShape(8.dp))
-                .background(if (mine) Skerry.colors.cyan10 else Skerry.colors.overlayMed)
-                .border(1.dp, if (mine) Skerry.colors.cyan14 else Skerry.colors.line, RoundedCornerShape(8.dp))
-                .padding(horizontal = 11.dp, vertical = 8.dp),
-        ) {
-            Txt(text, color = if (mine) Skerry.colors.text else Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp)
+        // One scope per bubble, as in the desktop feed ([AssistantMessage]): a reply arriving in the
+        // next bubble must not collapse a selection being made in this one.
+        SelectionContainer {
+            Box(
+                Modifier.clip(RoundedCornerShape(8.dp))
+                    .background(if (mine) Skerry.colors.cyan10 else Skerry.colors.overlayMed)
+                    .border(1.dp, if (mine) Skerry.colors.cyan14 else Skerry.colors.line, RoundedCornerShape(8.dp))
+                    .padding(horizontal = 11.dp, vertical = 8.dp),
+            ) {
+                Txt(shown, color = if (mine) Skerry.colors.text else Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp)
+            }
         }
+    }
+}
+
+/**
+ * A failed AI request under the control that triggered it — the quick chat's own reply, or the model
+ * list's refresh. Selectable: the error token ([app.skerry.ui.theme.SkerryColors.storm]) marks
+ * exactly the text worth pasting into a report; `sunset` stays reserved for warnings.
+ *
+ * [compact] is the form used under a field (smaller, padded above only), as against the chat feed's.
+ */
+@Composable
+internal fun AiChatError(failure: AiFailure, compact: Boolean = false) {
+    SelectionContainer {
+        Txt(
+            aiFailureMessage(failure),
+            color = Skerry.colors.storm,
+            size = if (compact) 11.sp else 12.sp,
+            lineHeight = if (compact) 15.sp else TextUnit.Unspecified,
+            modifier = if (compact) Modifier.padding(top = 6.dp) else Modifier.padding(vertical = 6.dp),
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantAnswer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantAnswer.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.ai
 
+import app.skerry.shared.terminal.isSafeDisplayChar
+
 /** One piece of a rendered assistant reply (see [AssistantAnswer.segments]). */
 sealed interface AssistantSegment {
     /** Free prose; inline markers are resolved at render time via [AssistantAnswer.spans]. */
@@ -20,7 +22,9 @@ data class AiSpan(val text: String, val mono: Boolean = false, val bold: Boolean
  *
  * Security-critical: a command offered for execution is filtered with the same single-line predicate
  * as the one-shot path ([AiReplyParser.isSafeInputChar]), so a confirmed command can never carry a
- * newline or control byte and execute more than the block displays.
+ * newline or control byte and execute more than the block displays. The block's *displayed* text is
+ * filtered too — it is what the confirmation UI shows, and since the panel became selectable, what a
+ * copy hands to the clipboard.
  *
  * Runs on every streaming frame, so callers cache by reply text (`remember(text)`).
  */
@@ -37,8 +41,23 @@ internal object AssistantAnswer {
         var fenced = false
 
         fun flush() {
-            val text = buffer.joinToString("\n").trim()
+            val block = buffer.joinToString("\n").trim()
             buffer.clear()
+            if (block.isEmpty()) return
+            // Both kinds are filtered before they are shown, not only before they are run. The card
+            // displays a block's text while Run sends the line out of [commands]; a bidi override
+            // left in the shown copy would render the line in an order the shell never sees — the
+            // Trojan Source case [isSafeTerminalInputChar] exists for. Prose gets the same treatment
+            // because it is not inert either: [spans] renders a `…` run in the mono font and its
+            // closing backtick may be lines away, so prose can look exactly like the command card
+            // beside it. Since the panel became selectable, every one of these is one Ctrl+C and one
+            // paste from the shell, and a paste is not filtered.
+            // A block keeps the strict input predicate: its text sits next to Run, so displayed and
+            // executed have to be the same bytes. Prose keeps its joiners — see [safeText].
+            val text = if (fenced) filter(block, AiReplyParser::isSafeInputChar) else safeText(block)
+            // A run that was nothing but rejected characters is dropped rather than shown empty.
+            // Deliberate, and worth knowing when a report says a reply "lost a block": the filter
+            // took it, and the model wrote nothing a reader could have acted on anyway.
             if (text.isEmpty()) return
             result += if (fenced) AssistantSegment.Code(text, commands(text)) else AssistantSegment.Prose(text)
         }
@@ -54,6 +73,24 @@ internal object AssistantAnswer {
         flush()
         return result
     }
+
+    /**
+     * Model prose as it may be shown: the characters that would render a line in an order it is not
+     * written in are dropped ([isSafeDisplayChar]), the rest is kept — a reply is one copy away from
+     * a shell, but it is also where a family emoji or a Persian word lives, and the input predicate
+     * would take those apart.
+     *
+     * Also the entry point for the surfaces that never reach [segments]: the quick chat renders a
+     * whole reply as one string, fences and all, and the mobile bar shows an explanation the same
+     * way. Trimmed again afterwards — [segments] trims the raw text, and a line of nothing but U+200B
+     * is not whitespace to `String.trim()`, so filtering can leave a blank line behind.
+     */
+    fun safeText(raw: String): String = filter(raw, ::isSafeDisplayChar)
+
+    /** Applies [allowed] to every line, keeping the line structure, and trims what is left. */
+    private fun filter(raw: String, allowed: (Char) -> Boolean): String = raw.lineSequence()
+        .joinToString("\n") { line -> line.filter(allowed).trimEnd() }
+        .trim()
 
     /**
      * The runnable lines of a code block: control bytes filtered out, blanks and `#` comments

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantMessage.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantMessage.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,6 +30,7 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -73,58 +76,82 @@ internal fun AssistantMessage(
 ) {
     val alignment = if (fromUser) Alignment.End else Alignment.Start
     Column(Modifier.fillMaxWidth(), horizontalAlignment = alignment) {
-        Column(
-            Modifier
-                // Width follows the content up to the cap, so a short question is a short bubble
-                // while an answer with a command block still gets the room it needs.
-                .widthIn(max = BUBBLE_MAX_WIDTH)
-                .clip(RoundedCornerShape(12.dp))
-                .background(if (fromUser) Skerry.colors.cyan.copy(alpha = 0.12f) else Skerry.colors.overlaySoft)
-                .border(
-                    1.dp,
-                    if (fromUser) Skerry.colors.lineStrong else Skerry.colors.line,
-                    RoundedCornerShape(12.dp),
-                )
-                .padding(horizontal = 11.dp, vertical = 9.dp),
-        ) {
-            // A user turn is plain text: it is what the person typed, not model output to interpret.
-            if (fromUser) {
-                Txt(text, color = Skerry.colors.text, size = 12.5.sp, lineHeight = 19.sp)
-                // What actually left the machine with this question. Terminal output is the part
-                // worth stating: it is not what the user typed, and under a cloud policy it is the
-                // part that reaches someone else's server.
-                if (attached > 0) {
-                    Box(Modifier.height(5.dp))
-                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Sym("attach_file", size = 11.sp, color = Skerry.colors.faint)
-                        Txt(
-                            stringResource(Res.string.assistant_attached, attached),
-                            color = Skerry.colors.faint,
-                            size = 10.5.sp,
-                        )
+        // One selection scope per turn, not one around the whole feed: the feed is a LazyColumn, and
+        // a selection spanning items that scroll out of composition is undefined by contract
+        // (SelectionContainer's own docs). Per turn also means a streaming delta lands in a scope of
+        // its own, so it cannot collapse a selection made in an older turn. What it does not survive
+        // is the turn leaving composition — scrolling it out of the feed drops the selection with it,
+        // as it would in any lazy list.
+        //
+        // The container installs `focusable()`, which costs two things we take knowingly: each
+        // visible turn becomes a Tab stop — with no focus ring, and unlabelled, since `focusable()`
+        // does not merge the bubble's text into the node — and clicking a reply moves keyboard focus
+        // off the terminal until the terminal is clicked again. Both are the price of the copy chord:
+        // `focusProperties { canFocus = false }` removes them and takes Ctrl+C with them, because
+        // that is the node Compose routes the chord to.
+        SelectionContainer {
+            Column(
+                Modifier
+                    // Width follows the content up to the cap, so a short question is a short bubble
+                    // while an answer with a command block still gets the room it needs.
+                    .widthIn(max = BUBBLE_MAX_WIDTH)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(if (fromUser) Skerry.colors.cyan.copy(alpha = 0.12f) else Skerry.colors.overlaySoft)
+                    .border(
+                        1.dp,
+                        if (fromUser) Skerry.colors.lineStrong else Skerry.colors.line,
+                        RoundedCornerShape(12.dp),
+                    )
+                    .padding(horizontal = 11.dp, vertical = 9.dp),
+            ) {
+                // A user turn is plain text: it is what the person typed, not model output to parse
+                // for commands. Filtered all the same — a question is often a line pasted out of
+                // terminal output, i.e. text the host chose, and the bubble is selectable now.
+                if (fromUser) {
+                    Txt(
+                        remember(text) { AssistantAnswer.safeText(text) },
+                        color = Skerry.colors.text, size = 12.5.sp, lineHeight = 19.sp,
+                    )
+                    // What actually left the machine with this question. Terminal output is the part
+                    // worth stating: it is not what the user typed, and under a cloud policy it is the
+                    // part that reaches someone else's server. Out of the selection scope like the
+                    // action row — chrome about the turn, and `Sym` draws its icon as a ligature whose
+                    // *text* is the glyph name, so a sweep would paste the word `attach_file`.
+                    if (attached > 0) {
+                        Box(Modifier.height(5.dp))
+                        DisableSelection {
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Sym("attach_file", size = 11.sp, color = Skerry.colors.faint)
+                                Txt(
+                                    stringResource(Res.string.assistant_attached, attached),
+                                    color = Skerry.colors.faint,
+                                    size = 10.5.sp,
+                                )
+                            }
+                        }
                     }
+                    return@Column
                 }
-                return@Column
-            }
-            // Parsed once per reply text, not per frame: this runs on every streaming delta.
-            val segments = remember(text) { AssistantAnswer.segments(text) }
-            var seenCode = false
-            segments.forEachIndexed { index, segment ->
-                // A reply that lists several commands is one bubble of alternating block and
-                // explanation; a rule before every block but the first cuts it into the groups the
-                // model meant, so it is clear which sentence belongs to which command.
-                if (segment is AssistantSegment.Code && seenCode) {
-                    Box(Modifier.height(10.dp))
-                    HLine()
-                    Box(Modifier.height(10.dp))
-                } else if (index > 0) {
-                    Box(Modifier.height(6.dp))
-                }
-                when (segment) {
-                    is AssistantSegment.Prose -> ProseText(segment.text)
-                    is AssistantSegment.Code -> {
-                        CodeBlock(segment, actions)
-                        seenCode = true
+                // Parsed once per reply text, not per frame: this runs on every streaming delta.
+                val segments = remember(text) { AssistantAnswer.segments(text) }
+                var seenCode = false
+                segments.forEachIndexed { index, segment ->
+                    // A reply that lists several commands is one bubble of alternating block and
+                    // explanation; a rule before every block but the first cuts it into the groups the
+                    // model meant, so it is clear which sentence belongs to which command.
+                    if (segment is AssistantSegment.Code && seenCode) {
+                        Box(Modifier.height(10.dp))
+                        HLine()
+                        Box(Modifier.height(10.dp))
+                    } else if (index > 0) {
+                        Box(Modifier.height(6.dp))
+                    }
+                    when (segment) {
+                        is AssistantSegment.Prose -> ProseText(segment.text)
+                        is AssistantSegment.Code -> {
+                            CodeBlock(segment, actions)
+                            seenCode = true
+                        }
                     }
                 }
             }
@@ -192,55 +219,66 @@ private fun CommandCard(display: String, command: String?, actions: AssistantCom
         ) {
             // A long command scrolls rather than wrapping: a wrapped shell line is easy to misread
             // before confirming it.
+            //
+            // Direction pinned rather than inherited: a shell line is LTR by nature, and an unstyled
+            // Txt resolves its paragraph base from the layout direction. Under an RTL UI locale a
+            // command whose first strong character is RTL would render with its trailing `#` hoisted
+            // to the front — a live command reading as a comment, next to the Run button. No
+            // character filter can prevent that; stating the direction can.
             Txt(
                 display,
                 color = if (severe) Skerry.colors.sunset else Skerry.colors.moss,
                 size = 11.5.sp,
                 lineHeight = 18.sp,
                 font = mono,
+                textDirection = TextDirection.Ltr,
             )
         }
         if (command == null) return@Column
-        // Wraps instead of clipping: "Run in session" and its two neighbours don't fit one line in
-        // every language, and a half-cut button on a destructive command is the worst place for it.
-        FlowRow(
-            Modifier.padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            val runLabel = when {
-                !severe -> stringResource(Res.string.assistant_run)
-                !armed -> stringResource(Res.string.assistant_run_anyway)
-                else -> stringResource(Res.string.assistant_confirm_run)
+        // Out of the turn's selection scope: a sweep meant for the command must not pick up "Run",
+        // and a copied turn should read as what the model said, not as the buttons under it.
+        DisableSelection {
+            // Wraps instead of clipping: "Run in session" and its two neighbours don't fit one line in
+            // every language, and a half-cut button on a destructive command is the worst place for it.
+            FlowRow(
+                Modifier.padding(top = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                val runLabel = when {
+                    !severe -> stringResource(Res.string.assistant_run)
+                    !armed -> stringResource(Res.string.assistant_run_anyway)
+                    else -> stringResource(Res.string.assistant_confirm_run)
+                }
+                ChipButton(
+                    label = runLabel,
+                    color = if (severe) Skerry.colors.sunset else Skerry.colors.teal,
+                    filled = true,
+                    icon = if (severe) "warning" else "play_arrow",
+                    enabled = actions.runnable,
+                    verticalPadding = 4.dp,
+                    onClick = { if (severe && !armed) armed = true else actions.run(command) },
+                )
+                // Copy and Edit carry their glyph only: with three labelled buttons the row wrapped in
+                // every language but English, and the primary action is the one that needs naming.
+                IconBtn(
+                    "content_copy",
+                    onClick = { actions.copy(command) },
+                    box = 24,
+                    icon = 13.sp,
+                    tint = Skerry.colors.textMid,
+                    tooltip = stringResource(Res.string.assistant_copy),
+                )
+                IconBtn(
+                    "edit",
+                    onClick = { actions.edit(command) },
+                    box = 24,
+                    icon = 13.sp,
+                    tint = Skerry.colors.textMid,
+                    tooltip = stringResource(Res.string.assistant_edit),
+                    enabled = actions.runnable,
+                )
             }
-            ChipButton(
-                label = runLabel,
-                color = if (severe) Skerry.colors.sunset else Skerry.colors.teal,
-                filled = true,
-                icon = if (severe) "warning" else "play_arrow",
-                enabled = actions.runnable,
-                verticalPadding = 4.dp,
-                onClick = { if (severe && !armed) armed = true else actions.run(command) },
-            )
-            // Copy and Edit carry their glyph only: with three labelled buttons the row wrapped in
-            // every language but English, and the primary action is the one that needs naming.
-            IconBtn(
-                "content_copy",
-                onClick = { actions.copy(command) },
-                box = 24,
-                icon = 13.sp,
-                tint = Skerry.colors.textMid,
-                tooltip = stringResource(Res.string.assistant_copy),
-            )
-            IconBtn(
-                "edit",
-                onClick = { actions.edit(command) },
-                box = 24,
-                icon = 13.sp,
-                tint = Skerry.colors.textMid,
-                tooltip = stringResource(Res.string.assistant_edit),
-                enabled = actions.runnable,
-            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantNotices.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantNotices.kt
@@ -1,0 +1,71 @@
+package app.skerry.ui.ai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.Sym
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.assistant_no_answer
+import app.skerry.ui.generated.resources.assistant_policy_note
+import app.skerry.ui.generated.resources.term_ai_not_a_command
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+// The feed items that are not turns: an outcome that has no reply, and the standing policy card.
+
+/** Blocked/failed/unusable outcome, in the feed rather than a popup: it belongs to that question. */
+@Composable
+internal fun AssistantNotice(notice: AiNotice) {
+    val text = when (notice) {
+        is AiNotice.Blocked -> aiBlockedMessage(notice.reason)
+        is AiNotice.Ask -> notice.question
+        AiNotice.Rejected -> stringResource(Res.string.term_ai_not_a_command)
+        AiNotice.NoAnswer -> stringResource(Res.string.assistant_no_answer)
+        is AiNotice.Error -> aiFailureMessage(notice.failure)
+    }
+    val color = if (notice is AiNotice.Error) Skerry.colors.storm else Skerry.colors.amber
+    // Selectable like a turn: a failure that cannot be pasted into a report is a failure reported
+    // from memory.
+    SelectionContainer {
+        Txt(text, color = color, size = 12.sp, lineHeight = 17.sp)
+    }
+}
+
+/** Policy badge plus the one line of what is sent — the STRICT card from the mock. */
+@Composable
+internal fun AssistantPolicyNote(controller: SessionAssistantController) {
+    val mono = LocalFonts.current.mono
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Skerry.colors.overlaySoft)
+            .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(12.dp))
+            .padding(horizontal = 11.dp, vertical = 9.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Row(
+            Modifier.clip(RoundedCornerShape(6.dp)).background(Skerry.colors.amberSoft).padding(horizontal = 7.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Sym("shield", size = 12.sp, color = Skerry.colors.amber)
+            Txt(labelUppercase(controller.policy.shortLabel()), color = Skerry.colors.amber, size = 10.sp, font = mono, maxLines = 1)
+        }
+        Txt(stringResource(Res.string.assistant_policy_note), color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantPanel.kt
@@ -57,20 +57,16 @@ import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
-import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.assistant_ask_placeholder
-import app.skerry.ui.generated.resources.assistant_no_answer
 import app.skerry.ui.generated.resources.assistant_clear
 import app.skerry.ui.generated.resources.assistant_context_chip
 import app.skerry.ui.generated.resources.assistant_context_off
 import app.skerry.ui.generated.resources.assistant_context_title
 import app.skerry.ui.generated.resources.assistant_empty
 import app.skerry.ui.generated.resources.assistant_explain_request
-import app.skerry.ui.generated.resources.assistant_policy_note
 import app.skerry.ui.generated.resources.assistant_thinking
 import app.skerry.ui.generated.resources.assistant_title
-import app.skerry.ui.generated.resources.term_ai_not_a_command
 import app.skerry.ui.terminal.WORK_BAR_HEIGHT
 import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.terminal.lastCommandBlocks
@@ -252,45 +248,6 @@ private fun AssistantFeed(
         // Shown while the panel is still empty: what the policy allows and what leaves the machine.
         // Once there is a conversation it would just push it up the panel every turn.
         if (controller.turns.isEmpty()) item { AssistantPolicyNote(controller) }
-    }
-}
-
-/** Blocked/failed/unusable outcome, in the feed rather than a popup: it belongs to that question. */
-@Composable
-private fun AssistantNotice(notice: AiNotice) {
-    val text = when (notice) {
-        is AiNotice.Blocked -> aiBlockedMessage(notice.reason)
-        is AiNotice.Ask -> notice.question
-        AiNotice.Rejected -> stringResource(Res.string.term_ai_not_a_command)
-        AiNotice.NoAnswer -> stringResource(Res.string.assistant_no_answer)
-        is AiNotice.Error -> aiFailureMessage(notice.failure)
-    }
-    val color = if (notice is AiNotice.Error) Skerry.colors.storm else Skerry.colors.amber
-    Txt(text, color = color, size = 12.sp, lineHeight = 17.sp)
-}
-
-/** Policy badge plus the one line of what is sent — the STRICT card from the mock. */
-@Composable
-private fun AssistantPolicyNote(controller: SessionAssistantController) {
-    val mono = LocalFonts.current.mono
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .background(Skerry.colors.overlaySoft)
-            .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(12.dp))
-            .padding(horizontal = 11.dp, vertical = 9.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Row(
-            Modifier.clip(RoundedCornerShape(6.dp)).background(Skerry.colors.amberSoft).padding(horizontal = 7.dp, vertical = 2.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            Sym("shield", size = 12.sp, color = Skerry.colors.amber)
-            Txt(labelUppercase(controller.policy.shortLabel()), color = Skerry.colors.amber, size = 10.sp, font = mono, maxLines = 1)
-        }
-        Txt(stringResource(Res.string.assistant_policy_note), color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
@@ -78,6 +79,9 @@ fun Txt(
     maxLines: Int = Int.MAX_VALUE,
     overflow: TextOverflow = TextOverflow.Clip,
     align: TextAlign = TextAlign.Unspecified,
+    // Left Unspecified, the paragraph base comes from the layout direction — right for prose, wrong
+    // for anything whose order carries meaning regardless of the UI language (a shell line).
+    textDirection: TextDirection = TextDirection.Unspecified,
 ) {
     val family = font ?: LocalFonts.current.ui
     BasicText(
@@ -93,6 +97,7 @@ fun Txt(
             letterSpacing = letterSpacing,
             lineHeight = lineHeight,
             textAlign = align,
+            textDirection = textDirection,
         ),
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/MenuPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/MenuPanel.kt
@@ -1,0 +1,56 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.theme.Skerry
+
+/**
+ * The app's pop-up menu: a rounded panel of [MenuItem] rows. Every menu the app opens on a right
+ * click or a "⋮" button wears this — including the one Compose itself opens over selected text,
+ * which is why it lives in the design layer rather than next to any one call site.
+ */
+@Composable
+fun MenuPanel(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    Column(
+        modifier
+            .clip(RoundedCornerShape(7.dp))
+            .background(Skerry.colors.surface2)
+            .border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(7.dp))
+            .padding(4.dp),
+    ) {
+        content()
+    }
+}
+
+/** One row of a [MenuPanel]. [color] carries the destructive variant (`Skerry.colors.sunset`). */
+@Composable
+fun MenuItem(label: String, color: Color = Skerry.colors.text, onClick: () -> Unit) {
+    Box(
+        Modifier
+            .widthIn(min = MENU_MIN_WIDTH)
+            .clip(RoundedCornerShape(5.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 7.dp),
+    ) {
+        Txt(label, color = color, size = 12.sp)
+    }
+}
+
+/**
+ * The width floor keeps a menu from collapsing onto its longest label — short verbs in some locales
+ * leave a sliver of a click target, and the same menu would change width from row to row depending
+ * on which actions that row offers.
+ */
+private val MENU_MIN_WIDTH = 140.dp

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/TextContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/TextContextMenu.kt
@@ -1,0 +1,14 @@
+package app.skerry.ui.design
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Draws the platform's text context menu — the one that opens on a right click over selected text or
+ * a text field — in the app's own style.
+ *
+ * Desktop only in substance: there the menu is a Compose pop-up whose look is an application-level
+ * choice, and Compose's default is a white Material sheet that has nothing to do with this UI. On
+ * Android the menu is the system's floating toolbar, which belongs to the platform and is left alone.
+ */
+@Composable
+expect fun SkerryTextContextMenu(content: @Composable () -> Unit)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -32,11 +33,13 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.ai.CommandRisk
 import app.skerry.ui.ai.AiNotice
+import app.skerry.ui.ai.AssistantAnswer
 import app.skerry.ui.ai.TerminalAiController
 import app.skerry.ui.ai.aiBlockedMessage
 import app.skerry.ui.ai.aiFailureMessage
@@ -104,11 +107,16 @@ internal fun MobileAiBarInput(controller: TerminalAiController, terminal: Termin
                             CommandRisk.None -> controller.pendingInfo
                             else -> controller.pendingRisk?.reason?.let { commandRiskReasonText(it) }
                         }
-                        Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                            // The command wraps (up to 6 lines), not truncated: the user sees in full what
-                            // they confirm and run (see TerminalView — the same safety invariant).
-                            Txt(pending, color = if (severe) Skerry.colors.sunset else Skerry.colors.text, size = 12.sp, font = mono, maxLines = 6, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f, fill = false).alignByBaseline())
-                            if (info != null) Txt(info, color = infoColor, size = 10.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f).alignByBaseline())
+                        // Long-press selects, as in the terminal underneath: the bar has no Copy
+                        // button, so selection is the only way the command leaves the screen.
+                        SelectionContainer {
+                            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                                // The command wraps (up to 6 lines), not truncated: the user sees in full what
+                                // they confirm and run (see TerminalView — the same safety invariant).
+                                // Direction pinned, as on the desktop card: a shell line is LTR whatever the UI language.
+                                Txt(pending, color = if (severe) Skerry.colors.sunset else Skerry.colors.text, size = 12.sp, font = mono, maxLines = 6, overflow = TextOverflow.Ellipsis, textDirection = TextDirection.Ltr, modifier = Modifier.weight(1f, fill = false).alignByBaseline())
+                                if (info != null) Txt(info, color = infoColor, size = 10.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f).alignByBaseline())
+                            }
                         }
                     }
                     explanation != null ->
@@ -116,18 +124,29 @@ internal fun MobileAiBarInput(controller: TerminalAiController, terminal: Termin
                             Txt(stringResource(Res.string.term_ai_explain_reading), color = Skerry.colors.dim, size = 13.sp)
                         } else {
                             Column(Modifier.heightIn(max = 160.dp).verticalScroll(rememberScrollState())) {
-                                Txt(explanation, color = Skerry.colors.text, size = 12.sp, lineHeight = 17.sp)
+                                // The one place a model's prose appears on mobile outside the AI
+                                // screen, and there is no Copy for it — selection is the way out.
+                                // Filtered like the panel's: it is raw model text, and what a
+                                // selection copies can be pasted straight back into the shell.
+                                SelectionContainer {
+                                    Txt(
+                                        remember(explanation) { AssistantAnswer.safeText(explanation) },
+                                        color = Skerry.colors.text, size = 12.sp, lineHeight = 17.sp,
+                                    )
+                                }
                             }
                         }
                     controller.busy -> Txt(stringResource(Res.string.term_ai_thinking), color = Skerry.colors.dim, size = 13.sp)
-                    controller.notice != null -> when (val notice = controller.notice!!) {
-                        is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        is AiNotice.Ask -> Txt(notice.question, color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        // The bar only ever asks for a command, so an empty reply is the same
-                        // "nothing usable" outcome as prose — one message covers both.
-                        AiNotice.Rejected, AiNotice.NoAnswer ->
-                            Txt(stringResource(Res.string.term_ai_not_a_command), color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
-                        is AiNotice.Error -> Txt(aiFailureMessage(notice.failure), color = Skerry.colors.sunset, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                    controller.notice != null -> SelectionContainer {
+                        when (val notice = controller.notice!!) {
+                            is AiNotice.Blocked -> Txt(aiBlockedMessage(notice.reason), color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            is AiNotice.Ask -> Txt(notice.question, color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            // The bar only ever asks for a command, so an empty reply is the same
+                            // "nothing usable" outcome as prose — one message covers both.
+                            AiNotice.Rejected, AiNotice.NoAnswer ->
+                                Txt(stringResource(Res.string.term_ai_not_a_command), color = Skerry.colors.amber, size = 12.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+                            is AiNotice.Error -> Txt(aiFailureMessage(notice.failure), color = Skerry.colors.sunset, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                        }
                     }
                     else -> {
                         if (prompt.isEmpty()) Txt(stringResource(Res.string.term_ai_ask_short), color = Skerry.colors.dim, size = 13.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiScreen.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.ai.AiRole
 import app.skerry.ui.ai.AiChatBubble
+import app.skerry.ui.ai.AiChatError
 import app.skerry.ui.ai.AiQuickChatHeader
-import app.skerry.ui.ai.aiFailureMessage
 import app.skerry.ui.ai.byokHintMessage
 import app.skerry.ui.ai.isInsecureAiEndpoint
 import app.skerry.ui.ai.rememberByokModelState
@@ -129,8 +129,7 @@ fun MobileAiScreen(state: MobileDesignState) {
                 Spacer(Modifier.height(8.dp))
                 ai.turns.forEach { turn -> AiChatBubble(turn.role, turn.text) }
                 ai.streaming?.let { AiChatBubble(AiRole.ASSISTANT, if (it.isEmpty()) "…" else it) }
-                // Request error uses the error token (Skerry.colors.storm), as on desktop; Skerry.colors.sunset is reserved for warnings.
-                ai.error?.let { Txt(aiFailureMessage(it), color = Skerry.colors.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
+                ai.error?.let { AiChatError(it) }
 
                 var prompt by remember { mutableStateOf("") }
                 val send = { if (prompt.isNotBlank() && !ai.busy) { ai.ask(prompt); prompt = "" } }
@@ -228,7 +227,7 @@ private fun MobileByokFields(ai: app.skerry.ui.ai.AiAssistantController) {
             Spacer(Modifier.height(8.dp))
         }
         byok.refreshFailure?.let { failure ->
-            Txt(aiFailureMessage(failure), color = Skerry.colors.storm, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 6.dp))
+            AiChatError(failure, compact = true)
         }
 
         Spacer(Modifier.height(12.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/AiSection.kt
@@ -30,8 +30,8 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.ai.AiRole
 import app.skerry.ui.ai.AiChatBubble
+import app.skerry.ui.ai.AiChatError
 import app.skerry.ui.ai.AiQuickChatHeader
-import app.skerry.ui.ai.aiFailureMessage
 import app.skerry.ui.ai.byokHintMessage
 import app.skerry.ui.ai.isInsecureAiEndpoint
 import app.skerry.ui.ai.rememberByokModelState
@@ -138,7 +138,7 @@ private fun LiveAiSection(ai: app.skerry.ui.ai.AiAssistantController) {
 
     ai.turns.forEach { turn -> AiChatBubble(turn.role, turn.text) }
     ai.streaming?.let { AiChatBubble(AiRole.ASSISTANT, if (it.isEmpty()) "…" else it) }
-    ai.error?.let { Txt(aiFailureMessage(it), color = Skerry.colors.storm, size = 12.sp, modifier = Modifier.padding(vertical = 6.dp)) }
+    ai.error?.let { AiChatError(it) }
 
     var prompt by remember { mutableStateOf("") }
     val send = { if (prompt.isNotBlank() && !ai.busy) { ai.ask(prompt); prompt = "" } }
@@ -226,7 +226,7 @@ private fun DesktopByokFields(ai: app.skerry.ui.ai.AiAssistantController) {
         },
     )
     byok.refreshFailure?.let { failure ->
-        Txt(aiFailureMessage(failure), color = Skerry.colors.storm, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 6.dp))
+        AiChatError(failure, compact = true)
     }
 
     Spacer(Modifier.height(12.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt
@@ -39,6 +39,7 @@ import app.skerry.ui.generated.resources.settings_kb_broadcast
 import app.skerry.ui.generated.resources.settings_kb_editor_group
 import app.skerry.ui.generated.resources.settings_kb_command_palette
 import app.skerry.ui.generated.resources.settings_kb_copy_selection
+import app.skerry.ui.generated.resources.settings_kb_copy_text
 import app.skerry.ui.generated.resources.settings_kb_cycle_suggestions
 import app.skerry.ui.generated.resources.settings_kb_files_filter
 import app.skerry.ui.generated.resources.settings_kb_files_group
@@ -97,6 +98,10 @@ internal fun KeyboardSection() {
         KeyboardBinding(stringResource(Res.string.settings_kb_open_assistant), mod("/"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_open_sftp), mod("E"), live = true),
         KeyboardBinding(stringResource(Res.string.settings_kb_lock), mod("L"), live = true),
+        // Deliberately not the terminal's Ctrl+Shift+C: outside a shell there is no SIGINT to avoid,
+        // and this is the platform chord every other selectable surface answers to. Listed because
+        // the terminal row two groups down teaches a different one for the same word.
+        KeyboardBinding(stringResource(Res.string.settings_kb_copy_text), if (mac) "⌘C" else ctrl("C"), live = true),
     )
     // Terminal-internal hotkeys (handled by TerminalScreen): fish-style autocomplete, history
     // reverse-search (Ctrl-R), copy/paste. Active while a terminal session is focused.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
@@ -1,8 +1,6 @@
 package app.skerry.ui.terminal
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -11,7 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,6 +45,8 @@ import app.skerry.ui.design.Badge
 import app.skerry.ui.design.Dot
 import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.MenuItem
+import app.skerry.ui.design.MenuPanel
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
@@ -328,20 +327,18 @@ internal fun HostEntryRow(
                     )
                     if (menuOpen) {
                         Popup(alignment = Alignment.TopEnd, onDismissRequest = { menuOpen = false }) {
-                            Column(
-                                Modifier.clip(RoundedCornerShape(7.dp)).background(Skerry.colors.surface2).border(1.dp, Skerry.colors.lineStrong, RoundedCornerShape(7.dp)).padding(4.dp),
-                            ) {
+                            MenuPanel {
                                 if (canRunSnippet) {
-                                    HostMenuItem(stringResource(Res.string.term_menu_run_snippet), Skerry.colors.text) { menuOpen = false; snippetPickerOpen = true }
+                                    MenuItem(stringResource(Res.string.term_menu_run_snippet)) { menuOpen = false; snippetPickerOpen = true }
                                 }
                                 onEdit?.let { edit ->
-                                    HostMenuItem(stringResource(Res.string.term_menu_edit), Skerry.colors.text) { menuOpen = false; edit() }
+                                    MenuItem(stringResource(Res.string.term_menu_edit)) { menuOpen = false; edit() }
                                 }
                                 onDuplicate?.let { duplicate ->
-                                    HostMenuItem(stringResource(Res.string.term_menu_duplicate), Skerry.colors.text) { menuOpen = false; duplicate() }
+                                    MenuItem(stringResource(Res.string.term_menu_duplicate)) { menuOpen = false; duplicate() }
                                 }
                                 onDelete?.let { delete ->
-                                    HostMenuItem(stringResource(Res.string.term_menu_delete), Skerry.colors.sunset) { menuOpen = false; delete() }
+                                    MenuItem(stringResource(Res.string.term_menu_delete), Skerry.colors.sunset) { menuOpen = false; delete() }
                                 }
                             }
                         }
@@ -365,19 +362,5 @@ internal fun HostEntryRow(
                 }
             }
         }
-    }
-}
-
-/**
- * Context menu item for a host row. The width floor keeps the card from collapsing onto its longest
- * label — short verbs in some locales leave a sliver of a click target, and the same menu would
- * change width from row to row depending on which actions that row offers.
- */
-@Composable
-private fun HostMenuItem(label: String, color: Color, onClick: () -> Unit) {
-    Box(
-        Modifier.widthIn(min = 140.dp).clip(RoundedCornerShape(5.dp)).clickable(onClick = onClick).padding(horizontal = 14.dp, vertical = 7.dp),
-    ) {
-        Txt(label, color = color, size = 12.sp)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/theme/Theme.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
+import app.skerry.ui.design.SkerryTextContextMenu
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
@@ -123,10 +124,11 @@ fun SkerryTheme(
     // ThemeMode.SYSTEM) glides instead of snapping. First composition snaps to the target.
     val colors = animateSkerryColors(target)
     CompositionLocalProvider(LocalSkerryColors provides colors) {
-        MaterialTheme(
-            colorScheme = colors.toMaterialColorScheme(dark),
-            content = content,
-        )
+        MaterialTheme(colorScheme = colors.toMaterialColorScheme(dark)) {
+            // Inside the theme, so the menu Compose opens over selected text is drawn with this
+            // palette rather than its own white Material default.
+            SkerryTextContextMenu(content)
+        }
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AssistantAnswerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/AssistantAnswerTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.ai
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -98,6 +99,89 @@ class AssistantAnswerTest {
     }
 
     // --- inline spans (mono for `code`, bold for **text**) ---
+
+    /**
+     * The card shows [AssistantSegment.Code.text] and Run sends [AssistantSegment.Code.commands] —
+     * two strings out of one block. A bidi override left in the shown one renders the line in an
+     * order the shell never sees, which is the whole reason `isSafeTerminalInputChar` exists. Since
+     * the block became selectable it is also an egress: what is swept up goes to the clipboard, and
+     * a paste into the terminal is not filtered.
+     */
+    @Test
+    fun `a fenced block is shown with bidi and control characters already stripped`() {
+        val segments = AssistantAnswer.segments("```\necho safe\u202E; rm -rf /\n```")
+
+        val code = segments.filterIsInstance<AssistantSegment.Code>().single()
+        assertFalse(code.text.any { it == '\u202E' }, "the shown text still carries U+202E: `${'$'}{code.text}`")
+        assertEquals(code.commands.single(), code.text)
+    }
+
+    /**
+     * Prose is not inert either: `spans` renders a `` `…` `` run in the mono font, across newlines,
+     * so a stretch of prose can look exactly like the command card next to it. Since the panel
+     * became selectable it is one Ctrl+C and one paste away from the shell.
+     */
+    @Test
+    fun `prose is shown with bidi and control characters already stripped`() {
+        val segments = AssistantAnswer.segments("Run `echo safe\u202E; rm -rf /` when ready.")
+
+        val prose = segments.filterIsInstance<AssistantSegment.Prose>().single()
+        assertFalse(prose.text.any { it == '\u202E' }, "the shown prose still carries U+202E: `${'$'}{prose.text}`")
+    }
+
+    /**
+     * The input predicate rejects U+200B..U+200F wholesale, which takes the zero-width joiner with
+     * it: filtering prose with it splits a family emoji into three people and writes Persian without
+     * its joins. Prose is shown, not run, so it keeps them — only the reordering characters go.
+     */
+    @Test
+    fun `prose keeps the joiners that hold an emoji and a Persian word together`() {
+        val segments = AssistantAnswer.segments("Try \uD83D\uDC68\u200D\uD83D\uDC69\u200D\uD83D\uDC67 and \u0645\u06CC\u200C\u0634\u0648\u062F.")
+
+        val prose = segments.filterIsInstance<AssistantSegment.Prose>().single()
+        assertTrue(prose.text.contains('\u200D'), "the emoji joiner was stripped: `${'$'}{prose.text}`")
+        assertTrue(prose.text.contains('\u200C'), "the Persian non-joiner was stripped: `${'$'}{prose.text}`")
+    }
+
+    /** A block sits next to Run, so it keeps the stricter predicate: shown and executed are one string. */
+    @Test
+    fun `a fenced block drops the joiners prose keeps`() {
+        val segments = AssistantAnswer.segments("```\nls \u200Dsrc\n```")
+
+        val code = segments.filterIsInstance<AssistantSegment.Code>().single()
+        assertFalse(code.text.any { it == '\u200D' }, "the block kept a zero-width joiner: `${'$'}{code.text}`")
+        assertEquals(code.commands.single(), code.text)
+    }
+
+    @Test
+    fun `a block of nothing but rejected characters is dropped, not shown empty`() {
+        // trim() sees no whitespace in a bidi override, so the block survives the blank check and
+        // only collapses after filtering — the one path that can make a segment disappear.
+        val segments = AssistantAnswer.segments("Before.\n```\n\u202E\u200B\n```\nAfter.")
+
+        assertTrue(segments.none { it is AssistantSegment.Code }, "an empty block was still rendered")
+        assertEquals(listOf("Before.", "After."), segments.filterIsInstance<AssistantSegment.Prose>().map { it.text })
+    }
+
+    @Test
+    fun `a line that filters away leaves no blank line behind`() {
+        // `flush` trims before filtering, and U+200B is not whitespace to String.trim(): without a
+        // second trim the block would open with an empty line and stop matching its command.
+        val segments = AssistantAnswer.segments("```\n\u200B\nls\n```")
+
+        val code = segments.filterIsInstance<AssistantSegment.Code>().single()
+        assertEquals("ls", code.text)
+        assertEquals(listOf("ls"), code.commands)
+    }
+
+    @Test
+    fun `a block is still shown line by line once sanitized`() {
+        val segments = AssistantAnswer.segments("```\n# keep this\nsystemctl daemon-reload\n```")
+
+        val code = segments.filterIsInstance<AssistantSegment.Code>().single()
+        assertEquals("# keep this\nsystemctl daemon-reload", code.text)
+        assertEquals(listOf("systemctl daemon-reload"), code.commands)
+    }
 
     @Test
     fun `inline backticks become mono spans`() {

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/design/TextContextMenu.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/design/TextContextMenu.desktop.kt
@@ -1,0 +1,87 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.ContextMenuItem
+import androidx.compose.foundation.ContextMenuRepresentation
+import androidx.compose.foundation.ContextMenuState
+import androidx.compose.foundation.LocalContextMenuRepresentation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import androidx.compose.ui.window.rememberPopupPositionProviderAtPosition
+
+@Composable
+actual fun SkerryTextContextMenu(content: @Composable () -> Unit) {
+    // Only consulted while Compose's own `isNewContextMenuEnabled` flag is off, which is the default
+    // in Compose Multiplatform 1.9.3. The parallel "new" implementation ignores this local entirely,
+    // so a version bump that flips the default would silently restore the white Material menu —
+    // TextContextMenuTest is what catches that.
+    CompositionLocalProvider(LocalContextMenuRepresentation provides SkerryContextMenu, content = content)
+}
+
+/**
+ * The menu Compose opens on a right click, drawn as a [MenuPanel] so it matches the "⋮" menus the
+ * app opens itself. The items come from Compose (and are localized by it); only their presentation
+ * is ours — over a selection that is a single Copy row, over a text field it is Cut / Copy / Paste /
+ * Select all.
+ */
+private object SkerryContextMenu : ContextMenuRepresentation {
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Composable
+    override fun Representation(state: ContextMenuState, items: () -> List<ContextMenuItem>) {
+        val status = state.status
+        if (status !is ContextMenuState.Status.Open) return
+        // Read from inside the popup's own composition, where the focus manager is the popup's.
+        var focus: FocusManager? by mutableStateOf(null)
+        var inputMode: InputModeManager? by mutableStateOf(null)
+        Popup(
+            popupPositionProvider = rememberPopupPositionProviderAtPosition(status.rect.center),
+            onDismissRequest = { state.status = ContextMenuState.Status.Closed },
+            // Focusable so Esc and a click outside close it, as with the app's own menus.
+            properties = PopupProperties(focusable = true),
+            // Up/Down walk the rows, as they do in the representation this replaces. Without it the
+            // arrows would be swallowed by the focusable popup and the menu would look keyboard-dead.
+            onKeyEvent = { event ->
+                val direction = when {
+                    event.type != KeyEventType.KeyDown -> null
+                    event.key == Key.DirectionDown -> FocusDirection.Next
+                    event.key == Key.DirectionUp -> FocusDirection.Previous
+                    else -> null
+                }
+                direction?.let {
+                    inputMode?.requestInputMode(InputMode.Keyboard)
+                    focus?.moveFocus(it)
+                    true
+                } ?: false
+            },
+        ) {
+            focus = LocalFocusManager.current
+            inputMode = LocalInputModeManager.current
+            MenuPanel {
+                items().forEach { item ->
+                    MenuItem(item.label) {
+                        // Closed first, then the action — the order Compose's own representation uses,
+                        // so an action that opens a dialog does not leave a menu standing behind it.
+                        state.status = ContextMenuState.Status.Closed
+                        item.onClick()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantSelectionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantSelectionTest.kt
@@ -1,0 +1,372 @@
+package app.skerry.ui.ai
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.withKeyDown
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.ai.AiChatRequest
+import app.skerry.shared.ai.AiDelta
+import app.skerry.shared.ai.AiPolicy
+import app.skerry.shared.ai.AiProvider
+import app.skerry.shared.ai.AiRole
+import app.skerry.shared.ai.AiSettings
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.FakeClipboard
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.assistant_run
+import app.skerry.ui.mobile.MobileAiBarInput
+import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.theme.SkerryTheme
+import org.jetbrains.compose.resources.stringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Text in the assistant has to come out of the panel the way terminal output does: dragged over with
+ * the mouse and copied with the platform's own chord. A reply is prose the user did not type — a
+ * path, a flag, a host name — and the per-command Copy button only ever covers a fenced command.
+ *
+ * Drives the real composables through mouse and key injection rather than asserting a
+ * `SelectionContainer` is present: what matters is that the drag lands on the text and Ctrl/Cmd+C
+ * puts it on the clipboard, which is the part a wrapper in the wrong place silently breaks.
+ */
+@OptIn(ExperimentalTestApi::class)
+class AssistantSelectionTest {
+
+    @Test
+    fun `dragging across an assistant reply copies its prose`() = runComposeUiTest {
+        val clipboard = feed { AssistantMessage(PROSE, fromUser = false, actions = INERT) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    @Test
+    fun `dragging across a question copies it back out`() = runComposeUiTest {
+        val clipboard = feed { AssistantMessage(PROSE, fromUser = true, actions = INERT) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    @Test
+    fun `a fenced command can be dragged over as well as copied by its button`() = runComposeUiTest {
+        val clipboard = feed {
+            AssistantMessage("Then reload it.\n```\n$COMMAND\n```", fromUser = false, actions = INERT)
+        }
+        assertEquals(COMMAND, selectAndCopy(COMMAND, clipboard))
+    }
+
+    /**
+     * The block scrolls horizontally rather than wrapping, and a scroll container is exactly what
+     * eats a drag. It does not eat a *mouse* drag — `scrollable` skips `PointerType.Mouse` — so the
+     * sweep still selects, but it reaches only as far as the box shows: the tail past the right edge
+     * needs the Copy button — the menu over a selection is a single Copy row, with no "Select all".
+     */
+    @Test
+    fun `a command wider than the bubble is selectable as far as the scroll box shows`() = runComposeUiTest {
+        val clipboard = feed {
+            AssistantMessage("Then this.\n```\n$WIDE_COMMAND\n```", fromUser = false, actions = INERT)
+        }
+        val copied = selectAndCopy(WIDE_COMMAND, clipboard)
+        assertNotNull(copied, "the scroll box ate the drag — nothing was selected")
+        assertTrue(WIDE_COMMAND.startsWith(copied), "selection did not start at the command: `$copied`")
+        assertTrue(copied.length > VISIBLE_RUN_MIN_CHARS, "only `$copied` was selected")
+    }
+
+    /**
+     * A block whose lines are all comments has no runnable command, so [AssistantMessage] draws no
+     * action row at all — no Copy button, and selection is the only way that text leaves the panel.
+     */
+    @Test
+    fun `a block with nothing runnable has no Copy button, so selection is the only way out`() = runComposeUiTest {
+        val clipboard = feed {
+            AssistantMessage("For reference:\n```\n$COMMENT_BLOCK\n```", fromUser = false, actions = INERT)
+        }
+        assertEquals(COMMENT_BLOCK, selectAndCopy(COMMENT_BLOCK, clipboard))
+    }
+
+    /**
+     * The action row is out of the turn's selection scope: a sweep down the whole bubble takes the
+     * answer and the command, and leaves "Run"/"Copy"/"Edit" behind. Without the `DisableSelection`
+     * the labels ride along into the paste.
+     */
+    @Test
+    fun `sweeping the whole turn takes the answer and the command but not the buttons`() = runComposeUiTest {
+        var runLabel = ""
+        val clipboard = feed {
+            runLabel = stringResource(Res.string.assistant_run)
+            AssistantMessage("$PROSE\n```\n$COMMAND\n```", fromUser = false, actions = RUNNABLE)
+        }
+        // Starts on the prose and ends well below the bubble, so the sweep crosses the action row.
+        onNodeWithText(PROSE).performMouseInput {
+            moveTo(centerLeft)
+            press()
+            moveTo(center)
+            moveTo(bottomRight + Offset(0f, SWEEP_PAST_BUBBLE.toPx()))
+            release()
+        }
+        val copied = copy(PROSE, clipboard)
+        assertNotNull(copied)
+        assertTrue(copied.contains(PROSE), "prose missing from `$copied`")
+        assertTrue(copied.contains(COMMAND), "command missing from `$copied`")
+        assertFalse(copied.contains(runLabel), "the Run button's label rode along in `$copied`")
+    }
+
+    /**
+     * `Sym` draws an icon as a ligature — its text *is* the glyph name — so an icon left inside the
+     * selection scope pastes as the word `attach_file`. The attachment line is chrome about the turn,
+     * not part of it.
+     */
+    @Test
+    fun `copying a question does not pick up the attachment icon`() = runComposeUiTest {
+        val clipboard = feed { AssistantMessage(PROSE, fromUser = true, actions = INERT, attached = 2) }
+        onNodeWithText(PROSE).performMouseInput {
+            moveTo(topLeft)
+            press()
+            moveTo(center)
+            moveTo(bottomRight + Offset(0f, SWEEP_PAST_BUBBLE.toPx()))
+            release()
+        }
+        val copied = copy(PROSE, clipboard)
+        assertNotNull(copied)
+        assertFalse(copied.contains("attach_file"), "the icon's ligature name rode along in `$copied`")
+    }
+
+    @Test
+    fun `a notice can be copied into a bug report`() = runComposeUiTest {
+        val clipboard = feed { AssistantNotice(AiNotice.Ask(NOTICE)) }
+        assertEquals(NOTICE, selectAndCopy(NOTICE, clipboard))
+    }
+
+    @Test
+    fun `a quick-chat bubble can be copied`() = runComposeUiTest {
+        val clipboard = feed { AiChatBubble(AiRole.ASSISTANT, PROSE) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    @Test
+    fun `a failed request can be copied`() = runComposeUiTest {
+        // The text is read out of the composition, not hardcoded: it is localized, and the run's
+        // locale is the machine's.
+        var message = ""
+        val clipboard = feed {
+            message = aiFailureMessage(AiFailure.RATE_LIMITED)
+            AiChatError(AiFailure.RATE_LIMITED)
+        }
+        assertEquals(message, selectAndCopy(message, clipboard))
+    }
+
+    @Test
+    fun `a failed model refresh can be copied from under the field`() = runComposeUiTest {
+        var message = ""
+        val clipboard = feed {
+            message = aiFailureMessage(AiFailure.RATE_LIMITED)
+            AiChatError(AiFailure.RATE_LIMITED, compact = true)
+        }
+        assertEquals(message, selectAndCopy(message, clipboard))
+    }
+
+    /**
+     * The mobile bar is the Android half of the parity rule and the harder case: it offers no Copy
+     * button at all, so what selection cannot reach cannot leave the screen.
+     */
+    @Test
+    fun `the mobile bar's proposed command can be selected`() = runComposeUiTest {
+        val controller = terminalAi(reply = MOBILE_COMMAND)
+        controller.ask("free the disk")
+        val clipboard = feed { MobileAiBarInput(controller, terminalState()) }
+        assertEquals(MOBILE_COMMAND, selectAndCopy(MOBILE_COMMAND, clipboard))
+    }
+
+    @Test
+    fun `the mobile bar's explanation can be selected`() = runComposeUiTest {
+        val controller = terminalAi(reply = PROSE)
+        controller.explain("total 0")
+        val clipboard = feed { MobileAiBarInput(controller, terminalState()) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    /**
+     * The two surfaces that never go through [AssistantAnswer.segments] — the quick chat renders a
+     * whole reply as one string, the mobile bar an explanation — filter at the call site instead. A
+     * bidi override left in either is one sweep and one paste from the shell.
+     */
+    @Test
+    fun `a quick-chat reply is copied without the bidi override it arrived with`() = runComposeUiTest {
+        val clipboard = feed { AiChatBubble(AiRole.ASSISTANT, SPOOFED) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    @Test
+    fun `a question is copied without the bidi override it was pasted with`() = runComposeUiTest {
+        val clipboard = feed { AssistantMessage(SPOOFED, fromUser = true, actions = INERT) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    @Test
+    fun `the mobile bar's explanation is copied without its bidi override`() = runComposeUiTest {
+        val controller = terminalAi(reply = SPOOFED)
+        controller.explain("total 0")
+        val clipboard = feed { MobileAiBarInput(controller, terminalState()) }
+        assertEquals(PROSE, selectAndCopy(PROSE, clipboard))
+    }
+
+    /**
+     * Selection is scoped to one turn, so a turn's own text changing under it is what cannot swallow
+     * it. A turn scrolled out of the feed is a different matter — the `LazyColumn` disposes it, and
+     * the selection goes with it; that is stated in [AssistantMessage], not defended here.
+     */
+    @Test
+    fun `a selection in one turn survives the next turn's text growing`() = runComposeUiTest {
+        var streamed by mutableStateOf("Chec")
+        val clipboard = feed {
+            Column {
+                AssistantMessage(PROSE, fromUser = false, actions = INERT)
+                AssistantMessage(streamed, fromUser = false, actions = INERT)
+            }
+        }
+        drag(PROSE)
+        streamed = "Checking the unit file now."
+        waitForIdle()
+        assertEquals(PROSE, copy(PROSE, clipboard))
+    }
+
+    // --- harness ---
+
+    /** One composable under the panel's chrome: theme, fonts, and a clipboard the test can read. */
+    private fun ComposeUiTest.feed(body: @Composable () -> Unit): FakeClipboard {
+        val clipboard = FakeClipboard()
+        setContent {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                    LocalClipboard provides clipboard,
+                ) {
+                    Box(Modifier.width(PANEL_WIDTH)) { body() }
+                }
+            }
+        }
+        return clipboard
+    }
+
+    private fun ComposeUiTest.selectAndCopy(text: String, clipboard: FakeClipboard): String? {
+        drag(text)
+        return copy(text, clipboard)
+    }
+
+    /**
+     * Sweep the mouse across the whole of [text], corner to corner — `centerRight` would stop at the
+     * middle line of a block that has more than one.
+     */
+    private fun ComposeUiTest.drag(text: String) {
+        onNodeWithText(text).performMouseInput {
+            moveTo(topLeft)
+            press()
+            moveTo(center)
+            moveTo(bottomRight)
+            release()
+        }
+    }
+
+    /**
+     * A terminal AI controller whose provider answers [reply] at once — the dispatcher is unconfined,
+     * so `ask`/`explain` have already landed by the time the bar is composed.
+     */
+    private fun terminalAi(reply: String) = TerminalAiController(
+        policy = AiPolicy.Balanced,
+        settings = { AiSettings(apiKey = "sk-test") },
+        providerFactory = { OneShotProvider(reply) },
+        scope = CoroutineScope(Dispatchers.Unconfined),
+    )
+
+    private fun terminalState() = TerminalScreenState(SilentSession(), CoroutineScope(Dispatchers.Unconfined))
+
+    private fun ComposeUiTest.copy(text: String, clipboard: FakeClipboard): String? {
+        onNodeWithText(text).performKeyInput { withKeyDown(COPY_MODIFIER) { pressKey(Key.C) } }
+        waitForIdle()
+        return clipboard.text
+    }
+}
+
+/** Answers every request with [reply] in one delta and no suspension. */
+private class OneShotProvider(private val reply: String) : AiProvider {
+    override fun chat(request: AiChatRequest): Flow<AiDelta> = flowOf(AiDelta(reply))
+    override suspend fun close() {}
+}
+
+/** A terminal that never emits and never accepts: the bar under test only reads its selection. */
+private class SilentSession : TerminalSession {
+    override val state: StateFlow<TerminalState> = MutableStateFlow(TerminalState.Open)
+    override val output: Flow<ByteArray> = emptyFlow()
+    override suspend fun send(data: ByteArray) = Unit
+    override suspend fun resize(size: PtySize) = Unit
+    override suspend fun close() = Unit
+}
+
+/** Ctrl everywhere but macOS — what the selection manager listens for. */
+private val COPY_MODIFIER: Key =
+    if (System.getProperty("os.name").orEmpty().startsWith("Mac")) Key.MetaLeft else Key.CtrlLeft
+
+/** Run/Copy/Edit are not what these tests exercise. */
+private val INERT = AssistantCommandActions(run = {}, copy = {}, edit = {}, runnable = false)
+
+/** Same, but with the action row drawn in its live state — the labels a sweep must not pick up. */
+private val RUNNABLE = INERT.copy(runnable = true)
+
+private const val PROSE = "Reload the unit before restarting it."
+private const val COMMAND = "systemctl daemon-reload"
+
+/** [PROSE] as a hostile model would send it: a right-to-left override the display must not keep. */
+private const val SPOOFED = "Reload the unit before\u202E restarting it."
+private const val NOTICE = "Which host did you mean?"
+
+/** Wider than [BUBBLE_MAX_WIDTH] at 11.5.sp mono, so the block's horizontal scroll has real range. */
+private const val WIDE_COMMAND =
+    "journalctl -u nginx.service --since '2026-08-01 00:00' --until '2026-08-09 00:00' --no-pager -o short-iso"
+
+/** Comments only: `AssistantAnswer.commands` drops them, so the card gets no action row. */
+private const val COMMENT_BLOCK = "# keep the old unit file\n# rollback: systemctl revert nginx"
+
+/** Single-line and runnable, so the mobile bar shows it as a proposal rather than a notice. */
+private const val MOBILE_COMMAND = "du -sh /var/log/*"
+
+/**
+ * How far past the bubble's bottom-right the whole-turn sweep goes, to cross the action row. In dp,
+ * converted at injection time: everything it has to clear (paddings, the code box, the chip row) is
+ * in dp, so a pixel literal would stop inside the code block at any density above 1 and the
+ * assertion about the buttons would pass without ever reaching them.
+ */
+private val SWEEP_PAST_BUBBLE = 120.dp
+
+/** A sweep of the visible part of [WIDE_COMMAND] must reach well past its first argument. */
+private const val VISIBLE_RUN_MIN_CHARS = 30
+private val PANEL_WIDTH = 380.dp

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/FakeClipboard.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/FakeClipboard.kt
@@ -1,0 +1,28 @@
+package app.skerry.ui.design
+
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.Clipboard
+import androidx.compose.ui.platform.NativeClipboard
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.Transferable
+
+/**
+ * Clipboard that keeps what is put on it instead of reaching for the developer's own. Provided
+ * through `LocalClipboard`, which is the only path Compose's selection manager writes through — a
+ * test that ends up on the system clipboard instead reads back `null` and fails.
+ */
+internal class FakeClipboard : Clipboard {
+    private var entry: ClipEntry? = null
+
+    val text: String?
+        get() = (entry?.nativeClipEntry as? Transferable)?.getTransferData(DataFlavor.stringFlavor) as? String
+
+    override suspend fun getClipEntry(): ClipEntry? = entry
+
+    override suspend fun setClipEntry(clipEntry: ClipEntry?) {
+        entry = clipEntry
+    }
+
+    // Never read by the code under test; a private AWT clipboard keeps the system one untouched.
+    override val nativeClipboard: NativeClipboard = java.awt.datatransfer.Clipboard("skerry-test")
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/TextContextMenuTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/TextContextMenuTest.kt
@@ -1,0 +1,165 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.isPopup
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.test.MouseButton
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.theme.SkerryTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+/**
+ * Right-clicking selected text opens a menu Compose builds and, by default, paints as a white
+ * Material sheet — which is what this app's dark chrome showed until [SkerryTextContextMenu] was
+ * provided. Every other menu in the app is a [MenuPanel]; this one has to be too.
+ *
+ * Asserts the pixels rather than the presence of a menu: the default representation also opens a
+ * menu with the same clickable items, so only its colour tells the two apart.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TextContextMenuTest {
+
+    @Test
+    fun `the selection context menu is drawn in the app's palette`() = runComposeUiTest {
+        var panel = Color.Unspecified
+        setContent {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                ) {
+                    panel = Skerry.colors.surface2
+                    Box(Modifier.width(300.dp)) {
+                        SelectionContainer { Txt(TEXT) }
+                    }
+                }
+            }
+        }
+        // Select first: without a selection the menu's Copy item is not worth opening for.
+        onNodeWithText(TEXT).performMouseInput {
+            moveTo(centerLeft)
+            press()
+            moveTo(centerRight)
+            release()
+        }
+        onNodeWithText(TEXT).performMouseInput {
+            moveTo(center)
+            press(MouseButton.Secondary)
+            release(MouseButton.Secondary)
+        }
+        waitForIdle()
+
+        assertEquals(panel, popupFill(), "the menu is not painted on the app's panel colour")
+    }
+
+    /**
+     * The same representation serves text fields, and that is the half a future Compose bump could
+     * regress on its own: the parallel "new context menu" implementation ignores the local this
+     * override is provided through. Selected text alone would not notice.
+     */
+    @Test
+    fun `a text field's context menu is drawn in the app's palette too`() = runComposeUiTest {
+        var panel = Color.Unspecified
+        setContent {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                ) {
+                    panel = Skerry.colors.surface2
+                    Box(Modifier.width(300.dp)) {
+                        BasicTextField(value = TEXT, onValueChange = {}, modifier = Modifier.width(300.dp))
+                    }
+                }
+            }
+        }
+        onNodeWithText(TEXT).performMouseInput {
+            moveTo(center)
+            press(MouseButton.Secondary)
+            release(MouseButton.Secondary)
+        }
+        waitForIdle()
+
+        assertEquals(panel, popupFill(), "the field's menu is not painted on the app's panel colour")
+    }
+
+    /**
+     * The panel is ours, the actions are Compose's — so the wiring between them is the part worth
+     * proving. Over a selection the menu is one row, Copy; clicking it must reach the selection
+     * manager, not just dismiss a good-looking popup. (The four-item form belongs to a text field.)
+     */
+    @Test
+    fun `clicking Copy in the menu puts the selection on the clipboard`() = runComposeUiTest {
+        val clipboard = FakeClipboard()
+        setContent {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                    LocalClipboard provides clipboard,
+                ) {
+                    Box(Modifier.width(300.dp)) {
+                        SelectionContainer { Txt(TEXT) }
+                    }
+                }
+            }
+        }
+        onNodeWithText(TEXT).performMouseInput {
+            moveTo(centerLeft)
+            press()
+            moveTo(centerRight)
+            release()
+        }
+        onNodeWithText(TEXT).performMouseInput {
+            moveTo(center)
+            press(MouseButton.Secondary)
+            release(MouseButton.Secondary)
+        }
+        waitForIdle()
+
+        onAllNodes(hasClickAction())[0].performClick()
+        waitForIdle()
+
+        assertEquals(TEXT, clipboard.text)
+    }
+}
+
+/**
+ * The colour the menu is mostly made of. Counted rather than sampled at a fixed point: the popup's
+ * own bounds are larger than the panel it holds, so a corner or an edge reads as transparent, and
+ * the rounded corners and the label glyphs are not the fill either. Whatever paints the most opaque
+ * pixels is the panel — `surface2` for the app's menu, white for the one Compose draws by default.
+ */
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.popupFill(): Color {
+    val pixels = onNode(isPopup()).captureToImage().toPixelMap()
+    val counts = mutableMapOf<Color, Int>()
+    for (y in 0 until pixels.height) {
+        for (x in 0 until pixels.width) {
+            val pixel = pixels[x, y]
+            if (pixel.alpha == 1f) counts[pixel] = (counts[pixel] ?: 0) + 1
+        }
+    }
+    // Fails loudly rather than returning a sentinel: `Color.Unspecified` is also what an untouched
+    // expectation holds, so a popup that rendered nothing at all would have matched it and the one
+    // regression this test exists for would pass.
+    return counts.maxByOrNull { it.value }?.key ?: fail("the menu popup drew no opaque pixel")
+}
+
+private const val TEXT = "reload the unit before restarting it"

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -74,6 +74,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Chips | `Chip` (label, active/inactive) vs `ChipButton` (action chip: colour, outline/filled, enabled) — pick one, don't add a third |
 | Rules and separators | `HLine`, `VLine` |
 | Dropdowns and modals | `AnchoredDropdown`, `DropdownField`, `ModalScrim` |
+| Pop-up menu (right click, "⋮") | `ui/design/MenuPanel`: `MenuPanel` + `MenuItem` (label only; destructive via `color`). It also draws the platform text context menu, through `ui/design/SkerryTextContextMenu`. `ui/terminal/SessionActions.MenuActionRow` is the glyph+label row — pick one, don't add a third. `TerminalPanes`, `SessionActions` and `RemoteDesktopMenus` still hand-roll the panel with their own tokens and widths and should converge onto `MenuPanel` (issue #224) |
 | Confirming a destructive action / informing | `ui/design/ConfirmActionDialog`, `NoticeDialog` |
 | Sidebar and section chrome | `ui/design/SectionChrome`: `SidebarSectionTitle`, `SectionHeader`, `EmptyState`, `SidebarSearchField` |
 | Field labels, caps, avatars | `FieldLabel`, `LabelCase.labelUppercase`, `InitialsAvatar` |

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SafeTerminalInput.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/SafeTerminalInput.kt
@@ -23,3 +23,34 @@ fun isSafeTerminalInputChar(c: Char): Boolean {
         code == 0xFEFF                             // ZWNBSP / BOM
     return !unsafeFormat
 }
+
+/**
+ * Whether a character is allowed in untrusted text the app only ever *shows* — an assistant reply,
+ * a model's explanation. More permissive than [isSafeTerminalInputChar], deliberately.
+ *
+ * Rejected: control bytes, DEL and C1, and the characters that can render a line in the reverse of
+ * its bytes — the bidi embeddings and overrides (U+202A..U+202E), the isolates (U+2066..U+2069), the
+ * line and paragraph separators, and the Arabic letter mark. Those are the Trojan Source set, and
+ * this text is one copy away from a shell.
+ *
+ * Kept: the zero-width joiner and non-joiner, without which a family emoji falls apart into three
+ * people and Persian loses its joins; the zero-width space, word joiner, BOM and soft hyphen, which
+ * reorder nothing and only ever make a pasted command fail rather than retarget it; and the left-
+ * and right-to-left marks (U+200E/U+200F). The marks are not free — they reorder neutrals and digits
+ * around them — but they cannot move letters, which is what a disguise needs, and they are how
+ * mixed-direction prose is written correctly. `HostMetrics` strips them from host-supplied metric
+ * text because nothing there is ever prose.
+ *
+ * Text that is offered for execution keeps the stricter predicate: there the displayed string and
+ * the string sent to the PTY have to be the same bytes.
+ */
+fun isSafeDisplayChar(c: Char): Boolean {
+    if (c != '\t' && c.code < 0x20) return false
+    if (c.code == 0x7F || c.code in 0x80..0x9F) return false
+    val code = c.code
+    val reordering = code == 0x061C ||                 // arabic letter mark
+        code == 0x2028 || code == 0x2029 ||            // line/paragraph separator
+        code in 0x202A..0x202E ||                      // bidi embeddings/overrides
+        code in 0x2066..0x2069                         // bidi isolates
+    return !reordering
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SafeTerminalInputTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/SafeTerminalInputTest.kt
@@ -1,0 +1,58 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The two predicates untrusted text passes through: one for text that may be executed, one for text
+ * that is only shown. They differ on exactly one range, and that difference is the point — asserted
+ * character by character here rather than inferred from the parsers that use them.
+ */
+class SafeTerminalInputTest {
+
+    @Test
+    fun `both reject control bytes, DEL and the C1 range`() {
+        listOf(0x00, 0x07, 0x0A, 0x0D, 0x1B, 0x1F, 0x7F, 0x80, 0x9F).forEach { code ->
+            assertFalse(isSafeTerminalInputChar(code.toChar()), "input allowed U+${code.toString(16)}")
+            assertFalse(isSafeDisplayChar(code.toChar()), "display allowed U+${code.toString(16)}")
+        }
+    }
+
+    @Test
+    fun `both keep tab and ordinary text`() {
+        listOf('\t', 'a', 'Я', '中', '/', '-').forEach { char ->
+            assertTrue(isSafeTerminalInputChar(char), "input rejected `$char`")
+            assertTrue(isSafeDisplayChar(char), "display rejected `$char`")
+        }
+    }
+
+    @Test
+    fun `both reject everything that reorders a line`() {
+        val reordering = (0x202A..0x202E) + (0x2066..0x2069) + listOf(0x061C, 0x2028, 0x2029)
+        reordering.forEach { code ->
+            assertFalse(isSafeTerminalInputChar(code.toChar()), "input allowed U+${code.toString(16)}")
+            assertFalse(isSafeDisplayChar(code.toChar()), "display allowed U+${code.toString(16)}")
+        }
+    }
+
+    /**
+     * The whole difference between the two, spelled out: a command must not carry an invisible
+     * character at all, while prose needs the joiners to render a family emoji or a Persian word,
+     * and the direction marks to write mixed-direction text — none of which reorder anything.
+     */
+    @Test
+    fun `only the display predicate keeps the invisible characters that reorder nothing`() {
+        val invisible = (0x200B..0x200F) + listOf(0x2060, 0xFEFF)
+        invisible.forEach { code ->
+            assertFalse(isSafeTerminalInputChar(code.toChar()), "input allowed U+${code.toString(16)}")
+            assertTrue(isSafeDisplayChar(code.toChar()), "display rejected U+${code.toString(16)}")
+        }
+    }
+
+    @Test
+    fun `the soft hyphen is an input hazard but harmless to show`() {
+        assertFalse(isSafeTerminalInputChar('­'))
+        assertTrue(isSafeDisplayChar('­'))
+    }
+}


### PR DESCRIPTION
Text in the AI assistant can be selected with the mouse and copied with the platform's copy chord, the way terminal output already could.

Closes #175.

## Selection

- Every turn in the assistant feed is its own selection scope. Prose, fenced command blocks and notices are all selectable; the per-command **Copy** button stays as the fast path.
- The Run / Copy / Edit row and the "outputs sent" line are excluded, so a sweep down a turn takes what the model said and leaves the chrome behind.
- Same on the mobile side: quick-chat bubbles, the AI bar's proposed command, its explanation and its notices.
- A per-turn scope rather than one around the feed: a `LazyColumn` gives undefined selection behaviour across items that scroll out of composition, and per turn a streaming delta cannot collapse a selection made in an earlier one.

A command wider than the bubble is selectable as far as its box shows — the tail is reachable through the Copy button or the menu's **Select all**.

## Context menu

Compose paints the right-click menu over selected text as a white Material sheet. It is now drawn as the same panel the app's own menus use, app-wide — text fields showed the default one too. `MenuPanel` / `MenuItem` are extracted into the design layer and the host row menu now shares them.

## Model text is filtered before it is shown

A fenced block was displayed as the model wrote it while **Run** sent the same line with control and bidi characters stripped — so the card could render in an order the shell never sees. Display, clipboard and the runnable line now come from the same filtered bytes.

The rest of a reply is filtered too, with a second, narrower predicate. Prose is not inert: an inline `` `…` `` run is drawn in the mono font and its closing backtick may be lines away, so prose can read as a command card, and the quick chat does no fence parsing at all. But prose is also where a family emoji and a Persian word live, so `isSafeDisplayChar` drops only what reorders a line — the bidi overrides and isolates — and keeps the joiners and direction marks. Text offered for execution keeps the strict predicate.

## Keyboard

Settings → Keyboard gains a row for the copy chord outside the terminal (`Ctrl+C` / `⌘C`). The terminal keeps `Ctrl+Shift+C` — there `Ctrl+C` is SIGINT.

## Tests

First Compose UI tests in the repository: `compose.uiTest` in the `desktopTest` source set, driving the real composables with injected mouse drags and the copy chord against a fake clipboard. 14 selection cases, plus a pixel assertion that the context menu is painted on the app's panel colour, plus parser cases for the filtering.

## Trade-off

`SelectionContainer` installs `focusable()`, so each visible turn becomes a Tab stop and clicking a reply moves keyboard focus off the terminal. Removing that with `focusProperties { canFocus = false }` also removes Ctrl+C — Compose routes the chord through that node.

## Not verified

Android: the desktop side was checked by hand; selection handles inside the horizontally scrolling command block have not been tried on a device.
