### PR TITLE
Keep the gate green across a commit that deletes or renames a file

### DIFF
--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -124,6 +124,35 @@ class TestDigest(SandboxCase):
         self.assertEqual(before, state.tree_digest("all", self.cwd),
                          "committing changes HEAD, not content — a gated tree stays gated")
 
+    def test_committing_a_deletion_does_not_invalidate(self):
+        self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
+        self.box.write("shared/src/commonMain/kotlin/B.kt", "val b = 1\n")
+        self.box.commit("two files")
+        os.remove(os.path.join(self.cwd, "shared/src/commonMain/kotlin/B.kt"))
+        before = state.tree_digest("all", self.cwd)
+        self.box.commit("drop one")
+        self.assertEqual(before, state.tree_digest("all", self.cwd),
+                         "a deleted file is gone either way — the commit only records that")
+
+    def test_committing_a_rename_does_not_invalidate(self):
+        self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
+        self.box.commit("one file")
+        os.remove(os.path.join(self.cwd, "shared/src/commonMain/kotlin/A.kt"))
+        self.box.write("shared/src/commonMain/kotlin/Moved.kt", "val a = 1\n")
+        before = state.tree_digest("all", self.cwd)
+        self.box.commit("move it")
+        self.assertEqual(before, state.tree_digest("all", self.cwd),
+                         "the hole this closes: a gate green before the commit reopened after it")
+
+    def test_deleting_a_file_still_invalidates(self):
+        self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
+        self.box.write("shared/src/commonMain/kotlin/B.kt", "val b = 1\n")
+        self.box.commit("two files")
+        before = state.tree_digest("all", self.cwd)
+        os.remove(os.path.join(self.cwd, "shared/src/commonMain/kotlin/B.kt"))
+        self.assertNotEqual(before, state.tree_digest("all", self.cwd),
+                            "deleting code is an edit like any other")
+
     def test_revert_restores_the_digest(self):
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
         original = state.tree_digest("all", self.cwd)

--- a/tools/harness/state.py
+++ b/tools/harness/state.py
@@ -108,8 +108,15 @@ def is_test(path: str) -> bool:
     return any(marker in path for marker in TEST_MARKERS)
 
 
-def _hash_file(root: str, path: str) -> str:
-    """Git's own blob id for a file on disk.
+class _Absent:
+    """Sentinel for a path that is tracked but no longer on disk. Not a content id."""
+
+
+ABSENT = _Absent()
+
+
+def _hash_file(root: str, path: str) -> str | _Absent:
+    """Git's own blob id for a file on disk, or [ABSENT] if it is no longer there.
 
     It has to be git's, not just any hash: entries from the index arrive as blob ids, and a file
     that keeps its content while moving from untracked to tracked must keep its content id too.
@@ -121,7 +128,7 @@ def _hash_file(root: str, path: str) -> str:
         header = f"blob {len(data)}\0".encode()
         return hashlib.sha1(header + data).hexdigest()
     except OSError:
-        return "absent"  # deleted in the worktree — a change like any other
+        return ABSENT
 
 
 def worktree_entries(cwd: str | None = None) -> dict[str, str]:
@@ -148,8 +155,17 @@ def worktree_entries(cwd: str | None = None) -> dict[str, str]:
         if code != 0:
             continue
         for path in out.split("\0"):
-            if path:
-                entries[path] = _hash_file(root, path)
+            if not path:
+                continue
+            content_id = _hash_file(root, path)
+            # A file deleted in the worktree is dropped rather than recorded as missing: after the
+            # commit the path leaves the index entirely, so recording it either way would make the
+            # commit look like an edit — the same hole a non-git hash used to open, one step later.
+            # Deleting still moves the digest, because the path stops being in the set at all.
+            if content_id is ABSENT:
+                entries.pop(path, None)
+            else:
+                entries[path] = content_id
     return entries
 
 


### PR DESCRIPTION
A path deleted in the worktree was recorded in the tree digest as the literal `"absent"`. After the commit that path leaves the index entirely, so the same content produced two different digests: every stage and the whole reviewer fan-out reopened on `git commit` — the one thing the content digest exists to avoid. On the branch for #227 that cost a full re-run of the gate and a deliberate override, because its diff renamed a test file.

A deleted path is now dropped from the entry set instead of being recorded as missing. Deleting a file still moves the digest, because the path stops being in the set at all; what no longer moves it is committing that deletion.

Three cases in `tools/harness/selftest.py`: a committed deletion and a committed rename keep the digest, and a deletion on its own still changes it — the last one guards against fixing this by ignoring deletions altogether.

Verified: `python3 tools/harness/selftest.py` — 75 tests, green. Both new cases fail against the previous `state.py`.