### PR TITLE
Stabilize UI-test flakes: wait for the seeded session and the SFTP listing

### DIFF
--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -26,6 +26,7 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.ai.AiAssistantController
+import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.mobile.MobileDesignApp
@@ -162,6 +163,20 @@ internal fun runDesktopShell(
             }
         }
         waitForIdle()
+        // The seeded session connects on the background scope, which waitForIdle does NOT wait
+        // for. A shortcut sent before it lands falls through the root handler (no Connected
+        // terminal to act on) and the test flakes only on a loaded runner — the CI shape of the
+        // `escape closes the find bar` failure. Hand the body the shell every test assumes: an
+        // active tab whose focused pane is connected.
+        if (sessions != null) {
+            waitUntil("seeded session reaches Connected", timeoutMillis = 10_000) {
+                val s = sessions.active?.focusedPane?.controller?.uiState
+                // A definitive failure must not burn the whole timeout and then report a generic
+                // "condition not satisfied" — the state carries the actual diagnosis.
+                if (s is ConnectionUiState.Error) error("seeded session failed to connect: ${s.message}")
+                s is ConnectionUiState.Connected
+            }
+        }
         val libraries = ShellLibraries(tunnels, snippets, runbooks, credentials, ai)
         body(DesktopShell(hosts, sessions, libraries, runner, state))
     } finally {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpPanelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpPanelTest.kt
@@ -85,7 +85,12 @@ class SftpPanelTest {
 
     private fun ComposeUiTest.openFiles() {
         onNodeWithContentDescription(string(Res.string.shell_tip_files)).performClick()
-        waitForIdle()
+        // The listing answers from the fake SFTP client on a background hop of its own: the Files
+        // view composes before the rows arrive, and a first-frame assertion on headers or rows
+        // flakes on a loaded runner. Hold until the remote pane has filled in.
+        waitUntil("remote listing shows $REMOTE_FILE", timeoutMillis = 10_000) {
+            onAllNodesWithText(REMOTE_FILE).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 }
 


### PR DESCRIPTION
## What it fixes

Two observed UI-test flakes, one root cause: a first-frame action racing state that arrives on a background coroutine `waitForIdle` does not await.

- `TerminalSearchTest > escape closes the find bar` (failed once on CI, passed on rerun): the seeded shell session connects on a background scope, and `Ctrl+Shift+F` sent before it reaches `Connected` falls through the root shortcut handler — `FindInTerminal` has no connected terminal to act on, the find bar never opens, and the search-field lookup fails.
- `SftpPanelTest > the columns menu takes a column out of both listings` (failed once locally under full-suite load): the Files view composes before the fake SFTP listing arrives on its own background hop, so first-frame assertions race the rows.

## Changes

- `runDesktopShell` hands the test body a shell whose focused pane is `Connected` (up to 10s), covering every desktop shell test that acts on the session as its first move — including the command-palette chord test, which shares the same handler guard. If the fake connect lands in `Error`, the wait fails immediately with the session's own error message instead of burning the timeout into a generic `ComposeTimeoutException`.
- `SftpPanelTest.openFiles` waits for the listing row instead of a bare `waitForIdle`, covering all three tests in the file.
- Both waits carry a `conditionDescription`, so a timeout names what never arrived.

Test-only change; no production code touched. Affected suites ran green 3× locally after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bxJPejMzM3LsLvXdwXWD4
