### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.3.1
-skerry.versionCode=10
+skerry.versionName=0.3.2
+skerry.versionCode=11

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.1"
+version = "0.3.2"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.1"
+version = "0.3.2"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Bump client and server version from 0.3.1 to 0.3.2.

Files changed:
- `gradle.properties` — `skerry.versionName` 0.3.1 → 0.3.2, `skerry.versionCode` 10 → 11
- `server/build.gradle.kts` — `version` 0.3.1 → 0.3.2
- `sync-wire/build.gradle.kts` — `version` 0.3.1 → 0.3.2