### PR TITLE
Sanitize peer- and server-authored text before drawing it

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -71,6 +71,8 @@
     <!-- Колонки списка (дата изменения / права) и быстрый фильтр по имени -->
     <string name="sftp_columns">Колонки</string>
     <string name="sftp_col_name">Имя</string>
+    <!-- Row name for an entry whose name is nothing but characters that cannot be drawn -->
+    <string name="sftp_unprintable_name">Непечатаемое имя</string>
     <string name="sftp_col_size">Размер</string>
     <string name="sftp_col_modified">Дата изменения</string>
     <string name="sftp_col_permissions">Права</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -71,6 +71,8 @@
     <!-- Listing columns (modified date / permissions) and the quick name filter -->
     <string name="sftp_columns">显示列</string>
     <string name="sftp_col_name">名称</string>
+    <!-- Row name for an entry whose name is nothing but characters that cannot be drawn -->
+    <string name="sftp_unprintable_name">无法显示的名称</string>
     <string name="sftp_col_size">大小</string>
     <string name="sftp_col_modified">修改时间</string>
     <string name="sftp_col_permissions">权限</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -70,6 +70,8 @@
     <!-- Listing columns (modified date / permissions) and the quick name filter -->
     <string name="sftp_columns">Columns</string>
     <string name="sftp_col_name">Name</string>
+    <!-- Row name for an entry whose name is nothing but characters that cannot be drawn -->
+    <string name="sftp_unprintable_name">Unprintable name</string>
     <string name="sftp_col_size">Size</string>
     <string name="sftp_col_modified">Modified</string>
     <string name="sftp_col_permissions">Permissions</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionFailureText.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.connection
 
