### PR TITLE
Vault: record private-key exports in the audit trail (#221)

### DIFF
--- a/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ExportFile.android.kt
+++ b/composeApp/src/androidMain/kotlin/app/skerry/ui/vault/ExportFile.android.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.vault
 import android.provider.DocumentsContract
 import app.skerry.ui.sftp.SafBridge
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 
 /**
@@ -21,7 +22,11 @@ import kotlinx.coroutines.withContext
 internal actual suspend fun exportTextFile(suggestedName: String, content: String): ExportOutcome {
     val ctx = SafBridge.context() ?: return ExportOutcome.Failed
     val uri = SafBridge.createDocument(suggestedName) ?: return ExportOutcome.Cancelled
-    return withContext(Dispatchers.IO) {
+    // NonCancellable, as on desktop: the document already exists at the Uri the user picked, so the
+    // write (or the cleanup delete, and the zeroing) runs to completion even if the screen is torn
+    // down mid-write. Delivery of the result to a cancelled caller is not this block's to promise —
+    // the key-export path hoists its own NonCancellable around the call; see exportPrivateKey.
+    return withContext(Dispatchers.IO + NonCancellable) {
         // Zeroed after the write, as on desktop: the String behind it can't be, but this copy can,
         // and a phone is the likelier of the two to have its heap dumped.
         val bytes = content.toByteArray(Charsets.UTF_8)

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -169,6 +169,7 @@
     <string name="settings_event_biometric_disabled">Выключена разблокировка биометрией</string>
     <string name="settings_event_unlocked_biometric">Разблокировка биометрией</string>
     <string name="settings_event_device_paired">Привязано новое устройство</string>
+    <string name="settings_event_key_exported">Ключ экспортирован в файл</string>
     <string name="settings_event_with_detail">%1$s: %2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">сегодня %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -172,6 +172,8 @@
         <item quantity="many">%1$d раз за %2$d дней</item>
         <item quantity="other">%1$d раза за %2$d дней</item>
     </plurals>
+    <string name="vault_kv_exported">Экспортировали</string>
+    <string name="vault_never_exported">ни разу</string>
 
     <string name="vault_meta_rotated">сменён %1$s</string>
     <string name="vault_meta_valid_until">действует до %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -169,6 +169,7 @@
     <string name="settings_event_biometric_disabled">生物识别解锁已禁用</string>
     <string name="settings_event_unlocked_biometric">通过生物识别解锁</string>
     <string name="settings_event_device_paired">新设备已配对</string>
+    <string name="settings_event_key_exported">密钥已导出到文件</string>
     <string name="settings_event_with_detail">%1$s：%2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">今天 %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -166,6 +166,8 @@
     <plurals name="vault_copies_window">
         <item quantity="other">%2$d 天内 %1$d 次</item>
     </plurals>
+    <string name="vault_kv_exported">导出</string>
+    <string name="vault_never_exported">从未</string>
 
     <string name="vault_meta_rotated">%1$s 轮换</string>
     <string name="vault_meta_valid_until">有效期至 %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -169,6 +169,7 @@
     <string name="settings_event_biometric_disabled">Biometric unlock disabled</string>
     <string name="settings_event_unlocked_biometric">Unlocked with biometrics</string>
     <string name="settings_event_device_paired">New device paired</string>
+    <string name="settings_event_key_exported">Key exported to file</string>
     <string name="settings_event_with_detail">%1$s: %2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">today %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -173,6 +173,8 @@
         <item quantity="one">%1$d time in %2$d days</item>
         <item quantity="other">%1$d times in %2$d days</item>
     </plurals>
+    <string name="vault_kv_exported">Exported</string>
+    <string name="vault_never_exported">never</string>
 
     <!-- Row meta line: the facts about a secret, type excluded (the badge says it). -->
     <string name="vault_meta_rotated">rotated %1$s</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/KeyValueRow.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/KeyValueRow.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -31,7 +32,9 @@ fun KeyValueRow(
     valueColor: Color = Skerry.colors.text,
 ) {
     Row(
-        modifier.fillMaxWidth().padding(vertical = 3.dp),
+        // One fact, one accessibility node: a screen reader announces "Exported, never" in a single
+        // stop instead of a label and an orphaned value two swipes apart.
+        modifier.fillMaxWidth().padding(vertical = 3.dp).semantics(mergeDescendants = true) {},
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -118,6 +118,13 @@ class CredentialManagerController(
      */
     fun recordCopied(id: String) = record(id, CredentialUsageLog::recordCopied)
 
+    /**
+     * Note that a secret's private material was written out to a file ("Export key"). Recorded only
+     * for a completed write — the caller ([app.skerry.ui.vault.keyExportAudit]) runs on
+     * [app.skerry.ui.vault.ExportOutcome.Saved] and nothing else.
+     */
+    fun recordExported(id: String) = record(id, CredentialUsageLog::recordExported)
+
     /** Usage trail of a secret: added / last used / copies. `null` when nothing was ever recorded. */
     fun usageOf(id: String): CredentialUsage? = usageById[id]
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -90,6 +90,7 @@ import app.skerry.ui.vault.SecretActions
 import app.skerry.ui.vault.secretActions
 import app.skerry.ui.vault.exportPrivateKey
 import app.skerry.ui.vault.exportPublic
+import app.skerry.ui.vault.keyExportAudit
 import app.skerry.ui.vault.VaultCategoryKind
 import app.skerry.ui.vault.VaultPresentation
 import app.skerry.ui.vault.title
@@ -117,6 +118,7 @@ import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.app.LocalSync
 import app.skerry.ui.sync.SyncStatus
 import app.skerry.ui.app.LocalSecretFileReader
+import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.vault.KeyFileBadges
 import app.skerry.ui.vault.KeyFileDetailBody
 import app.skerry.ui.vault.LinkKeyFileDialog
@@ -133,6 +135,7 @@ import app.skerry.ui.vault.SecretIcon
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.vault.SecretAuditRows
+import app.skerry.ui.vault.hasAuditTrail
 import app.skerry.ui.vault.SecretEncryptionRows
 import app.skerry.ui.vault.SecretFactRows
 import app.skerry.ui.vault.SecretRow
@@ -180,6 +183,8 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     val vault = LocalVault.current
     val biometrics = LocalVaultBiometrics.current
     val copyAuth = remember(vault, biometrics, scope) { SecretCopyAuthorizer(vault, biometrics, scope) }
+    // A saved export is recorded in the usage trail and the security log (issue #221).
+    val securityLog = LocalSecurityLog.current
     var exportFailed by remember { mutableStateOf(false) }
 
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
@@ -363,7 +368,12 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                     copyAuth.authorize { credentials.recordCopied(credential.id); copyPasswordToClipboard(pwd) }
                 },
                 // Private key material: re-authenticated like a password copy; see VaultView.
