### PR TITLE
Document each template variable on its own row (#256)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -105,6 +105,7 @@
     <string name="lib_snippet_vars_clipboard">Буфер обмена</string>
     <string name="lib_snippet_vars_clipboard_empty">(пусто)</string>
     <string name="lib_snippet_vars_vault">Секреты хранилища</string>
+    <string name="lib_snippet_vars_vault_unnamed">(непечатаемое имя)</string>
     <string name="lib_snippet_vars_vault_missing">В хранилище нет пароля с именем «%1$s»</string>
     <string name="lib_snippet_vars_vault_not_password">Запись «%1$s» в хранилище — не пароль</string>
     <string name="lib_snippet_vars_secret_note">Секреты вставляются открытым текстом — они видны на экране, в прокрутке и в истории shell.</string>
@@ -287,9 +288,11 @@
     <string name="lib_snippets_help_title">Сниппеты</string>
     <string name="lib_snippets_help_intro">Сниппет — одна команда, отправляемая в активную сессию. Плейсхолдеры ${{…}} раскрываются при запуске; подтверждение показывает точную строку до отправки.</string>
     <string name="lib_snippets_help_vars">Переменные</string>
-    <string name="lib_snippets_help_var_date">дата, время и Unix-время запуска; токены формата после двоеточия (YYYY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_date">дата запуска, YYYY-MM-DD; токены формата после двоеточия (YYYY, YY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_time">время запуска, HH:mm:ss; токены формата после двоеточия (HH, mm, ss, YYYY, YY, MM, DD)</string>
+    <string name="lib_snippets_help_var_timestamp">Unix-время запуска, в секундах</string>
     <string name="lib_snippets_help_var_uuid">случайный UUID</string>
-    <string name="lib_snippets_help_var_random">случайные символы; длина и набор после двоеточия — alnum, hex или special; неизвестное имя откатывается к набору по умолчанию</string>
+    <string name="lib_snippets_help_var_random">случайные символы; длина (не больше 64) и набор после двоеточия — alnum, hex или special; неизвестное имя откатывается к набору по умолчанию</string>
     <string name="lib_snippets_help_var_clipboard">системный буфер обмена, читается один раз при подтверждении</string>
     <string name="lib_snippets_help_var_vault">пароль из хранилища по имени записи</string>
     <string name="lib_snippets_help_var_param">любое другое имя запрашивает значение перед запуском; часть после двоеточия — предзаполненное значение</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -102,6 +102,7 @@
     <string name="lib_snippet_vars_clipboard">剪贴板</string>
     <string name="lib_snippet_vars_clipboard_empty">（空）</string>
     <string name="lib_snippet_vars_vault">保险库密钥</string>
+    <string name="lib_snippet_vars_vault_unnamed">（无法显示的名称）</string>
     <string name="lib_snippet_vars_vault_missing">保险库中没有名为“%1$s”的密码</string>
     <string name="lib_snippet_vars_vault_not_password">保险库条目“%1$s”不是密码</string>
     <string name="lib_snippet_vars_secret_note">密钥以明文形式插入命令——会显示在屏幕、回滚缓冲区和 shell 历史中。</string>
@@ -284,9 +285,11 @@
     <string name="lib_snippets_help_title">代码片段</string>
     <string name="lib_snippets_help_intro">片段是发送到当前会话的一条命令。${{…}} 占位符在运行时解析；确认框会在发送前显示确切的命令行。</string>
     <string name="lib_snippets_help_vars">变量</string>
-    <string name="lib_snippets_help_var_date">运行时的日期、时间和 Unix 时间戳；冒号后为格式标记（YYYY、MM、DD、HH、mm、ss）</string>
+    <string name="lib_snippets_help_var_date">运行日期，YYYY-MM-DD；冒号后为格式标记（YYYY、YY、MM、DD、HH、mm、ss）</string>
+    <string name="lib_snippets_help_var_time">运行时间，HH:mm:ss；冒号后为格式标记（HH、mm、ss、YYYY、YY、MM、DD）</string>
+    <string name="lib_snippets_help_var_timestamp">运行时的 Unix 时间，单位为秒</string>
     <string name="lib_snippets_help_var_uuid">随机 UUID</string>
-    <string name="lib_snippets_help_var_random">随机字符；冒号后为长度和字符集 — alnum、hex 或 special；未知名称回退到默认字符集</string>
+    <string name="lib_snippets_help_var_random">随机字符；冒号后为长度（最多 64）和字符集 — alnum、hex 或 special；未知名称回退到默认字符集</string>
     <string name="lib_snippets_help_var_clipboard">系统剪贴板，确认时读取一次</string>
     <string name="lib_snippets_help_var_vault">按条目名称取保险库中的密码</string>
     <string name="lib_snippets_help_var_param">其他任意名称会在运行前询问取值；冒号后的部分为预填默认值</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -103,6 +103,7 @@
     <string name="lib_snippet_vars_clipboard">Clipboard</string>
     <string name="lib_snippet_vars_clipboard_empty">(empty)</string>
     <string name="lib_snippet_vars_vault">Vault secrets</string>
+    <string name="lib_snippet_vars_vault_unnamed">(unprintable name)</string>
     <string name="lib_snippet_vars_vault_missing">No password named “%1$s” in the vault</string>
     <string name="lib_snippet_vars_vault_not_password">Vault entry “%1$s” is not a password</string>
     <string name="lib_snippet_vars_secret_note">Secrets are inserted as plain text — visible on screen, in scrollback and in shell history.</string>
@@ -286,9 +287,11 @@
     <string name="lib_snippets_help_title">Snippets</string>
     <string name="lib_snippets_help_intro">A snippet is one command sent to the active session. ${{…}} placeholders resolve when it runs; the confirmation shows the exact line before anything is sent.</string>
     <string name="lib_snippets_help_vars">Variables</string>
-    <string name="lib_snippets_help_var_date">date, time and Unix timestamp of the run; format tokens after a colon (YYYY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_date">date of the run, YYYY-MM-DD; format tokens after a colon (YYYY, YY, MM, DD, HH, mm, ss)</string>
+    <string name="lib_snippets_help_var_time">time of the run, HH:mm:ss; format tokens after a colon (HH, mm, ss, YYYY, YY, MM, DD)</string>
+    <string name="lib_snippets_help_var_timestamp">Unix time of the run, in seconds</string>
     <string name="lib_snippets_help_var_uuid">random UUID</string>
-    <string name="lib_snippets_help_var_random">random characters; length and charset after the colon — alnum, hex or special; an unknown name falls back to the default set</string>
+    <string name="lib_snippets_help_var_random">random characters; length (64 at most) and charset after the colon — alnum, hex or special; an unknown name falls back to the default set</string>
     <string name="lib_snippets_help_var_clipboard">system clipboard, read once at the confirmation</string>
     <string name="lib_snippets_help_var_vault">password from the vault, by entry name</string>
     <string name="lib_snippets_help_var_param">any other name asks for a value before the run; the part after the colon is the prefilled default</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
@@ -65,6 +65,13 @@ object UiTags {
     const val HELP_DIALOG: String = "nav.helpDialog"
 
     /**
+     * A help syntax row and the mono badge inside it; both repeat, one per row, in row order. The
+     * badge tag sits outside its padding, so what it measures is the badge as drawn.
+     */
+    const val HELP_ROW: String = "nav.helpDialog.row"
+    const val HELP_CODE: String = "nav.helpDialog.code"
+
+    /**
      * Command box of a runbook step. The steps are a repeating list, not captioned fields, so there
      * is no label to name them after; the tag repeats per step, in step order.
      */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/HelpDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/HelpDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -66,13 +67,20 @@ fun HelpDialog(title: String, closeLabel: String, onDismiss: () -> Unit, content
 @Composable
 fun HelpCodeRow(code: String, description: String) {
     Row(
-        Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        // One entry, one accessibility node: read as two, the placeholder announces as
+        // "$ { { date } }" and what it does arrives a swipe later with nothing tying them together.
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = 3.dp)
+            .semantics(mergeDescendants = true) {}
+            .testTag(UiTags.HELP_ROW),
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Txt(
             code, color = Skerry.colors.cyanBright, size = 11.5.sp, font = LocalFonts.current.mono,
             modifier = Modifier
+                .testTag(UiTags.HELP_CODE)
                 .clip(RoundedCornerShape(5.dp))
                 .background(Skerry.colors.terminalBg)
                 .padding(horizontal = 7.dp, vertical = 3.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetHelp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetHelp.kt
@@ -20,6 +20,8 @@ import app.skerry.ui.generated.resources.lib_snippets_help_var_clipboard
 import app.skerry.ui.generated.resources.lib_snippets_help_var_date
 import app.skerry.ui.generated.resources.lib_snippets_help_var_param
 import app.skerry.ui.generated.resources.lib_snippets_help_var_random
+import app.skerry.ui.generated.resources.lib_snippets_help_var_time
+import app.skerry.ui.generated.resources.lib_snippets_help_var_timestamp
 import app.skerry.ui.generated.resources.lib_snippets_help_var_uuid
 import app.skerry.ui.generated.resources.lib_snippets_help_var_vault
 import app.skerry.ui.generated.resources.lib_snippets_help_vars
@@ -57,7 +59,11 @@ val SNIPPET_HELP_EXAMPLES: List<SnippetDraft> = listOf(
 @Composable
 fun TemplateVariableHelpRows() {
     FieldLabel(stringResource(Res.string.lib_snippets_help_vars))
-    HelpCodeRow("\${{date}} · \${{time}} · \${{timestamp}}", stringResource(Res.string.lib_snippets_help_var_date))
+    // One placeholder per row: three in one badge left the description a two-word column at the
+    // right edge of a phone-width dialog (issue #256).
+    HelpCodeRow("\${{date}}", stringResource(Res.string.lib_snippets_help_var_date))
+    HelpCodeRow("\${{time}}", stringResource(Res.string.lib_snippets_help_var_time))
+    HelpCodeRow("\${{timestamp}}", stringResource(Res.string.lib_snippets_help_var_timestamp))
     HelpCodeRow("\${{uuid}}", stringResource(Res.string.lib_snippets_help_var_uuid))
     HelpCodeRow("\${{random:16,hex}}", stringResource(Res.string.lib_snippets_help_var_random))
     HelpCodeRow("\${{clipboard}}", stringResource(Res.string.lib_snippets_help_var_clipboard))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
@@ -47,6 +47,7 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.labelUppercase
+import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_clipboard_ref
@@ -245,9 +246,19 @@ private fun VariableRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Txt(variable.name, color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.weight(1f))
+        // A vault entry name is the whole text after `vault:` — unconstrained, and from a template
+        // that may have been shared; a parameter name is grammar-constrained but unbounded in
+        // length. Both are drawn through the filter the confirmation uses.
+        val label = if (variable.kind == SnippetVariableKind.VAULT) {
+            vaultEntryLabel(variable.name)
+        } else {
+            untrustedLabel(variable.name)
+        }
+        Txt(label, color = Skerry.colors.dim, size = 11.5.sp, modifier = Modifier.weight(1f))
         if (variable.editable) {
-            ParamInput(value, onValueChange, mono, Modifier.width(190.dp))
+            // The field sits outside a FormField, so it takes the caption beside it as its name
+            // explicitly — otherwise it is an unnamed input in a form that feeds a remote command.
+            ParamInput(value, onValueChange, mono, label, Modifier.width(190.dp))
         } else {
             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(5.dp)) {
                 Sym(if (variable.kind == SnippetVariableKind.VAULT) "lock" else "content_paste", size = 13.sp, color = Skerry.colors.faint)
@@ -262,7 +273,13 @@ private fun VariableRow(
 }
 
 @Composable
-private fun ParamInput(value: String, onValueChange: (String) -> Unit, mono: FontFamily, modifier: Modifier = Modifier) {
+private fun ParamInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    mono: FontFamily,
+    name: String,
+    modifier: Modifier = Modifier,
+) {
     val textColor = Skerry.colors.text
     val style = remember(mono, textColor) { TextStyle(color = textColor, fontSize = 11.5.sp, fontFamily = mono) }
     // The caller sanitizes what it stores, so the caret has to survive a value coming back
@@ -274,7 +291,7 @@ private fun ParamInput(value: String, onValueChange: (String) -> Unit, mono: Fon
         singleLine = true,
         textStyle = style,
         cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = modifier.fieldFocus(draft).fieldName(),
+        modifier = modifier.fieldFocus(draft).fieldName(fallback = name),
         decorationBox = { inner ->
             Box(
                 Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).background(Skerry.colors.bg)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
@@ -43,6 +43,7 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.rememberFieldDraft
+import app.skerry.ui.design.spaceLabel
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
@@ -51,6 +52,7 @@ import app.skerry.ui.generated.resources.lib_snippet_vars_clipboard_empty
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault_missing
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault_not_password
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unnamed
 import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.terminal.fetchSystemClipboardText
 import app.skerry.ui.theme.Skerry
@@ -91,6 +93,16 @@ internal fun maskSecrets(text: String, secrets: List<String>): String {
     }
     return masked
 }
+
+/**
+ * A `${'$'}{{vault:name}}` entry name as it may be drawn. The name comes from the template, which may
+ * have arrived from a team member: a bidi override in it would name one credential while another is
+ * looked up, in the row whose whole job is to say which secret goes into the command. A name that
+ * filters away to nothing gets a stand-in, or the row would name no entry at all.
+ */
+@Composable
+internal fun vaultEntryLabel(name: String): String =
+    spaceLabel(name, fallback = stringResource(Res.string.lib_snippet_vars_vault_unnamed))
 
 /** Vault reference resolution, done once when the confirmation opens. */
 internal sealed interface VaultRef {
@@ -212,7 +224,10 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
         key(name) {
             // The caption is the variable's own name, not chrome: `${{token}}` and `${{TOKEN}}` are
             // two different keys, and uppercasing the caption would draw and announce them alike.
-            FormField(name, uppercase = false) {
+            // The caption is also the field's accessible name. The parser bounds what a name may
+            // contain but not how long it is: unfiltered, a shared template could push the preview
+            // and the Run button out of the dialog with one very long parameter.
+            FormField(untrustedLabel(name), uppercase = false) {
                 val choices = values.paramChoices[name]
                 if (choices != null) {
                     DropdownField(
@@ -257,18 +272,19 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
         FieldLabel(stringResource(Res.string.lib_snippet_vars_vault))
         values.vaultRefs.forEach { name ->
             key(name) {
+                val shown = vaultEntryLabel(name)
                 when (values.vaultResolutions[name]) {
                     is VaultRef.Ok -> Row(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        Txt(name, color = Skerry.colors.text, size = 11.5.sp, font = mono)
+                        Txt(shown, color = Skerry.colors.text, size = 11.5.sp, font = mono)
                         Txt(SECRET_MASK, color = Skerry.colors.faint, size = 11.5.sp, font = mono)
                     }
                     VaultRef.NotAPassword ->
-                        Txt(stringResource(Res.string.lib_snippet_vars_vault_not_password, name), color = Skerry.colors.sunset, size = 11.5.sp)
+                        Txt(stringResource(Res.string.lib_snippet_vars_vault_not_password, shown), color = Skerry.colors.sunset, size = 11.5.sp)
                     else ->
-                        Txt(stringResource(Res.string.lib_snippet_vars_vault_missing, name), color = Skerry.colors.sunset, size = 11.5.sp)
+                        Txt(stringResource(Res.string.lib_snippet_vars_vault_missing, shown), color = Skerry.colors.sunset, size = 11.5.sp)
                 }
             }
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileHelpDialogTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileHelpDialogTest.kt
@@ -1,15 +1,21 @@
 package app.skerry.ui.mobile
 
+import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import app.skerry.ui.app.MobileRoute
 import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.MobileShell
 import app.skerry.ui.desktop.runMobileShell
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
@@ -17,9 +23,11 @@ import app.skerry.ui.generated.resources.help_add
 import app.skerry.ui.generated.resources.help_added
 import app.skerry.ui.generated.resources.help_button
 import app.skerry.ui.generated.resources.help_close
+import app.skerry.ui.generated.resources.lib_snippets_help_var_timestamp
 import app.skerry.ui.snippet.SNIPPET_HELP_EXAMPLES
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * The phone's help dialog: same composable as the desktop one, but reached through
@@ -30,11 +38,7 @@ class MobileHelpDialogTest {
 
     @Test
     fun `a snippet example is added from the phone's help dialog`() = runMobileShell { shell ->
-        shell.state.push(MobileRoute.Snippets)
-        waitForIdle()
-
-        onNodeWithText(string(Res.string.help_button)).performClick()
-        waitForIdle()
+        openHelp(shell, MobileRoute.Snippets)
         onNodeWithTag(UiTags.HELP_DIALOG).assertIsDisplayed()
 
         // The examples sit below the fold of the dialog's scroll on a phone-sized scene; a click
@@ -54,5 +58,86 @@ class MobileHelpDialogTest {
 
         onNodeWithText(string(Res.string.help_close)).performClick()
         waitForIdle()
+    }
+
+    /**
+     * Issue #256: a syntax badge that eats the row leaves the description a two-word column at the
+     * right edge. Measured on both dialogs that draw those rows, on the phone width where it breaks
+     * first: the badge and its description are read from the same row, so the share is of the space
+     * the row actually has, not of the padded card around it.
+     */
+    @Test
+    fun `no syntax badge crowds its description on a phone`() = runMobileShell { shell ->
+        // Snippets and runbooks: the third dialog drawing these rows (the vault's) opens only over a
+        // live credential controller, which the phone harness does not seed.
+        listOf(MobileRoute.Snippets, MobileRoute.Runbooks).forEach { route ->
+            openHelp(shell, route)
+            val rows = onAllNodesWithTag(UiTags.HELP_ROW, useUnmergedTree = true).fetchSemanticsNodes()
+            assertTrue(rows.isNotEmpty(), "$route documents its syntax in help rows")
+            val crowded = rows
+                // The row itself carries no text in the unmerged tree — name the offender by its badge.
+                .map { row -> row.children.first().text() to row.descriptionShare() }
+                .filter { (_, share) -> share < MIN_DESCRIPTION_SHARE_PERCENT }
+            assertEquals(emptyList(), crowded, "$route: descriptions under $MIN_DESCRIPTION_SHARE_PERCENT% of the row")
+            onNodeWithText(string(Res.string.help_close)).performClick()
+            waitForIdle()
+        }
+    }
+
+    /** Each moment placeholder is documented on its own row, so no badge has to carry three. */
+    @Test
+    fun `date, time and timestamp are separate rows`() = runMobileShell { shell ->
+        openHelp(shell, MobileRoute.Snippets)
+
+        val badges = onAllNodesWithTag(UiTags.HELP_CODE, useUnmergedTree = true)
+            .fetchSemanticsNodes()
+            .map { it.text() }
+        assertTrue(
+            badges.containsAll(listOf("\${{date}}", "\${{time}}", "\${{timestamp}}")),
+            "each moment placeholder has its own row, was $badges",
+        )
+    }
+
+    /**
+     * One row, one stop: a screen reader must announce the placeholder together with what it does.
+     * Split across two nodes, the badge reads as `$ { { timestamp } }` and its meaning arrives a
+     * swipe later, unattached — the same reason [app.skerry.ui.design.KeyValueRow] merges.
+     */
+    @Test
+    fun `a syntax row announces the placeholder with its description`() = runMobileShell { shell ->
+        openHelp(shell, MobileRoute.Snippets)
+
+        val description = string(Res.string.lib_snippets_help_var_timestamp)
+        val announced = onNodeWithText(description, substring = true).fetchSemanticsNode().text()
+        assertTrue(
+            announced.contains("\${{timestamp}}") && announced.contains(description),
+            "the row is one accessibility node, was \"$announced\"",
+        )
+    }
+
+    private fun ComposeUiTest.openHelp(shell: MobileShell, route: MobileRoute) {
+        shell.state.push(route)
+        waitForIdle()
+        onNodeWithText(string(Res.string.help_button)).performClick()
+        waitForIdle()
+    }
+
+    /** How much of the row is left for the description, in percent of the row's width. */
+    private fun SemanticsNode.descriptionShare(): Int {
+        val description = children.last()
+        return description.size.width * 100 / size.width
+    }
+
+    /** Everything the node carries as text — one badge, or a whole row once it is merged. */
+    private fun SemanticsNode.text(): String =
+        config.getOrNull(SemanticsProperties.Text).orEmpty().joinToString(" ") { it.text }
+
+    private companion object {
+        /**
+         * A description narrower than a quarter of its row wraps to the two-word column issue #256
+         * reported. The widest badge that survives the fix — `${'$'}{{env:dev|staging|prod}}` — leaves its
+         * description around a third of the row, so the floor is not a measurement of today's copy.
+         */
+        const val MIN_DESCRIPTION_SHARE_PERCENT = 25
     }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableVaultLabelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableVaultLabelTest.kt
@@ -1,0 +1,142 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.snippet.Snippet
+import app.skerry.ui.design.MAX_UNTRUSTED_LABEL_CHARS
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unnamed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * A `${{vault:name}}` entry name comes from the template, and a template can arrive from a team
+ * member. It names the credential about to be spliced into a remote command, so it is drawn through
+ * the same filter every other untrusted label uses: a right-to-left override in it would make the
+ * row read as one entry while another is looked up.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TemplateVariableVaultLabelTest {
+
+    // Escapes, not the raw glyphs: an invisible character in source is unreviewable.
+    private val reordered = "prod\u202Edb"
+    private val invisible = "stag\u200Bing"
+    private val notPassword = "web\u202D1"
+
+    /** Nothing of this name survives the filter — the row still has to name something. */
+    private val unprintable = "\u3164\u200B"
+
+    @Test
+    fun `the run confirmation filters a vault entry name before drawing it`() {
+        val values = TemplateVariableValues(
+            paramNames = emptyList(),
+            paramChoices = emptyMap(),
+            vaultRefs = listOf(reordered, invisible, notPassword, unprintable),
+            needsClipboard = false,
+            // All three draw sites: the resolved row and the two error sentences the name is
+            // spliced into.
+            vaultResolutions = mapOf(
+                reordered to VaultRef.Ok("s3cret"),
+                invisible to VaultRef.Missing,
+                notPassword to VaultRef.NotAPassword,
+                unprintable to VaultRef.Ok("s3cret"),
+            ),
+            params = mutableStateMapOf(),
+        )
+        runForm({ TemplateVariableFields(values, autoFocus = false) }) {
+            val drawn = drawnText()
+            assertTrue(drawn.any { it.contains("proddb") }, "the resolved entry is still named, was $drawn")
+            // The mask is the resolved row's own mark: the look-up still keys on the raw name, and
+            // only what is drawn was filtered.
+            assertEquals(2, drawn.count { it == SECRET_MASK }, "both resolved rows still draw, was $drawn")
+            assertTrue(drawn.none { it.hasFormatChars() }, "no formatting character reaches the screen, was $drawn")
+            assertTrue(
+                drawn.any { it.contains(string(Res.string.lib_snippet_vars_vault_unnamed)) },
+                "a name that filters away to nothing still names its row, was $drawn",
+            )
+        }
+    }
+
+    /**
+     * A parameter name is grammar-bound but not length-bound, and its caption is also the field's
+     * accessible name: unbounded, one shared template pushes the preview and the Run button out of
+     * the dialog.
+     */
+    @Test
+    fun `the run confirmation caps a parameter caption`() {
+        val long = "a".repeat(300)
+        val values = TemplateVariableValues(
+            paramNames = listOf(long),
+            paramChoices = emptyMap(),
+            vaultRefs = emptyList(),
+            needsClipboard = false,
+            vaultResolutions = emptyMap(),
+            params = mutableStateMapOf(),
+        )
+        runForm({ TemplateVariableFields(values, autoFocus = false) }) {
+            val drawn = drawnText()
+            assertTrue(drawn.any { it == untrustedLabel(long) }, "the caption is the filtered name")
+            assertTrue(drawn.none { it.length > MAX_UNTRUSTED_LABEL_CHARS }, "nothing longer is drawn, was $drawn")
+        }
+    }
+
+    /**
+     * The panel's parameter field sits outside a [app.skerry.ui.design.FormField], so it takes its
+     * name from the caption beside it explicitly — without that it is an unnamed input in a form
+     * whose values are spliced into a remote command.
+     */
+    @Test
+    fun `the run panel names its parameter field after the caption`() {
+        val snippet = Snippet(id = "s2", label = "Dump", command = "mysqldump \${{database}}")
+        runForm({
+            SnippetRunPanel(
+                entry = SnippetEntry(snippet),
+                targets = emptyList(),
+                activeTargetId = null,
+                mono = FontFamily.Monospace,
+                onRun = { _, _ -> true },
+                onCopy = {}, onEdit = {}, onDelete = {},
+            )
+        }) {
+            onNodeWithContentDescription("database").assertExists()
+        }
+    }
+
+    @Test
+    fun `the run panel filters a vault entry name before drawing it`() {
+        val snippet = Snippet(id = "s1", label = "Dump", command = "mysqldump -p\${{vault:$reordered}}")
+        runForm({
+            SnippetRunPanel(
+                entry = SnippetEntry(snippet),
+                targets = emptyList(),
+                activeTargetId = null,
+                mono = FontFamily.Monospace,
+                onRun = { _, _ -> true },
+                onCopy = {}, onEdit = {}, onDelete = {},
+            )
+        }) {
+            val drawn = drawnText()
+            // The command block quotes the template verbatim, which is a separate finding; the
+            // variables list is what names the credential, and that name is filtered.
+            assertTrue(drawn.any { it.contains("proddb") }, "the panel names the entry, was $drawn")
+        }
+    }
+
+    private fun ComposeUiTest.drawnText(): List<String> = onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
+
+    private fun String.hasFormatChars(): Boolean = any { it.category == CharCategory.FORMAT }
+
+    private fun SemanticsNode.allText(): List<String> =
+        config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } + children.flatMap { it.allText() }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/io/FileNames.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/io/FileNames.kt
@@ -1,11 +1,14 @@
 package app.skerry.shared.io
 
+import app.skerry.shared.snippet.INVISIBLE_LETTERS
+
 /**
  * Turns user data — a host label, a secret's name — into the stem of a file name a Save-As dialog
  * can be handed on any platform. A label may hold anything a person can type, including the two
  * spellings that stop being a name and start being a location: a separator and `..`.
  *
- * Everything that isn't a letter, digit, dash or underscore collapses to a dash; dots survive only
+ * Everything that isn't a letter, digit, dash or underscore collapses to a dash — as do the letters
+ * that draw as nothing, or two exports could offer names a Save-As dialog cannot tell apart; dots survive only
  * when [keepDots] (a host name is mostly dots), and never two in a row. The result is trimmed of
  * leading/trailing separators, cut to [maxLength], trimmed again — the cut can land on a separator —
  * lowercased when [lowercase], and falls back to [fallback] when nothing printable is left.
@@ -19,6 +22,9 @@ fun safeFileStem(
 ): String {
     val mapped = raw.map { ch ->
         when {
+            // The invisible letters pass isLetterOrDigit and draw as nothing, so two exports of
+            // different secrets could offer names a Save-As dialog cannot tell apart.
+            ch in INVISIBLE_LETTERS -> '-'
             ch.isLetterOrDigit() || ch == '-' || ch == '_' -> ch
             keepDots && ch == '.' -> ch
             else -> '-'

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetTemplate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetTemplate.kt
@@ -267,9 +267,12 @@ object SnippetTemplate {
             (alphabet ?: SnippetRandomAlphabets.DEFAULT)
     }
 
+    // The invisible letters are letters to `isLetterOrDigit`, so a shared template could carry two
+    // names that draw and announce identically — one prompted, the other spliced from its inline
+    // default without the user ever seeing a second field. Such a placeholder stays literal text.
     private fun isValidName(name: String): Boolean =
         name.isNotEmpty() && name.first().isLetter() &&
-            name.all { it.isLetterOrDigit() || it == '_' || it == '-' }
+            name.all { (it.isLetterOrDigit() || it == '_' || it == '-') && it !in INVISIBLE_LETTERS }
 
     private fun kindFor(name: String): SnippetVariableKind = when (name) {
         "date" -> SnippetVariableKind.DATE

--- a/shared/src/commonTest/kotlin/app/skerry/shared/io/FileNamesTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/io/FileNamesTest.kt
@@ -19,6 +19,15 @@ class FileNamesTest {
     }
 
     @Test
+    fun letters_that_draw_as_nothing_collapse_like_any_other_separator() {
+        // U+3164 is a letter to isLetterOrDigit but draws as nothing, so two exports of different
+        // secrets could offer file names the Save-As dialog cannot tell apart. Escaped, not the raw
+        // glyph — an invisible character in source is unreviewable.
+        assertEquals("prod-db", safeFileStem("prod\u3164db", fallback = "x"))
+        assertEquals("key", safeFileStem("\uFFA0", fallback = "key"))
+    }
+
+    @Test
     fun a_stem_with_nothing_printable_falls_back() {
         assertEquals("session", safeFileStem("   ", fallback = "session"))
         assertEquals("session", safeFileStem("///", fallback = "session"))

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetTemplateTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetTemplateTest.kt
@@ -92,6 +92,18 @@ class SnippetTemplateTest {
     }
 
     @Test
+    fun `a name carrying a character that draws as nothing stays literal`() {
+        // U+3164 is a letter, so the name rule accepted it: in a shared template the name with the
+        // filler and the name without it prompt for two values under one caption, and the one the
+        // user never fills is spliced from its inline default. Escaped, not the raw glyph — it
+        // draws as nothing, and an invisible character in source is unreviewable.
+        val filler = "echo ${'$'}{{token\u3164}}"
+        assertEquals(listOf(Literal(filler)), SnippetTemplate.parse(filler))
+        val blank = "echo ${'$'}{{\u3164}}"
+        assertEquals(listOf(Literal(blank)), SnippetTemplate.parse(blank))
+    }
+
+    @Test
     fun `shell syntax does not trigger parsing`() {
         assertFalse(SnippetTemplate.hasVariables("echo ${'$'}HOME ${'$'}{PATH} ${'$'}(date) ${'$'}${'$'}"))
     }


### PR DESCRIPTION
Closes #256.

The Variables block of the snippets and runbooks help dialog carried `${{date}}`, `${{time}}` and `${{timestamp}}` in one mono badge. On a phone that badge takes three quarters of the row, so the description beside it wraps into a two-word column at the right edge.

## What changed

- Each placeholder has its own row and its own description. The copy gained what the old sentence omitted: the `YY` token, the default formats (`YYYY-MM-DD`, `HH:mm:ss`), and the 64-character cap on `${{random:N}}`. All three locales.
- A help row is one accessibility node now, the way `KeyValueRow` already is — read as two, the placeholder announces as "$ { { date } }" and its meaning arrives a swipe later, unattached.

## Untrusted text on the same screens

- A `${{vault:name}}` entry name is everything after the colon, unvalidated, and a template can arrive from a team member. The confirmation rows and the run panel draw it through the untrusted-label filter, with a stand-in for a name that filters away to nothing. The lookup still keys on the raw name, so what resolves is unchanged.
- The placeholder name grammar accepted the letters that draw as nothing (Hangul fillers, blank braille), so a shared template could carry two names that render identically — one prompted, the other spliced from its inline default without a second field ever appearing. Such a placeholder stays literal text now, like every other malformed one.
- `safeFileStem` kept those same letters, so two exported keys could offer file names a Save-As dialog cannot tell apart.
- The run panel's inline parameter field sits outside a `FormField` and had no accessible name; it takes the caption beside it. The confirmation's caption is bounded in length, which the grammar is not.

## How to see it

Snippets → Help → Variables, on a phone-width window (and Runbooks → Help, which shares the block). The date/time/timestamp rows each keep their description on the left edge of the description column instead of a two-word ribbon at the right.

## Tests

`MobileHelpDialogTest` measures the badge and its description in the same row and requires the description to keep at least a quarter of it, across both dialogs that draw those rows; `TemplateVariableVaultLabelTest` covers the filtered names, the blank-name stand-in, the caption cap and the parameter field's accessible name; `SnippetTemplateTest` and `FileNamesTest` cover the invisible-letter rules. Every one of them was recorded failing before its fix.

Not verified live: Android on a device, other operating systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)