### PR TITLE
feat(android): keep SSH sessions alive in the background with per-session notifications

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -9,6 +9,18 @@
     <!-- USB-OTG serial (CDC/FTDI/CP210x/CH34x adapters). Not mandatory: we do not cut off devices
          without USB Host — serial will simply show no ports. -->
     <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+    <!-- Foreground service while an SSH session is open (keep-alive in the background). connectedDevice
+         type: no timeout, and keeping a network connection to an external device alive is its purpose. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <!-- Required by targetSDK 36 to START a connectedDevice FGS: at least one of the anyOf set
+         (BLUETOOTH_*/CHANGE_NETWORK_STATE/CHANGE_WIFI_STATE/NFC/USB...) must be held. Normal
+         permission — granted at install time, no runtime prompt. SSH keeps a network connection
+         to an external device alive, hence CHANGE_NETWORK_STATE. -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <!-- Notification for the keep-alive service. Optional: without it the service still runs, the
+         notification is simply not shown. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="false"
@@ -21,6 +33,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboardHidden|locale|layoutDirection"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
@@ -35,6 +48,12 @@
             android:name="app.skerry.shared.ai.local.LlmHostService"
             android:exported="false"
             android:process=":llm" />
+        <!-- Keeps the app process (and open SSH keep-alive loops) alive while sessions are open;
+             started/stopped by AndroidSessionKeepAlive via the shared ConnectionController. -->
+        <service
+            android:name="app.skerry.android.SessionKeepAliveService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
     </application>
 
 </manifest>

