### PR TITLE
Terminal responsiveness: transport, feed pipeline and draw path

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalFilePaths.kt
@@ -124,14 +124,22 @@ internal fun rowFilePathSpans(row: List<TermCell>): List<TextLinkSpan> {
     // Runs per visible row on every Canvas draw — bail out with zero allocation on rows that cannot
     // contain a path before touching StringBuilder/detection.
     if (!rowHasPathMarker(row)) return emptyList()
+    // A span touching a hyperlink-owned cell is dropped (the hyperlink owns it); one touching a
+    // concealed cell (SGR 8) is dropped whole too - a path with a hidden segment would hand SFTP
+    // a location the user never saw, clicks on its visible prefix included.
     return rowTextSpans(row, ::detectFilePaths).filterNot { span ->
-        (span.start until span.endExclusive).any { row.getOrNull(it)?.hyperlink != null }
+        (span.start until span.endExclusive).any {
+            row.getOrNull(it)?.let { cell -> cell.hyperlink != null || cell.style.hidden } == true
+        }
     }
 }
 
 /** The file-path span under column [col] in [row], or `null`. Used for Ctrl+click hit-testing. */
-internal fun filePathSpanAt(row: List<TermCell>, col: Int): TextLinkSpan? =
-    rowFilePathSpans(row).firstOrNull { col >= it.start && col < it.endExclusive }
+internal fun filePathSpanAt(row: List<TermCell>, col: Int): TextLinkSpan? {
+    // A concealed cell (SGR 8) is not a click target: the user cannot read what would open.
+    if (row.getOrNull(col)?.style?.hidden == true) return null
+    return rowFilePathSpans(row).firstOrNull { col >= it.start && col < it.endExclusive }
+}
 
 /**
  * The path a touch selection stands for, or `null`. Only a selection that is exactly one path

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
@@ -202,6 +202,11 @@ internal data class GlyphRun(
  */
 private fun TermCell.isPlainAscii(): Boolean = text.length == 1 && text[0].code in 0x20..0x7e
 
+// Test-only counter of actual row segmentations (single-threaded: draw phase or the sequential
+// test JVM - revisit before enabling parallel test execution). Pins that repaints reuse cached
+// runs instead of re-segmenting every visible row per frame.
+internal var glyphRunSegmentations = 0
+
 /**
  * Segments a grid row into glyph runs. Consecutive same-style ASCII cells are merged into one run (the
  * fast monospace drawText), while each non-ASCII glyph (mc box-drawing, CJK, symbols) is split into its
@@ -214,6 +219,7 @@ private fun TermCell.isPlainAscii(): Boolean = text.length == 1 && text[0].code 
  * so a token boundary inside otherwise identical cells becomes a boundary between runs.
  */
 internal fun glyphRuns(row: List<TermCell>, highlight: RowHighlight? = null): List<GlyphRun> {
+    glyphRunSegmentations++
     val runs = ArrayList<GlyphRun>()
     fun kindAt(col: Int) = highlight?.kindAt(col) ?: HighlightKind.None
     var g = 0

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalGlyphs.kt
@@ -264,8 +264,14 @@ internal fun TermStyle.toSpanStyle(palette: Palette, theme: TerminalTheme): Span
         bg == TermColor.Default -> Color.Unspecified
         else -> resolvedBg
     }
-    if (hidden) fgColor = bgColor.takeIf { it != Color.Unspecified } ?: theme.background
     if (dim) fgColor = fgColor.copy(alpha = 0.6f)
