### PR TITLE
Release 0.3.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.3.0
-skerry.versionCode=9
+skerry.versionName=0.3.1
+skerry.versionCode=10

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.0"
+version = "0.3.1"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/server/src/main/kotlin/app/skerry/server/metrics/ServerMetrics.kt
+++ b/server/src/main/kotlin/app/skerry/server/metrics/ServerMetrics.kt
@@ -121,6 +121,8 @@ class ServerMetrics(
         count("skerry.sync.ws.sessions.opened")
     }
 
+    // The duration timer is written last on purpose: it is the only one of the three an observer
+    // can wait on to know the whole close was accounted, and tests use it as that barrier.
     fun wsSessionClosed(reason: WsCloseReason, durationSeconds: Double) {
         wsSessions.decrementAndGet()
         count("skerry.sync.ws.sessions.closed", "reason" to reason.label)

--- a/server/src/main/kotlin/app/skerry/server/routes/SyncWebSocket.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/SyncWebSocket.kt
@@ -37,10 +37,11 @@ fun Route.syncWebSocket(services: Services) {
         val accountId = principal.accountId
         val deviceId = principal.deviceId
         // The gauge is maintained here, not from ChangeNotifier.subscriptions: each session collects
-        // three flows, so that counter is three times the number of sockets.
+        // four flows, so that counter is four times the number of sockets. Tests pin the multiple as
+        // WS_SUBSCRIPTIONS — a fifth channel has to move with it, or their waits pass too early.
         services.metrics.wsSessionOpened()
         val openedAt = System.nanoTime()
-        // Written by the three notification coroutines and by the reader, read in `finally`: an
+        // Written by the four notification coroutines and by the reader, read in `finally`: an
         // AtomicReference gives that a happens-before edge, and first-cause-wins keeps the label
         // truthful when a revoke and a client close race.
         val closeReason = AtomicReference(WsCloseReason.CLIENT_CLOSE)

--- a/server/src/test/kotlin/app/skerry/server/metrics/InstrumentationTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/metrics/InstrumentationTest.kt
@@ -3,6 +3,8 @@ package app.skerry.server.metrics
 import app.skerry.server.Services
 import app.skerry.server.configureServer
 import app.skerry.server.model.b64
+import app.skerry.server.routes.WS_SUBSCRIPTIONS
+import app.skerry.server.routes.awaitUntil
 import app.skerry.server.routes.changePassword
 import app.skerry.server.routes.pushRecord
 import app.skerry.server.routes.registerAccount
@@ -39,6 +41,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -51,9 +54,6 @@ class InstrumentationTest {
     private val alice = "alice@example.com"
     private val bob = "bob@example.com"
     private val password = "correct horse"
-
-    /** A single WS session subscribes to three notifier channels (account, teams, membership). */
-    private val wsSubscriptions = 3
 
     private fun withServer(
         extraEnv: Map<String, String> = emptyMap(),
@@ -78,6 +78,15 @@ class InstrumentationTest {
         scrape().lines().firstOrNull { it.startsWith("$series ") }?.substringAfterLast(' ')?.toDouble() ?: 0.0
 
     private fun ServerMetrics.has(prefix: String): Boolean = scrape().lines().any { it.startsWith(prefix) }
+
+    /**
+     * The socket's `finally` cancels the notifier collectors before it accounts the session closed,
+     * so a subscription count of zero does not yet mean the gauge, the reason counter and the
+     * duration timer have been written. `wsSessionClosed` writes the timer last, so waiting until
+     * that many sessions have been timed makes all three visible.
+     */
+    private suspend fun ServerMetrics.awaitSessionsAccountedClosed(sessions: Int) =
+        awaitUntil(2_000) { value("skerry_sync_ws_session_duration_seconds_count") >= sessions }
 
     // --- sync volume ---
 
@@ -310,7 +319,7 @@ class InstrumentationTest {
         val tokens: TokenResponse = client.registerAccount(alice, password, deviceId = "devA")
 
         client.webSocket("/sync", request = { bearerAuth(tokens.accessToken) }) {
-            withTimeout(2_000) { services.notifier.subscriptions.first { it >= wsSubscriptions } }
+            withTimeout(2_000) { services.notifier.subscriptions.first { it >= WS_SUBSCRIPTIONS } }
             assertEquals(1.0, services.metrics.value("skerry_sync_ws_sessions"))
             assertEquals(1.0, services.metrics.value("skerry_sync_ws_sessions_opened_total"))
 
@@ -320,6 +329,8 @@ class InstrumentationTest {
         }
         withTimeout(2_000) { services.notifier.subscriptions.first { it == 0 } }
 
+        services.metrics.awaitSessionsAccountedClosed(sessions = 1)
+
         assertEquals(0.0, services.metrics.value("skerry_sync_ws_sessions"), "the gauge must come back down")
         assertEquals(1.0, services.metrics.value("""skerry_sync_ws_frames_sent_total{kind="account"}"""))
         assertEquals(1.0, services.metrics.value("""skerry_sync_notify_published_total{kind="account"}"""))
@@ -327,7 +338,7 @@ class InstrumentationTest {
             1.0,
             services.metrics.value("""skerry_sync_ws_sessions_closed_total{reason="client_close"}"""),
         )
-        assertTrue(services.metrics.has("skerry_sync_ws_session_duration_seconds_count"))
+        // The duration histogram is not asserted here: the barrier above is exactly a wait on it.
     }
 
     @Test
@@ -339,12 +350,13 @@ class InstrumentationTest {
         val tokens: TokenResponse = client.registerAccount(alice, password, deviceId = "devA")
 
         client.webSocket("/sync", request = { bearerAuth(tokens.accessToken) }) {
-            withTimeout(2_000) { services.notifier.subscriptions.first { it >= wsSubscriptions } }
+            withTimeout(2_000) { services.notifier.subscriptions.first { it >= WS_SUBSCRIPTIONS } }
             services.devices.revoke(alice, "devA")
             services.notifier.publish(alice, 1)
             withTimeout(2_000) { closeReason.await() }
         }
         withTimeout(2_000) { services.notifier.subscriptions.first { it == 0 } }
+        services.metrics.awaitSessionsAccountedClosed(sessions = 1)
 
         // First cause wins: the revoke decided this close, not the client's reaction to it.
         assertEquals(
@@ -353,6 +365,14 @@ class InstrumentationTest {
             services.metrics.scrape().lines().filter { "ws_sessions_closed" in it }.toString(),
         )
         assertEquals(0.0, services.metrics.value("""skerry_sync_ws_sessions_closed_total{reason="client_close"}"""))
+        // The property is that a revoked device stops receiving pushes, not merely that the socket
+        // ends: sending the cursor before the revocation check would still close under this reason.
+        // Asserted over the whole series rather than one kind — every channel repeats the guard, and
+        // a mistyped label block would read as zero forever.
+        assertFalse(
+            services.metrics.has("skerry_sync_ws_frames_sent_total"),
+            "a revoked device must not receive the cursor that revealed the revocation",
+        )
     }
 
     // --- inventory and pool ---

--- a/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/RoutesTestSupport.kt
@@ -27,12 +27,32 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 import org.jetbrains.exposed.v1.jdbc.Database
 import java.math.BigInteger
 import java.nio.file.Files
 import java.security.SecureRandom
 
 val SRP_PARAMS: SRP6CryptoParams = SRP6CryptoParams.getInstance(2048, "SHA-256")
+
+/**
+ * A single WS session subscribes to account, team records, share directory and membership. A test
+ * that waits for fewer lets a publish land before its collector is subscribed, and the bus replays
+ * nothing — so this is one constant, not one per test file.
+ */
+const val WS_SUBSCRIPTIONS = 4
+
+/**
+ * Polls [condition] until it holds. What a socket test waits for is written by a coroutine on
+ * another dispatcher with no signal to subscribe to, so it is polled; the bound throws rather than
+ * returning, because a wait whose expiry nobody observes is a sleep, not a barrier.
+ */
+suspend fun awaitUntil(timeoutMillis: Long = 5_000, condition: suspend () -> Boolean) {
+    withTimeout(timeoutMillis) {
+        while (!condition()) delay(10)
+    }
+}
 
 fun testServices(
     adminToken: String = "",

--- a/server/src/test/kotlin/app/skerry/server/routes/ShareRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/ShareRoutesTest.kt
@@ -29,7 +29,6 @@ import io.ktor.websocket.readBytes
 import io.ktor.websocket.readText
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -97,7 +96,7 @@ class ShareRoutesTest {
         assertEquals(meta, listed.shares.first().meta)
 
         host.close()
-        withTimeout(5_000) { while (services.shares.list(teamId).isNotEmpty()) yield() }
+        awaitUntil { services.shares.list(teamId).isEmpty() }
         val after: SharesResponse = client.shares(mateToken).body()
         assertTrue(after.shares.isEmpty(), "a share must not outlive its host's socket")
     }
@@ -300,7 +299,7 @@ class ShareRoutesTest {
         val (ownerToken, mateToken) = client.teamOfTwo()
 
         val sync = client.webSocketSession("/sync") { bearerAuth(mateToken) }
-        withTimeout(5_000) { services.notifier.subscriptions.first { it >= 4 } }
+        withTimeout(5_000) { services.notifier.subscriptions.first { it >= WS_SUBSCRIPTIONS } }
 
         val host = client.webSocketSession(hostPath("s1", meta)) { bearerAuth(ownerToken) }
         assertEquals("shares:$teamId", withTimeout(5_000) { sync.nextText() })
@@ -312,10 +311,10 @@ class ShareRoutesTest {
     }
 
     private suspend fun app.skerry.server.Services.awaitShare() =
-        withTimeout(5_000) { while (shares.list(teamId).isEmpty()) yield() }
+        awaitUntil { shares.list(teamId).isNotEmpty() }
 
     private suspend fun app.skerry.server.Services.awaitViewers(count: Int) =
-        withTimeout(5_000) { while (shares.list(teamId).firstOrNull()?.viewers != count) yield() }
+        awaitUntil { shares.list(teamId).firstOrNull()?.viewers == count }
 
     /** Next binary frame, skipping the server's own text control frames. */
     private suspend fun DefaultClientWebSocketSession.nextBinary(): ByteArray {

--- a/server/src/test/kotlin/app/skerry/server/routes/SyncWebSocketTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/SyncWebSocketTest.kt
@@ -17,9 +17,6 @@ import kotlinx.coroutines.withTimeout
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-/** A single WS session subscribes to account, team records, share directory and membership. */
-private const val WS_SUBSCRIPTIONS = 4
-
 class SyncWebSocketTest {
 
     private val accountId = "alice@example.com"
@@ -38,6 +35,9 @@ class SyncWebSocketTest {
         client.webSocket("/sync", request = { bearerAuth(tokens.accessToken) }) {
             // Wait for all server subscriptions to register, then verify the push channel itself.
             withTimeout(2_000) { services.notifier.subscriptions.first { it >= WS_SUBSCRIPTIONS } }
+            // A fifth notifier channel would make every `>= WS_SUBSCRIPTIONS` wait pass before its
+            // collector subscribed, and a publish would be lost — fail here instead, once.
+            assertEquals(WS_SUBSCRIPTIONS, services.notifier.subscriptions.value)
             services.notifier.publish(accountId, 7)
             val frame = withTimeout(2_000) { incoming.receive() } as Frame.Text
             assertEquals("7", frame.readText())

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.0"
+version = "0.3.1"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Client and server both go out as 0.3.1: `gradle.properties` (`skerry.versionName`, `skerry.versionCode`), `server/build.gradle.kts` and `sync-wire/build.gradle.kts`.

No metainfo entry — the Flatpak packaging that carried it was removed in #229. The server version reported at `/admin/health` is stamped from `project.version` through `version.properties`, so it follows the bump on its own.

Also fixes a race that made the websocket session metrics tests fail on CI. The socket's `finally` cancels the notifier collectors before it accounts the session closed, so a subscription count of zero did not imply the gauge, the reason counter and the duration timer had been written; the tests now wait for the timer, which is written last. `InstrumentationTest` waited for three subscriptions where a session takes four, which could drop a publish — that count and the poll-under-a-timeout idiom the three test files each spelled their own way now live in `RoutesTestSupport`, and `SyncWebSocketTest` pins the count. The revocation test additionally asserts that a revoked device received no frame at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)