--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
@@ -1,0 +1,70 @@
+package app.skerry.android
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import app.skerry.ui.keepalive.SessionKeepAliveBridge
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Android implementation of [SessionKeepAliveBridge]: runs the foreground service while at least
+ * one session is open, one notification per live session (Termius-style), and stops the service
+ * when the last one closes. The session map tolerates unbalanced calls (a failed connect tears
+ * down without a matching start; multi-pane sessions interleave events) — [onSessionEnded] for an
+ * unknown id is a no-op, so stray events can never wedge the service.
+ */
+class AndroidSessionKeepAlive(
+    private val context: Context,
+    /**
+     * Called once, when the FIRST session opens (transition empty -> non-empty). The platform uses
+     * it for the lazy notification-permission request on Android 13+ — the request is tied to the
+     * user's first explicit connect instead of app startup, and never repeats.
+     */
+    private val onFirstSession: (() -> Unit)? = null,
+) : SessionKeepAliveBridge {
+
+    // sessionId -> host label. The source of truth for "is the service needed at all"; the service
+    // keeps its own copy for notification ids.
+    private val sessions = ConcurrentHashMap<String, String>()
+
+    init {
+        // Let the service rebuild its notification map after a system restart (see
+        // SessionKeepAliveService.replaySessionsFromBridge).
+        SessionKeepAliveService.bridgeInstance = this
+    }
+
+    /** Point-in-time copy of the live sessions, for the service to replay after a restart. */
+    fun snapshotSessions(): Map<String, String> = sessions.toMap()
+
+    override fun onSessionStarted(sessionId: String, hostLabel: String) {
+        val wasEmpty = sessions.isEmpty()
+        sessions[sessionId] = hostLabel
+        if (wasEmpty) onFirstSession?.invoke()
+        val intent = Intent(context, SessionKeepAliveService::class.java)
+            .setAction(SessionKeepAliveService.ACTION_ADD)
+            .putExtra(SessionKeepAliveService.EXTRA_SESSION_ID, sessionId)
+            .putExtra(SessionKeepAliveService.EXTRA_HOST_LABEL, hostLabel)
+        if (wasEmpty) {
+            // First session: bring the service up. startForegroundService is required on API 26+;
+            // called while the app is foreground (a session was just opened), exactly when Android
+            // permits it. Reconnects of an already-notified session take the plain path below.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        } else {
+            // Service already up (or a reconnect of a known session) — plain start is enough to
+            // deliver the intent; a dead service re-promotes itself inside onStartCommand.
+            runCatching { context.startService(intent) }
+        }
+    }
+
+    override fun onSessionEnded(sessionId: String) {
+        if (sessions.remove(sessionId) == null) return  // idempotent: unknown id is a no-op
+        val intent = Intent(context, SessionKeepAliveService::class.java)
+            .setAction(SessionKeepAliveService.ACTION_REMOVE)
+            .putExtra(SessionKeepAliveService.EXTRA_SESSION_ID, sessionId)
+        runCatching { context.startService(intent) }
+    }
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/AndroidSessionKeepAlive.kt
@@ -2,30 +2,44 @@ package app.skerry.android
 
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import android.util.Log
 import app.skerry.ui.keepalive.SessionKeepAliveBridge
-import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Android implementation of [SessionKeepAliveBridge]: runs the foreground service while at least
  * one session is open, one notification per live session (Termius-style), and stops the service
- * when the last one closes. The session map tolerates unbalanced calls (a failed connect tears
- * down without a matching start; multi-pane sessions interleave events) — [onSessionEnded] for an
- * unknown id is a no-op, so stray events can never wedge the service.
+ * when the last one closes.
+ *
+ * ONE instance per process (held by [KeepAliveRuntime.bridge]): the session map here is the
+ * authoritative process-side record the service replays after a system restart, and sessions
+ * started before an Activity recreation must still find their entry when they end — a per-Activity
+ * instance would forget them and never stop the service.
+ *
+ * The contract is "never throws": a platform refusal (background service-start restrictions) is
+ * logged and swallowed — it may cost the notification, never the SSH session that triggered it.
+ * The map tolerates unbalanced calls ([onSessionEnded] for an unknown id is a no-op), so stray
+ * events can never wedge the service.
  */
 class AndroidSessionKeepAlive(
     private val context: Context,
     /**
-     * Called once, when the FIRST session opens (transition empty -> non-empty). The platform uses
-     * it for the lazy notification-permission request on Android 13+ — the request is tied to the
-     * user's first explicit connect instead of app startup, and never repeats.
+     * Called once, when the FIRST session of the process opens (transition empty -> non-empty).
+     * The platform uses it for the lazy notification-permission request on Android 13+ — tied to
+     * the user's first explicit connect instead of app startup. Must itself be safe to call from
+     * any thread (see [KeepAliveRuntime.onFirstSession]).
      */
     private val onFirstSession: (() -> Unit)? = null,
 ) : SessionKeepAliveBridge {
 
+    private companion object {
+        const val TAG = "SkerryKeepAlive"
+    }
+
     // sessionId -> host label. The source of truth for "is the service needed at all"; the service
-    // keeps its own copy for notification ids.
-    private val sessions = ConcurrentHashMap<String, String>()
+    // keeps its own copy for notification ids. Guarded by [lock]: the empty -> non-empty transition
+    // must be computed atomically with the insert (bridge calls arrive from coroutine workers).
+    private val sessions = LinkedHashMap<String, String>()
+    private val lock = Any()
 
     init {
         // Let the service rebuild its notification map after a system restart (see
@@ -34,37 +48,47 @@ class AndroidSessionKeepAlive(
     }
 
     /** Point-in-time copy of the live sessions, for the service to replay after a restart. */
-    fun snapshotSessions(): Map<String, String> = sessions.toMap()
+    fun snapshotSessions(): Map<String, String> = synchronized(lock) { LinkedHashMap(sessions) }
 
     override fun onSessionStarted(sessionId: String, hostLabel: String) {
-        val wasEmpty = sessions.isEmpty()
-        sessions[sessionId] = hostLabel
-        if (wasEmpty) onFirstSession?.invoke()
+        val wasEmpty = synchronized(lock) {
+            val empty = sessions.isEmpty()
+            sessions[sessionId] = hostLabel
+            empty
+        }
+        if (wasEmpty) runCatching { onFirstSession?.invoke() }
+            .onFailure { Log.w(TAG, "first-session hook failed", it) }
         val intent = Intent(context, SessionKeepAliveService::class.java)
             .setAction(SessionKeepAliveService.ACTION_ADD)
             .putExtra(SessionKeepAliveService.EXTRA_SESSION_ID, sessionId)
             .putExtra(SessionKeepAliveService.EXTRA_HOST_LABEL, hostLabel)
         if (wasEmpty) {
-            // First session: bring the service up. startForegroundService is required on API 26+;
-            // called while the app is foreground (a session was just opened), exactly when Android
-            // permits it. Reconnects of an already-notified session take the plain path below.
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
-            }
+            // First session: bring the service up as foreground (required on API 26+). Normally the
+            // app is in the foreground here (the user just opened a session), where this is always
+            // allowed. Must never throw into the caller — a refusal costs the notification, not the
+            // just-established session.
+            runCatching { context.startForegroundService(intent) }
+                .onFailure { Log.w(TAG, "keep-alive service start refused", it) }
         } else {
             // Service already up (or a reconnect of a known session) — plain start is enough to
             // deliver the intent; a dead service re-promotes itself inside onStartCommand.
             runCatching { context.startService(intent) }
+                .onFailure { Log.w(TAG, "keep-alive add for $sessionId not delivered", it) }
         }
     }
 
     override fun onSessionEnded(sessionId: String) {
-        if (sessions.remove(sessionId) == null) return  // idempotent: unknown id is a no-op
+        val removed = synchronized(lock) { sessions.remove(sessionId) }
+        if (removed == null) return // idempotent: unknown id is a no-op
         val intent = Intent(context, SessionKeepAliveService::class.java)
             .setAction(SessionKeepAliveService.ACTION_REMOVE)
             .putExtra(SessionKeepAliveService.EXTRA_SESSION_ID, sessionId)
         runCatching { context.startService(intent) }
+            .onFailure {
+                // The service was never told: its notification stays until the next delivered
+                // event or service restart (which replays this map). Log so a stuck notification
+                // is diagnosable.
+                Log.w(TAG, "keep-alive remove for $sessionId not delivered", it)
+            }
     }
 }

--- a/androidApp/src/main/kotlin/app/skerry/android/KeepAliveRuntime.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/KeepAliveRuntime.kt
@@ -1,0 +1,167 @@
+package app.skerry.android
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import app.skerry.shared.rdp.RdpCredentials
+import app.skerry.shared.rdp.RdpRemoteDesktop
+import app.skerry.shared.rdp.RdpTarget
+import app.skerry.shared.rdp.RdpTransport
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshConnection
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.terminal.TerminalHistoryRecord
+import app.skerry.shared.terminal.TerminalHistoryStore
+import app.skerry.shared.terminal.VaultTerminalHistoryStore
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vnc.VncRemoteDesktop
+import app.skerry.shared.vnc.VncTransport
+import app.skerry.ui.connection.ConnectionController
+import app.skerry.ui.remote.RemoteDesktopController
+import app.skerry.ui.session.SessionsController
+import app.skerry.ui.teams.TeamsCoordinator
+import app.skerry.ui.terminal.TerminalSessionPrefs
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * Process-scoped half of the Android session keep-alive: the sessions graph, its scope, and the
+ * service bridge all outlive any single Activity — the foreground service keeps the process alive
+ * while sessions are open, and these objects keep the connections alive inside it, so returning to
+ * the app (or tapping a per-session notification) shows the same live terminal.
+ *
+ * Everything an Activity rebuilds on recreation (the dependency graph, the notification-permission
+ * hook, the live terminal prefs) is reached through replaceable references here rather than being
+ * captured at construction: a session graph pinning the FIRST Activity's graph would write history
+ * through a forever-locked first vault instance — two [app.skerry.shared.vault.FileVault] caches
+ * over one file silently losing records — and would 2FA-prompt into a dead composition.
+ */
+internal object KeepAliveRuntime {
+
+    /** The slice of the per-Activity dependency graph the session graph reads, per call. */
+    class GraphDeps(
+        val transport: SshTransport,
+        val vncTransport: VncTransport?,
+        val rdpTransport: RdpTransport?,
+        val vault: Vault?,
+        val teams: TeamsCoordinator?,
+    )
+
+    /**
+     * Scope of the process-lived connections. Main.immediate on purpose: [ConnectionController]'s
+     * serialization argument (disconnect vs. onSessionLost race) relies on its scope being the
+     * single main thread, exactly like the desktop composition scope it replaces. Never cancelled —
+     * its lifetime IS the process; per-session teardown goes through disconnect().
+     */
+    val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+    /** Rebuilt by every [MainActivity.onCreate]; read by the factories below at call time. */
+    @Volatile
+    var deps: GraphDeps? = null
+
+    /** The one bridge instance for the process (see [AndroidSessionKeepAlive]); set once. */
+    @Volatile
+    var bridge: AndroidSessionKeepAlive? = null
+
+    /**
+     * Live terminal settings for NEW sessions, refreshed by the UI on every settings change. A
+     * plain value, not a closure — a closure over the design state would retain the destroyed
+     * Activity for the process lifetime.
+     */
+    @Volatile
+    var terminalPrefs: TerminalSessionPrefs = TerminalSessionPrefs()
+
+    /**
+     * The current Activity's notification-permission hook (Android 13+), invoked once when the
+     * first session opens. Replaced in onCreate, cleared in onDestroy — never a static strong
+     * reference to a dead Activity.
+     */
+    @Volatile
+    var onFirstSession: (() -> Unit)? = null
+
+    /**
+     * Session id routed from a per-session notification tap; the UI activates that pane once and
+     * clears it. Compose state (not @Volatile) so the routing LaunchedEffect reacts to the tap.
+     */
+    var pendingSessionId by mutableStateOf<String?>(null)
+
+    @Volatile
+    private var built: SessionsController? = null
+
+    /** The process-scoped sessions controller, built on first use. */
+    val sessions: SessionsController? get() = built
+
+    fun sessionsController(): SessionsController = built ?: build().also { built = it }
+
+    // Reads the CURRENT graph on every connect: a reconnect after an Activity recreation must
+    // verify host keys against the vault the user actually unlocked and prompt 2FA into the live
+    // composition, not the first Activity's orphaned instances.
+    private val liveTransport = object : SshTransport {
+        override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection =
+            requireNotNull(deps) { "keep-alive transport used before the first dependency graph" }
+                .transport.connect(target, auth)
+    }
+
+    // Same indirection for history: writing through a stale FileVault instance would rewrite the
+    // vault file from a stale record cache (silent data loss). The vault-backed store is a thin
+    // stateless wrapper, cheap to derive per call; locked/absent vault degrades to no persistence.
+    private val liveHistory = object : TerminalHistoryStore {
+        private fun store(): TerminalHistoryStore? = deps?.vault?.let { VaultTerminalHistoryStore(it) }
+        override fun load(key: String): List<String> = store()?.load(key).orEmpty()
+        override fun save(key: String, commands: List<String>, label: String?) {
+            store()?.save(key, commands, label)
+        }
+        override fun all(): List<TerminalHistoryRecord> = store()?.all().orEmpty()
+    }
+
+    private fun build(): SessionsController {
+        var counter = 0
+        return SessionsController(
+            newId = { "sess-${counter++}" },
+            vncControllerFactory = { RemoteDesktopController(scope) },
+            openVncSession = { target, auth ->
+                val vnc = requireNotNull(deps?.vncTransport) { "no VNC transport wired" }
+                VncRemoteDesktop(vnc.connect(target, auth))
+            },
+            openRdpSession = { request ->
+                val rdp = requireNotNull(deps?.rdpTransport) { "no RDP transport wired" }
+                RdpRemoteDesktop(
+                    rdp.connect(
+                        RdpTarget(
+                            host = request.host,
+                            port = request.port,
+                            desktopWidth = request.width,
+                            desktopHeight = request.height,
+                            clientName = request.clientName,
+                            loadBalanceInfo = request.loadBalanceInfo,
+                            audioOutput = request.audioOutput,
+                            audioDeviceId = request.audioDeviceId,
+                            clipboard = request.clipboard,
+                            imageQuality = request.imageQuality,
+                        ),
+                        RdpCredentials(
+                            username = request.user,
+                            password = request.password,
+                            domain = request.domain,
+                        ),
+                    ),
+                )
+            },
+            // Desktop parity: the session half of the Teams activity feed (the coordinator holds
+            // the privacy gates). Reported to the CURRENT coordinator — the first one's sync link
+            // dies with its Activity.
+            onHostSessionOpened = { hostId -> deps?.teams?.reportSessionOpened(hostId) },
+            controllerFactory = {
+                ConnectionController(
+                    liveTransport,
+                    scope,
+                    history = liveHistory,
+                    terminalPrefs = { terminalPrefs },
+                    keepAlive = bridge,
+                )
+            },
+        )
+    }
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -1,12 +1,18 @@
 package app.skerry.android
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
@@ -25,6 +31,7 @@ import app.skerry.shared.ssh.SshjTransport
 import app.skerry.shared.ssh.KeyFileResolver
 import app.skerry.shared.vault.OkioSecretFileReader
 import app.skerry.ui.vault.AndroidSecretFileReader
+import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.KeyboardInteractivePromptController
 import app.skerry.shared.ssh.HostCertificateVerifier
 import app.skerry.shared.ssh.SshjCaKeyParser
@@ -51,10 +58,12 @@ import app.skerry.ui.AppDependencies
 import app.skerry.ui.ai.LocalAiDeps
 import app.skerry.ui.mobile.MobileDesignApp
 import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.app.MobileRoute
 import app.skerry.ui.secure.WindowBridge
 import app.skerry.ui.sftp.SafBridge
 import app.skerry.ui.vault.AndroidLockContext
 import app.skerry.ui.host.HostManagerController
+import app.skerry.ui.keepalive.SessionKeepAlive
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.known.KnownHostsController
 import app.skerry.ui.known.TrustedCaController
@@ -96,6 +105,32 @@ import java.util.UUID
  * private `filesDir`, cross-platform crypto (ionspin), okio-backed store.
  */
 class MainActivity : FragmentActivity() {
+
+    companion object {
+        // Process-scoped keep-alive graph: sessions + their coroutine scope survive Activity
+        // recreation (background recycle, task swipe). The foreground service keeps the process
+        // alive; this keeps the connections alive inside it, so returning to the app (or tapping a
+        // per-session notification) shows the same live terminal instead of a dropped session.
+        // Built lazily from the first dependency graph; null until the first onCreate.
+        @Volatile
+        private var keepAliveScope: CoroutineScope? = null
+        @Volatile
+        private var keepAliveSessions: app.skerry.ui.session.SessionsController? = null
+        // Terminal prefs read at connect time. Refreshed by the UI on every composition so a
+        // settings change applies to NEW sessions even when they're opened from the process-scoped
+        // controller (which outlives any composition). Never captures the Activity.
+        @Volatile
+        var currentTerminalPrefs: () -> app.skerry.ui.terminal.TerminalSessionPrefs =
+            { app.skerry.ui.terminal.TerminalSessionPrefs() }
+        // Session id routed from a per-session notification tap; the UI activates that tab once.
+        // Compose state (not @Volatile) so the LaunchedEffect key reacts to the tap.
+        var pendingSessionId by mutableStateOf<String?>(null)
+
+        fun keepAliveScope(): CoroutineScope =
+            keepAliveScope
+                ?: CoroutineScope(SupervisorJob() + Dispatchers.Default).also { keepAliveScope = it }
+    }
+
     // Tunnel manager scope, tied to Activity lifetime. Cancelled in onDestroy so a recreate (rotation)
     // doesn't leave the old polling scope orphaned; active tunnels are dropped in that case.
     private var tunnelScope: CoroutineScope? = null
@@ -113,10 +148,39 @@ class MainActivity : FragmentActivity() {
     // [buildDependencies], invoked from [MobileDesignApp].
     private var onVaultUnlocked: () -> Unit = {}
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        routeSessionTap(intent)
+    }
+
     override fun onDestroy() {
         tunnelScope?.cancel()
         tunnelScope = null
         super.onDestroy()
+    }
+
+    /** A per-session notification tap carries the session id — remember it for the UI to activate. */
+    private fun routeSessionTap(intent: Intent?) {
+        val id = intent?.getStringExtra(SessionKeepAliveService.EXTRA_SESSION_ID)
+        id?.let { pendingSessionId = it }
+    }
+
+    // Launcher registered once (ActivityResult API requires registration before STARTED); the actual
+    // request is deferred to the first session open via [requestNotificationPermissionIfNeeded].
+    private val requestNotifPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
+    private var notificationPermissionAsked = false
+
+    /** Android 13+ runtime permission for the keep-alive notification; asked once, lazily. */
+    private fun requestNotificationPermissionIfNeeded() {
+        if (notificationPermissionAsked) return
+        notificationPermissionAsked = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestNotifPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -126,6 +190,16 @@ class MainActivity : FragmentActivity() {
         // Window handed to WindowBridge so the shared UI can toggle FLAG_SECURE on screens with
         // secrets (vault, master password entry); see SecureScreen. Weak reference, no Activity leak.
         WindowBridge.install(window)
+
+        // Session keep-alive: while any SSH session is open, run the foreground service so
+        // backgrounding the app doesn't freeze the connection (Android only; desktop never sets
+        // this). Notification permission (Android 13+) is requested lazily, on the FIRST session
+        // open, so it never interrupts app startup — the service still runs without it, the user
+        // simply doesn't see the "session active" notification until they grant it.
+        SessionKeepAlive.bridge = AndroidSessionKeepAlive(
+            applicationContext,
+            onFirstSession = { requestNotificationPermissionIfNeeded() },
+        )
 
         // Context for keyguard checks: auto-lock on background should trigger only when the device is
         // actually locked, not when a system picker is open (see deviceMandatesAutoLock).
@@ -157,6 +231,13 @@ class MainActivity : FragmentActivity() {
         runBlocking { initializeVaultCrypto() }
 
         val deps = buildDependencies()
+        // Process-scoped keep-alive: build the sessions graph once (lives across Activity
+        // recreation while the foreground service keeps the process alive). Recreated only on
+        // process death; notification taps route into it via pendingSessionId below.
+        if (keepAliveSessions == null && deps.transport != null) {
+            keepAliveSessions = buildKeepAliveSessions(deps)
+        }
+        routeSessionTap(intent)
         // Layout state with persisted collapsed host groups: the set of names survives restart.
         // Created once here and held by composition.
         val dir = filesDir
@@ -217,10 +298,42 @@ class MainActivity : FragmentActivity() {
                 // App theme at the root: reads designState.themeMode, so a change from the theme picker
                 // recomposes the whole tree with the new palette (mirrors the desktop wiring in main.kt).
                 SkerryTheme(mode = designState.themeMode) {
+                    // Terminal prefs are read at connect time; keep the process-scoped controller's
+                    // factory pointed at the live settings (it outlives this composition).
+                    LaunchedEffect(designState) {
+                        currentTerminalPrefs = {
+                            app.skerry.ui.terminal.TerminalSessionPrefs(
+                                designState.terminalScrollback,
+                                designState.terminalCursorStyle,
+                                clipboardWriteEnabled = designState.allowServerClipboardWrite,
+                            )
+                        }
+                    }
+                    // A per-session notification tap: activate the tapped terminal tab AND navigate
+                    // to its screen. activate() alone switches the internal active tab but leaves the
+                    // user on whatever screen was up (Hosts) — the Sessions list does both steps, so a
+                    // notification tap must too. Cleared unconditionally — a stale id (session already
+                    // closed) must not wedge the state.
+                    LaunchedEffect(pendingSessionId) {
+                        val target = pendingSessionId
+                        if (target != null) {
+                            val sessions = keepAliveSessions
+                            if (sessions != null) {
+                                val tab = sessions.tabs.firstOrNull { it.id == target }
+                                if (tab != null) {
+                                    sessions.activate(target)
+                                    designState.push(if (tab.isVnc) MobileRoute.Vnc else MobileRoute.Terminal)
+                                }
+                            }
+                            pendingSessionId = null
+                        }
+                    }
                     MobileDesignApp(
                         deps,
                         keyboardInteractive = keyboardInteractive,
                         state = designState,
+                        sessions = keepAliveSessions,
+                        processScope = keepAliveScope(),
                         onVaultReset = onVaultReset,
                         // Secret migration + reload + sync session restore.
                         onVaultUnlocked = onVaultUnlocked,
@@ -467,6 +580,63 @@ class MainActivity : FragmentActivity() {
         }
     }
 
+    /**
+     * Builds the process-scoped sessions controller (keep-alive): it survives Activity recreation
+     * while the foreground service keeps the process alive, so backgrounding the app does not drop
+     * connections. Mirror of the MobileDesignApp internal factory, except the connection scope is
+     * process-scoped and terminal prefs come from [currentTerminalPrefs] (live settings, refreshed
+     * by the UI on every composition).
+     */
+    private fun buildKeepAliveSessions(deps: AppDependencies): app.skerry.ui.session.SessionsController {
+        val scope = keepAliveScope()
+        val t = deps.transport!!
+        var counter = 0
+        return app.skerry.ui.session.SessionsController(
+            newId = { "sess-${counter++}" },
+            vncControllerFactory = deps.vncTransport?.let { { app.skerry.ui.remote.RemoteDesktopController(scope) } },
+            openVncSession = deps.vncTransport?.let { vt ->
+                { target, auth -> app.skerry.shared.vnc.VncRemoteDesktop(vt.connect(target, auth)) }
+            },
+            openRdpSession = deps.rdpTransport?.let { rt ->
+                { request ->
+                    app.skerry.shared.rdp.RdpRemoteDesktop(
+                        rt.connect(
+                            app.skerry.shared.rdp.RdpTarget(
+                                host = request.host,
+                                port = request.port,
+                                desktopWidth = request.width,
+                                desktopHeight = request.height,
+                                clientName = request.clientName,
+                                loadBalanceInfo = request.loadBalanceInfo,
+                                audioOutput = request.audioOutput,
+                                audioDeviceId = request.audioDeviceId,
+                                clipboard = request.clipboard,
+                                imageQuality = request.imageQuality,
+                            ),
+                            app.skerry.shared.rdp.RdpCredentials(
+                                username = request.user,
+                                password = request.password,
+                                domain = request.domain,
+                            ),
+                        ),
+                    )
+                }
+            },
+            // Desktop parity: the session half of the Teams activity feed (the coordinator holds
+            // the privacy gates).
+            onHostSessionOpened = { hostId -> deps.teams?.reportSessionOpened(hostId) },
+            controllerFactory = {
+                ConnectionController(
+                    t, scope,
+                    history = deps.vault?.let { app.skerry.shared.terminal.VaultTerminalHistoryStore(it) },
+                    // Terminal settings are read at connect time — the process-scoped factory reads
+                    // the live settings via the static provider instead of capturing a composition.
+                    terminalPrefs = { currentTerminalPrefs() },
+                )
+            },
+        )
+    }
+
     private fun buildDependencies(): AppDependencies {
         val dir = filesDir
         val crypto = IonspinVaultCrypto()
@@ -711,6 +881,11 @@ class MainActivity : FragmentActivity() {
         // clears non-vault data and reflects the now-empty vault in the managers.
         onVaultReset = { resetScope ->
             tunnels.closeAll()
+            // The process-scoped keep-alive sessions belong to the wiped vault: tear them down and
+            // drop the graph so a fresh one is built after the reset (sessions carry credentials
+            // that are now meaningless).
+            keepAliveSessions?.disconnectAll()
+            keepAliveSessions = null
             // Team keys lived in the wiped vault; team vaults can no longer be opened, so lock their in-memory trace.
             teams.lock()
             // Reset wiped the dataKey, so the biometric artifact (`vault.bio`) and the sealed sync

--- a/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/MainActivity.kt
@@ -10,9 +10,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.core.view.WindowCompat
 import androidx.fragment.app.FragmentActivity
@@ -31,7 +29,6 @@ import app.skerry.shared.ssh.SshjTransport
 import app.skerry.shared.ssh.KeyFileResolver
 import app.skerry.shared.vault.OkioSecretFileReader
 import app.skerry.ui.vault.AndroidSecretFileReader
-import app.skerry.ui.connection.ConnectionController
 import app.skerry.ui.connection.KeyboardInteractivePromptController
 import app.skerry.shared.ssh.HostCertificateVerifier
 import app.skerry.shared.ssh.SshjCaKeyParser
@@ -63,7 +60,6 @@ import app.skerry.ui.secure.WindowBridge
 import app.skerry.ui.sftp.SafBridge
 import app.skerry.ui.vault.AndroidLockContext
 import app.skerry.ui.host.HostManagerController
-import app.skerry.ui.keepalive.SessionKeepAlive
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.known.KnownHostsController
 import app.skerry.ui.known.TrustedCaController
@@ -106,31 +102,6 @@ import java.util.UUID
  */
 class MainActivity : FragmentActivity() {
 
-    companion object {
-        // Process-scoped keep-alive graph: sessions + their coroutine scope survive Activity
-        // recreation (background recycle, task swipe). The foreground service keeps the process
-        // alive; this keeps the connections alive inside it, so returning to the app (or tapping a
-        // per-session notification) shows the same live terminal instead of a dropped session.
-        // Built lazily from the first dependency graph; null until the first onCreate.
-        @Volatile
-        private var keepAliveScope: CoroutineScope? = null
-        @Volatile
-        private var keepAliveSessions: app.skerry.ui.session.SessionsController? = null
-        // Terminal prefs read at connect time. Refreshed by the UI on every composition so a
-        // settings change applies to NEW sessions even when they're opened from the process-scoped
-        // controller (which outlives any composition). Never captures the Activity.
-        @Volatile
-        var currentTerminalPrefs: () -> app.skerry.ui.terminal.TerminalSessionPrefs =
-            { app.skerry.ui.terminal.TerminalSessionPrefs() }
-        // Session id routed from a per-session notification tap; the UI activates that tab once.
-        // Compose state (not @Volatile) so the LaunchedEffect key reacts to the tap.
-        var pendingSessionId by mutableStateOf<String?>(null)
-
-        fun keepAliveScope(): CoroutineScope =
-            keepAliveScope
-                ?: CoroutineScope(SupervisorJob() + Dispatchers.Default).also { keepAliveScope = it }
-    }
-
     // Tunnel manager scope, tied to Activity lifetime. Cancelled in onDestroy so a recreate (rotation)
     // doesn't leave the old polling scope orphaned; active tunnels are dropped in that case.
     private var tunnelScope: CoroutineScope? = null
@@ -156,13 +127,33 @@ class MainActivity : FragmentActivity() {
     override fun onDestroy() {
         tunnelScope?.cancel()
         tunnelScope = null
+        // Drop the process-scoped hook only if it is still ours: on a recreation the new Activity's
+        // onCreate has already replaced it, and clearing here would disarm the live one.
+        if (KeepAliveRuntime.onFirstSession === firstSessionHook) KeepAliveRuntime.onFirstSession = null
+        firstSessionHook = null
+        // Same identity rule for the dependency slice: swap ours for a teams-less copy, so the
+        // coordinator's lifecycleScope closures don't pin this destroyed Activity. Transport/vault
+        // hold only application-scoped state; sessions opened before the next launch simply skip
+        // the Teams activity report.
+        val published = publishedDeps
+        if (published != null && KeepAliveRuntime.deps === published) {
+            KeepAliveRuntime.deps = KeepAliveRuntime.GraphDeps(
+                published.transport, published.vncTransport, published.rdpTransport, published.vault, teams = null,
+            )
+        }
+        publishedDeps = null
         super.onDestroy()
     }
 
-    /** A per-session notification tap carries the session id — remember it for the UI to activate. */
+    /**
+     * A per-session notification tap carries the session id — remember it for the UI to activate.
+     * Honoured only with the per-process nonce from our own PendingIntents: MainActivity is the
+     * exported launcher, and a foreign intent must not be able to steer the active terminal.
+     */
     private fun routeSessionTap(intent: Intent?) {
-        val id = intent?.getStringExtra(SessionKeepAliveService.EXTRA_SESSION_ID)
-        id?.let { pendingSessionId = it }
+        if (intent?.getStringExtra(SessionKeepAliveService.EXTRA_TAP_NONCE) != SessionKeepAliveService.tapNonce) return
+        intent.getStringExtra(SessionKeepAliveService.EXTRA_SESSION_ID)
+            ?.let { KeepAliveRuntime.pendingSessionId = it }
     }
 
     // Launcher registered once (ActivityResult API requires registration before STARTED); the actual
@@ -171,6 +162,16 @@ class MainActivity : FragmentActivity() {
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
 
     private var notificationPermissionAsked = false
+
+    // This Activity's instance of the process-scoped first-session hook, kept to recognise it in
+    // onDestroy (see there).
+    private var firstSessionHook: (() -> Unit)? = null
+
+    // The dependency slice this Activity published to KeepAliveRuntime, to recognise it in
+    // onDestroy: the TeamsCoordinator's closures capture lifecycleScope (this Activity), and a
+    // process singleton must not pin a destroyed Activity while the foreground service keeps the
+    // process alive for hours.
+    private var publishedDeps: KeepAliveRuntime.GraphDeps? = null
 
     /** Android 13+ runtime permission for the keep-alive notification; asked once, lazily. */
     private fun requestNotificationPermissionIfNeeded() {
@@ -191,15 +192,19 @@ class MainActivity : FragmentActivity() {
         // secrets (vault, master password entry); see SecureScreen. Weak reference, no Activity leak.
         WindowBridge.install(window)
 
-        // Session keep-alive: while any SSH session is open, run the foreground service so
-        // backgrounding the app doesn't freeze the connection (Android only; desktop never sets
-        // this). Notification permission (Android 13+) is requested lazily, on the FIRST session
-        // open, so it never interrupts app startup — the service still runs without it, the user
-        // simply doesn't see the "session active" notification until they grant it.
-        SessionKeepAlive.bridge = AndroidSessionKeepAlive(
-            applicationContext,
-            onFirstSession = { requestNotificationPermissionIfNeeded() },
-        )
+        // Session keep-alive: while any session is open, run the foreground service so backgrounding
+        // the app doesn't freeze the connection (Android only; desktop injects no bridge). The
+        // bridge is process-scoped and created ONCE — an instance per Activity would forget sessions
+        // started before a recreation and never stop the service. Only the notification-permission
+        // hook is per-Activity (requested lazily on the FIRST session open, marshalled to the main
+        // thread — bridge calls arrive on coroutine workers); cleared in onDestroy.
+        if (KeepAliveRuntime.bridge == null) {
+            KeepAliveRuntime.bridge = AndroidSessionKeepAlive(applicationContext) {
+                KeepAliveRuntime.onFirstSession?.invoke()
+            }
+        }
+        firstSessionHook = { runOnUiThread { requestNotificationPermissionIfNeeded() } }
+        KeepAliveRuntime.onFirstSession = firstSessionHook
 
         // Context for keyguard checks: auto-lock on background should trigger only when the device is
         // actually locked, not when a system picker is open (see deviceMandatesAutoLock).
@@ -231,12 +236,16 @@ class MainActivity : FragmentActivity() {
         runBlocking { initializeVaultCrypto() }
 
         val deps = buildDependencies()
-        // Process-scoped keep-alive: build the sessions graph once (lives across Activity
-        // recreation while the foreground service keeps the process alive). Recreated only on
-        // process death; notification taps route into it via pendingSessionId below.
-        if (keepAliveSessions == null && deps.transport != null) {
-            keepAliveSessions = buildKeepAliveSessions(deps)
+        // Process-scoped keep-alive: publish THIS Activity's dependency slice for the session
+        // graph's call-time reads (a graph pinned to the first Activity's vault would silently
+        // lose vault records — two FileVault caches over one file), then build the sessions
+        // controller once. It lives across Activity recreation while the foreground service keeps
+        // the process alive; notification taps route into it via pendingSessionId below.
+        publishedDeps = deps.transport?.let {
+            KeepAliveRuntime.GraphDeps(it, deps.vncTransport, deps.rdpTransport, deps.vault, deps.teams)
         }
+        KeepAliveRuntime.deps = publishedDeps
+        val keepAliveSessions = if (KeepAliveRuntime.deps != null) KeepAliveRuntime.sessionsController() else null
         routeSessionTap(intent)
         // Layout state with persisted collapsed host groups: the set of names survives restart.
         // Created once here and held by composition.
@@ -298,34 +307,42 @@ class MainActivity : FragmentActivity() {
                 // App theme at the root: reads designState.themeMode, so a change from the theme picker
                 // recomposes the whole tree with the new palette (mirrors the desktop wiring in main.kt).
                 SkerryTheme(mode = designState.themeMode) {
-                    // Terminal prefs are read at connect time; keep the process-scoped controller's
-                    // factory pointed at the live settings (it outlives this composition).
-                    LaunchedEffect(designState) {
-                        currentTerminalPrefs = {
-                            app.skerry.ui.terminal.TerminalSessionPrefs(
-                                designState.terminalScrollback,
-                                designState.terminalCursorStyle,
-                                clipboardWriteEnabled = designState.allowServerClipboardWrite,
-                            )
-                        }
+                    // Terminal prefs are read at connect time; keep the process-scoped controller
+                    // pointed at the live settings (it outlives this composition). A VALUE snapshot,
+                    // not a closure — a closure over designState would retain this Activity after
+                    // destruction for the process lifetime.
+                    LaunchedEffect(
+                        designState.terminalScrollback,
+                        designState.terminalCursorStyle,
+                        designState.allowServerClipboardWrite,
+                    ) {
+                        KeepAliveRuntime.terminalPrefs = app.skerry.ui.terminal.TerminalSessionPrefs(
+                            designState.terminalScrollback,
+                            designState.terminalCursorStyle,
+                            clipboardWriteEnabled = designState.allowServerClipboardWrite,
+                        )
                     }
-                    // A per-session notification tap: activate the tapped terminal tab AND navigate
-                    // to its screen. activate() alone switches the internal active tab but leaves the
-                    // user on whatever screen was up (Hosts) — the Sessions list does both steps, so a
-                    // notification tap must too. Cleared unconditionally — a stale id (session already
-                    // closed) must not wedge the state.
-                    LaunchedEffect(pendingSessionId) {
-                        val target = pendingSessionId
+                    // A per-session notification tap: activate the tapped terminal AND navigate to
+                    // its screen. activate() alone switches the internal active tab but leaves the
+                    // user on whatever screen was up (Hosts) — the Sessions list does both steps, so
+                    // a notification tap must too. Notifications are keyed by PANE id (a split pane
+                    // has its own), so the lookup matches panes, not just tab ids. Cleared
+                    // unconditionally — a stale id (session already closed) must not wedge the state.
+                    LaunchedEffect(KeepAliveRuntime.pendingSessionId) {
+                        val target = KeepAliveRuntime.pendingSessionId
                         if (target != null) {
                             val sessions = keepAliveSessions
-                            if (sessions != null) {
-                                val tab = sessions.tabs.firstOrNull { it.id == target }
-                                if (tab != null) {
-                                    sessions.activate(target)
-                                    designState.push(if (tab.isVnc) MobileRoute.Vnc else MobileRoute.Terminal)
-                                }
+                            val tab = sessions?.tabs?.firstOrNull { t ->
+                                t.id == target || t.panes.any { it.id == target }
                             }
-                            pendingSessionId = null
+                            if (tab != null) {
+                                sessions.activate(tab.id)
+                                sessions.focusPane(tab.id, target)
+                                // Keep-alive covers terminal sessions only (VNC/RDP tabs never get
+                                // a notification), so the destination is always the terminal.
+                                designState.push(MobileRoute.Terminal)
+                            }
+                            KeepAliveRuntime.pendingSessionId = null
                         }
                     }
                     MobileDesignApp(
@@ -333,7 +350,6 @@ class MainActivity : FragmentActivity() {
                         keyboardInteractive = keyboardInteractive,
                         state = designState,
                         sessions = keepAliveSessions,
-                        processScope = keepAliveScope(),
                         onVaultReset = onVaultReset,
                         // Secret migration + reload + sync session restore.
                         onVaultUnlocked = onVaultUnlocked,
@@ -580,63 +596,6 @@ class MainActivity : FragmentActivity() {
         }
     }
 
-    /**
-     * Builds the process-scoped sessions controller (keep-alive): it survives Activity recreation
-     * while the foreground service keeps the process alive, so backgrounding the app does not drop
-     * connections. Mirror of the MobileDesignApp internal factory, except the connection scope is
-     * process-scoped and terminal prefs come from [currentTerminalPrefs] (live settings, refreshed
-     * by the UI on every composition).
-     */
-    private fun buildKeepAliveSessions(deps: AppDependencies): app.skerry.ui.session.SessionsController {
-        val scope = keepAliveScope()
-        val t = deps.transport!!
-        var counter = 0
-        return app.skerry.ui.session.SessionsController(
-            newId = { "sess-${counter++}" },
-            vncControllerFactory = deps.vncTransport?.let { { app.skerry.ui.remote.RemoteDesktopController(scope) } },
-            openVncSession = deps.vncTransport?.let { vt ->
-                { target, auth -> app.skerry.shared.vnc.VncRemoteDesktop(vt.connect(target, auth)) }
-            },
-            openRdpSession = deps.rdpTransport?.let { rt ->
-                { request ->
-                    app.skerry.shared.rdp.RdpRemoteDesktop(
-                        rt.connect(
-                            app.skerry.shared.rdp.RdpTarget(
-                                host = request.host,
-                                port = request.port,
-                                desktopWidth = request.width,
-                                desktopHeight = request.height,
-                                clientName = request.clientName,
-                                loadBalanceInfo = request.loadBalanceInfo,
-                                audioOutput = request.audioOutput,
-                                audioDeviceId = request.audioDeviceId,
-                                clipboard = request.clipboard,
-                                imageQuality = request.imageQuality,
-                            ),
-                            app.skerry.shared.rdp.RdpCredentials(
-                                username = request.user,
-                                password = request.password,
-                                domain = request.domain,
-                            ),
-                        ),
-                    )
-                }
-            },
-            // Desktop parity: the session half of the Teams activity feed (the coordinator holds
-            // the privacy gates).
-            onHostSessionOpened = { hostId -> deps.teams?.reportSessionOpened(hostId) },
-            controllerFactory = {
-                ConnectionController(
-                    t, scope,
-                    history = deps.vault?.let { app.skerry.shared.terminal.VaultTerminalHistoryStore(it) },
-                    // Terminal settings are read at connect time — the process-scoped factory reads
-                    // the live settings via the static provider instead of capturing a composition.
-                    terminalPrefs = { currentTerminalPrefs() },
-                )
-            },
-        )
-    }
-
     private fun buildDependencies(): AppDependencies {
         val dir = filesDir
         val crypto = IonspinVaultCrypto()
@@ -881,11 +840,10 @@ class MainActivity : FragmentActivity() {
         // clears non-vault data and reflects the now-empty vault in the managers.
         onVaultReset = { resetScope ->
             tunnels.closeAll()
-            // The process-scoped keep-alive sessions belong to the wiped vault: tear them down and
-            // drop the graph so a fresh one is built after the reset (sessions carry credentials
-            // that are now meaningless).
-            keepAliveSessions?.disconnectAll()
-            keepAliveSessions = null
+            // The process-scoped keep-alive sessions carry credentials of the wiped vault: tear
+            // them down. The graph itself stays — it reads the current dependency slice per call,
+            // so it is not bound to the wiped instance.
+            KeepAliveRuntime.sessions?.disconnectAll()
             // Team keys lived in the wiped vault; team vaults can no longer be opened, so lock their in-memory trace.
             teams.lock()
             // Reset wiped the dataKey, so the biometric artifact (`vault.bio`) and the sealed sync

--- a/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
@@ -1,0 +1,284 @@
+package app.skerry.android
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import app.skerry.ui.keepalive.KeepAliveNotificationRegistry
+
+/**
+ * Foreground service that keeps the app process — and with it the open SSH keep-alive loops —
+ * alive while sessions are open. Backgrounding the app therefore does not freeze the connection:
+ * the keepalive pings keep flowing, NAT/firewall idle timers don't fire, and returning to the app
+ * shows the same live terminal instead of a dropped session.
+ *
+ * One notification per live session (Termius-style): the summary notification ([SUMMARY_ID]) is
+ * the foreground one that must stay up while the service is foreground; each session gets its own
+ * notification titled with the host, and tapping it routes back to that exact terminal (the
+ * session id travels in the intent). The moment the last session closes, [ACTION_REMOVE] tears the
+ * service down and every notification disappears — the persistent notification is present exactly
+ * when it matters, never parked forever.
+ *
+ * [ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE] is deliberate: unlike dataSync, the
+ * connectedDevice type has no 6-hour timeout on Android 14+, and its semantics fit — we keep a
+ * network connection to an external device/server alive.
+ */
+class SessionKeepAliveService : Service() {
+
+    companion object {
+        const val ACTION_ADD = "app.skerry.android.action.KEEPALIVE_ADD"
+        const val ACTION_REMOVE = "app.skerry.android.action.KEEPALIVE_REMOVE"
+        const val ACTION_NOTIFICATION_DISMISSED = "app.skerry.android.action.KEEPALIVE_NOTIFICATION_DISMISSED"
+        const val EXTRA_SESSION_ID = "app.skerry.android.extra.SESSION_ID"
+        const val EXTRA_HOST_LABEL = "app.skerry.android.extra.HOST_LABEL"
+
+        private const val CHANNEL_ID = "session_keepalive"
+        // Foreground summary notification (must stay up while the service is foreground).
+        private const val SUMMARY_ID = 0x5E77
+        // Per-session notifications start here and increment.
+        private const val SESSION_ID_BASE = 0x5E78
+
+        /**
+         * The process-side bridge, registered by [AndroidSessionKeepAlive] so a system-restarted
+         * service (START_STICKY, null intent) can rebuild its notification map from the still-live
+         * session set instead of showing nothing.
+         */
+        @Volatile
+        var bridgeInstance: AndroidSessionKeepAlive? = null
+    }
+
+    // sessionId -> notification id. Kept only while the service lives; the process-side
+    // AndroidSessionKeepAlive map survives service death and re-promotes on the next change.
+    private val sessions = KeepAliveNotificationRegistry(SESSION_ID_BASE)
+    // sessionId -> host label, kept alongside [sessions] so a dismissed notification can be
+    // re-shown with its host title without consulting the process-side bridge.
+    private val sessionHosts = LinkedHashMap<String, String>()
+    // Registered while the service lives; re-shows notifications when one is swiped away.
+    private var dismissReceiver: BroadcastReceiver? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        registerDismissReceiver()
+    }
+
+    override fun onDestroy() {
+        dismissReceiver?.let { unregisterReceiver(it) }
+        dismissReceiver = null
+        super.onDestroy()
+    }
+
+    /**
+     * Registers the receiver for [ACTION_NOTIFICATION_DISMISSED]. A foreground-service
+     * notification can be swiped away by the user even with [Notification.Builder.setOngoing]
+     * (MIUI/HyperOS are lenient here); the keep-alive state itself is unaffected, but the
+     * notification is the only visible handle back to the live terminals — so re-show it.
+     * Re-registered on every service create (START_STICKY restart included).
+     */
+    private fun registerDismissReceiver() {
+        if (dismissReceiver != null) return
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                restoreNotifications()
+            }
+        }
+        val filter = IntentFilter(ACTION_NOTIFICATION_DISMISSED)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            registerReceiver(receiver, filter)
+        }
+        dismissReceiver = receiver
+    }
+
+    /** Re-shows the summary plus every per-session notification after a dismiss. */
+    private fun restoreNotifications() {
+        if (sessions.isEmpty) return
+        createChannel()
+        // The summary must be re-posted through startForeground so the service is still
+        // foreground (Android requires the foreground notification to be present).
+        startForegroundCompat(buildSummaryNotification(sessions.size))
+        for (sessionId in sessions.idsInOrder()) {
+            val hostLabel = sessionHosts[sessionId] ?: continue
+            val notifId = sessions.register(sessionId) // stable id, no-op if already registered
+            notificationManager().notify(notifId, buildSessionNotification(hostLabel, sessionId, notifId))
+        }
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent == null) {
+            // Service restarted by the system (START_STICKY) after it was killed while the process
+            // stayed alive. Our session map is gone, but AndroidSessionKeepAlive keeps the
+            // authoritative process-side copy — replay it so notifications come back.
+            replaySessionsFromBridge()
+            return START_STICKY
+        }
+        when (intent.action) {
+            ACTION_REMOVE -> removeSession(intent)
+            else -> addSession(intent) // ACTION_ADD; also the plain-start fallback path
+        }
+        return START_STICKY
+    }
+
+    /**
+     * Rebuilds the service's session map from the process-side [AndroidSessionKeepAlive] snapshot.
+     * Used when the system restarts this service (START_STICKY) with a null intent after the
+     * service was killed: the process and its sessions are still live, so the per-session
+     * notifications must come back.
+     *
+     * When the process itself is gone (a fresh START_STICKY launch after process death) the bridge
+     * holds nothing — the SSH keep-alive loops died with the process, so there is nothing to show.
+     * The service still has to call [startForeground] within 5s of start (it was restarted AS a
+     * foreground service), so it briefly goes foreground with an empty summary and then stops
+     * itself, rather than crashing with ForegroundServiceDidNotStartInTimeException.
+     */
+    private fun replaySessionsFromBridge() {
+        createChannel()
+        val snapshot = SessionKeepAliveService.bridgeInstance?.snapshotSessions().orEmpty()
+        if (snapshot.isEmpty()) {
+            startForegroundCompat(buildSummaryNotification(0))
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+            return
+        }
+        snapshot.forEach { (sessionId, hostLabel) ->
+            sessionHosts[sessionId] = hostLabel
+            addSessionInternal(sessionId, hostLabel)
+        }
+        updateSummary()
+    }
+
+    /**
+     * [Service.startForeground] with the manifest-declared type. API 29+ takes an explicit type;
+     * API 34+ requires it to match a manifest type and throws if none is given. connectedDevice is
+     * only defined from 34 — earlier versions accept 0.
+     */
+    private fun startForegroundCompat(summary: Notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+            } else {
+                0
+            }
+            startForeground(SUMMARY_ID, summary, type)
+        } else {
+            startForeground(SUMMARY_ID, summary)
+        }
+    }
+
+    private fun addSession(intent: Intent) {
+        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: return
+        val hostLabel = intent.getStringExtra(EXTRA_HOST_LABEL) ?: return
+        addSessionInternal(sessionId, hostLabel)
+    }
+
+    private fun addSessionInternal(sessionId: String, hostLabel: String) {
+        createChannel()
+        if (sessions.isEmpty) {
+            // First session (or the service was dead and is re-promoting): go foreground. The
+            // summary notification is the one Android requires to stay; sessions follow below.
+            startForegroundCompat(buildSummaryNotification(1))
+        }
+        sessionHosts[sessionId] = hostLabel
+        val notifId = sessions.register(sessionId)
+        notificationManager().notify(notifId, buildSessionNotification(hostLabel, sessionId, notifId))
+        updateSummary()
+    }
+
+    private fun removeSession(intent: Intent) {
+        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: return
+        val notifId = sessions.remove(sessionId) ?: return // idempotent
+        sessionHosts.remove(sessionId)
+        notificationManager().cancel(notifId)
+        if (sessions.isEmpty) {
+            stopForeground(STOP_FOREGROUND_REMOVE)
+            stopSelf()
+        } else {
+            updateSummary()
+        }
+    }
+
+    private fun updateSummary() {
+        if (sessions.isEmpty) return
+        notificationManager().notify(SUMMARY_ID, buildSummaryNotification(sessions.size))
+    }
+
+    private fun createChannel() {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.session_keepalive_channel_name),
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply { setShowBadge(false) }
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    /** Summary (foreground) notification: N sessions alive; tap opens the app. */
+    private fun buildSummaryNotification(count: Int): Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java),
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+        return Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.session_keepalive_title))
+            .setContentText(
+                resources.getQuantityString(R.plurals.session_keepalive_count, count, count)
+            )
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .setContentIntent(contentIntent)
+            .setDeleteIntent(notificationDismissedPendingIntent(SUMMARY_ID))
+            .build()
+    }
+
+    /** Per-session notification: host label as the title; tap routes to that terminal. */
+    private fun buildSessionNotification(hostLabel: String, sessionId: String, notifId: Int): Notification {
+        // requestCode = notifId (unique per session in this service) so FLAG_UPDATE_CURRENT can
+        // never mix two sessions' extras on a hashCode collision.
+        val tap = PendingIntent.getActivity(
+            this,
+            notifId,
+            Intent(this, MainActivity::class.java)
+                .putExtra(EXTRA_SESSION_ID, sessionId),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+        return Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle(hostLabel)
+            .setContentText(getString(R.string.session_keepalive_text))
+            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setOngoing(true)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .setContentIntent(tap)
+            .setDeleteIntent(notificationDismissedPendingIntent(notifId))
+            .build()
+    }
+
+    /**
+     * Fired when the user swipes a notification away: the receiver re-shows everything, so the
+     * keep-alive state never silently disappears from the shade. Request code distinct per
+     * notification (SUMMARY_ID / notifId) so FLAG_UPDATE_CURRENT never reuses a stale one.
+     */
+    private fun notificationDismissedPendingIntent(requestCode: Int): PendingIntent =
+        PendingIntent.getBroadcast(
+            this,
+            requestCode,
+            Intent(ACTION_NOTIFICATION_DISMISSED),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+
+    private fun notificationManager() = getSystemService(NotificationManager::class.java)
+}

--- a/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
+++ b/androidApp/src/main/kotlin/app/skerry/android/SessionKeepAliveService.kt
@@ -12,7 +12,10 @@ import android.content.IntentFilter
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
+import androidx.core.content.ContextCompat
 import app.skerry.ui.keepalive.KeepAliveNotificationRegistry
+import java.util.UUID
 
 /**
  * Foreground service that keeps the app process — and with it the open SSH keep-alive loops —
@@ -39,8 +42,21 @@ class SessionKeepAliveService : Service() {
         const val ACTION_NOTIFICATION_DISMISSED = "app.skerry.android.action.KEEPALIVE_NOTIFICATION_DISMISSED"
         const val EXTRA_SESSION_ID = "app.skerry.android.extra.SESSION_ID"
         const val EXTRA_HOST_LABEL = "app.skerry.android.extra.HOST_LABEL"
+        const val EXTRA_TAP_NONCE = "app.skerry.android.extra.TAP_NONCE"
 
+        /**
+         * Per-process random token carried by every per-session tap intent. MainActivity is the
+         * exported launcher, so any app can send it an intent with [EXTRA_SESSION_ID]; only intents
+         * carrying this nonce (obtainable solely from our own PendingIntents) may steer the active
+         * terminal. Process death invalidates outstanding taps — their sessions died with it anyway.
+         */
+        val tapNonce: String = UUID.randomUUID().toString()
+
+        private const val TAG = "SkerryKeepAlive"
         private const val CHANNEL_ID = "session_keepalive"
+        // One shade group for the summary + per-session notifications; without it each session is
+        // a top-level notification and TalkBack announces every one separately.
+        private const val GROUP_KEY = "app.skerry.sessions"
         // Foreground summary notification (must stay up while the service is foreground).
         private const val SUMMARY_ID = 0x5E77
         // Per-session notifications start here and increment.
@@ -90,11 +106,7 @@ class SessionKeepAliveService : Service() {
             }
         }
         val filter = IntentFilter(ACTION_NOTIFICATION_DISMISSED)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
-        } else {
-            registerReceiver(receiver, filter)
-        }
+        ContextCompat.registerReceiver(this, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         dismissReceiver = receiver
     }
 
@@ -122,6 +134,18 @@ class SessionKeepAliveService : Service() {
             replaySessionsFromBridge()
             return START_STICKY
         }
+        if (sessions.isEmpty) {
+            // A killed service can be re-created by a live ADD/REMOVE before the sticky null-intent
+            // restart lands. Seed from the authoritative bridge map first, so a single intent can't
+            // masquerade as the whole state (the other live sessions would lose their notifications
+            // and the last remove would stop the service under them). Cancel everything posted by
+            // the previous incarnation first — its ids may not line up with the reseeded registry,
+            // and a leftover would advertise a dead session forever (this service owns every
+            // notification the app posts, so cancelAll is safe).
+            notificationManager().cancelAll()
+            createChannel()
+            bridgeInstance?.snapshotSessions().orEmpty().forEach { (id, host) -> addSessionInternal(id, host) }
+        }
         when (intent.action) {
             ACTION_REMOVE -> removeSession(intent)
             else -> addSession(intent) // ACTION_ADD; also the plain-start fallback path
@@ -143,6 +167,11 @@ class SessionKeepAliveService : Service() {
      */
     private fun replaySessionsFromBridge() {
         createChannel()
+        // Notifications posted by the previous incarnation survive it in system_server, and the
+        // fresh registry re-derives CONTIGUOUS ids — after a mid-list removal the old sparse tail
+        // would linger as an undismissable duplicate. Clear everything and re-post (this service
+        // owns every notification the app posts); the immediate re-post below is flicker-free.
+        notificationManager().cancelAll()
         val snapshot = SessionKeepAliveService.bridgeInstance?.snapshotSessions().orEmpty()
         if (snapshot.isEmpty()) {
             startForegroundCompat(buildSummaryNotification(0))
@@ -176,8 +205,21 @@ class SessionKeepAliveService : Service() {
     }
 
     private fun addSession(intent: Intent) {
-        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: return
-        val hostLabel = intent.getStringExtra(EXTRA_HOST_LABEL) ?: return
+        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID)
+        val hostLabel = intent.getStringExtra(EXTRA_HOST_LABEL)
+        if (sessionId == null || hostLabel == null) {
+            // Malformed/replayed intent. If it arrived on the initial startForegroundService the OS
+            // still expects startForeground within its window — honor the contract, then let the
+            // empty service go, instead of crashing with ForegroundServiceDidNotStartInTime.
+            Log.w(TAG, "keep-alive add without extras dropped")
+            if (sessions.isEmpty) {
+                createChannel()
+                startForegroundCompat(buildSummaryNotification(0))
+                stopForeground(STOP_FOREGROUND_REMOVE)
+                stopSelf()
+            }
+            return
+        }
         addSessionInternal(sessionId, hostLabel)
     }
 
@@ -195,8 +237,16 @@ class SessionKeepAliveService : Service() {
     }
 
     private fun removeSession(intent: Intent) {
-        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID) ?: return
-        val notifId = sessions.remove(sessionId) ?: return // idempotent
+        val sessionId = intent.getStringExtra(EXTRA_SESSION_ID)
+        if (sessionId == null) {
+            Log.w(TAG, "keep-alive remove without session id dropped")
+            return
+        }
+        val notifId = sessions.remove(sessionId)
+        if (notifId == null) { // idempotent; a lone stray remove must not leave an idle service
+            if (sessions.isEmpty) stopSelf()
+            return
+        }
         sessionHosts.remove(sessionId)
         notificationManager().cancel(notifId)
         if (sessions.isEmpty) {
@@ -237,9 +287,14 @@ class SessionKeepAliveService : Service() {
             .setContentText(
                 resources.getQuantityString(R.plurals.session_keepalive_count, count, count)
             )
-            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setSmallIcon(R.drawable.ic_notification_session)
             .setOngoing(true)
             .setCategory(Notification.CATEGORY_SERVICE)
+            .setGroup(GROUP_KEY)
+            .setGroupSummary(true)
+            // A session count carries no host identity — showing it on the lock screen beats the
+            // system's "content hidden" placeholder (which TalkBack reads as exactly that).
+            .setVisibility(Notification.VISIBILITY_PUBLIC)
             .setContentIntent(contentIntent)
             .setDeleteIntent(notificationDismissedPendingIntent(SUMMARY_ID))
             .build()
@@ -253,15 +308,29 @@ class SessionKeepAliveService : Service() {
             this,
             notifId,
             Intent(this, MainActivity::class.java)
-                .putExtra(EXTRA_SESSION_ID, sessionId),
+                .putExtra(EXTRA_SESSION_ID, sessionId)
+                .putExtra(EXTRA_TAP_NONCE, tapNonce),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
+        // Redacted lock-screen version: no host name (the vault hides host identities behind the
+        // master password; the shade must not undo that). This honours the OS "hide sensitive
+        // content" setting — the platform's strongest app-side option; devices set to "show all
+        // content" still show the full notification.
+        val publicVersion = Notification.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.session_keepalive_public_title))
+            .setContentText(getString(R.string.session_keepalive_text))
+            .setSmallIcon(R.drawable.ic_notification_session)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .build()
         return Notification.Builder(this, CHANNEL_ID)
             .setContentTitle(hostLabel)
             .setContentText(getString(R.string.session_keepalive_text))
-            .setSmallIcon(android.R.drawable.stat_notify_sync)
+            .setSmallIcon(R.drawable.ic_notification_session)
             .setOngoing(true)
             .setCategory(Notification.CATEGORY_SERVICE)
+            .setGroup(GROUP_KEY)
+            .setVisibility(Notification.VISIBILITY_PRIVATE)
+            .setPublicVersion(publicVersion)
             .setContentIntent(tap)
             .setDeleteIntent(notificationDismissedPendingIntent(notifId))
             .build()
@@ -276,7 +345,9 @@ class SessionKeepAliveService : Service() {
         PendingIntent.getBroadcast(
             this,
             requestCode,
-            Intent(ACTION_NOTIFICATION_DISMISSED),
+            // Package-scoped: an implicit broadcast would never reach the NOT_EXPORTED receiver on
+            // Android 14+ (dead re-show path), and would let any app observe/forge dismissals.
+            Intent(ACTION_NOTIFICATION_DISMISSED).setPackage(packageName),
             PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
         )
 

--- a/androidApp/src/main/res/drawable/ic_notification_session.xml
+++ b/androidApp/src/main/res/drawable/ic_notification_session.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Status-bar small icon for the session keep-alive notification: monochrome (white alpha-only,
+     the system tints it) derivative of the brand mark in ic_launcher_foreground.xml — the "S"
+     stream plus the innermost signal arc. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="120"
+    android:viewportHeight="120">
+    <path
+        android:pathData="M75,40 A26,26 0 0 1 75,80"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="9"
+        android:strokeLineCap="round"
+        android:strokeAlpha="0.55" />
+    <path
+        android:pathData="M60,44 C60,37 53,34 46,34 C36,34 31,40 31,47 C31,60 60,54 60,68 C60,77 53,81 45,81 C36,81 31,77 31,70"
+        android:strokeColor="#FFFFFFFF"
+        android:strokeWidth="13"
+        android:strokeLineCap="round" />
+</vector>

--- a/androidApp/src/main/res/values-ru/strings.xml
+++ b/androidApp/src/main/res/values-ru/strings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Russian (values-ru). See values/strings.xml for the full set — keys must stay in sync across
+     values / values-zh / values-ru. -->
+<resources>
+    <string name="app_name">Skerry</string>
+    <string name="session_keepalive_channel_name">Поддержание сеанса</string>
+    <string name="session_keepalive_title">Сеансы SSH активны</string>
+    <string name="session_keepalive_text">Нажмите, чтобы вернуться к этому терминалу</string>
+    <plurals name="session_keepalive_count">
+        <item quantity="one">%1$d подключение активно</item>
+        <item quantity="few">%1$d подключения активны</item>
+        <item quantity="other">%1$d подключений активно</item>
+    </plurals>
+</resources>

--- a/androidApp/src/main/res/values-ru/strings.xml
+++ b/androidApp/src/main/res/values-ru/strings.xml
@@ -4,11 +4,13 @@
 <resources>
     <string name="app_name">Skerry</string>
     <string name="session_keepalive_channel_name">Поддержание сеанса</string>
-    <string name="session_keepalive_title">Сеансы SSH активны</string>
+    <string name="session_keepalive_title">Сеансы активны</string>
+    <string name="session_keepalive_public_title">Сеанс активен</string>
     <string name="session_keepalive_text">Нажмите, чтобы вернуться к этому терминалу</string>
     <plurals name="session_keepalive_count">
-        <item quantity="one">%1$d подключение активно</item>
-        <item quantity="few">%1$d подключения активны</item>
-        <item quantity="other">%1$d подключений активно</item>
+        <item quantity="one">%1$d сеанс активен</item>
+        <item quantity="few">%1$d сеанса активны</item>
+        <item quantity="many">%1$d сеансов активны</item>
+        <item quantity="other">%1$d сеансов активны</item>
     </plurals>
 </resources>

--- a/androidApp/src/main/res/values-zh/strings.xml
+++ b/androidApp/src/main/res/values-zh/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Chinese (values-zh). See values/strings.xml for the full set — keys must stay in sync across
+     values / values-zh / values-ru. -->
+<resources>
+    <string name="app_name">Skerry</string>
+    <string name="session_keepalive_channel_name">会话保活</string>
+    <string name="session_keepalive_title">SSH 会话保活中</string>
+    <string name="session_keepalive_text">点按返回此终端</string>
+    <plurals name="session_keepalive_count">
+        <item quantity="one">%1$d 个终端保持中</item>
+        <item quantity="other">%1$d 个终端保持中</item>
+    </plurals>
+</resources>

--- a/androidApp/src/main/res/values-zh/strings.xml
+++ b/androidApp/src/main/res/values-zh/strings.xml
@@ -4,10 +4,11 @@
 <resources>
     <string name="app_name">Skerry</string>
     <string name="session_keepalive_channel_name">会话保活</string>
-    <string name="session_keepalive_title">SSH 会话保活中</string>
+    <string name="session_keepalive_title">会话保持中</string>
+    <string name="session_keepalive_public_title">会话保持中</string>
     <string name="session_keepalive_text">点按返回此终端</string>
+    <!-- Chinese has a single CLDR plural category — only "other" is ever selected. -->
     <plurals name="session_keepalive_count">
-        <item quantity="one">%1$d 个终端保持中</item>
-        <item quantity="other">%1$d 个终端保持中</item>
+        <item quantity="other">%1$d 个会话保持中</item>
     </plurals>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Android platform resources only (launcher label). The app's UI strings live in
-  composeApp/src/commonMain/composeResources — this file exists so the manifest has no hardcoded
-  text and a locale-specific launcher label stays possible.
+  Android platform resources only (launcher label + session keep-alive notification). The app's UI
+  strings live in composeApp/src/commonMain/composeResources — this file exists so the manifest has
+  no hardcoded text and a locale-specific launcher label stays possible.
 -->
 <resources>
     <string name="app_name">Skerry</string>
+    <string name="session_keepalive_channel_name">Session keep-alive</string>
+    <string name="session_keepalive_title">SSH sessions active</string>
+    <string name="session_keepalive_text">Tap to return to this terminal</string>
+    <plurals name="session_keepalive_count">
+        <item quantity="one">%1$d terminal kept connected</item>
+        <item quantity="other">%1$d terminals kept connected</item>
+    </plurals>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -7,10 +7,14 @@
 <resources>
     <string name="app_name">Skerry</string>
     <string name="session_keepalive_channel_name">Session keep-alive</string>
-    <string name="session_keepalive_title">SSH sessions active</string>
+    <!-- "Sessions", not "SSH sessions": the keep-alive covers every terminal transport
+         (SSH, Telnet, serial, Mosh, container exec). -->
+    <string name="session_keepalive_title">Sessions active</string>
+    <!-- Lock-screen (publicVersion) title of ONE redacted per-session notification — singular. -->
+    <string name="session_keepalive_public_title">Session active</string>
     <string name="session_keepalive_text">Tap to return to this terminal</string>
     <plurals name="session_keepalive_count">
-        <item quantity="one">%1$d terminal kept connected</item>
-        <item quantity="other">%1$d terminals kept connected</item>
+        <item quantity="one">%1$d session active</item>
+        <item quantity="other">%1$d sessions active</item>
     </plurals>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -25,6 +25,7 @@ import app.skerry.shared.terminal.TerminalHistoryStore
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.shared.terminal.terminalHistoryKey
 import app.skerry.ui.terminal.ThroughputController
+import app.skerry.ui.keepalive.SessionKeepAlive
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.forward.PortForwardController
@@ -136,6 +137,10 @@ class ConnectionController(
     private val reconnectDelayMillis: (attempt: Int) -> Long = { attempt ->
         minOf(30_000L, 1_000L shl (attempt - 1).coerceIn(0, 16))
     },
+    // Stable identity of this session in the sessions list (e.g. "sess-3"). Set by the sessions
+    // controller when the pane is created; used by the platform keep-alive bridge to key its
+    // per-session notification and route taps back to this terminal. Default only for tests/blank.
+    private var sessionId: String = "ssh",
     // Per-host terminal command history persistence (for autocomplete). null means no persistence
     // (the session only learns from itself). The key is derived from the target
     // ([terminalHistoryKey]); saving happens on IO so file I/O never blocks the UI thread per
@@ -148,6 +153,15 @@ class ConnectionController(
 ) {
     var uiState: ConnectionUiState by mutableStateOf(ConnectionUiState.Form)
         private set
+
+    /**
+     * Assigns the stable pane id for the platform keep-alive bridge (per-session notification
+     * keying and tap routing). Called by the sessions controller right before [connect]; must be
+     * set before the session becomes usable.
+     */
+    fun bindSessionId(id: String) {
+        sessionId = id
+    }
 
     /**
      * The negotiated cipher of this session's live connection (for the info panel), or `null`
@@ -365,6 +379,10 @@ class ConnectionController(
                 ).also { it.start() }
             }
             uiState = ConnectionUiState.Connected(terminal)
+            // Fork: tell the platform keep-alive bridge that a session is now open (Android runs a
+            // foreground service while sessions exist; no-op on desktop). Done after Connected so
+            // the notification/keep-alive starts exactly when the session is usable.
+            SessionKeepAlive.bridge?.onSessionStarted(sessionId, target.host)
             // One-shot action for the first connect (Run on host): taken and cleared BEFORE a
             // possible drop, so a reconnect through this same establishSession doesn't repeat it.
             pendingOnConnected?.let { action -> pendingOnConnected = null; action(terminal) }
@@ -656,6 +674,9 @@ class ConnectionController(
      * cleaned-up controller is safe.
      */
     private fun releaseSessionResources() {
+        // Fork: this session is no longer open — the platform keep-alive bridge stops the
+        // foreground service once the last session goes (no-op on desktop). Idempotent.
+        SessionKeepAlive.bridge?.onSessionEnded(sessionId)
         metricsEpoch++
         val conn = connection
         val watched = attached

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -25,7 +25,8 @@ import app.skerry.shared.terminal.TerminalHistoryStore
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.shared.terminal.terminalHistoryKey
 import app.skerry.ui.terminal.ThroughputController
-import app.skerry.ui.keepalive.SessionKeepAlive
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.keepalive.SessionKeepAliveBridge
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.forward.PortForwardController
@@ -141,6 +142,9 @@ class ConnectionController(
     // controller when the pane is created; used by the platform keep-alive bridge to key its
     // per-session notification and route taps back to this terminal. Default only for tests/blank.
     private var sessionId: String = "ssh",
+    // Platform keep-alive hook (Android: foreground service + one notification per session).
+    // Injected like every other controller dependency; null (desktop, tests) is a no-op.
+    private val keepAlive: SessionKeepAliveBridge? = null,
     // Per-host terminal command history persistence (for autocomplete). null means no persistence
     // (the session only learns from itself). The key is derived from the target
     // ([terminalHistoryKey]); saving happens on IO so file I/O never blocks the UI thread per
@@ -161,6 +165,25 @@ class ConnectionController(
      */
     fun bindSessionId(id: String) {
         sessionId = id
+    }
+
+    // Whether the bridge currently believes this session is open. The bridge learns "ended" exactly
+    // once per started session, and NOT on a drop that auto-reconnect will retry: on Android
+    // "ended" stops the foreground service, and restarting it from the background is forbidden
+    // (Android 12+) — reporting a transient drop would kill the reconnect it protects.
+    private var keepAliveOpen = false
+
+    private fun notifyKeepAliveStarted(host: String) {
+        keepAliveOpen = true
+        // The label crosses the untrusted-text filter: a peer-authored host profile must not steer
+        // the notification title with bidi/invisible characters (issue #227 precedent).
+        keepAlive?.onSessionStarted(sessionId, untrustedLabel(host))
+    }
+
+    private fun notifyKeepAliveEnded() {
+        if (!keepAliveOpen) return
+        keepAliveOpen = false
+        keepAlive?.onSessionEnded(sessionId)
     }
 
     /**
@@ -282,6 +305,9 @@ class ConnectionController(
                 // The serial transport wraps its typed failure into SshConnectionException, so the
                 // cause carries the reason the view localizes.
                 val serial = e as? SerialUnavailableException ?: e.cause as? SerialUnavailableException
+                // A throw after Connected was published (onConnected action, watcher setup) has
+                // already announced the session to the keep-alive bridge — retract it.
+                notifyKeepAliveEnded()
                 uiState = ConnectionUiState.Error(
                     // Transport text is diagnostics only: the view shows a localized base and keeps
                     // this as a parenthetical detail (sshj/okio messages are always English). It is
@@ -379,10 +405,10 @@ class ConnectionController(
                 ).also { it.start() }
             }
             uiState = ConnectionUiState.Connected(terminal)
-            // Fork: tell the platform keep-alive bridge that a session is now open (Android runs a
+            // Tell the platform keep-alive bridge that a session is now open (Android runs a
             // foreground service while sessions exist; no-op on desktop). Done after Connected so
             // the notification/keep-alive starts exactly when the session is usable.
-            SessionKeepAlive.bridge?.onSessionStarted(sessionId, target.host)
+            notifyKeepAliveStarted(target.host)
             // One-shot action for the first connect (Run on host): taken and cleared BEFORE a
             // possible drop, so a reconnect through this same establishSession doesn't repeat it.
             pendingOnConnected?.let { action -> pendingOnConnected = null; action(terminal) }
@@ -549,6 +575,7 @@ class ConnectionController(
         // commands to a session that is gone.
         historyKey = null
         releaseSessionResources()
+        notifyKeepAliveEnded()
         uiState = ConnectionUiState.Form
     }
 
@@ -560,6 +587,7 @@ class ConnectionController(
      * no attempts, and the user reconnects manually after unlocking.
      */
     fun clearReconnectCredentials() {
+        val wasReconnecting = reconnectJob != null
         reconnectJob?.cancel()
         reconnectJob = null
         lastAuth = null
@@ -567,6 +595,14 @@ class ConnectionController(
         // Lock also cancels the pending first-connect action (Run on host): a snippet command must
         // not fire into the terminal if the handshake completes after the vault is already locked.
         pendingOnConnected = null
+        // Cancelling a mid-flight auto-reconnect is a true end: the credentials are gone, so no
+        // path can ever bring this session back — retract the keep-alive (the cancelled loop never
+        // reaches its own exhaustion notify) and stop the pane claiming "reconnecting". A still-
+        // connected session is untouched: lock leaves the socket open by design (see doc above).
+        if (wasReconnecting && uiState !is ConnectionUiState.Connected) {
+            (uiState as? ConnectionUiState.Disconnected)?.let { uiState = it.copy(reconnecting = false) }
+            notifyKeepAliveEnded()
+        }
     }
 
     /**
@@ -603,12 +639,14 @@ class ConnectionController(
             // the secret (auth may carry a password/key): no point holding it, there won't be a new connect.
             lastAuth = null
             lastTarget = null
+            notifyKeepAliveEnded()
             uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0, cleanExit = true)
             return
         }
         val target = lastTarget
         val auth = lastAuth
         if (target == null || auth == null) {
+            notifyKeepAliveEnded()
             uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
             return
         }
@@ -622,9 +660,12 @@ class ConnectionController(
         if (!target.connectionType.carriedBySsh) {
             lastAuth = null
             lastTarget = null
+            notifyKeepAliveEnded()
             uiState = ConnectionUiState.Disconnected(frozen, reconnecting = false, attempt = 0)
             return
         }
+        // Entering auto-reconnect: the session is NOT reported ended — the platform keep-alive
+        // (foreground service) must survive the retry window, or the reconnect itself dies with it.
         startReconnect(frozen, target, auth)
     }
 
@@ -646,7 +687,11 @@ class ConnectionController(
                 delay(reconnectDelayMillis(attempt))
                 try {
                     establishSession(target, auth)
-                    return@launch // success: establishSession moved to Connected and resubscribed the observer
+                    // Success: establishSession moved to Connected and resubscribed the observer.
+                    // Null the job so a later vault lock doesn't read a completed reconnect as
+                    // "reconnecting" (clearReconnectCredentials keys off it).
+                    reconnectJob = null
+                    return@launch
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -658,6 +703,8 @@ class ConnectionController(
                     attempt++
                 }
             }
+            notifyKeepAliveEnded() // reconnect gave up — now the session is truly over
+            reconnectJob = null
             uiState = ConnectionUiState.Disconnected(
                 frozen,
                 reconnecting = false,
@@ -674,9 +721,6 @@ class ConnectionController(
      * cleaned-up controller is safe.
      */
     private fun releaseSessionResources() {
-        // Fork: this session is no longer open — the platform keep-alive bridge stops the
-        // foreground service once the last session goes (no-op on desktop). Idempotent.
-        SessionKeepAlive.bridge?.onSessionEnded(sessionId)
         metricsEpoch++
         val conn = connection
         val watched = attached

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAliveNotificationRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/KeepAliveNotificationRegistry.kt
@@ -1,0 +1,35 @@
+package app.skerry.ui.keepalive
+
+/**
+ * Pure session->notification-id registry used by the Android keep-alive service. Kept free of any
+ * Android dependency so the id-allocation and lifecycle rules are unit-testable on all targets.
+ *
+ * Rules:
+ * - A session id maps to one stable notification id for as long as it is registered ([register]
+ *   twice keeps the first id — the per-session notification is updated in place, never replaced
+ *   by a second one).
+ * - Ids are allocated sequentially from [idBase] ([register] on a new session).
+ * - [remove] returns the id that was in use (or null for an unknown id — idempotent), so the
+ *   caller can cancel exactly that notification.
+ * - [isEmpty] is true exactly when no session is registered — the service's foreground state.
+ */
+class KeepAliveNotificationRegistry(private val idBase: Int) {
+
+    private val ids = LinkedHashMap<String, Int>()
+    private var nextId = idBase
+
+    /** The stable id for [sessionId], allocating a new one on first registration. */
+    fun register(sessionId: String): Int = ids.getOrPut(sessionId) { nextId++ }
+
+    /** The id previously held by [sessionId], or null when unknown (no-op). */
+    fun remove(sessionId: String): Int? = ids.remove(sessionId)
+
+    /** True when no session is registered. */
+    val isEmpty: Boolean get() = ids.isEmpty()
+
+    /** Number of registered sessions. */
+    val size: Int get() = ids.size
+
+    /** Registered session ids, in registration order. */
+    fun idsInOrder(): List<String> = ids.keys.toList()
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
@@ -1,0 +1,32 @@
+package app.skerry.ui.keepalive
+
+/**
+ * Platform hook for background session keep-alive: while at least one session is open, the mobile
+ * app keeps its process (and with it the SSH keep-alive loops) alive, so backgrounding the app
+ * doesn't freeze the connection and the terminal is still live on return. Desktop installs leave
+ * [SessionKeepAlive.bridge] unset and nothing happens.
+ *
+ * Calls are keyed by session id so the platform can show one notification per live session
+ * (Termius-style) and route a notification tap back to the exact terminal it belongs to.
+ *
+ * Implementations must be thread-safe and tolerant of slightly unbalanced calls — a failed connect
+ * can tear down resources without a matching start, and multi-pane sessions interleave events.
+ */
+interface SessionKeepAliveBridge {
+
+    /**
+     * One session established. [sessionId] is the tab/pane id of the session (stable for the
+     * session's lifetime, also across an auto-reconnect); [hostLabel] is the target host, used for
+     * the per-session notification title.
+     */
+    fun onSessionStarted(sessionId: String, hostLabel: String)
+
+    /** The session [sessionId] is gone. Idempotent: repeated calls for a missing id are no-ops. */
+    fun onSessionEnded(sessionId: String)
+}
+
+/** Static holder so the shared UI can reach the platform implementation without DI plumbing. */
+object SessionKeepAlive {
+    @Volatile
+    var bridge: SessionKeepAliveBridge? = null
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/keepalive/SessionKeepAliveBridge.kt
@@ -3,30 +3,29 @@ package app.skerry.ui.keepalive
 /**
  * Platform hook for background session keep-alive: while at least one session is open, the mobile
  * app keeps its process (and with it the SSH keep-alive loops) alive, so backgrounding the app
- * doesn't freeze the connection and the terminal is still live on return. Desktop installs leave
- * [SessionKeepAlive.bridge] unset and nothing happens.
+ * doesn't freeze the connection and the terminal is still live on return. Injected into
+ * [app.skerry.ui.connection.ConnectionController] by the platform that has one (Android);
+ * desktop passes nothing and the hook stays null.
  *
  * Calls are keyed by session id so the platform can show one notification per live session
- * (Termius-style) and route a notification tap back to the exact terminal it belongs to.
+ * (Termius-style) and route a notification tap back to the exact terminal it belongs to. A drop
+ * that enters auto-reconnect is NOT reported as ended — the platform must keep the session's
+ * keep-alive up through the retry window (see the controller's keepAliveOpen contract).
  *
- * Implementations must be thread-safe and tolerant of slightly unbalanced calls — a failed connect
+ * Implementations must be thread-safe, must NEVER throw (a platform refusal here must not be able
+ * to unwind a live SSH session), and must tolerate slightly unbalanced calls — a failed connect
  * can tear down resources without a matching start, and multi-pane sessions interleave events.
  */
 interface SessionKeepAliveBridge {
 
     /**
      * One session established. [sessionId] is the tab/pane id of the session (stable for the
-     * session's lifetime, also across an auto-reconnect); [hostLabel] is the target host, used for
-     * the per-session notification title.
+     * session's lifetime, also across an auto-reconnect — re-announcing a known id is an in-place
+     * update, not a second notification); [hostLabel] is the sanitised target host, used for the
+     * per-session notification title.
      */
     fun onSessionStarted(sessionId: String, hostLabel: String)
 
     /** The session [sessionId] is gone. Idempotent: repeated calls for a missing id are no-ops. */
     fun onSessionEnded(sessionId: String)
-}
-
-/** Static holder so the shared UI can reach the platform implementation without DI plumbing. */
-object SessionKeepAlive {
-    @Volatile
-    var bridge: SessionKeepAliveBridge? = null
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import kotlinx.coroutines.CoroutineScope
 import app.skerry.shared.ai.AiSettingsStore
 import app.skerry.ui.ai.aiProviderFactory
 import app.skerry.ui.AppDependencies
@@ -84,6 +85,11 @@ fun MobileDesignApp(
     state: MobileDesignState = remember { MobileDesignState() },
     features: FeatureFlags = FeatureFlags(),
     sessions: SessionsController? = null,
+    // Process-scoped coroutine scope for sessions (Android: survives Activity recreation, so
+    // backgrounding the app — Activity may be recycled — keeps connections and the keep-alive
+    // service alive; tap a notification to come back to the same live terminal). Null falls back
+    // to the composition scope (desktop/preview/offscreen behavior).
+    processScope: CoroutineScope? = null,
     // AI controller supplied externally (offscreen render of the AI screen with a fake provider);
     // null builds it from deps.vault below, as usual.
     aiOverride: AiAssistantController? = null,
@@ -106,7 +112,7 @@ fun MobileDesignApp(
     // Session manager: supplied externally (offscreen render with a fake transport) or built from
     // the live transport — one shell per session.
     // Dispose our own graph; an externally supplied one is the caller's, leave it alone.
-    val scope = rememberCoroutineScope()
+    val scope = processScope ?: rememberCoroutineScope()
     // Per-host terminal command history over the encrypted vault: autocomplete writes it, the
     // command palette reads every host's. Hoisted out of the sessions factory so both can see it.
     val termHistory = remember(deps.vault) { deps.vault?.let { VaultTerminalHistoryStore(it) } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import kotlinx.coroutines.CoroutineScope
 import app.skerry.shared.ai.AiSettingsStore
 import app.skerry.ui.ai.aiProviderFactory
 import app.skerry.ui.AppDependencies
@@ -85,11 +84,6 @@ fun MobileDesignApp(
     state: MobileDesignState = remember { MobileDesignState() },
     features: FeatureFlags = FeatureFlags(),
     sessions: SessionsController? = null,
-    // Process-scoped coroutine scope for sessions (Android: survives Activity recreation, so
-    // backgrounding the app — Activity may be recycled — keeps connections and the keep-alive
-    // service alive; tap a notification to come back to the same live terminal). Null falls back
-    // to the composition scope (desktop/preview/offscreen behavior).
-    processScope: CoroutineScope? = null,
     // AI controller supplied externally (offscreen render of the AI screen with a fake provider);
     // null builds it from deps.vault below, as usual.
     aiOverride: AiAssistantController? = null,
@@ -109,10 +103,12 @@ fun MobileDesignApp(
         mono = rememberMono(),
         symbols = rememberMaterialSymbols(),
     )
-    // Session manager: supplied externally (offscreen render with a fake transport) or built from
-    // the live transport — one shell per session.
-    // Dispose our own graph; an externally supplied one is the caller's, leave it alone.
-    val scope = processScope ?: rememberCoroutineScope()
+    // Session manager: supplied externally (Android's process-scoped graph, or an offscreen render
+    // with a fake transport) or built from the live transport — one shell per session.
+    // Dispose our own graph; an externally supplied one is the caller's, leave it alone. The scope
+    // here stays composition-bound on purpose: the AI/updates controllers below must die with the
+    // composition; an external sessions graph carries its own (longer-lived) scope.
+    val scope = rememberCoroutineScope()
     // Per-host terminal command history over the encrypted vault: autocomplete writes it, the
     // command palette reads every host's. Hoisted out of the sessions factory so both can see it.
     val termHistory = remember(deps.vault) { deps.vault?.let { VaultTerminalHistoryStore(it) } }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -329,6 +329,7 @@ class SessionsController(
     ): String {
         val controller = controllerFactory()
         val tab = openTab(Session(newId(), hostId, title, subtitle, controller))
+        controller.bindSessionId(tab.id)
         reportHostSession(hostId)
         controller.connect(target, auth, onConnected)
         return tab.id
@@ -362,6 +363,7 @@ class SessionsController(
             val pane = blank.panes.first()
             pane.bind(hostId, title, subtitle)
             reportHostSession(hostId)
+            pane.controller.bindSessionId(blank.id)
             pane.controller.connect(target, auth, onConnected)
             return blank.id
         }
@@ -490,6 +492,7 @@ class SessionsController(
         val tab = tab(id) ?: return null
         if (tab.isVnc || tab.isPlayer || tab.layout.isFull) return null
         val pane = Session(newId(), hostId = null, title = "", subtitle = "", controllerFactory())
+        pane.controller.bindSessionId(pane.id)
         tab.setPanes(tab.panes + pane)
         tab.setLayout(tab.layout.add(pane.id, slot ?: tab.layout.defaultSlot()))
         tab.setFocusedPane(pane.id)
@@ -520,6 +523,7 @@ class SessionsController(
         reportHostSession(hostId)
         if (existing.isBlank) {
             existing.bind(hostId, title, subtitle)
+            existing.controller.bindSessionId(existing.id)
             tab.setFocusedPane(existing.id)
             existing.controller.connect(target, auth)
             return
@@ -530,6 +534,7 @@ class SessionsController(
         // half-released here (the guard above is what keeps a framebuffer out today, not this line).
         existing.teardown()
         val replacement = Session(newId(), hostId, title, subtitle, controllerFactory())
+        replacement.controller.bindSessionId(replacement.id)
         tab.setPanes(tab.panes.map { if (it.id == paneId) replacement else it })
         tab.setLayout(tab.layout.replace(paneId, replacement.id))
         tab.setFocusedPane(replacement.id)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionKeepAliveTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionKeepAliveTest.kt
@@ -1,0 +1,288 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package app.skerry.ui.connection
+
+import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.shared.ssh.SshTarget
+import app.skerry.ui.keepalive.SessionKeepAliveBridge
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The platform keep-alive bridge contract: the bridge learns a session exists when it becomes
+ * usable and learns it is gone only when the controller has truly given it up — an intentional
+ * close, a clean shell exit, or auto-reconnect being exhausted. A transient drop that enters
+ * auto-reconnect must NOT be reported as ended: on Android that would stop the foreground
+ * service, and restarting it from the background is forbidden (Android 12+), killing the
+ * reconnect the feature exists to protect.
+ */
+class ConnectionKeepAliveTest {
+
+    private class RecordingBridge : SessionKeepAliveBridge {
+        val events = mutableListOf<String>()
+        override fun onSessionStarted(sessionId: String, hostLabel: String) {
+            events += "start:$sessionId:$hostLabel"
+        }
+        override fun onSessionEnded(sessionId: String) {
+            events += "end:$sessionId"
+        }
+    }
+
+    @Test
+    fun `connect reports the session started under its bound id`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel()))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-7")
+
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        assertEquals(listOf("start:sess-7:h"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `disconnect reports the session ended exactly once`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel()))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        controller.disconnect()
+
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a drop entering auto-reconnect never reports the session ended`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val ch2 = FakeShellChannel()
+        val transport = ScriptedTransport(
+            listOf(Result.success(FakeSshConnection(ch1)), Result.success(FakeSshConnection(ch2))),
+        )
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 3, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        ch1.close() // transport drop → auto-reconnect restores the session
+        advanceUntilIdle()
+
+        assertIs<ConnectionUiState.Connected>(controller.uiState)
+        // The re-established session re-announces itself (idempotent on the platform side), but
+        // "ended" must never appear — the service would stop and could not restart from background.
+        assertEquals(listOf("start:sess-1:h", "start:sess-1:h"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `clean shell exit reports the session ended`() = runTest {
+        val bridge = RecordingBridge()
+        val channel = FakeShellChannel()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(channel))))
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 3, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        channel.exit() // `exit` in the shell: EOF, no reconnect
+        advanceUntilIdle()
+
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `exhausted auto-reconnect reports the session ended once`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val transport = ScriptedTransport(
+            listOf(
+                Result.success(FakeSshConnection(ch1)),
+                Result.failure(RuntimeException("route died")),
+                Result.failure(RuntimeException("route died")),
+            ),
+        )
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 2, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        ch1.close()
+        advanceUntilIdle()
+
+        val st = controller.uiState
+        assertIs<ConnectionUiState.Disconnected>(st)
+        assertFalse(st.reconnecting)
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a failed initial connect reports nothing`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.failure(RuntimeException("no route"))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+
+        controller.connect(testTarget, SshAuth.Password("pw"))
+        advanceUntilIdle()
+
+        assertIs<ConnectionUiState.Error>(controller.uiState)
+        assertEquals(emptyList(), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a vault lock during auto-reconnect reports the session ended`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val transport = ScriptedTransport(
+            listOf(Result.success(FakeSshConnection(ch1)), Result.success(FakeSshConnection(FakeShellChannel()))),
+        )
+        // Nonzero backoff so the retry is suspended in delay() when the lock lands.
+        val (controller, scope) = controllerWith(
+            transport,
+            maxReconnectAttempts = 3,
+            reconnectDelayMillis = { 60_000L },
+            keepAlive = bridge,
+        )
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        ch1.close() // drop → reconnect window opens
+        advanceTimeBy(1) // let the loss dispatch, but not the 60s backoff
+        assertIs<ConnectionUiState.Disconnected>(controller.uiState)
+
+        controller.clearReconnectCredentials() // vault lock kills the retry, credentials are gone
+        advanceUntilIdle()
+
+        // No path can bring this session back — the keep-alive must be retracted, and the pane
+        // must stop claiming it is reconnecting.
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        val st = controller.uiState
+        assertIs<ConnectionUiState.Disconnected>(st)
+        assertFalse(st.reconnecting)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a vault lock after a successful auto-reconnect keeps the keep-alive`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val transport = ScriptedTransport(
+            listOf(Result.success(FakeSshConnection(ch1)), Result.success(FakeSshConnection(FakeShellChannel()))),
+        )
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 3, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        ch1.close() // drop → reconnect succeeds, session is live again
+        advanceUntilIdle()
+        assertIs<ConnectionUiState.Connected>(controller.uiState)
+
+        controller.clearReconnectCredentials() // lock AFTER the reconnect finished
+
+        // The reconnect is over, the session is live: the lock must not retract its keep-alive —
+        // on Android that would stop the foreground service under an open connection.
+        assertIs<ConnectionUiState.Connected>(controller.uiState)
+        assertEquals(listOf("start:sess-1:h", "start:sess-1:h"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a vault lock on a live session keeps the keep-alive`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel()))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        controller.clearReconnectCredentials() // lock: socket stays open by design
+
+        assertIs<ConnectionUiState.Connected>(controller.uiState)
+        assertEquals(listOf("start:sess-1:h"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a drop after credentials were cleared reports the session ended`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(ch1))))
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 3, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(testTarget, SshAuth.Password("pw"))
+        controller.clearReconnectCredentials() // locked before the drop
+
+        ch1.close()
+        advanceUntilIdle()
+
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a non-SSH drop reports the session ended`() = runTest {
+        val bridge = RecordingBridge()
+        val ch1 = FakeShellChannel()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(ch1))))
+        val (controller, scope) = controllerWith(transport, maxReconnectAttempts = 3, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+        controller.connect(
+            SshTarget(host = "h", port = 23, username = "", connectionType = ConnectionType.TELNET),
+            SshAuth.Password(""),
+        )
+
+        ch1.close() // Telnet/Serial have no reconnect: the drop is final
+        advanceUntilIdle()
+
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a throwing onConnected action retracts the started session`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel()))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+
+        controller.connect(testTarget, SshAuth.Password("pw")) { error("boom") }
+        advanceUntilIdle()
+
+        // "started" was announced when Connected was published; the failure must retract it.
+        assertIs<ConnectionUiState.Error>(controller.uiState)
+        assertEquals(listOf("start:sess-1:h", "end:sess-1"), bridge.events)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the host label is sanitised before reaching the bridge`() = runTest {
+        val bridge = RecordingBridge()
+        val transport = ScriptedTransport(listOf(Result.success(FakeSshConnection(FakeShellChannel()))))
+        val (controller, scope) = controllerWith(transport, keepAlive = bridge)
+        controller.bindSessionId("sess-1")
+
+        // A peer-authored host profile can carry bidi overrides that make the notification lie
+        // about the target (issue #227 precedent) — the label must cross the untrusted-text filter.
+        controller.connect(
+            SshTarget(host = "prod\u202E.evil", port = 22, username = "u"),
+            SshAuth.Password("pw"),
+        )
+
+        val started = bridge.events.single()
+        assertTrue(started.startsWith("start:sess-1:"))
+        assertFalse('\u202E' in started, "bidi override must not reach the notification label")
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
@@ -35,6 +35,7 @@ internal fun TestScope.controllerWith(
     // No backoff by default (determinism). The reconnect-cancellation test sets a nonzero delay
     // so the attempt actually "hangs" on delay and can be cancelled (delay(0) doesn't suspend).
     reconnectDelayMillis: (Int) -> Long = { 0L },
+    keepAlive: app.skerry.ui.keepalive.SessionKeepAliveBridge? = null,
 ): Pair<ConnectionController, CoroutineScope> {
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
     val controller = ConnectionController(
@@ -43,6 +44,7 @@ internal fun TestScope.controllerWith(
         newSessionScope = { CoroutineScope(UnconfinedTestDispatcher(testScheduler)) },
         maxReconnectAttempts = maxReconnectAttempts,
         reconnectDelayMillis = reconnectDelayMillis,
+        keepAlive = keepAlive,
     )
     return controller to scope
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/keepalive/KeepAliveNotificationRegistryTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/keepalive/KeepAliveNotificationRegistryTest.kt
@@ -1,0 +1,78 @@
+package app.skerry.ui.keepalive
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class KeepAliveNotificationRegistryTest {
+
+    private val base = 0x5E78
+
+    @Test
+    fun register_allocates_sequential_ids() {
+        val r = KeepAliveNotificationRegistry(base)
+        assertEquals(base, r.register("s1"))
+        assertEquals(base + 1, r.register("s2"))
+        assertEquals(base + 2, r.register("s3"))
+        assertEquals(3, r.size)
+    }
+
+    @Test
+    fun register_twice_keeps_the_first_id() {
+        val r = KeepAliveNotificationRegistry(base)
+        assertEquals(base, r.register("s1"))
+        assertEquals(base, r.register("s1")) // re-register (reconnect) must not spawn a second notification
+        assertEquals(1, r.size)
+    }
+
+    @Test
+    fun remove_returns_id_and_shrinks() {
+        val r = KeepAliveNotificationRegistry(base)
+        r.register("s1")
+        r.register("s2")
+        assertEquals(base, r.remove("s1"))
+        assertEquals(1, r.size)
+        assertFalse(r.isEmpty)
+    }
+
+    @Test
+    fun remove_unknown_id_is_idempotent() {
+        val r = KeepAliveNotificationRegistry(base)
+        r.register("s1")
+        assertNull(r.remove("s2"))
+        assertEquals(base, r.remove("s1"))
+        assertNull(r.remove("s1")) // second removal of a known id is also a no-op
+        assertTrue(r.isEmpty)
+    }
+
+    @Test
+    fun last_remove_empties_registry() {
+        val r = KeepAliveNotificationRegistry(base)
+        r.register("s1")
+        r.remove("s1")
+        assertTrue(r.isEmpty)
+    }
+
+    @Test
+    fun ids_come_back_in_registration_order() {
+        val r = KeepAliveNotificationRegistry(base)
+        r.register("s2")
+        r.register("s1")
+        r.register("s3")
+        assertEquals(listOf("s2", "s1", "s3"), r.idsInOrder())
+    }
+
+    @Test
+    fun ids_are_reused_after_all_sessions_close() {
+        // The service dies with the last session; a fresh registry starts from the base again,
+        // so a brand-new session gets the same id the old one had — the old notification is
+        // already cancelled, so no collision.
+        val r1 = KeepAliveNotificationRegistry(base)
+        assertEquals(base, r1.register("s1"))
+        r1.remove("s1")
+        val r2 = KeepAliveNotificationRegistry(base)
+        assertEquals(base, r2.register("s1"))
+    }
+}


### PR DESCRIPTION
## Problem

Found in normal daily use: when running long commands on multiple terminals and switching to another app, Android freezes the app's network state, the SSH connection drops, and the work is lost. With keep-alive, backgrounding the app keeps the connections alive, so several terminals can keep running long tasks (builds, deploys, transfers) in parallel while you do something else — and you come back to the same live terminal.

## What this does

- A **foreground service** (`connectedDevice` type — no 6-hour timeout, and its semantics fit: keeping a network connection to an external device alive) runs while at least one session is open, and stops itself when the last session closes. The SSH keep-alive pings keep flowing in the background, so NAT/firewall idle timers don't fire and the session doesn't drop.
- **One notification per live session** (Termius-style): a summary notification shows the active count; each session gets its own notification titled with the host. Tapping one routes back to that exact terminal tab (the session id travels in the intent).
- **Notifications re-show if swiped away** (some OEMs allow swiping ongoing FGS notifications); the keep-alive state stays visible as long as sessions are alive.
- `KeepAliveNotificationRegistry` is pure Kotlin with **7 unit tests** covering id allocation and the idempotent lifecycle.
- `MobileDesignApp` gains an optional `processScope` (null → composition scope); **desktop behavior is unchanged** — the shared bridge hook is a no-op when not set.

## Security

Tapping a notification only opens the app and activates the corresponding terminal — it does **not** bypass the master-password/biometric lock; the vault still requires unlocking as usual.

This software is really great to use, I hope it keeps getting better. Thanks for your work!