+    // Transparent, not painted-as-background: a bg-colored glyph is faintly legible under the
+    // half-alpha selection and search washes drawn beneath the text - the concealed character
+    // must contribute no strokes at all. LAST, so no later attribute can restore visibility:
+    // dim's copy(alpha = 0.6f) REPLACES alpha, and applied after Transparent (= black at alpha 0)
+    // it would paint the secret in 60% black. The cell's real background is painted separately
+    // by cellBgColor - this override touches only the glyph strokes.
+    if (hidden) fgColor = Color.Transparent
     // Underline (including modern 4:x forms and the SGR 58 color) is drawn manually in Canvas — Compose
     // TextDecoration can't do wavy/dotted/double or a separate color. Here only strikethrough, which is native.
     return SpanStyle(
@@ -294,6 +300,9 @@ internal val LINK_UNDERLINE_STYLE = TermStyle(
  * color (accounting for inverse and dim). Rendered separately from the glyph, so the color is computed here.
  */
 internal fun TermStyle.underlineDrawColor(palette: Palette, theme: TerminalTheme): Color {
+    // A concealed cell must not reveal even the POSITION of its text: an SGR 8;4 underline in the
+    // text color would trace the run of the hidden characters.
+    if (hidden) return Color.Transparent
     val base = if (underlineColor == TermColor.Default) {
         if (inverse) {
             if (bg == TermColor.Default) theme.background else bg.toComposeColor(theme, palette)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
@@ -193,8 +193,10 @@ internal fun rememberRowHighlights(
     window: IntRange,
 ): Map<Int, RowHighlight> {
     val settings = LocalTerminalHighlight.current
+    // `state` in the keys: the content version is per-emulator, and an in-place session switch
+    // could coincide on the counter — see the same note at TerminalScreen's searchWindow.
     return remember(
-        screen, window, settings, state.vocabulary, state.executedCommands,
+        state, state.screenContentVersion, window, settings, state.vocabulary, state.executedCommands,
         state.cursorRow, state.cursorCol, state.altScreen,
     ) {
         highlightRows(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalHighlightRows.kt
@@ -75,24 +75,69 @@ internal fun TermStyle.acceptsHighlight(): Boolean =
  * The command line (rows around the cursor) and output (everything else) never overlap: the cursor's
  * own chain of rows is excluded from the output pass, so a typed `ERROR` isn't recolored as a log
  * level while it is still being typed.
+ *
+ * Composed of the two split passes so the equivalence stays pinned by one entry point; the
+ * composition layer calls the passes separately to cache them under different keys.
  */
 internal fun highlightRows(
     source: HighlightSource,
     window: IntRange,
     settings: TerminalHighlight,
     vocabulary: CommandVocabulary,
+): Map<Int, RowHighlight> = overlayLiveCommand(
+    base = backgroundHighlightRows(
+        source = source.copy(cursor = null),
+        window = window,
+        settings = settings,
+        vocabulary = vocabulary,
+        liveChainStart = liveChainStart(source),
+    ),
+    source = source,
+    settings = settings,
+    vocabulary = vocabulary,
+)
+
+/** The first row of the cursor's soft-wrap chain, or null off-grid/on the alt screen. */
+internal fun liveChainStart(source: HighlightSource): Int? {
+    val cursor = source.cursor ?: return null
+    if (source.altScreen || cursor.row !in source.screen.indices) return null
+    return chainStart(source.screen, cursor.row)
+}
+
+// Test-only counters (single-threaded: written from composition or the sequential test JVM -
+// revisit before enabling parallel test execution). They pin that cursor moves do not rescan the
+// window and that content changes do re-run the overlay.
+internal var backgroundHighlightPasses = 0
+internal var liveOverlayPasses = 0
+
+/**
+ * The near-cursor-independent passes — executed commands and output — over the whole [window].
+ * This is the expensive scan (every visible row); its only cursor input is [liveChainStart] (the
+ * row, not the column), which changes when the cursor crosses a chain boundary — line editing and
+ * history recall keep it stable, so the composition layer caches this pass across those. The
+ * source's own cursor is ignored ([HighlightSource.cursor] may be anything; callers pass null).
+ */
+internal fun backgroundHighlightRows(
+    source: HighlightSource,
+    window: IntRange,
+    settings: TerminalHighlight,
+    vocabulary: CommandVocabulary,
+    liveChainStart: Int?,
 ): Map<Int, RowHighlight> {
     if (!settings.commandLine && !settings.output) return emptyMap()
+    backgroundHighlightPasses++
     val screen = source.screen
     val out = HashMap<Int, RowHighlight>()
     val commandRows = HashSet<Int>()
     if (settings.commandLine) {
-        commandRows += tokenizeSlices(source, commandLineSlices(source), vocabulary, out)
         // Commands already run keep their colors: the cursor has moved to the next prompt, and
-        // without this pass a command would go plain the moment it is executed.
+        // without this pass a command would go plain the moment it is executed. The live chain's
+        // start row is excluded here unconditionally - the overlay cannot always reclaim it (a
+        // cursor inside a prompt parses no live command line), and the old single pass never let
+        // the cursor's own row read as executed.
         for (r in window) {
             if (r in commandRows) continue
-            commandRows += tokenizeSlices(source, executedCommandSlices(source, r), vocabulary, out)
+            commandRows += tokenizeSlices(source, executedCommandSlices(source, r, liveChainStart), vocabulary, out)
         }
     }
     if (settings.output && !source.altScreen) {
@@ -101,6 +146,32 @@ internal fun highlightRows(
             outputHighlight(screen[r])?.let { out[r] = it }
         }
     }
+    return out
+}
+
+/**
+ * The cursor-dependent half: tokenizes the live command chain (≤ a handful of rows) and lays it
+ * over [base], removing whatever the background painted on those rows first — a typed `ERROR`
+ * must read as an argument, not as a log level. Cheap per cursor move: one map copy of at most a
+ * window's worth of entries plus the small live chain.
+ */
+internal fun overlayLiveCommand(
+    base: Map<Int, RowHighlight>,
+    source: HighlightSource,
+    settings: TerminalHighlight,
+    vocabulary: CommandVocabulary,
+): Map<Int, RowHighlight> {
+    if (!settings.commandLine) return base
+    liveOverlayPasses++
+    val slices = commandLineSlices(source)
+    if (slices.isEmpty()) return base
+    val live = HashMap<Int, RowHighlight>()
+    val claimed = tokenizeSlices(source, slices, vocabulary, live)
+    if (claimed.isEmpty()) return base
+    val out = HashMap<Int, RowHighlight>(base.size + live.size)
+    out.putAll(base)
+    claimed.forEach { out.remove(it) }
+    out.putAll(live)
     return out
 }
 
@@ -193,20 +264,42 @@ internal fun rememberRowHighlights(
     window: IntRange,
 ): Map<Int, RowHighlight> {
     val settings = LocalTerminalHighlight.current
+    // Two caches under different keys: the background pass scans the whole window and depends
+    // only on content — a cursor move (arrows, history) must not rescan it; the live-command
+    // overlay is the only cursor-keyed piece and touches at most a handful of rows.
     // `state` in the keys: the content version is per-emulator, and an in-place session switch
     // could coincide on the counter — see the same note at TerminalScreen's searchWindow.
-    return remember(
+    val liveSource = HighlightSource(
+        screen = screen,
+        cursor = TerminalPos(state.cursorRow, state.cursorCol),
+        altScreen = state.altScreen,
+        executedCommands = state.executedCommands,
+    )
+    // The chain-start ROW (not the column): stable across line editing and history recall, so the
+    // background cache survives them; it moves only when the cursor crosses a chain boundary.
+    val chainStart = liveChainStart(liveSource)
+    val background = remember(
         state, state.screenContentVersion, window, settings, state.vocabulary, state.executedCommands,
+        state.altScreen, chainStart,
+    ) {
+        backgroundHighlightRows(
+            source = liveSource.copy(cursor = null),
+            window = window,
+            settings = settings,
+            vocabulary = state.vocabulary,
+            liveChainStart = chainStart,
+        )
+    }
+    // screenContentVersion in the keys, not just `background`: remember compares with equals(),
+    // and two content-equal background maps (both empty, say) would keep a stale overlay while
+    // the live line's text changed under a stationary cursor (Delete, same-length history recall).
+    return remember(
+        state, state.screenContentVersion, background, settings, state.vocabulary,
         state.cursorRow, state.cursorCol, state.altScreen,
     ) {
-        highlightRows(
-            source = HighlightSource(
-                screen = screen,
-                cursor = TerminalPos(state.cursorRow, state.cursorCol),
-                altScreen = state.altScreen,
-                executedCommands = state.executedCommands,
-            ),
-            window = window,
+        overlayLiveCommand(
+            base = background,
+            source = liveSource,
             settings = settings,
             vocabulary = state.vocabulary,
         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
@@ -152,7 +152,8 @@ private fun chainLinkSpans(
     if (!hasSchemeMarker(screen, chain.rows)) return emptyMap()
     val flat = rowsText(screen, chain.rows) ?: return emptyMap()
     val found = detectPlainTextLinks(flat.text).filterNot { span ->
-        (chain.startClipped && span.start == 0) || (chain.endClipped && span.endExclusive == flat.text.length)
+        (chain.startClipped && span.start == 0) || (chain.endClipped && span.endExclusive == flat.text.length) ||
+            flat.coversConcealedCell(screen, span)
     }
     if (found.isEmpty()) return emptyMap()
     var out: MutableMap<Int, List<TextLinkSpan>>? = null
@@ -163,6 +164,20 @@ private fun chainLinkSpans(
     return out ?: emptyMap()
 }
 
+/**
+ * Whether any character of [span] came from a concealed cell (SGR 8). A bare URL is offered on the
+ * strength of its visible text, so a span with a hidden part is dropped whole: a server could print
+ * `https://example.com` visible and a `.evil.tld/x` tail concealed, and underlining just the
+ * visible prefix while opening the joined URI would make the spoof look MORE legitimate. (OSC 8
+ * hyperlinks stay per-cell: their target is never on-screen to begin with.)
+ */
+private fun RowText.coversConcealedCell(screen: List<List<TermCell>>, span: TextLinkSpan): Boolean {
+    for (i in span.start until span.endExclusive) {
+        if (screen[rowAt(i)].getOrNull(column(i))?.style?.hidden == true) return true
+    }
+    return false
+}
+
 /** URL spans on row [r] alone — hit-testing a single pointer position, not the draw pass. */
 internal fun rowLinkSpans(screen: List<List<TermCell>>, r: Int): List<TextLinkSpan> =
     linkSpansByRow(screen, r..r)[r] ?: emptyList()
@@ -170,3 +185,19 @@ internal fun rowLinkSpans(screen: List<List<TermCell>>, r: Int): List<TextLinkSp
 /** The plain-text URL under row [r], column [col] of [screen], or `null`. Ctrl+click hit-testing. */
 internal fun linkAt(screen: List<List<TermCell>>, r: Int, col: Int): String? =
     rowLinkSpans(screen, r).firstOrNull { col >= it.start && col < it.endExclusive }?.uri
+
+/**
+ * The openable URI under row [r], column [col]: the cell's own OSC 8 hyperlink first, then a bare
+ * URL detected in the row text — filtered through [isSafeLinkUri]. The single resolution point for
+ * both the hover affordance and the Ctrl+click, so the hand cursor can never appear where a click
+ * would open nothing (or the reverse).
+ *
+ * A concealed cell (SGR 8) resolves to nothing: its text is invisible, and an invisible click
+ * target would let a server hide where a click leads.
+ */
+internal fun openableLinkAt(screen: List<List<TermCell>>, r: Int, col: Int): String? {
+    val cell = screen.getOrNull(r)?.getOrNull(col)
+    if (cell?.style?.hidden == true) return null
+    val uri = cell?.hyperlink ?: linkAt(screen, r, col)
+    return uri?.takeIf(::isSafeLinkUri)
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalLinks.kt
@@ -104,6 +104,11 @@ private fun lineStartOf(screen: List<List<TermCell>>, r: Int): Int {
     return start
 }
 
+// Test-only counter, incremented by TerminalScreen's composition cache (NOT here - hover/click
+// hit-testing also routes through linkSpansByRow and must not count). Single-threaded: written
+// from composition or the sequential test JVM; revisit before enabling parallel test execution.
+internal var linkScanPasses = 0
+
 /**
  * URL spans per grid row for rows [window] of [screen], in column coordinates. A row that auto-wrap
  * cut out of a longer logical line is detected together with its neighbours, so a URL split at the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPromptScan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalPromptScan.kt
@@ -23,7 +23,10 @@ internal data class CommandLineSlice(val row: Int, val startCol: Int, val endCol
  */
 internal data class HighlightSource(
     val screen: List<List<TermCell>>,
-    val cursor: TerminalPos,
+    // Null for the cursor-independent background pass: no live command line exists there. The
+    // executed pass never reads the cursor - its live-chain exclusion arrives as an explicit row
+    // (see executedCommandSlices' liveChainStart).
+    val cursor: TerminalPos?,
     val altScreen: Boolean,
     val executedCommands: Set<String> = emptySet(),
 )
@@ -54,7 +57,8 @@ internal class CommandLineText(val text: String, private val rows: IntArray, pri
  */
 internal fun commandLineSlices(source: HighlightSource): List<CommandLineSlice> {
     val screen = source.screen
-    val cursor = source.cursor
+    // No cursor - the background pass: there is no live command line to find.
+    val cursor = source.cursor ?: return emptyList()
     // A full-screen app (vim, htop, mc) has no shell line: whatever the cursor sits on is the app's.
     if (source.altScreen) return emptyList()
     if (cursor.row !in screen.indices) return emptyList()
@@ -76,14 +80,22 @@ internal fun commandLineSlices(source: HighlightSource): List<CommandLineSlice> 
  * text after the prompt must equal a command this session executed. Output that merely contains a
  * `$ ` never matches, because it would have to be character-for-character a command that ran.
  */
-internal fun executedCommandSlices(source: HighlightSource, row: Int): List<CommandLineSlice> {
+internal fun executedCommandSlices(
+    source: HighlightSource,
+    row: Int,
+    liveChainStart: Int?,
+): List<CommandLineSlice> {
     val screen = source.screen
     if (source.altScreen || source.executedCommands.isEmpty()) return emptyList()
-    if (row !in screen.indices || source.cursor.row !in screen.indices) return emptyList()
+    if (row !in screen.indices) return emptyList()
     // Only the first row of a wrapped chain starts a command; the rest are handled with it.
     if (row > 0 && isFilledToEdge(screen[row - 1])) return emptyList()
-    // The line under the cursor is the live command line and is highlighted by its own path.
-    if (row == chainStart(screen, source.cursor.row)) return emptyList()
+    // The line under the cursor is the live command line and never reads as "already executed" -
+    // unconditionally, even when no live command line parses (cursor inside a prompt with a
+    // pre-filled answer). The exclusion arrives as an explicit row rather than being derived from
+    // a cursor, so the cursor-independent background pass can apply it without depending on the
+    // cursor column.
+    if (row == liveChainStart) return emptyList()
     if (!rowHasPromptMarker(screen[row])) return emptyList()
 
     val startCol = promptEndColumn(screen[row])
@@ -166,7 +178,7 @@ private fun promptEndColumn(row: List<TermCell>): Int {
 }
 
 /** First row of the soft-wrap chain containing [row]. */
-private fun chainStart(screen: List<List<TermCell>>, row: Int): Int {
+internal fun chainStart(screen: List<List<TermCell>>, row: Int): Int {
     var first = row
     while (first > 0 && row - first < MAX_COMMAND_ROWS && isFilledToEdge(screen[first - 1])) first--
     return first

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalRowText.kt
@@ -47,6 +47,9 @@ internal class RowText(val text: String, private val rowOf: IntArray?, private v
     /** Column the character at string index [index] was drawn in (single-row callers). */
     fun column(index: Int): Int = colOf[index]
 
+    /** Grid row the character at string index [index] came from (0 for a single-row flatten). */
+    fun rowAt(index: Int): Int = rowOf?.get(index) ?: 0
+
     /**
      * The part of the string span `[start, endExclusive)` that landed on grid [row], as a column
      * range, or `null` when the span does not touch that row. Columns are contiguous within a row —

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -125,6 +125,9 @@ private const val CURSOR_BLINK_MS = 530L
  */
 private fun TermCell.blocksLinkUnderline(): Boolean = style.underline || style.hidden
 
+/** Rows the glyph-run cache may hold - several draw windows; see the cache's comment. */
+private const val GLYPH_RUN_CACHE_ROWS = 512
+
 // Test-only counter of TerminalScreen body executions (single-threaded: composition or the
 // sequential test JVM; revisit before enabling parallel test execution). Pins that the cursor
 // blink repaints its overlay without recomposing the screen.
@@ -725,6 +728,21 @@ fun TerminalScreen(
               linkScanPasses++
               linkSpansByRow(screen, searchWindow)
           }
+          // Glyph runs per visible row: segmentation is O(row) with a per-run allocation, and the
+          // draw lambda re-executes on every repaint (selection drag, scroll) while rows and
+          // highlights are unchanged. Keyed by row INDEX: the remember drops the map on every
+          // publish (screenVersion, like the sibling caches above), so within its lifetime the
+          // snapshot is fixed and an index can never alias a changed row - while a content-keyed
+          // map would pay an O(cols) structural hash per lookup and alias content-equal duplicate
+          // rows (retry-loop logs) into one entry that their distinct highlight instances then
+          // evict from each other every frame. The highlight instance rides in the value: a
+          // rebuilt highlight (cursor move through the live line) must re-segment its row. Filled
+          // lazily from the draw phase - single (UI) thread, like glyphStyleCache - and capped so
+          // paging through deep history in an idle session cannot retain runs for the whole
+          // scrollback (the wholesale clear costs one window's re-segmentation).
+          val glyphRunCache = remember(state, screenVersion) {
+              HashMap<Int, Pair<RowHighlight?, List<GlyphRun>>>()
+          }
           // clipToBounds after padding: the scrollback row at the scroll boundary is drawn at top=-chh and
           // would otherwise spill into the top padding zone (desktop has no default clip, unlike Android)
           // — after `clear` the command row would peek there. The clip cuts it at the content edge.
@@ -776,7 +794,15 @@ fun TerminalScreen(
                   // (mc box-drawing, CJK, symbols) is drawn at its own column separately: a fallback font
                   // gives a non-cellWidth advance, and a long run would accumulate drift (ragged box
                   // horizontals, colored rows sliding). A wide cell — span=2.
-                  for (run in glyphRuns(row, highlightByRow[r])) {
+                  val rowHighlight = highlightByRow[r]
+                  val cachedRuns = glyphRunCache[r]
+                  val runs = if (cachedRuns != null && cachedRuns.first === rowHighlight) {
+                      cachedRuns.second
+                  } else {
+                      if (glyphRunCache.size >= GLYPH_RUN_CACHE_ROWS) glyphRunCache.clear()
+                      glyphRuns(row, rowHighlight).also { glyphRunCache[r] = rowHighlight to it }
+                  }
+                  for (run in runs) {
                       val x = run.col * cw
                       if (run.text.isNotBlank()) {
                           val byKind = glyphStyleCache.getOrPut(run.style) { arrayOfNulls(HIGHLIGHT_KIND_COUNT) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -119,6 +119,17 @@ private const val DOUBLE_CLICK_MS = 350
 /** Cursor blink half-period (ms), matching xterm's ~530ms phase. */
 private const val CURSOR_BLINK_MS = 530L
 
+/**
+ * Cells the link-underline passes (4-6) must not paint: an app underline is already there (no
+ * double line), or the cell is concealed (SGR 8) and the underline would trace the hidden run.
+ */
+private fun TermCell.blocksLinkUnderline(): Boolean = style.underline || style.hidden
+
+// Test-only counter of TerminalScreen body executions (single-threaded: composition or the
+// sequential test JVM; revisit before enabling parallel test execution). Pins that the cursor
+// blink repaints its overlay without recomposing the screen.
+internal var terminalScreenCompositions = 0
+
 private const val PADDING_DP = 14
 // Number of history matches shown at once in the reverse-search (Ctrl-R) overlay.
 private const val REVERSE_SEARCH_ROWS = 6
@@ -167,6 +178,7 @@ fun TerminalScreen(
     // panel of its own (split pane, recording playback, preview).
     onOpenPath: ((String) -> Unit)? = null,
 ) {
+    terminalScreenCompositions++
     // Terminal font/size from Appearance settings ([LocalTerminalAppearance]); defaults to Hack 13px
     // where no provider is set (mobile target/preview/connection screen). Ligatures always disabled
     // ([NO_LIGATURES]) so `->`/`=>`/`!=` never merge regardless of font.
@@ -441,20 +453,24 @@ fun TerminalScreen(
     // Cursor blink phase: with blink on, toggle a boolean once per half-period; otherwise the cursor
     // stays solid. The cursor is drawn as an overlay (see below), so blinking repaints only a small
     // Canvas, not the whole screen text.
-    var blinkOn by remember { mutableStateOf(true) }
+    // A State object, not a delegated property: the blink phase is read ONLY inside the cursor
+    // overlay's draw lambda, so each 530ms toggle invalidates that one small canvas's draw and
+    // never recomposes this screen - a composition-time read here made every idle pane recompose
+    // twice a second, per pane, focused or not.
+    val blinkOn = remember { mutableStateOf(true) }
     LaunchedEffect(state.cursorBlink, state.cursorVisible, closed) {
         if (!state.cursorBlink || !state.cursorVisible || closed) {
-            blinkOn = true
+            blinkOn.value = true
             return@LaunchedEffect
         }
         while (true) {
-            blinkOn = true
+            blinkOn.value = true
             delay(CURSOR_BLINK_MS)
-            blinkOn = false
+            blinkOn.value = false
             delay(CURSOR_BLINK_MS)
         }
     }
-    val cursorVisibleNow = sized && !closed && state.cursorVisible && blinkOn
+    val cursorComposed = sized && !closed && state.cursorVisible
 
     // A single state snapshot per recomposition: both the text overlay and the cursor overlay read the
     // same screen/cursor — otherwise the snapshot could diverge between the two draw passes (cursor at a
@@ -521,14 +537,10 @@ fun TerminalScreen(
         return TerminalPos(row, p.col.coerceIn(0, snap[row].size))
     }
 
-    // Is there an openable link (OSC 8 or bare text URL) under this cell? Mirrors the Ctrl+click
-    // resolution so the hand cursor appears exactly where a click would open something.
-    fun linkUnderPos(pos: TerminalPos): Boolean {
-        // One snapshot for both lookups: the cell's own OSC 8 URI and the wrap-chain text around it.
-        val snap = state.screen
-        val uri = snap.getOrNull(pos.row)?.getOrNull(pos.col)?.hyperlink ?: linkAt(snap, pos.row, pos.col)
-        return uri != null && isSafeLinkUri(uri)
-    }
+    // Is there an openable link (OSC 8 or bare text URL) under this cell? Shares [openableLinkAt]
+    // with the Ctrl+click handler, so the hand cursor appears exactly where a click would open.
+    fun linkUnderPos(pos: TerminalPos): Boolean =
+        openableLinkAt(state.screen, pos.row, pos.col) != null
 
     // The file-path span under this cell, or null. Only consulted after [linkUnderPos] says no: a
     // URL always wins, so a path is never offered where a link would open instead.
@@ -785,11 +797,15 @@ fun TerminalScreen(
                       val from = h
                       while (h < row.size && row[h].hyperlink == uri) h++
                       val to = h
+                      // blocksLinkUnderline skips concealed cells (SGR 8) in all three link passes:
+                      // LINK_UNDERLINE_STYLE carries its own color and hidden=false, so it bypasses
+                      // underlineDrawColor's hidden gate and would trace the hidden run's position.
+                      // Hit-testing refuses them too (openableLinkAt / filePathSpanAt).
                       var k = from
                       while (k < to) {
-                          if (row[k].style.underline) { k++; continue } // app already underlines — don't duplicate
+                          if (row[k].blocksLinkUnderline()) { k++; continue } // app already underlines — don't duplicate
                           val runStart = k
-                          while (k < to && !row[k].style.underline) k++
+                          while (k < to && !row[k].blocksLinkUnderline()) k++
                           drawCellUnderline(LINK_UNDERLINE_STYLE, runStart * cw, top, (k - runStart) * cw, chh, palette, underlineEffects, termTheme)
                       }
                   }
@@ -801,9 +817,9 @@ fun TerminalScreen(
                   for (link in linksByRow[r].orEmpty()) {
                       var k = link.start
                       while (k < link.endExclusive) {
-                          if (row[k].hyperlink != null || row[k].style.underline) { k++; continue }
+                          if (row[k].hyperlink != null || row[k].blocksLinkUnderline()) { k++; continue }
                           val runStart = k
-                          while (k < link.endExclusive && row[k].hyperlink == null && !row[k].style.underline) k++
+                          while (k < link.endExclusive && row[k].hyperlink == null && !row[k].blocksLinkUnderline()) k++
                           drawCellUnderline(LINK_UNDERLINE_STYLE, runStart * cw, top, (k - runStart) * cw, chh, palette, underlineEffects, termTheme)
                       }
                   }
@@ -813,9 +829,9 @@ fun TerminalScreen(
                   hoveredPath?.takeIf { it.row == r }?.let { hover ->
                       var k = hover.span.start
                       while (k < hover.span.endExclusive && k < row.size) {
-                          if (row[k].style.underline) { k++; continue }
+                          if (row[k].blocksLinkUnderline()) { k++; continue }
                           val runStart = k
-                          while (k < hover.span.endExclusive && k < row.size && !row[k].style.underline) k++
+                          while (k < hover.span.endExclusive && k < row.size && !row[k].blocksLinkUnderline()) k++
                           drawCellUnderline(LINK_UNDERLINE_STYLE, runStart * cw, top, (k - runStart) * cw, chh, palette, underlineEffects, termTheme)
                       }
                   }
@@ -1112,10 +1128,8 @@ fun TerminalScreen(
                         // row text. The URI comes from an untrusted server — open only safe web schemes,
                         // blocking file:/javascript:/anything else that could harm locally.
                         if (mods.isCtrlPressed) {
-                            val snap = state.screen
-                            val uri = snap.getOrNull(pos.row)?.getOrNull(pos.col)?.hyperlink
-                                ?: linkAt(snap, pos.row, pos.col)
-                            if (uri != null && isSafeLinkUri(uri)) {
+                            val uri = openableLinkAt(state.screen, pos.row, pos.col)
+                            if (uri != null) {
                                 runCatching { uriHandler.openUri(uri) }
                                 down.consume()
                                 return@awaitEachGesture
@@ -1197,11 +1211,18 @@ fun TerminalScreen(
 
       // Cursor overlay over the text per the DECSCUSR shape. Block — fill the cell + redraw the char in
       // a contrasting color; Underline — a bar at the bottom; Bar — a vertical line on the left. Geometry
-      // uses the same monospace metric as the text, offset by the scroll.
-      if (cursorVisibleNow && screen.isNotEmpty()) {
+      // uses the same monospace metric as the text, offset by the scroll. The blink phase gates
+      // the DRAW, not the composition: the canvas stays composed while the cursor exists, and the
+      // 530ms toggle repaints only this overlay.
+      if (cursorComposed && screen.isNotEmpty()) {
           val thickness = with(density) { 2.dp.toPx() }
-          val glyph = screen.getOrNull(cursorRow)?.getOrNull(cursorCol)?.text
+          // A concealed cell (SGR 8) must stay unreadable under the block cursor too: the text
+          // pass renders it transparent (TerminalGlyphs.toSpanStyle), and redrawing it here in
+          // the contrast color would reveal the one character the host asked to hide.
+          val glyph = screen.getOrNull(cursorRow)?.getOrNull(cursorCol)
+              ?.takeUnless { it.style.hidden }?.text
           Canvas(Modifier.fillMaxSize().padding(PADDING_DP.dp)) {
+              if (!blinkOn.value) return@Canvas
               val x = cursorCol * metrics.cellWidth
               val y = cursorRow * metrics.cellHeight - scroll.value.toFloat()
               when (state.cursorShape) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -668,7 +668,14 @@ fun TerminalScreen(
           // The same window the draw loop below walks, so a hit on the partly visible slack row is
           // highlighted too. derivedStateOf, not a plain read of scroll.value: this sits in
           // composition, and the raw value changes every pixel of a drag — the window changes per row.
-          val searchWindow by remember(metrics, viewportSize, screen) {
+          // Keys use the content VERSION, not the list: a remember key compares with equals(), and
+          // a structural list compare walks the scrollback on the Main thread on every publish.
+          // `state` stays in every version-keyed remember: the version is monotonic per EMULATOR,
+          // and an in-place session switch (mobile keeps the composition slot) could land on a
+          // coinciding counter — the state reference restores the per-session scope the screen
+          // instance used to provide.
+          val screenVersion = state.screenContentVersion
+          val searchWindow by remember(state, metrics, viewportSize, screenVersion) {
               derivedStateOf {
                   visibleRowWindow(scroll.value.toFloat(), viewportSize.height.toFloat(), metrics.cellHeight, screen.size)
               }
@@ -677,7 +684,7 @@ fun TerminalScreen(
           // layer knows the scroll position — so it keeps the state's anchor current.
           LaunchedEffect(state, searchWindow) { state.search.setAnchorRow(searchWindow.last) }
           val hitsByRow = remember(
-              screen, state.search.query, state.search.caseSensitive, state.search.regex, searchWindow,
+              state, screenVersion, state.search.query, state.search.caseSensitive, state.search.regex, searchWindow,
           ) {
               val query = state.search.query
               if (query.isNullOrEmpty()) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -701,6 +701,18 @@ fun TerminalScreen(
               }
           }
           val highlightByRow = rememberRowHighlights(state, screen, searchWindow)
+          // Plain-text URLs for the visible window: a URL cut by a soft wrap spans several rows,
+          // and its chain is joined and matched once rather than per row. Hoisted out of the draw
+          // phase like hitsByRow above - computed inline in the draw lambda it re-flattened and
+          // re-regexed the same rows on every repaint, sixty times a second during a scroll drag.
+          // searchWindow is a superset of the draw loop's window for any consistent scroll (it is
+          // built from the unpadded viewport height), and a fast drag inherits the same known,
+          // self-healing one-frame race as the search highlight - not new here; clicks resolve
+          // links from a fresh snapshot, never from this map.
+          val linksByRow = remember(state, screenVersion, searchWindow) {
+              linkScanPasses++
+              linkSpansByRow(screen, searchWindow)
+          }
           // clipToBounds after padding: the scrollback row at the scroll boundary is drawn at top=-chh and
           // would otherwise spill into the top padding zone (desktop has no default clip, unlike Android)
           // — after `clear` the command row would peek there. The clip cuts it at the content edge.
@@ -713,9 +725,6 @@ fun TerminalScreen(
               // whenever output streams while the user sits scrolled up in history. The search
               // highlight above derives its window from the same helper.
               val drawWindow = visibleRowWindow(scrollPx, size.height, chh, screen.size)
-              // Plain-text URLs for the whole window at once (pass 5 below): a URL cut by a soft wrap
-              // spans several rows, and its chain is joined and matched once rather than per row.
-              val linksByRow = linkSpansByRow(screen, drawWindow)
               for (r in drawWindow) {
                   val top = r * chh - scrollPx
                   val row = screen[r]

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.channels.ClosedSendChannelException
 import kotlinx.coroutines.selects.onTimeout
 import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -409,74 +410,14 @@ class TerminalScreenState(
     )
 
 
-    /**
-     * The emulator owner loop: applies commands strictly in order and publishes snapshots at a
-     * bounded rate. The first command after a quiet period publishes immediately; while commands
-     * keep arriving, the mid-window wait absorbs the stream and a publish happens once per
-     * [PUBLISH_MIN_INTERVAL_MS] — on the window edge if the stream pauses inside it (trailing
-     * publish), so the last batch of a burst is never left undrawn. select (not
-     * withTimeoutOrNull+receive) because select's clauses are atomic: a command cannot be lost to
-     * a timeout racing an in-flight receive.
-     */
-    @OptIn(ExperimentalCoroutinesApi::class)
+    /** The paced owner loop, extracted to its own class — see [EmulatorOwnerLoop]. */
     private suspend fun runEmulatorOwner() {
-        var lastPublishAt = Long.MIN_VALUE / 2
-        var dirty = false
-        var pending: ChannelResult<TerminalCommand>? = null
-        try {
-            while (true) {
-                val received = pending ?: commands.receiveCatching()
-                pending = null
-                val cmd = received.getOrNull() ?: break
-                applyCommand(cmd)
-                while (true) {
-                    val next = commands.tryReceive().getOrNull() ?: break
-                    applyCommand(next)
-                }
-                dirty = true
-                val now = nowMillis()
-                if (now - lastPublishAt >= PUBLISH_MIN_INTERVAL_MS) {
-                    publishSnapshot()
-                    lastPublishAt = now
-                    dirty = false
-                    continue
-                }
-                // The select below runs once per drained batch during a sub-window burst — its
-                // per-call allocation is bounded by burst cadence, not by the publish window.
-                val next = select<ChannelResult<TerminalCommand>?> {
-                    commands.onReceiveCatching { it }
-                    onTimeout(PUBLISH_MIN_INTERVAL_MS - (now - lastPublishAt)) { null }
-                }
-                if (next == null) {
-                    publishSnapshot()
-                    lastPublishAt = nowMillis()
-                    dirty = false
-                } else {
-                    pending = next
-                }
-            }
-        } finally {
-            // Every exit — channel close, parser fault, cancellation — lands the tail applied
-            // since the last publish: the coalescing window must never widen how much parsed
-            // output a fault can erase from the screen.
-            if (dirty) flushTailBestEffort()
-        }
-    }
-
-    /**
-     * Tail flush for [runEmulatorOwner]'s finally. [publishSnapshot] does not suspend, so no
-     * CancellationException can originate here; catching the rest keeps a flush-only failure
-     * from replacing an in-flight fault, while the trace keeps it visible on the clean-close
-     * path where this throw would otherwise be the only signal. No logging framework exists in
-     * this codebase — stderr is the convention (see the owner-level fault handler).
-     */
-    @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
-    private fun flushTailBestEffort() {
-        try {
-            publishSnapshot()
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
+        EmulatorOwnerLoop(
+            commands = commands,
+            nowMillis = nowMillis,
+            apply = ::applyCommand,
+            publish = ::publishSnapshot,
+        ).run()
     }
 
     /** Apply one command to the emulator (does not publish a snapshot; the caller batches that). */
@@ -1414,9 +1355,128 @@ internal const val FEED_BACKLOG_CHUNKS = 64
  * immediately (interactive echo latency is untouched); the cap only coalesces mid-stream.
  * 16ms aligns with the common 60Hz frame: Compose paints on the frame clock, so a faster cadence
  * only produces publishes whose work is thrown away between frames; the trailing-edge guarantee
- * bounds the added latency to one window either way.
+ * bounds the added latency to one window in steady state (a command landing mid-window starts a
+ * fresh drain budget, so one transitional interval can approach two windows — still bounded, not
+ * compounding). This constant is also the fairness bound of
+ * the emulator owner's drain (one window of parse work per publish, then a yield) — growing it
+ * grows the worst-case scheduling delay of the outbound writer on a saturated pool with it.
  */
 internal const val PUBLISH_MIN_INTERVAL_MS = 16L
+
+/**
+ * The emulator owner loop: applies commands strictly in order and publishes snapshots at a
+ * bounded rate. The first command after a quiet period publishes immediately; while commands keep
+ * arriving, the mid-window wait absorbs the stream and a publish happens once per
+ * [PUBLISH_MIN_INTERVAL_MS] — on the window edge if the stream pauses inside it (trailing
+ * publish), so the last batch of a burst is never left undrawn. select (not
+ * withTimeoutOrNull+receive) because select's clauses are atomic: a command cannot be lost to a
+ * timeout racing an in-flight receive.
+ *
+ * Its own class rather than methods on [TerminalScreenState]: the loop owns pacing only — the
+ * state object stays the sole owner of what applying and publishing mean.
+ */
+private class EmulatorOwnerLoop(
+    private val commands: Channel<TerminalCommand>,
+    private val nowMillis: () -> Long,
+    private val apply: suspend (TerminalCommand) -> Unit,
+    private val publish: () -> Unit,
+) {
+    private var lastPublishAt = Long.MIN_VALUE / 2
+    private var dirty = false
+
+    suspend fun run() {
+        var pending: ChannelResult<TerminalCommand>? = null
+        try {
+            while (true) {
+                val received = pending ?: commands.receiveCatching()
+                val cmd = received.getOrNull() ?: break
+                pending = step(cmd)
+            }
+        } finally {
+            // Every exit — channel close, parser fault, cancellation — lands the tail applied
+            // since the last publish: the coalescing window must never widen how much parsed
+            // output a fault can erase from the screen.
+            if (dirty) flushTailBestEffort()
+        }
+    }
+
+    /**
+     * One paced iteration: apply [cmd], drain up to a window's worth of queued work, then either
+     * publish (window elapsed) or wait for the window edge. Returns a command received while
+     * waiting — the caller's next iteration consumes it — or null when this step published.
+     */
+    private suspend fun step(cmd: TerminalCommand): ChannelResult<TerminalCommand>? {
+        val entered = nowMillis()
+        apply(cmd)
+        // Before the drain: a fault inside a drained command must still flush what this step
+        // already applied - the finally's guarantee covers the whole batch, not just its tail.
+        dirty = true
+        val windowSpentParsing = drainWithinWindow(entered)
+        val now = nowMillis()
+        if (now - lastPublishAt >= PUBLISH_MIN_INTERVAL_MS) {
+            publishNow(now)
+            // Mid-flood fairness: this coroutine shares the Default pool with the writer and
+            // other sessions; give them a slot before taking the next windowful.
+            if (windowSpentParsing) yield()
+            return null
+        }
+        val next = awaitWindowEdge(now - lastPublishAt)
+        if (next == null) publishNow(nowMillis())
+        return next
+    }
+
+    /**
+     * Applies queued commands until the queue empties or one window of parse time has passed
+     * [since] the step began; true when the budget was spent parsing. Budgeted from step entry,
+     * not from the last publish: after a quiet period the window is long expired, and a stale
+     * budget would return "spent" before draining anything — splitting an already-queued batch
+     * across two frames and mislabeling every interactive echo as a flood. A host that keeps the
+     * queue non-empty (dense flood at parse rate) still cannot postpone publishes or monopolize
+     * the dispatcher: at most one window of parse work per publish.
+     */
+    private suspend fun drainWithinWindow(since: Long): Boolean {
+        while (true) {
+            if (nowMillis() - since >= PUBLISH_MIN_INTERVAL_MS) return true
+            val next = commands.tryReceive().getOrNull() ?: return false
+            apply(next)
+        }
+    }
+
+    /**
+     * Waits for the next command or the window edge, whichever comes first; null means the edge.
+     * Runs once per drained batch during a sub-window burst — its per-call allocation is bounded
+     * by burst cadence, not by the publish window.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun awaitWindowEdge(elapsed: Long): ChannelResult<TerminalCommand>? =
+        select {
+            commands.onReceiveCatching { it }
+            onTimeout(PUBLISH_MIN_INTERVAL_MS - elapsed) { null }
+        }
+
+    private fun publishNow(at: Long) {
+        publish()
+        lastPublishAt = at
+        dirty = false
+    }
+
+    /**
+     * Tail flush for [run]'s finally. The publish callback ([TerminalScreenState.publishSnapshot])
+     * does not suspend, so no CancellationException can originate here; catching the rest keeps a
+     * flush-only failure from replacing an in-flight fault, while the trace keeps it visible on
+     * the clean-close path where this throw would otherwise be the only signal. No logging
+     * framework exists in this codebase — stderr is the convention (see the owner-level fault
+     * handler in [TerminalScreenState]).
+     */
+    @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
+    private fun flushTailBestEffort() {
+        try {
+            publish()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+}
 
 /** Command to the sole emulator owner; the queue preserves feed/resize ordering. */
 private sealed interface TerminalCommand {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -36,9 +36,13 @@ import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.ChannelResult
 import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -75,8 +79,10 @@ class TerminalScreenState(
     // an untrusted host must not silently overwrite the system clipboard until the user opts in.
     // Snapshotted at connect; also pushed live into an open session via [applyClipboardWriteEnabled].
     clipboardWriteEnabled: Boolean = false,
-    // Monotonic milliseconds, injectable for tests. Only the search refresh throttle reads it, and
-    // it must not step backwards (a wall clock would), or a refresh could be skipped for minutes.
+    // Monotonic milliseconds, injectable for tests. Two readers: the search refresh throttle and
+    // the publish-rate cap in the emulator owner loop. Must not step backwards (a wall clock
+    // would) — a backwards step would skip search refreshes for minutes and stretch the publish
+    // window past PUBLISH_MIN_INTERVAL_MS.
     private val nowMillis: () -> Long = { STARTED_AT.elapsedNow().inWholeMilliseconds },
 ) {
     // OSC 52 requests to write to the system clipboard. extraBufferCapacity keeps tryEmit from the
@@ -403,6 +409,76 @@ class TerminalScreenState(
     )
 
 
+    /**
+     * The emulator owner loop: applies commands strictly in order and publishes snapshots at a
+     * bounded rate. The first command after a quiet period publishes immediately; while commands
+     * keep arriving, the mid-window wait absorbs the stream and a publish happens once per
+     * [PUBLISH_MIN_INTERVAL_MS] — on the window edge if the stream pauses inside it (trailing
+     * publish), so the last batch of a burst is never left undrawn. select (not
+     * withTimeoutOrNull+receive) because select's clauses are atomic: a command cannot be lost to
+     * a timeout racing an in-flight receive.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private suspend fun runEmulatorOwner() {
+        var lastPublishAt = Long.MIN_VALUE / 2
+        var dirty = false
+        var pending: ChannelResult<TerminalCommand>? = null
+        try {
+            while (true) {
+                val received = pending ?: commands.receiveCatching()
+                pending = null
+                val cmd = received.getOrNull() ?: break
+                applyCommand(cmd)
+                while (true) {
+                    val next = commands.tryReceive().getOrNull() ?: break
+                    applyCommand(next)
+                }
+                dirty = true
+                val now = nowMillis()
+                if (now - lastPublishAt >= PUBLISH_MIN_INTERVAL_MS) {
+                    publishSnapshot()
+                    lastPublishAt = now
+                    dirty = false
+                    continue
+                }
+                // The select below runs once per drained batch during a sub-window burst — its
+                // per-call allocation is bounded by burst cadence, not by the publish window.
+                val next = select<ChannelResult<TerminalCommand>?> {
+                    commands.onReceiveCatching { it }
+                    onTimeout(PUBLISH_MIN_INTERVAL_MS - (now - lastPublishAt)) { null }
+                }
+                if (next == null) {
+                    publishSnapshot()
+                    lastPublishAt = nowMillis()
+                    dirty = false
+                } else {
+                    pending = next
+                }
+            }
+        } finally {
+            // Every exit — channel close, parser fault, cancellation — lands the tail applied
+            // since the last publish: the coalescing window must never widen how much parsed
+            // output a fault can erase from the screen.
+            if (dirty) flushTailBestEffort()
+        }
+    }
+
+    /**
+     * Tail flush for [runEmulatorOwner]'s finally. [publishSnapshot] does not suspend, so no
+     * CancellationException can originate here; catching the rest keeps a flush-only failure
+     * from replacing an in-flight fault, while the trace keeps it visible on the clean-close
+     * path where this throw would otherwise be the only signal. No logging framework exists in
+     * this codebase — stderr is the convention (see the owner-level fault handler).
+     */
+    @Suppress("TooGenericExceptionCaught", "PrintStackTrace")
+    private fun flushTailBestEffort() {
+        try {
+            publishSnapshot()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     /** Apply one command to the emulator (does not publish a snapshot; the caller batches that). */
     private suspend fun applyCommand(cmd: TerminalCommand) {
         applyInterceptor?.invoke()
@@ -492,7 +568,11 @@ class TerminalScreenState(
         if (token == null) stepMark = null
     }
 
-    /** Publish the emulator snapshot into Compose state (after feed/resize). */
+    /**
+     * Publish the emulator snapshot into Compose state (after feed/resize). Must stay
+     * non-suspend: [flushTailBestEffort]'s finally-safety (no swallowed cancellation) depends
+     * on no suspension point ever existing here.
+     */
     private fun publishSnapshot() {
         // The grid and the cursor apply as one atomic group: auto-fit reads them as a tuple under
         // snapshotFlow, and individual writes from this (session) thread could pair a fresh screen
@@ -1236,22 +1316,15 @@ class TerminalScreenState(
                 commands.close()
             }
         }
-        // Sole owner of the emulator: feed and resize run strictly in order. Publishes one snapshot
-        // per batch of immediately-available commands: under heavy output (build, cat) the PTY
-        // delivers many chunks in a row, and each publish re-copies the visible screen rows and
-        // renotifies every observer, so doing it per chunk is expensive (freezes/GC, especially on
-        // Android). When the queue is empty, behavior is unchanged (snapshot right away), so
-        // interactive latency does not grow.
+        // Sole owner of the emulator: feed and resize run strictly in order. Publishing is
+        // coalesced twice: a batch of immediately-available commands becomes one snapshot, and
+        // while the stream keeps producing, publishes are further capped to one per
+        // [PUBLISH_MIN_INTERVAL_MS] window (leading edge immediate, trailing edge guaranteed) —
+        // see the constant's doc. When the queue is empty, behavior is unchanged (snapshot right
+        // away), so interactive latency does not grow.
         scope.launch {
             try {
-                for (cmd in commands) {
-                    applyCommand(cmd)
-                    while (true) {
-                        val next = commands.tryReceive().getOrNull() ?: break
-                        applyCommand(next)
-                    }
-                    publishSnapshot()
-                }
+                runEmulatorOwner()
             } catch (e: CancellationException) {
                 throw e
             } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -1312,7 +1385,10 @@ class TerminalScreenState(
  */
 enum class MirroredInput { Typed, Pasted }
 
-/** Process start mark: the default monotonic clock behind [TerminalScreenState]'s refresh throttle. */
+/**
+ * Process start mark: the default monotonic clock behind [TerminalScreenState]'s search refresh
+ * throttle and its publish-rate cap.
+ */
 private val STARTED_AT = TimeSource.Monotonic.markNow()
 
 /** How many soft-wrapped rows [TerminalScreenState.logicalLineRows] joins in each direction. */
@@ -1329,6 +1405,18 @@ private const val MAX_JOINED_WRAP_ROWS = 64
  * (TerminalSession), ~2.5 MiB combined per session.
  */
 internal const val FEED_BACKLOG_CHUNKS = 64
+
+/**
+ * Minimum interval between snapshot publishes while the stream keeps producing. A publish costs a
+ * visible-grid copy, a policy compare, ~15 Compose state writes and a Main-dispatcher notification
+ * per registered snapshotFlow — at 200-500 PTY chunks/s that is hundreds of publishes per second
+ * for at most 60 visible frames. The first command after a quiet period always publishes
+ * immediately (interactive echo latency is untouched); the cap only coalesces mid-stream.
+ * 16ms aligns with the common 60Hz frame: Compose paints on the frame clock, so a faster cadence
+ * only produces publishes whose work is thrown away between frames; the trailing-edge guarantee
+ * bounds the added latency to one window either way.
+ */
+internal const val PUBLISH_MIN_INTERVAL_MS = 16L
 
 /** Command to the sole emulator owner; the queue preserves feed/resize ordering. */
 private sealed interface TerminalCommand {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -38,6 +38,8 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.ClosedSendChannelException
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -336,7 +338,30 @@ class TerminalScreenState(
     // The emulator is single-threaded: feed and resize must not be called from different coroutines.
     // All interactions go through this command queue, drained by the single collector below, so
     // PTY output and resize stay serialized relative to each other.
+    //
+    // The queue itself stays UNLIMITED: control commands (resize, recording, settings) are sent
+    // with fire-and-forget trySend from UI paths and must never be dropped on a full buffer. What
+    // is bounded is the Feed traffic specifically — the session collector takes a permit per chunk
+    // and the emulator returns it after parsing, so a backlog of unparsed output suspends the
+    // collector (and transitively the socket read) without ever touching control commands.
     private val commands = Channel<TerminalCommand>(Channel.UNLIMITED)
+
+    /** Backpressure for Feed commands only — see [FEED_BACKLOG_CHUNKS] and the comment above. */
+    private val feedPermits = Semaphore(FEED_BACKLOG_CHUNKS)
+
+    /**
+     * Test seam: invoked before each command is applied. The emulator has no reachable throw site
+     * through its public surface, so without this the owner loop's fault-recovery path (trace,
+     * queue close, permit return, session close) could regress with the whole suite green.
+     */
+    internal var applyInterceptor: (() -> Unit)? = null
+
+    /**
+     * Second test seam, scoped to the emulator half of a Resize: the loop-level seam above fires
+     * before the PTY call, so it cannot produce the ordering this one covers — PTY resize already
+     * succeeded, then the deliberately unguarded [TerminalEmulator.resize] call faults.
+     */
+    internal var emulatorResizeInterceptor: (() -> Unit)? = null
 
     // Outbound byte queue to the PTY (input, mouse reports, DSR/DA responses). The single consumer
     // in init serializes writes, preserving order across sends from different coroutines. UNLIMITED
@@ -380,8 +405,18 @@ class TerminalScreenState(
 
     /** Apply one command to the emulator (does not publish a snapshot; the caller batches that). */
     private suspend fun applyCommand(cmd: TerminalCommand) {
+        applyInterceptor?.invoke()
         when (cmd) {
-            is TerminalCommand.Feed -> feed(cmd.chunk)
+            // The permit was acquired by the session collector when the chunk was queued; releasing
+            // it only after the parse is what makes the cap measure *unapplied* work. In finally:
+            // a parser exception kills this loop, and a permit that never returns would wedge the
+            // still-live collector (SupervisorJob scope - siblings do not die together) on acquire,
+            // stalling the socket read for every subscriber of the session flow.
+            is TerminalCommand.Feed -> try {
+                feed(cmd.chunk)
+            } finally {
+                feedPermits.release()
+            }
             is TerminalCommand.StartRecording -> startRecorder(cmd)
             is TerminalCommand.StopRecording -> {
                 cmd.cast.complete(recorder?.finish())
@@ -396,9 +431,9 @@ class TerminalScreenState(
                 // wider than the application knows and the tail of rows would stay undrawn. A PTY
                 // resize failure must not kill this coroutine, or feed stops being processed and
                 // the terminal freezes.
-                try {
+                val ptyResized = try {
                     session.resize(cmd.size)
-                    emulator.resize(cmd.size.cols, cmd.size.rows)
+                    true
                 } catch (e: CancellationException) {
                     throw e // do not swallow scope cancellation
                 } catch (_: Exception) {
@@ -408,6 +443,14 @@ class TerminalScreenState(
                     // that retry. Written off the UI thread; the worst a race costs is one
                     // redundant resize command, and the dedup is best-effort anyway.
                     lastRequestedSize = null
+                    false
+                }
+                // Outside the catch: an emulator fault is a parser-class bug, not a PTY hiccup —
+                // it propagates to the owner-level handler (trace + close) like a feed fault,
+                // instead of leaving a silently stale grid.
+                if (ptyResized) {
+                    emulatorResizeInterceptor?.invoke()
+                    emulator.resize(cmd.size.cols, cmd.size.rows)
                 }
             }
         }
@@ -1178,7 +1221,17 @@ class TerminalScreenState(
         // in `for (cmd in commands)`.
         scope.launch {
             try {
-                session.output.collect { chunk -> commands.send(TerminalCommand.Feed(chunk)) }
+                session.output.collect { chunk ->
+                    // If the owner closes the queue between acquire and send, this chunk's permit
+                    // is lost with the throwing send - inert: the instance is already being torn
+                    // down and a reconnect builds a fresh one.
+                    feedPermits.acquire()
+                    commands.send(TerminalCommand.Feed(chunk))
+                }
+            } catch (_: ClosedSendChannelException) {
+                // The emulator owner died (parser fault) and closed the queue on its way out: stop
+                // feeding it. Deliberately NOT rethrown: the session flow must stay live for its
+                // other subscribers (share pump), and EOF still moves the session to Closed.
             } finally {
                 commands.close()
             }
@@ -1199,12 +1252,48 @@ class TerminalScreenState(
                     }
                     publishSnapshot()
                 }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                // A parser fault must not be invisible: without this, the pane silently stops
+                // painting while the session still reports Open. There is no logging framework in
+                // this codebase, so the trace goes to stderr; closing the session flips the state
+                // to Closed, which the connection layer answers with auto-reconnect - a live
+                // terminal again instead of a frozen one. Not rethrown: an unhandled sibling
+                // failure under the SupervisorJob scope would reach the platform's fatal handler.
+                // Printing the trace is safe against escape/secret injection as long as emulator
+                // exceptions never interpolate input into their messages - today they don't
+                // (numeric indices only); keep it that way.
+                e.printStackTrace()
+                try {
+                    session.close()
+                } catch (ce: CancellationException) {
+                    throw ce // scope died while closing - not a close failure
+                } catch (closeFailure: Exception) {
+                    closeFailure.printStackTrace()
+                }
             } finally {
+                // The scope is a SupervisorJob: this coroutine dying (parser exception) does NOT
+                // take the session collector with it. Close the queue so the collector's next send
+                // fails fast instead of feeding a channel nobody drains, and return the permits of
+                // the chunks being discarded so it cannot wedge on acquire meanwhile.
+                commands.close()
                 // Cancellation can leave a stop-recording queued with nobody to answer it; hand the
                 // take over here rather than leave the exporting caller awaiting forever.
                 while (true) {
                     val left = commands.tryReceive().getOrNull() ?: break
-                    if (left is TerminalCommand.StopRecording) left.cast.complete(recorder?.finish())
+                    // Exhaustive on purpose (no else): a future variant carrying a completion or a
+                    // resource token must force a decision here, or its awaiter hangs at teardown.
+                    when (left) {
+                        is TerminalCommand.StopRecording -> left.cast.complete(recorder?.finish())
+                        is TerminalCommand.Feed -> feedPermits.release()
+                        is TerminalCommand.StartRecording,
+                        is TerminalCommand.SetCursorDefault,
+                        is TerminalCommand.SetMaxScrollback,
+                        is TerminalCommand.SetClipboardWriteEnabled,
+                        is TerminalCommand.ExpectStep,
+                        is TerminalCommand.Resize -> Unit
+                    }
                 }
             }
         }
@@ -1228,6 +1317,18 @@ private val STARTED_AT = TimeSource.Monotonic.markNow()
 
 /** How many soft-wrapped rows [TerminalScreenState.logicalLineRows] joins in each direction. */
 private const val MAX_JOINED_WRAP_ROWS = 64
+
+/**
+ * How many PTY chunks may sit unapplied between the session collector and the emulator before the
+ * collector suspends. The suspension is the backpressure path: collector -> session's SharedFlow
+ * (SUSPEND on full) -> channel flow emit -> the blocking socket read pauses -> the TCP window
+ * closes and the server stops sending. Without a bound, `cat` of a large file piles chunks up
+ * faster than the emulator parses them and the screen freezes, then jumps. ~8 KiB per chunk, so
+ * the cap bounds this queue at ~512 KiB; the total client-side cushion before the socket read
+ * actually stalls also includes the session flow's own 256-slot buffer upstream
+ * (TerminalSession), ~2.5 MiB combined per session.
+ */
+internal const val FEED_BACKLOG_CHUNKS = 64
 
 /** Command to the sole emulator owner; the queue preserves feed/resize ordering. */
 private sealed interface TerminalCommand {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreenState.kt
@@ -134,6 +134,15 @@ class TerminalScreenState(
         private set
 
     /**
+     * The emulator's [TerminalEmulator.contentVersion] as of the last publish. Composition caches
+     * keyed on the screen's content (search hits, highlights, links) key on this cheap Long
+     * instead of the list itself — a structural list compare in a `remember` key walks the whole
+     * scrollback on the Main thread when the instance changed.
+     */
+    var screenContentVersion: Long by mutableStateOf(0L)
+        private set
+
+    /**
      * Mobile auto-fit font scale (issue #180), advanced by [TerminalScreen] when it is composed
      * with `autoFitEnabled`. Lives here rather than in composition on purpose: it must survive
      * switching to another session's tab and back (composition state keyed on the active session
@@ -520,7 +529,8 @@ class TerminalScreenState(
         // with a stale cursor there — counting the user's own wrapped command line as wide output.
         // Single writer, so the apply cannot conflict.
         Snapshot.withMutableSnapshot {
-            screen = emulator.lines // rows are already copied into immutable form inside the getter
+            screen = emulator.lines // the cached instance while nothing visible mutated
+            screenContentVersion = emulator.contentVersion
             cols = emulator.cols
             rows = emulator.rows
             cursorRow = emulator.cursorRow
@@ -1568,18 +1578,15 @@ internal fun lastCommandBlocks(text: String, count: Int): List<String> {
 internal fun lastCommandBlock(text: String): String? = lastCommandBlocks(text, 1).firstOrNull()
 
 /**
- * Whether two screen snapshots are the same as far as the UI is concerned — cell content **and** the
- * soft-wrap flags. Compose skips a state write whose new value is equivalent to the old one, and list
- * equality only compares cells: a row can drop its wrap without any cell changing (`ESC[K` over an
- * already-blank tail), and publishing that as "no change" would leave [TerminalScreen]'s link joining
- * reading wrap flags that no longer hold.
+ * Snapshots compare by IDENTITY, not structurally: at a full scrollback with repetitive output
+ * (`yes`, a spinner) a structural compare walked millions of equal cells per publish. The identity
+ * contract is upheld at the source — [TerminalEmulator.lines] returns the cached instance while
+ * nothing visible mutated and a new one after any cell, wrap-flag, scrollback or geometry change
+ * (see [TerminalEmulator.contentVersion]). The wrap-flag subtlety that used to force a structural
+ * compare (`ESC[K` dropping a wrap without any cell changing) is a version bump there too.
  */
-internal fun sameScreen(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean =
-    a == b && a.indices.all { a[it].wrapsToNextRow() == b[it].wrapsToNextRow() }
-
-/** [sameScreen] as the equivalence Compose uses to decide whether publishing a snapshot is a no-op. */
 private val SCREEN_SNAPSHOT_POLICY = object : SnapshotMutationPolicy<List<List<TermCell>>> {
-    override fun equivalent(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean = sameScreen(a, b)
+    override fun equivalent(a: List<List<TermCell>>, b: List<List<TermCell>>): Boolean = a === b
 }
 
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileTerminalTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/mobile/MobileTerminalTest.kt
@@ -8,6 +8,7 @@ import app.skerry.ui.forward.RateParts
 import app.skerry.ui.forward.RateUnit
 import app.skerry.ui.forward.rateParts
 import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.terminal.eagerPublishClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -30,7 +31,7 @@ class MobileTerminalTest {
             override suspend fun resize(size: PtySize) {}
             override suspend fun close() {}
         }
-        return TerminalScreenState(session, CoroutineScope(Job()))
+        return TerminalScreenState(session, CoroutineScope(Job()), nowMillis = eagerPublishClock())
     }
 
     private fun connected(): ConnectionUiState.Connected = ConnectionUiState.Connected(screen())

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookTerminalTargetTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookTerminalTargetTest.kt
@@ -6,6 +6,7 @@ import app.skerry.shared.terminal.STEP_MARK_OSC
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.terminal.eagerPublishClock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -37,7 +38,7 @@ class RunbookTerminalTargetTest {
     fun `a step declared through the target is reported back through it`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val terminal = TerminalScreenState(session, scope)
+        val terminal = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val target = runbookTarget("tab-1", terminal, controller = null)
         val token = RunbookMarker.token("run", 0)
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionStatusTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionStatusTest.kt
@@ -8,6 +8,7 @@ import app.skerry.ui.remote.FakeRemoteDesktop
 import app.skerry.ui.remote.RemoteDesktopScreenState
 import app.skerry.ui.remote.RemoteDesktopUiState
 import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.terminal.eagerPublishClock
 import app.skerry.ui.vnc.VncFailure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,7 +33,7 @@ class SessionStatusTest {
     @Test
     fun `a terminal connection maps every state onto its status`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val terminal = TerminalScreenState(FakeSession(), scope)
+        val terminal = TerminalScreenState(FakeSession(), scope, nowMillis = eagerPublishClock())
 
         assertEquals(SessionStatus.Idle, (null as ConnectionUiState?).asSessionStatus())
         assertEquals(SessionStatus.Idle, ConnectionUiState.Form.asSessionStatus())
@@ -45,7 +46,7 @@ class SessionStatusTest {
     @Test
     fun `a dropped shell is a failure until it exits cleanly or starts retrying`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val terminal = TerminalScreenState(FakeSession(), scope)
+        val terminal = TerminalScreenState(FakeSession(), scope, nowMillis = eagerPublishClock())
         fun dropped(reconnecting: Boolean, cleanExit: Boolean) =
             ConnectionUiState.Disconnected(terminal, reconnecting, attempt = 1, cleanExit = cleanExit)
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ConfirmationTailsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ConfirmationTailsTest.kt
@@ -42,7 +42,7 @@ class ConfirmationTailsTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         session.emit("\u001b[?1049h".encodeToByteArray()) // vim: alternate screen on
         state.typeInput("api-token=hunter2\r") // Enter in insert mode
@@ -61,7 +61,7 @@ class ConfirmationTailsTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         session.emit("\u001b[?1049h".encodeToByteArray())
         state.paste("secret-config-line\n")
@@ -79,7 +79,7 @@ class ConfirmationTailsTest {
     fun `a line sent into the alternate screen does not pollute the tracked line`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         session.emit("\u001b[?1049h".encodeToByteArray())
@@ -98,7 +98,7 @@ class ConfirmationTailsTest {
     fun `a half-typed line does not survive an alternate-screen round trip`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf ".forEach { state.typeInput(it.toString()) }
@@ -123,7 +123,7 @@ class ConfirmationTailsTest {
     fun `a screen quote cut at the cursor is not reported as complete`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // The host draws the recalled line, then the cursor steps back over "-db".
@@ -143,7 +143,7 @@ class ConfirmationTailsTest {
     fun `a screen quote with the cursor at the end keeps its count`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         session.emit("root@prod:~# rm -rf /srv/prod-db".encodeToByteArray())
@@ -162,7 +162,7 @@ class ConfirmationTailsTest {
     fun `a row with wide glyphs past the cursor still voids the count`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Three wide glyphs: 28 string characters in 31 columns. Two columns back leaves the last
@@ -184,7 +184,7 @@ class ConfirmationTailsTest {
     fun `a recalled line that wrapped is classified whole`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         val command = "rm -rf /srv/" + "x".repeat(70)
@@ -202,7 +202,7 @@ class ConfirmationTailsTest {
     fun `a soft-wrapped row is not reported with a complete count`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // 95 characters on an 80-column grid: the row wraps, and the host parks the cursor inside
@@ -224,7 +224,7 @@ class ConfirmationTailsTest {
     fun `a risky tail right of the cursor still trips the guard`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Cursor parked right after the prompt: everything the shell will run is right of it.
@@ -245,7 +245,7 @@ class ConfirmationTailsTest {
     fun `a recalled line the classifier cannot fully read is held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // The risky span sits past the classifier's 512-character window of the joined line AND
@@ -269,7 +269,7 @@ class ConfirmationTailsTest {
     fun `a line padded past the classifier's length cap is held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.paste("x".repeat(600) + " && rm -rf /srv\n")
@@ -283,7 +283,7 @@ class ConfirmationTailsTest {
     fun `a block padded past the classifier's line cap is held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         val block = (1..200).joinToString("\n") { "echo $it" } + "\nrm -rf /srv\n"
@@ -298,7 +298,7 @@ class ConfirmationTailsTest {
     fun `a harmless block inside the caps is not held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.paste("echo one\necho two\n")
@@ -318,7 +318,7 @@ class ConfirmationTailsTest {
     fun `the aside for a long input line states the uncut length`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // ~9000 chars of harmless filler push the risky line past MAX_DRAWN_COMMAND_CHARS, so it is
@@ -344,7 +344,7 @@ class ConfirmationTailsTest {
     fun `a ready-made line sent at a secret prompt is not held or quoted`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.echoOff = true // the transport reports a password prompt
 
@@ -369,7 +369,7 @@ class ConfirmationTailsTest {
     fun `a resolved vault secret is masked in the quote and replayed for real`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("echo hunter2 | sudo -S systemctl stop nginx\n", secrets = listOf("hunter2"))
@@ -399,7 +399,7 @@ class ConfirmationTailsTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         "ls".forEach { state.typeInput(it.toString()) }
         session.emit("$ ls".encodeToByteArray()) // the echo of what was typed

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalFilePathsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalFilePathsTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.terminal
 
 import app.skerry.shared.terminal.CellWidth
 import app.skerry.shared.terminal.TermCell
+import app.skerry.shared.terminal.TermStyle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -177,6 +178,26 @@ class TerminalFilePathsTest {
         val span = rowFilePathSpans(cells).single()
         assertEquals(3, span.start)
         assertEquals("/etc/hosts", filePathSpanAt(cells, 3)?.uri)
+    }
+
+    @Test
+    fun `a path with a concealed segment offers nothing`() {
+        // Visible "/var/log" + concealed "/../secret": SFTP would be handed a path the user never
+        // saw, so a span covering any hidden cell is dropped whole - clicks on the visible prefix
+        // included.
+        val hidden = TermStyle(hidden = true)
+        val cells = "see ".map { TermCell(it) } +
+            "/var/log".map { TermCell(it) } +
+            "/../secret".map { TermCell(it, hidden) }
+        assertTrue(rowFilePathSpans(cells).isEmpty())
+        assertNull(filePathSpanAt(cells, 5))
+    }
+
+    @Test
+    fun `a concealed cell offers no path to open`() {
+        // SGR 8: the pointed cell is invisible, so it must not be a click target.
+        val cells = "see /etc/hosts".map { TermCell(it, TermStyle(hidden = true)) }
+        assertNull(filePathSpanAt(cells, 6))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRowsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRowsTest.kt
@@ -279,4 +279,14 @@ class TerminalHighlightRowsTest {
         val map = highlight(screen, cursorCol = 23, executed = setOf("git status"))
         assertEquals(HighlightKind.Command, map.getValue(0).kindAt(13))
     }
+
+    @Test
+    fun `the cursor's own row never reads as an executed command, even from inside the prompt`() {
+        // Cursor inside the prompt parses no live command line (read -p with a pre-filled answer),
+        // so the overlay cannot reclaim the row - the background's executed pass must exclude the
+        // live chain unconditionally, as the old single pass did.
+        val screen = listOf(row("user@host:~$ git status"))
+        val map = highlight(screen, cursorCol = 5, executed = setOf("git status"))
+        assertEquals(HighlightKind.None, map[0]?.kindAt(13) ?: HighlightKind.None)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalLinksTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalLinksTest.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.terminal
 
 import app.skerry.shared.terminal.TermCell
 import app.skerry.shared.terminal.TermSnapshotRow
+import app.skerry.shared.terminal.TermStyle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -290,5 +291,68 @@ class TerminalLinksTest {
         val span = rowLinkSpans(listOf(cells), 0).single()
         assertEquals(3, span.start)                 // url starts after wide glyph (cols 0,1) + space (col 2)
         assertEquals("https://a.test", linkAt(listOf(cells), 0, 3))
+    }
+
+    // --- openableLinkAt: the single hover/Ctrl+click resolution point ---
+
+    @Test
+    fun `resolves the hyperlink and the bare url under a visible cell`() {
+        val osc = listOf(listOf(TermCell(text = "x", hyperlink = "https://osc.test")))
+        assertEquals("https://osc.test", openableLinkAt(osc, 0, 0))
+        val bare = listOf(row("https://a.test"))
+        assertEquals("https://a.test", openableLinkAt(bare, 0, 3))
+    }
+
+    @Test
+    fun `a concealed cell offers nothing to open`() {
+        // SGR 8: the cell's text is invisible, so there must be no invisible click target either -
+        // for the cell's own OSC 8 hyperlink and for a bare URL detected around it alike.
+        val hidden = TermStyle(hidden = true)
+        val osc = listOf(listOf(TermCell(text = "x", style = hidden, hyperlink = "https://osc.test")))
+        assertNull(openableLinkAt(osc, 0, 0))
+        val bare = listOf("https://a.test".map { TermCell(it, hidden) })
+        assertNull(openableLinkAt(bare, 0, 3))
+    }
+
+    @Test
+    fun `a url with a concealed tail is not a link at all`() {
+        // Visible "https://a.test" + concealed ".evil.tld/x" reads as one token to the detector;
+        // underlining only the visible prefix while opening the joined URI would make the spoof
+        // look MORE legitimate, so a span covering any hidden cell is dropped whole.
+        val hidden = TermStyle(hidden = true)
+        val cells = "https://a.test".map { TermCell(it) } + ".evil.tld/x".map { TermCell(it, hidden) }
+        assertTrue(rowLinkSpans(listOf(cells), 0).isEmpty())
+        assertNull(openableLinkAt(listOf(cells), 0, 3))
+    }
+
+    @Test
+    fun `a concealed tail on the wrapped row kills the whole link`() {
+        // The realistic shape of the spoof: the visible URL runs to the right margin and the
+        // concealed tail lands on the continuation row. Pins the multi-row rowAt mapping inside
+        // coversConcealedCell, which the single-row test above cannot reach.
+        val hidden = TermStyle(hidden = true)
+        val screen = listOf(
+            wrapped("go https://a.test"),
+            ".evil.tld/x".map { TermCell(it, hidden) },
+        )
+        assertTrue(rowLinkSpans(screen, 0).isEmpty())
+        assertTrue(rowLinkSpans(screen, 1).isEmpty())
+        assertNull(openableLinkAt(screen, 0, 5))
+    }
+
+    @Test
+    fun `the cell's own hyperlink wins over a bare url around it`() {
+        // A cell can carry an OSC 8 URI while sitting inside detectable bare-URL text; the
+        // explicit hyperlink is the server's declared target and must win.
+        val cells = "https://a.test".mapIndexed { i, ch ->
+            if (i == 0) TermCell(text = ch.toString(), hyperlink = "https://osc.test") else TermCell(ch)
+        }
+        assertEquals("https://osc.test", openableLinkAt(listOf(cells), 0, 0))
+    }
+
+    @Test
+    fun `an unsafe hyperlink never resolves`() {
+        val osc = listOf(listOf(TermCell(text = "x", hyperlink = "file:///etc/passwd")))
+        assertNull(openableLinkAt(osc, 0, 0))
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalPromptScanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalPromptScanTest.kt
@@ -78,6 +78,15 @@ class TerminalPromptScanTest {
     }
 
     @Test
+    fun `the cursor left of a real prompt terminator yields nothing`() {
+        // Unlike the password case above (no terminator at all), this reaches the
+        // cursor-column-inside-the-prompt branch: a valid `$ ` terminator exists at col 12, and
+        // the cursor sits left of it.
+        val screen = screenOf("user@host:~$ git status")
+        assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 5), altScreen = false)).isEmpty())
+    }
+
+    @Test
     fun `an empty prompt has no command line`() {
         val screen = screenOf("user@host:~$ ")
         assertTrue(commandLineSlices(HighlightSource(screen, TerminalPos(0, 13), altScreen = false)).isEmpty())

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -46,7 +47,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("ab".encodeToByteArray())
         session.emit("cd".encodeToByteArray())
@@ -60,7 +61,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // "П" (U+041F) in UTF-8 = 0xD0 0x9F, split across two chunks.
         session.emit(byteArrayOf(0xD0.toByte()))
@@ -93,7 +94,7 @@ class TerminalScreenStateTest {
             override suspend fun resize(size: PtySize) = Unit
             override suspend fun close() = Unit
         }
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         applied = { state.outputVersion }
         testScheduler.advanceUntilIdle()
 
@@ -114,7 +115,7 @@ class TerminalScreenStateTest {
         val total = FEED_BACKLOG_CHUNKS * 4
         val gate = CompletableDeferred<Unit>()
         val session = FloodingTerminalSession(total, resizeGate = gate)
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // Park the owner inside the first resize's PTY call; the collector then floods the queue
         // to the permit cap and suspends on acquire. Only now is the pipeline genuinely saturated.
@@ -137,7 +138,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val gate = CompletableDeferred<Unit>()
         val session = FloodingTerminalSession(chunks = FEED_BACKLOG_CHUNKS * 4, resizeGate = gate)
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // Same parked-owner construction as above: the collector is provably suspended on acquire
         // with a full backlog (emitted == cap) when the scope dies - tab closed mid-`cat`.
@@ -154,12 +155,110 @@ class TerminalScreenStateTest {
         assertEquals(0L, state.outputVersion)
     }
 
+    // --- Publish rate cap ---
+
+    @Test
+    fun `sustained output coalesces publishes to the frame window`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val total = 100
+        val session = FloodingTerminalSession(chunks = total, interChunkDelayMs = 1)
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+        testScheduler.advanceUntilIdle()
+
+        // Everything parsed, but published at the frame cadence, not once per chunk. Virtual time
+        // makes the count deterministic: ~total/window periodic publishes plus the leading edge
+        // and the close-fallback tail. The +3 margin stays below a half-effective cap (~2x rate),
+        // so that regression fails this bound too.
+        assertEquals(total.toLong(), state.outputVersion)
+        val expectedAtMost = total / PUBLISH_MIN_INTERVAL_MS.toInt() + 3
+        assertTrue(
+            state.snapshotVersion <= expectedAtMost,
+            "expected ~1 publish per ${PUBLISH_MIN_INTERVAL_MS}ms window, got ${state.snapshotVersion} for $total chunks",
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun `a single chunk after idle publishes immediately`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+
+        session.emit("x".encodeToByteArray())
+
+        // Leading edge: interactive echo is not deferred into a window.
+        assertEquals(1, state.snapshotVersion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `the tail of a burst is published when the stream ends mid-window`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FloodingTerminalSession(chunks = 5, interChunkDelayMs = 1)
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+        testScheduler.advanceUntilIdle()
+
+        // Chunk 1 publishes on the leading edge; 2-5 land inside the window; the flow completes,
+        // so the close-fallback (not onTimeout) lands the tail. The live-pause case is next test.
+        assertEquals(5L, state.outputVersion)
+        assertEquals(2, state.snapshotVersion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a pause mid-window publishes the tail while the session stays open`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+
+        session.emit("a".encodeToByteArray())
+        testScheduler.runCurrent()
+        assertEquals(1, state.snapshotVersion) // leading edge
+
+        session.emit("b".encodeToByteArray())
+        testScheduler.runCurrent()
+        // Applied but deferred: still inside the window, stream paused, channel NOT closed.
+        assertEquals(2L, state.outputVersion)
+        assertEquals(1, state.snapshotVersion)
+
+        // The onTimeout edge is the only thing that can land this tail - the session is live.
+        testScheduler.advanceTimeBy(PUBLISH_MIN_INTERVAL_MS)
+        testScheduler.runCurrent()
+        assertEquals(2, state.snapshotVersion)
+
+        // The pipeline is still alive after the trailing publish: more output keeps flowing.
+        testScheduler.advanceTimeBy(PUBLISH_MIN_INTERVAL_MS)
+        session.emit("c".encodeToByteArray())
+        testScheduler.runCurrent()
+        assertEquals(3L, state.outputVersion)
+        assertEquals(3, state.snapshotVersion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a parser fault still lands the applied-but-unpublished tail`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FloodingTerminalSession(chunks = 5, interChunkDelayMs = 1)
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+        var applies = 0
+        // Chunk 1 publishes (leading edge); chunk 2 is applied and deferred into the window;
+        // chunk 3 faults. The screen must still show chunk 2 - the coalescing window must not
+        // widen what a fault erases.
+        state.applyInterceptor = { if (++applies == 3) error("injected parser fault") }
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(2L, state.outputVersion)
+        assertEquals(2, state.snapshotVersion)
+        assertTrue(session.closed)
+        scope.cancel()
+    }
+
     @Test
     fun `parser fault closes the session and unwedges the collector`() = runTest {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val total = FEED_BACKLOG_CHUNKS * 2
         val session = FloodingTerminalSession(total)
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         var applies = 0
         // The faulting command's own permit is intentionally lost (the throw precedes the Feed
         // branch's try/finally) - inert, the whole semaphore dies with the session right after.
@@ -179,7 +278,7 @@ class TerminalScreenStateTest {
     fun `emulator resize fault propagates to the recovery handler`() = runTest {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val session = FloodingTerminalSession(chunks = 4)
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.emulatorResizeInterceptor = { error("injected emulator resize fault") }
 
         state.resize(PtySize(cols = 90, rows = 30))
@@ -198,7 +297,7 @@ class TerminalScreenStateTest {
     @Test
     fun `typed input is mirrored to the other panes`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
         val mirrored = mutableListOf<Pair<String, MirroredInput>>()
         state.inputMirror = { text, kind -> mirrored += text to kind }
 
@@ -213,7 +312,7 @@ class TerminalScreenStateTest {
     fun `mirrored input does not mirror again`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val mirrored = mutableListOf<String>()
         state.inputMirror = { text, _ -> mirrored += text }
 
@@ -235,7 +334,7 @@ class TerminalScreenStateTest {
     @Test
     fun `a snippet's line is tracked before the next input is classified`() = runTest {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInput("rm -rf ") // a snippet leaves a half-written command on the line
@@ -248,7 +347,7 @@ class TerminalScreenStateTest {
     @Test
     fun `a command held by the production guard is mirrored only once confirmed`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         val mirrored = mutableListOf<String>()
         state.inputMirror = { text, _ -> mirrored += text }
@@ -266,7 +365,7 @@ class TerminalScreenStateTest {
     @Test
     fun `a dismissed command is never mirrored`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         val mirrored = mutableListOf<String>()
         state.inputMirror = { text, _ -> mirrored += text }
@@ -283,9 +382,9 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val originSession = FakeTerminalSession().apply { echoOff = true }
         val atPromptSession = FakeTerminalSession().apply { echoOff = true }
-        val origin = TerminalScreenState(originSession, scope)
-        val atPrompt = TerminalScreenState(atPromptSession, scope)
-        val atShell = TerminalScreenState(FakeTerminalSession(), scope)
+        val origin = TerminalScreenState(originSession, scope, nowMillis = eagerPublishClock())
+        val atPrompt = TerminalScreenState(atPromptSession, scope, nowMillis = eagerPublishClock())
+        val atShell = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
 
         // Origin is at a password prompt: only the pane that is at one as well may take the secret.
         // The one sitting at an ordinary shell would echo it, store it in history and then run it.
@@ -301,7 +400,7 @@ class TerminalScreenStateTest {
     fun `an MFA prompt reads as a secret, ordinary output does not`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // SSH never reports echo suppression (only telnet does), so the prompt line is all there is
         // to go by. Under synchronized input a miss no longer costs one host's history: the secret
@@ -319,7 +418,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.send("ls -la\n")
 
@@ -330,7 +429,7 @@ class TerminalScreenStateTest {
     @Test
     fun `typed input and paste bump inputVersion but programmatic sends do not`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
 
         val v0 = state.inputVersion
         state.send("ls\n")
@@ -352,7 +451,7 @@ class TerminalScreenStateTest {
         // by being fed through it character by character as typed input is.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         val v0 = state.inputVersion
         state.sendUserInput("uptime\r")
@@ -449,7 +548,7 @@ class TerminalScreenStateTest {
     fun `lastOutput reads the last command block from the live screen`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit(
             ("Last login: Fri Jul 24 11:51:03 2026 from 178.205.96.77\r\n" +
@@ -471,6 +570,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("git push origin main"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("git pu")
@@ -492,6 +592,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("git push origin main"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
 
@@ -518,6 +619,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("git push origin main", "git push origin main --force-with-lease"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("git pu")
@@ -543,6 +645,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("git push origin main"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
 
@@ -563,6 +666,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("lsof -i", "ll -h"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("ll")
@@ -582,7 +686,7 @@ class TerminalScreenStateTest {
         // Ctrl-O runs the current line just like Enter does; the mobile keybar reaches it as ctrl + "/".
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         state.typeInput("rm -rf /srv")
 
@@ -606,7 +710,7 @@ class TerminalScreenStateTest {
     fun `a joined guess is classified but the dialog draws the line itself`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# rm -rf /srv/prod-db".encodeToByteArray())
 
@@ -630,7 +734,7 @@ class TerminalScreenStateTest {
     fun `a block that finishes a completed line is classified as the joined command`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = false)
         session.emit("root@prod:~# sudo r".encodeToByteArray())
 
@@ -651,7 +755,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         "systemctl restart ngi".forEach { state.typeInput(it.toString()) }
         state.typeInput("\t")
@@ -672,7 +776,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         "echo hello".forEach { state.typeInput(it.toString()) }
         state.typeInput("\t")
@@ -693,7 +797,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         "rm -rf /srv/bac".forEach { state.typeInput(it.toString()) }
         state.typeInput("\t")
@@ -713,7 +817,7 @@ class TerminalScreenStateTest {
     fun `a line typed onto after a completion is still classified`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /var/log/nginx/arch".forEach { state.typeInput(it.toString()) }
@@ -734,7 +838,7 @@ class TerminalScreenStateTest {
     fun `a line the quote cannot claim is drawn beside it`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /srv/back".forEach { state.typeInput(it.toString()) }
@@ -756,7 +860,7 @@ class TerminalScreenStateTest {
     fun `a line that diverged from the shell's is classified but not drawn as it`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# rm -rf /srv/backups-2019/x".encodeToByteArray())
 
@@ -780,7 +884,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         "rm -rf /srv/ba".forEach { state.typeInput(it.toString()) }
         state.typeInput("\t")
@@ -800,7 +904,7 @@ class TerminalScreenStateTest {
     fun `a reason with nothing drawable behind it quotes nothing`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /var/log/nginx/arch".forEach { state.typeInput(it.toString()) }
@@ -826,7 +930,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("\u001b[?1049h".encodeToByteArray())
 
@@ -848,7 +952,7 @@ class TerminalScreenStateTest {
     fun `a line whose cursor moved is not quoted as an append`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# sudo rm -rf /srv; deploy".encodeToByteArray())
 
@@ -872,7 +976,7 @@ class TerminalScreenStateTest {
     fun `dismissing a question does not disarm the line it was about`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /srv/data".forEach { state.typeInput(it.toString()) }
@@ -897,7 +1001,7 @@ class TerminalScreenStateTest {
     fun `a secret sent by a snippet takes the ghost with the line`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope, initialHistory = listOf("git push origin main"))
+        val state = TerminalScreenState(session, scope, initialHistory = listOf("git push origin main"), nowMillis = eagerPublishClock())
         session.emit("$ ".encodeToByteArray())
         state.typeInput("git pu")
         session.emit("git pu".encodeToByteArray())
@@ -919,7 +1023,7 @@ class TerminalScreenStateTest {
     fun `a wrapped line completed by the shell is still held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /srv/bac".forEach { state.typeInput(it.toString()) }
@@ -945,7 +1049,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
         state.resize(PtySize(cols = 20, rows = 6))
 
         "systemctl restart ngi".forEach { state.typeInput(it.toString()) }
@@ -967,7 +1071,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         "systemctl restart ngi".forEach { state.typeInput(it.toString()) }
         state.typeInput("\t")
@@ -993,7 +1097,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession().apply { echoOff = true }
         var saved: List<String>? = null
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { saved = it }, nowMillis = eagerPublishClock())
 
         state.sendUserInput("hunter2")
         session.echoOff = false // the prompt is answered; the shell echoes again
@@ -1011,7 +1115,7 @@ class TerminalScreenStateTest {
     fun `a ready-made command is not guessed against the alternate screen`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("\u001b[?1049h".encodeToByteArray()) // alt-screen
         session.emit("rm -rf /srv/data".encodeToByteArray()) // a line of the file being edited
@@ -1030,7 +1134,7 @@ class TerminalScreenStateTest {
     fun `a keybar Ctrl-O leaves the line unknown rather than guessed`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "uptime".forEach { state.typeInput(it.toString()) }
@@ -1053,7 +1157,7 @@ class TerminalScreenStateTest {
     fun `a line completed by the shell is not quoted as what was typed`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /sr".forEach { state.typeInput(it.toString()) }
@@ -1075,6 +1179,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("less /var/log/syslog", "ll -h"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("ll")
@@ -1097,6 +1202,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("systemctl restart nginx"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
 
@@ -1115,7 +1221,7 @@ class TerminalScreenStateTest {
         // "docker logs " — the key does something other than what the user is looking at.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         session.emit("$ ".encodeToByteArray())
         state.typeInput("docker")
         session.emit("docker".encodeToByteArray())
@@ -1139,6 +1245,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("backupdb", "backupfiles", "backends"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("back")
@@ -1163,6 +1270,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("echo 😀 done"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("echo 😀")
@@ -1181,6 +1289,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("git push origin main"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("git pu")
@@ -1204,6 +1313,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("uptime --pretty"),
+            nowMillis = eagerPublishClock(),
         )
         state.resize(PtySize(cols = 6, rows = 4))
         state.typeInput("uptime -")
@@ -1222,6 +1332,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("vimdiff a b"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("vim")
@@ -1242,6 +1353,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             FakeTerminalSession(), scope,
             onHistoryChanged = { snapshots += it },
+            nowMillis = eagerPublishClock(),
         )
         state.typeInput("uptime\n")
         assertEquals(listOf("uptime"), snapshots.last())
@@ -1255,6 +1367,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             session, scope,
             initialHistory = listOf("backupdb", "backupfiles"),
+            nowMillis = eagerPublishClock(),
         )
         session.emit("$ ".encodeToByteArray())
         state.typeInput("back")
@@ -1272,6 +1385,7 @@ class TerminalScreenStateTest {
         val state = TerminalScreenState(
             FakeTerminalSession(), scope,
             initialHistory = listOf("docker ps", "git status"),
+            nowMillis = eagerPublishClock(),
         )
         state.reverseSearch.open()
         state.reverseSearch.append("git")
@@ -1289,6 +1403,7 @@ class TerminalScreenStateTest {
             FakeTerminalSession(), scope,
             initialHistory = listOf("gti status", "git status"),
             onHistoryChanged = { snapshots += it },
+            nowMillis = eagerPublishClock(),
         )
         state.reverseSearch.open()
         state.reverseSearch.append("gti") // pick the typo entry
@@ -1305,7 +1420,7 @@ class TerminalScreenStateTest {
     fun `search finds matches in the buffer and selects one`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("alpha\r\nbeta\r\nalpha again\r\n".encodeToByteArray())
         state.search.open()
@@ -1322,7 +1437,7 @@ class TerminalScreenStateTest {
         // oldest one at the top of the scrollback.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\nfiller\r\nhit\r\nfiller\r\nhit\r\n".encodeToByteArray())
         state.search.open(anchorRow = 2) // viewport bottom sits on the second "hit"
@@ -1337,7 +1452,7 @@ class TerminalScreenStateTest {
     fun `next and previous cycle through matches`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\nhit\r\nhit\r\n".encodeToByteArray())
         state.search.open(anchorRow = 0)
@@ -1359,7 +1474,7 @@ class TerminalScreenStateTest {
     fun `case sensitivity and regex toggles re-run the search`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("Error 404\r\nerror 500\r\n".encodeToByteArray())
         state.search.open()
@@ -1381,7 +1496,7 @@ class TerminalScreenStateTest {
     fun `an invalid regex is reported without matches`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("anything\r\n".encodeToByteArray())
         state.search.open()
@@ -1466,7 +1581,9 @@ class TerminalScreenStateTest {
         // worth running even mid-stream.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope, nowMillis = { 0L }) // clock frozen: always throttled
+        // Eager clock: publishes are immediate (one window per read), while the total advance over
+        // this test stays below SEARCH_REFRESH_INTERVAL_MS - the search pass remains throttled.
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit one\r\n".encodeToByteArray())
         state.search.open()
@@ -1488,7 +1605,7 @@ class TerminalScreenStateTest {
         // node — a visible panel that no longer reacts to anything.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope, initialHistory = listOf("uptime"))
+        val state = TerminalScreenState(session, scope, initialHistory = listOf("uptime"), nowMillis = eagerPublishClock())
 
         session.emit("hit\r\n".encodeToByteArray())
         state.reverseSearch.open()
@@ -1505,7 +1622,7 @@ class TerminalScreenStateTest {
         // A stray paste (a whole log line, a file) is not a search term; an unbounded pattern also
         // hands the regex compiler unbounded work.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val state = TerminalScreenState(FakeTerminalSession(), scope)
+        val state = TerminalScreenState(FakeTerminalSession(), scope, nowMillis = eagerPublishClock())
 
         state.search.open()
         state.search.updateQuery("x".repeat(MAX_SEARCH_QUERY_LENGTH + 500))
@@ -1520,7 +1637,7 @@ class TerminalScreenStateTest {
         // an incremental search re-selects around that, not around the live cursor.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\nfiller\r\nhit\r\nfiller\r\nhit\r\n".encodeToByteArray())
         state.search.setAnchorRow(2) // user scrolled up: second "hit" is the last visible row
@@ -1535,7 +1652,7 @@ class TerminalScreenStateTest {
     fun `closing search drops the query and matches`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\n".encodeToByteArray())
         state.search.open()
@@ -1553,7 +1670,7 @@ class TerminalScreenStateTest {
         // The buffer is walked on every published snapshot, so a closed panel must cost nothing.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.search.open()
         state.search.updateQuery("hit")
@@ -1570,7 +1687,7 @@ class TerminalScreenStateTest {
         // buffer as it is now.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\n".encodeToByteArray())
         state.search.open()
@@ -1587,7 +1704,7 @@ class TerminalScreenStateTest {
     fun `a committed command joins the vocabulary and the executed set`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         assertFalse(state.vocabulary.isCommand("pveversion"), "unknown before it is ever run")
         state.typeInput("pveversion -v")
@@ -1602,7 +1719,7 @@ class TerminalScreenStateTest {
     fun `input typed at a password prompt never reaches the executed set`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.echoOff = true
         state.typeInput("hunter2")
@@ -1616,7 +1733,7 @@ class TerminalScreenStateTest {
     fun `the executed set stays bounded over a long session`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         repeat(MAX_EXECUTED_COMMANDS + 50) { i ->
             state.typeInput("cmd$i")
@@ -1640,7 +1757,7 @@ class TerminalScreenStateTest {
     fun `a chunk arriving during construction does not break initialization`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = EagerOutputSession("hello\r\n".encodeToByteArray())
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         assertTrue(state.screen.isNotEmpty(), "the eager chunk was applied")
         assertFalse(state.hasSuggestion)
@@ -1651,7 +1768,7 @@ class TerminalScreenStateTest {
     fun `an empty query clears matches without erroring`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hit\r\n".encodeToByteArray())
         state.search.open()
@@ -1668,7 +1785,7 @@ class TerminalScreenStateTest {
     fun `next and previous are no-ops without matches`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.search.open()
         state.search.updateQuery("nothing here")
@@ -1685,7 +1802,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.resize(PtySize(cols = 100, rows = 30))
 
@@ -1698,7 +1815,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // Narrow 5x3 grid: autowrap breaks the line at width 5.
         state.resize(PtySize(cols = 5, rows = 3))
@@ -1714,7 +1831,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // Default 80x24 before the first layout, then the emulator's live size.
         assertEquals(80, state.cols)
@@ -1730,7 +1847,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.resize(PtySize(cols = 90, rows = 25))
         state.resize(PtySize(cols = 90, rows = 25)) // same size — dedup, don't nudge the PTY
@@ -1744,7 +1861,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         assertEquals(TerminalState.Open, state.state.value)
         scope.cancel()
@@ -1755,7 +1872,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         assertEquals(false, state.applicationCursorKeys)
@@ -1771,7 +1888,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         // Defaults: cursor visible, block, blinking.
@@ -1793,7 +1910,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.beginSelection(TerminalPos(0, 0))
@@ -1808,7 +1925,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello".encodeToByteArray())
         state.beginSelection(TerminalPos(0, 0))
@@ -1825,7 +1942,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.selectWordAt(TerminalPos(0, 8)) // tap lands on "world"
@@ -1839,7 +1956,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.selectWordAt(TerminalPos(0, 0)) // tap lands on "h"
@@ -1853,7 +1970,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.beginSelection(TerminalPos(0, 0))
@@ -1869,7 +1986,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.beginSelection(TerminalPos(0, 0))
@@ -1885,7 +2002,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello".encodeToByteArray())
         state.moveSelectionStart(TerminalPos(0, 1))
@@ -1900,7 +2017,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         assertEquals(MouseTracking.Off, state.mouseTracking)
@@ -1916,7 +2033,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         assertEquals(MouseTracking.Off, state.mouseTracking)
@@ -1932,7 +2049,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         session.emit("$esc[?1000h$esc[?1006h".encodeToByteArray()) // Normal + SGR
@@ -1948,7 +2065,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello world".encodeToByteArray())
         state.selectWordAt(TerminalPos(0, 8)) // "world"
@@ -1964,7 +2081,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello".encodeToByteArray())
         val captured = state.capturePrimarySelection()
@@ -1979,7 +2096,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         assertEquals(false, state.mousePixels)
@@ -1993,7 +2110,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         session.emit("$esc[?1002h$esc[?1016h".encodeToByteArray()) // ButtonEvent + SGR-Pixels
@@ -2012,7 +2129,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         val handled = state.reportMouse(MouseButton.Left, MouseEventType.Press, TerminalPos(0, 0))
 
@@ -2026,7 +2143,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         session.emit("$esc[?2004h".encodeToByteArray()) // bracketed paste on
@@ -2041,7 +2158,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.paste("hi")
 
@@ -2054,7 +2171,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // A recoverable PTY resize failure: the handler must not die — feed still works after it.
         session.resizeError = { IllegalStateException("pty broke") }
@@ -2071,7 +2188,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // The PTY resize fails once (transient hiccup on a live connection)…
         session.resizeError = { IllegalStateException("pty broke") }
@@ -2091,7 +2208,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         // CancellationException must not be swallowed as a "recoverable failure": it must tear
         // down the handler coroutine (structured concurrency), or feed would keep working after cancellation.
@@ -2108,7 +2225,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         repeat(50) { state.send(it.toString()) }
 
@@ -2122,7 +2239,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         val before = state.snapshotVersion
         session.emit("a".encodeToByteArray())
@@ -2136,7 +2253,7 @@ class TerminalScreenStateTest {
     fun `osc 52 clipboard write is dropped when the gate is off by default`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         val copies = mutableListOf<String>()
@@ -2152,7 +2269,7 @@ class TerminalScreenStateTest {
     fun `osc 52 clipboard write reaches the UI once the gate is enabled`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope, clipboardWriteEnabled = true)
+        val state = TerminalScreenState(session, scope, clipboardWriteEnabled = true, nowMillis = eagerPublishClock())
         val esc = 27.toChar().toString()
 
         val copies = mutableListOf<String>()
@@ -2168,7 +2285,7 @@ class TerminalScreenStateTest {
     fun `applyClipboardWriteEnabled toggles the gate on an open session`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope) // starts off
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock()) // starts off
         val esc = 27.toChar().toString()
 
         val copies = mutableListOf<String>()
@@ -2190,7 +2307,7 @@ class TerminalScreenStateTest {
     fun `risky command is held before it reaches the pty on a production session`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /var/lib".forEach { state.typeInput(it.toString()) }
@@ -2213,7 +2330,7 @@ class TerminalScreenStateTest {
     fun `the quote for a typed block continues the line already on screen`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf /sr".forEach { state.typeInput(it.toString()) }
@@ -2231,7 +2348,7 @@ class TerminalScreenStateTest {
     fun `the quote for a pasted block carries the lines under the risky one`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.paste("rm -rf /srv\nchown -R nobody /srv/www\n")
@@ -2249,7 +2366,7 @@ class TerminalScreenStateTest {
     fun `a command finishing a half-typed line is held and quoted whole`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "rm -rf ".forEach { state.typeInput(it.toString()) }
@@ -2267,7 +2384,7 @@ class TerminalScreenStateTest {
     fun `a paste finishing a half-typed line is quoted with it`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "echo ".forEach { state.typeInput(it.toString()) }
@@ -2286,7 +2403,7 @@ class TerminalScreenStateTest {
     fun `a line edited by a control the client cannot follow is not quoted from`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# rm -rf /srv/data".encodeToByteArray())
 
@@ -2310,7 +2427,7 @@ class TerminalScreenStateTest {
     fun `a command joined onto a word is still classified on its own`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "git".forEach { state.typeInput(it.toString()) }
@@ -2329,7 +2446,7 @@ class TerminalScreenStateTest {
     fun `a line left behind by a command that already ran is not joined onto the next`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "sudo ".forEach { state.typeInput(it.toString()) }
@@ -2351,7 +2468,7 @@ class TerminalScreenStateTest {
     fun `the line is tracked again after a command that ran elsewhere`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("docker ps\r") // harmless: not held, but it moved the line
@@ -2371,7 +2488,7 @@ class TerminalScreenStateTest {
     fun `a block pasted onto a line the client lost track of is still quoted whole`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         "foo bar".forEach { state.typeInput(it.toString()) }
@@ -2391,7 +2508,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         state.sendUserInputGuarded("docker ps\r")
         session.emit("uptime".encodeToByteArray()) // echo, so the engine records what was typed
@@ -2412,7 +2529,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         state.sendUserInputGuarded("uptime") // Edit: the command lands on the line, nothing runs
         session.emit("uptime".encodeToByteArray())
@@ -2432,7 +2549,7 @@ class TerminalScreenStateTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
         val history = mutableListOf<List<String>>()
-        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it })
+        val state = TerminalScreenState(session, scope, onHistoryChanged = { history += it }, nowMillis = eagerPublishClock())
 
         state.sendUserInput("\u001b[A") // arrow up from the key panel: the shell recalled a command
         "uptime".forEach { state.typeInput(it.toString()) }
@@ -2457,7 +2574,7 @@ class TerminalScreenStateTest {
     fun `a ready-made command is classified against the line on screen`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# rm -rf /srv/data".encodeToByteArray())
 
@@ -2477,7 +2594,7 @@ class TerminalScreenStateTest {
     fun `a paste is classified against the line on screen`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         session.emit("root@prod:~# rm -rf /srv/data".encodeToByteArray())
 
@@ -2498,7 +2615,7 @@ class TerminalScreenStateTest {
     fun `a long block finishing a half-typed line is still held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // With a prompt on screen, as any live session has: the screen's candidates and the join are
@@ -2516,7 +2633,7 @@ class TerminalScreenStateTest {
     fun `confirming the held command sends it once`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
@@ -2532,7 +2649,7 @@ class TerminalScreenStateTest {
     fun `dismissing the held command sends nothing`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("shutdown now\r")
@@ -2547,7 +2664,7 @@ class TerminalScreenStateTest {
     fun `harmless commands and non-production sessions are not held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
         state.typeInput("ls -la\r")
@@ -2564,7 +2681,7 @@ class TerminalScreenStateTest {
     fun `a command recalled from history is caught off the screen line`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Nothing was typed locally (arrow-up recall) — the command exists only on the screen.
@@ -2579,7 +2696,7 @@ class TerminalScreenStateTest {
     fun `a multi-line input block is judged by every line, not just the first`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // The soft keyboard delivers a whole IME delta in one call — a clipboard insert can carry
@@ -2595,7 +2712,7 @@ class TerminalScreenStateTest {
     fun `a command pasted without a newline is still caught on Enter`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Paste, then Enter before the host echoed anything back: the screen line is still empty,
@@ -2611,7 +2728,7 @@ class TerminalScreenStateTest {
     fun `a ready-made command is dropped while another one is pending`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("rm -rf /var/lib\n")
@@ -2627,7 +2744,7 @@ class TerminalScreenStateTest {
     fun `a snippet command is held and then sent without touching autocomplete`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("systemctl stop nginx\n")
@@ -2643,7 +2760,7 @@ class TerminalScreenStateTest {
     fun `a harmless snippet command goes straight through`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("uptime\n")
@@ -2657,7 +2774,7 @@ class TerminalScreenStateTest {
     fun `a second risky command while one is pending does not replace it`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
@@ -2677,7 +2794,7 @@ class TerminalScreenStateTest {
     fun `a pasted command that would run is held too`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Paste carrying a newline runs on arrival — the classic "copied it off a wiki page" case.
@@ -2694,7 +2811,7 @@ class TerminalScreenStateTest {
     fun `a paste with no newline runs nothing and is not held`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Lands on the shell line for the user to read and edit; Enter is still guarded separately.
@@ -2709,7 +2826,7 @@ class TerminalScreenStateTest {
     fun `a password is never held or shown by the guard`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // At a password prompt the typed text is a secret, not a command: it must not be parked in
@@ -2726,7 +2843,7 @@ class TerminalScreenStateTest {
     fun `a password is still recognised once the session has scrollback`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // A real session is never on its first screenful: output scrolls history in long before any
@@ -2745,7 +2862,7 @@ class TerminalScreenStateTest {
     fun `a risky command recalled with arrow-up is still guarded after scrollback builds up`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Arrow-up recall: nothing is typed, the command is only on the screen line. The guard reads
@@ -2762,7 +2879,7 @@ class TerminalScreenStateTest {
     fun `full-screen apps are not guarded`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // vim/htop: there is no shell line to classify, and Enter there is not "run a command".
@@ -2780,7 +2897,7 @@ class TerminalScreenStateTest {
     fun `a paste is dropped while a confirmation is open`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
@@ -2799,7 +2916,7 @@ class TerminalScreenStateTest {
     fun `a harmless paste is dropped while a confirmation is open too`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
@@ -2816,7 +2933,7 @@ class TerminalScreenStateTest {
     fun `a pasted password is never held or shown by the guard`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         // Same rule as typing one: a password manager pastes the secret with a trailing newline, and
@@ -2833,7 +2950,7 @@ class TerminalScreenStateTest {
     fun `a harmless typed command is not sent while a confirmation is open`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.typeInput("rm -rf /var/lib\r")
@@ -2850,7 +2967,7 @@ class TerminalScreenStateTest {
     fun `a harmless ready-made command is dropped while a confirmation is open`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.guardPolicy = ProductionGuardPolicy(production = true, confirmWarnings = true)
 
         state.sendUserInputGuarded("rm -rf /var/lib\n")
@@ -2867,7 +2984,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         session.emit("hello".encodeToByteArray())
         state.beginSelection(TerminalPos(0, 2))
@@ -2882,7 +2999,7 @@ class TerminalScreenStateTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         state.resize(PtySize(cols = 4, rows = 4))
 
         // 中 does not fit in the last column: row 0 is marked wrapped and its column 3 stays blank.
@@ -2916,7 +3033,7 @@ class TerminalScreenStateTest {
     fun `a step report is taken once, by the step it belongs to`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar()
         val bel = 7.toChar()
         fun step(token: String, output: String, exitCode: Int) =
@@ -2945,7 +3062,7 @@ class TerminalScreenStateTest {
         // must not be able to park a copy of the screen in a field nothing ever clears.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar()
         val bel = 7.toChar()
 
@@ -2960,7 +3077,7 @@ class TerminalScreenStateTest {
     fun `ending the step drops the report the run never collected`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val esc = 27.toChar()
         val bel = 7.toChar()
         state.expectStepMark("sk_run_0")
@@ -2976,7 +3093,7 @@ class TerminalScreenStateTest {
     fun `output version moves on every batch from the host`() = runTest {
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val session = FakeTerminalSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
 
         val start = state.outputVersion
         session.emit("a".encodeToByteArray())
@@ -3003,6 +3120,7 @@ class TerminalScreenStateTest {
 private class FloodingTerminalSession(
     private val chunks: Int,
     private val resizeGate: CompletableDeferred<Unit>? = null,
+    private val interChunkDelayMs: Long = 0,
 ) : TerminalSession {
     private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
     override val state: StateFlow<TerminalState> = _state
@@ -3013,6 +3131,7 @@ private class FloodingTerminalSession(
 
     override val output: Flow<ByteArray> = flow {
         repeat(chunks) {
+            if (interChunkDelayMs > 0) delay(interChunkDelayMs)
             emit(byteArrayOf('x'.code.toByte()))
             emitted++
         }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -6,8 +6,6 @@ import app.skerry.shared.terminal.CursorShape
 import app.skerry.shared.terminal.MouseButton
 import app.skerry.shared.terminal.MouseEventType
 import app.skerry.shared.terminal.MouseTracking
-import app.skerry.shared.terminal.TermCell
-import app.skerry.shared.terminal.TermSnapshotRow
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.wrapsToNextRow
 import app.skerry.shared.terminal.TerminalSearchError
@@ -68,6 +66,26 @@ class TerminalScreenStateTest {
         session.emit(byteArrayOf(0x9F.toByte()))
 
         assertEquals("П", state.output)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a cursor-only publish keeps the screen instance and its content version`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val session = FakeTerminalSession()
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+
+        session.emit("hello".encodeToByteArray())
+        val before = state.screen
+        val version = state.screenContentVersion
+
+        session.emit("${27.toChar()}[H".encodeToByteArray())
+        assertTrue(before === state.screen)
+        assertEquals(version, state.screenContentVersion)
+
+        session.emit("x".encodeToByteArray())
+        assertFalse(before === state.screen)
+        assertTrue(state.screenContentVersion > version)
         scope.cancel()
     }
 
@@ -3072,19 +3090,10 @@ class TerminalScreenStateTest {
         scope.cancel()
     }
 
-    @Test
-    fun `a snapshot differing only in the soft-wrap flag is not treated as unchanged`() {
-        // Compose skips a state write when the new value is equivalent to the old one, and list
-        // equality only sees cells. A row can lose its wrap (EL over an already-blank tail) without a
-        // single cell changing — publishing that as "no change" would leave link joining on stale flags.
-        val cells = listOf(TermCell('a'), TermCell('b'))
-        val wrapped = listOf<List<TermCell>>(TermSnapshotRow(cells, wrapped = true))
-        val plain = listOf<List<TermCell>>(TermSnapshotRow(cells, wrapped = false))
-
-        assertTrue(sameScreen(wrapped, listOf(TermSnapshotRow(cells, wrapped = true))))
-        assertFalse(sameScreen(wrapped, plain))
-        assertFalse(sameScreen(plain, listOf<List<TermCell>>(listOf(TermCell('a')))))
-    }
+    // The wrap-flag invariant (`ESC[K` dropping a wrap must republish even when no cell changes)
+    // moved to the source with the identity policy: the behavioral case lives above
+    // (`clearing a soft wrap republishes...`) and the emulator's own identity test
+    // (`clearing a soft wrap replaces the snapshot...`) pins the version bump.
 
     // --- Runbook step marks ---
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -17,6 +17,7 @@ import app.skerry.shared.terminal.TerminalStepMark
 import app.skerry.shared.terminal.STEP_MARK_OSC
 import app.skerry.ui.session.paneSyncTargets
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -66,6 +67,129 @@ class TerminalScreenStateTest {
         session.emit(byteArrayOf(0x9F.toByte()))
 
         assertEquals("П", state.output)
+        scope.cancel()
+    }
+
+    // --- PTY backpressure ---
+
+    @Test
+    fun `pty backlog is bounded - the producer suspends until the emulator catches up`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val total = FEED_BACKLOG_CHUNKS * 4
+        var emitted = 0
+        var maxInFlight = 0
+        // Rebound after construction: the flow body runs at collection time, when `state` exists.
+        var applied: () -> Long = { 0L }
+        val session = object : TerminalSession {
+            override val state: StateFlow<TerminalState> = MutableStateFlow(TerminalState.Open)
+            override val output: Flow<ByteArray> = flow {
+                repeat(total) {
+                    emit(byteArrayOf('x'.code.toByte()))
+                    emitted++
+                    maxInFlight = maxOf(maxInFlight, emitted - applied().toInt())
+                }
+            }
+            override suspend fun send(data: ByteArray) = Unit
+            override suspend fun resize(size: PtySize) = Unit
+            override suspend fun close() = Unit
+        }
+        val state = TerminalScreenState(session, scope)
+        applied = { state.outputVersion }
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(total, emitted)
+        // The drain is asserted on what the emulator parsed, not on the producer's own counter:
+        // a Feed dropped after its permit was taken would leave emitted == total regardless.
+        assertEquals(total.toLong(), state.outputVersion)
+        assertTrue(
+            maxInFlight <= FEED_BACKLOG_CHUNKS + 1,
+            "unapplied backlog reached $maxInFlight chunks; cap is $FEED_BACKLOG_CHUNKS",
+        )
+        scope.cancel()
+    }
+
+    @Test
+    fun `control command lands behind a saturated feed backlog`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val total = FEED_BACKLOG_CHUNKS * 4
+        val gate = CompletableDeferred<Unit>()
+        val session = FloodingTerminalSession(total, resizeGate = gate)
+        val state = TerminalScreenState(session, scope)
+
+        // Park the owner inside the first resize's PTY call; the collector then floods the queue
+        // to the permit cap and suspends on acquire. Only now is the pipeline genuinely saturated.
+        state.resize(PtySize(cols = 90, rows = 30))
+        testScheduler.runCurrent()
+        assertEquals(FEED_BACKLOG_CHUNKS, session.emitted)
+
+        // Queued behind a full backlog of unparsed Feeds: must still be applied, exactly once.
+        state.resize(PtySize(cols = 100, rows = 40))
+        gate.complete(Unit)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(listOf(90 to 30, 100 to 40), session.resizes.map { it.cols to it.rows })
+        assertEquals(total.toLong(), state.outputVersion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `cancellation with a saturated backlog does not hang teardown`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val gate = CompletableDeferred<Unit>()
+        val session = FloodingTerminalSession(chunks = FEED_BACKLOG_CHUNKS * 4, resizeGate = gate)
+        val state = TerminalScreenState(session, scope)
+
+        // Same parked-owner construction as above: the collector is provably suspended on acquire
+        // with a full backlog (emitted == cap) when the scope dies - tab closed mid-`cat`.
+        state.resize(PtySize(cols = 90, rows = 30))
+        testScheduler.runCurrent()
+        assertEquals(FEED_BACKLOG_CHUNKS, session.emitted)
+
+        scope.cancel()
+        testScheduler.advanceUntilIdle()
+
+        // Terminates (a wedged collector would hang runTest) and the producer never ran past the
+        // cap: cancellation reached the acquire suspension point, not just the flow machinery.
+        assertEquals(FEED_BACKLOG_CHUNKS, session.emitted)
+        assertEquals(0L, state.outputVersion)
+    }
+
+    @Test
+    fun `parser fault closes the session and unwedges the collector`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val total = FEED_BACKLOG_CHUNKS * 2
+        val session = FloodingTerminalSession(total)
+        val state = TerminalScreenState(session, scope)
+        var applies = 0
+        // The faulting command's own permit is intentionally lost (the throw precedes the Feed
+        // branch's try/finally) - inert, the whole semaphore dies with the session right after.
+        state.applyInterceptor = { if (++applies == 3) error("injected parser fault") }
+        testScheduler.advanceUntilIdle()
+
+        // The owner died on the third command: two chunks parsed, the session was closed (the
+        // auto-reconnect trigger), and the collector exited via the closed queue instead of
+        // wedging on acquire - the producer stopped at the cap, not at `total`.
+        assertEquals(2L, state.outputVersion)
+        assertTrue(session.closed)
+        assertTrue(session.emitted < total)
+        scope.cancel()
+    }
+
+    @Test
+    fun `emulator resize fault propagates to the recovery handler`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FloodingTerminalSession(chunks = 4)
+        val state = TerminalScreenState(session, scope)
+        state.emulatorResizeInterceptor = { error("injected emulator resize fault") }
+
+        state.resize(PtySize(cols = 90, rows = 30))
+        testScheduler.advanceUntilIdle()
+
+        // The PTY resize succeeded (its failure is a locally absorbed hiccup), but the emulator
+        // half is a parser-class fault: it must reach the owner-level handler and close the
+        // session, not leave a silently stale grid.
+        assertEquals(listOf(90 to 30), session.resizes.map { it.cols to it.rows })
+        assertTrue(session.closed)
         scope.cancel()
     }
 
@@ -2868,6 +2992,44 @@ class TerminalScreenStateTest {
         assertEquals(redrawn, state.output, "the screen really is unchanged")
         assertEquals(start + 4, state.outputVersion)
         scope.cancel()
+    }
+}
+
+/**
+ * Emits [chunks] one-byte chunks as fast as the collector allows; records resizes. A [resizeGate]
+ * parks the emulator owner inside a Resize apply until completed — the only way, under the
+ * single-threaded test dispatcher, to hold a genuinely saturated feed backlog while the test acts.
+ */
+private class FloodingTerminalSession(
+    private val chunks: Int,
+    private val resizeGate: CompletableDeferred<Unit>? = null,
+) : TerminalSession {
+    private val _state = MutableStateFlow<TerminalState>(TerminalState.Open)
+    override val state: StateFlow<TerminalState> = _state
+
+    var emitted = 0
+        private set
+    val resizes = mutableListOf<PtySize>()
+
+    override val output: Flow<ByteArray> = flow {
+        repeat(chunks) {
+            emit(byteArrayOf('x'.code.toByte()))
+            emitted++
+        }
+    }
+
+    override suspend fun send(data: ByteArray) = Unit
+
+    override suspend fun resize(size: PtySize) {
+        resizeGate?.await()
+        resizes += size
+    }
+
+    var closed = false
+        private set
+
+    override suspend fun close() {
+        closed = true
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TerminalScreenStateTest.kt
@@ -236,6 +236,65 @@ class TerminalScreenStateTest {
     }
 
     @Test
+    fun `a batch queued during a quiet period is published whole, not split`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FloodingTerminalSession(chunks = 5)
+        // Scheduler clock, no delays: the whole batch is pre-queued at t=0 and parsing consumes
+        // no window budget. The leading-edge publish must cover the entire available batch - a
+        // drain budgeted from the stale lastPublishAt would return "spent" before draining and
+        // tear the first paint into two frames.
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(5L, state.outputVersion)
+        assertEquals(1, state.snapshotVersion)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a fault on a drained command still flushes the batch head`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val session = FloodingTerminalSession(chunks = 5)
+        val state = TerminalScreenState(session, scope, nowMillis = { testScheduler.currentTime })
+        var applies = 0
+        state.applyInterceptor = { if (++applies == 2) error("injected fault on a drained command") }
+        testScheduler.advanceUntilIdle()
+
+        // Chunk 1 was applied at the step head; chunk 2 faulted inside the drain of the SAME
+        // step. The finally must still land chunk 1 - dirty is set before the drain, not after.
+        assertEquals(1L, state.outputVersion)
+        assertEquals(1, state.snapshotVersion)
+        assertTrue(session.closed)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a dense backlog is published per window of parse work, not once at the end`() = runTest {
+        val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+        val total = FEED_BACKLOG_CHUNKS
+        val session = FloodingTerminalSession(chunks = total)
+        // Every clock read advances 1ms: parse work itself consumes the window, the way real time
+        // does under a flood. Without the in-drain window check the whole backlog is one batch and
+        // one publish; with it, a publish lands roughly every windowful of parsing.
+        var tick = 0L
+        val state = TerminalScreenState(session, scope, nowMillis = { ++tick })
+        testScheduler.advanceUntilIdle()
+
+        assertEquals(total.toLong(), state.outputVersion)
+        assertTrue(
+            state.snapshotVersion >= 3,
+            "expected a publish per parse window during a dense backlog, got ${state.snapshotVersion}",
+        )
+        // And the quota's own upper bound: a regression that publishes per drained command
+        // (~64 publishes) must fail here, not hide behind the floor.
+        assertTrue(
+            state.snapshotVersion <= total / (PUBLISH_MIN_INTERVAL_MS.toInt() / 2) + 2,
+            "expected at most ~1 publish per window, got ${state.snapshotVersion}",
+        )
+        scope.cancel()
+    }
+
+    @Test
     fun `a parser fault still lands the applied-but-unpublished tail`() = runTest {
         val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
         val session = FloodingTerminalSession(chunks = 5, interChunkDelayMs = 1)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TestClocks.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/TestClocks.kt
@@ -1,0 +1,19 @@
+package app.skerry.ui.terminal
+
+/**
+ * Clock whose every read advances past [PUBLISH_MIN_INTERVAL_MS]: the publish-rate cap sees each
+ * batch as arriving after a quiet window and publishes immediately. Tests that are not about the
+ * cap keep the pre-cap emit→assert semantics without controlling virtual time; the cap itself is
+ * covered by the dedicated TerminalScreenStateTest cases that inject the scheduler clock instead.
+ *
+ * A new emit→assert test that forgets to inject this gets the real clock: the second batch within
+ * one real window parks in the publish select and the assertion reads a stale screen — usually a
+ * deterministic failure, but a flake when the test thread stalls past the window. Inject this.
+ *
+ * The same instance also feeds the search refresh throttle (300ms): tests relying on "search stays
+ * throttled" hold as long as total reads stay under ~18 per test at 16ms per read.
+ */
+internal fun eagerPublishClock(): () -> Long {
+    var t = 0L
+    return { t += PUBLISH_MIN_INTERVAL_MS; t }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantTestFakes.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantTestFakes.kt
@@ -28,6 +28,7 @@ import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.FakeClipboard
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.terminal.TerminalScreenState
+import app.skerry.ui.terminal.eagerPublishClock
 import app.skerry.ui.theme.SkerryTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -108,7 +109,7 @@ internal fun terminalAi(reply: String) = TerminalAiController(
     scope = CoroutineScope(Dispatchers.Unconfined),
 )
 
-internal fun terminalState() = TerminalScreenState(SilentSession(), CoroutineScope(Dispatchers.Unconfined))
+internal fun terminalState() = TerminalScreenState(SilentSession(), CoroutineScope(Dispatchers.Unconfined), nowMillis = eagerPublishClock())
 
 /** Ctrl everywhere but macOS — what the selection manager listens for. */
 internal val COPY_MODIFIER: Key =

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SharedSessionLiveRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/SharedSessionLiveRenderTest.kt
@@ -68,7 +68,7 @@ class SharedSessionLiveRenderTest {
     @Test
     fun `a watched session renders as a live terminal with the sharing hints over it`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        val terminal = TerminalScreenState(WatchedSession(), scope)
+        val terminal = TerminalScreenState(WatchedSession(), scope, nowMillis = eagerPublishClock())
         val scene = ImageComposeScene(width = 900, height = 200, density = Density(1f)) {
             SkerryTheme {
                 CompositionLocalProvider(

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalAutoFitLiveTest.kt
@@ -86,7 +86,7 @@ class TerminalAutoFitLiveTest {
     fun `wide output converges the font once and a later wider line does not move it`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val session = ScriptedSession()
-        val terminal = TerminalScreenState(session, scope)
+        val terminal = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         var scene = autoFitScene(terminal)
         try {
             // Let the first layout resize land before printing, as on a live connect: output fed
@@ -153,7 +153,7 @@ class TerminalAutoFitLiveTest {
     fun `a frozen session never takes a reflow-less step`() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val session = ScriptedSession()
-        val terminal = TerminalScreenState(session, scope)
+        val terminal = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val scene = autoFitScene(terminal)
         try {
             waitForFrames(scene) { terminal.cols in 20..50 } // first layout resize has landed

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -6,11 +6,13 @@ import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
+import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
@@ -193,6 +195,61 @@ class TerminalHighlightRenderTest {
     }
 
     @Test
+    fun linkScanStaysCachedAcrossSelectionRepaints() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides TerminalHighlight(commandLine = false, output = false),
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                repeat(3) { frame() }
+                session.emit("see https://example.com")
+                repeat(5) { frame() }
+                val before = frame()
+                val passes = linkScanPasses
+                assertTrue(passes > 0, "the hoisted link scan must still be wired into composition")
+
+                // A selection drag repaints the canvas on every move; the scan keys on content and
+                // window, not on frames - computed in the draw phase it would rerun per repaint.
+                scene.sendPointerEvent(PointerEventType.Press, Offset(40f, 20f))
+                scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 24f))
+                val afterFirstMove = frame()
+                // Guard against a vacuous pass: the drag must actually paint a selection - a
+                // no-op pointer sequence would leave nothing invalidated and assert nothing.
+                assertTrue(
+                    !before.sameRowPixels(afterFirstMove, y = 20),
+                    "the drag must visibly change the frame (selection highlight)",
+                )
+                repeat(5) { step ->
+                    scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 24f))
+                    frame()
+                }
+                scene.sendPointerEvent(PointerEventType.Release, Offset(180f, 24f))
+                frame()
+                assertEquals(passes, linkScanPasses, "selection repaints must not rescan links")
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
     fun rewritingTheLineUnderAStationaryCursorRecomputesTheOverlay() {
         withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
             // Both lines are 8 cells, so after the rewrite the cursor lands on the same (row, col)
@@ -230,6 +287,14 @@ class TerminalHighlightRenderTest {
             repeat(4) { frame() }
             assertTrue(backgroundHighlightPasses > passes, "new content must rescan")
         }
+    }
+
+    /** Whether row [y] holds identical pixels in both frames — a cheap frame-delta probe. */
+    private fun PixelMap.sameRowPixels(other: PixelMap, y: Int): Boolean {
+        for (x in 0 until width) {
+            if (this[x, y].toArgb() != other[x, y].toArgb()) return false
+        }
+        return true
     }
 
     /** Whether opaque pixel [argb] matches [target] within [tolerance] on every channel. */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -492,6 +492,138 @@ class TerminalHighlightRenderTest {
     }
 
     @Test
+    fun glyphRunsStayCachedAcrossSelectionRepaints() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides TerminalHighlight(commandLine = false, output = false),
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                repeat(3) { frame() }
+                session.emit("hello world")
+                repeat(5) { frame() }
+                val segmentations = glyphRunSegmentations
+                assertTrue(segmentations > 0, "the draw pass must still segment rows into runs")
+
+                // A selection drag repaints the canvas per move; rows and highlights are unchanged,
+                // so every repaint must reuse the cached runs instead of re-segmenting the window.
+                scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f))
+                scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 24f))
+                val afterFirstMove = frame()
+                assertTrue(
+                    afterFirstMove.regionHasColor(selectionWash, 16..20, cell0InteriorY),
+                    "the drag must visibly paint the selection wash",
+                )
+                repeat(5) { step ->
+                    scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 24f))
+                    frame()
+                }
+                scene.sendPointerEvent(PointerEventType.Release, Offset(180f, 24f))
+                frame()
+                assertEquals(segmentations, glyphRunSegmentations, "selection repaints must not re-segment rows")
+
+                // New content really does re-segment.
+                session.emit("!")
+                repeat(5) { frame() }
+                assertTrue(glyphRunSegmentations > segmentations, "new content must re-segment its rows")
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun duplicateHighlightedRowsStayCachedAcrossRepaints() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides TerminalHighlight(commandLine = false, output = true),
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                repeat(3) { frame() }
+                // Two content-equal rows carry two DISTINCT RowHighlight instances - a
+                // content-keyed cache aliases them into one entry and the identity check misses
+                // alternately, re-segmenting both rows on every repaint. Retry-loop logs are
+                // exactly this shape. An idle frame does not re-execute the draw lambda, so the
+                // repaints are forced with a selection drag (wash-guarded against a no-op).
+                session.emit("ERROR connection lost\r\nERROR connection lost\r\n")
+                repeat(5) { frame() }
+                val segmentations = glyphRunSegmentations
+                scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 60f))
+                scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 64f))
+                val afterFirstMove = frame()
+                // Probe columns 3..5 of the dragged row: the cursor block sits on column 0 and
+                // would read as cursor color, not wash.
+                assertTrue(
+                    afterFirstMove.regionHasColor(selectionWash, 40..56, 54..64),
+                    "the drag must visibly paint the selection wash",
+                )
+                repeat(4) { step ->
+                    scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 64f))
+                    frame()
+                }
+                scene.sendPointerEvent(PointerEventType.Release, Offset(160f, 64f))
+                frame()
+                assertEquals(
+                    segmentations, glyphRunSegmentations,
+                    "repaints of duplicate highlighted rows must not re-segment",
+                )
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun aHighlightChangeResegmentsItsRows() {
+        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frame ->
+            session.emit("$ ls -la")
+            repeat(5) { frame() }
+            val segmentations = glyphRunSegmentations
+            // A cursor move through the live line rebuilds that row's RowHighlight instance; the
+            // run cache must treat it as a miss - runs bake the highlight kinds in.
+            session.emit("\u001b[D")
+            repeat(5) { frame() }
+            assertTrue(
+                glyphRunSegmentations > segmentations,
+                "a rebuilt highlight must re-segment its row",
+            )
+        }
+    }
+
+    @Test
     fun rewritingTheLineUnderAStationaryCursorRecomputesTheOverlay() {
         withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
             // Both lines are 8 cells, so after the rewrite the cursor lands on the same (row, col)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -22,6 +22,7 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.math.abs
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
@@ -188,6 +189,46 @@ class TerminalHighlightRenderTest {
             }
         } finally {
             scope.cancel()
+        }
+    }
+
+    @Test
+    fun rewritingTheLineUnderAStationaryCursorRecomputesTheOverlay() {
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+            // Both lines are 8 cells, so after the rewrite the cursor lands on the same (row, col)
+            // and the background map is empty both times (no output markers, nothing executed) -
+            // the exact shape where keying the overlay on the background map alone kept stale
+            // spans painted over the new text.
+            session.emit("$ ls -la")
+            repeat(5) { frame() }
+            val passes = liveOverlayPasses
+
+            session.emit("\r$ git st")
+            repeat(5) { frame() }
+            assertTrue(
+                liveOverlayPasses > passes,
+                "an in-place rewrite under a stationary cursor must recompute the live overlay",
+            )
+        }
+    }
+
+    @Test
+    fun cursorMovesDoNotRescanTheBackgroundPass() {
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+            session.emit("\r\nERROR failed to bind\r\nuser@host:~$ echo hi")
+            repeat(4) { frame() }
+            val passes = backgroundHighlightPasses
+
+            // Pure cursor motion over the live line: the whole-window output/executed scan must
+            // stay cached - only the small live-command overlay may recompute.
+            session.emit("\u001b[D")
+            repeat(4) { frame() }
+            assertEquals(passes, backgroundHighlightPasses, "a cursor move must not rescan the window")
+
+            // Real content invalidates the background pass.
+            session.emit("x")
+            repeat(4) { frame() }
+            assertTrue(backgroundHighlightPasses > passes, "new content must rescan")
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.graphics.toPixelMap
@@ -58,6 +59,11 @@ class TerminalHighlightRenderTest {
         override suspend fun close() {}
         fun emit(text: String) {
             check(_output.tryEmit(text.encodeToByteArray())) { "output buffer overflow" }
+        }
+
+        /** Transport drop: the session reports Closed, the way a dead connection does. */
+        fun die() {
+            _state.value = TerminalState.Closed()
         }
     }
 
@@ -194,6 +200,243 @@ class TerminalHighlightRenderTest {
         }
     }
 
+    /** Real-time poll: the blink coroutine delays on the wall clock, not the render clock. */
+    private fun pollFrames(frame: () -> PixelMap, tries: Int = 25, cond: (PixelMap) -> Boolean): Boolean {
+        repeat(tries) {
+            Thread.sleep(100)
+            if (cond(frame())) return true
+        }
+        return false
+    }
+
+    // NightSea's cursor #2BBDEE happens to equal ansi[6] (cyan) - the cursor-presence probes below
+    // are sound only because these scenarios emit plain uncolored text; re-verify if extending.
+    // The cell-0 interior region is tied to the defaults these scenes run under: 13px font, 18px
+    // line height, PADDING_DP=14, Density(1f) - re-derive on change; a drifted region fails
+    // loudly on the sampled-while-lit / drag-painted gates, never silently.
+    private val cell0InteriorX = 16..20
+    private val cell0InteriorY = 18..28
+
+    /** Cell 0 including the underline band at the row's bottom edge. */
+    private val cell0WithUnderlineY = 16..31
+
+    // Row 0's link-underline band under the 19 cells of "https://example.com". The link cyan
+    // equals theme.cursor, so the probe stays inside this band - the tests park the blink cursor
+    // on row 2, clear of it.
+    private val urlUnderlineX = 16..160
+    private val urlUnderlineY = 29..31
+
+    /** Row 0's underline band under the 4 cells of the OSC 8 anchor text "link". */
+    private val hyperlinkBandX = 16..44
+
+    /** LINK_UNDERLINE_STYLE's own color - carried by the style, not by the cell's text color. */
+    private val linkCyan = Color(0xFF2BBDEE).toArgb()
+
+    /** What a selected blank cell reads as on screen: the half-alpha wash over the background. */
+    private val selectionWash = theme.selection.compositeOver(theme.background).toArgb()
+
+    @Test
+    fun cursorBlinkRepaintsWithoutRecomposingTheScreen() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            session.emit("x")
+            repeat(5) { frame() }
+            // Two-phase poll: a single sample races the wall-clock blink phase on a cold JVM.
+            assertTrue(
+                pollFrames(frame) { it.hasColorNear(theme.cursor.toArgb()) },
+                "the cursor must become visible",
+            )
+            val compositions = terminalScreenCompositions
+            assertTrue(
+                pollFrames(frame) { !it.hasColorNear(theme.cursor.toArgb()) },
+                "the cursor must blink off within ~2.5s",
+            )
+            assertEquals(
+                compositions, terminalScreenCompositions,
+                "a blink toggle must repaint the overlay, not recompose the screen",
+            )
+        }
+    }
+
+    @Test
+    fun aSteadyCursorNeverBlanks() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            // DECSCUSR 2 = steady block; the effect's early-return must pin the phase on.
+            session.emit("${'\u001b'}[2 qx")
+            repeat(5) { frame() }
+            // Longer than two half-periods: a blink regression would blank at least once.
+            repeat(13) {
+                Thread.sleep(100)
+                assertTrue(frame().hasColorNear(theme.cursor.toArgb()), "a steady cursor must never blank")
+            }
+        }
+    }
+
+    @Test
+    fun aClosedSessionHidesTheCursor() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            session.emit("x")
+            assertTrue(
+                pollFrames(frame) { it.hasColorNear(theme.cursor.toArgb()) },
+                "the cursor must become visible first",
+            )
+            session.die()
+            repeat(3) { frame() }
+            // Gone and stays gone: the overlay is not composed for a dead session.
+            repeat(5) {
+                Thread.sleep(100)
+                assertFalse(frame().hasColorNear(theme.cursor.toArgb()), "a dead session must not draw a cursor")
+            }
+        }
+    }
+
+    @Test
+    fun concealedTextStaysHiddenUnderTheSelectionWash() {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val session = FakeSession()
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
+        try {
+            ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
+                scene.setContent {
+                    SkerryTheme {
+                        CompositionLocalProvider(
+                            LocalTerminalTheme provides theme,
+                            LocalTerminalHighlight provides TerminalHighlight(commandLine = false, output = false),
+                            LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                        ) {
+                            TerminalScreen(state, Modifier.fillMaxSize())
+                        }
+                    }
+                }
+                var timeNanos = 0L
+                fun frame(): PixelMap {
+                    Snapshot.sendApplyNotifications()
+                    timeNanos += 16_666_667L
+                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
+                }
+                repeat(3) { frame() }
+                // Concealed AND dim X at cell 0 (SGR 2;8 - the combination where a naive alpha
+                // override repainted the secret in 60% black); cursor sits at cell 1, clear of
+                // the probed region.
+                session.emit("${'\u001b'}[2;8mX")
+                repeat(5) { frame() }
+                // Select across the row: the wash paints under the glyph pass, and hidden strokes
+                // of any color read through it as non-uniformity.
+                scene.sendPointerEvent(PointerEventType.Press, Offset(16f, 20f))
+                scene.sendPointerEvent(PointerEventType.Move, Offset(120f, 24f))
+                repeat(3) { frame() }
+                val after = frame()
+                // Guard against a vacuous pass: the wash color itself must be present on blank
+                // cells clear of the cursor cell - a frame delta on the probed row would also be
+                // satisfied by a mere cursor blink.
+                assertTrue(
+                    after.regionHasColor(selectionWash, 60..110, cell0InteriorY),
+                    "the drag must visibly paint the selection wash",
+                )
+                assertTrue(
+                    after.regionIsUniform(cell0InteriorX, cell0InteriorY, tolerance = 8),
+                    "the concealed cell under the wash must be indistinguishable from blank cells",
+                )
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun concealedTextDrawsNoUnderline() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            // SGR 8;4: concealed and underlined. The underline would trace the position and run
+            // length of the hidden text - the whole cell, band included, must stay blank.
+            session.emit("${'\u001b'}[8;4mX")
+            repeat(5) { frame() }
+            assertTrue(
+                frame().regionIsUniform(cell0InteriorX, cell0WithUnderlineY, tolerance = 8),
+                "a concealed cell must not draw its underline",
+            )
+        }
+    }
+
+    @Test
+    fun concealedUrlDrawsNoLinkUnderline() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            // Visible URL first: pins the probe region to where the link underline actually lands,
+            // so a drifted band cannot make the concealed assertion below pass vacuously.
+            session.emit("https://example.com\r\n\r\n")
+            repeat(5) { frame() }
+            assertTrue(
+                // Tolerance 90: the ~1.3px line antialiases against the near-black background,
+                // so no pixel reads as pure cyan (the strongest measures ~#1F8BB0, blue off by 62);
+                // 90 still cannot match the background itself (green differs by 175) or the
+                // foreground (red differs by 187).
+                frame().regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90),
+                "a visible bare URL must get the link underline",
+            )
+            // The same URL concealed (SGR 8): LINK_UNDERLINE_STYLE carries its own color and
+            // hidden=false, so underlineDrawColor's hidden gate never sees it - the link passes
+            // themselves must skip concealed cells, or the underline traces the hidden run.
+            session.emit("${'\u001b'}[2J${'\u001b'}[H${'\u001b'}[8mhttps://example.com${'\u001b'}[0m\r\n\r\n")
+            repeat(5) { frame() }
+            assertFalse(
+                // The same wide tolerance makes this STRICTER: even a faint antialiased trace
+                // of the underline fails it.
+                frame().regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90),
+                "a concealed URL must not draw the link underline",
+            )
+        }
+    }
+
+    @Test
+    fun concealedHyperlinkDrawsNoLinkUnderline() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            // Visible OSC 8 hyperlink first: pins the probe band for pass 4, a structurally
+            // separate loop (keyed on the cell's hyperlink) from the bare-URL pass 5 that
+            // concealedUrlDrawsNoLinkUnderline covers.
+            session.emit("\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007\r\n\r\n")
+            repeat(5) { frame() }
+            assertTrue(
+                frame().regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90),
+                "a visible OSC 8 hyperlink must get the link underline",
+            )
+            // The same hyperlink concealed (SGR 8): the span filter that protects bare URLs never
+            // sees OSC 8 cells, so pass 4 needs its own hidden gate - and its own test.
+            session.emit(
+                "\u001b[2J\u001b[H\u001b]8;;https://example.com\u0007\u001b[8mlink\u001b[0m\u001b]8;;\u0007\r\n\r\n",
+            )
+            repeat(5) { frame() }
+            assertFalse(
+                frame().regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90),
+                "a concealed OSC 8 hyperlink must not draw the link underline",
+            )
+        }
+    }
+
+    @Test
+    fun concealedTextStaysHiddenUnderTheBlockCursor() {
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+            // SGR 8 conceals X; CUB puts the block cursor onto it. The text pass renders the
+            // glyph transparent (TerminalGlyphs.toSpanStyle); the cursor overlay must not repaint
+            // it readable in the contrast color.
+            session.emit("${'\u001b'}[8mX${'\u001b'}[D")
+            repeat(5) { frame() }
+            var checkedWhileLit = false
+            var attempts = 0
+            while (!checkedWhileLit && attempts++ < 25) {
+                Thread.sleep(100)
+                val px = frame()
+                if (px.regionHasColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY)) {
+                    // A solid block: any glyph stroke inside the interior (antialiased or not)
+                    // breaks the uniform cursor fill and reveals the concealed character.
+                    assertTrue(
+                        px.regionAllNearColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY, tolerance = 40),
+                        "a concealed glyph must not be redrawn readable under the cursor",
+                    )
+                    checkedWhileLit = true
+                }
+            }
+            assertTrue(checkedWhileLit, "the block cursor must have been sampled while lit")
+        }
+    }
+
     @Test
     fun linkScanStaysCachedAcrossSelectionRepaints() {
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
@@ -221,7 +464,6 @@ class TerminalHighlightRenderTest {
                 repeat(3) { frame() }
                 session.emit("see https://example.com")
                 repeat(5) { frame() }
-                val before = frame()
                 val passes = linkScanPasses
                 assertTrue(passes > 0, "the hoisted link scan must still be wired into composition")
 
@@ -230,11 +472,11 @@ class TerminalHighlightRenderTest {
                 scene.sendPointerEvent(PointerEventType.Press, Offset(40f, 20f))
                 scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 24f))
                 val afterFirstMove = frame()
-                // Guard against a vacuous pass: the drag must actually paint a selection - a
-                // no-op pointer sequence would leave nothing invalidated and assert nothing.
+                // Guard against a vacuous pass: the wash color must be present on the blank cell 3
+                // inside the dragged range - a frame delta would also be satisfied by cursor blink.
                 assertTrue(
-                    !before.sameRowPixels(afterFirstMove, y = 20),
-                    "the drag must visibly change the frame (selection highlight)",
+                    afterFirstMove.regionHasColor(selectionWash, 39..44, cell0InteriorY),
+                    "the drag must visibly paint the selection wash",
                 )
                 repeat(5) { step ->
                     scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 24f))
@@ -289,12 +531,35 @@ class TerminalHighlightRenderTest {
         }
     }
 
-    /** Whether row [y] holds identical pixels in both frames — a cheap frame-delta probe. */
-    private fun PixelMap.sameRowPixels(other: PixelMap, y: Int): Boolean {
-        for (x in 0 until width) {
-            if (this[x, y].toArgb() != other[x, y].toArgb()) return false
+    /** Whether every pixel inside the region matches the region's own first pixel within [tolerance]. */
+    private fun PixelMap.regionIsUniform(xs: IntRange, ys: IntRange, tolerance: Int): Boolean {
+        val ref = this[xs.first, ys.first].toArgb()
+        for (y in ys) {
+            for (x in xs) {
+                if (x < width && y < height && !matches(this[x, y].toArgb(), ref, tolerance)) return false
+            }
         }
         return true
+    }
+
+    /** Whether every pixel inside the region matches [argb] within [tolerance]. */
+    private fun PixelMap.regionAllNearColor(argb: Int, xs: IntRange, ys: IntRange, tolerance: Int): Boolean {
+        for (y in ys) {
+            for (x in xs) {
+                if (x < width && y < height && !matches(this[x, y].toArgb(), argb, tolerance)) return false
+            }
+        }
+        return true
+    }
+
+    /** Whether any pixel inside the region matches [argb] within [tolerance]. */
+    private fun PixelMap.regionHasColor(argb: Int, xs: IntRange, ys: IntRange, tolerance: Int = 2): Boolean {
+        for (y in ys) {
+            for (x in xs) {
+                if (x < width && y < height && matches(this[x, y].toArgb(), argb, tolerance)) return true
+            }
+        }
+        return false
     }
 
     /** Whether opaque pixel [argb] matches [target] within [tolerance] on every channel. */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -68,7 +68,7 @@ class TerminalHighlightRenderTest {
         // Unconfined: feed/resize run synchronously at the emit point, making frames deterministic.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         try {
             ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
                 scene.setContent {
@@ -150,7 +150,7 @@ class TerminalHighlightRenderTest {
         // through typeInput so the executed-command set is populated the way it is in a session.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         try {
             ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->
                 scene.setContent {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
@@ -65,7 +65,7 @@ class TerminalSearchRenderTest {
         // Unconfined: feed/resize run synchronously at the emit point, making frames deterministic.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val theme = TerminalThemes.NightSea
         try {
             ImageComposeScene(width = 420, height = 240, density = Density(1f)).use { scene ->

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalThemeSwitchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalThemeSwitchRenderTest.kt
@@ -61,7 +61,7 @@ class TerminalThemeSwitchRenderTest {
         // Unconfined: feed/resize run synchronously at the emit point, making test frames deterministic.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
         val session = FakeSession()
-        val state = TerminalScreenState(session, scope)
+        val state = TerminalScreenState(session, scope, nowMillis = eagerPublishClock())
         val theme = mutableStateOf(TerminalThemes.NightSea)
         try {
             ImageComposeScene(width = 400, height = 260, density = Density(1f)).use { scene ->

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/AutocompleteEngine.kt
@@ -259,17 +259,37 @@ class AutocompleteEngine(
             .map { head + it }
     }
 
+    /**
+     * Cache for [sessionTokens], keyed on the history snapshot's identity: history.commands is an
+     * immutable list replaced as a whole on record/preload/forget, so `===` is exact. Key and
+     * value travel in ONE immutable holder behind a single Volatile field - sessionTokens is
+     * reached from the UI thread (typing) and the session scope (publish -> refreshSuggestion),
+     * and two separately published fields can pair a fresh key with a stale value: the exact tear
+     * [CommandHistory]'s own State holder exists to prevent. Two writers may lose an update to
+     * each other; no reader can ever see a mismatched pair.
+     */
+    private class TokensCache(val commands: List<String>, val tokens: List<String>)
+
+    @Volatile
+    private var tokensCache: TokensCache? = null
+
     /** Distinct arguments (not the first word) from command history, newest first, deduplicated. */
-    private fun sessionTokens(): List<String> {
+    // internal, not private: the caching contract (same instance until history changes) is pinned
+    // by an identity test. The scan is O(history x words) and used to run on every keystroke.
+    internal fun sessionTokens(): List<String> {
+        val commands = history.commands
+        tokensCache?.let { if (it.commands === commands) return it.tokens }
         val seen = LinkedHashSet<String>()
-        for (cmd in history.commands) {
+        for (cmd in commands) {
             val parts = cmd.split(' ')
             for (i in 1 until parts.size) {
                 val t = parts[i]
                 if (t.length >= 2) seen.add(t)
             }
         }
-        return seen.toList()
+        val tokens = seen.toList()
+        tokensCache = TokensCache(commands, tokens)
+        return tokens
     }
 
     /** Skips an ESC sequence (CSI/`ESC [ … final` or plain `ESC x`); returns the index past it. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CharMetrics.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/CharMetrics.kt
@@ -51,8 +51,18 @@ internal object CharMetrics {
         cp in 0xFE20..0xFE2F ||          // combining half marks
         cp in 0xE0100..0xE01EF           // variation selectors supplement
 
+    // One shared instance per printable ASCII char: feed() calls codePointToString once per
+    // printed character, and streaming plain text allocated a fresh one-char String per byte.
+    private val ASCII_STRINGS = Array(0x7F - 0x20) { (0x20 + it).toChar().toString() }
+
+    // Box-drawing glyphs get the same treatment: TUI borders (tmux, mc, htop) repeat them across
+    // whole rows, and the generic BMP branch allocated one String per cell.
+    private val BOX_DRAWING_STRINGS = Array(0x80) { (0x2500 + it).toChar().toString() }
+
     /** Codepoint to string: BMP is one Char, astral is a surrogate pair, invalid is U+FFFD. */
     fun codePointToString(cp: Int): String = when {
+        cp in 0x20..0x7E -> ASCII_STRINGS[cp - 0x20]
+        cp in 0x2500..0x257F -> BOX_DRAWING_STRINGS[cp - 0x2500]
         cp in 0..0xFFFF && cp !in 0xD800..0xDFFF -> cp.toChar().toString()
         cp in 0x10000..0x10FFFF -> {
             val v = cp - 0x10000

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
@@ -227,10 +227,31 @@ class TerminalEmulator(
      */
     val lines: List<List<TermCell>>
         get() {
+            snapshotCache?.takeIf { snapshotVersion == contentVersion }?.let { return it }
             val screenRows = ArrayList<List<TermCell>>(grid.size)
                 .apply { grid.forEach { add(TermSnapshotRow(it.toList(), it.wrapped)) } }
-            return if (altScreen) screenRows else SnapshotLines(scrollback.frozen(), screenRows)
+            val built = if (altScreen) screenRows else SnapshotLines(scrollback.frozen(), screenRows)
+            snapshotCache = built
+            snapshotVersion = contentVersion
+            return built
         }
+
+    /**
+     * Bumped by every mutation that can change what [lines] returns — cell writes, wrap flags,
+     * scrollback, geometry, buffer switches. The render layer compares snapshots by identity, so
+     * an unchanged version returning the cached instance is what makes "nothing visible changed"
+     * (a cursor-only move, a mode switch) publish as a no-op; a missed [markDirty] site would
+     * freeze the screen, which is why every grid/scrollback writer calls it at its entry.
+     */
+    var contentVersion: Long = 0L
+        private set
+
+    private var snapshotCache: List<List<TermCell>>? = null
+    private var snapshotVersion: Long = -1L
+
+    private fun markDirty() {
+        contentVersion++
+    }
 
     private var style = TermStyle()
 
@@ -983,6 +1004,7 @@ class TerminalEmulator(
     // --- Printing and movement ------------------------------------------------
 
     private fun putCodePoint(cp: Int) {
+        markDirty()
         if (CharMetrics.isCombining(cp) && appendCombining(cp)) return // attached to the base — cursor unchanged
         val w = CharMetrics.charWidth(cp)
         if (pendingWrap) {
@@ -1032,6 +1054,7 @@ class TerminalEmulator(
         val base = row[baseCol]
         if (base.width == CellWidth.Continuation) return false                   // guard: never attach to a bare continuation
         if (base.text.length >= MAX_GRAPHEME_LEN) return true                    // cluster full — silently drop the mark
+        markDirty()
         row[baseCol] = base.copy(text = base.text + CharMetrics.codePointToString(cp))
         return true
     }
@@ -1068,12 +1091,14 @@ class TerminalEmulator(
     // --- Scrolling ---------------------------------------------------------
 
     private fun scrollUp(n: Int) = repeat(n.coerceAtMost(scrollBottom - scrollTop + 1)) {
+        markDirty()
         val removed = grid.removeAt(scrollTop)
         if (!altScreen && scrollTop == 0) pushScrollback(removed)
         grid.add(scrollBottom, blankRow())
     }
 
     private fun scrollDown(n: Int) = repeat(n.coerceAtMost(scrollBottom - scrollTop + 1)) {
+        markDirty()
         grid.removeAt(scrollBottom)
         grid.add(scrollTop, blankRow())
     }
@@ -1091,6 +1116,7 @@ class TerminalEmulator(
      */
     private fun trimScrollback() {
         val dropped = scrollback.trimTo(maxScrollback)
+        if (dropped > 0) markDirty()
         if (dropped == 0 || stepMarkRow == NO_STEP_MARK) return
         val shifted = stepMarkRow - dropped
         stepMarkRow = shifted.coerceAtLeast(0)
@@ -1102,6 +1128,7 @@ class TerminalEmulator(
     // --- Erase / insert / delete ------------------------------------------
 
     private fun eraseLine(mode: Int) {
+        markDirty()
         val row = grid[cy]
         when (mode) {
             // Erasing the tail (0) or the whole row (2) removes its continuation — clear wrapped so
@@ -1113,6 +1140,7 @@ class TerminalEmulator(
     }
 
     private fun eraseDisplay(mode: Int) {
+        markDirty()
         when (mode) {
             0 -> { eraseLine(0); for (r in cy + 1 until rows) blankLine(r) }
             1 -> { for (r in 0 until cy) blankLine(r); eraseLine(1) }
@@ -1131,6 +1159,7 @@ class TerminalEmulator(
      * scrollable. Trailing empty rows aren't moved to history, else every `clear` would spawn a screen
      * of blank rows. The alt screen has no scrollback — clear in place.
      */
+    // Caller must markDirty() first (eraseDisplay does): this writer relies on its entry frame.
     private fun clearScreenToScrollback() {
         if (altScreen) {
             for (r in 0 until rows) blankLine(r)
@@ -1149,17 +1178,20 @@ class TerminalEmulator(
     }
 
     private fun eraseChars(n: Int) {
+        markDirty()
         val row = grid[cy]
         for (c in cx until (cx + n).coerceAtMost(cols)) row[c] = blankCell()
     }
 
     private fun insertChars(n: Int) {
+        markDirty()
         val row = grid[cy]
         repeat(n.coerceAtMost(cols - cx)) { row.add(cx, blankCell()) }
         while (row.size > cols) row.removeAt(row.size - 1)
     }
 
     private fun deleteChars(n: Int) {
+        markDirty()
         val row = grid[cy]
         repeat(n.coerceAtMost(cols - cx)) { row.removeAt(cx) }
         while (row.size < cols) row.add(blankCell())
@@ -1167,6 +1199,7 @@ class TerminalEmulator(
 
     private fun insertLines(n: Int) {
         if (cy < scrollTop || cy > scrollBottom) return
+        markDirty()
         repeat(n.coerceAtMost(scrollBottom - cy + 1)) {
             grid.removeAt(scrollBottom)
             grid.add(cy, blankRow())
@@ -1177,6 +1210,7 @@ class TerminalEmulator(
 
     private fun deleteLines(n: Int) {
         if (cy < scrollTop || cy > scrollBottom) return
+        markDirty()
         repeat(n.coerceAtMost(scrollBottom - cy + 1)) {
             grid.removeAt(cy)
             grid.add(scrollBottom, blankRow())
@@ -1212,6 +1246,7 @@ class TerminalEmulator(
 
     private fun setAltScreen(on: Boolean, saveRestore: Boolean) {
         if (on == altScreen) return
+        markDirty()
         if (on) {
             if (saveRestore) saveCursor()
             val fresh = freshScreen()
@@ -1265,6 +1300,7 @@ class TerminalEmulator(
     }
 
     private fun reset() {
+        markDirty()
         primaryGrid = freshScreen()
         altGrid = null
         grid = primaryGrid
@@ -1329,6 +1365,7 @@ class TerminalEmulator(
         val nc = newCols.coerceIn(1, MAX_DIMENSION)
         val nr = newRows.coerceIn(1, MAX_DIMENSION)
         if (nc == cols && nr == rows) return
+        markDirty()
         val wasPendingWrap = pendingWrap
         val (newCy, newCx) = reflowPrimary(nc, nr, trackCursor = !altScreen)
         if (!altScreen) grid = primaryGrid
@@ -1356,6 +1393,7 @@ class TerminalEmulator(
      * result to state. Returns the new cursor position `(cy, cx)` in new-grid coordinates (meaningful
      * only with [trackCursor]).
      */
+    // Caller must markDirty() first (resize does): this writer relies on its entry frame.
     private fun reflowPrimary(nc: Int, nr: Int, trackCursor: Boolean): Pair<Int, Int> {
         val src = ArrayList<TermRow>(scrollback.size + primaryGrid.size).apply {
             addAll(scrollback.rows); addAll(primaryGrid)
@@ -1378,6 +1416,7 @@ class TerminalEmulator(
     }
 
     /** Resize the grid without reflow (alt-screen): trim/pad columns and rows. */
+    // Caller must markDirty() first (resize does): this writer relies on its entry frame.
     private fun resizeGrid(g: MutableList<TermRow>, nc: Int, nr: Int, activePrimary: Boolean) {
         for (row in g) {
             while (row.size > nc) row.removeAt(row.size - 1)
@@ -1412,6 +1451,7 @@ class TerminalEmulator(
     private fun blankRow() = TermRow(MutableList(cols) { blankCell() })
 
     private fun blankLine(r: Int) {
+        markDirty()
         val row = grid[r]
         for (c in 0 until cols) row[c] = blankCell()
         row.wrapped = false

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalEmulator.kt
@@ -1446,7 +1446,18 @@ class TerminalEmulator(
      * — without the inverse flag the row tail would draw with the normal background. Glyph attributes
      * (bold/underline/strike) aren't carried on a blank cell: xterm doesn't apply them on erase.
      */
-    private fun blankCell() = TermCell(' ', TermStyle(fg = style.fg, bg = style.bg, inverse = style.inverse))
+    // Erases and scrolls fill whole regions with blanks, and a TermCell+TermStyle pair per cell
+    // made every clear O(cols) garbage. TermCell is immutable, so all blanks of the current style
+    // can be one instance; the cache holds the last one and is replaced when the style moved on.
+    private var cachedBlank = TermCell(' ', TermStyle())
+
+    private fun blankCell(): TermCell {
+        val cached = cachedBlank
+        val cs = cached.style
+        if (cs.fg == style.fg && cs.bg == style.bg && cs.inverse == style.inverse) return cached
+        return TermCell(' ', TermStyle(fg = style.fg, bg = style.bg, inverse = style.inverse))
+            .also { cachedBlank = it }
+    }
 
     private fun blankRow() = TermRow(MutableList(cols) { blankCell() })
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSession.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalSession.kt
@@ -108,12 +108,18 @@ class ShellTerminalSession(
     override suspend fun close() {
         // Set state explicitly: collection may not have started yet (no subscriber), so the
         // collector's finally block would never run even though the session is already closed.
-        channel.close()
-        // Our own close is not a clean shell exit: cleanExit=false (the caller initiated it).
-        // Don't overwrite a [Closed] already set by collection: if the server sent a clean EOF
-        // first (cleanExit=true), that value must reach observers. Only transition from Open.
-        _state.update { current ->
-            if (current == TerminalState.Open) TerminalState.Closed(cleanExit = false) else current
+        try {
+            channel.close()
+        } finally {
+            // In finally: a close that throws (socket already broken by the fault being cleaned
+            // up) must still flip the state - observers key auto-reconnect off Closed, and a
+            // session stuck Open is a frozen pane. Our own close is not a clean shell exit:
+            // cleanExit=false (the caller initiated it). Don't overwrite a [Closed] already set
+            // by collection: if the server sent a clean EOF first (cleanExit=true), that value
+            // must reach observers. Only transition from Open.
+            _state.update { current ->
+                if (current == TerminalState.Open) TerminalState.Closed(cleanExit = false) else current
+            }
         }
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/AutocompleteEngineTest.kt
@@ -1,6 +1,8 @@
 package app.skerry.shared.terminal
 
 import kotlin.test.Test
+import kotlin.test.assertSame
+import kotlin.test.assertNotSame
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -129,6 +131,22 @@ class CommandHistoryTest {
 }
 
 class AutocompleteEngineTest {
+
+    @Test
+    fun `session tokens are cached until history changes`() {
+        // The token scan is O(history x words) and runs per keystroke; history.commands is an
+        // immutable snapshot replaced on record, so instance identity is the cache key.
+        val history = CommandHistory()
+        val engine = AutocompleteEngine(history = history)
+        history.record("cat /var/log/syslog")
+        val first = engine.sessionTokens()
+        assertEquals(listOf("/var/log/syslog"), first)
+        assertSame(first, engine.sessionTokens())
+        history.record("cd /etc")
+        val second = engine.sessionTokens()
+        assertNotSame(first, second)
+        assertTrue("/etc" in second)
+    }
 
     /**
      * A completion only stays a prefix until something is typed onto it: the shell inserted its own

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CharMetricsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/CharMetricsTest.kt
@@ -3,10 +3,38 @@ package app.skerry.shared.terminal
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /** Focused tests of the pure [CharMetrics] API; grid behavior is covered via TerminalEmulatorTest. */
 class CharMetricsTest {
+
+    @Test
+    fun `printable ascii resolves to one shared instance per char`() {
+        // feed() calls codePointToString once per printed character: streaming plain text must
+        // not allocate a fresh one-char String per byte.
+        assertSame(CharMetrics.codePointToString('a'.code), CharMetrics.codePointToString('a'.code))
+        assertSame(CharMetrics.codePointToString(0x20), CharMetrics.codePointToString(0x20))
+        assertSame(CharMetrics.codePointToString(0x7E), CharMetrics.codePointToString(0x7E))
+        assertEquals("a", CharMetrics.codePointToString('a'.code))
+        assertEquals("~", CharMetrics.codePointToString(0x7E))
+    }
+
+    @Test
+    fun `box-drawing glyphs resolve to one shared instance per char`() {
+        // TUI borders (tmux, mc, htop) repeat these across whole rows.
+        assertSame(CharMetrics.codePointToString(0x2500), CharMetrics.codePointToString(0x2500))
+        assertSame(CharMetrics.codePointToString(0x257F), CharMetrics.codePointToString(0x257F))
+        assertEquals("\u2500", CharMetrics.codePointToString(0x2500))
+    }
+
+    @Test
+    fun `table boundaries fall through to the general branch`() {
+        assertEquals("\u001F", CharMetrics.codePointToString(0x1F))
+        assertEquals("\u007F", CharMetrics.codePointToString(0x7F))
+        assertEquals("\u24FF", CharMetrics.codePointToString(0x24FF))
+        assertEquals("\u2580", CharMetrics.codePointToString(0x2580))
+    }
 
     @Test
     fun `width is 2 for CJK and emoji, 1 for latin`() {

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
@@ -1460,4 +1460,94 @@ class TerminalEmulatorTest {
         assertEquals(4, emu.lines.size)
         assertEquals("", emu.asText())
     }
+
+    // Snapshot identity: the render layer compares snapshots by identity (not structurally), so
+    // [TerminalEmulator.lines] must return the SAME instance while nothing visible mutated and a
+    // NEW one after any cell, wrap-flag, scrollback or geometry change.
+
+    @Test
+    fun `a cursor-only move keeps the snapshot instance`() {
+        val emu = emulate(chunks = arrayOf("hello"))
+        val before = emu.lines
+        emu.feed("${esc}[H".encodeToByteArray())
+        assertTrue(before === emu.lines)
+    }
+
+    @Test
+    fun `printing replaces the snapshot instance`() {
+        val emu = emulate(chunks = arrayOf("hello"))
+        val before = emu.lines
+        emu.feed("x".encodeToByteArray())
+        assertFalse(before === emu.lines)
+    }
+
+    @Test
+    fun `clearing a soft wrap replaces the snapshot even when no cell changes`() {
+        // 中 does not fit in the last column: row 0 is wrapped, its column 3 blank. EL from that
+        // blank column changes no cell, only the wrap flag - identity must still change, or the
+        // render layer's link joining reads stale flags.
+        val emu = emulate(cols = 4, rows = 4, chunks = arrayOf("ABC中"))
+        val before = emu.lines
+        emu.feed("${esc}[1;4H${esc}[K".encodeToByteArray())
+        assertFalse(before === emu.lines)
+    }
+
+    @Test
+    fun `scrolling replaces the snapshot instance`() {
+        val emu = emulate(cols = 10, rows = 2, chunks = arrayOf("a\r\nb"))
+        val before = emu.lines
+        emu.feed("\r\nc".encodeToByteArray())
+        assertFalse(before === emu.lines)
+    }
+
+    @Test
+    fun `resize replaces the snapshot instance`() {
+        val emu = emulate(chunks = arrayOf("hello"))
+        val before = emu.lines
+        emu.resize(100, 30)
+        assertFalse(before === emu.lines)
+    }
+
+    @Test
+    fun `every cell-mutating control sequence replaces the snapshot instance`() {
+        // The cache fails silently in exactly one direction - a mutator without markDirty freezes
+        // the screen - and single-read tests cannot see it. Each case reads the instance BEFORE
+        // the mutator, so a missed markDirty in any of them fails here.
+        fun assertReplaces(label: String, setup: String, mutator: String) {
+            val emu = emulate(cols = 10, rows = 4, chunks = arrayOf(setup))
+            val before = emu.lines
+            emu.feed(mutator.encodeToByteArray())
+            assertFalse(before === emu.lines, "expected a new snapshot after $label")
+        }
+        assertReplaces("ECH", "abc${esc}[1G", "${esc}[2X")
+        assertReplaces("ICH", "abc${esc}[1G", "${esc}[2@")
+        assertReplaces("DCH", "abc${esc}[1G", "${esc}[1P")
+        assertReplaces("IL", "a\r\nb${esc}[1;1H", "${esc}[1L")
+        assertReplaces("DL", "a\r\nb${esc}[1;1H", "${esc}[1M")
+        assertReplaces("RI at top scrolls down", "a${esc}[1;1H", "${esc}M")
+        assertReplaces("ED2 clear to scrollback", "abc", "${esc}[2J")
+        assertReplaces("EL", "abc${esc}[1G", "${esc}[K")
+        assertReplaces("RIS", "abc", "${esc}c")
+        assertReplaces("combining mark attach", "e", "́")
+    }
+
+    @Test
+    fun `shrinking scrollback on the fly replaces the snapshot instance`() {
+        val emu = TerminalEmulator(cols = 20, rows = 4)
+        emu.feedLines(1..50)
+        val before = emu.lines
+        emu.applyMaxScrollback(10)
+        assertFalse(before === emu.lines)
+    }
+
+    @Test
+    fun `entering and leaving the alternate screen replaces the snapshot instance`() {
+        val emu = emulate(chunks = arrayOf("hello"))
+        val before = emu.lines
+        emu.feed("${esc}[?1049h".encodeToByteArray())
+        val alt = emu.lines
+        assertFalse(before === alt)
+        emu.feed("${esc}[?1049l".encodeToByteArray())
+        assertFalse(alt === emu.lines)
+    }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalEmulatorTest.kt
@@ -1,11 +1,34 @@
 package app.skerry.shared.terminal
 
 import kotlin.test.Test
+import kotlin.test.assertSame
+import kotlin.test.assertNotSame
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class TerminalEmulatorTest {
+
+    @Test
+    fun `blank cells of an unchanged style share one instance`() {
+        // Erases and scrolls fill whole regions with blanks; allocating a TermCell+TermStyle per
+        // cell made every clear O(cols) garbage. TermCell is immutable, so sharing is safe.
+        val emu = TerminalEmulator(cols = 10, rows = 3)
+        emu.feed("x\u001b[K".encodeToByteArray())
+        val row = emu.lines[0]
+        assertSame(row[3], row[4])
+    }
+
+    @Test
+    fun `a style change produces a different blank`() {
+        val emu = TerminalEmulator(cols = 10, rows = 3)
+        emu.feed("\u001b[K".encodeToByteArray())
+        val plain = emu.lines[0][5]
+        emu.feed("\u001b[44m\u001b[K".encodeToByteArray())
+        val colored = emu.lines[0][5]
+        assertNotSame(plain, colored)
+        assertEquals(TermColor.Indexed(4), colored.style.bg)
+    }
 
     // ESC/BEL by number — no invisible control bytes in the source.
     private val esc = 27.toChar().toString()

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalSessionTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalSessionTest.kt
@@ -145,6 +145,20 @@ class TerminalSessionTest {
     }
 
     @Test
+    fun `close moves to closed even when the channel close throws`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher)
+        val session = ShellTerminalSession(CloseFailingShellChannel(), scope)
+
+        // The close failure surfaces to the caller, but the state must flip regardless: observers
+        // (auto-reconnect) key off Closed, and a session stuck Open would freeze the pane.
+        assertFailsWith<SshConnectionException> { session.close() }
+
+        assertEquals(TerminalState.Closed(cleanExit = false), session.state.value)
+        scope.cancel()
+    }
+
+    @Test
     fun `transport error closes session without crashing the scope and without cleanExit`() = runTest {
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val scope = CoroutineScope(dispatcher)
@@ -227,4 +241,15 @@ private class ThrowingShellChannel : ShellChannel {
     override suspend fun write(data: ByteArray) {}
     override suspend fun resize(size: PtySize) {}
     override suspend fun close() {}
+}
+
+/** Channel whose close itself fails — a socket already broken by the same fault being cleaned up. */
+private class CloseFailingShellChannel : ShellChannel {
+    override val isOpen: Boolean get() = true
+    override val output: Flow<ByteArray> = flow { }
+    override suspend fun write(data: ByteArray) {}
+    override suspend fun resize(size: PtySize) {}
+    override suspend fun close() {
+        throw SshConnectionException("close failed")
+    }
 }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
@@ -63,6 +63,17 @@ class SshjTransportTest {
     }
 
     @Test
+    fun `transport socket has nagle disabled`() = runTest {
+        val connection = connect()
+        try {
+            val socket = (connection as SshjConnection).transportSocket
+            assertTrue(socket != null && socket.tcpNoDelay)
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    @Test
     fun `exposes negotiated cipher after connect`() = runTest {
         val connection = connect()
         try {

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/TcpNoDelaySocketFactoryTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/TcpNoDelaySocketFactoryTest.kt
@@ -1,0 +1,30 @@
+package app.skerry.shared.ssh
+
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class TcpNoDelaySocketFactoryTest {
+
+    @Test
+    fun `unconnected socket has nagle disabled`() {
+        TcpNoDelaySocketFactory.createSocket().use { socket ->
+            assertTrue(socket.tcpNoDelay)
+        }
+    }
+
+    @Test
+    fun `connected socket variants have nagle disabled`() {
+        ServerSocket(0, 1, InetAddress.getLoopbackAddress()).use { server ->
+            val host = server.inetAddress.hostAddress
+            val port = server.localPort
+            TcpNoDelaySocketFactory.createSocket(host, port).use { socket ->
+                assertTrue(socket.tcpNoDelay)
+            }
+            TcpNoDelaySocketFactory.createSocket(server.inetAddress, port).use { socket ->
+                assertTrue(socket.tcpNoDelay)
+            }
+        }
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjConnection.kt
@@ -35,6 +35,10 @@ internal class SshjConnection(
     override val isConnected: Boolean
         get() = client.isConnected && client.isAuthenticated
 
+    // Test-only view of the transport socket: the TCP_NODELAY wiring (TcpNoDelaySocketFactory
+    // installed in dial()) is not observable from the peer, so the test asserts on the socket.
+    internal val transportSocket: java.net.Socket? get() = client.socket
+
     override suspend fun exec(command: String): ExecResult = withContext(Dispatchers.IO) {
         try {
             // Entire exec is under a timeout: otherwise a server process that hangs without closing

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -115,12 +115,13 @@ class SshjTransport(
                 .also { authenticate(it, next.username, next.auth, hop = true, host = next.host, port = next.port) }
         }
         val client = SSHClient(sshjConfig())
-        // TCP connect timeout: sshj's default is 0 = wait forever. Without this, "Test
-        // connection" to a nonexistent/firewalled address hangs with no way to cancel from the
-        // UI. (Protocol-level KEX/I-O timeout is separate, sshj default ~30s; round-trip ping
-        // is its own thing.) For a connectVia hop the TCP dial happened upstream; the timeout is
-        // harmless there.
+        // TCP connect timeout (see the constant's doc). Protocol-level KEX/I-O timeout is
+        // separate, sshj default ~30s; round-trip ping is its own thing. For a connectVia hop
+        // the TCP dial happened upstream; the timeout is harmless there.
         client.connectTimeout = CONNECT_TIMEOUT_MILLIS
+        // Keystroke latency: see TcpNoDelaySocketFactory. Only the entry-point client owns a TCP
+        // socket (hops ride upstream direct-tcpip channels, where setting it is a no-op).
+        client.socketFactory = TcpNoDelaySocketFactory
         configure(client)
         val hostKeyRefused = installHostKeyVerifier(client)
         opened += client
@@ -292,10 +293,6 @@ class SshjTransport(
         } catch (e: IOException) {
             throw SshConnectionException("Connection dropped during authentication", e)
         }
-    }
-
-    private companion object {
-        const val CONNECT_TIMEOUT_MILLIS = 10_000
     }
 }
 

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/TcpNoDelaySocketFactory.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/TcpNoDelaySocketFactory.kt
@@ -1,0 +1,55 @@
+package app.skerry.shared.ssh
+
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.Socket
+import javax.net.SocketFactory
+
+/**
+ * TCP connect timeout for the SSH transport. sshj's own default is 0 = wait forever; without a cap,
+ * "Test connection" to a nonexistent/firewalled address hangs with no way to cancel from the UI.
+ */
+internal const val CONNECT_TIMEOUT_MILLIS = 10_000
+
+/**
+ * Socket factory for the SSH transport with Nagle's algorithm off.
+ *
+ * Interactive SSH traffic is many small packets — one per keystroke — and Nagle holds each one back
+ * until the previous segment is ACKed, adding up to one RTT of typing latency on WAN links. OpenSSH
+ * disables it for interactive sessions for exactly this reason; sshj keeps the JVM default (Nagle
+ * on) and its SocketClient has no knob for it, so the factory is the supported way in. Forwarded
+ * sockets already set the flag (see SshjForwards) — this brings the transport itself in line.
+ *
+ * sshj only ever calls the no-arg [createSocket] (then `socket.connect(addr, connectTimeout)`).
+ * The connecting overloads still route through it and connect under [CONNECT_TIMEOUT_MILLIS]:
+ * the eagerly-connecting `Socket(host, port)` constructors have no timeout at all, and an sshj
+ * upgrade that switched overloads would otherwise silently reintroduce the indefinite hang the
+ * timeout exists to kill.
+ */
+internal object TcpNoDelaySocketFactory : SocketFactory() {
+
+    override fun createSocket(): Socket = Socket().apply { tcpNoDelay = true }
+
+    override fun createSocket(host: String, port: Int): Socket =
+        connected(InetSocketAddress(host, port), local = null)
+
+    override fun createSocket(host: String, port: Int, localHost: InetAddress, localPort: Int): Socket =
+        connected(InetSocketAddress(host, port), InetSocketAddress(localHost, localPort))
+
+    override fun createSocket(host: InetAddress, port: Int): Socket =
+        connected(InetSocketAddress(host, port), local = null)
+
+    override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress, localPort: Int): Socket =
+        connected(InetSocketAddress(address, port), InetSocketAddress(localAddress, localPort))
+
+    private fun connected(remote: InetSocketAddress, local: InetSocketAddress?): Socket =
+        createSocket().apply {
+            try {
+                local?.let(::bind)
+                connect(remote, CONNECT_TIMEOUT_MILLIS)
+            } catch (e: Exception) {
+                runCatching { close() }
+                throw e
+            }
+        }
+}


### PR DESCRIPTION
Fixes the terminal's input-to-glass latency and steady-state overhead found by a full rendering/responsiveness audit. Nine changes, one commit each, ordered transport → feed pipeline → draw path.

## What changed

1. **TCP_NODELAY on the SSH socket** (`b324a653`) — sshj has no knob for it, so a `SocketFactory` sets it on every socket it creates. Interactive keystrokes no longer wait out Nagle's algorithm on high-RTT links.
2. **Bounded PTY→emulator channel** (`35738af8`) — a semaphore (64 chunks) between the socket reader and the emulator; a server flooding output now backpressures the socket instead of growing an unbounded in-memory backlog. Session teardown returns permits, and a failed shell-channel close no longer leaks the reader.
3. **Frame-capped snapshot publishes** (`e60078ed`) — the emulator publishes at most one snapshot per 16 ms window; a burst of small writes coalesces into one recomposition instead of dozens.
4. **Bounded drain quota** (`77663fd9`) — the emulator owner drains at most a frame window's worth of parsing before it must publish and yield, so a flood cannot starve the UI of publishes (and Ctrl+C stays responsive).
5. **Identity-based snapshot comparison** (`56ab63dd`) — the emulator keeps a content version and a cached snapshot instance; the UI compares snapshots by reference instead of deep-equality over the whole grid on every publish.
6. **Highlight decoupled from the cursor** (`6af45d1e`) — the syntax-highlight window scan is split into a content-keyed background pass and a small cursor-keyed live-line overlay; arrow keys and history recall no longer rescan every visible row.
7. **Link scan hoisted out of the draw phase** (`6ea3d041`) — bare-URL detection runs once per content change in composition, not on every repaint of a selection drag.
8. **Cursor blink in the draw phase** (`fce55d59`) — the blink phase is a `State` read only inside the cursor overlay's draw lambda; an idle pane no longer recomposes the whole screen twice a second. Review of the overlay surfaced and fixed concealed-text (SGR 8) leaks: hidden glyphs render as `Color.Transparent` (after `dim`, which otherwise repainted them at 60 % alpha under selection/search washes), the block cursor no longer redraws a hidden glyph in the contrast color, link underlines skip concealed cells, and hit-testing refuses them — a bare URL or file path whose span covers any hidden cell is dropped whole, so a visible `https://example.com` prefix cannot open a concealed `.evil.tld` tail. OSC 8 hyperlinks stay per-cell (their target is never on-screen).
9. **Allocation tail** (`96d5a2cd`) — shared string instances for printable ASCII and box-drawing glyphs (one allocation per printed byte before), shared blank-cell instances on erase/scroll, per-row glyph-run memoization across repaints (512-row cap), and an identity-keyed cache for the autocomplete token scan that ran O(history×words) per keystroke (single `@Volatile` holder — the scan is reached from both the typing and the publish paths).

Every change is TDD'd: failing test first, then the fix, then the test re-run with the fix reverted to prove it catches the regression. Each commit passed the full gate (tests, build+lint, detekt, Android compile) and a seven-reviewer fan-out (project rules, Kotlin/Compose, security, silent failures, test coverage, performance, a11y) with all findings fixed or dispositioned below.

## How to verify by eye

- **Typing over a high-RTT link**: latency between keystroke and echo should drop noticeably (Nagle removed).
- **`cat` a multi-MB file, or `yes` with a full scrollback**: output streams smoothly, the UI never freezes, and Ctrl+C interrupts promptly.
- **Arrow keys / history recall on a highlighted prompt**: no hitching on long scrollback.
- **Selection drag over long output**: smooth at 60 fps; link underlines and highlighting unchanged.
- **Idle panes**: cursor blinks without waking the rest of the screen (battery on laptops/Android).
- **Concealed text**: `echo -e "\e[8msecret\e[0m"` — the text stays invisible under selection, search washes and the block cursor; `echo -e "\e[8mhttps://example.com\e[0m"` gets no underline and no Ctrl+click.

## Not verified live

- No real WAN/high-latency link was tested; the TCP_NODELAY effect is verified at the socket-option level and by unit tests only.
- Android on a physical device (all changes are commonMain and `:androidApp:compileDebugKotlin` is green, but no on-device run).
- Screen-reader interaction: terminal text was not exposed to AT before this branch and still is not (pre-existing gap, unchanged).

## Reviewer findings consciously not acted on

- **Selection/clipboard copies concealed (SGR 8) text** — pre-existing, deliberate xterm-parity behavior; on mobile the Open-path chip shows the full resolved path (tail included) before the tap. Fixing it needs cell-style plumbing through `TerminalSelection`; out of this branch's scope.
- **OS reduced-motion auto-detection for cursor blink** — pre-existing gap; blink is already configurable per profile.
- **Glyph-run cache's 512-row cap branch has no test** — statically verified by three reviewers; a test needs a scroll-driving helper and a cache-size gauge; noted as follow-up if the cache is touched again.
- **`HashMap<Int, …>` boxes its key** (~40 boxed `Integer`s per frame on the hit path) — orders of magnitude below the segmentation-and-list churn the cache removes; an array-indexed design was not worth the complexity.
- **Highlighted rows re-segment when the scroll window shifts** — `backgroundHighlightRows` rebuilds highlight instances per window; pre-existing behavior, the cache still covers same-window repaints (drag, blink, momentum).
- Minor per-item test suggestions (transport-factory overload tests, an 18-read budget assertion, a slot-reuse coincidence render test, a stronger recalled-command assertion, a boundary-row render test, hidden+strikethrough combination, `forget()`-invalidation, blankCell a→b→a reuse) — each rejected with the reviewer's concurrence as testing either the framework itself or a path already pinned by an equivalent test.
- A deterministic test for the token-cache tearing fix is not feasible; the single-`@Volatile`-holder shape is the fix, mirroring `CommandHistory.State`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)