-                onExportKey = { export -> exportPrivateKey(copyAuth, export, scope) { exportFailed = it.worthReporting } },
+                onExportKey = { export ->
+                    exportPrivateKey(
+                        copyAuth, export, scope,
+                        onSaved = keyExportAudit(credentials, securityLog, credential.id),
+                    ) { exportFailed = it.worthReporting }
+                },
                 onExportPublic = { export -> exportPublic(export, scope) { exportFailed = it.worthReporting } },
                 // Close the detail sheet before showing a centered dialog (rename/delete): otherwise the
                 // sheet, drawn on top, would cover it and leave only its edge visible.
@@ -660,10 +670,11 @@ private fun MobileSecretDetailSheet(
                 }
                 SecretSectionLabel(encryptionSectionTitle())
                 SecretEncryptionRows(syncing)
-                // Only a password is ever copied out of the vault; see the desktop panel.
-                if (secret is CredentialSecret.Password) {
+                // Same rule as the desktop panel: audit shows for every secret whose material can
+                // leave the vault — password copies and private-key exports.
+                if (hasAuditTrail(credential)) {
                     SecretSectionLabel(auditSectionTitle())
-                    SecretAuditRows(usage)
+                    SecretAuditRows(credential, usage)
                 }
                 Spacer(Modifier.height(8.dp))
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
@@ -32,6 +32,7 @@ import app.skerry.shared.vault.SecurityEvent
 import app.skerry.shared.vault.SecurityEventType
 import app.skerry.shared.vault.securityMoment
 import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.app.LocalCredentials
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.DropdownField
 import app.skerry.ui.design.GhostButton
@@ -64,6 +65,7 @@ import app.skerry.ui.generated.resources.settings_change_pw_title
 import app.skerry.ui.generated.resources.settings_event_biometric_disabled
 import app.skerry.ui.generated.resources.settings_event_biometric_enabled
 import app.skerry.ui.generated.resources.settings_event_device_paired
+import app.skerry.ui.generated.resources.settings_event_key_exported
 import app.skerry.ui.generated.resources.settings_event_line
 import app.skerry.ui.generated.resources.settings_event_password_changed
 import app.skerry.ui.generated.resources.settings_event_unlocked_biometric
@@ -292,8 +294,27 @@ internal fun masterPasswordSubtitle(lastChangeAt: String?): String {
 @Composable
 internal fun securityEventLine(event: SecurityEvent): String {
     val label = event.type.eventLabel()
-    val head = event.detail?.let { stringResource(Res.string.settings_event_with_detail, label, it) } ?: label
+    val credentials = LocalCredentials.current
+    val detail = securityEventDisplayDetail(event.type, event.detail) { id -> credentials?.find(id)?.label }
+    val head = detail?.let { stringResource(Res.string.settings_event_with_detail, label, it) } ?: label
     return stringResource(Res.string.settings_event_line, head, securityEventTime(event.at))
+}
+
+/**
+ * The detail an event line shows, if any. Most events store a human detail and show it verbatim
+ * ([SecurityEventType.DevicePaired] — a device name). [SecurityEventType.KeyExported] stores the
+ * credential id (labels are secret, the log is plaintext on disk), and an id is not for humans:
+ * it is resolved to the label via [labelOf] at render time, and when it no longer resolves (the
+ * secret was deleted, or the keychain was not loaded this run) the line shows no detail rather
+ * than a raw UUID.
+ */
+internal fun securityEventDisplayDetail(
+    type: SecurityEventType,
+    detail: String?,
+    labelOf: (String) -> String?,
+): String? = when (type) {
+    SecurityEventType.KeyExported -> detail?.let(labelOf)
+    else -> detail
 }
 
 /** Localized event type label. */
@@ -306,6 +327,7 @@ private fun SecurityEventType.eventLabel(): String = stringResource(
         SecurityEventType.BiometricDisabled -> Res.string.settings_event_biometric_disabled
         SecurityEventType.UnlockedBiometric -> Res.string.settings_event_unlocked_biometric
         SecurityEventType.DevicePaired -> Res.string.settings_event_device_paired
+        SecurityEventType.KeyExported -> Res.string.settings_event_key_exported
     },
 )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretExport.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/SecretExport.kt
@@ -3,8 +3,13 @@ package app.skerry.ui.vault
 import app.skerry.shared.io.safeFileStem
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.SecurityEventType
+import app.skerry.shared.vault.SecurityLog
+import app.skerry.ui.identity.CredentialManagerController
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * One file "Export" writes: the [fileName] offered in the Save-As dialog and the [content] written
@@ -109,17 +114,73 @@ fun secretActions(credential: Credential): SecretActions = when {
  * [ExportOutcome.worthReporting]); it never runs when authorization is refused, which is the
  * behaviour `SecretExportGateTest` pins down. [write] is [exportTextFile] in the app and a fake in
  * tests — the only way to exercise this without a native file dialog.
+ *
+ * [onSaved] is the audit hook (issue #221), and it is deliberately not defaulted: a screen that
+ * exports without saying what to record is the same silent-wiring bug class as #218. It runs only
+ * for [ExportOutcome.Saved] — a dismissed prompt, a closed Save-As and a failed write all leave no
+ * file, and an audit trail that says otherwise is worse than none. It must stay a plain non-suspend
+ * lambda: the `runCatching` around it would silently swallow a real cancellation if it ever
+ * suspended.
  */
 internal fun exportPrivateKey(
     auth: SecretCopyAuthorizer,
     export: SecretExport.PrivateKey,
     scope: CoroutineScope,
     write: suspend (SecretExport) -> ExportOutcome = { exportTextFile(it.fileName, it.content) },
+    onSaved: () -> Unit,
     onOutcome: (ExportOutcome) -> Unit,
 ) {
     auth.authorize(SecretAccess.EXPORT) {
-        scope.launch { onOutcome(guardedExport { write(export) }) }
+        scope.launch {
+            // The whole write-plus-audit stretch runs under NonCancellable, hoisted HERE and not
+            // only inside the platform writers: withContext's prompt-cancellation guarantee checks
+            // the *caller's* job at the dispatch back, so a writer's completed Saved would be
+            // discarded into a CancellationException if the screen's scope died mid-write — key on
+            // disk, no audit record, no outcome. With this job non-cancellable the result is
+            // always delivered. A write that itself throws CancellationException (the composition
+            // genuinely gone before anything landed) still propagates out of guardedExport and
+            // records nothing. runCatching around the hook: an audit-write failure (disk full)
+            // must not suppress the outcome report or cancel the screen's shared scope — the same
+            // best-effort rule the usage-log half documents on its own record path.
+            val outcome = withContext(NonCancellable) {
+                val written = guardedExport { write(export) }
+                if (written == ExportOutcome.Saved) runCatching { onSaved() }
+                written
+            }
+            onOutcome(outcome)
+        }
     }
+}
+
+/**
+ * What a saved key export records, in both places a user looks after something suspicious: the
+ * secret's own usage trail ("Exported — today 09:14" on its panel) and the security event log in
+ * Settings. One producer for both screens — the desktop panel and the mobile sheet wiring their own
+ * pairs would drift the first time one of them was edited.
+ *
+ * The security event carries [credentialId] only, never the label — the label is treated as secret
+ * everywhere else ([Credential.toString] redacts it) and the security log is plaintext on disk.
+ * A `null` [securityLog] (a build without one wired) still records the usage trail.
+ */
+internal fun keyExportAudit(
+    credentials: CredentialManagerController,
+    securityLog: SecurityLog?,
+    credentialId: String,
+): () -> Unit = {
+    credentials.recordExported(credentialId)
+    securityLog?.record(SecurityEventType.KeyExported, credentialId)
+}
+
+/**
+ * Whether the detail panel has an audit section to show: any secret whose material can leave the
+ * vault — a password (clipboard copy) or anything with an exportable private key. A file-backed
+ * secret has neither; its material never entered the vault. A type check rather than
+ * `privateKeyExport(credential) != null`: this runs on every recomposition of the detail panel,
+ * and building a PEM-carrying export object just to null-check it is allocation for nothing.
+ */
+internal fun hasAuditTrail(credential: Credential): Boolean = when (credential.secret) {
+    is CredentialSecret.Password, is CredentialSecret.PrivateKey, is CredentialSecret.Certificate -> true
+    is CredentialSecret.KeyFile -> false
 }
 
 /** Writes public material (the certificate) — no gate, the same as copying it to the clipboard. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.VaultCrypto
@@ -20,6 +21,7 @@ import app.skerry.ui.generated.resources.vault_kv_added
 import app.skerry.ui.generated.resources.vault_kv_changed
 import app.skerry.ui.generated.resources.vault_kv_cipher
 import app.skerry.ui.generated.resources.vault_kv_copied
+import app.skerry.ui.generated.resources.vault_kv_exported
 import app.skerry.ui.generated.resources.vault_kv_fingerprint
 import app.skerry.ui.generated.resources.vault_kv_kdf
 import app.skerry.ui.generated.resources.vault_kv_last_used
@@ -32,6 +34,7 @@ import app.skerry.ui.generated.resources.vault_section_audit
 import app.skerry.ui.generated.resources.vault_section_encryption
 import app.skerry.ui.generated.resources.vault_stored_ciphertext
 import app.skerry.ui.generated.resources.vault_stored_local
+import app.skerry.ui.generated.resources.vault_never_exported
 import app.skerry.ui.generated.resources.vault_value_never
 import app.skerry.ui.generated.resources.vault_value_unknown
 import app.skerry.ui.design.KeyValueRow
@@ -115,18 +118,32 @@ fun SecretEncryptionRows(syncing: Boolean, modifier: Modifier = Modifier) {
 }
 
 /**
- * What this device did with the secret: how often it was copied to the clipboard inside the audit
- * window. Per-device by design (see [app.skerry.shared.vault.CredentialUsageLog]) — a copy made on
- * the phone is not counted here, and the log is not synced.
+ * What this device did with the secret — the ways its material left the vault. A password leaves
+ * via the clipboard, so its row counts copies inside the audit window; a key or a certificate
+ * leaves via "Export key", so its row states the last export ("never" until there was one — the
+ * panel of an exported key must not look like the panel of one that never left, issue #221).
+ * Per-device by design (see [app.skerry.shared.vault.CredentialUsageLog]) — a copy or an export
+ * made on the phone is not counted here, and the log is not synced.
  */
 @Composable
-fun SecretAuditRows(usage: CredentialUsage?, modifier: Modifier = Modifier) {
-    val copies = VaultPresentation.copiesWithin(usage, COPY_WINDOW_DAYS) { at -> securityMoment(at)?.daysAgo }
+fun SecretAuditRows(credential: Credential, usage: CredentialUsage?, modifier: Modifier = Modifier) {
     Column(modifier.fillMaxWidth()) {
-        KeyValueRow(
-            stringResource(Res.string.vault_kv_copied),
-            pluralStringResource(Res.plurals.vault_copies_window, copies, copies, COPY_WINDOW_DAYS),
-        )
+        if (credential.secret is CredentialSecret.Password) {
+            val copies = VaultPresentation.copiesWithin(usage, COPY_WINDOW_DAYS) { at -> securityMoment(at)?.daysAgo }
+            KeyValueRow(
+                stringResource(Res.string.vault_kv_copied),
+                pluralStringResource(Res.plurals.vault_copies_window, copies, copies, COPY_WINDOW_DAYS),
+            )
+        }
+        // Type check, not privateKeyExport(...) != null — same recomposition-allocation reasoning
+        // as hasAuditTrail.
+        if (credential.secret is CredentialSecret.PrivateKey || credential.secret is CredentialSecret.Certificate) {
+            KeyValueRow(
+                stringResource(Res.string.vault_kv_exported),
+                usage?.exportedAt?.lastOrNull()?.let { momentLabel(it) }
+                    ?: stringResource(Res.string.vault_never_exported),
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -224,12 +224,12 @@ internal fun LiveSecretDetail(
         }
         SecretSectionLabel(encryptionSectionTitle())
         SecretEncryptionRows(syncing)
-        // Audit counts clipboard copies, and only a password ever leaves the vault that way: for a
-        // key or a certificate the copy button hands over the public half, which is not a secret.
-        // (An exported key is not a copy and is not counted — the log records clipboard events.)
-        if (secret is CredentialSecret.Password) {
+        // Audit shows for every secret whose material can leave the vault: a password (clipboard
+        // copies) and anything with an exportable private key (file exports). A file-backed secret
+        // has neither — its material never entered the vault.
+        if (hasAuditTrail(credential)) {
             SecretSectionLabel(auditSectionTitle())
-            SecretAuditRows(usage)
+            SecretAuditRows(credential, usage)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -39,6 +39,7 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyGenerator
+import app.skerry.ui.app.LocalSecurityLog
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.help_button
@@ -142,6 +143,8 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     val vault = LocalVault.current
     val biometrics = LocalVaultBiometrics.current
     val copyAuth = remember(vault, biometrics, scope) { SecretCopyAuthorizer(vault, biometrics, scope) }
+    // A saved export is recorded in the usage trail and the security log (issue #221).
+    val securityLog = LocalSecurityLog.current
     var exportFailed by remember { mutableStateOf(false) }
 
     var category by remember { mutableStateOf(VaultCategoryKind.SSH_KEYS) }
@@ -220,7 +223,10 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                             // cancelled Save-As stays silent; a failed write must not, or the user
                             // walks away believing they have a backup.
                             onExportKey = { export ->
-                                exportPrivateKey(copyAuth, export, scope) { exportFailed = it.worthReporting }
+                                exportPrivateKey(
+                                    copyAuth, export, scope,
+                                    onSaved = keyExportAudit(credentials, securityLog, credential.id),
+                                ) { exportFailed = it.worthReporting }
                             },
                             // The certificate is public — no gate, like the Copy button next to it.
                             onExportPublic = { export ->

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
@@ -206,6 +206,17 @@ class CredentialManagerControllerTest {
     }
 
     @Test
+    fun `exporting a key is recorded against it`() = runTest {
+        val usage = FakeUsageLog()
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault()), usage = usage, scope = CoroutineScope(Dispatchers.Unconfined)) { "gen" }
+
+        controller.recordExported("gen")
+
+        assertEquals(listOf("exported:gen"), usage.events)
+        assertEquals(1, controller.usageOf("gen")?.exportedAt?.size)
+    }
+
+    @Test
     fun `usage events run off the caller thread in the order they were submitted`() = runTest {
         // The production lane: one thread, so a forget can't overtake a still-pending recordUsed and
         // the in-memory mirror can't lose an update to a concurrent one.
@@ -263,6 +274,11 @@ private class FakeUsageLog : CredentialUsageLog {
     override fun recordCopied(credentialId: String): CredentialUsage {
         events += "copied:$credentialId"
         return store(credentialId) { it.copy(copiedAt = it.copiedAt + "t") }
+    }
+
+    override fun recordExported(credentialId: String): CredentialUsage {
+        events += "exported:$credentialId"
+        return store(credentialId) { it.copy(exportedAt = it.exportedAt + "t") }
     }
 
     override fun forget(credentialId: String) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/settings/SecurityEventDisplayDetailTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/settings/SecurityEventDisplayDetailTest.kt
@@ -1,0 +1,41 @@
+package app.skerry.ui.settings
+
+import app.skerry.shared.vault.SecurityEventType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * What the security event list shows as an event's detail. A [SecurityEventType.KeyExported] event
+ * stores the credential id (the label is secret and the log is plaintext on disk), but the id is an
+ * opaque UUID no screen ever shows — so at display time it is resolved to the label, and an id that
+ * no longer resolves (secret deleted, keychain not loaded this run) shows no detail at all rather than a UUID a
+ * screen reader would spell out character by character. Every other event type shows its detail
+ * verbatim — [SecurityEventType.DevicePaired] stores a human device name on purpose.
+ */
+class SecurityEventDisplayDetailTest {
+
+    @Test
+    fun `a key export resolves its credential id to the label`() {
+        val detail = securityEventDisplayDetail(SecurityEventType.KeyExported, "cred-1") { id ->
+            if (id == "cred-1") "prod bastion" else null
+        }
+        assertEquals("prod bastion", detail)
+    }
+
+    @Test
+    fun `an unresolvable id shows no detail, not the raw id`() {
+        assertNull(securityEventDisplayDetail(SecurityEventType.KeyExported, "cred-gone") { null })
+    }
+
+    @Test
+    fun `other event types pass their detail through untouched`() {
+        val detail = securityEventDisplayDetail(SecurityEventType.DevicePaired, "iPhone 16 Pro") { null }
+        assertEquals("iPhone 16 Pro", detail)
+    }
+
+    @Test
+    fun `a detail-less event stays detail-less`() {
+        assertNull(securityEventDisplayDetail(SecurityEventType.KeyExported, null) { "never called" })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/KeyExportAuditTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/KeyExportAuditTest.kt
@@ -1,0 +1,132 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.CredentialUsage
+import app.skerry.shared.vault.CredentialUsageLog
+import app.skerry.shared.vault.SecurityEvent
+import app.skerry.shared.vault.SecurityEventType
+import app.skerry.shared.vault.SecurityLog
+import app.skerry.ui.identity.CredentialManagerController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The audit half of issue #221: a saved key export must land in both places a user looks after
+ * something suspicious — the secret's own usage trail and the security event log — and the security
+ * event must carry the credential id, never the label (the vault treats labels as secret).
+ * [keyExportAudit] is the one callback both screens hand to [exportPrivateKey], so this is the
+ * wiring test for it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class KeyExportAuditTest {
+
+    private val key = SecretExport.PrivateKey("id_ed25519.pem", "-----BEGIN OPENSSH PRIVATE KEY-----")
+
+    private fun controller(usage: CredentialUsageLog) = CredentialManagerController(
+        CredentialStore(FakeUnlockedVault("master")),
+        usage = usage,
+        scope = CoroutineScope(Dispatchers.Unconfined),
+    ) { "gen" }
+
+    @Test
+    fun `a saved export lands in the usage trail and the security log, id only`() = runTest {
+        val usage = RecordingUsageLog()
+        val securityLog = ExportRecordingSecurityLog()
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(
+            auth, key, scope = this,
+            write = { ExportOutcome.Saved },
+            onSaved = keyExportAudit(controller(usage), securityLog, "cred-1"),
+        ) {}
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(listOf("exported:cred-1"), usage.events)
+        assertEquals(listOf<Pair<SecurityEventType, String?>>(SecurityEventType.KeyExported to "cred-1"), securityLog.records)
+    }
+
+    @Test
+    fun `a cancelled save-as leaves both logs untouched`() = runTest {
+        val usage = RecordingUsageLog()
+        val securityLog = ExportRecordingSecurityLog()
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(
+            auth, key, scope = this,
+            write = { ExportOutcome.Cancelled },
+            onSaved = keyExportAudit(controller(usage), securityLog, "cred-1"),
+        ) {}
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertTrue(usage.events.isEmpty(), "no file was written, yet the trail says otherwise: ${usage.events}")
+        assertTrue(securityLog.records.isEmpty())
+    }
+
+    @Test
+    fun `a missing security log does not stop the usage trail`() = runTest {
+        val usage = RecordingUsageLog()
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(
+            auth, key, scope = this,
+            write = { ExportOutcome.Saved },
+            onSaved = keyExportAudit(controller(usage), securityLog = null, credentialId = "cred-1"),
+        ) {}
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(listOf("exported:cred-1"), usage.events)
+    }
+}
+
+/** Usage log that records the calls themselves; only the export event matters here. */
+private class RecordingUsageLog : CredentialUsageLog {
+    val events = mutableListOf<String>()
+    private val entries = mutableMapOf<String, CredentialUsage>()
+
+    override fun of(credentialId: String): CredentialUsage? = entries[credentialId]
+    override fun all(): List<CredentialUsage> = entries.values.toList()
+    override fun recordAdded(credentialId: String): CredentialUsage = store(credentialId) { it }
+    override fun recordChanged(credentialId: String): CredentialUsage = store(credentialId) { it }
+    override fun recordUsed(credentialId: String): CredentialUsage = store(credentialId) { it }
+    override fun recordCopied(credentialId: String): CredentialUsage = store(credentialId) { it }
+
+    override fun recordExported(credentialId: String): CredentialUsage {
+        events += "exported:$credentialId"
+        return store(credentialId) { it.copy(exportedAt = it.exportedAt + "t") }
+    }
+
+    override fun forget(credentialId: String) { entries -= credentialId }
+    override fun clear() = entries.clear()
+
+    private fun store(id: String, edit: (CredentialUsage) -> CredentialUsage): CredentialUsage =
+        edit(entries[id] ?: CredentialUsage(id)).also { entries[id] = it }
+}
+
+/** Security log that keeps what was recorded — type and detail — so the test asserts on the pair. */
+private class ExportRecordingSecurityLog : SecurityLog {
+    val records = mutableListOf<Pair<SecurityEventType, String?>>()
+
+    override fun record(type: SecurityEventType, detail: String?) { records += type to detail }
+    override fun recent(limit: Int): List<SecurityEvent> = emptyList()
+    override fun lastPasswordChangeAt(): String? = null
+    override fun clear() = records.clear()
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/SecretExportGateTest.kt
@@ -1,11 +1,16 @@
 package app.skerry.ui.vault
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -30,7 +35,7 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }) {}
+        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }, onSaved = {}) {}
         advanceUntilIdle()
 
         assertTrue(written.isEmpty(), "the key reached disk without authorization: $written")
@@ -48,7 +53,7 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }) {}
+        exportPrivateKey(auth, key, scope = this, write = { written += it.fileName; ExportOutcome.Saved }, onSaved = {}) {}
         auth.dismiss()
         auth.submitPassword("master")
         advanceUntilIdle()
@@ -82,7 +87,7 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { error("no document provider") }) { reported = it }
+        exportPrivateKey(auth, key, scope = this, write = { error("no document provider") }, onSaved = {}) { reported = it }
         auth.submitPassword("master")
         advanceUntilIdle()
 
@@ -105,7 +110,7 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { throw CancellationException("screen left") }) {
+        exportPrivateKey(auth, key, scope = this, write = { throw CancellationException("screen left") }, onSaved = {}) {
             reported = it
         }
         auth.submitPassword("master")
@@ -132,12 +137,137 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Failed }) { reported = it }
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Failed }, onSaved = {}) { reported = it }
         auth.submitPassword("master")
         advanceUntilIdle()
 
         assertEquals(ExportOutcome.Failed, reported)
         assertTrue(reported!!.worthReporting)
+    }
+
+    @Test
+    fun `a saved export is recorded inside the authorized action`() = runTest {
+        // The audit trail must say what actually happened: a record made at the button press would
+        // log an export that a dismissed prompt then never performs.
+        var recorded = 0
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Saved }, onSaved = { recorded++ }) {}
+        advanceUntilIdle()
+        assertEquals(0, recorded, "recorded before the user re-authenticated")
+
+        auth.submitPassword("master")
+        advanceUntilIdle()
+        assertEquals(1, recorded)
+    }
+
+    @Test
+    fun `a cancelled save-as records no export`() = runTest {
+        var recorded = 0
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Cancelled }, onSaved = { recorded++ }) {}
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(0, recorded, "a closed Save-As dialog wrote nothing, yet an export was recorded")
+    }
+
+    @Test
+    fun `a failed write records no export`() = runTest {
+        var recorded = 0
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Failed }, onSaved = { recorded++ }) {}
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(0, recorded, "a failed write left no file, yet an export was recorded")
+    }
+
+    @Test
+    fun `an audit hook that throws still reports the outcome and leaves the scope alive`() = runTest {
+        // The audit write is best-effort: a full disk under the security log must not suppress the
+        // export's own outcome (the file IS on disk) and must not cancel the screen's shared scope —
+        // that would silently kill every later action on the panel.
+        var reported: ExportOutcome? = null
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(
+            auth, key, scope = this,
+            write = { ExportOutcome.Saved },
+            onSaved = { error("audit log: disk full") },
+        ) { reported = it }
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(ExportOutcome.Saved, reported)
+
+        var laterWorkRan = false
+        launch { laterWorkRan = true }
+        advanceUntilIdle()
+        assertTrue(laterWorkRan, "the scope was cancelled — later actions on this screen are dead")
+    }
+
+    @Test
+    fun `a write that lands while the screen is torn down still records and reports`() = runTest {
+        // The platform writers finish the write on another dispatcher; withContext's prompt
+        // cancellation would discard their Saved at the resume into a cancelled screen scope —
+        // leaving the key on disk with no audit record. The write-plus-audit stretch runs under
+        // NonCancellable in the caller, so a completed write always delivers its outcome.
+        var recorded = 0
+        var reported: ExportOutcome? = null
+        val screenScope = CoroutineScope(coroutineContext + Job())
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(
+            auth, key, scope = screenScope,
+            write = {
+                // Mimic the platform shape: the write completes on its own dispatcher under
+                // NonCancellable while the screen's scope dies mid-flight.
+                withContext(StandardTestDispatcher(testScheduler) + NonCancellable) {
+                    screenScope.cancel()
+                    ExportOutcome.Saved
+                }
+            },
+            onSaved = { recorded++ },
+        ) { reported = it }
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(1, recorded, "the key is on disk — its audit record must not be lost to the teardown")
+        assertEquals(ExportOutcome.Saved, reported)
+    }
+
+    @Test
+    fun `a dismissed prompt records no export`() = runTest {
+        var recorded = 0
+        val auth = SecretCopyAuthorizer(
+            FakeUnlockedVault("master"), biometrics = null, scope = this,
+            kdfDispatcher = StandardTestDispatcher(testScheduler),
+        )
+
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Saved }, onSaved = { recorded++ }) {}
+        auth.dismiss()
+        auth.submitPassword("master")
+        advanceUntilIdle()
+
+        assertEquals(0, recorded)
     }
 
     @Test