+import app.skerry.ui.design.sanitizeServerText
+
 /**
  * One banner or notice line's worth of transport diagnostics. Passed to [sanitizeServerText] with
  * newlines disallowed, so a multi-line reason folds into one line instead of being wrapped or

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/HostConnect.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vnc.VncAuth
+import app.skerry.ui.design.untrustedLabel
 
 /**
  * Pure helpers wiring a saved host profile to a live session. Kept separate from UI so the
@@ -39,10 +40,14 @@ fun Host.toTarget(jump: SshJump? = null): SshTarget =
  */
 fun Host.connectionSubtitle(): String {
     val spec = container?.takeIf { connectionType == ConnectionType.CONTAINER && it.isComplete }
+    // Sanitized like the catalog's own caption ([app.skerry.ui.host.rowSubtitle]): for a profile a
+    // team member shared, every field spliced in here is that member's text. The local-shell
+    // fallback reads the sanitized path, not the raw one — a path made only of format characters is
+    // blank once drawn, and the caption would otherwise go empty instead of naming the shell.
     return when {
-        connectionType == ConnectionType.LOCAL -> address.ifBlank { "local shell" }
-        spec != null -> "${containerLabel(spec)} · $username@$address"
-        else -> "$username@$address:$port"
+        connectionType == ConnectionType.LOCAL -> untrustedLabel(address).ifBlank { "local shell" }
+        spec != null -> untrustedLabel("${containerLabel(spec)} · $username@$address")
+        else -> untrustedLabel("$username@$address:$port")
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/JumpChain.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/JumpChain.kt
@@ -4,6 +4,7 @@ import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshJump
 import app.skerry.shared.vault.Credential
+import app.skerry.ui.host.rowLabel
 
 /**
  * Why a ProxyJump chain could not be assembled. Typed (not a message string) so every surface
@@ -99,7 +100,7 @@ fun jumpRouteLabel(host: Host, findHost: (String) -> Host?): String? {
     while (true) {
         if (!visited.add(jumpId)) break
         val hop = findHost(jumpId)
-        labels += hop?.label ?: "?"
+        labels += hop?.rowLabel() ?: "?"
         jumpId = hop?.jumpHostId ?: break
     }
     return labels.asReversed().joinToString(" → ")

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/KeyboardInteractiveDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/KeyboardInteractiveDialog.kt
@@ -43,6 +43,7 @@ import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.generated.resources.Res
@@ -274,56 +275,3 @@ private fun PromptField(
 private const val MAX_TITLE_CHARS = 120
 private const val MAX_INSTRUCTION_CHARS = 600
 private const val MAX_PROMPT_CHARS = 200
-
-/**
- * Makes server-supplied text safe to render: drops control characters (including the escape
- * sequences a terminal would act on and the bidi overrides that could reorder the sentence), keeps
- * newlines only inside longer blocks, collapses runs of blank lines and caps the length.
- *
- * Truncation is silent rather than marked with an ellipsis — the cap is generous enough that only a
- * server trying to flood the dialog reaches it.
- */
-internal fun sanitizeServerText(text: String, maxChars: Int, allowNewlines: Boolean): String {
-    val cleaned = buildString(minOf(text.length, maxChars)) {
-        for (ch in text) {
-            if (length >= maxChars) break
-            when (classifyServerChar(ch, allowNewlines)) {
-                ServerChar.Keep -> append(ch)
-                // Runs collapse: a server padding with blank lines or tabs gets one separator.
-                ServerChar.Break -> if (isNotEmpty() && last() != '\n') append('\n')
-                ServerChar.Space -> if (isNotEmpty() && last() != ' ') append(' ')
-                ServerChar.Drop -> Unit
-            }
-        }
-    }
-    // The cap counts UTF-16 units, so it can fall between the halves of an astral character and
-    // leave an orphan that draws as U+FFFD — in the caption and in the field's name alike. Same
-    // cut, same treatment as the terminal title's and the team label's.
-    return cleaned.dropLastWhile { it.isHighSurrogate() }.trim()
-}
-
-/** What [sanitizeServerText] does with one character of server text. */
-private const val LINE_SEPARATOR = '\u2028'
-private const val PARAGRAPH_SEPARATOR = '\u2029'
-
-private enum class ServerChar { Keep, Break, Space, Drop }
-
-private fun classifyServerChar(ch: Char, allowNewlines: Boolean): ServerChar = when {
-    ch == '\n' && allowNewlines -> ServerChar.Break
-    // Where newlines survive, the carriage return of a CRLF must not become a space before every
-    // one of them; it carries nothing the newline does not already say.
-    ch == '\r' && allowNewlines -> ServerChar.Drop
-    // Single-line sink: fold rather than drop, or the words either side are glued together
-    // ("Accessdeniedby policy"), which reads worse than the wrapped original.
-    ch == '\n' || ch == '\r' || ch == '\t' -> ServerChar.Space
-    ch.isISOControl() -> ServerChar.Drop
-    // The whole format category rather than the bidi overrides alone: the marks (LRM/RLM/ALM) reorder
-    // the neutral runs of a prompt the user reads before typing a secret, and the zero-width set lets
-    // one carry content nothing renders. Naming ranges left both classes in, and would leave whatever
-    // Unicode adds next. Covers the BOM too, which used to have a branch of its own.
-    ch.category == CharCategory.FORMAT -> ServerChar.Drop
-    // Not in that category, but they end a line wherever the text is laid out — a single-line
-    // caption is exactly what a server would use them to turn into several.
-    ch == LINE_SEPARATOR || ch == PARAGRAPH_SEPARATOR -> ServerChar.Drop
-    else -> ServerChar.Keep
-}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/PasswordDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/PasswordDialog.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
+import app.skerry.ui.host.rowLabel
 import app.skerry.shared.ssh.isRdp
 import app.skerry.shared.ssh.isVnc
 import app.skerry.shared.vault.Credential
@@ -96,7 +97,7 @@ fun DesktopPasswordDialog(
                 .clickable(interactionSource = noop, indication = null, onClick = {})
                 .padding(26.dp),
         ) {
-            Txt(stringResource(Res.string.shell_connect_to, host.label), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+            Txt(stringResource(Res.string.shell_connect_to, host.rowLabel()), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
             Txt(host.connectionSubtitle(), color = Skerry.colors.dim, size = 12.5.sp, font = LocalFonts.current.mono, modifier = Modifier.padding(top = 4.dp, bottom = 16.dp))
 
             Txt(stringResource(Res.string.shell_password_caps), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp, modifier = Modifier.padding(bottom = 5.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/UntrustedText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/UntrustedText.kt
@@ -1,0 +1,108 @@
+package app.skerry.ui.design
+
+/**
+ * One line of text this client did not write, made fit to draw: a remote host's file name, a
+ * profile a team member shared, a team space's name.
+ *
+ * Such a string reaches the screen exactly as its author typed it — the server never sees a shared
+ * record (it travels inside the sealed envelope) and an SFTP listing is whatever the far side
+ * answers. A bidi override reverses the tail of the line in every layout, so a name ending in
+ * `.exe` can draw as one ending in `.png`; a zero-width formatter makes two different names draw
+ * as one.
+ *
+ * The whole format category goes, not just the reordering characters that [app.skerry.shared.terminal.isSafeDisplayChar]
+ * rejects. That predicate is right for prose the app only shows — an assistant's answer, where
+ * dropping a joiner breaks an emoji or a Persian word and no identity rides on the string. A label
+ * is the opposite case: it is what tells one host, one file, one space from another, so a
+ * character that renders as nothing is exactly the one that must not survive. Same choice the
+ * keyboard-interactive prompt already makes, and this is that same filter.
+ */
+internal fun untrustedLabel(raw: String, maxChars: Int = MAX_UNTRUSTED_LABEL_CHARS): String =
+    sanitizeServerText(raw, maxChars, allowNewlines = false)
+
+/**
+ * How much of an id stands in for a name that filtered away to nothing — enough to tell two rows
+ * apart, short enough to read as an id rather than as a name.
+ */
+internal const val SHORT_ID_CHARS = 8
+
+/**
+ * Cap on a label of untrusted origin. Generous — a row shows a fraction of it and ellipsizes the
+ * rest — but bounded: the string arrives from somewhere with no length limit of its own.
+ */
+internal const val MAX_UNTRUSTED_LABEL_CHARS = 120
+
+/**
+ * Makes server-supplied text safe to render: drops control characters (including the escape
+ * sequences a terminal would act on and the bidi overrides that could reorder the sentence), keeps
+ * newlines only inside longer blocks, collapses runs of blank lines and caps the length.
+ *
+ * Truncation is silent rather than marked with an ellipsis — the cap is generous enough that only a
+ * server trying to flood the dialog reaches it. It bounds the scan as well as the result: text past
+ * [SCAN_FACTOR] times the cap is never looked at, so a flood of characters this drops costs no more
+ * than a flood of characters it keeps.
+ */
+internal fun sanitizeServerText(text: String, maxChars: Int, allowNewlines: Boolean): String {
+    // The loop below stops on what it has *kept*, so a text made of nothing but the characters it
+    // drops would be scanned in full however long it is — the cap has to bound the input too, or
+    // padding a name with a million zero-width spaces is a scan the far side gets for free. The
+    // factor leaves room for ordinary text carrying formatting and still bounds a flood.
+    val bounded = if (text.length > maxChars * SCAN_FACTOR) text.take(maxChars * SCAN_FACTOR) else text
+    val cleaned = buildString(minOf(bounded.length, maxChars)) {
+        for (ch in bounded) {
+            if (length >= maxChars) break
+            when (classifyServerChar(ch, allowNewlines)) {
+                ServerChar.Keep -> append(ch)
+                // Runs collapse: a server padding with blank lines or tabs gets one separator.
+                ServerChar.Break -> if (isNotEmpty() && last() != '\n') append('\n')
+                ServerChar.Space -> if (isNotEmpty() && last() != ' ') append(' ')
+                ServerChar.Drop -> Unit
+            }
+        }
+    }
+    // The cap counts UTF-16 units, so it can fall between the halves of an astral character and
+    // leave an orphan that draws as U+FFFD — in the caption and in the field's name alike. Same
+    // cut, same treatment as the terminal title's and the team label's.
+    return cleaned.dropLastWhile { it.isHighSurrogate() }.trim()
+}
+
+/** How much input [sanitizeServerText] is willing to walk for each character it may keep. */
+private const val SCAN_FACTOR = 8
+
+/** What [sanitizeServerText] does with one character of server text. */
+private const val LINE_SEPARATOR = '\u2028'
+private const val PARAGRAPH_SEPARATOR = '\u2029'
+
+private enum class ServerChar { Keep, Break, Space, Drop }
+
+/**
+ * Letters and a symbol that draw nothing at all: the Hangul fillers (choseong, jungseong, the
+ * compatibility one and its halfwidth form) and the blank braille pattern. They are `Lo`/`So`, not
+ * format characters, so nothing else drops them and `isBlank()` calls a name made of them a name.
+ */
+private val INVISIBLE_LETTERS = charArrayOf('\u115F', '\u1160', '\u3164', '\uFFA0', '\u2800')
+
+private fun classifyServerChar(ch: Char, allowNewlines: Boolean): ServerChar = when {
+    ch == '\n' && allowNewlines -> ServerChar.Break
+    // Where newlines survive, the carriage return of a CRLF must not become a space before every
+    // one of them; it carries nothing the newline does not already say.
+    ch == '\r' && allowNewlines -> ServerChar.Drop
+    // Single-line sink: fold rather than drop, or the words either side are glued together
+    // ("Accessdeniedby policy"), which reads worse than the wrapped original.
+    ch == '\n' || ch == '\r' || ch == '\t' -> ServerChar.Space
+    ch.isISOControl() -> ServerChar.Drop
+    // The whole format category rather than the bidi overrides alone: the marks (LRM/RLM/ALM) reorder
+    // the neutral runs of a prompt the user reads before typing a secret, and the zero-width set lets
+    // one carry content nothing renders. Naming ranges left both classes in, and would leave whatever
+    // Unicode adds next. Covers the BOM too, which used to have a branch of its own.
+    ch.category == CharCategory.FORMAT -> ServerChar.Drop
+    // Not in that category, but they end a line wherever the text is laid out — a single-line
+    // caption is exactly what a server would use them to turn into several.
+    ch == LINE_SEPARATOR || ch == PARAGRAPH_SEPARATOR -> ServerChar.Drop
+    // Letters and a symbol by category, nothing at all on screen: a name made only of these is not
+    // blank to `isBlank()`, so it would slip past the stand-in a row falls back to and draw as an
+    // empty line. Three code points, not a confusables table — homoglyphs are a different problem
+    // and not one a client can close.
+    ch in INVISIBLE_LETTERS -> ServerChar.Drop
+    else -> ServerChar.Keep
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
@@ -45,6 +45,7 @@ import app.skerry.ui.connection.toSshAuth
 import app.skerry.ui.app.CustomGroup
 import app.skerry.ui.app.GroupDialog
 import app.skerry.ui.host.GroupDialog as GroupEditDialog
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.session.BroadcastPanel
 import app.skerry.ui.session.SessionView
@@ -184,7 +185,7 @@ internal fun DesktopChrome(
         state.recordRecentHost(host.id)
         sessions?.openRdp(
             host.id,
-            host.label,
+            host.rowLabel(),
             host.connectionSubtitle(),
             app.skerry.ui.remote.RdpConnectRequest(
                 host = host.address,
@@ -240,7 +241,7 @@ internal fun DesktopChrome(
                     if (cred != null) {
                         state.recordRecentHost(host.id)
                         sessions?.openVnc(
-                            host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
+                            host.id, host.rowLabel(), host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
                             remoteResize = host.vncResizeToWindow,
                             onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
                         )
@@ -442,7 +443,7 @@ internal fun DesktopChrome(
                     pendingVncHost = null
                     state.recordRecentHost(host.id)
                     sessions?.openVnc(
-                        host.id, host.label, host.connectionSubtitle(), host.toTarget(), auth,
+                        host.id, host.rowLabel(), host.connectionSubtitle(), host.toTarget(), auth,
                         remoteResize = host.vncResizeToWindow,
                         onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
                     )
@@ -593,7 +594,7 @@ internal fun DesktopChrome(
                     .orEmpty().ifBlank { stringResource(Res.string.shell_this_session) }
                 val connectPane = LocalConnectPane.current
                 ConfirmActionDialog(
-                    title = stringResource(Res.string.shell_replace_pane_title, pending.host.label),
+                    title = stringResource(Res.string.shell_replace_pane_title, pending.host.rowLabel()),
                     message = stringResource(Res.string.shell_close_pane_message, paneName),
                     confirmLabel = stringResource(Res.string.shell_connect),
                     onConfirm = { connectPane(pending.host, pending.paneId); state.dismissPaneConnect() },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
@@ -17,6 +17,7 @@ import app.skerry.shared.ssh.SshJump
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.connectionSubtitle
 import app.skerry.ui.connection.toTarget
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.snippet.SnippetManager
@@ -190,7 +191,7 @@ internal fun openHostSession(
     state.recordRecentHost(host.id)
     sessions?.connect(
         hostId = host.id,
-        title = host.label,
+        title = host.rowLabel(),
         subtitle = host.connectionSubtitle(),
         target = host.toTarget(jump),
         auth = auth,
@@ -221,7 +222,7 @@ internal fun openPaneSession(
         tabId = tabId,
         paneId = paneId,
         hostId = host.id,
-        title = host.label,
+        title = host.rowLabel(),
         subtitle = host.connectionSubtitle(),
         target = host.toTarget(jump),
         auth = auth,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/DisplayName.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/DisplayName.kt
@@ -1,0 +1,41 @@
+package app.skerry.ui.files
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_unprintable_name
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * A listing entry's name as it is drawn — in a row, in the icon it picks, in the confirmation that
+ * acts on it, in the transfer strip.
+ *
+ * The name is the far side's text ([untrustedLabel] says what that costs), and a name made only of
+ * the characters filtering drops leaves nothing at all: an empty row, or a delete confirmation
+ * reading "«» will be removed permanently". One stand-in for every such sink, so the row and the
+ * dialog opened from it always name the same thing.
+ *
+ * The rename field is deliberately not one of them: what a text field holds is edited and submitted,
+ * so it must be the real name, not a drawing of it.
+ */
+@Composable
+internal fun fileDisplayName(raw: String): String {
+    val unprintable = stringResource(Res.string.sftp_unprintable_name)
+    // remember: a listing row re-composes on every cursor move and every selection paint, and the
+    // filter is a scan and an allocation the name has not earned twice.
+    return remember(raw, unprintable) { untrustedLabel(raw).ifBlank { unprintable } }
+}
+
+/**
+ * A directory path as it is drawn — a breadcrumb, a work-bar subtitle, the destination half of a
+ * transfer confirmation.
+ *
+ * Assembled from the names the far side reported as the user walked into them, so it carries the
+ * same tricks a single name does. Its own cap: a path is legitimately longer than a name, and the
+ * one drawn next to a sanitized file name must not be the raw half of the same sentence.
+ */
+internal fun fileDisplayPath(raw: String): String = untrustedLabel(raw, MAX_DISPLAY_PATH_CHARS)
+
+/** Cap on a drawn path — deep but bounded; the row ellipsizes long before this. */
+private const val MAX_DISPLAY_PATH_CHARS = 300

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
@@ -191,7 +191,7 @@ fun FileEditorScreen(
     if (confirmDiscard) {
         ConfirmDangerDialog(
             title = stringResource(Res.string.sftp_edit_discard_q),
-            body = stringResource(Res.string.sftp_edit_discard_body, controller.name),
+            body = stringResource(Res.string.sftp_edit_discard_body, fileDisplayName(controller.name)),
             confirmLabel = stringResource(Res.string.sftp_edit_discard),
             onConfirm = { confirmDiscard = false; onClose() },
             onDismiss = { confirmDiscard = false },
@@ -201,7 +201,7 @@ fun FileEditorScreen(
     if (controller.conflict) {
         ConfirmDangerDialog(
             title = stringResource(Res.string.sftp_edit_conflict_q),
-            body = stringResource(Res.string.sftp_edit_conflict_body, controller.name),
+            body = stringResource(Res.string.sftp_edit_conflict_body, fileDisplayName(controller.name)),
             confirmLabel = stringResource(Res.string.sftp_overwrite),
             onConfirm = controller::confirmOverwrite,
             onDismiss = controller::dismissConflict,
@@ -245,9 +245,9 @@ private fun EditorHeader(
             size = 13.sp,
             weight = FontWeight.SemiBold,
         )
-        Txt(controller.name, color = Skerry.colors.textBright, size = 12.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+        Txt(fileDisplayName(controller.name), color = Skerry.colors.textBright, size = 12.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
         Txt(
-            controller.path,
+            fileDisplayPath(controller.path),
             color = Skerry.colors.faint,
             size = 11.sp,
             font = mono,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/DeleteHostDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/DeleteHostDialog.kt
@@ -53,7 +53,7 @@ fun DesktopDeleteHostDialog(host: Host, onDismiss: () -> Unit, onConfirm: () -> 
                 .consumeClicks()
                 .padding(26.dp),
         ) {
-            Txt(stringResource(Res.string.shell_delete_host_title, host.label), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+            Txt(stringResource(Res.string.shell_delete_host_title, host.rowLabel()), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
             Txt(host.connectionSubtitle(), color = Skerry.colors.dim, size = 12.5.sp, font = LocalFonts.current.mono, modifier = Modifier.padding(top = 4.dp, bottom = 14.dp))
             Txt(
                 stringResource(Res.string.shell_delete_host_body),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostSection.kt
@@ -3,6 +3,8 @@ package app.skerry.ui.host
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.isRemoteDesktop
+import app.skerry.ui.design.SHORT_ID_CHARS
+import app.skerry.ui.design.untrustedLabel
 
 /**
  * Which part of the shell a saved profile belongs to. The catalog is one store (a profile is a
@@ -23,19 +25,40 @@ val Host.section: HostSection
 fun List<Host>.inSection(section: HostSection): List<Host> = filter { it.section == section }
 
 /**
+ * The name a profile is drawn under.
+ *
+ * A profile shared through a team was named by whoever shared it, and the name travels inside the
+ * sealed envelope — the server never sees it and could not validate it. So the catalog draws it
+ * through [untrustedLabel] rather than raw: a bidi override in a name makes one host row draw as
+ * another.
+ *
+ * A name that is nothing but the characters filtering drops leaves nothing to draw, and a blank row
+ * is one the user cannot tell from any other: the address stands in, and the id after it. The id is
+ * a peer's text as well for a shared record, so it is filtered like the rest. Same ladder as a team
+ * space's label.
+ */
+fun Host.rowLabel(): String =
+    untrustedLabel(label).ifBlank { untrustedLabel(address) }.ifBlank { untrustedLabel(id.take(SHORT_ID_CHARS)) }
+
+/**
  * Secondary caption for a profile in the host lists: `user@address` where there is a user, and
  * `address:port` where there isn't — a remote desktop authenticates with a password and has no
  * username, so the usual form would render as a bare "@10.0.0.5". A port of 0 (local shell) drops
  * the suffix, leaving just the shell path (blank for the system default).
+ *
+ * Sanitized for the same reason as [rowLabel]: the username and the address of a shared profile are
+ * a peer's text too, and this line is what tells two rows with the same name apart.
  */
-fun Host.rowSubtitle(): String = when {
-    // The port belongs to the address a row identifies a profile by: two profiles on the same
-    // machine (a jump host and a container gateway, 22 and 2222) are otherwise the same line.
-    username.isNotBlank() && port > 0 -> "$username@$address:$port"
-    username.isNotBlank() -> "$username@$address"
-    port > 0 -> "$address:$port"
-    else -> address
-}
+fun Host.rowSubtitle(): String = untrustedLabel(
+    when {
+        // The port belongs to the address a row identifies a profile by: two profiles on the same
+        // machine (a jump host and a container gateway, 22 and 2222) are otherwise the same line.
+        username.isNotBlank() && port > 0 -> "$username@$address:$port"
+        username.isNotBlank() -> "$username@$address"
+        port > 0 -> "$address:$port"
+        else -> address
+    },
+)
 
 /** Section a transport is filed under — the profile-level [Host.section] follows it. */
 val ConnectionType.section: HostSection

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionContainer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionContainer.kt
@@ -31,6 +31,7 @@ import app.skerry.ui.connection.ContainerBrowseController
 import app.skerry.ui.connection.ContainerBrowseStatus
 import app.skerry.ui.connection.containerBrowseFailureText
 import app.skerry.ui.connection.toSshAuth
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.host.AuthMode
 import app.skerry.ui.host.NewConnectionFormState
 import app.skerry.ui.identity.CredentialManagerController
@@ -161,8 +162,8 @@ private fun ContainerBrowseResults(browser: ContainerBrowseController?, onPick: 
                                 verticalAlignment = Alignment.CenterVertically,
                                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                             ) {
-                                Txt(entry.name, color = Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
-                                val detail = listOf(entry.image, entry.status, entry.containers.joinToString(","))
+                                Txt(untrustedLabel(entry.name), color = Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
+                                val detail = listOf(entry.image, entry.status, entry.containers.joinToString(",")).map(::untrustedLabel)
                                     .filter { it.isNotBlank() }
                                     .joinToString(" · ")
                                 if (detail.isNotEmpty()) Txt(detail, color = Skerry.colors.faint, size = 11.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionPickers.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionPickers.kt
@@ -67,6 +67,7 @@ import app.skerry.ui.generated.resources.conn_protocol_ssh
 import app.skerry.ui.generated.resources.conn_protocol_telnet
 import app.skerry.ui.generated.resources.conn_protocol_vnc
 import app.skerry.ui.generated.resources.conn_protocol_rdp
+import app.skerry.ui.host.rowLabel
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.AnchoredDropdown
@@ -237,7 +238,7 @@ internal fun JumpHostPicker(form: NewConnectionFormState, allHosts: List<Host>, 
     DropdownField(
         value = selected,
         options = listOf<Host?>(null) + candidates,
-        label = { it?.label ?: stringResource(Res.string.conn_jump_none) },
+        label = { it?.rowLabel() ?: stringResource(Res.string.conn_jump_none) },
         onPick = { form.jumpHostId = it?.id },
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
@@ -189,7 +189,7 @@ fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
     if (line == null) {
         ConfirmActionDialog(
             title = stringResource(Res.string.guard_prod_connect_title),
-            message = stringResource(Res.string.guard_prod_connect_message, request.host.label),
+            message = stringResource(Res.string.guard_prod_connect_message, request.host.rowLabel()),
             confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),
             onConfirm = { onDismiss(); request.proceed() },
             onDismiss = onDismiss,
@@ -198,7 +198,7 @@ fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
     }
     ProdCommandSheet(
         title = stringResource(Res.string.guard_prod_snippet_title),
-        subtitle = stringResource(Res.string.guard_prod_snippet_message, request.host.label),
+        subtitle = stringResource(Res.string.guard_prod_snippet_message, request.host.rowLabel()),
         command = line,
         reason = remember(line) { prodDisplayRisk(line) }?.assessment?.reason,
         confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/metrics/HostMetrics.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/metrics/HostMetrics.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.metrics
 
+import app.skerry.ui.design.untrustedLabel
 import kotlin.math.roundToInt
 
 /**
@@ -140,14 +141,14 @@ fun parseHostMetrics(raw: String): HostMetrics? {
         ?.split(WHITESPACE)?.firstOrNull()?.toDoubleOrNull()?.toLong()
     val loadAverage = section(lines, "@LOAD").firstOrNull()
         ?.split(WHITESPACE)?.take(3)?.takeIf { it.size == 3 }?.joinToString(" ")
-        // Same treatment as OS/kernel: the exec answer is whatever the host chose to send, and this
-        // string reaches the CPU tile, the System card and the alert feed.
+        // The exec answer is whatever the host chose to send, and this string reaches the CPU tile,
+        // the System card and the alert feed.
         ?.let { hostText(it, FACT_MAX_LEN) }
-    // OS/kernel come from the remote (trusted but potentially misbehaving) host — cap the length
-    // so an anomalously long string can't break the info panel layout (defence-in-depth).
+    // OS/kernel come from the remote host and land in the System card — same filter and same cap
+    // as every other field it sends, or a PRETTY_NAME ending in an override draws the row backwards.
     val osName = section(lines, "@OS").firstOrNull { it.startsWith("PRETTY_NAME=") }
-        ?.removePrefix("PRETTY_NAME=")?.trim('"')?.take(FACT_MAX_LEN)?.takeIf { it.isNotBlank() }
-    val kernel = section(lines, "@KERNEL").firstOrNull()?.take(FACT_MAX_LEN)?.takeIf { it.isNotBlank() }
+        ?.removePrefix("PRETTY_NAME=")?.trim('"')?.let { hostText(it, FACT_MAX_LEN) }
+    val kernel = section(lines, "@KERNEL").firstOrNull()?.let { hostText(it, FACT_MAX_LEN) }
     val cpuCount = section(lines, "@CPU").firstOrNull()?.toIntOrNull()
     val net = parseNetCounters(section(lines, "@NET"))
     val processes = parseProcesses(section(lines, "@PROC"))
@@ -202,24 +203,13 @@ private const val NAME_MAX_LEN = 40
 private const val LIST_MAX_ROWS = 8
 
 /**
- * A string coming from the remote host, made safe to draw: control characters (escape sequences
- * that would repaint the screen) removed and the length capped so one anomalous line can't stretch
- * a card. Blank input yields null — the caller drops the row rather than drawing an empty one.
+ * A string coming from the remote host, made safe to draw — [untrustedLabel] with this card's own
+ * cap. A process or container named with a RIGHT-TO-LEFT OVERRIDE draws its own row backwards,
+ * which is how a busy process passes for an idle one at a glance. Blank input yields null: the
+ * caller drops the row rather than drawing an empty one.
  */
 private fun hostText(raw: String, max: Int): String? =
-    raw.filter { it.code >= 0x20 && it.code !in INVISIBLE_CODES && it.code !in BIDI_CODES }
-        .take(max)
-        .takeIf { it.isNotBlank() }
-
-/** DEL and the C1 control block — invisible, and a terminal would act on some of them. */
-private val INVISIBLE_CODES = (0x7F..0x9F) + listOf(0x200B, 0x200C, 0x200D, 0xFEFF)
-
-/**
- * Bidirectional and other Unicode format controls. A process or container named with a
- * RIGHT-TO-LEFT OVERRIDE draws its own row backwards, which is how a busy process passes for an
- * idle one at a glance.
- */
-private val BIDI_CODES = (0x200E..0x200F) + (0x202A..0x202E) + (0x2060..0x2069)
+    untrustedLabel(raw, max).takeIf { it.isNotBlank() }
 
 /**
  * Kernel-backed filesystems `df` reports next to the real ones. They're either RAM (tmpfs), a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/metrics/MonitorConnectionCard.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/metrics/MonitorConnectionCard.kt
@@ -14,6 +14,7 @@ import app.skerry.ui.connection.jumpRouteLabel
 import app.skerry.ui.connection.shortCipher
 import app.skerry.ui.design.Card
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.mon_card_connection
 import app.skerry.ui.generated.resources.mon_card_system
@@ -31,6 +32,7 @@ import app.skerry.ui.generated.resources.term_info_uptime
 import app.skerry.ui.generated.resources.term_info_user
 import app.skerry.ui.generated.resources.term_system_load
 import app.skerry.ui.generated.resources.term_system_vcpu
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 
@@ -59,9 +61,9 @@ internal fun connectionFacts(hostId: String?, paneTitle: String?, cipher: String
     val credentials = LocalCredentials.current
     val host = hostId?.let { hosts?.find(it) }
     return ConnectionFacts(
-        host = host?.label ?: paneTitle ?: NO_DATA,
-        address = host?.let { "${it.address}:${it.port}" } ?: NO_DATA,
-        user = host?.username ?: NO_DATA,
+        host = host?.rowLabel() ?: paneTitle ?: NO_DATA,
+        address = host?.let { untrustedLabel("${it.address}:${it.port}") } ?: NO_DATA,
+        user = host?.let { untrustedLabel(it.username) } ?: NO_DATA,
         jump = host?.let { h -> jumpRouteLabel(h) { id -> hosts?.find(id) } },
         credential = host?.credentialId?.let { id -> credentials?.find(id) }?.secret,
         hasCredential = host != null,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
@@ -36,6 +36,7 @@ import app.skerry.ui.connection.toSshAuth
 import app.skerry.ui.connection.toTarget
 import app.skerry.ui.connection.toVncAuth
 import app.skerry.ui.connection.connectableSecrets
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.nav.PlatformBackHandler
 import app.skerry.ui.session.SessionsController
@@ -155,7 +156,7 @@ internal fun MobileChrome(
                     val cred = credentials?.useForConnect(host.credentialId)
                     if (cred != null) {
                         sessions?.openVnc(
-                            host.id, host.label, host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
+                            host.id, host.rowLabel(), host.connectionSubtitle(), host.toTarget(), cred.toVncAuth(),
                             remoteResize = host.vncResizeToWindow,
                             onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
                         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileConnectionContainer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileConnectionContainer.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.container.ContainerEntry
 import app.skerry.shared.container.ContainerRuntime
 import app.skerry.shared.ssh.SshAuth
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.host.AuthMode
 import app.skerry.ui.host.NewConnectionFormState
 import app.skerry.ui.generated.resources.Res
@@ -159,8 +160,8 @@ private fun MobileContainerBrowseResults(browser: ContainerBrowseController?, on
                                     .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) { onPick(entry) }
                                     .padding(horizontal = 12.dp, vertical = 9.dp),
                             ) {
-                                Txt(entry.name, color = Skerry.colors.text, size = 14.sp)
-                                val detail = listOf(entry.image, entry.status, entry.containers.joinToString(","))
+                                Txt(untrustedLabel(entry.name), color = Skerry.colors.text, size = 14.sp)
+                                val detail = listOf(entry.image, entry.status, entry.containers.joinToString(",")).map(::untrustedLabel)
                                     .filter { it.isNotBlank() }
                                     .joinToString(" · ")
                                 if (detail.isNotEmpty()) Txt(detail, color = Skerry.colors.faint, size = 11.5.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileConnectionPickers.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileConnectionPickers.kt
@@ -66,6 +66,7 @@ import app.skerry.ui.generated.resources.conn_protocol_telnet
 import app.skerry.ui.generated.resources.conn_protocol_vnc
 import app.skerry.ui.generated.resources.conn_protocol_rdp
 import app.skerry.ui.generated.resources.conn_protocol_local
+import app.skerry.ui.host.rowLabel
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.AiPolicy
 import app.skerry.ui.ai.shortLabel
@@ -312,7 +313,7 @@ internal fun MobileJumpHostPicker(form: NewConnectionFormState, allHosts: List<H
                 MobileGroupOption(stringResource(Res.string.conn_jump_none), selected = selected == null) { form.jumpHostId = null; menuOpen = false }
                 candidates.forEach { host ->
                     key(host.id) {
-                        MobileGroupOption(host.label, selected = form.jumpHostId == host.id) { form.jumpHostId = host.id; menuOpen = false }
+                        MobileGroupOption(host.rowLabel(), selected = form.jumpHostId == host.id) { form.jumpHostId = host.id; menuOpen = false }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFiles.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFiles.kt
@@ -38,10 +38,11 @@ fun mobileFileRowMeta(item: FileItem): SizeParts? =
  * Leading row icon ([Sym] ligature): directory → `folder`, symlink → `link`, shell script →
  * `terminal`, other file → `description`.
  */
-fun mobileFileIcon(item: FileItem): String = when (item.type) {
+fun mobileFileIcon(item: FileItem, name: String): String = when (item.type) {
     FileItemType.Directory -> "folder"
     FileItemType.Symlink -> "link"
-    FileItemType.File, FileItemType.Other -> if (item.name.endsWith(".sh")) "terminal" else "description"
+    // [name] is what the row draws (sanitized): the icon must not claim an extension the row does not.
+    FileItemType.File, FileItemType.Other -> if (name.endsWith(".sh")) "terminal" else "description"
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.PathJumpField
+import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_connecting
 import app.skerry.ui.generated.resources.sftp_files_title
@@ -95,6 +96,10 @@ internal fun MobileFilesBreadcrumbRow(
     filterActive: Boolean = false,
 ) {
     var editing by remember(path) { mutableStateOf(false) }
+    // Drawn filtered, edited raw: what the field submits has to be the path the pane is actually in
+    // (a tab or a zero-width character in a directory name is legal on the far side). Same split as
+    // the desktop pane's PathField.
+    val shownPath = fileDisplayPath(path)
     Row(
         Modifier.fillMaxWidth().padding(start = 22.dp, end = 22.dp, top = 4.dp, bottom = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -121,7 +126,7 @@ internal fun MobileFilesBreadcrumbRow(
             }
         } else {
             Txt(
-                mobileFilesBreadcrumb(label, path),
+                mobileFilesBreadcrumb(label, shownPath),
                 color = Skerry.colors.dim,
                 size = 12.sp,
                 font = mono,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
@@ -35,10 +35,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.TransferState
 import app.skerry.ui.files.fileBrowserFailureText
+import app.skerry.ui.files.fileDisplayName
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_tip_close
@@ -159,6 +161,7 @@ private fun MobileFileRow(
 ) {
     var menuOpen by remember { mutableStateOf(false) }
     val isDir = entry.type == FileItemType.Directory
+    val shownName = fileDisplayName(entry.name)
     Row(
         Modifier
             .fillMaxWidth()
@@ -169,16 +172,18 @@ private fun MobileFileRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(13.dp),
     ) {
-        Sym(mobileFileIcon(entry), size = 23.sp, color = if (isDir) Skerry.colors.cyanBright else Skerry.colors.dim)
+        Sym(mobileFileIcon(entry, shownName), size = 23.sp, color = if (isDir) Skerry.colors.cyanBright else Skerry.colors.dim)
         Column(Modifier.weight(1f)) {
-            Txt(entry.name, color = Skerry.colors.text, size = 14.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            // The server chose this name; the row and the icon read the same sanitized form of it
+            // (see [untrustedLabel]) so neither can claim an extension the other does not.
+            Txt(shownName, color = Skerry.colors.text, size = 14.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
             mobileFileMetaText(entry)?.let { Txt(it, color = Skerry.colors.faint, size = 11.sp) }
         }
         Sym(mobileFileTrailingIcon(entry.type), size = 20.sp, color = Skerry.colors.faint)
     }
     if (menuOpen) {
         MobileActionSheet(
-            title = entry.name,
+            title = shownName,
             actions = buildList {
                 onDownloadHere?.let { dl ->
                     add(MobileSheetAction(stringResource(Res.string.sftp_download_to_device), onClick = dl, icon = "download"))
@@ -226,6 +231,14 @@ private fun MobileFileUpRow(mono: FontFamily, onClick: () -> Unit) {
 }
 
 /**
+ * The file a transfer card names. Blank is not "unprintable": a transfer that failed before it
+ * reported a file has no name yet, and says so with the neutral stand-in.
+ */
+@Composable
+private fun transferName(raw: String): String =
+    if (raw.isBlank()) stringResource(Res.string.ftail_file_fallback) else fileDisplayName(raw)
+
+/**
  * Mobile layout's transfer card (below the list): direction icon + name + percent + bar.
  * Active shows live progress; Failed shows the error with a close button; Idle renders nothing.
  */
@@ -252,7 +265,7 @@ internal fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDis
                     horizontalArrangement = Arrangement.spacedBy(9.dp),
                 ) {
                     Sym(if (up) "upload" else "download", size = 17.sp, color = Skerry.colors.cyan)
-                    Txt(transfer.name, color = Skerry.colors.textBright, size = 12.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                    Txt(transferName(transfer.name), color = Skerry.colors.textBright, size = 12.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
                     Txt("$percent%", color = Skerry.colors.dim, size = 11.sp)
                 }
                 Spacer(Modifier.height(8.dp))
@@ -278,7 +291,7 @@ internal fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDis
                 Txt(
                     stringResource(
                         Res.string.sftp_transfer_error,
-                        transfer.name.ifBlank { stringResource(Res.string.ftail_file_fallback) },
+                        transferName(transfer.name),
                         transferFailureText(transfer.failure),
                     ),
                     color = Skerry.colors.sunset, size = 11.5.sp, maxLines = 6, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -29,6 +29,7 @@ import app.skerry.ui.files.FileEditController
 import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.TransferCoordinator
+import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.files.platformLocalBrowser
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_local_label
@@ -37,18 +38,15 @@ import app.skerry.ui.generated.resources.sftp_connecting
 import app.skerry.ui.generated.resources.sftp_create
 import app.skerry.ui.generated.resources.sftp_create_directory
 import app.skerry.ui.generated.resources.sftp_new_folder
-import app.skerry.ui.generated.resources.sftp_overwrite
-import app.skerry.ui.generated.resources.sftp_overwrite_many
-import app.skerry.ui.generated.resources.sftp_overwrite_one
-import app.skerry.ui.generated.resources.sftp_overwrite_q
 import app.skerry.ui.generated.resources.sftp_unavailable
 import app.skerry.ui.generated.resources.sftp_upload_file
+import app.skerry.ui.sftp.ConfirmOverwriteDialog
 import app.skerry.ui.sftp.pickDownloadTarget
 import app.skerry.ui.sftp.pickUploadSource
+import app.skerry.ui.sftp.safeDownloadName
 import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
-import app.skerry.ui.sftp.ConfirmDangerDialog
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.sftp.NameDialog
@@ -159,7 +157,7 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                     // the transfer card updates) and doesn't needlessly invalidate the list.
                     val onTransfer = remember(c, uiScope) {
                         { item: FileItem ->
-                            uiScope.launch { pickDownloadTarget(item.name)?.let { c.downloadToTarget(item, it) } }
+                            uiScope.launch { pickDownloadTarget(safeDownloadName(item.name))?.let { c.downloadToTarget(item, it) } }
                             Unit
                         }
                     }
@@ -252,12 +250,8 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
         // Overwrite conflict (download/upload found a same-named object at the destination) — the
         // same confirmation dialog as desktop; the coordinator is shared, so [overwrite] state is shared too.
         c?.overwrite?.let { conflict ->
-            val single = conflict.names.singleOrNull()
-            ConfirmDangerDialog(
-                title = stringResource(Res.string.sftp_overwrite_q),
-                body = if (single != null) stringResource(Res.string.sftp_overwrite_one, single)
-                else stringResource(Res.string.sftp_overwrite_many, conflict.names.size),
-                confirmLabel = stringResource(Res.string.sftp_overwrite),
+            ConfirmOverwriteDialog(
+                names = conflict.names,
                 onConfirm = { c.resolveOverwrite(true) },
                 onDismiss = { c.resolveOverwrite(false) },
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -27,8 +27,11 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.host.section
 import app.skerry.shared.host.Host
 import app.skerry.ui.generated.resources.Res
@@ -52,6 +55,7 @@ import app.skerry.ui.generated.resources.shell_details
 import app.skerry.ui.generated.resources.shell_edit_host
 import app.skerry.ui.generated.resources.shell_duplicate_host
 import app.skerry.ui.generated.resources.shell_delete_host
+import app.skerry.ui.terminal.MAX_NOTE_CHARS
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.design.HLine
@@ -78,7 +82,7 @@ data class HostDetailRow(val label: String, val value: String, val mono: Boolean
  */
 @Composable
 fun mobileHostDetailRows(host: Host, findHost: (String) -> Host? = { null }): List<HostDetailRow> = listOfNotNull(
-    HostDetailRow(stringResource(Res.string.shtail_host_address), host.address, mono = true),
+    HostDetailRow(stringResource(Res.string.shtail_host_address), untrustedLabel(host.address), mono = true),
     HostDetailRow(stringResource(Res.string.shtail_host_port), host.port.toString(), mono = true),
     HostDetailRow(
         stringResource(Res.string.shtail_host_auth),
@@ -87,7 +91,14 @@ fun mobileHostDetailRows(host: Host, findHost: (String) -> Host? = { null }): Li
     ),
     jumpRouteLabel(host, findHost)?.let { HostDetailRow(stringResource(Res.string.shtail_host_jump), it, mono = false) },
     HostDetailRow(stringResource(Res.string.shtail_host_group), host.group?.takeIf { it.isNotBlank() } ?: ungroupedLabel(), mono = false),
-    host.notes?.takeIf { it.isNotBlank() }?.let { HostDetailRow(stringResource(Res.string.shtail_host_notes), it, mono = false) },
+    // A note is free-form prose: it keeps its lines, and is capped like every other peer string.
+    host.notes?.takeIf { it.isNotBlank() }?.let {
+        HostDetailRow(
+            stringResource(Res.string.shtail_host_notes),
+            sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true),
+            mono = false,
+        )
+    },
 )
 
 /**
@@ -128,7 +139,7 @@ fun MobileHostDetailScreen(state: MobileDesignState) {
                 Sym("dns", size = 32.sp, color = Skerry.colors.cyanBright)
             }
             Spacer(Modifier.height(12.dp))
-            Txt(host.label, color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
+            Txt(host.rowLabel(), color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
             Spacer(Modifier.height(3.dp))
             Txt(
                 host.rowSubtitle(),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostsView.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.host.rowLabel
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -292,8 +293,8 @@ private fun MobileHostRow(host: Host, onClick: () -> Unit) {
     val status = LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle
     MobileCatalogRow(
         icon = host.connectionType.icon,
-        label = host.label,
-        subtitle = host.rowSubtitle(),
+        label = remember(host) { host.rowLabel() },
+        subtitle = remember(host) { host.rowSubtitle() },
         dotColor = sessionDotColor(status),
         statusText = sessionStatusText(status),
         onClick = onClick,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePasswordSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePasswordSheet.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
 import app.skerry.shared.vault.Credential
+import app.skerry.ui.connection.connectionSubtitle
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.secure.SecureScreen
 import app.skerry.ui.vault.VaultPresentation
 import app.skerry.ui.generated.resources.shell_use_saved_secret
@@ -62,9 +64,9 @@ fun MobilePasswordSheet(
         onDismiss = onDismiss,
         panelModifier = Modifier.padding(start = 22.dp, end = 22.dp, bottom = 30.dp),
     ) {
-        Txt(host.label, color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
+        Txt(host.rowLabel(), color = Skerry.colors.text, size = 20.sp, weight = FontWeight.Bold)
             Spacer(Modifier.height(3.dp))
-            Txt("${host.username}@${host.address}:${host.port}", color = Skerry.colors.dim, size = 12.5.sp, font = LocalFonts.current.mono)
+            Txt(host.connectionSubtitle(), color = Skerry.colors.dim, size = 12.5.sp, font = LocalFonts.current.mono)
             Spacer(Modifier.height(18.dp))
             Txt(stringResource(Res.string.term_password_label), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp)
             Spacer(Modifier.height(6.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePortsView.kt
@@ -46,6 +46,7 @@ import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.forward.rateFraction
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.sftp.humanSize
 import app.skerry.ui.tunnel.AutostartFailureBanner
 import app.skerry.ui.tunnel.BindExposureWarning
@@ -215,7 +216,7 @@ private fun LiveMobilePortsBody(
                     val onRemoveRow = remember(entry.id, manager) { { manager.delete(entry.id) } }
                     LiveTunnelCard(
                         entry = entry,
-                        via = hosts?.find(entry.tunnel.hostId)?.label ?: entry.tunnel.hostId,
+                        via = hosts?.find(entry.tunnel.hostId)?.rowLabel() ?: entry.tunnel.hostId,
                         mono = mono,
                         onToggle = onToggle,
                         onEdit = onEditRow,
@@ -352,7 +353,9 @@ private fun MobileTunnelEditorSheet(
     val (badgeBg, badgeFg) = form.direction.badgeColors()
     // The tunnel dials this host over SSH, so remote desktops are not candidates.
     val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
-    val hostName = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
+    // Filtered once per catalog change: the sheet around it recomposes on every keystroke.
+    val hostOptions = remember(hostList) { hostList.map { it.id to it.rowLabel() } }
+    val hostName = hostOptions.firstOrNull { it.first == form.hostId }?.second ?: stringResource(Res.string.ports_select_host)
 
     MobileBottomSheet(
         onDismiss = onDismiss,
@@ -382,7 +385,7 @@ private fun MobileTunnelEditorSheet(
             Spacer(Modifier.height(14.dp))
             MobileFormField(stringResource(Res.string.ports_field_type)) { PortTypeSelect(form.direction) { form.direction = it } }
             Spacer(Modifier.height(14.dp))
-            MobileFormField(stringResource(Res.string.ports_field_via_host)) { MobileHostPicker(hostName, hostList.map { it.id to it.label }) { form.hostId = it } }
+            MobileFormField(stringResource(Res.string.ports_field_via_host)) { MobileHostPicker(hostName, hostOptions) { form.hostId = it } }
             Spacer(Modifier.height(14.dp))
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 MobileFormField(stringResource(Res.string.ports_field_bind_address), Modifier.weight(1f)) { PortInput(form.bindHost, { form.bindHost = it }, TunnelFormState.DEFAULT_BIND_HOST, mono, selectAllOnFocus = form.isDefaultBindHost) }
@@ -475,7 +478,8 @@ private fun MobileServicesSheet(
     // The tunnel dials this host over SSH, so remote desktops are not candidates.
     val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
     var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
-    val hostName = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
+    val hostOptions = remember(hostList) { hostList.map { it.id to it.rowLabel() } }
+    val hostName = hostOptions.firstOrNull { it.first == hostId }?.second
         ?: stringResource(Res.string.ports_select_host)
 
     MobileBottomSheet(
@@ -501,7 +505,7 @@ private fun MobileServicesSheet(
         Txt(stringResource(Res.string.ports_services_hint), color = Skerry.colors.faint, size = 12.sp, lineHeight = 17.sp)
         Spacer(Modifier.height(16.dp))
         MobileFormField(stringResource(Res.string.ports_field_via_host)) {
-            MobileHostPicker(hostName, hostList.map { it.id to it.label }) { hostId = it }
+            MobileHostPicker(hostName, hostOptions) { hostId = it }
         }
         Spacer(Modifier.height(14.dp))
         Box(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSessionActions.kt
@@ -13,6 +13,7 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshJump
 import app.skerry.ui.connection.connectionSubtitle
 import app.skerry.ui.connection.toTarget
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.MobileRoute
@@ -37,7 +38,7 @@ internal fun openMobileSession(
 ) {
     sessions?.open(
         hostId = host.id,
-        title = host.label,
+        title = host.rowLabel(),
         subtitle = host.connectionSubtitle(),
         target = host.toTarget(jump),
         auth = auth,
@@ -55,7 +56,7 @@ internal fun openMobileRdp(
 ) {
     sessions?.openRdp(
         host.id,
-        host.label,
+        host.rowLabel(),
         host.connectionSubtitle(),
         app.skerry.ui.remote.RdpConnectRequest(
             host = host.address,
@@ -85,7 +86,7 @@ internal fun openMobileVnc(
     auth: app.skerry.shared.vnc.VncAuth,
 ) {
     sessions?.openVnc(
-        host.id, host.label, host.connectionSubtitle(), host.toTarget(), auth,
+        host.id, host.rowLabel(), host.connectionSubtitle(), host.toTarget(), auth,
         remoteResize = host.vncResizeToWindow,
         onRemoteResizeChanged = { on -> hostManager?.setVncResizeToWindow(host.id, on) },
     )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
@@ -26,6 +26,7 @@ import app.skerry.ui.design.InitialsAvatar
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_nothing_shared
 import app.skerry.ui.generated.resources.lib_teams_status_invited
@@ -101,7 +102,7 @@ internal fun MobileTeamChip(team: TeamUi, active: Boolean, onClick: () -> Unit) 
         horizontalArrangement = Arrangement.spacedBy(7.dp),
     ) {
         Sym(if (invited) "mail" else "group", size = 15.sp, color = fg)
-        Txt(team.name, color = fg, size = 12.5.sp)
+        Txt(untrustedLabel(team.name), color = fg, size = 12.5.sp)
     }
 }
 
@@ -127,10 +128,11 @@ internal fun MobileMemberRow(
     ) {
         InitialsAvatar(m.accountId, size = 28.dp)
         Column(Modifier.weight(1f)) {
-            Txt(m.accountId, color = Skerry.colors.text, size = 12.5.sp, font = mono, weight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Txt(untrustedLabel(m.accountId), color = Skerry.colors.text, size = 12.5.sp, font = mono, weight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
             // Same rule as the desktop table: an access list we failed to read is "?", never an
             // empty chip row — the phone is where granting and revoking actually happens.
-            val tags = row.scopes.joinToString(" ") { "#$it" }
+            // A space name is a peer's too, and here it shares a line with "last seen".
+            val tags = row.scopes.joinToString(" ") { "#${untrustedLabel(it)}" }
             // A grant list that didn't load leaves a "?" — whether or not other scopes did load.
             val scopes = listOf(tags, if (row.scopesKnown) "" else UNKNOWN_VALUE).filter { it.isNotEmpty() }.joinToString(" ")
             Txt(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -35,7 +35,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.SHORT_ID_CHARS
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.host.rowLabel
 import app.skerry.shared.host.Host
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.host.inSection
@@ -377,7 +380,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
         val (title, message) = when (c) {
             is MobileTeamsConfirm.Leave -> stringResource(Res.string.lib_teams_leave) to stringResource(Res.string.lib_teams_leave_message)
             is MobileTeamsConfirm.Delete -> stringResource(Res.string.lib_teams_delete) to stringResource(Res.string.lib_teams_delete_message)
-            is MobileTeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, c.accountId)
+            is MobileTeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, untrustedLabel(c.accountId))
             is MobileTeamsConfirm.DeleteScope -> stringResource(Res.string.lib_teams_scope_delete) to stringResource(Res.string.lib_teams_scope_delete_message)
         }
         ConfirmActionDialog(
@@ -447,7 +450,7 @@ private fun MobileTeamDetail(
     val sharedSnippets = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultSnippetStore(it).all() } ?: emptyList() }
     val sharedRunbooks = remember(team.id, scopeId, tick, spaceVault) { spaceVault?.let { VaultRunbookStore(it).all() } ?: emptyList() }
 
-    Txt(team.name, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, modifier = Modifier.padding(top = 10.dp))
+    Txt(untrustedLabel(team.name), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, modifier = Modifier.padding(top = 10.dp))
     Txt(stringResource(Res.string.lib_teams_members_count, team.memberCount), color = Skerry.colors.dim, size = 12.sp, modifier = Modifier.padding(top = 2.dp))
 
     if (invited) {
@@ -513,7 +516,7 @@ private fun MobileTeamDetail(
 
     MobileSharedSection(
         heading = stringResource(Res.string.lib_teams_shared_hosts_count, sharedHosts.size),
-        items = sharedHosts.map { SharedRecordUi(it.id, it.label, it.rowSubtitle()) },
+        items = sharedHosts.map { SharedRecordUi(it.id, it.rowLabel(), it.rowSubtitle()) },
         shareLabel = stringResource(Res.string.lib_teams_share_host).takeIf { canWrite },
         onShare = { onShare(RecordType.HOST) },
         canUnshare = canWrite,
@@ -523,7 +526,7 @@ private fun MobileTeamDetail(
     )
     MobileSharedSection(
         heading = stringResource(Res.string.lib_teams_shared_snippets_count, sharedSnippets.size),
-        items = sharedSnippets.map { SharedRecordUi(it.id, it.label, it.command) },
+        items = sharedSnippets.map { SharedRecordUi(it.id, untrustedLabel(it.label), untrustedLabel(it.command)) },
         shareLabel = stringResource(Res.string.lib_teams_share_snippet).takeIf { canWrite },
         onShare = { onShare(RecordType.SNIPPET) },
         canUnshare = canWrite,
@@ -533,7 +536,7 @@ private fun MobileTeamDetail(
     )
     MobileSharedSection(
         heading = stringResource(Res.string.lib_teams_shared_runbooks_count, sharedRunbooks.size),
-        items = sharedRunbooks.map { SharedRecordUi(it.id, it.label, runbookSummary(it.steps.size)) },
+        items = sharedRunbooks.map { SharedRecordUi(it.id, untrustedLabel(it.label), runbookSummary(it.steps.size)) },
         shareLabel = stringResource(Res.string.lib_teams_share_runbook).takeIf { canWrite },
         onShare = { onShare(RecordType.RUNBOOK) },
         canUnshare = canWrite,
@@ -579,11 +582,11 @@ internal fun MobileTeamHostsSections(hostsSnapshot: List<Host>, section: HostSec
             // Sanitized like the desktop sidebar's (see spaceLabel): the name is a peer's, arrives
             // inside the sealed envelope, and the server never sees it — so the same string must not
             // be scrubbed on one platform and drawn raw on the other.
-            val teamName = spaceLabel(team.name, fallback = team.id.take(SHORT_TEAM_ID_CHARS))
+            val teamName = spaceLabel(team.name, fallback = team.id.take(SHORT_ID_CHARS))
             val spaces = listOf(TeamScopeRef(team.id) to teamName) +
                 team.scopes.filter { it.hasKey }.map {
                     TeamScopeRef(team.id, it.id) to
-                        "$teamName · ${spaceLabel(it.name, fallback = it.id.take(SHORT_TEAM_ID_CHARS))}"
+                        "$teamName · ${spaceLabel(it.name, fallback = it.id.take(SHORT_ID_CHARS))}"
                 }
             spaces.mapNotNull { (ref, label) ->
                 val vault = teams.spaceVault(ref) ?: return@mapNotNull null
@@ -634,13 +637,11 @@ private fun MobileTeamHostRow(host: Host, onClick: () -> Unit) {
     val status = LocalSessions.current?.sessionStatusFor(host.id) ?: SessionStatus.Idle
     MobileCatalogRow(
         icon = "group",
-        label = host.label,
-        subtitle = host.rowSubtitle(),
+        label = remember(host) { host.rowLabel() },
+        subtitle = remember(host) { host.rowSubtitle() },
         dotColor = sessionDotColor(status),
         statusText = sessionStatusText(status),
         onClick = onClick,
     )
 }
 
-/** Same stand-in as the desktop sidebar's when a peer's space name sanitizes away to nothing. */
-private const val SHORT_TEAM_ID_CHARS = 8

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -74,6 +74,7 @@ import app.skerry.ui.generated.resources.vault_subtitle_key_file_cert
 import app.skerry.ui.generated.resources.vault_subtitle_password
 import app.skerry.ui.generated.resources.vault_subtitle_private_key
 import app.skerry.ui.generated.resources.vault_title
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.secure.SecureScreen
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -232,7 +233,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                             credential = credential,
                             usage = credentials.usageOf(credential.id),
                             usedBy = VaultPresentation.usedByLabel(
-                                hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.label },
+                                hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.rowLabel() },
                                 snippetCount = VaultPresentation.snippetsUsing(credential.label, snippetList).size,
                             ),
                             mono = mono,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.mobile
 
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.remote.remoteKeyEvent
 import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.rememberClipboardActions
@@ -213,7 +214,7 @@ private fun MobileVncBar(
     ) {
         MobileVncIcon("arrow_back") { state.pop() }
         Txt(
-            screen?.serverName ?: title,
+            screen?.serverName?.let { untrustedLabel(it) } ?: title,
             color = Skerry.colors.text, size = 13.sp, modifier = Modifier.weight(1f).padding(start = 4.dp),
         )
         if (screen != null) MobileVncIcon("tune") { onPanelOpenChange(!panelOpen) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/FilePicker.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/FilePicker.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.sftp
 
+import app.skerry.ui.design.untrustedLabel
+
 /**
  * Picks a local location for an SFTP transfer via the native platform dialog. Returns a handle
  * ([DownloadTarget]/[UploadSource]) rather than a raw path, because on Android the picker returns a
@@ -9,8 +11,30 @@ package app.skerry.ui.sftp
  * - android: staging = a temp file in cache, finalize copies it to the chosen Uri.
  *
  * Returns `null` if the user cancelled or the platform doesn't support picking.
+ *
+ * [suggestedName] is only ever a *name*: the caller passes it through [safeDownloadName], because
+ * the string comes from the remote side and this is the one hop where it would become part of a
+ * local file name.
  */
 expect suspend fun pickDownloadTarget(suggestedName: String): DownloadTarget?
+
+/**
+ * A remote entry's name, made fit to seed a save dialog: no directory part, no characters that
+ * would draw it as a different name in the dialog's own field.
+ *
+ * Not [app.skerry.shared.io.safeFileStem], which maps everything outside a small whitelist to `-`:
+ * that is right for a name this app invents (a recording's file name) and wrong here, where the
+ * user is about to read the preset and would find `report (1).log` rewritten for no reason.
+ */
+internal fun safeDownloadName(raw: String): String =
+    untrustedLabel(raw.substringAfterLast('/').substringAfterLast('\\'))
+        // Every leading dot, not one: `..` would otherwise save as `.`, and `..name` as `.name` —
+        // a file the file manager then hides, which is not what the user pressed Save for.
+        .trimStart('.')
+        .ifBlank { DOWNLOAD_FALLBACK_NAME }
+
+/** What a name that is nothing but path separators or unprintable characters saves as. */
+private const val DOWNLOAD_FALLBACK_NAME = "download"
 
 expect suspend fun pickUploadSource(): UploadSource?
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpDialogs.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.ui.files.fileDisplayName
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_already_exists
 import app.skerry.ui.generated.resources.sftp_cancel
@@ -56,6 +57,10 @@ import app.skerry.ui.generated.resources.sftp_delete_items_q
 import app.skerry.ui.generated.resources.sftp_items_count
 import app.skerry.ui.generated.resources.sftp_move
 import app.skerry.ui.generated.resources.sftp_move_to_q
+import app.skerry.ui.generated.resources.sftp_overwrite
+import app.skerry.ui.generated.resources.sftp_overwrite_many
+import app.skerry.ui.generated.resources.sftp_overwrite_one
+import app.skerry.ui.generated.resources.sftp_overwrite_q
 import app.skerry.ui.generated.resources.sftp_transfer_body
 import app.skerry.ui.generated.resources.sftp_what_single
 import org.jetbrains.compose.resources.stringResource
@@ -65,6 +70,7 @@ import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.theme.Skerry
 import androidx.compose.ui.platform.testTag
 import app.skerry.ui.app.UiTags
@@ -80,6 +86,8 @@ internal fun NameDialog(
     onDismiss: () -> Unit,
     existing: Set<String> = emptySet(),
 ) {
+    // [initial] is the raw name on purpose, unlike every drawn one: this field is edited and
+    // submitted, so it has to hold the name the server actually has (see [fileDisplayName]).
     // Keyed on initial: on a re-show under a different entry (rename without leaving composition) the
     // field must reset to the new name rather than keep the old one.
     var name by remember(initial) { mutableStateOf(initial) }
@@ -158,6 +166,26 @@ internal fun NameDialog(
 }
 
 /**
+ * Confirmation for a transfer that found same-named objects at the destination ([names] are the
+ * clashing entries, chosen by whichever side wrote them). Shared by both shells: the coordinator
+ * behind it is shared, and so is the answer the user gives it.
+ */
+@Composable
+internal fun ConfirmOverwriteDialog(names: List<String>, onConfirm: () -> Unit, onDismiss: () -> Unit) {
+    val single = names.singleOrNull()
+    ConfirmDangerDialog(
+        title = stringResource(Res.string.sftp_overwrite_q),
+        // The name is the other side's text and this dialog decides which file stops existing, so
+        // it is drawn the way the listing row is (see [untrustedLabel]).
+        body = if (single != null) stringResource(Res.string.sftp_overwrite_one, fileDisplayName(single))
+        else stringResource(Res.string.sftp_overwrite_many, names.size),
+        confirmLabel = stringResource(Res.string.sftp_overwrite),
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}
+
+/**
  * Confirmation for deleting a batch of [items] (F8 on the active pane): a single item — its name,
  * several — a count. The text warns about recursion if the batch contains a directory.
  */
@@ -172,8 +200,8 @@ internal fun ConfirmDeleteItemsDialog(items: List<FileItem>, onConfirm: () -> Un
     }
     val body = when {
         single != null && single.type == FileItemType.Directory ->
-            stringResource(Res.string.sftp_delete_folder_body, single.name)
-        single != null -> stringResource(Res.string.sftp_delete_file_body, single.name)
+            stringResource(Res.string.sftp_delete_folder_body, fileDisplayName(single.name))
+        single != null -> stringResource(Res.string.sftp_delete_file_body, fileDisplayName(single.name))
         hasDir -> stringResource(Res.string.sftp_delete_items_dirs_body, items.size)
         else -> stringResource(Res.string.sftp_delete_items_body, items.size)
     }
@@ -192,7 +220,7 @@ internal fun ConfirmCopyDialog(
     onDismiss: () -> Unit,
 ) {
     val single = items.singleOrNull()
-    val what = if (single != null) stringResource(Res.string.sftp_what_single, single.name) else stringResource(Res.string.sftp_items_count, items.size)
+    val what = if (single != null) stringResource(Res.string.sftp_what_single, fileDisplayName(single.name)) else stringResource(Res.string.sftp_items_count, items.size)
     ConfirmDangerDialog(
         title = stringResource(Res.string.sftp_copy_to_q, destLabel),
         body = stringResource(Res.string.sftp_transfer_body, what, destPath),
@@ -217,7 +245,7 @@ internal fun ConfirmMoveDialog(
     onDismiss: () -> Unit,
 ) {
     val single = items.singleOrNull()
-    val what = if (single != null) stringResource(Res.string.sftp_what_single, single.name) else stringResource(Res.string.sftp_items_count, items.size)
+    val what = if (single != null) stringResource(Res.string.sftp_what_single, fileDisplayName(single.name)) else stringResource(Res.string.sftp_items_count, items.size)
     ConfirmDangerDialog(
         title = stringResource(Res.string.sftp_move_to_q, destLabel),
         body = stringResource(Res.string.sftp_transfer_body, what, destPath),
@@ -323,8 +351,8 @@ internal fun ConfirmDeleteDialog(entry: FileItem, onConfirm: () -> Unit, onDismi
     SftpDialogFrame(onDismiss = onDismiss) {
             Txt(if (isDir) stringResource(Res.string.sftp_delete_folder_q) else stringResource(Res.string.sftp_delete_file_q), color = Skerry.colors.text, size = 14.sp, weight = FontWeight.SemiBold)
             Txt(
-                if (isDir) stringResource(Res.string.sftp_delete_folder_body, entry.name)
-                else stringResource(Res.string.sftp_delete_file_body, entry.name),
+                if (isDir) stringResource(Res.string.sftp_delete_folder_body, fileDisplayName(entry.name))
+                else stringResource(Res.string.sftp_delete_file_body, fileDisplayName(entry.name)),
                 color = Skerry.colors.faint,
                 size = 12.sp,
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpListing.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpListing.kt
@@ -44,6 +44,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.files.FilePaneController
+import app.skerry.ui.files.fileDisplayName
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_col_modified
 import app.skerry.ui.generated.resources.sftp_col_name
@@ -110,10 +111,14 @@ internal fun LivePaneList(
                         pane.setCursor(entry)
                         pane.open(entry)
                     }
+                    // The name is whatever the server answered with, and this row is what the user
+                    // clicks to download or open: a bidi override in it draws one extension over
+                    // another. The icon reads the same sanitized string, so the two cannot disagree.
+                    val shownName = fileDisplayName(entry.name)
                     LiveFileRow(
-                        icon = sftpFileIcon(entry.name, entry.type),
+                        icon = sftpFileIcon(shownName, entry.type),
                         iconColor = if (entry.type == FileItemType.Directory) Skerry.colors.cyanBright else Skerry.colors.faint,
-                        name = entry.name,
+                        name = shownName,
                         directory = entry.type == FileItemType.Directory,
                         // An enabled column always occupies its fixed-width slot — an empty value
                         // renders as a blank slot, otherwise rows with a missing value (a directory's

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
@@ -43,6 +43,7 @@ import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
 import app.skerry.ui.files.PathJumpField
 import app.skerry.ui.files.fileBrowserFailureText
+import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_tip_close
 import app.skerry.ui.generated.resources.ftail_fkey_copy
@@ -294,7 +295,8 @@ private fun PathField(
     var editing by remember(pane) { mutableStateOf(false) }
     if (!editing) {
         Txt(
-            pane.path,
+            // Drawn only — the editing branch below keeps the real path, which is what is submitted.
+            fileDisplayPath(pane.path),
             color = Skerry.colors.textBright,
             size = 11.5.sp,
             font = mono,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -40,14 +40,11 @@ import app.skerry.ui.files.FKeyBar
 import app.skerry.ui.files.FileEditorScreen
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.TransferCoordinator
+import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.files.platformLocalBrowser
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_open_failed
 import app.skerry.ui.generated.resources.sftp_create
-import app.skerry.ui.generated.resources.sftp_overwrite
-import app.skerry.ui.generated.resources.sftp_overwrite_many
-import app.skerry.ui.generated.resources.sftp_overwrite_one
-import app.skerry.ui.generated.resources.sftp_overwrite_q
 import app.skerry.ui.generated.resources.sftp_new_folder
 import app.skerry.ui.generated.resources.sftp_opening
 import app.skerry.ui.generated.resources.sftp_pane_local
@@ -279,7 +276,7 @@ private fun LiveSftpView(
             // address stands in.
             label = WorkBarLabel.Solo(
                 hostName,
-                c?.remote?.path?.let { stringResource(Res.string.sftp_wbar_subtitle, it) } ?: hostLabel,
+                c?.remote?.path?.let { stringResource(Res.string.sftp_wbar_subtitle, fileDisplayPath(it)) } ?: hostLabel,
                 status,
             ),
         ) {
@@ -398,7 +395,7 @@ private fun LiveSftpView(
             LaunchedEffect(pane) { moveTarget = null }
         } else {
             val fromLocal = pane === coord.local
-            val destPath = if (fromLocal) coord.remote.path else coord.local.path
+            val destPath = fileDisplayPath(if (fromLocal) coord.remote.path else coord.local.path)
             ConfirmMoveDialog(
                 items = items,
                 destLabel = if (fromLocal) stringResource(Res.string.sftp_pane_remote) else stringResource(Res.string.sftp_pane_local),
@@ -418,7 +415,7 @@ private fun LiveSftpView(
             LaunchedEffect(pane) { copyTarget = null }
         } else {
             val fromLocal = pane === coord.local
-            val destPath = if (fromLocal) coord.remote.path else coord.local.path
+            val destPath = fileDisplayPath(if (fromLocal) coord.remote.path else coord.local.path)
             ConfirmCopyDialog(
                 items = items,
                 destLabel = if (fromLocal) stringResource(Res.string.sftp_pane_remote) else stringResource(Res.string.sftp_pane_local),
@@ -435,12 +432,8 @@ private fun LiveSftpView(
     // Overwrite conflict: a transfer (F5/F6 or drag) found same-named entries in the destination. Raised
     // by the coordinator after copy confirmation — otherwise we'd silently overwrite without asking.
     c?.overwrite?.let { conflict ->
-        val single = conflict.names.singleOrNull()
-        ConfirmDangerDialog(
-            title = stringResource(Res.string.sftp_overwrite_q),
-            body = if (single != null) stringResource(Res.string.sftp_overwrite_one, single)
-            else stringResource(Res.string.sftp_overwrite_many, conflict.names.size),
-            confirmLabel = stringResource(Res.string.sftp_overwrite),
+        ConfirmOverwriteDialog(
+            names = conflict.names,
             onConfirm = { c.resolveOverwrite(true) },
             onDismiss = { c.resolveOverwrite(false) },
         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
@@ -25,6 +25,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.files.TransferEntry
 import app.skerry.ui.files.TransferStatus
+import app.skerry.ui.files.fileDisplayName
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.generated.resources.Res
@@ -80,10 +81,12 @@ private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: 
                 else -> Skerry.colors.teal
             },
         )
+        // Blank is not "unprintable": a transfer that failed before it named a file has no name yet.
+        val name = if (entry.name.isBlank()) stringResource(Res.string.ftail_file_fallback) else fileDisplayName(entry.name)
         val title = if (entry.fileCount > 1) {
-            stringResource(Res.string.ftail_transfer_counter, entry.name, entry.fileIndex, entry.fileCount)
+            stringResource(Res.string.ftail_transfer_counter, name, entry.fileIndex, entry.fileCount)
         } else {
-            entry.name.ifBlank { stringResource(Res.string.ftail_file_fallback) }
+            name
         }
         Txt(
             title,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
@@ -36,6 +36,7 @@ import app.skerry.ui.design.InitialsAvatar
 import app.skerry.ui.design.Toggle
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.rememberModalPresence
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.share_allow_input
 import androidx.compose.runtime.rememberCoroutineScope
@@ -194,13 +195,13 @@ internal fun SharePanel(
                 } else {
                     Txt(stringResource(Res.string.share_pick_team), size = 11.sp, color = Skerry.colors.faint)
                     teams.forEach { (id, name) ->
-                        ChipButton(name, color = Skerry.colors.cyan, onClick = { onShare(id, name) }, modifier = Modifier.fillMaxWidth())
+                        ChipButton(untrustedLabel(name), color = Skerry.colors.cyan, onClick = { onShare(id, name) }, modifier = Modifier.fillMaxWidth())
                     }
                 }
             }
             ShareUiState.Starting -> Txt(stringResource(Res.string.share_starting), size = 12.sp, color = Skerry.colors.dim)
             is ShareUiState.Live -> {
-                Txt(stringResource(Res.string.share_live, state.teamName), size = 12.sp, color = Skerry.colors.cyanBright)
+                Txt(stringResource(Res.string.share_live, untrustedLabel(state.teamName)), size = 12.sp, color = Skerry.colors.cyanBright)
                 if (state.viewerAccounts.isEmpty()) {
                     Txt(stringResource(Res.string.share_viewers, state.viewers), size = 11.5.sp, color = Skerry.colors.dim)
                 } else {
@@ -213,7 +214,7 @@ internal fun SharePanel(
                         val extra = state.viewerAccounts.size - MAX_SHOWN_VIEWERS
                         Txt(
                             if (extra > 0) stringResource(Res.string.share_viewers, state.viewers)
-                            else state.viewerAccounts.joinToString(", "),
+                            else state.viewerAccounts.joinToString(", ") { untrustedLabel(it) },
                             size = 11.5.sp,
                             color = Skerry.colors.dim,
                             maxLines = 1,
@@ -226,7 +227,7 @@ internal fun SharePanel(
                     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                         InitialsAvatar(account, size = 20.dp)
                         Txt(
-                            stringResource(Res.string.share_control_wants, account),
+                            stringResource(Res.string.share_control_wants, untrustedLabel(account)),
                             size = 11.5.sp,
                             color = Skerry.colors.amber,
                             modifier = Modifier.weight(1f),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/share/SharedSessionsList.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/share/SharedSessionsList.kt
@@ -17,6 +17,7 @@ import app.skerry.shared.terminal.TerminalSession
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSharedSessions
 import app.skerry.ui.app.LocalShowTerminal
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.InitialsAvatar
@@ -89,12 +90,12 @@ private fun SharedSessionRow(share: SharedSessionUi, onJoin: () -> Unit) {
         InitialsAvatar(share.hostAccountId, size = 26.dp)
         Column(Modifier.weight(1f)) {
             Txt(
-                share.label.ifBlank { stringResource(Res.string.share_unnamed) },
+                untrustedLabel(share.label).ifBlank { stringResource(Res.string.share_unnamed) },
                 size = 12.5.sp,
                 color = Skerry.colors.text,
             )
             Txt(
-                stringResource(Res.string.share_started_by, share.hostAccountId, share.viewers),
+                stringResource(Res.string.share_started_by, untrustedLabel(share.hostAccountId), share.viewers),
                 size = 11.sp,
                 color = Skerry.colors.dim,
             )
@@ -119,8 +120,10 @@ fun rememberJoinSharedSession(): (SharedSessionUi) -> Unit {
             onOpened = { viewer ->
                 showWatchedSession(
                     sessions = sessions,
-                    title = share.label.ifBlank { unnamed },
-                    subtitle = share.hostAccountId,
+                    // The same filtering the row above got: the tab, the session list and the
+                    // broadcast targets all draw this title from here on.
+                    title = untrustedLabel(share.label).ifBlank { unnamed },
+                    subtitle = untrustedLabel(share.hostAccountId),
                     viewer = viewer,
                     // The pane and the viewer are the same session from here on: the terminal
                     // overlay finds the viewer by the pane it is drawing.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamActivityFeedView.kt
@@ -36,6 +36,7 @@ import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_actor_you
 import app.skerry.ui.generated.resources.lib_teams_event_accept
@@ -203,7 +204,8 @@ internal fun ActivityRow(row: TeamActivityRow, mono: androidx.compose.ui.text.fo
             Txt(eventLabel(row), color = Skerry.colors.textBright, size = 12.5.sp, weight = FontWeight.Medium)
             row.subject?.let { subject ->
                 Txt(
-                    subject,
+                    // Record names come from a peer's vault, and this row is what says who did what.
+                    untrustedLabel(subject),
                     // A name we resolved reads as a name; a bare short id is shown as the id it is.
                     color = if (row.subjectResolved) Skerry.colors.cyanBright else Skerry.colors.faint,
                     size = 12.sp, font = mono, modifier = Modifier.weight(1f),
@@ -222,9 +224,9 @@ internal fun ActivityRow(row: TeamActivityRow, mono: androidx.compose.ui.text.fo
 /** Actor, share space, and reported length — everything about the row that isn't the event itself. */
 @Composable
 private fun metaLine(row: TeamActivityRow): String {
-    val actor = if (row.isSelf) stringResource(Res.string.lib_teams_actor_you) else row.actorAccountId
+    val actor = if (row.isSelf) stringResource(Res.string.lib_teams_actor_you) else untrustedLabel(row.actorAccountId)
     val parts = mutableListOf(actor)
-    row.scopeName?.let { parts += stringResource(Res.string.lib_teams_feed_in_scope, it) }
+    row.scopeName?.let { parts += stringResource(Res.string.lib_teams_feed_in_scope, untrustedLabel(it)) }
     row.durationSec?.let { seconds ->
         parts += if (seconds < 60) stringResource(Res.string.lib_teams_feed_duration_short)
         else stringResource(Res.string.lib_teams_feed_duration, (seconds / 60).toString())

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
@@ -28,6 +28,7 @@ import app.skerry.ui.design.InitialsAvatar
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_col_last_seen
 import app.skerry.ui.generated.resources.lib_teams_col_member
@@ -93,7 +94,7 @@ private fun MemberRow(row: TeamMemberRowUi, now: Long, scopesLoading: Boolean, o
         ) {
             InitialsAvatar(member.accountId, size = 28.dp)
             Txt(
-                member.accountId,
+                untrustedLabel(member.accountId),
                 color = if (invited) Skerry.colors.dim else Skerry.colors.text,
                 size = 12.5.sp,
                 font = mono,
@@ -152,7 +153,7 @@ private fun ScopeTag(name: String) {
             .border(1.dp, Skerry.colors.line, RoundedCornerShape(20.dp))
             .padding(horizontal = 9.dp, vertical = 2.dp),
     ) {
-        Txt("#$name", color = Skerry.colors.dim, size = 10.5.sp, font = LocalFonts.current.mono, maxLines = 1)
+        Txt("#${untrustedLabel(name)}", color = Skerry.colors.dim, size = 10.5.sp, font = LocalFonts.current.mono, maxLines = 1)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamRoleUi.kt
@@ -23,6 +23,7 @@ import app.skerry.shared.team.TeamRole
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.generated.resources.lib_teams_role_admin
@@ -102,7 +103,7 @@ internal fun RolePickerDialog(
     val mono = LocalFonts.current.mono
     TeamsDialogCard(onDismiss) {
         Txt(stringResource(Res.string.lib_teams_role_picker_title), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
-        Txt(accountId, color = Skerry.colors.dim, size = 12.sp, font = mono, modifier = Modifier.padding(top = 4.dp, bottom = 14.dp))
+        Txt(untrustedLabel(accountId), color = Skerry.colors.dim, size = 12.sp, font = mono, modifier = Modifier.padding(top = 4.dp, bottom = 14.dp))
         Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
             assignable.forEach { role ->
                 val active = role == current

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
@@ -34,6 +34,7 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_scope_access_hint
 import app.skerry.ui.generated.resources.lib_teams_scope_access_title
@@ -75,7 +76,7 @@ private fun ScopeChipRow(
     ) {
         ScopeChip(stringResource(Res.string.lib_teams_scope_all), active = selected.isEmpty(), muted = false) { onSelect("") }
         scopes.forEach { scope ->
-            ScopeChip(scope.name, active = selected == scope.id, muted = !scope.hasKey) { onSelect(scope.id) }
+            ScopeChip(untrustedLabel(scope.name), active = selected == scope.id, muted = !scope.hasKey) { onSelect(scope.id) }
         }
         if (canManage) {
             GhostButton(stringResource(Res.string.lib_teams_scope_new), onClick = onNew, icon = "add")
@@ -202,7 +203,7 @@ internal fun ScopeAccessDialog(
 ) {
     val mono = LocalFonts.current.mono
     TeamsDialogCard(onDismiss) {
-        Txt(stringResource(Res.string.lib_teams_scope_access_title, scopeName), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+        Txt(stringResource(Res.string.lib_teams_scope_access_title, untrustedLabel(scopeName)), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
         Txt(
             stringResource(Res.string.lib_teams_scope_access_hint),
             color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp,
@@ -223,7 +224,7 @@ internal fun ScopeAccessDialog(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    Txt(member.accountId, color = if (has) Skerry.colors.textBright else Skerry.colors.dim, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
+                    Txt(untrustedLabel(member.accountId), color = if (has) Skerry.colors.textBright else Skerry.colors.dim, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
                     if (has) {
                         GhostButton(
                             stringResource(Res.string.lib_teams_scope_revoke),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -50,6 +50,7 @@ import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_accept
 import app.skerry.ui.generated.resources.lib_teams_decline
@@ -76,6 +77,7 @@ import app.skerry.ui.generated.resources.lib_teams_shared_runbooks_count
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
 import app.skerry.ui.generated.resources.lib_teams_synced_never
 import app.skerry.ui.host.rowSubtitle
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.theme.Skerry
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
@@ -184,7 +186,7 @@ private fun TeamHeader(
 ) {
     SectionHeader(
         title = stringResource(Res.string.lib_teams_header_title),
-        subtitle = stringResource(Res.string.lib_teams_header_subtitle, team.name, team.memberCount),
+        subtitle = stringResource(Res.string.lib_teams_header_subtitle, untrustedLabel(team.name), team.memberCount),
         actions = {
             if (!invited) SyncPill(lastSyncedAt, onSync)
             if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
@@ -314,7 +316,7 @@ private fun InviteBanner(tc: TeamsCoordinator, team: TeamUi, busy: Boolean, onAc
             if (p == null) {
                 Txt(stringResource(Res.string.lib_teams_invite_unverified), color = Skerry.colors.sunset, size = 11.5.sp)
             } else {
-                Txt(stringResource(Res.string.lib_teams_invited_by, p.accountId), color = Skerry.colors.dim, size = 11.5.sp)
+                Txt(stringResource(Res.string.lib_teams_invited_by, untrustedLabel(p.accountId)), color = Skerry.colors.dim, size = 11.5.sp)
                 Txt(stringResource(Res.string.lib_teams_invited_fingerprint, p.fingerprint), color = Skerry.colors.cyanBright, size = 11.5.sp, font = mono)
             }
         }
@@ -352,16 +354,18 @@ internal fun SharedRecordsView(
     val records = remember(team.id, scopeId, tick, spaceVault, view) {
         when (view) {
             TeamSharedView.HOSTS -> spaceVault?.let { vault ->
-                VaultHostStore(vault).all().map { SharedRecordUi(it.id, it.label, it.rowSubtitle()) }
+                VaultHostStore(vault).all().map { SharedRecordUi(it.id, it.rowLabel(), it.rowSubtitle()) }
             }
             TeamSharedView.SNIPPETS -> spaceVault?.let { vault ->
-                VaultSnippetStore(vault).all().map { SharedRecordUi(it.id, it.label, it.command) }
+                VaultSnippetStore(vault).all().map { SharedRecordUi(it.id, untrustedLabel(it.label), untrustedLabel(it.command)) }
             }
             else -> null
         } ?: emptyList()
     }
     val items = if (view == TeamSharedView.RUNBOOKS) {
-        runbooks.map { SharedRecordUi(it.id, it.label, runbookSummary(it.steps.size)) }
+        // Not inside the remember above: the second line is a localized string built in the
+        // composition, so the row is rebuilt on recomposition either way.
+        runbooks.map { SharedRecordUi(it.id, untrustedLabel(it.label), runbookSummary(it.steps.size)) }
     } else {
         records
     }
@@ -423,7 +427,7 @@ internal fun SharePicker(
     val sharedIds = remember(ref, kind, tick) { tc.sharedRecordIds(ref.teamId, kind) }
     val items = when (kind) {
         RecordType.HOST ->
-            (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.label, "${it.username}@${it.address}") }
+            (hosts?.hosts ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.rowLabel(), it.rowSubtitle()) }
         RecordType.SNIPPET ->
             (snippets?.snippets ?: emptyList()).filter { it.id !in sharedIds }.map { ShareItem(it.id, it.snippet.label, it.snippet.command) }
         else ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -60,6 +60,7 @@ import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_accept
 import app.skerry.ui.generated.resources.lib_teams_create
@@ -253,7 +254,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
         val (title, message) = when (c) {
             is TeamsConfirm.Leave -> stringResource(Res.string.lib_teams_leave) to stringResource(Res.string.lib_teams_leave_message)
             is TeamsConfirm.Delete -> stringResource(Res.string.lib_teams_delete) to stringResource(Res.string.lib_teams_delete_message)
-            is TeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, c.accountId)
+            is TeamsConfirm.Remove -> stringResource(Res.string.lib_teams_remove_member_title) to stringResource(Res.string.lib_teams_remove_member_message, untrustedLabel(c.accountId))
             is TeamsConfirm.DeleteScope -> stringResource(Res.string.lib_teams_scope_delete) to stringResource(Res.string.lib_teams_scope_delete_message)
         }
         ConfirmActionDialog(
@@ -360,7 +361,7 @@ private fun LiveTeamRow(team: TeamUi, active: Boolean, onClick: () -> Unit) {
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Sym(if (invited) "mail" else "group", size = 16.sp, color = fg)
-        Txt(team.name, color = fg, size = 12.5.sp)
+        Txt(untrustedLabel(team.name), color = fg, size = 12.5.sp)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
@@ -45,6 +45,7 @@ import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_palette_empty
 import app.skerry.ui.generated.resources.term_palette_hint
@@ -179,7 +180,7 @@ private fun CommandRow(suggestion: CommandSuggestion, mono: FontFamily, onClick:
         Txt(highlightMatches(suggestion), color = Skerry.colors.textBright, size = 12.5.sp, font = mono, modifier = Modifier.weight(1f))
         val origin = when {
             suggestion.fromCurrentHost -> stringResource(Res.string.term_palette_this_host)
-            else -> suggestion.hostLabel
+            else -> suggestion.hostLabel?.let { untrustedLabel(it) }
         }
         if (origin != null) {
             Txt(origin, color = if (suggestion.fromCurrentHost) Skerry.colors.cyanBright else Skerry.colors.faint, size = 10.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.host.rowSubtitle
 import app.skerry.shared.host.Host
 import app.skerry.ui.app.DesktopDesignState
@@ -49,6 +50,8 @@ import app.skerry.ui.design.MenuItem
 import app.skerry.ui.design.MenuPanel
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_menu_delete
 import app.skerry.ui.generated.resources.term_menu_duplicate
@@ -90,8 +93,11 @@ internal fun TeamHostRow(host: Host, mono: FontFamily) {
     ) {
         Sym(host.connectionType.icon, size = 14.sp, color = Skerry.colors.faint)
         Column(Modifier.weight(1f)) {
-            Txt(host.label, color = Skerry.colors.dim, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
-            Txt(host.rowSubtitle(), color = Skerry.colors.faint, size = 10.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            // Filtered once per profile, not once per repaint of a list that draws every row it has.
+            val name = remember(host) { host.rowLabel() }
+            val subtitle = remember(host) { host.rowSubtitle() }
+            Txt(name, color = Skerry.colors.dim, size = 12.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Txt(subtitle, color = Skerry.colors.faint, size = 10.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis)
         }
     }
 }
@@ -119,13 +125,15 @@ internal fun RecentHostRow(host: Host, mono: FontFamily) {
     ) {
         Sym(host.connectionType.icon, size = 14.sp, color = Skerry.colors.faint)
         Column(Modifier.weight(1f)) {
+            val name = remember(host) { host.rowLabel() }
+            val subtitle = remember(host) { host.rowSubtitle() }
             Txt(
-                host.label,
+                name,
                 color = Skerry.colors.dim, size = 12.sp,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
             )
             Txt(
-                host.rowSubtitle(),
+                subtitle,
                 color = Skerry.colors.faint, size = 10.5.sp, font = mono,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
             )
@@ -180,7 +188,7 @@ internal fun HostRow(
             },
     ) {
         HostEntryRow(
-            label = host.label,
+            label = remember(host) { host.rowLabel() },
             // Selection highlight: marks the row clicked in double-click mode (and the most recently
             // connected one in single-click mode). Distinct from the live-connection status dot.
             selected = host.id == selectedHostId,
@@ -216,7 +224,9 @@ internal fun DropLine() {
 @Composable
 internal fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily) {
     HostEntryRow(
-        label = host.name,
+        // Design data, not a peer's — but [HostEntryRow] draws its label as given, so it is filtered
+        // here like every other caller's.
+        label = untrustedLabel(host.name),
         selected = state.selectedHost == host.name,
         dot = host.status.color,
         badge = host.badge,
@@ -237,7 +247,8 @@ private const val NOTE_TOOLTIP_DELAY_MS = 450L
  * [onEdit]/[onDuplicate]/[onDelete] are provided (live catalog) or a snippet can be run on the host
  * ([host] != null and [LocalSnippets] is present), a trailing "⋮" button opens a menu (Run
  * snippet.../Edit/Duplicate/Delete); its click is intercepted before [onClick], so opening the menu
- * doesn't trigger a connection. "Run snippet..." opens the snippet picker and runs it on [host] via
+ * doesn't trigger a connection. [label] is drawn as given: a caller holding a profile passes
+ * [app.skerry.ui.host.rowLabel], never [app.skerry.shared.host.Host.label] itself. "Run snippet..." opens the snippet picker and runs it on [host] via
  * [LocalRunSnippetOnHost]. A profile carrying [Host.notes] shows them as a hover tooltip.
  */
 @Composable
@@ -282,8 +293,13 @@ internal fun HostEntryRow(
     // would still collect the row's 8dp item spacing and shift the label sideways on hover.
     Box(Modifier.fillMaxWidth()) {
         val note = host?.notes
+        // A shared profile's note is its author's text; it keeps its lines (prose), but not the
+        // characters that would let it draw as something else, and not more of them than a tooltip
+        // can hold — the field has no cap of its own.
+        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
         // Suppressed while the row's own popups are up, so the note doesn't land on top of them.
-        if (noteVisible && !note.isNullOrBlank() && !menuOpen && !snippetPickerOpen) HoverTooltip(note)
+        val popupOpen = menuOpen || snippetPickerOpen
+        if (noteVisible && !popupOpen && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
         Row(
             Modifier
                 .fillMaxWidth()
@@ -306,6 +322,8 @@ internal fun HostEntryRow(
             Dot(dot)
             Sym(icon, size = 13.sp, color = Skerry.colors.faint)
             Txt(
+                // Already sanitized by the caller ([app.skerry.ui.host.rowLabel]); filtering again
+                // here would only repeat the scan on the sidebar's longest list.
                 label,
                 color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim, size = 11.5.sp, font = mono,
                 maxLines = 1, overflow = TextOverflow.Ellipsis,
@@ -366,3 +384,6 @@ internal fun HostEntryRow(
         }
     }
 }
+
+/** How much of a profile's note a tooltip or a detail row will draw. */
+internal const val MAX_NOTE_CHARS = 600

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebarSections.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostsSidebarSections.kt
@@ -38,12 +38,14 @@ import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamScopeRef
 import androidx.compose.runtime.collectAsState
+import app.skerry.ui.design.SHORT_ID_CHARS
 import app.skerry.ui.teams.AutoPullTeamsOnOnline
 import app.skerry.ui.generated.resources.lib_teams_sidebar
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.rd_add_first
 import app.skerry.ui.generated.resources.shtail_group_collapse
@@ -69,7 +71,6 @@ import app.skerry.ui.host.ungroupedLabel
 import app.skerry.ui.host.icon
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
-import app.skerry.shared.snippet.sanitizeSnippetValue
 
 /**
  * Host folder header: collapse chevron + icon + name + count. The chevron ([collapsed] ->
@@ -359,21 +360,10 @@ internal fun LiveHostFolder(
  * Peer-authored and never seen by the server (the name travels inside the sealed envelope), so it is
  * sanitized rather than trusted: the label is both drawn and used as the collapse chevron's
  * accessible name, and a bidi override in it would make a folder announce as a space other than the
- * one its hosts belong to. Cut to length first — filtering a name a hostile peer made pathologically
- * long before throwing most of it away is work for nothing.
+ * one its hosts belong to — see [untrustedLabel], which the cap and the filtering come from.
  */
 internal fun spaceLabel(raw: String, fallback: String): String =
-    // sanitizeSnippetValue, not stripUnsafeFormatChars: the latter keeps every C0 control on purpose
-    // (a multi-line snippet has to stay multi-line), and this is a one-line label — a newline or a
-    // NUL in a peer's name has no business in a folder header or in what it announces.
-    // dropLastWhile: cutting to length can land between the halves of an astral character.
-    sanitizeSnippetValue(raw.take(MAX_SPACE_NAME_CHARS).dropLastWhile { it.isHighSurrogate() })
+    untrustedLabel(raw)
         // A name made only of the characters the sanitizer drops leaves nothing to draw, and a blank
         // folder header is one the user cannot tell from any other. Fall back to the space's id.
         .ifBlank { fallback }
-
-/** How much of an id stands in for a name that sanitized away — enough to tell two spaces apart. */
-private const val SHORT_ID_CHARS = 8
-
-/** Cap on a team-space label: a sidebar row shows a fraction of this, and the name is a peer's. */
-internal const val MAX_SPACE_NAME_CHARS = 120

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPanes.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPanes.kt
@@ -78,6 +78,7 @@ import app.skerry.ui.generated.resources.term_pane_change_host
 import app.skerry.ui.generated.resources.term_pane_close
 import app.skerry.ui.generated.resources.term_pane_menu
 import app.skerry.ui.generated.resources.term_select_host_placeholder
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.session.PaneDragState
 import app.skerry.ui.session.PaneEdge
 import app.skerry.ui.session.Session
@@ -339,7 +340,7 @@ internal fun PaneHostPicker(onPick: (Host) -> Unit) {
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Sym("dns", size = 14.sp, color = Skerry.colors.cyanBright)
-                Txt(host.label, color = Skerry.colors.dim, size = 11.5.sp, font = mono, modifier = Modifier.weight(1f))
+                Txt(host.rowLabel(), color = Skerry.colors.dim, size = 11.5.sp, font = mono, modifier = Modifier.weight(1f))
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelPanels.kt
@@ -75,6 +75,7 @@ import app.skerry.ui.generated.resources.ports_services_unsupported
 import app.skerry.ui.generated.resources.ports_socks_hint
 import app.skerry.ui.generated.resources.ports_tunnel_detail
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.FormField
@@ -114,7 +115,9 @@ internal fun TunnelEditor(
     val (badgeBg, badgeFg) = form.direction.badgeColors()
     // The tunnel dials this host over SSH, so remote desktops are not candidates.
     val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
-    val hostLabel = form.hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label } ?: stringResource(Res.string.ports_select_host)
+    // Filtered once per catalog change, not once per recomposition of the form around it.
+    val hostOptions = remember(hostList) { hostList.map { it.id to it.rowLabel() } }
+    val hostLabel = form.hostId?.let { id -> hostOptions.firstOrNull { it.first == id }?.second } ?: stringResource(Res.string.ports_select_host)
 
     SidePanel {
         PanelHeader(
@@ -132,7 +135,7 @@ internal fun TunnelEditor(
         }
         Box(Modifier.padding(bottom = 12.dp))
         FormField(stringResource(Res.string.ports_field_via_host), top = 0.dp) {
-            HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { form.hostId = it })
+            HostPicker(hostLabel, hostOptions, onPick = { form.hostId = it })
         }
         Box(Modifier.padding(bottom = 12.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -284,7 +287,8 @@ internal fun ServicesPanel(
     // then rejected as Unsupported. MOSH qualifies — it dials the same SSH hop.
     val hostList = hosts?.hosts?.filter { it.connectionType.usesSshAuth } ?: emptyList()
     var hostId by remember { mutableStateOf(scan.scannedHostId ?: hostList.firstOrNull()?.id) }
-    val hostLabel = hostId?.let { id -> hostList.firstOrNull { it.id == id }?.label }
+    val hostOptions = remember(hostList) { hostList.map { it.id to it.rowLabel() } }
+    val hostLabel = hostOptions.firstOrNull { it.first == hostId }?.second
         ?: stringResource(Res.string.ports_select_host)
 
     SidePanel {
@@ -295,7 +299,7 @@ internal fun ServicesPanel(
         )
         Txt(stringResource(Res.string.ports_services_hint), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(bottom = 14.dp))
         FormField(stringResource(Res.string.ports_field_via_host), top = 0.dp) {
-            HostPicker(hostLabel, hostList.map { it.id to it.label }, onPick = { hostId = it })
+            HostPicker(hostLabel, hostOptions, onPick = { hostId = it })
         }
         Box(Modifier.padding(bottom = 12.dp))
         PrimaryButton(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelsView.kt
@@ -50,6 +50,7 @@ import app.skerry.ui.generated.resources.ports_remove_confirm_title
 import app.skerry.ui.generated.resources.ports_remove_inactive_message
 import app.skerry.ui.generated.resources.ports_tunnels
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.platform.testTag
@@ -153,7 +154,7 @@ private fun GlobalTunnelsBody(
     val selected = tunnels.firstOrNull { it.id == selectedId }
     val editorVisible = panel == TunnelPanel.Editor && (adding || selected != null)
 
-    fun hostLabel(hostId: String): String = hosts?.find(hostId)?.label ?: hostId
+    fun hostLabel(hostId: String): String = hosts?.find(hostId)?.rowLabel() ?: hostId
 
     // Tunnel for which the delete-confirmation dialog is shown (null — no dialog). Local state
     // suffices since deletion (manager.delete) is self-contained, unlike session close.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -71,6 +71,7 @@ import app.skerry.ui.generated.resources.vault_used_by
 import app.skerry.ui.generated.resources.vault_used_by_one
 import app.skerry.ui.generated.resources.vault_used_by_snippets
 import app.skerry.ui.generated.resources.vault_used_by_snippets_one
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.known.shortFingerprint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -249,7 +250,7 @@ internal fun UsedByHosts(hosts: List<Host>, snippetLabels: List<String>, mono: F
             else stringResource(Res.string.vault_used_by, hosts.size),
         )
         FlowRow(Modifier.fillMaxWidth().padding(bottom = 20.dp), horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
-            hosts.forEach { HostPill(it.label, mono) }
+            hosts.forEach { HostPill(it.rowLabel(), mono) }
         }
     }
     // Snippets referencing this secret by name (${{vault:label}}) — a rename/delete breaks them,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -60,6 +60,7 @@ import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_link_key_file
 import app.skerry.ui.generated.resources.vault_sidebar_header
 import app.skerry.ui.host.HostDraft
+import app.skerry.ui.host.rowLabel
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
 import app.skerry.ui.identity.CredentialManagerController
@@ -185,7 +186,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                                     inspector = inspector,
                                     usage = credentials.usageOf(credential.id),
                                     usedBy = VaultPresentation.usedByLabel(
-                                        hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.label },
+                                        hostLabels = VaultPresentation.hostsUsing(credential.id, hosts).map { it.rowLabel() },
                                         snippetCount = VaultPresentation.snippetsUsing(credential.label, snippetList).size,
                                     ),
                                     mono = mono,

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/HostConnectTest.kt
@@ -44,6 +44,28 @@ class HostConnectTest {
         assertEquals("deploy@example.com:2222", host(address = "example.com", port = 2222, username = "deploy").connectionSubtitle())
     }
 
+    /**
+     * Every field spliced into the caption belongs to whoever wrote the profile, and a shared one
+     * was written by a team member: a bidi override in the username reverses the line the user
+     * reads before typing a password into it. Escapes, not the characters themselves.
+     */
+    @Test
+    fun subtitle_drops_a_bidi_override_in_the_username() {
+        assertEquals("root@example.com:22", host(address = "example.com", username = "ro\u202Eot").connectionSubtitle())
+    }
+
+    @Test
+    fun subtitle_drops_the_zero_width_formatters_in_the_address() {
+        assertEquals("root@example.com:22", host(address = "exam\u200Bple.com").connectionSubtitle())
+    }
+
+    /** A local shell has no host to name; a path made only of such characters must not blank it. */
+    @Test
+    fun local_subtitle_falls_back_when_the_path_filters_away() {
+        val local = host(address = "\u202E\u200B").copy(connectionType = ConnectionType.LOCAL)
+        assertEquals("local shell", local.connectionSubtitle())
+    }
+
     @Test
     fun container_target_carries_the_spec_and_the_host_fields() {
         val profile = host().copy(

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/SanitizeServerTextTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/SanitizeServerTextTest.kt
@@ -1,4 +1,4 @@
-package app.skerry.ui.connection
+package app.skerry.ui.design
 
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/UntrustedLabelTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/UntrustedLabelTest.kt
@@ -1,0 +1,96 @@
+package app.skerry.ui.design
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * The filter every label of foreign origin passes through — a remote file name, a shared profile, a
+ * team space. What each screen does with the result is covered where it is drawn (the listing and
+ * the host rows); what is pinned here is the shape of the string that comes out.
+ *
+ * Written as escapes, never as the characters themselves: they are invisible in a diff, and a
+ * reviewer could not tell the fixture from the expectation.
+ */
+class UntrustedLabelTest {
+
+    @Test
+    fun `a bidi override is dropped`() {
+        val label = untrustedLabel("invoice\u202Egnp.exe")
+        assertEquals("invoicegnp.exe", label)
+        assertFalse(label.any { it.category == CharCategory.FORMAT })
+    }
+
+    @Test
+    fun `the zero-width formatters go too`() {
+        assertEquals("report.log", untrustedLabel("re\u200Bport\u200D.log\uFEFF"))
+    }
+
+    /** Control bytes as well: a one-line label has no use for a newline, and none for a NUL. */
+    @Test
+    fun `control characters are flattened or dropped`() {
+        assertEquals("a b", untrustedLabel("a\nb"))
+        assertEquals("ab", untrustedLabel("a\u0000b"))
+    }
+
+    @Test
+    fun `a name longer than the cap is cut to it`() {
+        assertEquals(MAX_UNTRUSTED_LABEL_CHARS, untrustedLabel("o".repeat(5_000)).length)
+    }
+
+    /**
+     * The cap counts UTF-16 units, so it can fall between the halves of an astral character; the
+     * label would then draw U+FFFD in place of the character the peer typed.
+     */
+    @Test
+    fun `the cut is not made through a surrogate pair`() {
+        val label = untrustedLabel("o".repeat(MAX_UNTRUSTED_LABEL_CHARS - 1) + "🚀")
+        assertEquals(MAX_UNTRUSTED_LABEL_CHARS - 1, label.length)
+        assertFalse(label.any { it.isSurrogate() }, "half of the astral character was left in the label")
+    }
+
+    /** A pair that fits stays whole — the cut is the only thing that may take one apart. */
+    @Test
+    fun `an astral character inside the cap survives`() {
+        assertEquals("ops 🚀", untrustedLabel("ops 🚀"))
+    }
+
+    /**
+     * The scan is bounded by the input, not only by what it keeps: a name padded with a million
+     * characters that draw as nothing must not cost a million comparisons. Past the bound the tail
+     * is never looked at — a name written that way is not one.
+     */
+    @Test
+    fun `a flood of invisible characters is not scanned past the bound`() {
+        assertEquals("", untrustedLabel("\u200B".repeat(50_000) + "prod"))
+    }
+
+    /** Just inside the bound the same tail survives — the cut is the flood's, not everyone's. */
+    @Test
+    fun `formatting inside the bound does not cost the tail`() {
+        assertEquals("prod", untrustedLabel("\u200B".repeat(100) + "prod"))
+    }
+
+    /**
+     * Letters and a symbol by category, nothing at all on screen. They are not format characters,
+     * so `isBlank()` says such a name is a name — and the stand-in a row falls back to would never
+     * fire. Dropping the three closes that, and nothing wider: homoglyphs are a different problem.
+     */
+    @Test
+    fun `the invisible letters are dropped so a nameless name reads as blank`() {
+        assertEquals("", untrustedLabel("\u3164\u115F\u2800"))
+        assertEquals("ops", untrustedLabel("ops\u3164"))
+    }
+
+    @Test
+    fun `an ordinary name is left alone`() {
+        assertEquals("Платформа · прод", untrustedLabel("Платформа · прод"))
+    }
+
+    /** Filtering an already filtered label changes nothing — the sinks stack the call. */
+    @Test
+    fun `the filter is idempotent`() {
+        val once = untrustedLabel("web\u202E10-")
+        assertEquals(once, untrustedLabel(once))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostGroupingTest.kt
@@ -176,6 +176,24 @@ class HostRowSubtitleTest {
         assertEquals("10.0.0.5:5901", h.rowSubtitle())
     }
 
+    /**
+     * The name a row is drawn under, when the profile came from a team member: filtered, and never
+     * blank — a row with nothing in it is one neither the eye nor a screen reader can place.
+     * Escapes, not the characters themselves.
+     */
+    @Test
+    fun row_label_drops_a_bidi_override() {
+        assertEquals("web10-", host("a").copy(label = "web\u202E10-").rowLabel())
+    }
+
+    @Test
+    fun row_label_falls_back_to_the_address_then_to_the_id() {
+        val noName = host("a").copy(label = "\u202E\u200B", address = "10.0.0.5")
+        assertEquals("10.0.0.5", noName.rowLabel())
+        val nothingDrawable = host("h-shared-4f2a91").copy(label = "\u202E", address = "\u200B")
+        assertEquals("h-shared", nothingDrawable.rowLabel())
+    }
+
     @Test
     fun a_local_shell_shows_its_shell_path_or_a_name() {
         val shell = host("c", type = ConnectionType.LOCAL).copy(username = "", address = "/bin/zsh", port = 0)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileFilesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileFilesTest.kt
@@ -57,11 +57,13 @@ class MobileFilesTest {
 
     @Test
     fun leading_icon_maps_by_type_and_script_extension() {
-        assertEquals("folder", mobileFileIcon(item("html", FileItemType.Directory)))
-        assertEquals("link", mobileFileIcon(item("current", FileItemType.Symlink)))
-        assertEquals("description", mobileFileIcon(item("nginx.conf", FileItemType.File)))
+        // The name is passed separately on purpose: the row draws a filtered form of it, and the
+        // icon has to read the same string it does.
+        assertEquals("folder", mobileFileIcon(item("html", FileItemType.Directory), "html"))
+        assertEquals("link", mobileFileIcon(item("current", FileItemType.Symlink), "current"))
+        assertEquals("description", mobileFileIcon(item("nginx.conf", FileItemType.File), "nginx.conf"))
         // Shell script: terminal icon.
-        assertEquals("terminal", mobileFileIcon(item("deploy.sh", FileItemType.File)))
+        assertEquals("terminal", mobileFileIcon(item("deploy.sh", FileItemType.File), "deploy.sh"))
     }
 
     // Row trailing icon (the action shown by the layout)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SafeDownloadNameTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/SafeDownloadNameTest.kt
@@ -1,0 +1,44 @@
+package app.skerry.ui.sftp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The name a download's "save to…" dialog is seeded with.
+ *
+ * It is the one hop where a name the remote side chose becomes part of a local file name, so it
+ * carries a directory part it must lose and formatting it must not keep — a preset the user accepts
+ * without reading is the whole point of a preset.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+class SafeDownloadNameTest {
+
+    @Test
+    fun `an ordinary name is kept`() {
+        assertEquals("invoice.pdf", safeDownloadName("invoice.pdf"))
+    }
+
+    @Test
+    fun `a directory part is dropped, posix and windows alike`() {
+        assertEquals("authorized_keys", safeDownloadName("../../.ssh/authorized_keys"))
+        assertEquals("evil.exe", safeDownloadName("..\\windows\\evil.exe"))
+    }
+
+    @Test
+    fun `a bidi override never reaches the dialog`() {
+        assertEquals("invoicegnp.exe", safeDownloadName("invoice\u202Egnp.exe"))
+    }
+
+    /** A leading dot would save a file the file manager then hides. */
+    @Test
+    fun `a leading dot is dropped`() {
+        assertEquals("bashrc", safeDownloadName(".bashrc"))
+    }
+
+    @Test
+    fun `a name with nothing left falls back to something savable`() {
+        assertEquals("download", safeDownloadName("\u202E\u200B"))
+        assertEquals("download", safeDownloadName("/"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/connection/PasswordDialogNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/connection/PasswordDialogNameTest.kt
@@ -1,0 +1,40 @@
+package app.skerry.ui.connection
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.shared.host.Host
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shell_connect_to
+import kotlin.test.Test
+
+/**
+ * The host a password prompt says it is about to authenticate to.
+ *
+ * This is the screen where the answer is a secret, so the name on it decides which machine gets the
+ * password. A shared profile was named by a team member and the sync server never validated it; the
+ * phone sheet is pinned by [app.skerry.ui.mobile.MobilePeerNameTest], this is its desktop twin.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PasswordDialogNameTest {
+
+    @Test
+    fun `the prompt names the host flattened`() = runForm({
+        DesktopPasswordDialog(host = sharedHost(), onDismiss = {}, onConnect = {})
+    }) {
+        onNodeWithText(string(Res.string.shell_connect_to, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.shell_connect_to, SPOOFED)).assertDoesNotExist()
+        // The address line is the shared helper's, so a container or local profile reads right too.
+        onNodeWithText("root@10.0.0.5:22").assertIsDisplayed()
+    }
+}
+
+private fun sharedHost(): Host =
+    Host(id = "h-shared", label = SPOOFED, address = "10.0.0.5", port = 22, username = "root")
+
+private const val SPOOFED = "web\u202E10-"
+private const val FLATTENED = "web10-"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ProdGuardDialogNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ProdGuardDialogNameTest.kt
@@ -1,0 +1,51 @@
+package app.skerry.ui.host
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.shared.host.Host
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.guard_prod_connect_message
+import app.skerry.ui.generated.resources.guard_prod_snippet_message
+import kotlin.test.Test
+
+/**
+ * The name a confirmation dialog puts in front of the user.
+ *
+ * A dialog is where a host name stops being decoration: "this host is tagged #prod" is the last
+ * line read before a session opens on production, and the snippet variant is read before a command
+ * runs there by itself. Both name the host from a profile a team member may have written, so both
+ * draw it the way the catalog row does.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ProdGuardDialogNameTest {
+
+    @Test
+    fun `the connect confirmation names the host flattened`() = runForm({
+        ProdConnectDialog(ProdConnectRequest(host(), snippetLine = null) {}, onDismiss = {})
+    }) {
+        onNodeWithText(string(Res.string.guard_prod_connect_message, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.guard_prod_connect_message, SPOOFED)).assertDoesNotExist()
+    }
+
+    /** The branch that matters more: the command runs the moment the session opens. */
+    @Test
+    fun `the snippet confirmation names the host flattened too`() = runForm({
+        ProdConnectDialog(ProdConnectRequest(host(), snippetLine = "systemctl restart api") {}, onDismiss = {})
+    }) {
+        onNodeWithText(string(Res.string.guard_prod_snippet_message, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.guard_prod_snippet_message, SPOOFED)).assertDoesNotExist()
+    }
+}
+
+private fun host(): Host =
+    Host(id = "h-prod", label = SPOOFED, address = "10.0.0.7", port = 22, username = "root", tags = listOf("prod"))
+
+/** U+202E before the tail: drawn as `db-prod-staging` unless the dialog filters it. */
+private const val SPOOFED = "db-prod\u202Egnigats-"
+
+private const val FLATTENED = "db-prodgnigats-"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobilePeerNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobilePeerNameTest.kt
@@ -1,0 +1,87 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.shared.host.Host
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.files.FilePaneController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+
+/**
+ * The Android half of the same fix: a name a server chose and a name a team member chose, drawn on
+ * the phone.
+ *
+ * Parity is the point. The desktop listing and the desktop password dialog filter these strings;
+ * if the phone does not, the same directory and the same profile spoof exactly as before on the
+ * platform that has no hover, no status bar and less room to notice anything is off.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobilePeerNameTest {
+
+    @Test
+    fun `the phone listing draws the server's name flattened`() {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val pane = FilePaneController(OneEntryBrowser, scope)
+        pane.start()
+        try {
+            runForm({
+                MobileLivePane(
+                    pane = pane,
+                    mono = FontFamily.Monospace,
+                    onTransfer = {},
+                    onDownloadHere = null,
+                    onOpenEditor = { _, _ -> },
+                    modifier = Modifier,
+                )
+            }) {
+                onNodeWithText(FLAT_FILE).assertIsDisplayed()
+                onNodeWithText(SPOOFED_FILE).assertDoesNotExist()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** The screen where the answer is a secret: it must name the machine it is about to be sent to. */
+    @Test
+    fun `the phone password sheet names the host flattened`() = runForm({
+        MobilePasswordSheet(host = sharedHost(), onDismiss = {}, onConnect = {})
+    }) {
+        onNodeWithText(FLAT_HOST).assertIsDisplayed()
+        onNodeWithText(SPOOFED_HOST).assertDoesNotExist()
+        // The address line is the helper's, not a hand-rolled one — a container or local profile
+        // would otherwise read wrong here and nowhere else.
+        onNodeWithText("root@10.0.0.5:22").assertIsDisplayed()
+    }
+}
+
+private fun sharedHost(): Host =
+    Host(id = "h-shared", label = SPOOFED_HOST, address = "10.0.0.5", port = 22, username = "root")
+
+/** One canned listing, the way the desktop test stubs its own. */
+private object OneEntryBrowser : FileBrowser {
+    override val label: String = "stub"
+    override suspend fun realpath(path: String): String = "/"
+    override suspend fun list(path: String): List<FileItem> = listOf(
+        FileItem(SPOOFED_FILE, "/var/www/$SPOOFED_FILE", FileItemType.File, 12, 0),
+    )
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+}
+
+private const val SPOOFED_FILE = "invoice\u202Egnp.exe"
+private const val FLAT_FILE = "invoicegnp.exe"
+private const val SPOOFED_HOST = "web\u202E10-"
+private const val FLAT_HOST = "web10-"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpDialogNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpDialogNameTest.kt
@@ -1,0 +1,88 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_delete_file_body
+import app.skerry.ui.generated.resources.sftp_overwrite_one
+import app.skerry.ui.generated.resources.sftp_transfer_body
+import app.skerry.ui.generated.resources.sftp_unprintable_name
+import app.skerry.ui.generated.resources.sftp_what_single
+import kotlin.test.Test
+
+/**
+ * The name in the confirmation that acts on a listing row.
+ *
+ * The row itself is filtered, and a dialog that is not would be worse than both being raw: the user
+ * reads "Delete X?" over a row that says something else, and the irreversible action is the one
+ * taken on the dialog's word. Copy, move and overwrite name the same server-chosen string.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SftpDialogNameTest {
+
+    @Test
+    fun `the delete confirmation names the file flattened`() = runForm({
+        ConfirmDeleteItemsDialog(listOf(entry()), onConfirm = {}, onDismiss = {})
+    }) {
+        onNodeWithText(string(Res.string.sftp_delete_file_body, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.sftp_delete_file_body, SPOOFED)).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the copy confirmation names the file flattened`() = runForm({
+        ConfirmCopyDialog(listOf(entry()), destLabel = "this Mac", destPath = "/tmp", onConfirm = {}, onDismiss = {})
+    }) {
+        val what = string(Res.string.sftp_what_single, FLATTENED)
+        onNodeWithText(string(Res.string.sftp_transfer_body, what, "/tmp")).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the move confirmation names the file flattened`() = runForm({
+        ConfirmMoveDialog(listOf(entry()), destLabel = "this Mac", destPath = "/tmp", onConfirm = {}, onDismiss = {})
+    }) {
+        val what = string(Res.string.sftp_what_single, FLATTENED)
+        onNodeWithText(string(Res.string.sftp_transfer_body, what, "/tmp")).assertIsDisplayed()
+    }
+
+    /** The phone deletes through a dialog of its own — the same name, a different composable. */
+    @Test
+    fun `the single-entry delete confirmation names the file flattened`() = runForm({
+        ConfirmDeleteDialog(entry(), onConfirm = {}, onDismiss = {})
+    }) {
+        onNodeWithText(string(Res.string.sftp_delete_file_body, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.sftp_delete_file_body, SPOOFED)).assertDoesNotExist()
+    }
+
+    /** A name that filters away entirely still has to name the row the dialog was opened from. */
+    @Test
+    fun `a name that filters away is named by the same stand-in as the row`() = runForm({
+        ConfirmDeleteDialog(entry(name = "\u202E\u200B\uFEFF"), onConfirm = {}, onDismiss = {})
+    }) {
+        val unprintable = string(Res.string.sftp_unprintable_name)
+        onNodeWithText(string(Res.string.sftp_delete_file_body, unprintable)).assertIsDisplayed()
+    }
+
+    /** The overwrite prompt decides which file is destroyed, and names it with the server's string. */
+    @Test
+    fun `the overwrite confirmation names the file flattened`() = runForm({
+        ConfirmOverwriteDialog(names = listOf(SPOOFED), onConfirm = {}, onDismiss = {})
+    }) {
+        onNodeWithText(string(Res.string.sftp_overwrite_one, FLATTENED)).assertIsDisplayed()
+        onNodeWithText(string(Res.string.sftp_overwrite_one, SPOOFED)).assertDoesNotExist()
+    }
+}
+
+private fun entry(name: String = SPOOFED): FileItem =
+    FileItem(name = name, path = "/var/www/$name", type = FileItemType.File, size = 10, modifiedEpochSeconds = 0)
+
+/** U+202E before the tail: drawn as `invoiceexe.png`, the file it deletes ends in `.exe`. */
+private const val SPOOFED = "invoice\u202Egnp.exe"
+
+private const val FLATTENED = "invoicegnp.exe"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingNameTest.kt
@@ -1,0 +1,103 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_unprintable_name
+import app.skerry.ui.files.FilePaneController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+
+/**
+ * What the remote listing draws for a name the server chose.
+ *
+ * A directory listing is the one screen made entirely of strings the other side wrote, and it is
+ * also the screen the user clicks to download and to open. A bidi override inside a name reverses
+ * the tail of it in every layout: the fixture below is drawn as `invoiceexe.png` while the file it
+ * opens ends in `.exe`, so the extension the eye reads is not the extension on disk. Zero-width
+ * characters make two different files draw as one — `archive.\u200Bzip` and `archive.zip` are the
+ * same row to the eye and a different file to the server.
+ *
+ * Written as escapes, never as the characters themselves: they are invisible in a diff, and a
+ * reviewer could not tell the fixture from the expectation.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SftpListingNameTest {
+
+    @Test
+    fun `a bidi override in a remote file name never reaches the row`() = listing(SPOOFED) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the zero-width formatters go too`() = listing("re\u200Bport\u200D.log") {
+        onNodeWithText("report.log").assertIsDisplayed()
+    }
+
+    /** The extension is what the icon is picked from, so a formatter inside it must not survive. */
+    @Test
+    fun `a formatter inside the extension is dropped`() = listing("archive.\u200Bzip") {
+        onNodeWithText("archive.zip").assertIsDisplayed()
+    }
+
+    /** A name that is nothing but such characters would otherwise leave the row nameless. */
+    @Test
+    fun `a name that filters away leaves the row named`() = listing("\u202E\u200B\uFEFF") {
+        onNodeWithText(string(Res.string.sftp_unprintable_name)).assertIsDisplayed()
+    }
+
+    @Test
+    fun `an ordinary name is drawn as the server sent it`() = listing("nginx.conf") {
+        onNodeWithText("nginx.conf").assertIsDisplayed()
+    }
+
+    /** One remote entry on screen, drawn by the live listing the session panel uses. */
+    private fun listing(name: String, body: ComposeUiTest.() -> Unit) {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val pane = FilePaneController(StubBrowser, scope)
+        val entries = listOf(
+            FileItem(name = name, path = "/var/www/$name", type = FileItemType.File, size = 12, modifiedEpochSeconds = 0),
+        )
+        try {
+            runForm({
+                LivePaneList(
+                    pane = pane,
+                    entries = entries,
+                    mono = FontFamily.Monospace,
+                    listState = rememberLazyListState(),
+                    active = true,
+                    onActivate = {},
+                )
+            }, body)
+        } finally {
+            scope.cancel()
+        }
+    }
+}
+
+/** The listing under test is handed its entries directly; the browser is only what the pane holds. */
+private object StubBrowser : FileBrowser {
+    override val label: String = "stub"
+    override suspend fun realpath(path: String): String = "/"
+    override suspend fun list(path: String): List<FileItem> = emptyList()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+}
+
+/** U+202E before the tail: the row draws as `invoiceexe.png`, the file it opens is `invoicegnp.exe`. */
+private const val SPOOFED = "invoice\u202Egnp.exe"
+
+private const val FLATTENED = "invoicegnp.exe"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamMemberNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamMemberNameTest.kt
@@ -1,0 +1,82 @@
+package app.skerry.ui.teams
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.mobile.MobileMemberRow
+import kotlin.test.Test
+
+/**
+ * The account id a team screen puts in front of a decision.
+ *
+ * An account id is only length-checked when it registers, and the member list comes from the sync
+ * server: the row is where the operator reads who they are about to grant a share space to, change
+ * the role of, or remove. A bidi override in it makes one row read as another account's.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TeamMemberNameTest {
+
+    @Test
+    fun `a member row draws the account id flattened`() = runForm({
+        TeamMemberTable(
+            rows = listOf(row()),
+            now = NOW,
+            onChangeRole = {},
+            onRemove = {},
+        )
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    /** The phone draws the same row, and the removal it opens is irreversible. */
+    @Test
+    fun `the phone member row draws the account id flattened`() = runForm({
+        MobileMemberRow(row(), now = NOW, onChangeRole = {}, onRemove = {})
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    /** The role picker names the same account, over the control that changes what it may do. */
+    @Test
+    fun `the role picker draws the account id flattened`() = runForm({
+        RolePickerDialog(
+            accountId = SPOOFED,
+            current = TeamRole.EDITOR,
+            assignable = listOf(TeamRole.EDITOR, TeamRole.VIEWER),
+            onPick = {},
+            onDismiss = {},
+        )
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+}
+
+private fun row(): TeamMemberRowUi = TeamMemberRowUi(
+    member = TeamMember(
+        accountId = SPOOFED,
+        role = TeamRole.EDITOR,
+        status = TeamMemberStatus.ACTIVE,
+        createdAt = NOW,
+        lastSeenAt = NOW,
+    ),
+    isOwner = false,
+    scopes = emptyList(),
+    scopesKnown = true,
+    manageable = true,
+)
+
+private const val NOW = 1_700_000_000_000L
+
+/** U+202E before the tail: the row draws as another account unless it is filtered. */
+private const val SPOOFED = "alice\u202Ebob"
+
+private const val FLATTENED = "alicebob"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeNameTest.kt
@@ -1,0 +1,42 @@
+package app.skerry.ui.teams
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+
+/**
+ * The name of a share space, drawn where the team screen lists them.
+ *
+ * A scope is named by whoever created it and the name reaches every member through the server,
+ * which never inspects it: the chip that says which space the records below belong to is the one
+ * line telling a shared production space from a shared staging one, and a bidi override in it
+ * reverses exactly that.
+ *
+ * Written as escapes, never as the characters themselves.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TeamScopeNameTest {
+
+    @Test
+    fun `a scope chip draws its peer-authored name flattened`() = runForm({
+        ScopeSection(
+            scopes = listOf(TeamScopeUi(id = "s1", name = SPOOFED, memberCount = 2, hasKey = true)),
+            selected = "s1",
+            canManage = false,
+            onSelect = {},
+            onNew = {},
+            onAccess = {},
+            onDelete = {},
+        )
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+}
+
+/** U+202E before the tail: the chip draws as `prod-gnigats`'s mirror unless it is filtered. */
+private const val SPOOFED = "prod-\u202Egnigats"
+
+private const val FLATTENED = "prod-gnigats"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowLabelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowLabelTest.kt
@@ -1,0 +1,138 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.host.Host
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.design.MAX_UNTRUSTED_LABEL_CHARS
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.seededHosts
+import app.skerry.ui.host.HostDragState
+import app.skerry.ui.host.HostSection
+import kotlin.test.Test
+
+/**
+ * What a host row draws when the profile was written by a team member rather than on this machine.
+ *
+ * A shared host travels inside the sealed envelope, so the sync server never sees its name and
+ * could not validate it if it wanted to: whatever the peer typed is what the row draws. A bidi
+ * override reverses the tail of the string in every layout — the fixture below is drawn as
+ * `web-01` while the profile it opens is a different one — and the zero-width formatters make two
+ * names that differ nowhere the eye can reach.
+ *
+ * Written as escapes, never as the characters themselves: they are invisible in a diff, and a
+ * reviewer could not tell the fixture from the expectation.
+ */
+@OptIn(ExperimentalTestApi::class)
+class HostRowLabelTest {
+
+    @Test
+    fun `a bidi override in a shared host name is dropped from the team row`() = runForm({
+        TeamHostRow(host(label = SPOOFED), FontFamily.Monospace)
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    /** Two names that differ only by an invisible character must not draw as the same row. */
+    @Test
+    fun `the zero-width formatters go too`() = runForm({
+        TeamHostRow(host(label = "db\u200B-mas\u200Dter"), FontFamily.Monospace)
+    }) {
+        onNodeWithText("db-master").assertIsDisplayed()
+    }
+
+    /** The recent-connections row draws the same peer-authored string. */
+    @Test
+    fun `a recent row flattens the name as well`() = runForm({
+        RecentHostRow(host(label = SPOOFED), FontFamily.Monospace)
+    }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    /** And the catalog row — the third drawing of the same string, and the one #227 named. */
+    @Test
+    fun `the catalog row flattens the name as well`() = runForm({ CatalogRow(host(label = SPOOFED)) }) {
+        onNodeWithText(FLATTENED).assertIsDisplayed()
+        onNodeWithText(SPOOFED).assertDoesNotExist()
+    }
+
+    /**
+     * A name made only of what the filter drops leaves nothing to draw, and a row with no name is
+     * one neither the eye nor a screen reader can tell from its neighbour.
+     */
+    @Test
+    fun `a name that filters away falls back to the address`() = runForm({
+        CatalogRow(host(label = "\u202E\u200B", address = "10.0.0.5"))
+    }) {
+        onNodeWithText("10.0.0.5").assertIsDisplayed()
+    }
+
+    /** Both fields hostile: the id is ours, so it is what is left to tell two rows apart. */
+    @Test
+    fun `a profile with nothing drawable left falls back to its id`() = runForm({
+        CatalogRow(Host(id = "h-shared-4f2a91", label = "\u202E", address = "\u200B", port = 22, username = ""))
+    }) {
+        onNodeWithText("h-shared").assertIsDisplayed()
+    }
+
+    /**
+     * The address line under the name is peer-authored too: it is assembled from the profile's own
+     * username and address, both typed by whoever shared it.
+     */
+    @Test
+    fun `the address line is flattened too`() = runForm({
+        TeamHostRow(host(label = "db-master", username = "ro\u202Eot"), FontFamily.Monospace)
+    }) {
+        onNodeWithText("root@10.0.0.5:22").assertIsDisplayed()
+    }
+
+    /** A name a hostile peer made pathologically long is cut, and never mid-character. */
+    @Test
+    fun `a long name is cut to the cap`() = runForm({
+        TeamHostRow(host(label = "o".repeat(5_000)), FontFamily.Monospace)
+    }) {
+        onNodeWithText("o".repeat(MAX_UNTRUSTED_LABEL_CHARS)).assertIsDisplayed()
+    }
+
+    /** An ordinary name is drawn exactly as the peer wrote it. */
+    @Test
+    fun `an ordinary name is left alone`() = runForm({
+        TeamHostRow(host(label = "Платформа · прод"), FontFamily.Monospace)
+    }) {
+        onNodeWithText("Платформа · прод").assertIsDisplayed()
+    }
+}
+
+/** The live sidebar row, with the collaborators it needs and nothing it does in this test. */
+@Composable
+private fun CatalogRow(host: Host) {
+    HostRow(
+        host = host,
+        state = DesktopDesignState(),
+        section = HostSection.Terminal,
+        controller = seededHosts(),
+        sessions = null,
+        connect = {},
+        mono = FontFamily.Monospace,
+        selectedHostId = null,
+        onSelectHost = {},
+        dragState = HostDragState(),
+        foldersProvider = { emptyList() },
+    )
+}
+
+private fun host(
+    label: String,
+    username: String = "root",
+    address: String = "10.0.0.5",
+): Host = Host(id = "h-shared", label = label, address = address, port = 22, username = username)
+
+/** U+202E before the tail: the row is drawn as `web-01`, the profile it opens is `web10-`. */
+private const val SPOOFED = "web\u202E10-"
+
+private const val FLATTENED = "web10-"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TeamSpaceLabelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TeamSpaceLabelTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.terminal
 
+import app.skerry.ui.design.MAX_UNTRUSTED_LABEL_CHARS
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -36,10 +37,10 @@ class TeamSpaceLabelTest {
         assertEquals("opsprod", spaceLabel("ops\u0000prod", fallback = FALLBACK))
     }
 
-    /** Cut before filtering: a pathologically long name is not scanned in full to be thrown away. */
+    /** A pathologically long name is cut, and not scanned past the bound the filter sets. */
     @Test
     fun `a name longer than the cap is cut to it`() {
-        assertEquals(MAX_SPACE_NAME_CHARS, spaceLabel("o".repeat(5_000), fallback = FALLBACK).length)
+        assertEquals(MAX_UNTRUSTED_LABEL_CHARS, spaceLabel("o".repeat(5_000), fallback = FALLBACK).length)
     }
 
     /**
@@ -48,9 +49,9 @@ class TeamSpaceLabelTest {
      */
     @Test
     fun `the cut is not made through a surrogate pair`() {
-        val name = "o".repeat(MAX_SPACE_NAME_CHARS - 1) + "\uD83D\uDE80"
+        val name = "o".repeat(MAX_UNTRUSTED_LABEL_CHARS - 1) + "\uD83D\uDE80"
         val label = spaceLabel(name, fallback = FALLBACK)
-        assertEquals(MAX_SPACE_NAME_CHARS - 1, label.length)
+        assertEquals(MAX_UNTRUSTED_LABEL_CHARS - 1, label.length)
         assertFalse(label.any { it.isSurrogate() }, "half of the emoji was left in the label")
     }
 

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -86,6 +86,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Caret and select-on-focus for a field whose value is a caller-owned `String` | `ui/design/FieldDraft`: `rememberFieldDraft` + `Modifier.fieldFocus`, told whether the field is masked and single-line so it applies the never-select rules itself; `rememberSeededDraft` for a find or filter bar, which selects its query only while it is the one the bar opened with. A field that owns its own `TextFieldValue` and selects on *open* (`PathJumpField`, `TerminalSearchBar`) is the other, deliberate shape — don't hand-roll a third |
 | Tunnel/snippet form state (desktop and mobile) | `TunnelFormState`, `SnippetFormState` |
 | Secret display | `VaultPresentation.secretStyle` |
+| One line of text a server or a team member wrote | `ui/design/UntrustedText`: `untrustedLabel` (row names, host labels, team and space names, container and metric rows) and `sanitizeServerText` for the longer multi-line kind (a prompt, a failure reason). Cap, drop the control and format characters, cut without splitting a surrogate pair. A profile's own free-form note keeps its lines: same helper, `sanitizeServerText(note, MAX_NOTE_CHARS, allowNewlines = true)`. Don't write a fourth variant — `spaceLabel`, `Host.rowLabel` and `HostMetrics.hostText` are all this one |
 | Terminal screen state (incl. scrollback search) | `ui/terminal/TerminalScreenState` |
 | Tiled session panes (split/resize/navigate) | `ui/session/PaneLayout` |
 | Remote-desktop screen | `ui/remote/RemoteDesktopController`, `RemoteDesktopScreenState` |


### PR DESCRIPTION
Text a server or a team member wrote reached the screen exactly as written. A bidi override reverses the tail of a line in every layout, so a file name ending in `.exe` draws as one ending in `.png`, and the row is what the user clicks to download or open. Zero-width formatters make two different names draw as one. A shared host profile travels inside the sealed envelope, so the sync server never sees its name and cannot validate it.

## The filter

`ui/design/UntrustedText` is the single implementation for this class of string:

- `sanitizeServerText(text, maxChars, allowNewlines)` — moved here from the keyboard-interactive dialog, which had the only complete version. Caps the result, drops control and format characters and the letters that draw nothing (Hangul fillers, braille blank), collapses runs, trims, and cuts without splitting a surrogate pair. The scan is bounded by input length as well, so a name padded with a million zero-width spaces costs no more than a name of the same drawn length.
- `untrustedLabel(raw, maxChars)` — the one-line form, used wherever a name identifies something.
- `ui/files/DisplayName` — `fileDisplayName` and `fileDisplayPath` for listings, with the localized stand-in a name that filters away falls back to, so a row and the confirmation opened from it always name the same thing.

`spaceLabel`, `Host.rowLabel`/`rowSubtitle`, `connectionSubtitle` and `HostMetrics.hostText` all route through it; the three hand-rolled variants and the duplicated overwrite dialog are gone.

`Host.rowLabel()` falls back label → address → short id, each filtered, so a row is never nameless.

## Where it applies

Desktop and Android alike: SFTP listings and their delete / copy / move / overwrite confirmations, the transfer strip, the file editor and its dialogs, drawn paths and breadcrumbs, host rows, session and tab titles, the password and production-guard dialogs, team and share-space names, shared records, member account ids, the activity feed, tunnel and jump-host pickers, container listings, host metrics, the VNC desktop name.

Editable values stay raw, because they are submitted rather than read: the rename field, the path editor, the connection form. The download picker is seeded through `safeDownloadName`, which drops the directory part before filtering.

## Deliberately not done

- The display predicate `isSafeDisplayChar` keeps zero-width joiners on purpose — right for prose the app only shows, wrong for a label, where a character that renders as nothing is exactly the one that must not survive.
- Homoglyph collisions are out of reach for a client; the filter closes the reordering and invisible-character classes and the KDoc says so rather than claiming more.

## Tests

`kotlin.test` on JUnit 5, fixtures written as escapes so they are visible in a diff. Unit coverage of the filter (bidi, zero-width, invisible letters, controls, cap, surrogate-safe cut, scan bound, idempotence, blank fallbacks) plus render tests pinning the sinks: host rows and the fallback ladder, the SFTP listing and its dialogs, both password prompts, the production-guard dialog, team member, role and scope names, and the Android listing.

## Verified

`./gradlew test allTests`, `build`, `detektAll` and `:androidApp:compileDebugKotlin` are green. Not verified on a live device, a live server, or another OS.

Closes #227
