### PR TITLE
Interactive runbook steps, snippet variable charsets and choices, help dialogs

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -76,4 +76,10 @@
     <string name="qr_cancel">Отмена</string>
     <string name="command_clipped_partial">показано частично</string>
     <string name="command_clipped">показано частично · %1$d симв.</string>
+
+    <!-- Help dialogs (snippets / runbooks / vault) -->
+    <string name="help_button">Справка</string>
+    <string name="help_close">Закрыть</string>
+    <string name="help_add">Добавить</string>
+    <string name="help_added">Добавлено</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -282,4 +282,17 @@
     <string name="lib_teams_runbook_steps">шагов: %1$d</string>
     <string name="lib_teams_record_runbook">сценарий</string>
     <string name="lib_teams_scope_access_unknown">Список доступа не получен — сервер не ответил</string>
+
+    <!-- Snippets help dialog -->
+    <string name="lib_snippets_help_title">Сниппеты</string>
+    <string name="lib_snippets_help_intro">Сниппет — одна команда, отправляемая в активную сессию. Плейсхолдеры ${{…}} раскрываются при запуске; подтверждение показывает точную строку до отправки.</string>
+    <string name="lib_snippets_help_vars">Переменные</string>
+    <string name="lib_snippets_help_var_date">дата, время и Unix-время запуска; токены формата после двоеточия (YYYY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_uuid">случайный UUID</string>
+    <string name="lib_snippets_help_var_random">случайные символы; длина и набор после двоеточия — alnum, hex или special; неизвестное имя откатывается к набору по умолчанию</string>
+    <string name="lib_snippets_help_var_clipboard">системный буфер обмена, читается один раз при подтверждении</string>
+    <string name="lib_snippets_help_var_vault">пароль из хранилища по имени записи</string>
+    <string name="lib_snippets_help_var_param">любое другое имя запрашивает значение перед запуском; часть после двоеточия — предзаполненное значение</string>
+    <string name="lib_snippets_help_var_choices">варианты через | превращаются в список выбора; первый — значение по умолчанию</string>
+    <string name="lib_snippets_help_examples">Примеры</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
@@ -26,8 +26,11 @@
     <string name="runbook_step_down">Ниже</string>
     <string name="runbook_step_confirm">Спрашивать перед запуском</string>
     <string name="runbook_step_continue_on_error">Продолжать при ошибке</string>
+    <string name="runbook_step_interactive">Интерактивный</string>
     <string name="runbook_save">Сохранить</string>
     <string name="runbook_delete">Удалить</string>
+    <string name="runbook_delete_title">Удалить раннбук</string>
+    <string name="runbook_delete_message">«%1$s» и история его прогонов будут удалены.</string>
     <string name="runbook_run">Запустить</string>
     <string name="runbook_run_title">Запуск сценария</string>
     <string name="runbook_run_needs_session">Сначала подключитесь — сценарий выполняется в терминале.</string>
@@ -43,6 +46,7 @@
     <string name="runbook_panel_failed">Остановлен из-за ошибки</string>
     <string name="runbook_panel_stopped">Остановлен</string>
     <string name="runbook_panel_run_step">Выполнить шаг</string>
+    <string name="runbook_panel_complete_step">Завершить шаг</string>
     <string name="runbook_panel_skip_step">Пропустить</string>
     <string name="runbook_panel_stop">Остановить</string>
     <string name="runbook_panel_close">Закрыть</string>
@@ -101,6 +105,7 @@
     <string name="runbook_status_skipped">пропущен</string>
     <string name="runbook_status_stopped">остановлен</string>
     <string name="runbook_status_confirm">нужно подтверждение</string>
+    <string name="runbook_status_interactive">интерактивный — завершите сами</string>
     <string name="runbook_dur_seconds">%1$s с</string>
     <string name="runbook_dur_minutes">%1$d мин %2$d с</string>
     <string name="runbook_transfer_of">%1$s из %2$s</string>
@@ -110,4 +115,13 @@
     <string name="runbook_history_empty">Прогонов ещё не было</string>
     <string name="runbook_history_failed_at">сбой на шаге %1$d</string>
     <string name="runbook_history_last">последний прогон %1$s</string>
+
+    <!-- Runbooks help dialog -->
+    <string name="runbook_help_title">Раннбуки</string>
+    <string name="runbook_help_intro">Раннбук — упорядоченная процедура, выполняемая в шелле одной сессии, шаг за шагом. Коды выхода решают, как продолжается прогон; значения ${{…}} собираются один раз на старте и общие для всех шагов.</string>
+    <string name="runbook_help_flags">Параметры шага</string>
+    <string name="runbook_help_flag_confirm">пауза перед шагом, пока вы его не подтвердите</string>
+    <string name="runbook_help_flag_continue">ошибка фиксируется, прогон продолжается</string>
+    <string name="runbook_help_flag_interactive">строка отправляется как есть, шаг завершаете вы сами — для TUI-программ и меню, удерживающих терминал</string>
+    <string name="runbook_help_examples">Примеры</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -176,4 +176,14 @@
     <string name="vault_meta_rotated">сменён %1$s</string>
     <string name="vault_meta_valid_until">действует до %1$s</string>
     <string name="vault_kv_changed">Изменён</string>
+
+    <!-- Vault help dialog -->
+    <string name="vault_help_title">Хранилище</string>
+    <string name="vault_help_intro">Учётные данные подключений, зашифрованные мастер-паролем. Синхронизация переносит только зашифрованные записи.</string>
+    <string name="vault_help_categories">Категории</string>
+    <string name="vault_help_keys">создаются здесь или подключаются из файла; используются для входа на хосты</string>
+    <string name="vault_help_passwords">пароли хостов и учёток; копирования фиксируются в журнале использования</string>
+    <string name="vault_help_certificates">SSH-сертификаты, импортированные из файлов, в паре с ключом</string>
+    <string name="vault_help_snippets">В сниппетах</string>
+    <string name="vault_help_snippets_hint">сниппет или шаг раннбука ссылается на сохранённый пароль по имени записи; во всех превью он маскируется</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings.xml
@@ -76,4 +76,10 @@
     <string name="qr_cancel">取消</string>
     <string name="command_clipped_partial">仅显示部分</string>
     <string name="command_clipped">仅显示部分 · %1$d 字符</string>
+
+    <!-- Help dialogs (snippets / runbooks / vault) -->
+    <string name="help_button">帮助</string>
+    <string name="help_close">关闭</string>
+    <string name="help_add">添加</string>
+    <string name="help_added">已添加</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -279,4 +279,17 @@
     <string name="lib_teams_runbook_steps">%1$d 步</string>
     <string name="lib_teams_record_runbook">运行手册</string>
     <string name="lib_teams_scope_access_unknown">无法获取访问列表 — 服务器未响应</string>
+
+    <!-- Snippets help dialog -->
+    <string name="lib_snippets_help_title">代码片段</string>
+    <string name="lib_snippets_help_intro">片段是发送到当前会话的一条命令。${{…}} 占位符在运行时解析；确认框会在发送前显示确切的命令行。</string>
+    <string name="lib_snippets_help_vars">变量</string>
+    <string name="lib_snippets_help_var_date">运行时的日期、时间和 Unix 时间戳；冒号后为格式标记（YYYY、MM、DD、HH、mm、ss）</string>
+    <string name="lib_snippets_help_var_uuid">随机 UUID</string>
+    <string name="lib_snippets_help_var_random">随机字符；冒号后为长度和字符集 — alnum、hex 或 special；未知名称回退到默认字符集</string>
+    <string name="lib_snippets_help_var_clipboard">系统剪贴板，确认时读取一次</string>
+    <string name="lib_snippets_help_var_vault">按条目名称取保险库中的密码</string>
+    <string name="lib_snippets_help_var_param">其他任意名称会在运行前询问取值；冒号后的部分为预填默认值</string>
+    <string name="lib_snippets_help_var_choices">用 | 分隔的选项会变成选择列表；第一项为默认值</string>
+    <string name="lib_snippets_help_examples">示例</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
@@ -26,8 +26,11 @@
     <string name="runbook_step_down">下移</string>
     <string name="runbook_step_confirm">运行前询问</string>
     <string name="runbook_step_continue_on_error">失败后继续</string>
+    <string name="runbook_step_interactive">交互式</string>
     <string name="runbook_save">保存</string>
     <string name="runbook_delete">删除</string>
+    <string name="runbook_delete_title">删除运行手册</string>
+    <string name="runbook_delete_message">“%1$s”及其运行历史将被删除。</string>
     <string name="runbook_run">运行</string>
     <string name="runbook_run_title">运行运行手册</string>
     <string name="runbook_run_needs_session">请先建立会话 — 运行手册在终端中执行。</string>
@@ -43,6 +46,7 @@
     <string name="runbook_panel_failed">因失败而停止</string>
     <string name="runbook_panel_stopped">已停止</string>
     <string name="runbook_panel_run_step">执行此步骤</string>
+    <string name="runbook_panel_complete_step">完成步骤</string>
     <string name="runbook_panel_skip_step">跳过</string>
     <string name="runbook_panel_stop">停止运行</string>
     <string name="runbook_panel_close">关闭</string>
@@ -95,6 +99,7 @@
     <string name="runbook_status_skipped">已跳过</string>
     <string name="runbook_status_stopped">已停止</string>
     <string name="runbook_status_confirm">待确认</string>
+    <string name="runbook_status_interactive">交互式——请手动完成</string>
     <string name="runbook_dur_seconds">%1$s 秒</string>
     <string name="runbook_dur_minutes">%1$d 分 %2$d 秒</string>
     <string name="runbook_transfer_of">%1$s / %2$s</string>
@@ -104,4 +109,13 @@
     <string name="runbook_history_empty">尚无运行记录</string>
     <string name="runbook_history_failed_at">第 %1$d 步失败</string>
     <string name="runbook_history_last">上次运行 %1$s</string>
+
+    <!-- Runbooks help dialog -->
+    <string name="runbook_help_title">运行手册</string>
+    <string name="runbook_help_intro">运行手册是在同一会话的 shell 中按顺序逐步执行的过程。退出码决定运行如何继续；${{…}} 的取值在开始时收集一次，供所有步骤共用。</string>
+    <string name="runbook_help_flags">步骤选项</string>
+    <string name="runbook_help_flag_confirm">在该步骤前暂停，直到你批准</string>
+    <string name="runbook_help_flag_continue">记录失败并继续运行</string>
+    <string name="runbook_help_flag_interactive">命令按原样发送，由你手动完成该步骤 — 适用于占住终端的 TUI 程序和菜单</string>
+    <string name="runbook_help_examples">示例</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -170,4 +170,14 @@
     <string name="vault_meta_rotated">%1$s 轮换</string>
     <string name="vault_meta_valid_until">有效期至 %1$s</string>
     <string name="vault_kv_changed">更改于</string>
+
+    <!-- Vault help dialog -->
+    <string name="vault_help_title">保险库</string>
+    <string name="vault_help_intro">连接所用的凭据，以主密码加密存储。同步只传输加密记录。</string>
+    <string name="vault_help_categories">类别</string>
+    <string name="vault_help_keys">在此生成或从文件链接；用于主机身份验证</string>
+    <string name="vault_help_passwords">主机和账号密码；复制操作会记入使用日志</string>
+    <string name="vault_help_certificates">从文件导入的 SSH 证书，与密钥配对</string>
+    <string name="vault_help_snippets">在片段中</string>
+    <string name="vault_help_snippets_hint">片段或运行手册步骤按条目名称引用已存密码；在所有预览中均以掩码显示</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -77,4 +77,10 @@
     <string name="qr_cancel">Cancel</string>
     <string name="command_clipped_partial">shown in part</string>
     <string name="command_clipped">shown in part · %1$d chars</string>
+
+    <!-- Help dialogs (snippets / runbooks / vault) -->
+    <string name="help_button">Help</string>
+    <string name="help_close">Close</string>
+    <string name="help_add">Add</string>
+    <string name="help_added">Added</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -281,4 +281,17 @@
     <string name="lib_teams_runbook_steps">%1$d steps</string>
     <string name="lib_teams_record_runbook">runbook</string>
     <string name="lib_teams_scope_access_unknown">Access list unavailable — the server did not answer</string>
+
+    <!-- Snippets help dialog -->
+    <string name="lib_snippets_help_title">Snippets</string>
+    <string name="lib_snippets_help_intro">A snippet is one command sent to the active session. ${{…}} placeholders resolve when it runs; the confirmation shows the exact line before anything is sent.</string>
+    <string name="lib_snippets_help_vars">Variables</string>
+    <string name="lib_snippets_help_var_date">date, time and Unix timestamp of the run; format tokens after a colon (YYYY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_uuid">random UUID</string>
+    <string name="lib_snippets_help_var_random">random characters; length and charset after the colon — alnum, hex or special; an unknown name falls back to the default set</string>
+    <string name="lib_snippets_help_var_clipboard">system clipboard, read once at the confirmation</string>
+    <string name="lib_snippets_help_var_vault">password from the vault, by entry name</string>
+    <string name="lib_snippets_help_var_param">any other name asks for a value before the run; the part after the colon is the prefilled default</string>
+    <string name="lib_snippets_help_var_choices">options separated by | become a list to pick from; the first is the default</string>
+    <string name="lib_snippets_help_examples">Examples</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
@@ -26,8 +26,11 @@
     <string name="runbook_step_down">Move down</string>
     <string name="runbook_step_confirm">Ask before running</string>
     <string name="runbook_step_continue_on_error">Keep going if it fails</string>
+    <string name="runbook_step_interactive">Interactive</string>
     <string name="runbook_save">Save</string>
     <string name="runbook_delete">Delete</string>
+    <string name="runbook_delete_title">Delete runbook</string>
+    <string name="runbook_delete_message">“%1$s” and its run history will be deleted.</string>
     <string name="runbook_run">Run</string>
     <string name="runbook_run_title">Run runbook</string>
     <string name="runbook_run_needs_session">Connect a session first — a runbook runs in a terminal.</string>
@@ -43,6 +46,7 @@
     <string name="runbook_panel_failed">Stopped on a failure</string>
     <string name="runbook_panel_stopped">Stopped</string>
     <string name="runbook_panel_run_step">Run this step</string>
+    <string name="runbook_panel_complete_step">Complete step</string>
     <string name="runbook_panel_skip_step">Skip</string>
     <string name="runbook_panel_stop">Stop run</string>
     <string name="runbook_panel_close">Close</string>
@@ -97,6 +101,7 @@
     <string name="runbook_status_skipped">skipped</string>
     <string name="runbook_status_stopped">stopped</string>
     <string name="runbook_status_confirm">needs a go-ahead</string>
+    <string name="runbook_status_interactive">interactive — complete it yourself</string>
     <string name="runbook_dur_seconds">%1$s s</string>
     <string name="runbook_dur_minutes">%1$d m %2$d s</string>
     <string name="runbook_transfer_of">%1$s of %2$s</string>
@@ -106,4 +111,13 @@
     <string name="runbook_history_empty">No runs yet</string>
     <string name="runbook_history_failed_at">failed at step %1$d</string>
     <string name="runbook_history_last">last run %1$s</string>
+
+    <!-- Runbooks help dialog -->
+    <string name="runbook_help_title">Runbooks</string>
+    <string name="runbook_help_intro">A runbook is an ordered procedure run in one session's shell, one step at a time. Exit codes decide how the run continues; ${{…}} values are collected once at start and shared by every step.</string>
+    <string name="runbook_help_flags">Step options</string>
+    <string name="runbook_help_flag_confirm">pauses before the step until you approve it</string>
+    <string name="runbook_help_flag_continue">a failure is recorded and the run continues</string>
+    <string name="runbook_help_flag_interactive">the line is sent as-is and you finish the step yourself — for TUI programs and menus that hold the terminal</string>
+    <string name="runbook_help_examples">Examples</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -178,4 +178,14 @@
     <string name="vault_meta_rotated">rotated %1$s</string>
     <string name="vault_meta_valid_until">valid until %1$s</string>
     <string name="vault_kv_changed">Changed</string>
+
+    <!-- Vault help dialog -->
+    <string name="vault_help_title">Vault</string>
+    <string name="vault_help_intro">Credentials for connections, stored encrypted under the master password. Sync moves only encrypted records.</string>
+    <string name="vault_help_categories">Categories</string>
+    <string name="vault_help_keys">generated here or linked from a file; used to authenticate to hosts</string>
+    <string name="vault_help_passwords">host and login passwords; copies are recorded in the usage log</string>
+    <string name="vault_help_certificates">SSH certificates imported from files, paired with a key</string>
+    <string name="vault_help_snippets">In snippets</string>
+    <string name="vault_help_snippets_hint">a snippet or runbook step references a stored password by entry name; it is masked in every preview</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
@@ -60,6 +60,10 @@ object UiTags {
     const val NEW_GROUP: String = "nav.newGroup"
     const val NEW_RUNBOOK: String = "nav.newRunbook"
 
+    /** Help button in a library screen's header and the dialog it opens (one screen at a time). */
+    const val HELP: String = "nav.help"
+    const val HELP_DIALOG: String = "nav.helpDialog"
+
     /**
      * Command box of a runbook step. The steps are a repeating list, not captioned fields, so there
      * is no label to name them after; the tag repeats per step, in step order.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DropdownField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DropdownField.kt
@@ -57,11 +57,16 @@ fun <T> DropdownField(
     )
 }
 
-/** Layout select trigger: value on the left, chevron on the right (clickable, opens the dropdown). */
+/**
+ * Layout select trigger: value on the left, chevron on the right (clickable, opens the dropdown).
+ * Carries [fieldValueName] itself: inside a captioned [FormField] a screen reader would otherwise
+ * announce only the picked value, never the field's name — and every call site would have to
+ * remember the fix by hand (two already did, on their own custom triggers).
+ */
 @Composable
 fun SelectTrigger(value: String, onClick: () -> Unit) {
     Row(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).clickable(onClick = onClick).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp),
+        Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).fieldValueName(value).clickable(onClick = onClick).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/HelpDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/HelpDialog.kt
@@ -1,0 +1,126 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.theme.Skerry
+
+/**
+ * Help modal for a library screen (snippets, runbooks, vault): a titled card with scrollable
+ * guidance content and a single Close control. Content rows come from the callers —
+ * [HelpCodeRow] for a syntax entry, [HelpExampleRow] for a template offered with a one-click
+ * create. Built the way [app.skerry.ui.runbook.RunbookStartDialog] is (scrim + card), because
+ * [ConfirmActionDialog]/[NoticeDialog] are title+message shapes without room for a list.
+ */
+@Composable
+fun HelpDialog(title: String, closeLabel: String, onDismiss: () -> Unit, content: @Composable ColumnScope.() -> Unit) {
+    ModalScrim(onDismiss = onDismiss) {
+        Column(
+            Modifier
+                .widthIn(max = 720.dp)
+                .fillMaxWidth()
+                .padding(20.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Skerry.colors.surfaceDeep)
+                .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(12.dp))
+                .consumeClicks()
+                .padding(26.dp)
+                .testTag(UiTags.HELP_DIALOG),
+        ) {
+            Txt(title, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+            // Sized against the viewport, not a fixed cap: on a short screen (landscape phone) a
+            // fixed content height would push the Close row past the edge with no way to reach it.
+            // weight(fill = false) lets short content stay short and long content stop where the
+            // title and the button row still fit.
+            Column(
+                Modifier.weight(1f, fill = false).verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+            ) { content() }
+            Row(Modifier.fillMaxWidth().padding(top = 16.dp), horizontalArrangement = Arrangement.End) {
+                GhostButton(closeLabel, onClick = onDismiss)
+            }
+        }
+    }
+}
+
+/** One syntax entry: the placeholder itself in mono, what it does beside it. */
+@Composable
+fun HelpCodeRow(code: String, description: String) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(
+            code, color = Skerry.colors.cyanBright, size = 11.5.sp, font = LocalFonts.current.mono,
+            modifier = Modifier
+                .clip(RoundedCornerShape(5.dp))
+                .background(Skerry.colors.terminalBg)
+                .padding(horizontal = 7.dp, vertical = 3.dp),
+        )
+        Txt(description, color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 15.sp, modifier = Modifier.weight(1f))
+    }
+}
+
+/**
+ * One offered template: name, its command line (or step summary) and a create button. [added]
+ * flips the button into an inert "done" state — the dialog stays open so the rest can be added,
+ * and a double click must not save the same template twice.
+ */
+@Composable
+fun HelpExampleRow(
+    label: String,
+    detail: String,
+    addLabel: String,
+    addedLabel: String,
+    added: Boolean,
+    onAdd: () -> Unit,
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(Skerry.colors.card)
+            .border(1.dp, Skerry.colors.line, RoundedCornerShape(8.dp))
+            .padding(horizontal = 11.dp, vertical = 9.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Txt(label, color = Skerry.colors.text, size = 12.sp, weight = FontWeight.Medium)
+            Txt(
+                detail, color = Skerry.colors.faint, size = 10.5.sp, font = LocalFonts.current.mono,
+                lineHeight = 14.sp, modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+        Box(Modifier.align(Alignment.CenterVertically)) {
+            ChipButton(
+                label = if (added) addedLabel else addLabel,
+                color = if (added) Skerry.colors.moss else Skerry.colors.cyan,
+                onClick = onAdd,
+                enabled = !added,
+                icon = if (added) "check" else "add",
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/UntrustedText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/UntrustedText.kt
@@ -93,7 +93,9 @@ private enum class ServerChar { Keep, Break, Space, Drop }
  * format characters, so nothing else drops them — a name made of them passes `isBlank()`, and a
  * quoted `curl\u2800evil.sh` reads as two words and runs as one.
  */
-internal val INVISIBLE_LETTERS = charArrayOf('\u115F', '\u1160', '\u3164', '\uFFA0', '\u2800')
+// One definition for the whole app: the shared sanitizers drop exactly this set, and two
+// hand-synced copies would drift invisibly (the characters render as nothing).
+internal val INVISIBLE_LETTERS: Set<Char> = app.skerry.shared.snippet.INVISIBLE_LETTERS
 
 private fun classifyServerChar(ch: Char, allowNewlines: Boolean): ServerChar = when {
     ch == '\n' && allowNewlines -> ServerChar.Break

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
@@ -52,6 +52,7 @@ import app.skerry.ui.session.SessionView
 import app.skerry.ui.session.broadcastTargets
 import app.skerry.ui.session.PaneSyncBinder
 import app.skerry.ui.session.SessionsController
+import app.skerry.ui.runbook.RunbookPauseAnnouncer
 import app.skerry.ui.runbook.RunbookStartDialog
 import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.snippet.SnippetRunDialog
@@ -506,6 +507,9 @@ internal fun DesktopChrome(
             // (Viewport); the mobile chrome shows the run in its floating panel instead.
             val runSessions = LocalSessions.current
             LocalRunbookRunner.current?.let { runner ->
+                // Composed here — before any run exists — so the announcer observes the flip into a
+                // pause instead of appearing together with it (see RunbookPauseAnnouncer).
+                RunbookPauseAnnouncer(runner)
                 RunbookStartDialog(runner) { runSessions?.setActiveView(SessionView.Runbook) }
             }
             // Delete-host-profile confirmation (invoked from the sidebar's context menu). The keychain

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
@@ -56,6 +56,7 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalRunbookRunner
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.runbook.RunbookRunPanel
+import app.skerry.ui.runbook.RunbookPauseAnnouncer
 import app.skerry.ui.runbook.RunbookStartDialog
 import app.skerry.ui.runbook.runInActiveTab
 import app.skerry.ui.snippet.SnippetRunDialog
@@ -289,6 +290,9 @@ internal fun MobileChrome(
                     )
                 }
                 RunbookStartDialog(runner)
+                // Composed here — before any run exists — so the announcer observes the flip into a
+                // pause instead of appearing together with it (see RunbookPauseAnnouncer).
+                RunbookPauseAnnouncer(runner)
             }
             // Recording player: an overlay over whatever screen is up, so a recording can be watched
             // from More without an open session (desktop toolbar parity).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileChrome.kt
@@ -47,7 +47,13 @@ import org.jetbrains.compose.resources.stringResource
  * each call site's prior behavior without visual changes.
  */
 @Composable
-internal fun MobilePushHeader(title: String, onBack: () -> Unit, plainBack: Boolean = false) {
+internal fun MobilePushHeader(
+    title: String,
+    onBack: () -> Unit,
+    plainBack: Boolean = false,
+    /** Drawn at the right edge — the help "?" on the library screens; most screens have none. */
+    actions: (@Composable () -> Unit)? = null,
+) {
     Row(
         Modifier.fillMaxWidth().padding(start = 12.dp, end = 12.dp, top = 2.dp, bottom = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -68,6 +74,10 @@ internal fun MobilePushHeader(title: String, onBack: () -> Unit, plainBack: Bool
             size = 27.sp, color = Skerry.colors.cyanBright, modifier = backModifier,
         )
         Txt(title, color = Skerry.colors.text, size = 18.sp, weight = FontWeight.Bold)
+        if (actions != null) {
+            Box(Modifier.weight(1f))
+            actions()
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileLockScreens.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileLockScreens.kt
@@ -374,7 +374,9 @@ private fun MobileLockField(
         onValueChange = onValueChange,
         singleLine = true,
         visualTransformation = PasswordVisualTransformation(),
-        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 15.sp, fontFamily = LocalFonts.current.ui),
+        // lineHeight pinned for the same reason as the desktop gate's LockPasswordField: without it
+        // the text sits high next to the taller icon and jumps when typing starts.
+        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 15.sp, fontFamily = LocalFonts.current.ui, lineHeight = 21.sp),
         cursorBrush = SolidColor(Skerry.colors.cyan),
         keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = KeyboardType.Password),
         keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }),
@@ -393,8 +395,8 @@ private fun MobileLockField(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Sym("lock", size = 19.sp, color = Skerry.colors.faint)
-                Box(Modifier.weight(1f)) {
-                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 15.sp)
+                Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 15.sp, lineHeight = 21.sp)
                     inner()
                 }
             }
@@ -415,7 +417,7 @@ private fun MobileLockPlainField(
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
-        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 15.sp, fontFamily = LocalFonts.current.ui),
+        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 15.sp, fontFamily = LocalFonts.current.ui, lineHeight = 21.sp),
         cursorBrush = SolidColor(Skerry.colors.cyan),
         // Confirm word is uppercase (RESET): disable autocorrect (otherwise the IME rewrites it to
         // "Reset" and the comparison never matches) and force uppercase capitalization.
@@ -436,8 +438,8 @@ private fun MobileLockPlainField(
                     .padding(horizontal = 14.dp, vertical = 14.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(Modifier.weight(1f)) {
-                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 15.sp)
+                Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 15.sp, lineHeight = 21.sp)
                     inner()
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileRunbooksView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileRunbooksView.kt
@@ -38,11 +38,16 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.MobileRoute
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.design.ConfirmActionDialog
+import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.runbook_delete
+import app.skerry.ui.generated.resources.runbook_delete_message
+import app.skerry.ui.generated.resources.runbook_delete_title
 import app.skerry.ui.generated.resources.runbook_empty_mobile
 import app.skerry.ui.generated.resources.runbook_new
 import app.skerry.ui.generated.resources.runbook_run
@@ -54,6 +59,7 @@ import app.skerry.ui.generated.resources.runbook_step_count
 import app.skerry.ui.generated.resources.runbook_untitled
 import app.skerry.ui.runbook.RunbookEditorFields
 import app.skerry.ui.runbook.RunbookEntry
+import app.skerry.ui.runbook.RunbookHelpDialog
 import app.skerry.ui.runbook.RunbookFormState
 import app.skerry.ui.runbook.RunbookManager
 import app.skerry.ui.runbook.runbookTarget
@@ -91,17 +97,24 @@ fun MobileRunbooksScreen(state: MobileDesignState) {
 
     var editing by remember { mutableStateOf<RunbookEntry?>(null) }
     var adding by remember { mutableStateOf(false) }
+    var helpOpen by remember { mutableStateOf(false) }
     val sheetOpen = adding || editing != null
+    val overlayOpen = sheetOpen || helpOpen
 
     // An open sheet hides the tab bar, which would otherwise float over the fields above the keyboard.
-    LaunchedEffect(sheetOpen) { state.modalOverlay(sheetOpen) }
+    LaunchedEffect(overlayOpen) { state.modalOverlay(overlayOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
 
     val runbooks = manager.runbooks
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
-            MobilePushHeader(stringResource(Res.string.runbook_section), onBack = state::pop)
+            MobilePushHeader(
+                stringResource(Res.string.runbook_section), onBack = state::pop,
+                actions = {
+                    GhostButton(stringResource(Res.string.help_button), onClick = { helpOpen = true }, icon = "help")
+                },
+            )
             if (runbooks.isEmpty()) {
                 Txt(
                     stringResource(Res.string.runbook_empty_mobile), color = Skerry.colors.faint, size = 13.sp,
@@ -121,7 +134,7 @@ fun MobileRunbooksScreen(state: MobileDesignState) {
             Spacer(Modifier.height(176.dp))
         }
 
-        if (!sheetOpen) {
+        if (!overlayOpen) {
             MobileFabButton(
                 onClick = { adding = true; editing = null },
                 modifier = Modifier.align(Alignment.BottomEnd).padding(end = 22.dp, bottom = 104.dp).testTag(UiTags.NEW_RUNBOOK),
@@ -158,6 +171,8 @@ fun MobileRunbooksScreen(state: MobileDesignState) {
                 },
             )
         }
+
+        if (helpOpen) RunbookHelpDialog(manager, onDismiss = { helpOpen = false })
     }
 }
 
@@ -210,6 +225,26 @@ private fun MobileRunbookEditSheet(
     // Shared form state (desktop <-> mobile): same fields, same validation, same draft assembly.
     val form = remember(entry) { RunbookFormState.fromEntry(entry) }
     val history = LocalRunbookHistory.current
+    var confirmDelete by remember { mutableStateOf(false) }
+
+    if (confirmDelete && entry != null) {
+        ConfirmActionDialog(
+            title = stringResource(Res.string.runbook_delete_title),
+            message = stringResource(
+                Res.string.runbook_delete_message,
+                entry.runbook.label.ifBlank { stringResource(Res.string.runbook_untitled) },
+            ),
+            confirmLabel = stringResource(Res.string.runbook_delete),
+            onConfirm = {
+                confirmDelete = false
+                manager.delete(entry.id)
+                // The runbook is gone; its run log has nothing left to belong to.
+                history?.forget(entry.id)
+                onDeleted()
+            },
+            onDismiss = { confirmDelete = false },
+        )
+    }
 
     MobileBottomSheet(onDismiss = onDismiss, maxHeightFraction = 0.92f) {
         Column(Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -233,14 +268,11 @@ private fun MobileRunbookEditSheet(
                     modifier = Modifier.fillMaxWidth().testTag(UiTags.FORM_SAVE),
                 )
                 if (entry != null) {
+                    // Held for confirmation: deleting a whole procedure silently is one misclick
+                    // away from losing it and its run history (desktop parity).
                     MobileSheetButton(
                         stringResource(Res.string.runbook_delete),
-                        onClick = {
-                            manager.delete(entry.id)
-                            // The runbook is gone; its run log has nothing left to belong to.
-                            history?.forget(entry.id)
-                            onDeleted()
-                        },
+                        onClick = { confirmDelete = true },
                         filled = false, danger = true, modifier = Modifier.fillMaxWidth(),
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.snippet.Snippet
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.snippet.SnippetHelpDialog
 import app.skerry.ui.snippet.SnippetDraft
 import app.skerry.ui.snippet.SnippetEntry
 import app.skerry.ui.snippet.SnippetFormState
@@ -42,6 +43,7 @@ import app.skerry.ui.snippet.installStarterPack
 import app.skerry.ui.snippet.matches
 import app.skerry.ui.snippet.snippetTagSuggestions
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.lib_snippets_add_tag
 import app.skerry.ui.generated.resources.lib_snippets_delete
 import app.skerry.ui.generated.resources.lib_snippets_edit
@@ -66,6 +68,7 @@ import app.skerry.ui.generated.resources.lib_snippets_search
 import app.skerry.ui.generated.resources.lib_snippets_untitled
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.ChipButton
+import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.app.LocalSnippets
@@ -111,10 +114,11 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
 
     var editing by remember { mutableStateOf<SnippetEntry?>(null) }
     var adding by remember { mutableStateOf(false) }
+    var helpOpen by remember { mutableStateOf(false) }
     var renamingTag by remember { mutableStateOf<String?>(null) }
     val editSheetOpen = adding || editing != null
     // Any sheet (edit or rename) hides the tab bar and the add FAB.
-    val sheetOpen = editSheetOpen || renamingTag != null
+    val sheetOpen = editSheetOpen || renamingTag != null || helpOpen
 
     // Open edit sheet hides the tab bar (otherwise it floats above the input fields over the keyboard).
     LaunchedEffect(sheetOpen) { state.modalOverlay(sheetOpen) }
@@ -126,7 +130,12 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
         Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
             // A push screen since the library left the tab bar (More → Snippets), so it carries a
             // back arrow instead of a bare title.
-            MobilePushHeader(stringResource(Res.string.lib_snippets_screen_title), onBack = state::pop)
+            MobilePushHeader(
+                stringResource(Res.string.lib_snippets_screen_title), onBack = state::pop,
+                actions = {
+                    GhostButton(stringResource(Res.string.help_button), onClick = { helpOpen = true }, icon = "help")
+                },
+            )
             if (snippets.isEmpty()) {
                 Column(
                     Modifier.fillMaxWidth().padding(horizontal = 22.dp, vertical = 30.dp),
@@ -193,6 +202,8 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
                 },
             )
         }
+
+        if (helpOpen) SnippetHelpDialog(manager, onDismiss = { helpOpen = false })
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -41,6 +41,7 @@ import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialUsage
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.vault_add_password
 import app.skerry.ui.generated.resources.vault_any_principal
 import app.skerry.ui.generated.resources.vault_badge_expired
@@ -80,6 +81,7 @@ import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.known.shortFingerprint
+import app.skerry.ui.vault.VaultHelpDialog
 import app.skerry.ui.vault.SecretCopyAuthorizer
 import app.skerry.ui.vault.SecretExport
 import app.skerry.ui.vault.privateKeyExport
@@ -183,6 +185,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
     var selectedId by remember { mutableStateOf<String?>(null) }
     var showGenerate by remember { mutableStateOf(false) }
+    var showHelp by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
     val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
@@ -200,7 +203,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     // writes the flag only on value change (not every list recomposition); DisposableEffect clears it
     // on leaving the tab so the tab bar isn't left hidden.
     val modalOpen = showGenerate || showAddPassword || showImportCert || showLinkKeyFile || pendingRename != null || pendingDelete != null ||
-        selectedCred != null || copyAuth.passwordPromptVisible || exportFailed
+        selectedCred != null || copyAuth.passwordPromptVisible || exportFailed || showHelp
     LaunchedEffect(modalOpen) { state.modalOverlay(modalOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
 
@@ -210,7 +213,12 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
 
     Box(Modifier.fillMaxSize()) {
         Column(Modifier.fillMaxSize().background(Skerry.colors.bg).verticalScroll(rememberScrollState())) {
-            MobilePushHeader(stringResource(Res.string.vault_title), onBack = state::pop, plainBack = true)
+            MobilePushHeader(
+                stringResource(Res.string.vault_title), onBack = state::pop, plainBack = true,
+                actions = {
+                    GhostButton(stringResource(Res.string.help_button), onClick = { showHelp = true }, icon = "help")
+                },
+            )
             MobileVaultSummary(allCreds.size)
             MobileCategoryPills(category, allCreds) { category = it; selectedId = null }
             MobileVaultAction(
@@ -245,6 +253,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
             Spacer(Modifier.height(96.dp))
         }
 
+        if (showHelp) VaultHelpDialog(onDismiss = { showHelp = false })
         if (showGenerate && generator != null) {
             GenerateKeyDialog(
                 onDismiss = { showGenerate = false },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookEditorFields.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookEditorFields.kt
@@ -60,6 +60,7 @@ import app.skerry.ui.generated.resources.runbook_step_add
 import app.skerry.ui.generated.resources.runbook_step_command
 import app.skerry.ui.generated.resources.runbook_step_confirm
 import app.skerry.ui.generated.resources.runbook_step_continue_on_error
+import app.skerry.ui.generated.resources.runbook_step_interactive
 import app.skerry.ui.generated.resources.runbook_step_down
 import app.skerry.ui.generated.resources.runbook_step_local
 import app.skerry.ui.generated.resources.runbook_step_n
@@ -231,6 +232,12 @@ private fun StepEditor(
         StepFlagRow(stringResource(Res.string.runbook_step_confirm), step.confirm) { step.confirm = !step.confirm }
         StepFlagRow(stringResource(Res.string.runbook_step_continue_on_error), step.continueOnError) {
             step.continueOnError = !step.continueOnError
+        }
+        // A transfer has no shell to hold, so the flag only exists on command rows.
+        if (step.kind == RunbookStepKind.COMMAND) {
+            StepFlagRow(stringResource(Res.string.runbook_step_interactive), step.interactive) {
+                step.interactive = !step.interactive
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookFormState.kt
@@ -32,6 +32,7 @@ class RunbookStepDraft internal constructor(
     direction: RunbookTransferDirection = RunbookTransferDirection.UPLOAD,
     confirm: Boolean = true,
     continueOnError: Boolean = false,
+    interactive: Boolean = false,
 ) {
     var kind: RunbookStepKind by mutableStateOf(kind)
     var title: String by mutableStateOf(title)
@@ -41,6 +42,9 @@ class RunbookStepDraft internal constructor(
     var direction: RunbookTransferDirection by mutableStateOf(direction)
     var confirm: Boolean by mutableStateOf(confirm)
     var continueOnError: Boolean by mutableStateOf(continueOnError)
+
+    /** Command rows only; a transfer has no shell to hold ([RunbookStep.Command.interactive]). */
+    var interactive: Boolean by mutableStateOf(interactive)
 
     /** Whether the row says what to do: a command line, or both ends of a transfer. */
     internal val filled: Boolean
@@ -56,6 +60,7 @@ class RunbookStepDraft internal constructor(
             command = command,
             confirm = confirm,
             continueOnError = continueOnError,
+            interactive = interactive,
         )
         RunbookStepKind.TRANSFER -> RunbookStep.Transfer(
             id = stepId,
@@ -165,6 +170,7 @@ private fun RunbookStep.toDraft(): RunbookStepDraft = when (this) {
         command = command,
         confirm = confirm,
         continueOnError = continueOnError,
+        interactive = interactive,
     )
     is RunbookStep.Transfer -> RunbookStepDraft(
         stepId = id,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookHelp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookHelp.kt
@@ -1,0 +1,135 @@
+package app.skerry.ui.runbook
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.ui.design.FieldLabel
+import app.skerry.ui.design.HelpCodeRow
+import app.skerry.ui.design.HelpDialog
+import app.skerry.ui.design.HelpExampleRow
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_add
+import app.skerry.ui.generated.resources.help_added
+import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.generated.resources.runbook_help_examples
+import app.skerry.ui.generated.resources.runbook_help_flag_confirm
+import app.skerry.ui.generated.resources.runbook_help_flag_continue
+import app.skerry.ui.generated.resources.runbook_help_flag_interactive
+import app.skerry.ui.generated.resources.runbook_help_flags
+import app.skerry.ui.generated.resources.runbook_help_intro
+import app.skerry.ui.generated.resources.runbook_help_title
+import app.skerry.ui.generated.resources.runbook_step_confirm
+import app.skerry.ui.generated.resources.runbook_step_continue_on_error
+import app.skerry.ui.generated.resources.runbook_step_interactive
+import app.skerry.ui.snippet.TemplateVariableHelpRows
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Example runbooks offered from the help dialog, one-click each. Labels, step titles and commands
+ * are user data (they land in the vault and sync), so they stay in English like
+ * [app.skerry.ui.snippet.STARTER_SNIPPETS]; only the dialog chrome is localized. Step ids are
+ * empty — [RunbookManager.save] assigns them, the same contract the editor uses.
+ */
+val RUNBOOK_HELP_EXAMPLES: List<RunbookDraft> = listOf(
+    RunbookDraft(
+        label = "Package install & verify",
+        description = "Install a package, then check it actually landed.",
+        steps = listOf(
+            RunbookStep.Command(id = "", title = "Update package index", command = "sudo apt-get update"),
+            RunbookStep.Command(id = "", title = "Install", command = "sudo apt-get install -y \${{package}}"),
+            RunbookStep.Command(id = "", title = "Verify", command = "dpkg -s \${{package}}", confirm = false),
+        ),
+        tags = listOf("ops"),
+    ),
+    RunbookDraft(
+        label = "Disk space check",
+        description = "Where the space went.",
+        steps = listOf(
+            RunbookStep.Command(id = "", title = "Filesystems", command = "df -h", confirm = false),
+            RunbookStep.Command(
+                id = "", title = "Largest under /var",
+                command = "sudo du -sh /var/* | sort -rh | head -10",
+                confirm = false, continueOnError = true,
+            ),
+        ),
+        tags = listOf("disk"),
+    ),
+    RunbookDraft(
+        label = "Service restart & health",
+        description = "Restart a service, then read its status and recent log.",
+        steps = listOf(
+            RunbookStep.Command(id = "", title = "Restart", command = "sudo systemctl restart \${{service}}"),
+            RunbookStep.Command(
+                id = "", title = "Status", command = "systemctl status \${{service}} --no-pager",
+                confirm = false, continueOnError = true,
+            ),
+            RunbookStep.Command(
+                id = "", title = "Recent log", command = "journalctl -u \${{service}} -n 50 --no-pager",
+                confirm = false,
+            ),
+        ),
+        tags = listOf("monitoring"),
+    ),
+    RunbookDraft(
+        label = "Interactive triage",
+        description = "Look around in htop, continue when done.",
+        steps = listOf(
+            RunbookStep.Command(id = "", title = "Look around", command = "htop", confirm = false, interactive = true),
+            RunbookStep.Command(id = "", title = "Load snapshot", command = "uptime", confirm = false),
+        ),
+        tags = listOf("monitoring"),
+    ),
+)
+
+/** The step list as the example row prints it: `n steps · first command…`. */
+private fun RunbookDraft.summary(): String {
+    val first = steps.filterIsInstance<RunbookStep.Command>().firstOrNull()?.command.orEmpty()
+    return "${steps.size} · $first …"
+}
+
+/** Help for the runbooks library: what a run does, the step flags, and one-click examples. */
+@Composable
+fun RunbookHelpDialog(manager: RunbookManager, onDismiss: () -> Unit) {
+    val added = remember { mutableStateOf(setOf<String>()) }
+    HelpDialog(
+        title = stringResource(Res.string.runbook_help_title),
+        closeLabel = stringResource(Res.string.help_close),
+        onDismiss = onDismiss,
+    ) {
+        Txt(
+            stringResource(Res.string.runbook_help_intro),
+            color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp,
+        )
+        FieldLabel(stringResource(Res.string.runbook_help_flags))
+        HelpCodeRow(stringResource(Res.string.runbook_step_confirm), stringResource(Res.string.runbook_help_flag_confirm))
+        HelpCodeRow(
+            stringResource(Res.string.runbook_step_continue_on_error),
+            stringResource(Res.string.runbook_help_flag_continue),
+        )
+        HelpCodeRow(
+            stringResource(Res.string.runbook_step_interactive),
+            stringResource(Res.string.runbook_help_flag_interactive),
+        )
+        // Steps take the same ${{…}} placeholders a snippet does — the same reference, so the
+        // syntax is documented once and cannot drift between the two dialogs.
+        TemplateVariableHelpRows()
+        FieldLabel(stringResource(Res.string.runbook_help_examples))
+        RUNBOOK_HELP_EXAMPLES.forEach { draft ->
+            HelpExampleRow(
+                label = draft.label,
+                detail = draft.summary(),
+                addLabel = stringResource(Res.string.help_add),
+                addedLabel = stringResource(Res.string.help_added),
+                added = draft.label in added.value,
+                onAdd = {
+                    manager.save(draft)
+                    added.value += draft.label
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncer.kt
@@ -1,0 +1,35 @@
+package app.skerry.ui.runbook
+
+import androidx.compose.runtime.Composable
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_status_confirm
+import app.skerry.ui.generated.resources.runbook_status_interactive
+import app.skerry.ui.generated.resources.runbook_step_n
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Announces the run's own pauses — a confirmation gate, an interactive step waiting to be
+ * completed — to a screen reader whose focus is elsewhere (WCAG 4.1.3; see [StatusAnnouncer]).
+ *
+ * Composed from the chrome, not from the run panel: the announcer only fires on a *change* of its
+ * message, so it must exist before the run does — a panel that appears already saying "waiting for
+ * you" is an insertion, not a change, and stays silent. The message carries the step number for
+ * the same reason: two consecutive interactive steps would otherwise produce the same string
+ * twice, and the second would be deduplicated into silence.
+ */
+@Composable
+fun RunbookPauseAnnouncer(runner: RunbookRunner) {
+    val run = runner.run
+    val state = run?.steps?.getOrNull(run.currentIndex)
+    val message = when (state?.status) {
+        RunbookStepStatus.AWAITING_CONFIRM ->
+            stringResource(Res.string.runbook_step_n, state.index + 1) + " · " +
+                stringResource(Res.string.runbook_status_confirm)
+        RunbookStepStatus.AWAITING_COMPLETE ->
+            stringResource(Res.string.runbook_step_n, state.index + 1) + " · " +
+                stringResource(Res.string.runbook_status_interactive)
+        else -> ""
+    }
+    StatusAnnouncer(message)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunOutput.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunOutput.kt
@@ -35,6 +35,7 @@ import app.skerry.ui.generated.resources.runbook_panel_done_with_failures
 import app.skerry.ui.generated.resources.runbook_panel_exit_code
 import app.skerry.ui.generated.resources.runbook_panel_failed
 import app.skerry.ui.generated.resources.runbook_panel_no_sftp
+import app.skerry.ui.generated.resources.runbook_status_interactive
 import app.skerry.ui.generated.resources.runbook_panel_running
 import app.skerry.ui.generated.resources.runbook_panel_status_unreadable
 import app.skerry.ui.generated.resources.runbook_panel_stopped
@@ -162,6 +163,7 @@ internal fun stepStatusText(state: RunbookStepState): String {
         RunbookStepStatus.PENDING -> stringResource(Res.string.runbook_status_waiting)
         RunbookStepStatus.AWAITING_CONFIRM -> stringResource(Res.string.runbook_status_confirm)
         RunbookStepStatus.RUNNING -> stringResource(Res.string.runbook_status_running)
+        RunbookStepStatus.AWAITING_COMPLETE -> stringResource(Res.string.runbook_status_interactive)
         RunbookStepStatus.SKIPPED -> stringResource(Res.string.runbook_status_skipped)
         RunbookStepStatus.STOPPED -> stringResource(Res.string.runbook_status_stopped)
         // A settled step always has a duration (it is written with the status), so this is the
@@ -203,6 +205,7 @@ internal fun runStatusColor(status: RunbookStepStatus): Color = when (status) {
     RunbookStepStatus.PENDING -> Skerry.colors.faint
     RunbookStepStatus.AWAITING_CONFIRM -> Skerry.colors.cyanBright
     RunbookStepStatus.RUNNING -> Skerry.colors.cyan
+    RunbookStepStatus.AWAITING_COMPLETE -> Skerry.colors.cyanBright
     RunbookStepStatus.SUCCEEDED -> Skerry.colors.moss
     RunbookStepStatus.FAILED -> Skerry.colors.sunset
     RunbookStepStatus.SKIPPED -> Skerry.colors.dim
@@ -216,6 +219,7 @@ internal fun runStatusIcon(status: RunbookStepStatus): String? = when (status) {
     RunbookStepStatus.SKIPPED -> "skip_next"
     RunbookStepStatus.STOPPED -> "stop_circle"
     RunbookStepStatus.AWAITING_CONFIRM -> "pause_circle"
+    RunbookStepStatus.AWAITING_COMPLETE -> "touch_app"
     RunbookStepStatus.PENDING, RunbookStepStatus.RUNNING -> null
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
@@ -31,6 +31,7 @@ import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_panel_close
+import app.skerry.ui.generated.resources.runbook_panel_complete_step
 import app.skerry.ui.generated.resources.runbook_panel_done
 import app.skerry.ui.generated.resources.runbook_panel_done_with_failures
 import app.skerry.ui.generated.resources.runbook_panel_failed
@@ -101,10 +102,17 @@ fun RunbookRunPanel(runner: RunbookRunner, run: RunbookSessionRun, modifier: Mod
                         fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
                     )
                 }
-                RunbookPhase.RUNNING -> GhostButton(
-                    stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
-                    fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
-                )
+                RunbookPhase.RUNNING -> {
+                    // An interactive step has no probe to report it done — the user says so here.
+                    if (run.steps.getOrNull(run.currentIndex)?.status == RunbookStepStatus.AWAITING_COMPLETE) {
+                        PrimaryButton(stringResource(Res.string.runbook_panel_complete_step), onClick = runner::completeStep)
+                        GhostButton(stringResource(Res.string.runbook_panel_skip_step), onClick = runner::skipStep)
+                    }
+                    GhostButton(
+                        stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
+                        fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                    )
+                }
                 else -> GhostButton(stringResource(Res.string.runbook_panel_close), onClick = runner::close)
             }
         }
@@ -118,7 +126,13 @@ private fun StepRow(state: RunbookStepState, mono: androidx.compose.ui.text.font
         Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(7.dp))
-            .background(if (state.status == RunbookStepStatus.AWAITING_CONFIRM) Skerry.colors.cyan10 else Color.Transparent)
+            .background(
+                if (state.status == RunbookStepStatus.AWAITING_CONFIRM || state.status == RunbookStepStatus.AWAITING_COMPLETE) {
+                    Skerry.colors.cyan10
+                } else {
+                    Color.Transparent
+                },
+            )
             .padding(horizontal = 8.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -150,9 +164,16 @@ private fun StepRow(state: RunbookStepState, mono: androidx.compose.ui.text.font
                 Txt(failureText(failure), color = Skerry.colors.sunset, size = 10.5.sp, lineHeight = 14.sp)
             }
         }
-        state.exitCode?.let { code ->
+        val code = state.exitCode
+        if (code != null) {
             Box(Modifier.padding(top = 1.dp)) {
                 Txt(exitCodeText(code), color = color, size = 10.5.sp, font = mono)
+            }
+        } else {
+            // The row's state in words, not only in icon and colour: the docked panel is read by
+            // screen readers too, and "waiting for you" is exactly what they must not miss.
+            Box(Modifier.padding(top = 1.dp)) {
+                Txt(stepStatusText(state), color = color, size = 10.5.sp, font = mono, maxLines = 1)
             }
         }
     }
@@ -162,6 +183,7 @@ private fun statusIcon(status: RunbookStepStatus): String = when (status) {
     RunbookStepStatus.PENDING -> "radio_button_unchecked"
     RunbookStepStatus.AWAITING_CONFIRM -> "pause_circle"
     RunbookStepStatus.RUNNING -> "play_circle"
+    RunbookStepStatus.AWAITING_COMPLETE -> "touch_app"
     RunbookStepStatus.SUCCEEDED -> "check_circle"
     RunbookStepStatus.FAILED -> "error"
     RunbookStepStatus.SKIPPED -> "skip_next"

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunView.kt
@@ -46,6 +46,7 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_panel_close
+import app.skerry.ui.generated.resources.runbook_panel_complete_step
 import app.skerry.ui.generated.resources.runbook_panel_run_step
 import app.skerry.ui.generated.resources.runbook_panel_skip_step
 import app.skerry.ui.generated.resources.runbook_panel_stalled
@@ -180,10 +181,17 @@ private fun RunbookRunActions(runner: RunbookRunner, run: RunbookSessionRun, onC
                     fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
                 )
             }
-            RunbookPhase.RUNNING -> GhostButton(
-                stringResource(Res.string.runbook_panel_stop), onClick = runner::stop, icon = "stop_circle",
-                fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
-            )
+            RunbookPhase.RUNNING -> {
+                // An interactive step has no probe to report it done — the user says so here.
+                if (run.steps.getOrNull(run.currentIndex)?.status == RunbookStepStatus.AWAITING_COMPLETE) {
+                    PrimaryButton(stringResource(Res.string.runbook_panel_complete_step), onClick = runner::completeStep)
+                    GhostButton(stringResource(Res.string.runbook_panel_skip_step), onClick = runner::skipStep)
+                }
+                GhostButton(
+                    stringResource(Res.string.runbook_panel_stop), onClick = runner::stop, icon = "stop_circle",
+                    fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                )
+            }
             else -> GhostButton(stringResource(Res.string.runbook_panel_close), onClick = onClose)
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
@@ -10,6 +10,7 @@ import app.skerry.shared.runbook.RunbookMarker
 import app.skerry.shared.runbook.RunbookPolicy
 import app.skerry.shared.runbook.RunbookRunRecord
 import app.skerry.shared.runbook.RunbookScript
+import app.skerry.shared.runbook.RunbookStep
 import app.skerry.shared.runbook.RunbookTransferDirection
 import app.skerry.shared.sftp.SftpProgress
 import app.skerry.shared.snippet.SnippetRunEnvironment
@@ -194,15 +195,56 @@ class RunbookRunner(
         flushReport()
     }
 
-    /** The user skipped the step the run is paused on; the run continues with the next one. */
+    /**
+     * The user skipped the step the run is waiting on — at a confirmation pause, or while an
+     * interactive step waits to be completed. The run continues with the next one.
+     */
     fun skipStep() {
         val run = run ?: return
-        if (run.phase != RunbookPhase.AWAITING_CONFIRM) return
         val index = run.currentIndex
-        run.steps.getOrNull(index)?.status = RunbookStepStatus.SKIPPED
+        val state = run.steps.getOrNull(index) ?: return
+        when (state.status) {
+            // No watcher exists during a confirmation pause, so nothing races this branch.
+            RunbookStepStatus.AWAITING_CONFIRM -> state.status = RunbookStepStatus.SKIPPED
+            RunbookStepStatus.AWAITING_COMPLETE -> if (!settleInteractive(state, RunbookStepStatus.SKIPPED)) return
+            else -> return
+        }
         advance(index + 1)
         flushReport()
     }
+
+    /**
+     * The user declared the interactive step done ([RunbookStep.Command.interactive]). There is no
+     * exit code to read — the click is the verdict — so the step is settled as succeeded with none,
+     * and the run moves on. No-op unless the run is waiting on exactly that.
+     */
+    fun completeStep() {
+        val run = run ?: return
+        val index = run.currentIndex
+        val state = run.steps.getOrNull(index) ?: return
+        if (!settleInteractive(state, RunbookStepStatus.SUCCEEDED)) return
+        advance(index + 1)
+        flushReport()
+    }
+
+    /**
+     * Ends the interactive step the run is waiting on, whole check-then-act inside the lock: the
+     * liveness watcher runs on a multi-threaded scope and its `stop()` can land between an
+     * unlocked status read and the settle — the click would then overwrite STOPPED and type the
+     * next command into a session already declared dead. Returns false (the caller must not
+     * advance) when the step is no longer waiting; the generation bump refuses any watcher poll
+     * still in flight, same discipline as [watch]'s finish path.
+     */
+    private fun settleInteractive(state: RunbookStepState, status: RunbookStepStatus): Boolean =
+        synchronized(lock) {
+            if (state.status != RunbookStepStatus.AWAITING_COMPLETE) return false
+            generation++
+            watchJob?.cancel()
+            watchJob = null
+            state.status = status
+            state.finishedAtMillis = now()
+            true
+        }
 
     /**
      * Ends the run where it stands: the step in flight is left as [RunbookStepStatus.STOPPED] and
@@ -223,6 +265,30 @@ class RunbookRunner(
             watchJob = null
             run?.let { stopRun(it) }
         }
+        phase = RunbookPhase.STOPPED
+        report()
+        flushReport()
+    }
+
+    /**
+     * A watcher's stop — refused when the run has already moved past the step the watcher was
+     * observing. The watcher's staleness check and its `isLive` read are not atomic: a Complete
+     * click can settle the step (bumping the generation) in between, and an unguarded [stop]
+     * would then stop the *next* step on the strength of an observation about the previous one.
+     * The user's own Stop carries no stamp — it always applies to whatever run is current.
+     */
+    private fun stopIfCurrent(generationAtStart: Int) {
+        synchronized(lock) {
+            if (generationAtStart != generation) return
+            if (!active) return
+            generation++
+            watchJob?.cancel()
+            watchJob = null
+            run?.let { stopRun(it) }
+        }
+        // Outside the lock, like [stop]: the terminal has its own synchronization, and anything
+        // racing this was already refused by the generation bump above.
+        run?.target?.expectStep(null, emptyList())
         phase = RunbookPhase.STOPPED
         report()
         flushReport()
@@ -281,6 +347,15 @@ class RunbookRunner(
         phase = RunbookPhase.RUNNING
         when (resolved) {
             is ResolvedRunbookStep.Command -> {
+                if ((state.step as? RunbookStep.Command)?.interactive == true) {
+                    // Sent as-is: an interactive program never exits, so a probe around the line
+                    // would never run — and nothing is declared to the terminal, so nothing of the
+                    // program's screen is captured or hidden. Only the user ends this step.
+                    state.status = RunbookStepStatus.AWAITING_COMPLETE
+                    run.target.send(resolved.line + "\n")
+                    watchLiveness(run)
+                    return
+                }
                 val token = RunbookMarker.token(runId, index)
                 // Declared before the line is sent, never after: the terminal reports only the step
                 // it was told to expect, and the echo it must hide starts arriving immediately.
@@ -290,6 +365,28 @@ class RunbookRunner(
             }
             is ResolvedRunbookStep.Transfer -> transfer(run, index, resolved)
         }
+    }
+
+    /**
+     * The only thing watched during an interactive step: whether the session is still there. There
+     * is no mark to poll for and no watchdog to feed — a TUI that redraws nothing for an hour is
+     * healthy — but a dropped connection must still end the run instead of leaving it waiting for
+     * a click that can no longer mean anything.
+     */
+    private fun watchLiveness(run: RunbookSessionRun) {
+        val generationAtStart = synchronized(lock) { generation }
+        val target = run.target
+        val job = scope.launch {
+            while (true) {
+                delay(pollIntervalMillis)
+                if (stale(generationAtStart)) return@launch
+                if (!target.isLive()) {
+                    stopIfCurrent(generationAtStart)
+                    return@launch
+                }
+            }
+        }
+        publishJob(job, generationAtStart)
     }
 
     /**
@@ -315,7 +412,7 @@ class RunbookRunner(
                 delay(pollIntervalMillis)
                 if (stale(generationAtStart)) return@launch
                 if (!target.isLive()) {
-                    stop()
+                    stopIfCurrent(generationAtStart)
                     return@launch
                 }
                 val mark = target.takeMark(token)
@@ -461,7 +558,11 @@ class RunbookRunner(
     /** Ends the run where it stands, leaving the step it was on marked as stopped. */
     private fun stopRun(run: RunbookSessionRun) {
         run.steps.getOrNull(run.currentIndex)?.let {
-            if (it.status == RunbookStepStatus.RUNNING || it.status == RunbookStepStatus.AWAITING_CONFIRM) {
+            if (
+                it.status == RunbookStepStatus.RUNNING ||
+                it.status == RunbookStepStatus.AWAITING_CONFIRM ||
+                it.status == RunbookStepStatus.AWAITING_COMPLETE
+            ) {
                 it.status = RunbookStepStatus.STOPPED
                 it.finishedAtMillis = now()
             }
@@ -480,17 +581,22 @@ class RunbookRunner(
      */
     private fun report() {
         val phase = phase ?: return
-        if (reported || phase == RunbookPhase.RUNNING || phase == RunbookPhase.AWAITING_CONFIRM) return
         val runbook = runbook ?: return
         val run = run ?: return
-        reported = true
-        pendingReport = run.runRecord(
-            id = runId,
-            runbookId = runbook.id,
-            startedAt = startedAt,
-            durationMillis = now() - startedAt,
-            phase = phase,
-        )
+        // Check-then-set under the lock: a watcher's stop tail and the user's own Stop can reach
+        // here concurrently, and an unlocked flag would let both park a record — one run, two
+        // history entries. The record build is cheap; the vault write stays in flushReport.
+        synchronized(lock) {
+            if (reported || phase == RunbookPhase.RUNNING || phase == RunbookPhase.AWAITING_CONFIRM) return
+            reported = true
+            pendingReport = run.runRecord(
+                id = runId,
+                runbookId = runbook.id,
+                startedAt = startedAt,
+                durationMillis = now() - startedAt,
+                phase = phase,
+            )
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
@@ -62,6 +62,12 @@ enum class RunbookStepStatus {
 
     /** Sent to the shell (or moving over SFTP); waiting for it to report. */
     RUNNING,
+
+    /**
+     * An interactive step ([RunbookStep.Command.interactive]): its line was sent bare and only the
+     * user can end it — complete, skip or stop. There is no probe and no exit code to wait for.
+     */
+    AWAITING_COMPLETE,
     SUCCEEDED,
 
     /** Failed — a non-zero exit code, or a transfer that threw ([RunbookStepState.failure]). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.runbook.RunbookStep
 import app.skerry.shared.snippet.stripUnsafeFormatChars
 import app.skerry.shared.snippet.SnippetSegment
 import app.skerry.ui.design.CancelButton
@@ -132,6 +133,9 @@ private fun RunbookStartDialogContent(
                                 }
                                 if (step.confirm) Sym("pause_circle", size = 13.sp, color = Skerry.colors.cyanBright)
                                 if (step.continueOnError) Sym("skip_next", size = 13.sp, color = Skerry.colors.dim)
+                                if ((step as? RunbookStep.Command)?.interactive == true) {
+                                    Sym("touch_app", size = 13.sp, color = Skerry.colors.cyanBright)
+                                }
                             }
                             Txt(
                                 request.script.resolve(index) { values.value(it, masked = true) }?.summaryLine().orEmpty(),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
@@ -34,9 +34,11 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.LocalRunbookHistory
 import app.skerry.ui.app.LocalRunbooks
 import app.skerry.ui.design.Chip
+import app.skerry.ui.design.ConfirmActionDialog
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.SidebarSearchField
@@ -45,7 +47,11 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_count
+import app.skerry.ui.generated.resources.runbook_delete
+import app.skerry.ui.generated.resources.runbook_delete_message
+import app.skerry.ui.generated.resources.runbook_delete_title
 import app.skerry.ui.generated.resources.runbook_empty
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.runbook_new
 import app.skerry.ui.generated.resources.runbook_no_matches
 import app.skerry.ui.generated.resources.runbook_section
@@ -106,6 +112,8 @@ private fun LiveRunbooksView(manager: RunbookManager, state: DesktopDesignState,
     var selectedId by remember { mutableStateOf<String?>(null) }
     var mode by remember { mutableStateOf<RunbookPanelMode>(RunbookPanelMode.Run) }
     var query by remember { mutableStateOf("") }
+    var helpOpen by remember { mutableStateOf(false) }
+    var pendingDelete by remember { mutableStateOf<RunbookEntry?>(null) }
     val history = LocalRunbookHistory.current
 
     val all = manager.runbooks
@@ -121,6 +129,7 @@ private fun LiveRunbooksView(manager: RunbookManager, state: DesktopDesignState,
             query = query,
             onQuery = { query = it },
             onNew = { mode = RunbookPanelMode.New },
+            onHelp = { helpOpen = true },
         )
         HLine()
         Row(Modifier.weight(1f).fillMaxWidth()) {
@@ -174,17 +183,33 @@ private fun LiveRunbooksView(manager: RunbookManager, state: DesktopDesignState,
                             state = state,
                             mono = mono,
                             onEdit = { mode = RunbookPanelMode.Edit(selected.id) },
-                            onDelete = {
-                            manager.delete(selected.id)
-                            // The runbook is gone; its run log has nothing left to belong to.
-                            history?.forget(selected.id)
-                            selectedId = null
-                        },
+                            // Held for confirmation: deleting a whole procedure silently is one
+                            // misclick away from losing it and its run history.
+                            onDelete = { pendingDelete = selected },
                         )
                     }
                 }
             }
         }
+    }
+    if (helpOpen) RunbookHelpDialog(manager, onDismiss = { helpOpen = false })
+    pendingDelete?.let { entry ->
+        ConfirmActionDialog(
+            title = stringResource(Res.string.runbook_delete_title),
+            message = stringResource(
+                Res.string.runbook_delete_message,
+                entry.runbook.label.ifBlank { stringResource(Res.string.runbook_untitled) },
+            ),
+            confirmLabel = stringResource(Res.string.runbook_delete),
+            onConfirm = {
+                manager.delete(entry.id)
+                // The runbook is gone; its run log has nothing left to belong to.
+                history?.forget(entry.id)
+                if (selectedId == entry.id) selectedId = null
+                pendingDelete = null
+            },
+            onDismiss = { pendingDelete = null },
+        )
     }
 }
 
@@ -195,6 +220,7 @@ private fun RunbooksHeader(
     query: String,
     onQuery: (String) -> Unit,
     onNew: () -> Unit,
+    onHelp: (() -> Unit)? = null,
 ) {
     SectionHeader(
         title = stringResource(Res.string.runbook_section),
@@ -205,6 +231,9 @@ private fun RunbooksHeader(
         actions = {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
                 SidebarSearchField(query, onQuery, stringResource(Res.string.runbook_search), Modifier.width(SEARCH_WIDTH))
+                if (onHelp != null) {
+                    GhostButton(stringResource(Res.string.help_button), onClick = onHelp, icon = "help", modifier = Modifier.testTag(UiTags.HELP))
+                }
                 PrimaryButton(stringResource(Res.string.runbook_new), onClick = onNew, icon = "add", modifier = Modifier.testTag(UiTags.NEW_RUNBOOK))
             }
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetHelp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetHelp.kt
@@ -1,0 +1,98 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import app.skerry.ui.design.FieldLabel
+import app.skerry.ui.design.HelpCodeRow
+import app.skerry.ui.design.HelpDialog
+import app.skerry.ui.design.HelpExampleRow
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_add
+import app.skerry.ui.generated.resources.help_added
+import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.generated.resources.lib_snippets_help_examples
+import app.skerry.ui.generated.resources.lib_snippets_help_intro
+import app.skerry.ui.generated.resources.lib_snippets_help_title
+import app.skerry.ui.generated.resources.lib_snippets_help_var_choices
+import app.skerry.ui.generated.resources.lib_snippets_help_var_clipboard
+import app.skerry.ui.generated.resources.lib_snippets_help_var_date
+import app.skerry.ui.generated.resources.lib_snippets_help_var_param
+import app.skerry.ui.generated.resources.lib_snippets_help_var_random
+import app.skerry.ui.generated.resources.lib_snippets_help_var_uuid
+import app.skerry.ui.generated.resources.lib_snippets_help_var_vault
+import app.skerry.ui.generated.resources.lib_snippets_help_vars
+import app.skerry.ui.theme.Skerry
+import androidx.compose.ui.unit.sp
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Example snippets offered from the help dialog, one-click each. Labels and commands are user data
+ * (they land in the vault and sync), so they stay in English like [STARTER_SNIPPETS]; only the
+ * dialog chrome is localized. Deliberately overlapping the starter pack in spirit but not in
+ * content: these show the variable syntax in use, which the pack's plain commands don't.
+ */
+val SNIPPET_HELP_EXAMPLES: List<SnippetDraft> = listOf(
+    SnippetDraft(label = "Load check", command = "uptime && free -h && df -h", tags = listOf("monitoring")),
+    SnippetDraft(
+        label = "Package install & verify",
+        command = "sudo apt-get install -y \${{package}} && dpkg -s \${{package}}",
+        tags = listOf("ops"),
+    ),
+    SnippetDraft(label = "Archive logs by date", command = "tar -czf logs_\${{date}}.tar.gz /var/log", tags = listOf("ops")),
+    SnippetDraft(label = "Random hex token", command = "echo \${{random:16,hex}}", tags = listOf("ops")),
+    SnippetDraft(
+        label = "Restart chosen service",
+        command = "sudo systemctl restart \${{service:nginx|postgresql|docker}}",
+        tags = listOf("monitoring"),
+    ),
+)
+
+/**
+ * The `${{…}}` variable reference, one row per kind — shared by the snippet and runbook help
+ * dialogs, because runbook steps take exactly the same placeholders and the reference must not
+ * drift between the two.
+ */
+@Composable
+fun TemplateVariableHelpRows() {
+    FieldLabel(stringResource(Res.string.lib_snippets_help_vars))
+    HelpCodeRow("\${{date}} · \${{time}} · \${{timestamp}}", stringResource(Res.string.lib_snippets_help_var_date))
+    HelpCodeRow("\${{uuid}}", stringResource(Res.string.lib_snippets_help_var_uuid))
+    HelpCodeRow("\${{random:16,hex}}", stringResource(Res.string.lib_snippets_help_var_random))
+    HelpCodeRow("\${{clipboard}}", stringResource(Res.string.lib_snippets_help_var_clipboard))
+    HelpCodeRow("\${{vault:prod-db}}", stringResource(Res.string.lib_snippets_help_var_vault))
+    HelpCodeRow("\${{host:web-1}}", stringResource(Res.string.lib_snippets_help_var_param))
+    HelpCodeRow("\${{env:dev|staging|prod}}", stringResource(Res.string.lib_snippets_help_var_choices))
+}
+
+/** Help for the snippets library: the `${{…}}` syntax and a few one-click examples. */
+@Composable
+fun SnippetHelpDialog(manager: SnippetManager, onDismiss: () -> Unit) {
+    val added = remember { mutableStateOf(setOf<String>()) }
+    HelpDialog(
+        title = stringResource(Res.string.lib_snippets_help_title),
+        closeLabel = stringResource(Res.string.help_close),
+        onDismiss = onDismiss,
+    ) {
+        Txt(
+            stringResource(Res.string.lib_snippets_help_intro),
+            color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp,
+        )
+        TemplateVariableHelpRows()
+        FieldLabel(stringResource(Res.string.lib_snippets_help_examples))
+        SNIPPET_HELP_EXAMPLES.forEach { draft ->
+            HelpExampleRow(
+                label = draft.label,
+                detail = draft.command,
+                addLabel = stringResource(Res.string.help_add),
+                addedLabel = stringResource(Res.string.help_added),
+                added = draft.label in added.value,
+                onAdd = {
+                    manager.save(draft)
+                    added.value += draft.label
+                },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
@@ -30,6 +30,7 @@ import app.skerry.ui.design.ChipButton
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.SidebarSearchField
@@ -38,6 +39,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_command_count
 import app.skerry.ui.generated.resources.lib_snippets_empty
 import app.skerry.ui.generated.resources.lib_snippets_facts_variables
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.lib_snippets_new
 import app.skerry.ui.generated.resources.lib_snippets_no_matches
 import app.skerry.ui.generated.resources.lib_snippets_screen_title
@@ -93,6 +95,7 @@ private sealed interface PanelMode {
 private fun LiveSnippetsView(manager: SnippetManager, library: SnippetLibraryState, mono: FontFamily) {
     var selectedId by remember { mutableStateOf<String?>(null) }
     var mode by remember { mutableStateOf<PanelMode>(PanelMode.Run) }
+    var helpOpen by remember { mutableStateOf(false) }
 
     val all = manager.snippets
     val visible = library.visible(all)
@@ -111,6 +114,7 @@ private fun LiveSnippetsView(manager: SnippetManager, library: SnippetLibrarySta
             query = library.query,
             onQuery = { library.query = it },
             onNew = { mode = PanelMode.New },
+            onHelp = { helpOpen = true },
         )
         if (all.any { it.snippet.tags.isNotEmpty() }) {
             SnippetTagFilterRow(
@@ -176,6 +180,7 @@ private fun LiveSnippetsView(manager: SnippetManager, library: SnippetLibrarySta
             }
         }
     }
+    if (helpOpen) SnippetHelpDialog(manager, onDismiss = { helpOpen = false })
 }
 
 @Composable
@@ -184,6 +189,7 @@ private fun SnippetsHeader(
     query: String,
     onQuery: (String) -> Unit,
     onNew: () -> Unit,
+    onHelp: (() -> Unit)? = null,
 ) {
     val commands = pluralStringResource(Res.plurals.lib_snippets_command_count, facts.total, facts.total)
     SectionHeader(
@@ -198,6 +204,9 @@ private fun SnippetsHeader(
         actions = {
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp), verticalAlignment = Alignment.CenterVertically) {
                 SidebarSearchField(query, onQuery, stringResource(Res.string.lib_snippets_search), Modifier.width(SEARCH_WIDTH))
+                if (onHelp != null) {
+                    GhostButton(stringResource(Res.string.help_button), onClick = onHelp, icon = "help", modifier = Modifier.testTag(UiTags.HELP))
+                }
                 PrimaryButton(stringResource(Res.string.lib_snippets_new), onClick = onNew, icon = "add", modifier = Modifier.testTag(UiTags.NEW_SNIPPET))
             }
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
@@ -32,14 +32,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.snippet.SnippetSegment
 import app.skerry.shared.snippet.SnippetVariableKind
+import app.skerry.shared.snippet.paramChoices
+import app.skerry.shared.snippet.paramDefault
 import app.skerry.shared.snippet.sanitizeSnippetValue
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.design.DropdownField
 import app.skerry.ui.design.FieldLabel
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.rememberFieldDraft
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippet_vars_clipboard
@@ -80,6 +84,8 @@ private fun resolveVaultRef(name: String, credentials: CredentialManagerControll
 class TemplateVariableValues internal constructor(
     /** Prompted parameters in first-appearance order. */
     val paramNames: List<String>,
+    /** Options per parameter (`${{name:default|opt1|opt2}}`); absent for free-text parameters. */
+    val paramChoices: Map<String, List<String>>,
     /** Distinct `${{vault:name}}` entry names referenced. */
     val vaultRefs: List<String>,
     /** Whether anything references `${{clipboard}}` (it is only read if so). */
@@ -132,18 +138,18 @@ fun rememberTemplateVariableValues(
     val credentials = LocalCredentials.current
     val clipboard = LocalClipboard.current
     val values = remember(request) {
-        val paramNames = variables.filter { it.kind == SnippetVariableKind.PARAM }.map { it.name }.distinct()
+        val params = variables.filter { it.kind == SnippetVariableKind.PARAM }
+        val paramNames = params.map { it.name }.distinct()
         val vaultRefs = variables.filter { it.kind == SnippetVariableKind.VAULT }.map { it.format.orEmpty() }.distinct()
+        val firstByName = paramNames.associateWith { name -> params.first { it.name == name } }
         TemplateVariableValues(
             paramNames = paramNames,
+            paramChoices = firstByName.mapValues { (_, v) -> v.paramChoices() }.filterValues { it.isNotEmpty() },
             vaultRefs = vaultRefs,
             needsClipboard = variables.any { it.kind == SnippetVariableKind.CLIPBOARD },
             vaultResolutions = vaultRefs.associateWith { resolveVaultRef(it, credentials) },
             params = mutableStateMapOf<String, String>().apply {
-                paramNames.forEach { name ->
-                    val default = variables.firstOrNull { it.kind == SnippetVariableKind.PARAM && it.name == name }?.format
-                    put(name, initialParams[name] ?: default ?: "")
-                }
+                paramNames.forEach { name -> put(name, paramSeed(firstByName.getValue(name), initialParams[name])) }
             },
         )
     }
@@ -162,23 +168,38 @@ fun rememberTemplateVariableValues(
 fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = true) {
     val mono = LocalFonts.current.mono
     val firstFieldFocus = remember { FocusRequester() }
-    values.paramNames.forEachIndexed { index, name ->
+    val firstTextParam = values.paramNames.firstOrNull { it !in values.paramChoices }
+    values.paramNames.forEach { name ->
         key(name) {
             // The caption is the variable's own name, not chrome: `${{token}}` and `${{TOKEN}}` are
             // two different keys, and uppercasing the caption would draw and announce them alike.
             FormField(name, uppercase = false) {
-                ParamField(
-                    value = values.params[name].orEmpty(),
-                    onChange = { values.params[name] = sanitizeSnippetValue(it) },
-                    modifier = if (index == 0) Modifier.focusRequester(firstFieldFocus) else Modifier,
-                    // The default from the template (or the previous run) is a suggestion: select it,
-                    // so the autofocused first field takes a replacement rather than a prefix.
-                    selectAllOnFocus = values.isSeeded(name),
-                )
+                val choices = values.paramChoices[name]
+                if (choices != null) {
+                    DropdownField(
+                        value = values.params[name].orEmpty(),
+                        options = choices,
+                        // Options come pre-sanitized from paramChoices(), so the picked string, the
+                        // selected highlight and the sent value are already one string. The label
+                        // filter adds the cap and space-folding every untrusted label carries — a
+                        // menu row may draw shortened, but the confirmed line shows the true value.
+                        label = { untrustedLabel(it) },
+                        onPick = { values.params[name] = it },
+                    )
+                } else {
+                    ParamField(
+                        value = values.params[name].orEmpty(),
+                        onChange = { values.params[name] = sanitizeSnippetValue(it) },
+                        modifier = if (name == firstTextParam) Modifier.focusRequester(firstFieldFocus) else Modifier,
+                        // The default from the template (or the previous run) is a suggestion: select it,
+                        // so the autofocused first field takes a replacement rather than a prefix.
+                        selectAllOnFocus = values.isSeeded(name),
+                    )
+                }
             }
         }
     }
-    if (values.paramNames.isNotEmpty() && autoFocus) {
+    if (firstTextParam != null && autoFocus) {
         LaunchedEffect(Unit) { firstFieldFocus.requestFocus() }
     }
     if (values.needsClipboard) {
@@ -213,6 +234,19 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
             }
         }
     }
+}
+
+/**
+ * What a parameter's field starts out holding. A free-text parameter keeps the previous run's
+ * value, else the inline default. A choice parameter must start on one of its options: the
+ * previous run's value only if it is still offered, else the default (always the first option
+ * when present), else the first option — a stale remembered value must not resurrect a choice
+ * the template no longer contains.
+ */
+internal fun paramSeed(variable: SnippetSegment.Variable, previous: String?): String {
+    val choices = variable.paramChoices()
+    if (choices.isEmpty()) return previous ?: variable.paramDefault() ?: ""
+    return previous?.takeIf { it in choices } ?: variable.paramDefault() ?: choices.first()
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
@@ -411,7 +411,9 @@ private fun LockPasswordField(
         onValueChange = onValueChange,
         singleLine = true,
         visualTransformation = PasswordVisualTransformation(),
-        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 14.sp, fontFamily = LocalFonts.current.ui),
+        // lineHeight pinned (as ModalTextField pins it): without it the text takes the font's
+        // natural leading, sits high next to the taller icon, and jumps when typing starts.
+        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 14.sp, fontFamily = LocalFonts.current.ui, lineHeight = 20.sp),
         cursorBrush = SolidColor(Skerry.colors.cyan),
         keyboardOptions = KeyboardOptions(imeAction = imeAction, keyboardType = KeyboardType.Password),
         keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }),
@@ -431,8 +433,8 @@ private fun LockPasswordField(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Sym("lock", size = 18.sp, color = Skerry.colors.faint)
-                Box(Modifier.weight(1f)) {
-                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 14.sp)
+                Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 14.sp, lineHeight = 20.sp)
                     innerTextField()
                 }
             }
@@ -453,7 +455,7 @@ private fun LockTextField(
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
-        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 14.sp, fontFamily = LocalFonts.current.ui),
+        textStyle = TextStyle(color = Skerry.colors.text, fontSize = 14.sp, fontFamily = LocalFonts.current.ui, lineHeight = 20.sp),
         cursorBrush = SolidColor(Skerry.colors.cyan),
         keyboardOptions = KeyboardOptions(imeAction = imeAction),
         keyboardActions = KeyboardActions(onDone = { onSubmit() }, onGo = { onSubmit() }),
@@ -467,8 +469,8 @@ private fun LockTextField(
                     .padding(horizontal = 14.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Box(Modifier.weight(1f)) {
-                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 14.sp)
+                Box(Modifier.weight(1f), contentAlignment = Alignment.CenterStart) {
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 14.sp, lineHeight = 20.sp)
                     innerTextField()
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultHelp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultHelp.kt
@@ -1,0 +1,48 @@
+package app.skerry.ui.vault
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.design.FieldLabel
+import app.skerry.ui.design.HelpCodeRow
+import app.skerry.ui.design.HelpDialog
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.generated.resources.vault_help_categories
+import app.skerry.ui.generated.resources.vault_help_certificates
+import app.skerry.ui.generated.resources.vault_help_intro
+import app.skerry.ui.generated.resources.vault_help_keys
+import app.skerry.ui.generated.resources.vault_help_passwords
+import app.skerry.ui.generated.resources.vault_help_snippets
+import app.skerry.ui.generated.resources.vault_help_snippets_hint
+import app.skerry.ui.generated.resources.vault_help_title
+import app.skerry.ui.generated.resources.vtail_category_certificates
+import app.skerry.ui.generated.resources.vtail_category_passwords
+import app.skerry.ui.generated.resources.vtail_category_ssh_keys
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * Help for the vault: what each category holds and how a snippet references a stored password.
+ * Guidance only — a secret is generated or imported, never templated, so unlike the snippet and
+ * runbook dialogs there is nothing to offer one-click.
+ */
+@Composable
+fun VaultHelpDialog(onDismiss: () -> Unit) {
+    HelpDialog(
+        title = stringResource(Res.string.vault_help_title),
+        closeLabel = stringResource(Res.string.help_close),
+        onDismiss = onDismiss,
+    ) {
+        Txt(
+            stringResource(Res.string.vault_help_intro),
+            color = Skerry.colors.dim, size = 12.sp, lineHeight = 17.sp,
+        )
+        FieldLabel(stringResource(Res.string.vault_help_categories))
+        HelpCodeRow(stringResource(Res.string.vtail_category_ssh_keys), stringResource(Res.string.vault_help_keys))
+        HelpCodeRow(stringResource(Res.string.vtail_category_passwords), stringResource(Res.string.vault_help_passwords))
+        HelpCodeRow(stringResource(Res.string.vtail_category_certificates), stringResource(Res.string.vault_help_certificates))
+        FieldLabel(stringResource(Res.string.vault_help_snippets))
+        HelpCodeRow("\${{vault:prod-db}}", stringResource(Res.string.vault_help_snippets_hint))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
@@ -38,7 +39,9 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
+import app.skerry.ui.app.UiTags
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.vault_export_dismiss
 import app.skerry.ui.generated.resources.vault_export_failed_message
 import app.skerry.ui.generated.resources.vault_export_failed_title
@@ -144,6 +147,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
     var selectedId by remember { mutableStateOf<String?>(null) }
     var showGenerate by remember { mutableStateOf(false) }
+    var showHelp by remember { mutableStateOf(false) }
     var showAddPassword by remember { mutableStateOf(false) }
     val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
@@ -172,6 +176,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                     onAddPassword = { showAddPassword = true },
                     onImportCert = { showImportCert = true },
                     onLinkKeyFile = { showLinkKeyFile = true },
+                    onHelp = { showHelp = true },
                 )
                 Row(Modifier.weight(1f).fillMaxWidth()) {
                     if (credItems.isEmpty()) {
@@ -228,6 +233,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                 }
             }
         }
+        if (showHelp) VaultHelpDialog(onDismiss = { showHelp = false })
         if (showGenerate && generator != null) {
             GenerateKeyDialog(
                 onDismiss = { showGenerate = false },
@@ -414,6 +420,7 @@ private fun VaultHeader(
     onAddPassword: () -> Unit,
     onImportCert: () -> Unit,
     onLinkKeyFile: () -> Unit,
+    onHelp: (() -> Unit)? = null,
 ) {
     SectionHeader(
         // The section names the whole keychain and how it is protected; which slice of it is on
@@ -424,6 +431,9 @@ private fun VaultHeader(
             pluralStringResource(Res.plurals.vault_item_count, itemCount, itemCount),
         ),
         actions = {
+            if (onHelp != null) {
+                GhostButton(stringResource(Res.string.help_button), onClick = onHelp, icon = "help", modifier = Modifier.testTag(UiTags.HELP))
+            }
             when (category) {
                 // "Link file" sits in both key and certificate categories: which one a file-backed
                 // secret lands in depends on whether it names a certificate.

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookFormStateTest.kt
@@ -39,6 +39,17 @@ class RunbookFormStateTest {
     }
 
     @Test
+    fun `an interactive step survives the edit round-trip`() {
+        val form = RunbookFormState.fromEntry(
+            entry(RunbookStep.Command(id = "s1", command = "htop", interactive = true)),
+        )
+        assertTrue(form.steps[0].interactive)
+
+        val saved = form.toDraft().steps[0] as RunbookStep.Command
+        assertTrue(saved.interactive)
+    }
+
+    @Test
     fun `save needs a name and at least one command`() {
         val form = RunbookFormState.fromEntry(null)
         form.label = "Deploy"

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookHelpExamplesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookHelpExamplesTest.kt
@@ -1,0 +1,46 @@
+package app.skerry.ui.runbook
+
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.shared.runbook.isRunnable
+import app.skerry.shared.snippet.SnippetTemplate
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class RunbookHelpExamplesTest {
+
+    @Test
+    fun every_example_names_itself_and_every_step_is_runnable() {
+        RUNBOOK_HELP_EXAMPLES.forEach { draft ->
+            assertTrue(draft.label.isNotBlank())
+            assertTrue(draft.steps.isNotEmpty(), draft.label)
+            draft.steps.forEach { step -> assertTrue(step.isRunnable, "${draft.label}: ${step.title}") }
+        }
+    }
+
+    @Test
+    fun example_placeholders_parse_as_variables_not_literal_text() {
+        val commands = RUNBOOK_HELP_EXAMPLES.flatMap { it.steps }.filterIsInstance<RunbookStep.Command>()
+        commands.filter { "\${{" in it.command }.forEach { step ->
+            assertTrue(SnippetTemplate.hasVariables(step.command), step.command)
+        }
+    }
+
+    @Test
+    fun one_example_shows_an_interactive_step() {
+        // The dialog explains the interactive flag; an example must let the user try it in a click.
+        assertTrue(
+            RUNBOOK_HELP_EXAMPLES.flatMap { it.steps }
+                .filterIsInstance<RunbookStep.Command>()
+                .any { it.interactive },
+        )
+    }
+
+    @Test
+    fun example_step_ids_are_left_for_the_manager_to_assign() {
+        // The same contract the editor uses: a blank id is replaced on save, a non-blank one is
+        // kept — and a hardcoded id here would collide when the example is added twice.
+        RUNBOOK_HELP_EXAMPLES.flatMap { it.steps }.forEach { step ->
+            assertTrue(step.id.isBlank())
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunSummaryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunSummaryTest.kt
@@ -54,7 +54,7 @@ class RunbookRunSummaryTest {
     private fun environment() = SnippetRunEnvironment(
         moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
         newUuid = { "uuid" },
-        randomChars = { n -> "r".repeat(n) },
+        randomChars = { n, _ -> "r".repeat(n) },
     )
 
     private fun runbook(steps: Int, policy: RunbookPolicy = RunbookPolicy(), continueOnError: Boolean = false) = Runbook(

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
@@ -95,7 +95,7 @@ class RunbookRunnerTest {
     private fun environment() = SnippetRunEnvironment(
         moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
         newUuid = { "uuid" },
-        randomChars = { n -> "r".repeat(n) },
+        randomChars = { n, _ -> "r".repeat(n) },
     )
 
     private fun runbook(vararg steps: RunbookStep, policy: RunbookPolicy = RunbookPolicy(watchdogMinutes = 1)) =
@@ -103,6 +103,9 @@ class RunbookRunnerTest {
 
     private fun step(id: String, command: String, confirm: Boolean = false, continueOnError: Boolean = false) =
         RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, continueOnError = continueOnError)
+
+    private fun interactive(id: String, command: String, confirm: Boolean = false) =
+        RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, interactive = true)
 
     private fun transfer(
         id: String,
@@ -716,6 +719,168 @@ class RunbookRunnerTest {
         assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
         assertEquals(RunbookPhase.STOPPED, r.phase)
         assertTrue(term.sent.isEmpty(), "the step after a stopped transfer must not be sent")
+    }
+
+    // --- interactive steps: the command is sent bare and the user decides when it is done ---
+
+    @Test
+    fun an_interactive_step_is_sent_bare_and_waits_for_the_user() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
+
+        // As-is: no probe around the line — an interactive program never exits, so a marker would
+        // never appear — and nothing declared to the terminal, so nothing is captured or hidden.
+        assertEquals(listOf("htop\n"), term.sent)
+        assertTrue(term.expected.isEmpty(), "no step token may be declared for an interactive step")
+        assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
+        assertEquals(RunbookPhase.RUNNING, r.phase)
+
+        // However long it runs, only the user finishes it — and the terminal is never polled for a
+        // mark that cannot come.
+        testScheduler.advanceTimeBy(stallAfter * 5); testScheduler.runCurrent()
+        assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
+        assertEquals(0, term.polls, "an interactive step has no mark to poll for")
+        assertFalse(r.only.steps[0].stalled, "the watchdog has no meaning without a probe")
+    }
+
+    @Test
+    fun completing_an_interactive_step_moves_to_the_next() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "mc"), step("s2", "df -h")), term.target()) { "" }
+
+        r.completeStep()
+
+        assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
+        assertNull(r.only.steps[0].exitCode, "the user's word is not an exit code")
+        // The next step is an ordinary one again: probe and declaration return.
+        assertEquals(RunbookMarker.probeLine("df -h", RunbookMarker.token(RUN_ID, 1)) + "\n", term.sent[1])
+        assertEquals(RunbookStepStatus.RUNNING, r.only.steps[1].status)
+    }
+
+    @Test
+    fun completing_the_last_interactive_step_finishes_the_run() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
+        r.completeStep()
+
+        assertEquals(RunbookPhase.DONE, r.phase)
+        assertFalse(r.hadFailures)
+    }
+
+    @Test
+    fun completing_is_refused_while_an_ordinary_step_runs() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "sleep 5"), step("s2", "df -h")), term.target()) { "" }
+
+        r.completeStep()
+
+        // Only the shell's exit code may finish a probed step — the button must not exist for it.
+        assertEquals(RunbookStepStatus.RUNNING, r.only.steps[0].status)
+        assertEquals(1, term.sent.size)
+    }
+
+    @Test
+    fun skipping_an_interactive_step_moves_on_without_counting_it_done() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "mc"), step("s2", "uptime")), term.target()) { "" }
+
+        r.skipStep()
+
+        assertEquals(RunbookStepStatus.SKIPPED, r.only.steps[0].status)
+        assertEquals(RunbookStepStatus.RUNNING, r.only.steps[1].status)
+    }
+
+    @Test
+    fun stopping_an_interactive_step_settles_it() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop"), step("s2", "uptime")), term.target()) { "" }
+
+        r.stop()
+
+        assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
+        assertEquals(RunbookPhase.STOPPED, r.phase)
+        assertEquals(1, term.sent.size, "nothing further may be sent after Stop")
+    }
+
+    @Test
+    fun losing_the_session_ends_an_interactive_run() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
+        term.live = false
+        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+
+        assertEquals(RunbookPhase.STOPPED, r.phase)
+        assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
+    }
+
+    @Test
+    fun an_interactive_step_with_confirm_pauses_first() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop", confirm = true)), term.target()) { "" }
+
+        assertEquals(RunbookStepStatus.AWAITING_CONFIRM, r.only.steps[0].status)
+        assertTrue(term.sent.isEmpty())
+
+        r.confirmStep()
+
+        assertEquals(listOf("htop\n"), term.sent)
+        assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
+    }
+
+    @Test
+    fun an_interactive_line_still_resolves_its_variables() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "docker exec -it \${{container}} sh")), term.target()) { "web-1" }
+
+        assertEquals(listOf("docker exec -it web-1 sh\n"), term.sent)
+    }
+
+    @Test
+    fun a_late_complete_after_stop_is_refused() = runnerTest { r, term ->
+        // The liveness watcher's stop() and the user's click race on different threads; whichever
+        // settles the step first wins, and the loser must be a no-op. Here stop wins: the click
+        // landing afterwards must not overwrite STOPPED or type the next step into a dead session.
+        // (settleInteractive does its whole check-then-act under the lock for exactly this.)
+        r.startNow(runbook(interactive("s1", "htop"), step("s2", "uptime")), term.target()) { "" }
+        r.stop()
+
+        r.completeStep()
+
+        assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
+        assertEquals(RunbookPhase.STOPPED, r.phase)
+        assertEquals(1, term.sent.size, "a resurrected run would have typed s2")
+    }
+
+    @Test
+    fun a_late_skip_after_stop_is_refused() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop"), step("s2", "uptime")), term.target()) { "" }
+        r.stop()
+
+        r.skipStep()
+
+        assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
+        assertEquals(RunbookPhase.STOPPED, r.phase)
+        assertEquals(1, term.sent.size)
+    }
+
+    @Test
+    fun skipping_an_interactive_step_advances_into_a_transfer() = runnerTest { r, term ->
+        // The one step-kind hand-off new to this feature: an interactive settle must start SFTP
+        // for the next step exactly as an exit code would.
+        val sftp = FakeSftpClient()
+        sftp.seedDir("/srv/incoming")
+        term.sftp = sftp
+
+        r.startNow(runbook(interactive("s1", "mc"), transfer("s2")), term.target()) { "" }
+        r.skipStep()
+        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+
+        assertEquals(RunbookStepStatus.SKIPPED, r.only.steps[0].status)
+        assertEquals("/tmp/release.tgz" to "/srv/incoming/release.tgz", sftp.lastUpload)
+        assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[1].status)
+        assertEquals(RunbookPhase.DONE, r.phase)
+    }
+
+    @Test
+    fun a_report_from_a_previous_step_cannot_finish_an_interactive_one() = runnerTest { r, term ->
+        // The interactive program may print anything, including a stale mark of an earlier run
+        // parked in the terminal. The user's click is the only way this step ends.
+        r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
+        term.complete(0, 0)
+        testScheduler.advanceTimeBy(poll * 5); testScheduler.runCurrent()
+
+        assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
     }
 
     private companion object {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookValueSnapshotTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookValueSnapshotTest.kt
@@ -20,7 +20,7 @@ class RunbookValueSnapshotTest {
     private val environment = SnippetRunEnvironment(
         moment = SnippetMoment(2026, 8, 4, 12, 0, 0, epochSeconds = 1_785_000_000L),
         newUuid = { "uuid" },
-        randomChars = { "r".repeat(it) },
+        randomChars = { n, _ -> "r".repeat(n) },
     )
 
     private fun scriptOf(vararg commands: String): RunbookScript = RunbookScript.of(

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetHelpExamplesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetHelpExamplesTest.kt
@@ -1,0 +1,36 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.SnippetTemplate
+import app.skerry.shared.snippet.SnippetVariableKind
+import app.skerry.shared.snippet.paramChoices
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SnippetHelpExamplesTest {
+
+    @Test
+    fun every_example_names_itself_and_says_what_to_run() {
+        SNIPPET_HELP_EXAMPLES.forEach { draft ->
+            assertTrue(draft.label.isNotBlank())
+            assertTrue(draft.command.isNotBlank())
+        }
+    }
+
+    @Test
+    fun example_placeholders_parse_as_variables_not_literal_text() {
+        // A typo'd placeholder silently stays literal — the example would ship broken and look fine.
+        val withVars = SNIPPET_HELP_EXAMPLES.filter { "\${{" in it.command }
+        assertTrue(withVars.isNotEmpty())
+        withVars.forEach { draft ->
+            assertTrue(SnippetTemplate.hasVariables(draft.command), draft.label)
+        }
+    }
+
+    @Test
+    fun the_examples_show_the_new_syntax_in_use() {
+        // The dialog documents charsets and choice lists; at least one example must exercise each.
+        val all = SNIPPET_HELP_EXAMPLES.flatMap { SnippetTemplate.variables(it.command) }
+        assertTrue(all.any { it.kind == SnippetVariableKind.RANDOM && it.format?.contains(',') == true })
+        assertTrue(all.any { it.kind == SnippetVariableKind.PARAM && it.paramChoices().isNotEmpty() })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
@@ -15,7 +15,7 @@ class SnippetManagerTest {
     private val fixedEnvironment = SnippetRunEnvironment(
         moment = SnippetMoment(year = 2026, month = 7, day = 3, hour = 9, minute = 5, second = 42, epochSeconds = 1_782_000_000L),
         newUuid = { "fixed-uuid" },
-        randomChars = { n -> "r".repeat(n) },
+        randomChars = { n, _ -> "r".repeat(n) },
     )
 
     private fun managerWith(

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetPanelPreviewTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetPanelPreviewTest.kt
@@ -12,7 +12,7 @@ class SnippetPanelPreviewTest {
     private val environment = SnippetRunEnvironment(
         moment = SnippetMoment(year = 2026, month = 8, day = 2, hour = 9, minute = 12, second = 0, epochSeconds = 1_785_000_000L),
         newUuid = { "fixed-uuid" },
-        randomChars = { n -> "r".repeat(n) },
+        randomChars = { n, _ -> "r".repeat(n) },
     )
 
     private fun preview(command: String, params: Map<String, String> = emptyMap()): String {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateParamSeedTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateParamSeedTest.kt
@@ -1,0 +1,38 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.SnippetSegment
+import app.skerry.shared.snippet.SnippetTemplate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TemplateParamSeedTest {
+
+    private fun param(cmd: String) = SnippetTemplate.parse(cmd).single() as SnippetSegment.Variable
+
+    @Test
+    fun `free-text parameter prefers the previous value over the inline default`() {
+        val v = param("\${{container:web-1}}")
+        assertEquals("web-1", paramSeed(v, previous = null))
+        assertEquals("db-2", paramSeed(v, previous = "db-2"))
+        assertEquals("", paramSeed(param("\${{container}}"), previous = null))
+    }
+
+    @Test
+    fun `choice parameter starts on the default option`() {
+        val v = param("\${{env:dev|staging|prod}}")
+        assertEquals("dev", paramSeed(v, previous = null))
+    }
+
+    @Test
+    fun `choice parameter keeps the previous value only while it is still offered`() {
+        val v = param("\${{env:dev|staging|prod}}")
+        assertEquals("prod", paramSeed(v, previous = "prod"))
+        // A remembered value the template no longer offers must not resurrect as a choice.
+        assertEquals("dev", paramSeed(v, previous = "qa"))
+    }
+
+    @Test
+    fun `choice parameter without a default starts on the first option`() {
+        assertEquals("dev", paramSeed(param("\${{env:|dev|prod}}"), previous = null))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
@@ -9,6 +9,7 @@ class TemplateVariableValuesTest {
 
     private fun values(params: Map<String, String>) = TemplateVariableValues(
         paramNames = params.keys.toList(),
+        paramChoices = emptyMap(),
         vaultRefs = emptyList(),
         needsClipboard = false,
         vaultResolutions = emptyMap(),

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/help/HelpDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/help/HelpDialogTest.kt
@@ -1,0 +1,113 @@
+package app.skerry.ui.help
+
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import app.skerry.ui.app.DesktopView
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.runDesktopShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_add
+import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.generated.resources.vault_help_intro
+import app.skerry.ui.runbook.RUNBOOK_HELP_EXAMPLES
+import app.skerry.ui.snippet.SNIPPET_HELP_EXAMPLES
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The help dialogs of the three library screens: they open from the header, an example lands in
+ * the library on one click and only once, and Close puts the screen back.
+ */
+@OptIn(ExperimentalTestApi::class)
+class HelpDialogTest {
+
+    @Test
+    fun `a snippet example is added from the help dialog on one click`() = runDesktopShell { shell ->
+        openView(DesktopView.Snippets)
+        openHelp()
+
+        val example = SNIPPET_HELP_EXAMPLES.first()
+        scrollHelpToExamples()
+        onAllNodesWithText(string(Res.string.help_add))[0].performClick()
+        waitForIdle()
+
+        assertEquals(listOf(example.label), shell.snippets.snippets.map { it.snippet.label })
+
+        // The button flipped to its inert "added" state: clicking the row again must not duplicate.
+        onAllNodesWithText(string(Res.string.help_add)).fetchSemanticsNodes().let { remaining ->
+            assertEquals(SNIPPET_HELP_EXAMPLES.size - 1, remaining.size)
+        }
+
+        closeHelp()
+        // Twice on screen once added: the library row and the run panel that selected it.
+        onAllNodesWithText(example.label).onFirst().assertIsDisplayed()
+    }
+
+    @Test
+    fun `a runbook example is added from the help dialog on one click`() = runDesktopShell { shell ->
+        openView(DesktopView.Runbooks)
+        openHelp()
+        scrollHelpToExamples()
+
+        onAllNodesWithText(string(Res.string.help_add))[0].performClick()
+        waitForIdle()
+
+        val example = RUNBOOK_HELP_EXAMPLES.first()
+        val saved = shell.runbooks.runbooks.single().runbook
+        assertEquals(example.label, saved.label)
+        assertEquals(example.steps.size, saved.steps.size)
+        assertTrue(saved.steps.all { it.id.isNotBlank() }, "the manager assigns step ids")
+
+        closeHelp()
+        onAllNodesWithText(example.label).onFirst().assertIsDisplayed()
+    }
+
+    @Test
+    fun `the vault help explains without offering anything to add`() = runDesktopShell {
+        openView(DesktopView.Vault)
+        openHelp()
+
+        onNodeWithText(string(Res.string.vault_help_intro)).assertIsDisplayed()
+        onAllNodesWithText(string(Res.string.help_add)).fetchSemanticsNodes().let {
+            assertEquals(0, it.size, "the vault has no templated secrets to offer")
+        }
+
+        closeHelp()
+    }
+
+    private fun ComposeUiTest.openView(view: DesktopView) {
+        onNodeWithTag(UiTags.railView(view)).performClick()
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.openHelp() {
+        onNodeWithTag(UiTags.HELP).performClick()
+        waitForIdle()
+        onNodeWithTag(UiTags.HELP_DIALOG).assertIsDisplayed()
+    }
+
+    /**
+     * The examples sit below the dialog's scroll viewport once the variables reference is in the
+     * content; a click on a fully clipped node lands clamped somewhere else instead of failing,
+     * and performScrollTo is a no-op there (clipped bounds are zero, so the delta is zero).
+     */
+    private fun ComposeUiTest.scrollHelpToExamples() {
+        onNodeWithTag(UiTags.HELP_DIALOG).performSemanticsAction(SemanticsActions.ScrollBy) { it(0f, 2000f) }
+        waitForIdle()
+    }
+
+    private fun ComposeUiTest.closeHelp() {
+        onNodeWithText(string(Res.string.help_close)).performClick()
+        waitForIdle()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileHelpDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileHelpDialogTest.kt
@@ -1,0 +1,58 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.runMobileShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.help_add
+import app.skerry.ui.generated.resources.help_added
+import app.skerry.ui.generated.resources.help_button
+import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.snippet.SNIPPET_HELP_EXAMPLES
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The phone's help dialog: same composable as the desktop one, but reached through
+ * [MobilePushHeader]'s actions slot — the wiring this test exists for.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileHelpDialogTest {
+
+    @Test
+    fun `a snippet example is added from the phone's help dialog`() = runMobileShell { shell ->
+        shell.state.push(MobileRoute.Snippets)
+        waitForIdle()
+
+        onNodeWithText(string(Res.string.help_button)).performClick()
+        waitForIdle()
+        onNodeWithTag(UiTags.HELP_DIALOG).assertIsDisplayed()
+
+        // The examples sit below the fold of the dialog's scroll on a phone-sized scene; a click
+        // on an off-scene node lands clamped somewhere else instead of failing.
+        // The phone-width card wraps every description, so the examples land far below the
+        // content viewport; performScrollTo is a no-op on a fully clipped node (its clipped
+        // bounds are zero, so the computed delta is zero) — drive the scroll semantics directly.
+        onNodeWithTag(UiTags.HELP_DIALOG).performSemanticsAction(SemanticsActions.ScrollBy) { it(0f, 2000f) }
+        waitForIdle()
+        onAllNodesWithText(string(Res.string.help_add))[0].performClick()
+        waitForIdle()
+        onAllNodesWithText(string(Res.string.help_added))[0].assertIsDisplayed()
+        assertEquals(
+            listOf(SNIPPET_HELP_EXAMPLES.first().label),
+            shell.snippets.snippets.map { it.snippet.label },
+        )
+
+        onNodeWithText(string(Res.string.help_close)).performClick()
+        waitForIdle()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
@@ -1,0 +1,88 @@
+package app.skerry.ui.runbook
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasContentDescription
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.shared.snippet.SnippetMoment
+import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.ui.desktop.runForm
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+
+/**
+ * The announcer's message across the run's own pauses: it must change on every pause — a repeat of
+ * the same string is deduplicated into silence by the live region, which is exactly why the step
+ * number is part of it (two consecutive interactive steps would otherwise announce once).
+ */
+@OptIn(ExperimentalTestApi::class)
+class RunbookPauseAnnouncerTest {
+
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    @Test
+    fun `each pause announces itself with its step number`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = RunbookRunner(
+            scope = scope,
+            newId = { "run" },
+            environment = {
+                SnippetRunEnvironment(
+                    moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
+                    newUuid = { "u" },
+                    randomChars = { n, _ -> "r".repeat(n) },
+                )
+            },
+        )
+        val target = RunbookTarget(
+            sessionId = "tab-1",
+            send = {},
+            expectStep = { _, _ -> },
+            takeMark = { null },
+            outputVersion = { 0L },
+        )
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "mc", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s3", command = "reboot", confirm = true),
+            ),
+        )
+        try {
+            runForm({ RunbookPauseAnnouncer(runner) }) {
+                // Composed before the run exists: the first pause is a change, not an insertion.
+                onNode(polite).assert(hasContentDescription(""))
+
+                runner.requestStart(runbook, target)
+                runner.confirmStart { "" }
+                waitForIdle()
+                onNode(polite).assert(hasContentDescription("Step 1", substring = true))
+
+                runner.completeStep()
+                waitForIdle()
+                // The next interactive pause is a different string — not deduplicated into silence.
+                onNode(polite).assert(hasContentDescription("Step 2", substring = true))
+
+                runner.completeStep()
+                waitForIdle()
+                // A confirmation pause announces too, with its own wording.
+                onNode(polite).assert(hasContentDescription("Step 3", substring = true))
+
+                runner.stop()
+                waitForIdle()
+                onNode(polite).assert(hasContentDescription(""))
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
@@ -1,0 +1,80 @@
+package app.skerry.ui.runbook
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.shared.snippet.SnippetMoment
+import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_panel_complete_step
+import app.skerry.ui.generated.resources.runbook_panel_skip_step
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The docked panel's interactive-step wiring. The panel is the phone's only run surface and its
+ * button row is written independently of [RunbookRunView]'s — nothing but a test keeps the two
+ * from drifting, and the runner's state machine cannot see a button that was never composed.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RunbookRunPanelTest {
+
+    @Test
+    fun `the panel completes and skips an interactive step`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val sent = mutableListOf<String>()
+        val runner = RunbookRunner(
+            scope = scope,
+            newId = { "run" },
+            environment = {
+                SnippetRunEnvironment(
+                    moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
+                    newUuid = { "u" },
+                    randomChars = { n, _ -> "r".repeat(n) },
+                )
+            },
+        )
+        val target = RunbookTarget(
+            sessionId = "tab-1",
+            send = { sent += it },
+            expectStep = { _, _ -> },
+            takeMark = { null },
+            outputVersion = { 0L },
+        )
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "mc", confirm = false, interactive = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target)
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithText(string(Res.string.runbook_panel_complete_step)).performClick()
+                waitForIdle()
+                assertEquals(RunbookStepStatus.SUCCEEDED, runner.run?.steps?.get(0)?.status)
+
+                onNodeWithText(string(Res.string.runbook_panel_skip_step)).performClick()
+                waitForIdle()
+                assertEquals(RunbookStepStatus.SKIPPED, runner.run?.steps?.get(1)?.status)
+                assertEquals(RunbookPhase.DONE, runner.phase)
+
+                // The run is over: the interactive controls are gone with the state they served.
+                onNodeWithText(string(Res.string.runbook_panel_complete_step)).assertDoesNotExist()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunTest.kt
@@ -19,6 +19,7 @@ import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_delete
+import app.skerry.ui.generated.resources.runbook_panel_complete_step
 import app.skerry.ui.generated.resources.runbook_run
 import app.skerry.ui.generated.resources.runbook_run_title
 import app.skerry.ui.generated.resources.shell_cancel
@@ -81,6 +82,37 @@ class RunbookRunTest {
     }
 
     @Test
+    fun `an interactive step is completed from the run view`() = runDesktopShell { shell ->
+        shell.runbooks.save(
+            RunbookDraft(
+                label = INTERACTIVE_RUNBOOK,
+                steps = listOf(
+                    RunbookStep.Command(id = "", title = "Look around", command = "htop", confirm = false, interactive = true),
+                    RunbookStep.Command(id = "", title = "Disk", command = "df -h", confirm = false),
+                ),
+            ),
+        )
+        openRunbooks()
+        FakeShellInput.clear()
+        onRunbookRow(INTERACTIVE_RUNBOOK).performClick()
+        waitForIdle()
+        onNodeWithText(string(Res.string.runbook_run)).performClick()
+        waitForIdle()
+        confirmStart()
+
+        // Sent as-is: the interactive line reaches the shell with no probe printf around it.
+        waitUntil { FakeShellInput.all().any { it.contains("htop") } }
+        assertTrue(FakeShellInput.all().none { it.contains("printf") })
+
+        // The user's click is the step's only ending — and it is what starts the next step.
+        onNodeWithText(string(Res.string.runbook_panel_complete_step)).performClick()
+        waitForIdle()
+
+        assertEquals(RunbookStepStatus.SUCCEEDED, shell.runner.run?.steps?.get(0)?.status)
+        waitUntil { FakeShellInput.all().any { it.contains("df -h") } }
+    }
+
+    @Test
     fun `deleting a runbook takes its row with it`() = runDesktopShell { shell ->
         shell.seedRunbook()
         openRunbooks()
@@ -88,6 +120,11 @@ class RunbookRunTest {
         waitForIdle()
 
         onNodeWithText(string(Res.string.runbook_delete)).performClick()
+        waitForIdle()
+
+        // Deleting is loud now: nothing happens until the confirmation is answered.
+        assertEquals(listOf(RUNBOOK_NAME), shell.runbooks.runbooks.map { it.runbook.label })
+        onNodeWithTag(UiTags.FORM_SAVE).performClick()
         waitForIdle()
 
         assertEquals(emptyList(), shell.runbooks.runbooks.map { it.runbook.label })
@@ -131,3 +168,4 @@ class RunbookRunTest {
 
 private const val RUNBOOK_NAME = "Morning check"
 private const val FIRST_COMMAND = "uptime"
+private const val INTERACTIVE_RUNBOOK = "Triage"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetChoiceRunTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetChoiceRunTest.kt
@@ -1,0 +1,53 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.ui.app.DesktopView
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.FakeShellInput
+import app.skerry.ui.desktop.runDesktopShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_run
+import kotlin.test.Test
+
+/**
+ * The choice-parameter path end to end: `${{name:a|b|c}}` renders a picker in the run
+ * confirmation, the picked option — not the default — is what reaches the session. The parsing
+ * and seeding are unit-tested; what only this can catch is the wiring from a click on an option
+ * to the line the terminal is sent.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SnippetChoiceRunTest {
+
+    @Test
+    fun `the picked option lands in the sent command line`() = runDesktopShell { shell ->
+        onNodeWithTag(UiTags.railView(DesktopView.Snippets)).performClick()
+        waitForIdle()
+        shell.snippets.save(
+            SnippetDraft(label = "Restart service", command = "sudo systemctl restart \${{env:dev|staging|prod}}"),
+        )
+        waitForIdle()
+        FakeShellInput.clear()
+
+        // The saved snippet is the library's only row and comes pre-selected; Run opens the
+        // confirmation with the picker seeded on the default option.
+        onNodeWithText(string(Res.string.lib_snippets_run)).performClick()
+        waitForIdle()
+        onNodeWithText("dev").assertIsDisplayed()
+
+        // Pick a different option; the trigger takes it over.
+        onNodeWithText("dev").performClick()
+        waitForIdle()
+        onAllNodesWithText("staging").onFirst().performClick()
+        waitForIdle()
+
+        onNodeWithTag(UiTags.FORM_SAVE).performClick()
+        waitUntil { FakeShellInput.all().any { it.contains("sudo systemctl restart staging") } }
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/runbook/Runbook.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/runbook/Runbook.kt
@@ -76,7 +76,14 @@ sealed interface RunbookStep {
     val confirm: Boolean
     val continueOnError: Boolean
 
-    /** A command line sent to the session's shell; its exit code decides how the run continues. */
+    /**
+     * A command line sent to the session's shell; its exit code decides how the run continues.
+     *
+     * [interactive] sends the line as-is, with no exit-code probe around it, and the run waits for
+     * the user to say the step is done — for programs that hold the terminal (a TUI, a menu waiting
+     * on a digit), whose probe would otherwise never run and leave the step stuck. The exit code is
+     * unknowable then; the user's go-ahead is the step's verdict.
+     */
     @Serializable
     data class Command(
         override val id: String,
@@ -84,6 +91,7 @@ sealed interface RunbookStep {
         val command: String,
         override val confirm: Boolean = true,
         override val continueOnError: Boolean = false,
+        val interactive: Boolean = false,
     ) : RunbookStep
 
     /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetTemplate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetTemplate.kt
@@ -49,13 +49,70 @@ data class SnippetMoment(
 /**
  * Machine-value providers for one snippet run, captured once when the run is initiated so the
  * previewed command is exactly the one sent (see the TOCTOU rule in coding-guidelines §3).
- * [randomChars] returns the given number of characters from a cryptographically secure source.
+ * [randomChars] returns the given number of characters drawn uniformly from the given non-empty
+ * alphabet by a cryptographically secure source.
  */
 class SnippetRunEnvironment(
     val moment: SnippetMoment,
     val newUuid: () -> String,
-    val randomChars: (Int) -> String,
+    val randomChars: (Int, String) -> String,
 )
+
+/**
+ * Alphabets for `${'$'}{{random}}`. Every character must be safe to splice unquoted into the
+ * confirmed command line — no shell metacharacters, quotes, whitespace, or glob/expansion
+ * triggers (see the shell-safety test). [DEFAULT] is the historic alphabet used when no charset
+ * is named, kept unchanged so existing snippets keep their output shape.
+ */
+object SnippetRandomAlphabets {
+    const val DEFAULT = "abcdefghijklmnopqrstuvwxyz0123456789"
+    const val ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZ$DEFAULT"
+    const val HEX = "0123456789abcdef"
+
+    // No `#` (starts a shell comment at word start — the confirmed line would run truncated),
+    // no `^` (bash history substitution at line start), no `=` (a draw containing it, spliced as
+    // the line's first word, parses as a variable assignment; zsh aborts on word-initial `=`).
+    // Position-dependent, so a per-draw check can't save them: a value must be inert wherever
+    // the template splices it.
+    const val SPECIAL = "$ALNUM@%_+-:,./"
+
+    /** Alphabet for a `${'$'}{{random:…}}` charset token, or `null` if the token names none. */
+    fun forName(name: String): String? = when (name) {
+        "alnum" -> ALNUM
+        "hex" -> HEX
+        "special" -> SPECIAL
+        else -> null
+    }
+}
+
+/**
+ * Default value a PARAM prefills its prompt with: the format itself, or — when the format is an
+ * option list — its first entry, sanitized like the options are (`null` when nothing of it
+ * survives). Non-PARAM kinds have no default. A plain default (no `|`) is kept verbatim, as it
+ * always was.
+ */
+fun SnippetSegment.Variable.paramDefault(): String? {
+    if (kind != SnippetVariableKind.PARAM) return null
+    val format = format ?: return null
+    if ('|' !in format) return format
+    return sanitizeSnippetValue(format.substringBefore('|').trim()).ifEmpty { null }
+}
+
+/**
+ * Options a PARAM offers at run time (`${'$'}{{name:default|opt1|opt2}}`), each already in the form
+ * that will be spliced ([sanitizeSnippetValue]): what the picker offers, what it shows as selected
+ * and what the run sends must be one string, or a bidi/invisible character in a shared template
+ * makes the user pick one thing and run another. An option nothing survives of is dropped, not
+ * offered as a blank row (same rule the untrusted-label filter follows). Duplicates dropped; empty
+ * when the format holds no `|`-separated list or the kind is not PARAM. The default, when present,
+ * is always one of the options — it is the list's first surviving entry.
+ */
+fun SnippetSegment.Variable.paramChoices(): List<String> {
+    if (kind != SnippetVariableKind.PARAM) return emptyList()
+    val format = format ?: return emptyList()
+    if ('|' !in format) return emptyList()
+    return format.split('|').map { sanitizeSnippetValue(it.trim()) }.filter { it.isNotEmpty() }.distinct()
+}
 
 /**
  * Parser and machine-side resolver for dynamic snippet variables. Pure logic — clipboard, vault
@@ -106,8 +163,10 @@ object SnippetTemplate {
             SnippetVariableKind.TIME -> formatMoment(variable.format ?: "HH:mm:ss", env.moment)
             SnippetVariableKind.TIMESTAMP -> env.moment.epochSeconds.toString()
             SnippetVariableKind.UUID -> env.newUuid()
-            SnippetVariableKind.RANDOM ->
-                env.randomChars((variable.format?.toIntOrNull() ?: DEFAULT_RANDOM_LENGTH).coerceIn(1, MAX_RANDOM_LENGTH))
+            SnippetVariableKind.RANDOM -> {
+                val (length, alphabet) = randomSpec(variable.format)
+                env.randomChars(length, alphabet)
+            }
             else -> null
         }
 
@@ -190,6 +249,24 @@ object SnippetTemplate {
         )
     }
 
+    /**
+     * `${'$'}{{random:…}}` format: comma-separated tokens, the first numeric one is the length,
+     * the first known charset name picks the alphabet ([SnippetRandomAlphabets.forName]); order
+     * is free and unknown tokens are ignored — garbage degrades to the defaults, same as the
+     * historic length-only behavior.
+     */
+    private fun randomSpec(format: String?): Pair<Int, String> {
+        var length: Int? = null
+        var alphabet: String? = null
+        for (token in format.orEmpty().split(',')) {
+            val trimmed = token.trim()
+            if (length == null) length = trimmed.toIntOrNull()
+            if (alphabet == null) alphabet = SnippetRandomAlphabets.forName(trimmed)
+        }
+        return (length ?: DEFAULT_RANDOM_LENGTH).coerceIn(1, MAX_RANDOM_LENGTH) to
+            (alphabet ?: SnippetRandomAlphabets.DEFAULT)
+    }
+
     private fun isValidName(name: String): Boolean =
         name.isNotEmpty() && name.first().isLetter() &&
             name.all { it.isLetterOrDigit() || it == '_' || it == '-' }
@@ -224,6 +301,16 @@ object SnippetTemplate {
 }
 
 /**
+ * Characters that draw as nothing but count as letters (Hangul fillers U+115F/U+1160/U+3164/U+FFA0,
+ * Braille blank U+2800), so the format-category filters keep them: two strings differing only by
+ * one of these render identically while executing differently. Never legitimate in a command or a
+ * spliced value, so both filters below drop them. Public because the UI's untrusted-label filter
+ * rejects exactly this set — one definition, not two hand-synced copies. Escapes, not the raw
+ * glyphs: an invisible character in source is unreviewable.
+ */
+val INVISIBLE_LETTERS: Set<Char> = setOf('\u115F', '\u1160', '\u3164', '\uFFA0', '\u2800')
+
+/**
  * Removes bidi/format (and DEL/C1) characters from literal template text while keeping its
  * whitespace and newlines: a snippet can arrive via Teams sharing, so the literal part is not
  * trusted to render the same way it executes (Trojan Source in the preview/palette vs the PTY) —
@@ -231,7 +318,7 @@ object SnippetTemplate {
  * they are the user's own saved text, not a rendering trick.
  */
 fun stripUnsafeFormatChars(text: String): String =
-    text.filter { it.code < 0x20 || isSafeTerminalInputChar(it) }
+    text.filter { (it.code < 0x20 || isSafeTerminalInputChar(it)) && it !in INVISIBLE_LETTERS }
 
 /**
  * Flattens an untrusted variable value (clipboard contents, vault secret, user parameter) into
@@ -250,7 +337,7 @@ fun sanitizeSnippetValue(raw: String): String = buildString(raw.length) {
         }
         when {
             c == '\r' || c == '\n' || c == '\t' -> append(' ')
-            isSafeTerminalInputChar(c) -> append(c)
+            isSafeTerminalInputChar(c) && c !in INVISIBLE_LETTERS -> append(c)
         }
         i++
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/runbook/RunbookFormatTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/runbook/RunbookFormatTest.kt
@@ -51,6 +51,33 @@ class RunbookFormatTest {
     }
 
     @Test
+    fun `a step stored before interactive steps existed reads as a probed one`() {
+        val stored = """
+            {"id":"rb","label":"Deploy","steps":[
+              {"kind":"command","id":"s1","command":"uptime"}
+            ]}
+        """.trimIndent()
+
+        val runbook = json.decodeFromString(Runbook.serializer(), stored)
+
+        val step = assertIs<RunbookStep.Command>(runbook.steps.single())
+        assertEquals(false, step.interactive)
+    }
+
+    @Test
+    fun `an interactive step survives the stored round-trip`() {
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", interactive = true)),
+        )
+
+        val restored = json.decodeFromString(Runbook.serializer(), json.encodeToString(Runbook.serializer(), runbook))
+
+        val step = assertIs<RunbookStep.Command>(restored.steps.single())
+        assertEquals(true, step.interactive)
+    }
+
+    @Test
     fun `a runbook stored before run policy existed gets the default policy`() {
         val stored = """{"id":"rb","label":"Deploy","steps":[]}"""
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/runbook/RunbookScriptTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/runbook/RunbookScriptTest.kt
@@ -18,7 +18,7 @@ class RunbookScriptTest {
         return SnippetRunEnvironment(
             moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
             newUuid = { "uuid-${++uuids}" },
-            randomChars = { n -> "r${++randoms}".padEnd(n, 'x') },
+            randomChars = { n, _ -> "r${++randoms}".padEnd(n, 'x') },
         )
     }
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetTemplateTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetTemplateTest.kt
@@ -101,7 +101,7 @@ class SnippetTemplateTest {
     private val env = SnippetRunEnvironment(
         moment = SnippetMoment(year = 2026, month = 7, day = 3, hour = 9, minute = 5, second = 42, epochSeconds = 1_782_000_000L),
         newUuid = { "aabbccdd-0000-0000-0000-000000000000" },
-        randomChars = { n -> "x".repeat(n) },
+        randomChars = { n, _ -> "x".repeat(n) },
     )
 
     private fun variable(cmd: String) = SnippetTemplate.parse(cmd).single() as Variable
@@ -162,7 +162,7 @@ class SnippetTemplateTest {
     @Test
     fun `machine values are drawn once and stay stable across assemble calls`() {
         var draws = 0
-        val counting = SnippetRunEnvironment(env.moment, newUuid = { "uuid-${++draws}" }, randomChars = { "r".repeat(it) })
+        val counting = SnippetRunEnvironment(env.moment, newUuid = { "uuid-${++draws}" }, randomChars = { n, _ -> "r".repeat(n) })
         val segments = SnippetTemplate.parse("a ${'$'}{{uuid}} b ${'$'}{{uuid}} c")
 
         val machine = SnippetTemplate.machineValues(segments, counting)
@@ -199,8 +199,148 @@ class SnippetTemplateTest {
 
     @Test
     fun `a date-time format cannot smuggle bidi text into the line`() {
-        val segments = SnippetTemplate.parse("echo ${'$'}{{time:a‮b}}")
+        val segments = SnippetTemplate.parse("echo ${'$'}{{time:a\u202Eb}}")
         assertEquals("echo ab", SnippetTemplate.resolve(segments, env) { "" })
+    }
+
+    // --- random charsets ---
+
+    private class RecordingEnv {
+        val alphabets = mutableListOf<String>()
+        val env = SnippetRunEnvironment(
+            moment = SnippetMoment(year = 2026, month = 7, day = 3, hour = 9, minute = 5, second = 42, epochSeconds = 1_782_000_000L),
+            newUuid = { "u" },
+            randomChars = { n, alphabet ->
+                alphabets += alphabet
+                "x".repeat(n)
+            },
+        )
+    }
+
+    @Test
+    fun `random charset picks the alphabet`() {
+        val recording = RecordingEnv()
+        SnippetTemplate.resolveMachine(variable("${'$'}{{random:12,hex}}"), recording.env)
+        SnippetTemplate.resolveMachine(variable("${'$'}{{random:12,alnum}}"), recording.env)
+        SnippetTemplate.resolveMachine(variable("${'$'}{{random:12,special}}"), recording.env)
+        SnippetTemplate.resolveMachine(variable("${'$'}{{random:12}}"), recording.env)
+        assertEquals(
+            listOf(
+                SnippetRandomAlphabets.HEX,
+                SnippetRandomAlphabets.ALNUM,
+                SnippetRandomAlphabets.SPECIAL,
+                SnippetRandomAlphabets.DEFAULT,
+            ),
+            recording.alphabets,
+        )
+    }
+
+    @Test
+    fun `random charset keeps the requested length and clamp`() {
+        assertEquals(12, SnippetTemplate.resolveMachine(variable("${'$'}{{random:12,hex}}"), env)!!.length)
+        assertEquals(64, SnippetTemplate.resolveMachine(variable("${'$'}{{random:999,hex}}"), env)!!.length)
+    }
+
+    @Test
+    fun `random charset survives garbage and token order`() {
+        val recording = RecordingEnv()
+        // Unknown charset falls back to the default alphabet, the length is still honored.
+        assertEquals(16, SnippetTemplate.resolveMachine(variable("${'$'}{{random:16,bogus}}"), recording.env)!!.length)
+        // A charset alone keeps the default length.
+        assertEquals(8, SnippetTemplate.resolveMachine(variable("${'$'}{{random:hex}}"), recording.env)!!.length)
+        // Token order does not matter.
+        assertEquals(16, SnippetTemplate.resolveMachine(variable("${'$'}{{random:hex,16}}"), recording.env)!!.length)
+        assertEquals(
+            listOf(SnippetRandomAlphabets.DEFAULT, SnippetRandomAlphabets.HEX, SnippetRandomAlphabets.HEX),
+            recording.alphabets,
+        )
+    }
+
+    @Test
+    fun `random alphabets are shell-safe`() {
+        // The generated value is spliced unquoted into the confirmed line, so no character may be
+        // a shell metacharacter, a quote, whitespace, or a glob/expansion trigger — nor `#` (word
+        // -start comment truncates the confirmed line), `^` (history substitution at line start)
+        // or `=` (a first-word splice would parse as a variable assignment).
+        val unsafe = " \t\"'`\\${'$'}|&;()<>*?[]{}!~#^="
+        for (alphabet in listOf(
+            SnippetRandomAlphabets.DEFAULT,
+            SnippetRandomAlphabets.ALNUM,
+            SnippetRandomAlphabets.HEX,
+            SnippetRandomAlphabets.SPECIAL,
+        )) {
+            assertTrue(alphabet.isNotEmpty())
+            assertTrue(alphabet.none { it in unsafe }, "unsafe char in $alphabet")
+            assertEquals(alphabet.length, alphabet.toSet().size, "duplicate chars in $alphabet")
+        }
+        // The default alphabet is the historic one — `${'$'}{{random}}` output must not change shape.
+        assertEquals("abcdefghijklmnopqrstuvwxyz0123456789", SnippetRandomAlphabets.DEFAULT)
+        assertTrue(SnippetRandomAlphabets.HEX.all { it in "0123456789abcdef" })
+        assertTrue(SnippetRandomAlphabets.ALNUM.any { it.isUpperCase() })
+        assertTrue(SnippetRandomAlphabets.SPECIAL.any { !it.isLetterOrDigit() })
+    }
+
+    // --- param choices ---
+
+    @Test
+    fun `param choices split on pipe with the first as default`() {
+        val v = variable("${'$'}{{env:dev|staging|prod}}")
+        assertEquals(SnippetVariableKind.PARAM, v.kind)
+        assertEquals("dev", v.paramDefault())
+        assertEquals(listOf("dev", "staging", "prod"), v.paramChoices())
+    }
+
+    @Test
+    fun `param without pipe has a default and no choices`() {
+        val v = variable("${'$'}{{container:web-1}}")
+        assertEquals("web-1", v.paramDefault())
+        assertEquals(emptyList(), v.paramChoices())
+
+        val bare = variable("${'$'}{{container}}")
+        assertNull(bare.paramDefault())
+        assertEquals(emptyList(), bare.paramChoices())
+    }
+
+    @Test
+    fun `param choices drop blanks and duplicates and may lack a default`() {
+        val v = variable("${'$'}{{env:|dev|dev| prod }}")
+        assertNull(v.paramDefault())
+        assertEquals(listOf("dev", "prod"), v.paramChoices())
+    }
+
+    @Test
+    fun `choice options are sanitized so what is picked is what runs`() {
+        // The option list can arrive in a team-shared template; picker, selected highlight and the
+        // sent line must agree on one string, so options are sanitized at the parse, not on pick.
+        val v = variable("${'$'}{{env:a\tb|de\u202Ev}}")
+        assertEquals(listOf("a b", "dev"), v.paramChoices())
+        assertEquals("a b", v.paramDefault())
+    }
+
+    @Test
+    fun `an option of invisible characters is dropped, not offered as a blank row`() {
+        // Zero-width/bidi characters are not whitespace, so trim() keeps them; without the
+        // sanitize such an option renders as an empty row and splices as an empty string.
+        val v = variable("${'$'}{{env:\u200B\u202E|dev|prod}}")
+        assertNull(v.paramDefault())
+        assertEquals(listOf("dev", "prod"), v.paramChoices())
+    }
+
+    @Test
+    fun `sanitize strips invisible letters`() {
+        // Hangul fillers and the Braille blank count as letters, not format characters — kept by
+        // the format-category filter, invisible on screen. Two values differing only by one of
+        // these would draw identically and execute differently.
+        assertEquals("web-1", sanitizeSnippetValue("web-1\u3164"))
+        assertEquals("ab", sanitizeSnippetValue("a\u115F\u1160\uFFA0\u2800b"))
+        assertEquals("echo a", stripUnsafeFormatChars("echo a\u3164"))
+    }
+
+    @Test
+    fun `choices never apply to non-param variables`() {
+        // A vault entry named "a|b" is a name, not an option list.
+        assertEquals(emptyList(), variable("${'$'}{{vault:a|b}}").paramChoices())
+        assertNull(variable("${'$'}{{vault:a|b}}").paramDefault())
     }
 
     // --- value sanitization ---

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/snippet/SnippetRunEnvironmentCapture.jvm.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/snippet/SnippetRunEnvironmentCapture.jvm.kt
@@ -8,9 +8,6 @@ import java.util.UUID
 
 private val secureRandom = SecureRandom()
 
-/** Lowercase alphanumerics: safe in file names, hostnames and unquoted shell words. */
-private const val RANDOM_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789"
-
 actual fun captureSnippetRunEnvironment(): SnippetRunEnvironment {
     // One clock read: ${{timestamp}} and ${{time}} from the same run must agree on the second.
     val instant = Instant.now()
@@ -26,6 +23,6 @@ actual fun captureSnippetRunEnvironment(): SnippetRunEnvironment {
             epochSeconds = instant.epochSecond,
         ),
         newUuid = { UUID.randomUUID().toString() },
-        randomChars = { n -> buildString(n) { repeat(n) { append(RANDOM_ALPHABET[secureRandom.nextInt(RANDOM_ALPHABET.length)]) } } },
+        randomChars = { n, alphabet -> buildString(n) { repeat(n) { append(alphabet[secureRandom.nextInt(alphabet.length)]) } } },
     )
 }


### PR DESCRIPTION
Implements #160.

## Interactive runbook steps

A command step can be marked **Interactive**. Its line is sent to the shell as-is, with no exit-code probe around it — an interactive program (a TUI, a menu waiting on a digit) never exits, so the probe would never fire and the step would hang. The run waits until the user clicks **Complete step** (or Skip, or Stop) in the run panel; the click is the step's verdict, recorded without an exit code. A liveness watcher still ends the run if the session drops mid-step. The flag is a toggle on command steps in the editor, shown in the start-dialog preview, and stored with a default so runbooks written before it keep loading.

## Snippet variable enhancements

- `${{random:16,hex}}` — the random builtin takes a charset next to the length: `alnum`, `hex` or `special`. Every alphabet is safe to splice unquoted into a shell line in any position (no `#`, `^`, `=`, quotes, whitespace or metacharacters). Unknown tokens fall back to the defaults, as documented in the help dialog.
- `${{name:default|opt1|opt2}}` — a prompted parameter with options renders a dropdown instead of a text field, in both the snippet confirmation and the runbook start dialog. Options are sanitized at the parse, so what the picker offers, what it highlights as selected and what the run sends are one string; options that reduce to nothing (zero-width/bidi-only) are dropped instead of appearing as blank rows.

## Help dialogs

Snippets, Runbooks and Vault screens get a **Help** button (desktop headers and the phone's push headers). The dialog documents the `${{…}}` variable reference — shared between the snippet and runbook dialogs so it cannot drift — the runbook step flags, and offers one-click example templates (load check, package install & verify, service restart & health, an interactive htop triage). Vault help is guidance only.

## Fixes

- Runbook deletion now asks for confirmation on desktop and mobile; the dialog names the runbook and its run history is deleted with it.
- Lock-screen password fields (desktop and mobile) pin their line height and center the text vertically — it no longer hugs the top of the field next to the taller lock icon, and no longer jumps when typing starts.
- The docked run panel now states each step's status in words, and a chrome-level live-region announcer reports confirmation and interactive pauses to screen readers on both platforms.
- `SelectTrigger` (the dropdown primitive) now joins the field caption into its accessible name.
- The invisible-letter set (Hangul fillers, Braille blank) is a single shared definition consumed by both the snippet sanitizers and the UI's untrusted-label filter.

## Verification

Run a runbook with an interactive step (e.g. `htop`, confirm off, Interactive on): the command line arrives bare, the run pauses with **Complete step / Skip / Stop run** in the panel; complete it and the next step dispatches normally. Save a snippet with `${{env:dev|staging|prod}}` and run it: the confirmation shows a dropdown seeded on `dev`; the picked option lands in the sent line. Open Help on the three screens; add an example with one click. Delete a runbook: a confirmation names it first.

Not verified live: real SSH host runs (covered by the state-machine and Compose UI tests), Android on a device, the lock-screen centering by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)