@@ -148,7 +278,7 @@ class SecretExportGateTest {
             kdfDispatcher = StandardTestDispatcher(testScheduler),
         )
 
-        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Cancelled }) { reported = it }
+        exportPrivateKey(auth, key, scope = this, write = { ExportOutcome.Cancelled }, onSaved = {}) { reported = it }
         auth.submitPassword("master")
         advanceUntilIdle()
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultUsagePresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultUsagePresentationTest.kt
@@ -1,8 +1,12 @@
 package app.skerry.ui.vault
 
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialUsage
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Pure presentation over [CredentialUsage]: what the detail panel states as fact — how many
@@ -30,4 +34,30 @@ class VaultUsagePresentationTest {
     fun `no usage means no copies`() {
         assertEquals(0, VaultPresentation.copiesWithin(null, days = 30, daysAgo = daysAgo))
     }
+
+    // The audit section shows for every secret whose material can leave the vault: a password
+    // (clipboard) and anything with an exportable private key. A file-backed secret has neither —
+    // its material never entered the vault (issue #221).
+
+    @Test
+    fun `a password has an audit trail`() {
+        assertTrue(hasAuditTrail(credential(CredentialSecret.Password("pw"))))
+    }
+
+    @Test
+    fun `a private key has an audit trail`() {
+        assertTrue(hasAuditTrail(credential(CredentialSecret.PrivateKey("-----BEGIN", null))))
+    }
+
+    @Test
+    fun `a certificate has an audit trail`() {
+        assertTrue(hasAuditTrail(credential(CredentialSecret.Certificate("-----BEGIN", "ssh-ed25519-cert", null))))
+    }
+
+    @Test
+    fun `a file-backed secret has none`() {
+        assertFalse(hasAuditTrail(credential(CredentialSecret.KeyFile("/home/u/.ssh/id", null, null))))
+    }
+
+    private fun credential(secret: CredentialSecret) = Credential(id = "c1", label = "Key", secret = secret)
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/vault/ExportFile.desktop.kt
@@ -7,6 +7,7 @@ import java.awt.FileDialog
 import java.awt.Frame
 import java.io.File
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.swing.Swing
 import kotlinx.coroutines.withContext
 import org.jetbrains.compose.resources.getString
@@ -28,7 +29,12 @@ internal actual suspend fun exportTextFile(suggestedName: String, content: Strin
         val name = dialog.file ?: return@withContext null
         File(dir, name).absolutePath
     } ?: return ExportOutcome.Cancelled
-    return withContext(Dispatchers.IO) {
+    // NonCancellable: once the user has confirmed the Save-As, the write itself (and the zeroing in
+    // finally) runs to completion even if the calling scope dies mid-write — for every caller,
+    // recordings included. It does NOT guarantee delivery of the result: withContext's prompt
+    // cancellation checks the caller's job at the resume, so a caller that must not lose a Saved
+    // (the key-export audit) hoists its own NonCancellable around the call — see exportPrivateKey.
+    return withContext(Dispatchers.IO + NonCancellable) {
         // What travels through here is secret: a session recording holds whatever the server printed,
         // and a keychain export is the private key itself. writePrivateFile attaches 0600 as the file
         // is created (where the platform has permissions) — writing first and hardening after would

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/KeyValueRowSemanticsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/KeyValueRowSemanticsTest.kt
@@ -1,0 +1,24 @@
+package app.skerry.ui.design
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithText
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+
+/**
+ * A fact row is one fact: "Exported — never" must reach a screen reader as a single announcement,
+ * not as two unrelated stops ("Exported", swipe, "never"). The label and the value merge into one
+ * accessibility node.
+ */
+@OptIn(ExperimentalTestApi::class)
+class KeyValueRowSemanticsTest {
+
+    @Test
+    fun `label and value are one accessibility node`() = runForm(
+        content = { KeyValueRow("Exported", "never") },
+    ) {
+        onNodeWithText("Exported").assert(hasText("never"))
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialUsage.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialUsage.kt
@@ -11,8 +11,9 @@ import okio.Path
  * What the app can honestly say about one keychain secret's life: when it was added
  * ([addedAt] — first stamp wins, a later edit is not a second birth), when its material was last
  * replaced ([changedAt] — a rotated password, a re-imported key; a rename is not a rotation), when
- * it last authenticated a connection ([lastUsedAt]) and when it was copied to the clipboard
- * ([copiedAt], oldest first).
+ * it last authenticated a connection ([lastUsedAt]), when it was copied to the clipboard
+ * ([copiedAt], oldest first) and when its private material was written out to a file
+ * ([exportedAt], oldest first — the most consequential way material leaves the vault, issue #221).
  *
  * Timestamps are ISO-8601 strings from the app's clock, as in [SecurityEvent] — the UI turns them
  * into "today 09:14" / "3 days ago" via [securityMoment]. A secret with no entry has never been
@@ -25,6 +26,7 @@ data class CredentialUsage(
     val changedAt: String? = null,
     val lastUsedAt: String? = null,
     val copiedAt: List<String> = emptyList(),
+    val exportedAt: List<String> = emptyList(),
 )
 
 /**
@@ -62,6 +64,9 @@ interface CredentialUsageLog {
     /** Append a clipboard copy of the secret. */
     fun recordCopied(credentialId: String): CredentialUsage
 
+    /** Append an export of the secret's private material to a file. */
+    fun recordExported(credentialId: String): CredentialUsage
+
     /** Drop everything known about a secret (it was deleted from the keychain). */
     fun forget(credentialId: String)
 
@@ -74,8 +79,9 @@ interface CredentialUsageLog {
  * by desktop and Android (like [FileSecurityLog]). A corrupt or missing file reads as an empty log,
  * so a damaged audit trail degrades to "nothing known" instead of blocking the keychain.
  *
- * Only the last [maxCopies] copies of a secret are kept — the panel counts copies inside a window,
- * not since the beginning of time, and an unbounded list would grow with every clipboard action.
+ * Only the last [maxCopies] copies (and, separately, exports) of a secret are kept — the panel
+ * counts copies inside a window, not since the beginning of time, and an unbounded list would grow
+ * with every clipboard action. Exports are far rarer, but the same cap keeps the file bounded.
  *
  * Mutations are read-modify-write and are serialized with a multiplatform [SynchronizedObject]
  * (like [FileSecurityLog]): copies are recorded from the UI coroutine while a connection being
@@ -112,6 +118,10 @@ class FileCredentialUsageLog(
 
     override fun recordCopied(credentialId: String): CredentialUsage = update(credentialId) {
         it.copy(copiedAt = (it.copiedAt + clock()).takeLast(maxCopies))
+    }
+
+    override fun recordExported(credentialId: String): CredentialUsage = update(credentialId) {
+        it.copy(exportedAt = (it.exportedAt + clock()).takeLast(maxCopies))
     }
 
     override fun forget(credentialId: String): Unit = synchronized(lock) {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecurityLog.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecurityLog.kt
@@ -9,8 +9,8 @@ import okio.Path
 
 /**
  * Type of security event. Fixed set of what the app can honestly track: master password,
- * biometrics, and device-pairing lifecycle. UI labels are localized separately; only stable
- * identifiers live here.
+ * biometrics, device-pairing lifecycle, and key material leaving the vault. UI labels are
+ * localized separately; only stable identifiers live here.
  */
 enum class SecurityEventType {
     /** Vault created (initial master password setup) — baseline for "last password change". */
@@ -30,6 +30,13 @@ enum class SecurityEventType {
 
     /** New device paired (quick pairing) — [detail] carries the device name. */
     DevicePaired,
+
+    /**
+     * A private key left the vault as a file ("Export key", behind re-authentication) — [detail]
+     * carries the credential id, never the label: the vault treats labels as secret
+     * ([Credential.toString] redacts them), and this log is plaintext on disk.
+     */
+    KeyExported,
 }
 
 /**

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileCredentialUsageLogTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileCredentialUsageLogTest.kt
@@ -88,6 +88,36 @@ class FileCredentialUsageLogTest {
     }
 
     @Test
+    fun exportsAccumulateNewestLast() {
+        val l = log()
+        clock = 2
+        l.recordExported("cred-1")
+        clock = 6
+        l.recordExported("cred-1")
+        val exports = l.of("cred-1")!!.exportedAt
+        assertEquals(2, exports.size)
+        assertTrue(exports.last().endsWith(":06Z"))
+    }
+
+    @Test
+    fun exportCapDropsOldest() {
+        val l = log(maxCopies = 3)
+        repeat(5) { clock = it.toLong(); l.recordExported("cred-1") }
+        val exports = l.of("cred-1")!!.exportedAt
+        assertEquals(3, exports.size)
+        assertTrue(exports.first().endsWith(":02Z"))
+        assertTrue(exports.last().endsWith(":04Z"))
+    }
+
+    @Test
+    fun exportsPersistAcrossInstances() {
+        // An export is the audit event a user comes back to days later — it must survive restart.
+        clock = 7
+        log().recordExported("cred-1")
+        assertTrue(log().of("cred-1")!!.exportedAt.single().endsWith(":07Z"))
+    }
+
+    @Test
     fun usageIsPerCredential() {
         val l = log()
         clock = 1


### PR DESCRIPTION
Closes #221.

Since #220, "Export key" writes the stored private key to a file behind re-authentication — the most consequential way material leaves the vault, and the only one that recorded nothing. A completed export is now recorded in both places a user checks after something suspicious.

## What it does

**The secret's own panel.** `CredentialUsage` gains `exportedAt` (device-local, never synced, capped like clipboard copies), recorded via `CredentialUsageLog.recordExported`. The detail panel's Audit section now shows for keys and certificates too, with an "Exported — today 09:14 / never" row, so the panel of a key exported five minutes ago no longer looks identical to one that never left the device. Passwords keep their copy counter; file-backed secrets have no audit section — their material never entered the vault.

**Settings → Security.** A completed export records `SecurityEventType.KeyExported` with the credential id as detail — never the label, which the vault treats as secret while this log is plaintext on disk. The event line resolves the id to the label at render time; an id that no longer resolves (deleted secret, keychain not loaded) shows no detail rather than a raw UUID.

**When it records.** Only inside the authorized action and only on `ExportOutcome.Saved`. A dismissed re-auth prompt, a closed Save-As dialog and a failed write all record nothing. "Export certificate" (public half) records nothing. The `onSaved` hook of `exportPrivateKey` has no default, so a screen cannot compile an unaudited key export — the wiring-drift class of #218.

**Cancellation and failure hardening** (found by the review fan-out, reproduced by tests before fixing):
- The write-plus-audit stretch runs under a caller-side `NonCancellable`: `withContext`'s prompt-cancellation guarantee would otherwise discard a completed write's `Saved` at the resume into a cancelled screen scope — key on disk, no audit record, no outcome reported.
- An audit hook that throws (disk full under the security log) neither suppresses the outcome report nor cancels the screen's shared coroutine scope.
- The platform writers run their write, cleanup and buffer-zeroing under `Dispatchers.IO + NonCancellable`, so a confirmed Save-As always finishes its file work.

**Accessibility.** `KeyValueRow` merges label and value into one semantics node, so every fact row ("Exported — never") reaches a screen reader as a single announcement instead of two swipe stops.

## Tests

19 new/extended cases, each confirmed failing before its implementation: export accumulation/cap/persistence in the shared log; `onSaved` fires only after re-auth and only on Saved (dismissed/cancelled/failed each pinned to zero records); both audit halves written with the id, never the label; a missing security log still records the usage trail; a throwing hook still reports Saved and leaves the scope alive; a write completing while the screen is torn down still records and reports (dispatcher-crossing fake matching the platform writers' shape); id→label display resolution; audit-section gating per secret type; the `KeyValueRow` semantics merge.

## Recorded decisions

- The usage-trail half is asynchronous best-effort on the controller's app-lifetime lane (documented policy); the security-log half is the synchronous record inside the protected stretch.
- On Android the export completes even if the vault auto-locks behind the SAF picker: the user re-authenticated for exactly this export and the pick is their own hand.
- A build older than this one cannot decode a security log containing `KeyExported` and will reread it as empty — accepted: downgrade-only, a 50-entry device-local convenience log.
- `securityLog.record` stays synchronous on the caller's dispatcher, consistent with all six pre-existing call sites; moving it off-thread belongs in `FileSecurityLog` for all of them at once.

## How to verify

1. Vault → an SSH key → Export key → re-authenticate → save. The key's panel now shows Audit / "Exported — today HH:MM"; Settings → Security → recent events shows "Key exported to file: <key label>".
2. Cancel the Save-As dialog instead: the panel still says "never", no security event.
3. Dismiss the re-auth prompt: same — nothing recorded.
4. Export the certificate of a certificate credential: no audit entry (public material).
5. Delete the exported key: its usage trail dies with it; the security event stays, now without a label.

Not verified live: real devices (desktop dialog flow and Android SAF were exercised through the injected-writer test seam only), the Android auto-lock-behind-picker path, and screen-reader output of the merged rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bxJPejMzM3LsLvXdwXWD4