### PR TITLE
Auto-shrink the mobile terminal font when wide output wraps (#180)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -125,4 +125,7 @@
     <string name="term_header_monitor">Мониторинг хоста</string>
     <string name="term_header_menu">Меню сессии</string>
     <string name="term_session_new">Новая сессия</string>
+    <string name="term_autofit_shrink">Уменьшить шрифт терминала</string>
+    <string name="term_autofit_grow">Увеличить шрифт терминала</string>
+    <string name="term_autofit_restore">Вернуть размер шрифта</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -122,4 +122,7 @@
     <string name="term_header_monitor">主机监控</string>
     <string name="term_header_menu">会话菜单</string>
     <string name="term_session_new">新建会话</string>
+    <string name="term_autofit_shrink">缩小终端字体</string>
+    <string name="term_autofit_grow">放大终端字体</string>
+    <string name="term_autofit_restore">恢复字体大小</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -123,4 +123,7 @@
     <string name="term_header_monitor">Host monitor</string>
     <string name="term_header_menu">Session menu</string>
     <string name="term_session_new">New session</string>
+    <string name="term_autofit_shrink">Shrink terminal font</string>
+    <string name="term_autofit_grow">Enlarge terminal font</string>
+    <string name="term_autofit_restore">Restore font size</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/GlyphButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/GlyphButton.kt
@@ -1,0 +1,66 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.theme.Skerry
+
+/**
+ * Square icon-glyph tap target: a [Sym] centered in a rounded box that carries the accessible
+ * name and [Role.Button]. Extracted once the third private copy of the shape appeared (terminal
+ * header icons, the auto-fit nudge) — each copy was free to drift, and one already had (a text
+ * glyph where its visual sibling used the icon font).
+ *
+ * [onLongClick] adds a secondary action; pass [onLongClickLabel] with it so assistive tech can
+ * announce the gesture.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun GlyphButton(
+    icon: String,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    box: Dp = 40.dp,
+    iconSize: TextUnit = 21.sp,
+    iconColor: Color = Skerry.colors.dim,
+    background: Color = Color.Transparent,
+    onLongClick: (() -> Unit)? = null,
+    onLongClickLabel: String? = null,
+) {
+    Box(
+        modifier
+            .size(box)
+            .clip(RoundedCornerShape(10.dp))
+            .background(background)
+            .semantics { contentDescription = label }
+            .combinedClickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                role = Role.Button,
+                onLongClickLabel = onLongClickLabel,
+                onLongClick = onLongClick,
+                onClick = onClick,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym(icon, size = iconSize, color = iconColor)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalChrome.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -48,6 +47,7 @@ import app.skerry.ui.generated.resources.term_session_new
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.immersive.hiddenSystemBarsPadding
 import app.skerry.ui.design.Dot
+import app.skerry.ui.design.GlyphButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
@@ -145,22 +145,7 @@ private fun HeaderIcon(
     size: TextUnit = 21.sp,
     color: Color = Skerry.colors.dim,
     onClick: () -> Unit,
-) {
-    Box(
-        Modifier
-            .size(40.dp)
-            .clip(RoundedCornerShape(10.dp))
-            .semantics { contentDescription = label }
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = onClick,
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        Sym(icon, size = size, color = color)
-    }
-}
+) = GlyphButton(icon, label, onClick, iconSize = size, iconColor = color)
 
 /**
  * Session strip under the header: one chip per open shell plus a "+" that goes to the catalog.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -32,7 +32,11 @@ import app.skerry.shared.host.Host
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.connectionErrorText
 import app.skerry.ui.immersive.ImmersiveScreen
+import androidx.compose.ui.Alignment
+import app.skerry.ui.terminal.LocalTerminalAppearance
+import app.skerry.ui.terminal.TerminalAutoFitControls
 import app.skerry.ui.terminal.TerminalScreen
+import app.skerry.ui.terminal.autoFitFloor
 import app.skerry.ui.terminal.RecordingOutcome
 import app.skerry.shared.share.ShareFrame
 import app.skerry.ui.app.LocalSessionShare
@@ -230,6 +234,14 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                             Modifier.fillMaxSize(),
                             imeInput = true,
                             imeTransform = imeTransform,
+                            // Wide output on a phone turns into a wall of wrapped lines; the fit
+                            // converges once per session and the controls below nudge it after.
+                            autoFitEnabled = true,
+                        )
+                        TerminalAutoFitControls(
+                            fit = st.terminal.autoFit,
+                            floor = autoFitFloor(LocalTerminalAppearance.current.fontSizeSp),
+                            modifier = Modifier.align(Alignment.BottomEnd).padding(end = 10.dp, bottom = 8.dp),
                         )
                     }
                     // Desktop opens a path on Ctrl+click; touch has no such chord, so the affordance is
@@ -271,7 +283,13 @@ fun MobileTerminalScreen(state: MobileDesignState) {
                 // Drop: frozen screen at the moment of loss, no keybar (channel is dead). Header status —
                 // "disconnected" in red. Detailed mobile parity (auto-reconnect) is a separate task.
                 is ConnectionUiState.Disconnected ->
-                    TerminalScreen(st.terminal, Modifier.weight(1f).fillMaxWidth())
+                    // autoFitEnabled keeps the frozen screen at its converged scale — snapping the
+                    // last output back to 100% at the moment of loss would re-wrap exactly the
+                    // lines the user may want to read. Deliberately no nudge controls here: the
+                    // session's command queue is closed, so a nudge could only rescale glyphs
+                    // without reflowing the grid — "+" would clip the tails of the very wide
+                    // lines being read.
+                    TerminalScreen(st.terminal, Modifier.weight(1f).fillMaxWidth(), autoFitEnabled = true)
             }
         }
         if (paletteOpen && snippets != null && activeTerminal != null) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAutoFit.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalAutoFit.kt
@@ -1,0 +1,246 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.wrapsToNextRow
+import app.skerry.ui.design.GlyphButton
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.design.Txt
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_autofit_grow
+import app.skerry.ui.generated.resources.term_autofit_restore
+import app.skerry.ui.generated.resources.term_autofit_shrink
+import app.skerry.ui.theme.Skerry
+import kotlin.math.roundToInt
+import org.jetbrains.compose.resources.stringResource
+
+/** One auto/manual step of the fit scale (×0.9 ≈ 1px of font at the default 13px size). */
+private const val AUTOFIT_STEP = 0.9f
+
+/**
+ * Never auto-shrink below this font size (px). Deliberately under the Appearance slider's 8px
+ * minimum: the shrunken view exists to *read wide output* on a phone, which needs smaller than
+ * a size anyone would type at all day.
+ */
+private const val AUTOFIT_MIN_PX = 6f
+
+private const val AUTOFIT_LINE_HEIGHT_RATIO = 1.2f
+
+/**
+ * Line-height ratio to use while auto-shrunk: tightened toward the glyph height, Termux-style —
+ * the user's ratio (18/13 by default) is tuned for a reading size and leaves visually huge gaps
+ * at 7-8px. Never looser than the user's own Appearance ratio though, which would *gain* row gap
+ * the moment the fit engages for anyone who configured a ratio denser than 1.2. Restored together
+ * with the font size.
+ */
+fun autoFitLineHeightRatio(userRatio: Float): Float = minOf(userRatio, AUTOFIT_LINE_HEIGHT_RATIO)
+
+/** Smallest allowed auto-fit scale for [baseFontSizeSp] — the [AUTOFIT_MIN_PX] floor. */
+fun autoFitFloor(baseFontSizeSp: Int): Float =
+    (AUTOFIT_MIN_PX / baseFontSizeSp.coerceAtLeast(1)).coerceAtMost(1f)
+
+/**
+ * Auto-shrink for narrow screens, Termux "shrink to fit"-style (issue #180): when the live grid
+ * holds soft-wrapped rows, the font scales down in steps until the output fits. Unlike Termux's
+ * live loop this converges **once per session and then sticks** — a continuous restore loop would
+ * re-wrap at the boundary and oscillate. After convergence only [nudgeDown]/[nudgeUp] (the manual
+ * −/+ buttons) move the scale, and the first tap hands control over for good ([locked]).
+ *
+ * One instance lives on [TerminalScreenState] — it must survive tab switches (composition-local
+ * state resets when the active session changes and back) and die with the session.
+ *
+ * The machine itself is pure: [TerminalScreen] calls [onScreenSettled] once per *settled* snapshot
+ * — one whose grid width already reflects the current scale. Feeding it mid-reflow snapshots would
+ * double-step past the fit, which is why the caller gates on the expected column count.
+ */
+@Stable
+class TerminalAutoFitState {
+
+    private enum class Phase {
+        /** No wide line seen yet — the font stays at the user's own size. */
+        Waiting,
+
+        /** Wide rows on screen — stepping down until they fit. */
+        Shrinking,
+
+        /** Output fits and the one extra margin step is applied — the next settled screen locks in. */
+        Overshot,
+
+        /** Done for this session: only the manual buttons move the scale now. */
+        Converged,
+    }
+
+    private var phase = Phase.Waiting
+
+    /** Current font scale, 1 = the user's own size. Applied by [TerminalScreen] while auto-fit is on. */
+    var scale: Float by mutableStateOf(1f)
+        private set
+
+    /** True once a manual button was tapped — auto convergence is out for the rest of the session. */
+    var locked: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Whether the manual controls should be visible: the scale has moved, or the user already took
+     * over. A session that never printed a wide line keeps its terminal free of chrome.
+     */
+    val active: Boolean get() = scale < 1f || locked
+
+    /** True once auto-fit finished for this session (visible for tests/diagnostics). */
+    val converged: Boolean get() = phase == Phase.Converged
+
+    /**
+     * Advance on a settled screen: [wrapped] — whether the live grid still holds a soft-wrapped
+     * row (see [gridNeedsShrink]), [floor] — [autoFitFloor] of the user's font size.
+     */
+    fun onScreenSettled(wrapped: Boolean, floor: Float) {
+        if (locked || phase == Phase.Converged) return
+        if (wrapped) {
+            // Still (or again) too wide: step down. Re-entering from Overshot restarts the margin
+            // logic — a wider line arrived while the previous fit was settling.
+            phase = Phase.Shrinking
+            scale = stepDown(scale, floor)
+            return
+        }
+        // Exhaustive on purpose: a future phase must choose its fits-now behavior explicitly
+        // instead of falling into a silent default.
+        when (phase) {
+            Phase.Waiting -> Unit // nothing wide has appeared yet
+            Phase.Shrinking -> {
+                // Fits now — one extra margin step so a line ending at the very edge (or a slightly
+                // wider one arriving next) doesn't sit on the wrap boundary.
+                phase = Phase.Overshot
+                scale = stepDown(scale, floor)
+            }
+            Phase.Overshot -> phase = Phase.Converged
+            Phase.Converged -> Unit // unreachable — filtered by the early return above
+        }
+    }
+
+    /** Manual "−": one step down. The first tap takes convergence away from the machine. */
+    fun nudgeDown(floor: Float) {
+        locked = true
+        scale = stepDown(scale, floor)
+    }
+
+    /** Manual "+": one step back up, never past the user's own size. */
+    fun nudgeUp() {
+        locked = true
+        scale = (scale / AUTOFIT_STEP).coerceAtMost(1f)
+    }
+
+    /**
+     * Long-press on "+": straight back to the user's own size in one gesture — from a deep floor
+     * the single-step button takes a dozen taps, a real cost under a motor impairment. Stays
+     * [locked]: an explicit restore is the strongest "hands off" signal there is.
+     */
+    fun restoreFull() {
+        locked = true
+        scale = 1f
+    }
+
+    private fun stepDown(value: Float, floor: Float): Float =
+        (value * AUTOFIT_STEP).coerceAtLeast(floor.coerceAtMost(1f))
+}
+
+/**
+ * Whether the live grid asks for a smaller font: any soft-wrapped row among the last [rows] rows
+ * of [screen] (the visible grid — scrollback above it must not drive the font to the floor over a
+ * line that long since scrolled away), excluding the logical line the cursor sits on — the user's
+ * own command line soft-wraps while being typed, and shrinking mid-keystroke would yank the font
+ * under their fingers.
+ */
+fun gridNeedsShrink(screen: List<List<TermCell>>, rows: Int, cursorRow: Int): Boolean {
+    if (screen.isEmpty()) return false
+    val gridStart = (screen.size - rows).coerceAtLeast(0)
+    // The cursor's logical line: walk to the first row of the wrap chain, then to its last cut.
+    // Rows lineStart..lineEnd-1 carry the chain's wrapped flags and are the ones to ignore.
+    // Both the clamp and the walk stop at gridStart: the scan below never looks above it, and
+    // a host that streams one endless line chains wrap flags through the whole scrollback —
+    // an unbounded walk on every snapshot (the same trap MAX_JOINED_WRAP_ROWS exists for).
+    val cursor = cursorRow.coerceIn(gridStart, screen.lastIndex)
+    var lineStart = cursor
+    while (lineStart > gridStart && screen[lineStart - 1].wrapsToNextRow()) lineStart--
+    var lineEnd = cursor
+    while (lineEnd < screen.lastIndex && screen[lineEnd].wrapsToNextRow()) lineEnd++
+    for (i in gridStart until screen.size) {
+        if (i >= lineStart && i < lineEnd) continue
+        if (screen[i].wrapsToNextRow()) return true
+    }
+    return false
+}
+
+/**
+ * Manual −/+ nudge over the mobile terminal, with the current scale as a percentage. Nothing is
+ * drawn until the fit first engages ([TerminalAutoFitState.active]) — a session that never printed
+ * a wide line keeps its screen clean. Buttons that can do nothing are hidden, not disabled: "−"
+ * disappears at the floor and "+" at the user's own size, since a permanently dead button under
+ * the thumb reads as broken. Long-pressing "+" restores the user's size in one gesture.
+ *
+ * The chip background is 0.95 alpha with fully opaque text — the overlay floats over arbitrary
+ * terminal pixels, and stacking a translucent text on a translucent chip fell under AA contrast
+ * in the light themes (the RemoteDesktopBar precedent).
+ */
+@Composable
+fun TerminalAutoFitControls(fit: TerminalAutoFitState, floor: Float, modifier: Modifier = Modifier) {
+    // The announcer is composed from screen mount, BEFORE the active gate: a live region that
+    // appears together with its first value is an insertion, not a change, and Android announces
+    // only changes — the auto-engage moment (the one change the user did not cause themselves)
+    // would stay silent. StatusAnnouncer also carries the size workaround a 0dp node needs.
+    StatusAnnouncer(if (fit.active) "${(fit.scale * 100).roundToInt()}%" else "")
+    if (!fit.active) return
+    val chip = Skerry.colors.surface2.copy(alpha = 0.95f)
+    Row(
+        modifier,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Txt(
+            "${(fit.scale * 100).roundToInt()}%",
+            color = Skerry.colors.textBright,
+            size = 12.sp,
+            modifier = Modifier
+                .clip(RoundedCornerShape(10.dp))
+                .background(chip)
+                .padding(horizontal = 8.dp, vertical = 9.dp),
+        )
+        if (fit.scale > floor) {
+            GlyphButton(
+                icon = "remove",
+                label = stringResource(Res.string.term_autofit_shrink),
+                onClick = { fit.nudgeDown(floor) },
+                box = 44.dp,
+                iconSize = 20.sp,
+                iconColor = Skerry.colors.text,
+                background = chip,
+            )
+        }
+        if (fit.scale < 1f) {
+            GlyphButton(
+                icon = "add",
+                label = stringResource(Res.string.term_autofit_grow),
+                onClick = { fit.nudgeUp() },
+                box = 44.dp,
+                iconSize = 20.sp,
+                iconColor = Skerry.colors.text,
+                background = chip,
+                onLongClick = { fit.restoreFull() },
+                onLongClickLabel = stringResource(Res.string.term_autofit_restore),
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -90,6 +90,7 @@ import app.skerry.shared.terminal.CursorShape
 import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
+import app.skerry.shared.terminal.TermCell
 import app.skerry.shared.terminal.TermStyle
 import app.skerry.shared.terminal.highlight.HighlightKind
 import app.skerry.shared.terminal.highlight.applyTo
@@ -126,6 +127,19 @@ private const val REVERSE_SEARCH_ROWS = 6
 private const val HANDLE_RADIUS_DP = 7
 private const val HANDLE_TOUCH_RADIUS_DP = 22
 
+/**
+ * One consistent settled-screen read for the auto-fit machine (see the convergence effect in
+ * [TerminalScreen]). [version] sits first so the equality snapshotFlow dedupes on short-circuits
+ * before ever comparing the row list.
+ */
+private data class AutoFitScreenRead(
+    val version: Int,
+    val cols: Int,
+    val screen: List<List<TermCell>>,
+    val rows: Int,
+    val cursorRow: Int,
+)
+
 @Composable
 fun TerminalScreen(
     state: TerminalScreenState,
@@ -133,6 +147,11 @@ fun TerminalScreen(
     imeInput: Boolean = false,
     imeTransform: ((String) -> String)? = null,
     fixedGrid: PtySize? = null,
+    // Auto-shrink the font while wide output soft-wraps (issue #180, mobile: a narrow screen turns
+    // wide output into a wall of wrapped lines). The state machine lives on
+    // [TerminalScreenState.autoFit]; desktop keeps the user's font size. Ignored with a pinned
+    // grid, whose font is scaled to the recording's geometry instead.
+    autoFitEnabled: Boolean = false,
     // Whether this is the pane the user is typing into. On a split every pane draws its own
     // terminal, and only the focused one claims the keyboard — otherwise the last one composed
     // would take it and the accent border would point at a pane that receives nothing.
@@ -186,17 +205,30 @@ fun TerminalScreen(
     // With a pinned grid ([fixedGrid]) the font is scaled so that grid fills the viewport; the scale
     // is derived from metrics measured at the unscaled size, so the style has to be built twice.
     val baseMetrics = remember(baseStyle, density) { terminalMetrics(measurer, baseStyle, density) }
-    val fontScale = if (fixedGrid == null) 1f else fitFontScale(
-        viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, baseMetrics,
-        fixedGrid.cols, fixedGrid.rows,
-    )
-    val textStyle = remember(baseStyle, fontScale) {
+    val autoFitOn = autoFitEnabled && fixedGrid == null
+    val fontScale = when {
+        fixedGrid != null -> fitFontScale(
+            viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, baseMetrics,
+            fixedGrid.cols, fixedGrid.rows,
+        )
+        autoFitOn -> state.autoFit.scale
+        else -> 1f
+    }
+    // While auto-shrunk the row gap tightens toward the glyph height ([AUTOFIT_LINE_HEIGHT_RATIO]):
+    // the user's own line-height ratio is tuned for a reading size and leaves visually huge gaps at
+    // 7-8px. Restored together with the font size.
+    val autoFitShrunk = autoFitOn && fontScale < 1f
+    val textStyle = remember(baseStyle, fontScale, autoFitShrunk) {
         if (fontScale == 1f) {
             baseStyle
         } else {
             baseStyle.copy(
                 fontSize = baseStyle.fontSize * fontScale,
-                lineHeight = baseStyle.lineHeight * fontScale,
+                lineHeight = if (autoFitShrunk) {
+                    baseStyle.fontSize * fontScale * autoFitLineHeightRatio(appearance.lineHeight)
+                } else {
+                    baseStyle.lineHeight * fontScale
+                },
                 letterSpacing = baseStyle.letterSpacing * fontScale,
             )
         }
@@ -359,6 +391,51 @@ fun TerminalScreen(
         val content = gridSizeFor(viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, metrics)
         state.resize(if (fixedGrid == null) content else fixedGrid.copy(widthPx = content.widthPx, heightPx = content.heightPx))
         sized = true
+    }
+
+    // Auto-fit convergence (issue #180): one machine step per *settled* snapshot — one whose grid
+    // width matches what the current metrics imply. Right after a step the emulator still holds the
+    // previous, narrower grid with its old wrap flags; stepping again on it would run far past the
+    // fit, so snapshots are skipped until the resize above (debounce included) has landed. Each
+    // step shrinks the font -> metrics change -> the resize effect reflows the grid -> the next
+    // settled snapshot drives the next step, until the output fits or the floor is reached.
+    if (autoFitOn) {
+        val autoFitFloorScale = autoFitFloor(appearance.fontSizeSp)
+        LaunchedEffect(state, viewportSize, metrics, paddingPx, autoFitFloorScale) {
+            if (viewportSize.width == 0 || viewportSize.height == 0) return@LaunchedEffect
+            val expectedCols =
+                gridSizeFor(viewportSize.width.toFloat(), viewportSize.height.toFloat(), paddingPx, metrics).cols
+            // All four values are read inside snapshotFlow so they come from one consistent
+            // snapshot: publishes are individual writes from the session scope, and piecemeal
+            // reads in the collect body could pair a fresh screen with a stale cursor — counting
+            // the user's own wrapped command line as wide output and taking a spurious step.
+            // One scale-moving step per effect instance: after a step the grid keeps its old
+            // column count until recomposition rebuilds metrics and restarts this effect, so
+            // snapshots streaming in during that gap still pass the cols gate with stale wrap
+            // flags — stepping on them would run past the fit. A step that did not move the
+            // scale (already at the floor, Overshot -> Converged) restarts nothing and must
+            // not latch, or the machine would freeze there.
+            var stepped = false
+            snapshotFlow {
+                AutoFitScreenRead(state.snapshotVersion, state.cols, state.screen, state.rows, state.cursorRow)
+            }.collect { read ->
+                if (stepped) return@collect
+                // Nothing left to decide once the machine is done or handed over — skip the scan,
+                // not just the step: this collector outlives convergence by the whole session.
+                if (state.autoFit.converged || state.autoFit.locked) return@collect
+                // A dead session cannot reflow (its command queue closed with the output), so a
+                // step here would only rescale the frozen glyphs without re-wrapping them —
+                // exactly what the Disconnected screen declines to offer manually.
+                if (state.state.value is TerminalState.Closed) return@collect
+                if (read.cols != expectedCols) return@collect
+                val before = state.autoFit.scale
+                state.autoFit.onScreenSettled(
+                    wrapped = gridNeedsShrink(read.screen, read.rows, read.cursorRow),
+                    floor = autoFitFloorScale,
+                )
+                if (state.autoFit.scale != before) stepped = true
+            }
+        }
     }
 
     // Cursor blink phase: with blink on, toggle a boolean once per half-period; otherwise the cursor

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.SnapshotMutationPolicy
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.AutocompleteEngine
 import app.skerry.shared.terminal.CommandHistory
@@ -122,6 +123,14 @@ class TerminalScreenState(
     /** Screen snapshot (rows top to bottom) for rendering. */
     var screen: List<List<TermCell>> by mutableStateOf(emptyList(), SCREEN_SNAPSHOT_POLICY)
         private set
+
+    /**
+     * Mobile auto-fit font scale (issue #180), advanced by [TerminalScreen] when it is composed
+     * with `autoFitEnabled`. Lives here rather than in composition on purpose: it must survive
+     * switching to another session's tab and back (composition state keyed on the active session
+     * resets on every switch, re-converging each time) and reset with the session on reconnect.
+     */
+    val autoFit = TerminalAutoFitState()
 
     /**
      * Monotonic snapshot publish counter, incremented on every feed/resize even if [screen] is
@@ -393,7 +402,12 @@ class TerminalScreenState(
                 } catch (e: CancellationException) {
                     throw e // do not swallow scope cancellation
                 } catch (_: Exception) {
-                    // only recoverable failures (e.g. PTY dropped); Error propagates
+                    // Only recoverable failures (e.g. PTY dropped); Error propagates. The dedup
+                    // memo is cleared so the next request at the same size is re-attempted rather
+                    // than silently dropped — auto-fit's settled-snapshot gate waits on exactly
+                    // that retry. Written off the UI thread; the worst a race costs is one
+                    // redundant resize command, and the dedup is best-effort anyway.
+                    lastRequestedSize = null
                 }
             }
         }
@@ -437,11 +451,17 @@ class TerminalScreenState(
 
     /** Publish the emulator snapshot into Compose state (after feed/resize). */
     private fun publishSnapshot() {
-        screen = emulator.lines // rows are already copied into immutable form inside the getter
-        cols = emulator.cols
-        rows = emulator.rows
-        cursorRow = emulator.cursorRow
-        cursorCol = emulator.cursorCol
+        // The grid and the cursor apply as one atomic group: auto-fit reads them as a tuple under
+        // snapshotFlow, and individual writes from this (session) thread could pair a fresh screen
+        // with a stale cursor there — counting the user's own wrapped command line as wide output.
+        // Single writer, so the apply cannot conflict.
+        Snapshot.withMutableSnapshot {
+            screen = emulator.lines // rows are already copied into immutable form inside the getter
+            cols = emulator.cols
+            rows = emulator.rows
+            cursorRow = emulator.cursorRow
+            cursorCol = emulator.cursorCol
+        }
         cursorVisible = emulator.cursorVisible
         cursorShape = emulator.cursorShape
         cursorBlink = emulator.cursorBlink
@@ -1165,9 +1185,10 @@ class TerminalScreenState(
         }
         // Sole owner of the emulator: feed and resize run strictly in order. Publishes one snapshot
         // per batch of immediately-available commands: under heavy output (build, cat) the PTY
-        // delivers many chunks in a row, and publishSnapshot copies the whole scrollback, so doing
-        // it per chunk is expensive (freezes/GC, especially on Android). When the queue is empty,
-        // behavior is unchanged (snapshot right away), so interactive latency does not grow.
+        // delivers many chunks in a row, and each publish re-copies the visible screen rows and
+        // renotifies every observer, so doing it per chunk is expensive (freezes/GC, especially on
+        // Android). When the queue is empty, behavior is unchanged (snapshot right away), so
+        // interactive latency does not grow.
         scope.launch {
             try {
                 for (cmd in commands) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitTest.kt
@@ -1,0 +1,198 @@
+package app.skerry.ui.terminal
+
+import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermSnapshotRow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The auto-fit machine (issue #180): wide soft-wrapped output on a phone shrinks the font in steps
+ * until it fits, converges once per session, then only the manual buttons move it. The machine is
+ * pure state — [TerminalScreen] feeds it one settled screen at a time — so the convergence rules
+ * are tested here without composition.
+ */
+class TerminalAutoFitTest {
+
+    private val tolerance = 1e-4f
+
+    // -- convergence ------------------------------------------------------------------------------
+
+    @Test
+    fun `without a wide line the scale never moves`() {
+        val fit = TerminalAutoFitState()
+        repeat(5) { fit.onScreenSettled(wrapped = false, floor = 0.5f) }
+        assertEquals(1f, fit.scale)
+        assertFalse(fit.converged)
+        assertFalse(fit.active)
+    }
+
+    @Test
+    fun `wide output shrinks step by step, takes one margin step, then locks in`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(0.9f, fit.scale, tolerance)
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(0.9f * 0.9f, fit.scale, tolerance)
+        // Fits now — one extra margin step so nothing sits right at the edge…
+        fit.onScreenSettled(wrapped = false, floor = 0.5f)
+        assertEquals(0.9f * 0.9f * 0.9f, fit.scale, tolerance)
+        assertFalse(fit.converged)
+        // …and the settled margin screen locks it in.
+        fit.onScreenSettled(wrapped = false, floor = 0.5f)
+        assertTrue(fit.converged)
+        // A later wide line must not move a converged scale — that is the whole point.
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(0.9f * 0.9f * 0.9f, fit.scale, tolerance)
+    }
+
+    @Test
+    fun `shrinking clamps at the floor and still converges once output fits`() {
+        val fit = TerminalAutoFitState()
+        repeat(10) { fit.onScreenSettled(wrapped = true, floor = 0.8f) }
+        assertEquals(0.8f, fit.scale)
+        fit.onScreenSettled(wrapped = false, floor = 0.8f) // margin step is a no-op at the floor
+        assertEquals(0.8f, fit.scale)
+        fit.onScreenSettled(wrapped = false, floor = 0.8f)
+        assertTrue(fit.converged)
+    }
+
+    @Test
+    fun `a re-wrap during the margin step resumes shrinking`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = 0.5f) // 0.9
+        fit.onScreenSettled(wrapped = false, floor = 0.5f) // margin -> 0.81
+        fit.onScreenSettled(wrapped = true, floor = 0.5f) // wider line arrived -> keep shrinking
+        assertEquals(0.9f * 0.9f * 0.9f, fit.scale, tolerance)
+        assertFalse(fit.converged)
+        fit.onScreenSettled(wrapped = false, floor = 0.5f) // margin again
+        fit.onScreenSettled(wrapped = false, floor = 0.5f)
+        assertTrue(fit.converged)
+    }
+
+    // -- manual control ---------------------------------------------------------------------------
+
+    @Test
+    fun `a manual nudge locks auto convergence out for the session`() {
+        val fit = TerminalAutoFitState()
+        fit.nudgeDown(floor = 0.5f)
+        assertTrue(fit.locked)
+        assertEquals(0.9f, fit.scale, tolerance)
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(0.9f, fit.scale, tolerance)
+    }
+
+    @Test
+    fun `nudges stop at the floor and at the user's own size`() {
+        val fit = TerminalAutoFitState()
+        repeat(20) { fit.nudgeDown(floor = 0.7f) }
+        assertEquals(0.7f, fit.scale)
+        repeat(20) { fit.nudgeUp() }
+        assertEquals(1f, fit.scale)
+    }
+
+    @Test
+    fun `controls engage only after the scale first moves`() {
+        val fit = TerminalAutoFitState()
+        assertFalse(fit.active)
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertTrue(fit.active)
+    }
+
+    @Test
+    fun `a manual nudge back to full size keeps the controls engaged`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        fit.nudgeUp()
+        fit.nudgeUp()
+        assertEquals(1f, fit.scale)
+        // locked at 100% — auto-fit stays handed over, and the controls must not vanish under
+        // the finger that just tapped them.
+        assertTrue(fit.active)
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(1f, fit.scale)
+    }
+
+    @Test
+    fun `restore-full returns to the user's size in one step and locks`() {
+        val fit = TerminalAutoFitState()
+        repeat(5) { fit.onScreenSettled(wrapped = true, floor = 0.5f) }
+        fit.restoreFull()
+        assertEquals(1f, fit.scale)
+        assertTrue(fit.locked)
+        assertTrue(fit.active)
+        fit.onScreenSettled(wrapped = true, floor = 0.5f)
+        assertEquals(1f, fit.scale)
+    }
+
+    // -- line height ------------------------------------------------------------------------------
+
+    @Test
+    fun `the shrunk line height tightens to 1_2 but never past the user's own ratio`() {
+        assertEquals(1.2f, autoFitLineHeightRatio(18f / 13f), tolerance) // default 1.385 tightens
+        assertEquals(1.05f, autoFitLineHeightRatio(1.05f), tolerance) // denser user ratio wins
+        assertEquals(1.2f, autoFitLineHeightRatio(2f), tolerance)
+    }
+
+    // -- floor ------------------------------------------------------------------------------------
+
+    @Test
+    fun `the floor is the 6px equivalent of the user's font size`() {
+        assertEquals(6f / 13f, autoFitFloor(13), tolerance)
+        assertEquals(0.75f, autoFitFloor(8), tolerance)
+        // Degenerate sizes never produce a floor above 1 (no auto-*grow*).
+        assertTrue(autoFitFloor(4) <= 1f)
+        assertTrue(autoFitFloor(0) <= 1f)
+    }
+
+    // -- wrapped-row detection --------------------------------------------------------------------
+
+    private fun row(text: String = " ", wrapped: Boolean = false): List<TermCell> =
+        TermSnapshotRow(text.map { TermCell(it) }, wrapped)
+
+    @Test
+    fun `a wrapped row in the live grid asks to shrink`() {
+        val screen = listOf(row(), row(wrapped = true), row(), row())
+        assertTrue(gridNeedsShrink(screen, rows = 4, cursorRow = 3))
+    }
+
+    @Test
+    fun `a wrapped row that lives only in scrollback does not`() {
+        // 2 scrollback rows (the first wrapped) + a clean 3-row grid: history must not drive the
+        // font to the floor over a line that long since scrolled away.
+        val screen = listOf(row(wrapped = true), row(), row(), row(), row())
+        assertFalse(gridNeedsShrink(screen, rows = 3, cursorRow = 4))
+    }
+
+    @Test
+    fun `the line being typed under the cursor does not shrink the font`() {
+        // The user's own command line soft-wraps while being typed: rows 2-3 are one logical line
+        // with the cursor on its tail. Shrinking mid-typing would yank the font under the finger.
+        val screen = listOf(row(), row(), row(wrapped = true), row())
+        assertFalse(gridNeedsShrink(screen, rows = 4, cursorRow = 3))
+    }
+
+    @Test
+    fun `the cursor sitting mid-line excludes the whole logical line`() {
+        // One logical line spread over rows 1-3 (two wrap cuts), cursor parked on the middle row.
+        val screen = listOf(row(), row(wrapped = true), row(wrapped = true), row())
+        assertFalse(gridNeedsShrink(screen, rows = 4, cursorRow = 2))
+    }
+
+    @Test
+    fun `a wide line above the cursor's own wrapped line still shrinks`() {
+        val screen = listOf(row(wrapped = true), row(), row(wrapped = true), row())
+        assertTrue(gridNeedsShrink(screen, rows = 4, cursorRow = 3))
+    }
+
+    @Test
+    fun `empty screens and an out-of-range cursor are safe`() {
+        assertFalse(gridNeedsShrink(emptyList(), rows = 4, cursorRow = 0))
+        // The cursor index clamps into the buffer; the wide line sits apart from either edge row,
+        // so it still counts after clamping in both directions.
+        val screen = listOf(row(), row(wrapped = true), row(), row())
+        assertTrue(gridNeedsShrink(screen, rows = 4, cursorRow = 99))
+        assertTrue(gridNeedsShrink(screen, rows = 4, cursorRow = -5))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -1943,6 +1943,26 @@ class TerminalScreenStateTest {
     }
 
     @Test
+    fun `a failed resize does not poison the same-size dedup`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope)
+
+        // The PTY resize fails once (transient hiccup on a live connection)…
+        session.resizeError = { IllegalStateException("pty broke") }
+        state.resize(PtySize(cols = 50, rows = 12))
+        session.resizeError = null
+        // …and the next request at the SAME size must reach the session again. The failed
+        // attempt never landed, so deduping the retry away would leave the PTY at the old size
+        // for good — with auto-fit's settled-snapshot gate waiting on exactly that resize.
+        state.resize(PtySize(cols = 50, rows = 12))
+
+        assertEquals(listOf(PtySize(cols = 50, rows = 12)), session.resizes)
+        scope.cancel()
+    }
+
+    @Test
     fun `a cancellation during resize tears down the command handler`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitControlsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitControlsTest.kt
@@ -1,0 +1,102 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.term_autofit_grow
+import app.skerry.ui.generated.resources.term_autofit_shrink
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The manual −/+ nudge over the mobile terminal: stays out of the way until auto-fit engages,
+ * then actually moves the machine — a row that renders but taps into nothing is what a render
+ * test cannot see.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TerminalAutoFitControlsTest {
+
+    private val floor = autoFitFloor(13)
+
+    /** The scale announcer for screen readers (see StatusAnnouncer's insertion-vs-change contract). */
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    @Test
+    fun `nothing is drawn until the fit engages`() {
+        val fit = TerminalAutoFitState()
+        runForm({ TerminalAutoFitControls(fit, floor) }) {
+            onNodeWithText("100%").assertDoesNotExist()
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
+            onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).assertDoesNotExist()
+            // The announcer must already be composed, silent: appearing together with its first
+            // value would be an insertion, and Android announces only changes.
+            onNode(polite).assertContentDescriptionEquals("")
+        }
+    }
+
+    @Test
+    fun `the engaged scale reaches the screen-reader announcer`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        runForm({ TerminalAutoFitControls(fit, floor) }) {
+            onNode(polite).assertContentDescriptionEquals("90%")
+        }
+    }
+
+    @Test
+    fun `a tap on plus steps the scale up and takes over from the machine`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        runForm({ TerminalAutoFitControls(fit, floor) }) {
+            onNodeWithText("90%").assertExists()
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow)).performClick()
+            waitForIdle()
+            assertEquals(1f, fit.scale)
+            assertTrue(fit.locked)
+            // Back at 100% there is nothing to grow into — the "+" hides rather than sit dead.
+            onNodeWithText("100%").assertExists()
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `a long press on plus restores the user's size in one gesture`() {
+        val fit = TerminalAutoFitState()
+        repeat(4) { fit.onScreenSettled(wrapped = true, floor = floor) }
+        runForm({ TerminalAutoFitControls(fit, floor) }) {
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow))
+                .performTouchInput { longClick() }
+            waitForIdle()
+            assertEquals(1f, fit.scale)
+            assertTrue(fit.locked)
+        }
+    }
+
+    @Test
+    fun `a tap on minus steps the scale down and the button hides at the floor`() {
+        val fit = TerminalAutoFitState()
+        fit.onScreenSettled(wrapped = true, floor = floor)
+        runForm({ TerminalAutoFitControls(fit, floor) }) {
+            onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).performClick()
+            waitForIdle()
+            assertEquals(0.9f * 0.9f, fit.scale, absoluteTolerance = 1e-4f)
+            assertTrue(fit.locked)
+            // Drive it to the floor: the "−" must disappear, "+" must stay.
+            while (fit.scale > floor) fit.nudgeDown(floor)
+            waitForIdle()
+            onNodeWithContentDescription(string(Res.string.term_autofit_shrink)).assertDoesNotExist()
+            onNodeWithContentDescription(string(Res.string.term_autofit_grow)).assertExists()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
@@ -1,0 +1,196 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Density
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.rememberMaterialSymbols
+import app.skerry.ui.design.rememberMono
+import app.skerry.ui.design.rememberUiFont
+import app.skerry.ui.theme.Skerry
+import app.skerry.ui.theme.SkerryTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The auto-fit loop end to end (issue #180): a live [TerminalScreen] on a narrow scene, wide
+ * output arrives, and the machine on [TerminalScreenState.autoFit] has to drive the real
+ * metrics -> resize -> reflow cycle to a converged scale — and then hold it. The machine's rules
+ * are unit-tested in TerminalAutoFitTest; what only this test can see is the loop's plumbing:
+ * a settled-snapshot gate that never opens (nothing converges) or one that doesn't gate
+ * (the scale runs to the floor past the fit).
+ */
+class TerminalAutoFitLiveTest {
+
+    /** Replays scripted shell output on demand; input/resize are accepted and dropped. */
+    private class ScriptedSession : TerminalSession {
+        private val stateFlow = MutableStateFlow<TerminalState>(TerminalState.Open)
+        override val state: StateFlow<TerminalState> = stateFlow
+
+        /** Connection loss: what the Disconnected screen freezes over. */
+        fun drop() {
+            stateFlow.value = TerminalState.Closed()
+        }
+        // Replay covers prints landing before the collector attaches; the extra buffer absorbs
+        // the streaming-pressure phase, whose prints outpace the emulator's drain.
+        private val chunks = MutableSharedFlow<ByteArray>(replay = 8, extraBufferCapacity = 64)
+        override val output: Flow<ByteArray> = chunks
+
+        fun print(text: String) {
+            check(chunks.tryEmit(text.encodeToByteArray()))
+        }
+
+        override suspend fun send(data: ByteArray) = Unit
+        override suspend fun resize(size: PtySize) = Unit
+        override suspend fun close() = Unit
+    }
+
+    /** Virtual frame clock, shared across wait phases so scene time never runs backwards. */
+    private var frame = 0L
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun autoFitScene(terminal: TerminalScreenState): ImageComposeScene =
+        ImageComposeScene(width = 300, height = 400, density = Density(1f)) {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(rememberUiFont(), rememberMono(), rememberMaterialSymbols()),
+                ) {
+                    Box(Modifier.fillMaxSize().background(Skerry.colors.terminalBg)) {
+                        TerminalScreen(terminal, Modifier.fillMaxSize(), autoFitEnabled = true)
+                    }
+                }
+            }
+        }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Test
+    fun `wide output converges the font once and a later wider line does not move it`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val session = ScriptedSession()
+        val terminal = TerminalScreenState(session, scope)
+        var scene = autoFitScene(terminal)
+        try {
+            // Let the first layout resize land before printing, as on a live connect: output fed
+            // into the default 80x24 grid would get pushed into scrollback by the initial reflow,
+            // and scrollback is deliberately outside the fit.
+            waitForFrames(scene) { terminal.cols in 20..50 }
+            // A 50-char line on a ~34-col grid soft-wraps; the fit has to land well above the 6px
+            // floor, so a floor-runaway is distinguishable from an honest convergence. The cursor
+            // ends on its own short prompt line — the line being typed is excluded on purpose.
+            // More wide lines keep streaming in WHILE the fit converges — the step-per-settled
+            // discipline must hold under exactly this pressure (snapshots published between a
+            // step and its reflow still carry the old grid and must not drive extra steps).
+            // Best-effort race amplifier, not a deterministic reproduction: the prints ride the
+            // test's frame cadence, so whether one lands inside the step-to-restart window is
+            // scheduling luck — a run that hits it fails loudly, a run that misses proves less.
+            session.print("ok\r\n" + "x".repeat(50) + "\r\n$ ")
+            var pressure = 0
+            waitForFrames(scene) {
+                if (pressure < 12 && !terminal.autoFit.converged) {
+                    session.print("x".repeat(50) + "\r\n$ ")
+                    pressure++
+                }
+                terminal.autoFit.converged
+            }
+            assertTrue(terminal.autoFit.converged, "auto-fit did not converge; scale=${terminal.autoFit.scale}")
+            val converged = terminal.autoFit.scale
+            assertTrue(converged < 1f, "converged without shrinking")
+            val floor = autoFitFloor(13)
+            assertTrue(converged > floor, "ran to the floor past the fit: $converged")
+
+            // Once per session: an even wider line afterwards must not move a converged scale.
+            session.print("y".repeat(90) + "\r\n$ ")
+            waitForFrames(scene, framesAfterSettled = 30) { false }
+            assertEquals(converged, terminal.autoFit.scale, "a converged scale moved on later output")
+
+            // Remount survival: the fit lives on TerminalScreenState, not in composition — a
+            // remount of the screen against the same state (switching to another session's tab
+            // and back, or the Disconnected screen replacing the live one) must keep the
+            // converged scale instead of re-running convergence from 100%. The session is
+            // dropped first for the Disconnected shape; note the converged gate returns before
+            // the closed-session gate here — the frozen pre-convergence step is pinned by the
+            // dedicated test below, not by this phase.
+            session.drop()
+            scene.close()
+            scene = autoFitScene(terminal)
+            waitForFrames(scene, framesAfterSettled = 30) { false }
+            assertEquals(converged, terminal.autoFit.scale, "a remount reset the converged scale")
+            assertTrue(terminal.autoFit.converged, "a remount re-armed convergence")
+        } finally {
+            scene.close()
+            scope.cancel()
+        }
+    }
+
+    /**
+     * A dead session must never take a step: its command queue is closed with the output, so a
+     * step could only rescale the frozen glyphs without re-wrapping them — the exact effect the
+     * Disconnected screen declines to offer manually. The drop lands BEFORE the wide line, so the
+     * machine is still Waiting when the wrapped rows appear on the frozen screen: without the
+     * closed-session gate the very next settled snapshot would take one 0.9x step.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    @Test
+    fun `a frozen session never takes a reflow-less step`() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val session = ScriptedSession()
+        val terminal = TerminalScreenState(session, scope)
+        val scene = autoFitScene(terminal)
+        try {
+            waitForFrames(scene) { terminal.cols in 20..50 } // first layout resize has landed
+            session.drop()
+            session.print("ok\r\n" + "x".repeat(50) + "\r\n$ ")
+            waitForFrames(scene, framesAfterSettled = 30) { false }
+            assertEquals(1f, terminal.autoFit.scale, "a frozen session's wide output moved the scale")
+            assertFalse(terminal.autoFit.converged, "a frozen session converged")
+        } finally {
+            scene.close()
+            scope.cancel()
+        }
+    }
+
+    /**
+     * Renders frames in real time until [done] (or a timeout — the resize debounce is a real
+     * 150ms per convergence step, so the loop needs seconds, not frames). With [framesAfterSettled]
+     * set, renders exactly that many more frames instead — "assert nothing changes" needs a fixed
+     * observation window, not an exit condition.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun waitForFrames(
+        scene: ImageComposeScene,
+        framesAfterSettled: Int = 0,
+        done: () -> Boolean,
+    ) {
+        if (framesAfterSettled > 0) {
+            repeat(framesAfterSettled) {
+                scene.render(++frame * 16_000_000L)
+                Thread.sleep(32)
+            }
+            return
+        }
+        val deadline = System.currentTimeMillis() + 30_000
+        while (!done() && System.currentTimeMillis() < deadline) {
+            scene.render(++frame * 16_000_000L)
+            Thread.sleep(32)
+        }
+    }
+}

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -67,7 +67,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Any text on screen | `ui/design/DesignPrimitives.Txt` — never a raw `Text()` |
 | Any icon | `ui/design/Sym` (Material Symbols glyph) + `DesignFonts` |
 | Fonts | `ui/design/DesignFoundation`: `rememberUiFont`, `rememberMono`, `rememberMaterialSymbols` |
-| Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` |
+| Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` (hover/tooltip chrome); `ui/design/GlyphButton` for a touch glyph box — square tap target, `Role.Button`, optional long-press — don't hand-roll the `Box`+`Sym`+`clickable` shape again |
 | Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` |
 | A setting as a label + switch row | `ToggleRow` (optional second line); `SettingToggleRow` / `MobileSyncToggleRow` are its settings and sync scales and should converge onto it |
 | A fact as a label + value row in a detail panel | `KeyValueRow`; `InfoRow` (session info panel) and `CardRow` (tunnel dashboard) are the same shape and should converge onto it |


### PR DESCRIPTION
Closes #180.

## What it does

On the mobile terminal, wide output (`docker ps`, `git log --graph`, long log lines) soft-wraps into a wall of text. This adds Termux-style **shrink to fit**: while the live grid holds soft-wrapped rows, the font scales down in steps (×0.9, floor at a 6px equivalent — deliberately below the Appearance slider's 8px minimum, since the shrunken view exists to *read* wide output) until rows fit. The fit **converges once per session and then sticks** — no continuous re-shrink loop that would oscillate at the wrap boundary.

Once the fit engages, floating controls appear bottom-right: the current scale as a percentage, and −/+ buttons (44dp targets). The first manual tap hands control over for the rest of the session; long-pressing **+** restores the user's font size in one gesture. A session that never prints a wide line shows no extra chrome. Desktop terminals keep the user's font size.

## Behavior details

- The scale lives on `TerminalScreenState`: it survives switching tabs and back, resets with the session on reconnect.
- Only the **visible grid** drives the fit — a wide line that long since scrolled into history cannot drag the font to the floor, and the line being typed under the cursor is excluded (typing a long command doesn't shrink the font mid-keystroke).
- Convergence steps only on *settled* snapshots (grid width already reflects the current scale), one scale-moving step per reflow cycle, and never on a dead session — the frozen Disconnected screen keeps its converged scale but takes no further steps (its command queue cannot reflow).
- While shrunk, line height tightens toward the glyph height (ratio 1.2), never looser than the user's own Appearance ratio; both restore with the size.
- The percentage is announced to screen readers via a polite live region composed before the fit engages, so the first auto-shrink is announced as a change; buttons carry localized labels (en/ru/zh) and `Role.Button`.
- A remote host can at most drive the font to the floor once per session; the controls appear immediately and the machine never raises the scale on its own.

## Also in this change

- `GlyphButton` — shared touch glyph-box primitive (square target, `Role.Button`, optional long-press), now used by the terminal header icons too; added to the abstraction catalogue.
- A failed PTY resize no longer poisons the same-size dedup in `TerminalScreenState.resize` — the next request at the same size is re-attempted.
- The grid/cursor snapshot group publishes atomically (`Snapshot.withMutableSnapshot`), so a concurrent reader can no longer pair a fresh screen with a stale cursor.

## Tests

- `TerminalAutoFitTest` (commonTest): the convergence machine (step/overshoot/lock/floor/re-wrap), manual nudges, restore-full, line-height ratio, and wrapped-row detection incl. scrollback and cursor-line exclusion.
- `TerminalAutoFitLiveTest` (desktopTest): the real metrics → resize → reflow loop end to end — converges once under streaming pressure, later wider lines don't move it, the scale survives a remount (tab switch / Disconnected), and a frozen session never takes a reflow-less step.
- `TerminalAutoFitControlsTest` (desktopTest): controls hidden until the fit engages, tap/long-press semantics, button hiding at the floor and at 100%, and the screen-reader announcer contract.
- `TerminalScreenStateTest`: a failed resize can be retried at the same size.

## Limitations

- If the very first auto-fit resize fails on a transient PTY error before any step lands, convergence stalls silently until the next viewport/metrics change retriggers it (on a phone the IME show/hide does this routinely); the manual controls are not yet visible at that point.
- Verified with the desktop test suite only — not yet exercised live on an Android device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bxJPejMzM3LsLvXdwXWD4
