### PR TITLE
Make the mobile runbook panel collapsible so it stops covering the output (#177)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_runbook.xml
@@ -50,6 +50,8 @@
     <string name="runbook_panel_skip_step">Пропустить</string>
     <string name="runbook_panel_stop">Остановить</string>
     <string name="runbook_panel_close">Закрыть</string>
+    <string name="runbook_panel_collapse">Свернуть панель</string>
+    <string name="runbook_panel_expand">Развернуть панель</string>
     <string name="runbook_panel_exit_code">код %1$d</string>
     <string name="runbook_panel_status_unreadable">статус не прочитан</string>
     <string name="runbook_panel_progress">%1$d из %2$d</string>
@@ -104,6 +106,8 @@
     <string name="runbook_status_running">выполняется</string>
     <string name="runbook_status_skipped">пропущен</string>
     <string name="runbook_status_stopped">остановлен</string>
+    <string name="runbook_status_failed">не удался</string>
+    <string name="runbook_status_failed_count">шагов с ошибкой: %1$d</string>
     <string name="runbook_status_confirm">нужно подтверждение</string>
     <string name="runbook_status_interactive">интерактивный — завершите сами</string>
     <string name="runbook_dur_seconds">%1$s с</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_runbook.xml
@@ -50,6 +50,8 @@
     <string name="runbook_panel_skip_step">跳过</string>
     <string name="runbook_panel_stop">停止运行</string>
     <string name="runbook_panel_close">关闭</string>
+    <string name="runbook_panel_collapse">收起面板</string>
+    <string name="runbook_panel_expand">展开面板</string>
     <string name="runbook_panel_exit_code">退出码 %1$d</string>
     <string name="runbook_panel_status_unreadable">状态无法读取</string>
     <string name="runbook_panel_progress">%1$d / %2$d</string>
@@ -98,6 +100,8 @@
     <string name="runbook_status_running">执行中</string>
     <string name="runbook_status_skipped">已跳过</string>
     <string name="runbook_status_stopped">已停止</string>
+    <string name="runbook_status_failed">失败</string>
+    <string name="runbook_status_failed_count">%1$d 个步骤失败</string>
     <string name="runbook_status_confirm">待确认</string>
     <string name="runbook_status_interactive">交互式——请手动完成</string>
     <string name="runbook_dur_seconds">%1$s 秒</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_runbook.xml
@@ -50,6 +50,8 @@
     <string name="runbook_panel_skip_step">Skip</string>
     <string name="runbook_panel_stop">Stop run</string>
     <string name="runbook_panel_close">Close</string>
+    <string name="runbook_panel_collapse">Collapse panel</string>
+    <string name="runbook_panel_expand">Expand panel</string>
     <string name="runbook_panel_exit_code">exit %1$d</string>
     <string name="runbook_panel_status_unreadable">status unreadable</string>
     <string name="runbook_panel_progress">%1$d of %2$d</string>
@@ -100,6 +102,8 @@
     <string name="runbook_status_running">running</string>
     <string name="runbook_status_skipped">skipped</string>
     <string name="runbook_status_stopped">stopped</string>
+    <string name="runbook_status_failed">failed</string>
+    <string name="runbook_status_failed_count">%1$d steps failed</string>
     <string name="runbook_status_confirm">needs a go-ahead</string>
     <string name="runbook_status_interactive">interactive — complete it yourself</string>
     <string name="runbook_dur_seconds">%1$s s</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAppChrome.kt
@@ -275,8 +275,9 @@ internal fun MobileChrome(
             // Confirmation for a snippet with ${{…}} variables — every launch path (terminal
             // palette, Snippets tab) parks such a run in SnippetManager.pendingRun. Desktop parity.
             LocalSnippets.current?.let { SnippetRunDialog(it) }
-            // Runbooks: the live progress panel (bottom of the terminal screen, non-modal so the
-            // output stays readable) and the start confirmation above it. Desktop parity.
+            // Runbooks: the live progress panel (bottom of the terminal screen, non-modal and
+            // collapsible to its header — on a phone the full panel covers the live output it
+            // exists to keep readable) and the start confirmation above it. Desktop parity.
             LocalRunbookRunner.current?.let { runner ->
                 // Not gated on the terminal route: a run paused on a confirmation would otherwise
                 // lose its only Run/Skip/Stop buttons the moment the user opened another screen,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncer.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncer.kt
@@ -1,16 +1,23 @@
 package app.skerry.ui.runbook
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_panel_stalled
 import app.skerry.ui.generated.resources.runbook_status_confirm
+import app.skerry.ui.generated.resources.runbook_status_failed
+import app.skerry.ui.generated.resources.runbook_status_failed_count
 import app.skerry.ui.generated.resources.runbook_status_interactive
 import app.skerry.ui.generated.resources.runbook_step_n
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Announces the run's own pauses — a confirmation gate, an interactive step waiting to be
- * completed — to a screen reader whose focus is elsewhere (WCAG 4.1.3; see [StatusAnnouncer]).
+ * Announces the run's attention signals — a confirmation gate, an interactive step waiting to be
+ * completed, the run ending, a step going quiet, a tolerated failure — to a screen reader whose
+ * focus is elsewhere (WCAG 4.1.3; see [StatusAnnouncer]). The same signals that reopen a collapsed
+ * [RunbookRunPanel]: Compose does not announce node insertion, so without this a non-sighted user
+ * gets none of them.
  *
  * Composed from the chrome, not from the run panel: the announcer only fires on a *change* of its
  * message, so it must exist before the run does — a panel that appears already saying "waiting for
@@ -21,15 +28,51 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun RunbookPauseAnnouncer(runner: RunbookRunner) {
     val run = runner.run
+    val phase = runner.phase
     val state = run?.steps?.getOrNull(run.currentIndex)
-    val message = when (state?.status) {
-        RunbookStepStatus.AWAITING_CONFIRM ->
+    val message = when {
+        state?.status == RunbookStepStatus.AWAITING_CONFIRM ->
             stringResource(Res.string.runbook_step_n, state.index + 1) + " · " +
                 stringResource(Res.string.runbook_status_confirm)
-        RunbookStepStatus.AWAITING_COMPLETE ->
+        state?.status == RunbookStepStatus.AWAITING_COMPLETE ->
             stringResource(Res.string.runbook_step_n, state.index + 1) + " · " +
                 stringResource(Res.string.runbook_status_interactive)
+        // The run's endings, in the panel's own words ("Finished", "Stopped on a failure", …).
+        phase != null && phase != RunbookPhase.RUNNING && phase != RunbookPhase.AWAITING_CONFIRM ->
+            runPhaseLabel(phase, runner.hadFailures)
+        state?.stalled == true ->
+            stringResource(Res.string.runbook_step_n, state.index + 1) + " · " +
+                stringResource(Res.string.runbook_panel_stalled)
         else -> ""
     }
-    StatusAnnouncer(message)
+    // A tolerated failure keeps the run in RUNNING and moves past the failed step, so none of the
+    // branches above can see it. Voiced from the failure count — and *held*, not flashed: the live
+    // region reads changes, and a message reverted a frame later can be cut mid-utterance.
+    val failedCount = run?.steps?.count { it.status == RunbookStepStatus.FAILED } ?: 0
+    val lastFailed = run?.steps?.lastOrNull { it.status == RunbookStepStatus.FAILED }
+    val unheardCount = failedCount - (run?.announcedFailures ?: 0)
+    val failureMessage =
+        if (unheardCount > 0 && lastFailed != null && message.isEmpty()) {
+            // Recomposition can coalesce back-to-back dispatch-time failures (two transfer steps in
+            // a session with no SFTP channel) into one frame; a single-step line would voice only
+            // the newest and silently drop the rest, so several unheard failures are said as a count.
+            if (unheardCount > 1) {
+                stringResource(Res.string.runbook_status_failed_count, unheardCount)
+            } else {
+                stringResource(Res.string.runbook_step_n, lastFailed.index + 1) + " · " +
+                    stringResource(Res.string.runbook_status_failed)
+            }
+        } else {
+            null
+        }
+    // Any other message taking the region counts the failures as heard — the failure line must not
+    // come back over something more current. (A pause landing in the same frame as the failure wins
+    // the region, and a tolerated failure of the LAST step always lands together with the run's own
+    // ending — deterministically, failStep -> advance -> finish is one call stack; either way the
+    // reopened panel's red row still carries the failure itself.) A failure line on display marks
+    // nothing: its own text changes with the step index and count, and that is what dedups it.
+    LaunchedEffect(message, failedCount) {
+        if (run != null && message.isNotEmpty()) run.announcedFailures = failedCount
+    }
+    StatusAnnouncer(failureMessage ?: message)
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunPanel.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,15 +26,18 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.snippet.stripUnsafeFormatChars
 import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.runbook_panel_close
+import app.skerry.ui.generated.resources.runbook_panel_collapse
 import app.skerry.ui.generated.resources.runbook_panel_complete_step
 import app.skerry.ui.generated.resources.runbook_panel_done
 import app.skerry.ui.generated.resources.runbook_panel_done_with_failures
+import app.skerry.ui.generated.resources.runbook_panel_expand
 import app.skerry.ui.generated.resources.runbook_panel_failed
 import app.skerry.ui.generated.resources.runbook_panel_progress
 import app.skerry.ui.generated.resources.runbook_panel_run_step
@@ -52,6 +56,14 @@ import org.jetbrains.compose.resources.stringResource
  * whole point is that the user reads the command's real output while deciding whether to go on, so
  * the panel sits beside it and the terminal underneath stays usable (scroll, select, type).
  *
+ * On a phone the panel is nearly as wide as the screen and sits right over the live output — the
+ * opposite of its purpose — so it collapses to its header line. It reopens by itself whenever the
+ * run needs the user: a confirmation pause and a finished run have their only buttons here, a
+ * stalled step its warning, and a failed step its red row. An interactive step deliberately does
+ * not reopen it — a collapsed panel over a full-screen TUI is exactly what the user collapsed it
+ * for. The collapse flag lives on [RunbookSessionRun], so it survives the panel leaving
+ * composition (a tab switch) and dies with the run.
+ *
  * Renders nothing when no run is in flight, so a caller can place it unconditionally.
  */
 @Composable
@@ -59,6 +71,36 @@ fun RunbookRunPanel(runner: RunbookRunner, run: RunbookSessionRun, modifier: Mod
     val phase = runner.phase ?: return
     val runbook = runner.runbook ?: return
     val mono = LocalFonts.current.mono
+    val collapsed = run.panelCollapsed
+    val stalled = run.steps.getOrNull(run.currentIndex)?.stalled == true
+    // Reopens on a signal the run has not shown yet — another pause, the end, a step going quiet.
+    // The comparison is against the run's own memory, not the effect's keys: the effect re-runs on
+    // every re-entry into composition (a tab switch back), and acting on the bare condition there
+    // would undo a deliberate re-collapse of the very signal the user already saw. A signal that
+    // fired while the panel was off-screen is still unseen and still reopens it on return. The one
+    // string that can repeat is the same step stalling again after output resumed: that warning was
+    // dismissed once and stays dismissed — a step printing slightly slower than the watchdog must
+    // not yank the panel open every cycle (the announcer may still voice it; a spoken sentence
+    // costs less than a panel over the output).
+    val signal = when {
+        phase != RunbookPhase.RUNNING -> "${phase.name}:${run.currentIndex}"
+        stalled -> "stalled:${run.currentIndex}"
+        else -> null
+    }
+    LaunchedEffect(signal) {
+        if (signal != null && signal != run.panelSeenSignal) {
+            run.panelCollapsed = false
+            run.panelSeenSignal = signal
+        }
+    }
+    // A tolerated failure never leaves RUNNING (continueOnError, stopOnFirstFailure=false), so the
+    // phase key above never fires for it — each failure beyond the count already shown is its own
+    // reopen signal, or a phone-sized run could fail step after step behind a collapsed header.
+    val failedSteps = run.steps.count { it.status == RunbookStepStatus.FAILED }
+    LaunchedEffect(failedSteps) {
+        if (failedSteps > run.panelSeenFailures) run.panelCollapsed = false
+        run.panelSeenFailures = failedSteps
+    }
 
     Column(
         modifier
@@ -73,7 +115,9 @@ fun RunbookRunPanel(runner: RunbookRunner, run: RunbookSessionRun, modifier: Mod
             Sym("checklist", size = 16.sp, color = runPhaseColor(phase, runner.hadFailures))
             Column(Modifier.weight(1f)) {
                 Txt(
-                    runbook.label.ifBlank { stringResource(Res.string.runbook_untitled) },
+                    // Stripped like every other surface showing this label: a runbook can arrive
+                    // over sync, and while collapsed this line is the whole panel.
+                    stripUnsafeFormatChars(runbook.label).ifBlank { stringResource(Res.string.runbook_untitled) },
                     color = Skerry.colors.textBright, size = 13.sp, weight = FontWeight.SemiBold,
                     maxLines = 1, overflow = TextOverflow.Ellipsis,
                 )
@@ -83,37 +127,49 @@ fun RunbookRunPanel(runner: RunbookRunner, run: RunbookSessionRun, modifier: Mod
                     color = runPhaseColor(phase, runner.hadFailures), size = 11.sp,
                 )
             }
+            IconBtn(
+                name = if (collapsed) "expand_less" else "expand_more",
+                onClick = { run.panelCollapsed = !collapsed },
+                box = 24, icon = 16.sp,
+                label = stringResource(
+                    if (collapsed) Res.string.runbook_panel_expand else Res.string.runbook_panel_collapse,
+                ),
+            )
         }
 
-        Column(
-            Modifier.heightIn(max = 260.dp).verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(6.dp),
-        ) {
-            run.steps.forEach { state -> key(state) { StepRow(state, mono) } }
-        }
+        // Held outside the collapse branch, or every expand would land the list back at the top.
+        val stepScroll = rememberScrollState()
+        if (!collapsed) {
+            Column(
+                Modifier.heightIn(max = 260.dp).verticalScroll(stepScroll),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                run.steps.forEach { state -> key(state) { StepRow(state, mono) } }
+            }
 
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-            when (phase) {
-                RunbookPhase.AWAITING_CONFIRM -> {
-                    PrimaryButton(stringResource(Res.string.runbook_panel_run_step), onClick = runner::confirmStep)
-                    GhostButton(stringResource(Res.string.runbook_panel_skip_step), onClick = runner::skipStep)
-                    GhostButton(
-                        stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
-                        fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
-                    )
-                }
-                RunbookPhase.RUNNING -> {
-                    // An interactive step has no probe to report it done — the user says so here.
-                    if (run.steps.getOrNull(run.currentIndex)?.status == RunbookStepStatus.AWAITING_COMPLETE) {
-                        PrimaryButton(stringResource(Res.string.runbook_panel_complete_step), onClick = runner::completeStep)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                when (phase) {
+                    RunbookPhase.AWAITING_CONFIRM -> {
+                        PrimaryButton(stringResource(Res.string.runbook_panel_run_step), onClick = runner::confirmStep)
                         GhostButton(stringResource(Res.string.runbook_panel_skip_step), onClick = runner::skipStep)
+                        GhostButton(
+                            stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
+                            fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                        )
                     }
-                    GhostButton(
-                        stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
-                        fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
-                    )
+                    RunbookPhase.RUNNING -> {
+                        // An interactive step has no probe to report it done — the user says so here.
+                        if (run.steps.getOrNull(run.currentIndex)?.status == RunbookStepStatus.AWAITING_COMPLETE) {
+                            PrimaryButton(stringResource(Res.string.runbook_panel_complete_step), onClick = runner::completeStep)
+                            GhostButton(stringResource(Res.string.runbook_panel_skip_step), onClick = runner::skipStep)
+                        }
+                        GhostButton(
+                            stringResource(Res.string.runbook_panel_stop), onClick = runner::stop,
+                            fg = Skerry.colors.sunset, border = Skerry.colors.sunset.copy(alpha = 0.3f),
+                        )
+                    }
+                    else -> GhostButton(stringResource(Res.string.runbook_panel_close), onClick = runner::close)
                 }
-                else -> GhostButton(stringResource(Res.string.runbook_panel_close), onClick = runner::close)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookSessionRun.kt
@@ -179,6 +179,36 @@ class RunbookSessionRun internal constructor(internal val target: RunbookTarget,
     var hadFailures: Boolean by mutableStateOf(false)
         internal set
 
+    /**
+     * Whether the phone's docked panel is collapsed to its header ([RunbookRunPanel]). Lives on
+     * the run, not in the panel's composition: switching tabs and back must not reset the user's
+     * choice, and a new run — a new instance of this class — must start expanded. The desktop run
+     * surface ignores it.
+     */
+    var panelCollapsed: Boolean by mutableStateOf(false)
+
+    /**
+     * Failed steps the panel has already had on screen; a failure beyond this count reopens a
+     * collapsed panel. A count rather than a flag: with [RunbookStep.continueOnError] a run can
+     * fail more than once, and each new failure is news.
+     */
+    internal var panelSeenFailures: Int = 0
+
+    /**
+     * The last pause/end/stall signal the panel reopened for (`"PHASE:step"` / `"stalled:step"`).
+     * The reopen effect re-runs on every re-entry into composition, and without this memory a tab
+     * switch back would undo a deliberate re-collapse of the very same pause; a signal that fired
+     * while the panel was off-screen is still unseen and still reopens it.
+     */
+    internal var panelSeenSignal: String? = null
+
+    /**
+     * Failed steps counted as heard because another message took the live region over their line.
+     * A failure line actually on display marks nothing here — its own text (step index or count)
+     * is what dedups it. Announcer-side twin of [panelSeenFailures].
+     */
+    internal var announcedFailures: Int = 0
+
     /** Steps that already have a verdict — what "3 of 7" counts. */
     val finishedCount: Int
         get() = steps.count {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
@@ -198,7 +198,9 @@ private fun LiveRunbooksView(manager: RunbookManager, state: DesktopDesignState,
             title = stringResource(Res.string.runbook_delete_title),
             message = stringResource(
                 Res.string.runbook_delete_message,
-                entry.runbook.label.ifBlank { stringResource(Res.string.runbook_untitled) },
+                // Stripped like every other surface showing this label (a runbook can arrive over
+                // sync): this dialog is the last thing read before a delete.
+                stripUnsafeFormatChars(entry.runbook.label).ifBlank { stringResource(Res.string.runbook_untitled) },
             ),
             confirmLabel = stringResource(Res.string.runbook_delete),
             onConfirm = {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookPauseAnnouncerTest.kt
@@ -10,7 +10,15 @@ import app.skerry.shared.runbook.Runbook
 import app.skerry.shared.runbook.RunbookStep
 import app.skerry.shared.snippet.SnippetMoment
 import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.shared.runbook.RunbookTransferDirection
 import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_panel_done_with_failures
+import app.skerry.ui.generated.resources.runbook_panel_stalled
+import app.skerry.ui.generated.resources.runbook_panel_stopped
+import app.skerry.ui.generated.resources.runbook_status_failed
+import app.skerry.ui.generated.resources.runbook_status_failed_count
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -27,27 +35,34 @@ class RunbookPauseAnnouncerTest {
 
     private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
 
+    // The poll interval is effectively infinite: the step-mark watcher re-derives the stall flag on
+    // every poll, and a test that sets the flag by hand must not race it.
+    private fun announcerRunner(scope: CoroutineScope): RunbookRunner = RunbookRunner(
+        scope = scope,
+        newId = { "run" },
+        environment = {
+            SnippetRunEnvironment(
+                moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
+                newUuid = { "u" },
+                randomChars = { n, _ -> "r".repeat(n) },
+            )
+        },
+        pollIntervalMillis = 1_000_000L,
+    )
+
+    private fun target(): RunbookTarget = RunbookTarget(
+        sessionId = "tab-1",
+        send = { _, _ -> },
+        expectStep = { _, _ -> },
+        takeMark = { null },
+        outputVersion = { 0L },
+    )
+
     @Test
     fun `each pause announces itself with its step number`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val runner = RunbookRunner(
-            scope = scope,
-            newId = { "run" },
-            environment = {
-                SnippetRunEnvironment(
-                    moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
-                    newUuid = { "u" },
-                    randomChars = { n, _ -> "r".repeat(n) },
-                )
-            },
-        )
-        val target = RunbookTarget(
-            sessionId = "tab-1",
-            send = { _, _ -> },
-            expectStep = { _, _ -> },
-            takeMark = { null },
-            outputVersion = { 0L },
-        )
+        val runner = announcerRunner(scope)
+        val target = target()
         val runbook = Runbook(
             id = "rb", label = "Ops",
             steps = listOf(
@@ -78,7 +93,124 @@ class RunbookPauseAnnouncerTest {
 
                 runner.stop()
                 waitForIdle()
+                // The ending is a signal too: it reopens a collapsed panel, and it must be said —
+                // Compose announces no node insertion, so this line is all a non-sighted user gets.
+                onNode(polite).assert(hasContentDescription(string(Res.string.runbook_panel_stopped)))
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a stalled step announces itself`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = announcerRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "sleep 600", confirm = false)),
+        )
+        try {
+            runForm({ RunbookPauseAnnouncer(runner) }) {
+                runner.requestStart(runbook, target())
+                runner.confirmStart { "" }
+                waitForIdle()
                 onNode(polite).assert(hasContentDescription(""))
+
+                // Flagged directly, like the panel's own stall test: detection is the runner's
+                // business — this is about the warning being said, not derived.
+                runner.run?.steps?.get(0)?.stalled = true
+                waitForIdle()
+                onNode(polite).assert(hasContentDescription(string(Res.string.runbook_panel_stalled), substring = true))
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `coalesced failures are announced as a count`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = announcerRunner(scope)
+        fun transfer(id: String) = RunbookStep.Transfer(
+            id = id, localPath = "/tmp/a", remotePath = "/tmp/b", confirm = false, continueOnError = true,
+        )
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(transfer("s1"), transfer("s2"), RunbookStep.Command(id = "s3", command = "sleep 600", confirm = false)),
+        )
+        try {
+            runForm({ RunbookPauseAnnouncer(runner) }) {
+                runner.requestStart(runbook, target())
+                runner.confirmStart { "" }
+                // Both transfers fail on dispatch, possibly inside one recomposition — a
+                // single-step line would voice only the newest and drop the first one.
+                waitUntil(timeoutMillis = 5_000) { runner.run?.steps?.get(1)?.status == RunbookStepStatus.FAILED }
+                waitForIdle()
+                onNode(polite).assert(hasContentDescription(string(Res.string.runbook_status_failed_count, 2)))
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a tolerated failure on the last step folds into the ending`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = announcerRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Transfer(
+                    id = "s1", localPath = "/tmp/a", remotePath = "/tmp/b", confirm = false, continueOnError = true,
+                ),
+            ),
+        )
+        try {
+            runForm({ RunbookPauseAnnouncer(runner) }) {
+                runner.requestStart(runbook, target())
+                runner.confirmStart { "" }
+                // failStep -> advance past the end -> finish(DONE) happen in one call stack, so the
+                // failure and the ending land in the same snapshot — deterministically, not as a
+                // race — and the ending's own words carry the failure.
+                waitUntil(timeoutMillis = 5_000) { runner.phase == RunbookPhase.DONE }
+                waitForIdle()
+                onNode(polite).assert(hasContentDescription(string(Res.string.runbook_panel_done_with_failures)))
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a tolerated failure announces itself`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = announcerRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                // No SFTP channel on the test target: fails on dispatch, the run carries on.
+                RunbookStep.Transfer(
+                    id = "s1", localPath = "/tmp/a", remotePath = "/tmp/b",
+                    direction = RunbookTransferDirection.UPLOAD, confirm = false, continueOnError = true,
+                ),
+                RunbookStep.Command(id = "s2", command = "sleep 600", confirm = false),
+            ),
+        )
+        try {
+            runForm({ RunbookPauseAnnouncer(runner) }) {
+                runner.requestStart(runbook, target())
+                runner.confirmStart { "" }
+                waitUntil(timeoutMillis = 5_000) { runner.run?.steps?.get(0)?.status == RunbookStepStatus.FAILED }
+                waitForIdle()
+                // The failure keeps the run in RUNNING and moves on — no pause, no ending, and the
+                // reopened panel's red row is a node insertion. This line is all a screen reader gets.
+                onNode(polite).assert(hasContentDescription(string(Res.string.runbook_status_failed), substring = true))
+                onNode(polite).assert(hasContentDescription("Step 1", substring = true))
             }
         } finally {
             runner.close()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
@@ -1,6 +1,8 @@
 package app.skerry.ui.runbook
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import app.skerry.shared.runbook.Runbook
@@ -10,8 +12,13 @@ import app.skerry.shared.snippet.SnippetRunEnvironment
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_panel_close
+import app.skerry.ui.generated.resources.runbook_panel_collapse
 import app.skerry.ui.generated.resources.runbook_panel_complete_step
+import app.skerry.ui.generated.resources.runbook_panel_expand
+import app.skerry.ui.generated.resources.runbook_panel_run_step
 import app.skerry.ui.generated.resources.runbook_panel_skip_step
+import app.skerry.ui.generated.resources.runbook_panel_stop
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -27,28 +34,30 @@ import kotlin.test.assertEquals
 @OptIn(ExperimentalTestApi::class)
 class RunbookRunPanelTest {
 
+    private fun panelRunner(scope: CoroutineScope): RunbookRunner = RunbookRunner(
+        scope = scope,
+        newId = { "run" },
+        environment = {
+            SnippetRunEnvironment(
+                moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
+                newUuid = { "u" },
+                randomChars = { n, _ -> "r".repeat(n) },
+            )
+        },
+    )
+
+    private fun target(sent: MutableList<String> = mutableListOf()): RunbookTarget = RunbookTarget(
+        sessionId = "tab-1",
+        send = { line, _ -> sent += line },
+        expectStep = { _, _ -> },
+        takeMark = { null },
+        outputVersion = { 0L },
+    )
+
     @Test
     fun `the panel completes and skips an interactive step`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val sent = mutableListOf<String>()
-        val runner = RunbookRunner(
-            scope = scope,
-            newId = { "run" },
-            environment = {
-                SnippetRunEnvironment(
-                    moment = SnippetMoment(2026, 8, 14, 12, 0, 0, epochSeconds = 1_786_000_000L),
-                    newUuid = { "u" },
-                    randomChars = { n, _ -> "r".repeat(n) },
-                )
-            },
-        )
-        val target = RunbookTarget(
-            sessionId = "tab-1",
-            send = { line, _ -> sent += line },
-            expectStep = { _, _ -> },
-            takeMark = { null },
-            outputVersion = { 0L },
-        )
+        val runner = panelRunner(scope)
         val runbook = Runbook(
             id = "rb", label = "Ops",
             steps = listOf(
@@ -57,7 +66,7 @@ class RunbookRunPanelTest {
             ),
         )
         try {
-            runner.requestStart(runbook, target)
+            runner.requestStart(runbook, target())
             runner.confirmStart { "" }
             runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
                 onNodeWithText(string(Res.string.runbook_panel_complete_step)).performClick()
@@ -71,6 +80,370 @@ class RunbookRunPanelTest {
 
                 // The run is over: the interactive controls are gone with the state they served.
                 onNodeWithText(string(Res.string.runbook_panel_complete_step)).assertDoesNotExist()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `the panel collapses to its header and expands back`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true)),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithText("htop").assertExists()
+
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                // Collapsed: the step list and the button row are gone, the header stays.
+                onNodeWithText("htop").assertDoesNotExist()
+                onNodeWithText(string(Res.string.runbook_panel_stop)).assertDoesNotExist()
+                onNodeWithText("Ops").assertExists()
+
+                onNodeWithContentDescription(string(Res.string.runbook_panel_expand)).performClick()
+                waitForIdle()
+                onNodeWithText("htop").assertExists()
+                onNodeWithText(string(Res.string.runbook_panel_stop)).assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `the end of the run expands a collapsed panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true)),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+
+                // A collapsed panel on a finished run must reopen by itself: its Close button is
+                // the only way to dismiss the run, and it lives in the collapsible body.
+                runner.stop()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_close)).assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a stalled step expands a collapsed panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true)),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText("htop").assertDoesNotExist()
+
+                // Flagged directly: stall *detection* is the runner's business and has its own
+                // tests — this one is about the panel reacting to the flag.
+                runner.run?.steps?.get(0)?.stalled = true
+                waitForIdle()
+                onNodeWithText("htop").assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `advancing between steps keeps the panel collapsed`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "mc", confirm = false, interactive = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+
+                // s1 done, s2 (interactive) starts: the phase never leaves RUNNING, so the user's
+                // collapse must survive the step change — an interactive step is exactly what the
+                // panel gets collapsed for.
+                runner.completeStep()
+                waitForIdle()
+                onNodeWithText("mc").assertDoesNotExist()
+                onNodeWithText(string(Res.string.runbook_panel_stop)).assertDoesNotExist()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a tolerated failure expands a collapsed panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                // No SFTP channel on the test target: fails on dispatch, and the run carries on.
+                RunbookStep.Transfer(id = "s2", localPath = "/tmp/a", remotePath = "/tmp/b", confirm = false, continueOnError = true),
+                RunbookStep.Command(id = "s3", command = "mc", confirm = false, interactive = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText("htop").assertDoesNotExist()
+
+                // The failure keeps the phase at RUNNING (continueOnError), so only the failure
+                // count can reopen the panel — a run must not fail behind a collapsed header.
+                runner.completeStep()
+                waitUntil(timeoutMillis = 5_000) { runner.run?.steps?.get(1)?.status == RunbookStepStatus.FAILED }
+                waitForIdle()
+                onNodeWithText("mc").assertExists()
+                assertEquals(RunbookPhase.RUNNING, runner.phase)
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a new run starts expanded even after a collapsed finish`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val first = Runbook(
+            id = "rb1", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true)),
+        )
+        val second = Runbook(
+            id = "rb2", label = "Deploy",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "mc", confirm = false, interactive = true)),
+        )
+        try {
+            runner.requestStart(first, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                runner.stop()
+                waitForIdle()
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_close)).assertDoesNotExist()
+
+                // The collapse belonged to the finished run: the next run is a new decision.
+                runner.requestStart(second, target())
+                runner.confirmStart { "" }
+                waitForIdle()
+                onNodeWithText("mc").assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `the collapse survives the panel leaving composition`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true)),
+        )
+        val visible = mutableStateOf(true)
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ if (visible.value) runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText("htop").assertDoesNotExist()
+
+                // A tab switch takes the panel out of composition; coming back must not undo the
+                // user's collapse mid-interactive-step — the flag lives on the run, not in remember.
+                visible.value = false
+                waitForIdle()
+                visible.value = true
+                waitForIdle()
+                onNodeWithText("Ops").assertExists()
+                onNodeWithText("htop").assertDoesNotExist()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a re-collapse during a pause survives the panel leaving composition`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "systemctl restart app", confirm = true),
+            ),
+        )
+        val visible = mutableStateOf(true)
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ if (visible.value) runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                runner.completeStep()
+                waitForIdle()
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_run_step)).assertDoesNotExist()
+
+                // The reopen effect re-runs on every re-entry into composition; the pause it would
+                // act on is the one the user already collapsed over — not a fresh signal.
+                visible.value = false
+                waitForIdle()
+                visible.value = true
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_run_step)).assertDoesNotExist()
+                onNodeWithText("Ops").assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `each new tolerated failure reopens a re-collapsed panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        fun transfer(id: String) = RunbookStep.Transfer(
+            id = id, localPath = "/tmp/a", remotePath = "/tmp/b", confirm = false, continueOnError = true,
+        )
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                transfer("s2"),
+                RunbookStep.Command(id = "s3", command = "mc", confirm = false, interactive = true),
+                transfer("s4"),
+                RunbookStep.Command(id = "s5", command = "vi", confirm = false, interactive = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+
+                runner.completeStep()
+                waitUntil(timeoutMillis = 5_000) { runner.run?.steps?.get(1)?.status == RunbookStepStatus.FAILED }
+                waitForIdle()
+                onNodeWithText("mc").assertExists()
+
+                // The first failure was seen and dismissed; the second is news of its own.
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText("mc").assertDoesNotExist()
+                runner.completeStep()
+                waitUntil(timeoutMillis = 5_000) { runner.run?.steps?.get(3)?.status == RunbookStepStatus.FAILED }
+                waitForIdle()
+                onNodeWithText("vi").assertExists()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a re-collapse during a pause is not fought by the panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "systemctl restart app", confirm = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                runner.completeStep()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_run_step)).assertExists()
+
+                // The reopen is keyed on the signal, not the collapse flag: collapsing an
+                // already-paused run is the user's word and stays until the next signal.
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_run_step)).assertDoesNotExist()
+            }
+        } finally {
+            runner.close()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a confirmation pause expands a collapsed panel`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val runner = panelRunner(scope)
+        val runbook = Runbook(
+            id = "rb", label = "Ops",
+            steps = listOf(
+                RunbookStep.Command(id = "s1", command = "htop", confirm = false, interactive = true),
+                RunbookStep.Command(id = "s2", command = "systemctl restart app", confirm = true),
+            ),
+        )
+        try {
+            runner.requestStart(runbook, target())
+            runner.confirmStart { "" }
+            runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
+                onNodeWithContentDescription(string(Res.string.runbook_panel_collapse)).performClick()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_stop)).assertDoesNotExist()
+
+                // The interactive step is declared done off-screen; the run pauses on s2's
+                // confirmation — the panel must reopen by itself, or the pause has no buttons.
+                runner.completeStep()
+                waitForIdle()
+                onNodeWithText(string(Res.string.runbook_panel_run_step)).assertExists()
+                assertEquals(RunbookPhase.AWAITING_CONFIRM, runner.phase)
             }
         } finally {
             runner.close()


### PR DESCRIPTION
Part 1 of #177 (the reconnect-stall report is tracked separately in the issue — steps requested from the reporter).

## What this does

On a phone the runbook progress panel is 320dp wide — nearly the full portrait screen — and docked over the lower half of the terminal, hiding the live output of the command being executed. This change makes it collapsible:

- A chevron in the panel header collapses it to a single header line (runbook name, phase, progress); the terminal output underneath stays readable. The step list scroll position survives the round-trip.
- The panel reopens by itself on every signal the run has not shown yet: a confirmation pause, the run ending, a step going quiet past the watchdog, and each tolerated failure (`continueOnError` keeps the phase at RUNNING, so failures get their own reopen signal, counted per failure). A signal that fires while the panel is off-screen still reopens it on return.
- The collapse choice is remembered on the run itself: switching session tabs and back does not undo it, and a new run always starts expanded.
- An interactive step deliberately does not reopen the panel — a collapsed panel over a full-screen TUI is exactly what the user collapsed it for. The same goes for a repeat stall of the same step: a step printing slightly slower than the watchdog must not yank the panel open every cycle.

Screen-reader parity: the announcer now voices the same signals — run endings ("Finished", "Stopped on a failure", …), stalled steps, and tolerated failures ("Step N · failed", or "N steps failed" when several land in one recomposition). These were previously silent node insertions.

Also sanitizes the runbook label (bidi/invisible characters) in the panel header and the delete confirmation, matching the other label surfaces.

Desktop is unaffected: it uses its own run surface (`RunbookRunView`), which does not cover the terminal.

## Tests

- `RunbookRunPanelTest` (12): collapse/expand, every reopen signal, re-collapse sticking through re-entry into composition, per-failure reopen, new-run reset.
- `RunbookPauseAnnouncerTest` (5): pause/ending/stall/failure announcements, coalesced failures as a count, the deterministic fold of a last-step tolerated failure into the ending.

## How to verify

On a phone (or a narrow window): run a runbook of 3+ steps → the panel shows a chevron in its header. Collapse it → the live output is visible, only the header line remains. A step with "Ask before running" reopens the panel by itself. Collapse it during the pause and switch tabs away and back → it stays collapsed.

Not verified live: real device, TalkBack by ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bxJPejMzM3LsLvXdwXWD4