### PR TITLE
Give the Remote Desktops section a way to collapse its hosts panel

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_shell.xml
@@ -118,6 +118,7 @@
     <string name="shell_tip_close">Закрыть</string>
     <string name="shell_tip_show_options">Показать варианты</string>
     <string name="shell_tip_show_hosts">Показать хосты</string>
+    <string name="shell_tip_hide_hosts">Скрыть хосты</string>
     <string name="shell_tip_back">Назад</string>
     <string name="shell_tip_remove">Удалить</string>
     <string name="shell_tip_pause">Пауза</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -118,6 +118,7 @@
     <string name="shell_tip_close">关闭</string>
     <string name="shell_tip_show_options">显示选项</string>
     <string name="shell_tip_show_hosts">显示主机</string>
+    <string name="shell_tip_hide_hosts">隐藏主机</string>
     <string name="shell_tip_back">返回</string>
     <string name="shell_tip_remove">移除</string>
     <string name="shell_tip_pause">暂停</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -118,6 +118,7 @@
     <string name="shell_tip_close">Close</string>
     <string name="shell_tip_show_options">Show options</string>
     <string name="shell_tip_show_hosts">Show hosts</string>
+    <string name="shell_tip_hide_hosts">Hide hosts</string>
     <string name="shell_tip_back">Back</string>
     <string name="shell_tip_remove">Remove</string>
     <string name="shell_tip_pause">Pause</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalView.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.expandHorizontally
 import androidx.compose.animation.shrinkHorizontally
 import app.skerry.ui.design.EmptyState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Column
@@ -14,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -46,7 +44,6 @@ import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.connection.connectionErrorText
-import app.skerry.ui.design.Sym
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_connecting
 import app.skerry.ui.generated.resources.term_connection_failed
@@ -71,7 +68,6 @@ import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.host.isProdHostId
 import app.skerry.ui.host.prodOutline
-import app.skerry.ui.generated.resources.shell_tip_show_hosts
 
 /** Height of a pane's own header on a split grid; a single-pane tab is named by the [WorkBar]. */
 internal val PANE_HEADER_HEIGHT = 26.dp
@@ -202,29 +198,6 @@ private fun soloHostPicker(state: DesktopDesignState, tab: Tab?): ((Host) -> Uni
         // A pane that already holds a session is re-pointed only after a confirmation: the old
         // connection goes down with it. An empty pane has nothing to lose and connects straight away.
         if (pane.isBlank) connectPane(host, pane.id) else state.requestPaneConnect(tab.id, pane.id, host)
-    }
-}
-
-/**
- * Slim reopen strip shown at a view's left edge while the hosts sidebar is collapsed. Painted in
- * the sidebar's own surface so it reads as the panel peeking out; clicking it restores the panel.
- * The terminal reopens from the work bar's chevron instead; this is what the remote-desktop view
- * still uses, which has no bar of its own yet.
- */
-@Composable
-internal fun SidebarReopenHandle(onClick: () -> Unit) {
-    Box(
-        Modifier.width(16.dp).fillMaxHeight().background(Skerry.colors.surface2).clickable(onClick = onClick),
-        contentAlignment = Alignment.Center,
-    ) {
-        // The strip is the only way back to the sidebar on a remote-desktop view, and it draws
-        // nothing but a chevron — without a name it is a focusable element that says nothing.
-        Sym(
-            "chevron_right",
-            contentDescription = stringResource(Res.string.shell_tip_show_hosts),
-            size = 16.sp,
-            color = Skerry.colors.faint,
-        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vnc/VncView.kt
@@ -20,6 +20,7 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -71,6 +72,8 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.rd_no_session
 import app.skerry.ui.generated.resources.rd_pick_to_connect
+import app.skerry.ui.generated.resources.shell_tip_hide_hosts
+import app.skerry.ui.generated.resources.shell_tip_show_hosts
 import app.skerry.ui.generated.resources.vnc_connecting
 import app.skerry.ui.generated.resources.vnc_connection_lost
 import app.skerry.ui.generated.resources.vnc_quality_auto
@@ -80,7 +83,6 @@ import app.skerry.ui.generated.resources.vnc_quality_medium
 import app.skerry.ui.generated.resources.vnc_session_closed
 import app.skerry.ui.design.EmptyState
 import app.skerry.ui.terminal.HostsSidebar
-import app.skerry.ui.terminal.SidebarReopenHandle
 import app.skerry.ui.terminal.plainTextClipEntry
 import app.skerry.ui.terminal.readPlainText
 import app.skerry.ui.app.remoteChromeHidden
@@ -116,11 +118,14 @@ fun RemoteDesktopsView(state: DesktopDesignState) {
             // selected tab (see workAreaSection).
             HostsSidebar(state, state.section)
         }
+        // The section renders no work bar, so this strip is its only sidebar control — present
+        // whether the panel is open or shut, one click either way (issue #178). Only full-window
+        // mode takes it off screen, along with the rest of the chrome.
         AnimatedVisibility(
-            visible = state.sidebarHidden && !immersive,
+            visible = !immersive,
             enter = fadeIn() + expandHorizontally(expandFrom = Alignment.Start),
             exit = fadeOut() + shrinkHorizontally(shrinkTowards = Alignment.Start),
-        ) { SidebarReopenHandle(onClick = state::toggleSidebar) }
+        ) { SidebarToggleHandle(hidden = state.sidebarHidden, onClick = state::toggleSidebar) }
         Box(Modifier.weight(1f).fillMaxHeight()) {
             if (sessions?.activeDesktop != null) {
                 VncView(state)
@@ -133,6 +138,28 @@ fun RemoteDesktopsView(state: DesktopDesignState) {
                 )
             }
         }
+    }
+}
+
+/**
+ * Slim strip on the hosts panel's edge, painted in the panel's own surface so it reads as the panel
+ * peeking out. The chevron points the way the panel will travel, like the work bar's toggle does in
+ * the terminal section — and the strip is all chevron, so it carries the action's name itself.
+ */
+@Composable
+private fun SidebarToggleHandle(hidden: Boolean, onClick: () -> Unit) {
+    Box(
+        Modifier.width(16.dp).fillMaxHeight().background(Skerry.colors.surface2).clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Sym(
+            if (hidden) "chevron_right" else "chevron_left",
+            contentDescription = stringResource(
+                if (hidden) Res.string.shell_tip_show_hosts else Res.string.shell_tip_hide_hosts,
+            ),
+            size = 16.sp,
+            color = Skerry.colors.faint,
+        )
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/RemoteSidebarCollapseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/RemoteSidebarCollapseTest.kt
@@ -1,0 +1,85 @@
+package app.skerry.ui.desktop
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import app.skerry.shared.ssh.isVnc
+import app.skerry.shared.vnc.VncAuth
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.connection.connectionSubtitle
+import app.skerry.ui.connection.toTarget
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.shell_tip_hide_hosts
+import app.skerry.ui.generated.resources.shell_tip_show_hosts
+import app.skerry.ui.host.HostSection
+import app.skerry.ui.remote.RemoteDesktopUiState
+import kotlin.test.Test
+
+/**
+ * Issue #178: the Remote Desktops section had a handle to *re*open the hosts panel but nothing to
+ * collapse it — the only collapse control in the app was the terminal work bar's chevron, so giving
+ * a desktop session the full width meant a round trip through the terminal section.
+ *
+ * The desktops section renders no work bar, so the collapse control lives on the sidebar's own
+ * edge, symmetrical with the reopen handle that was already there.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RemoteSidebarCollapseTest {
+
+    /** No session open on purpose: the panel must collapse from the empty-state screen too. */
+    @Test
+    fun `the desktops section collapses and reopens its hosts panel in place`() = runDesktopShell(withSessions = false) { shell ->
+        onNodeWithTag(UiTags.railSection(HostSection.RemoteDesktops)).performClick()
+        waitForIdle()
+        onScreen(UiTags.HOST_SIDEBAR).assertIsDisplayed()
+
+        onNodeWithContentDescription(string(Res.string.shell_tip_hide_hosts)).performClick()
+        waitForIdle()
+        onScreen(UiTags.HOST_SIDEBAR).assertDoesNotExist()
+        check(shell.state.sidebarHidden) { "the collapse handle must drive the shared sidebar preference" }
+
+        onNodeWithContentDescription(string(Res.string.shell_tip_show_hosts)).performClick()
+        waitForIdle()
+        onScreen(UiTags.HOST_SIDEBAR).assertIsDisplayed()
+        check(!shell.state.sidebarHidden) { "reopening must flip the shared preference back" }
+    }
+
+    /**
+     * The other half of the handle's visibility rule: beside a live framebuffer it still toggles
+     * the panel, and only full-window mode takes it off screen — together with the rest of the
+     * chrome, whose way back is the desktop's floating bar, not this strip.
+     */
+    @Test
+    fun `full-window mode takes the handle with the rest of the chrome`() = runDesktopShell { shell ->
+        val sessions = checkNotNull(shell.sessions)
+        // Dialing the seeded VNC host over the fake session, the way the offscreen render does:
+        // a desktop lives in a tab of its own, so the section alone would show its empty state.
+        val desktop = shell.hosts.hosts.first { it.connectionType.isVnc }
+        checkNotNull(
+            sessions.openVnc(desktop.id, desktop.label, desktop.connectionSubtitle(), desktop.toTarget(), VncAuth.None),
+        ) { "fake VNC transport not wired" }
+        // The connect lands on the background scope, which waitForIdle does NOT wait for (see the
+        // seeded-session wait in ShellHarness). Without this the test can run entirely against the
+        // Connecting placeholder — never composing the framebuffer whose LocalLifecycleOwner read
+        // is the regression WithTestLifecycle exists to catch.
+        waitUntil("desktop session reaches Connected", timeoutMillis = 10_000) {
+            sessions.activeDesktop?.focusedPane?.vncController?.uiState is RemoteDesktopUiState.Connected
+        }
+        waitForIdle()
+
+        onNodeWithContentDescription(string(Res.string.shell_tip_hide_hosts)).performClick()
+        waitForIdle()
+        onScreen(UiTags.HOST_SIDEBAR).assertDoesNotExist()
+        check(shell.state.sidebarHidden) { "the handle must work beside a connected desktop too" }
+
+        shell.state.toggleRemoteImmersive()
+        waitForIdle()
+        onNodeWithContentDescription(string(Res.string.shell_tip_show_hosts)).assertDoesNotExist()
+
+        shell.state.exitRemoteImmersive()
+        waitForIdle()
+        onNodeWithContentDescription(string(Res.string.shell_tip_show_hosts)).assertIsDisplayed()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -3,6 +3,11 @@ package app.skerry.ui.desktop
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontFamily
 import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.LocalFonts
@@ -155,19 +160,21 @@ internal fun runDesktopShell(
             SkerryTheme {
                 // A live AI controller only so the settings panel offers its AI tab: without one the
                 // tab is hidden, and a walk over SETTINGS_NAV would silently skip an entry.
-                DesktopDesignApp(
-                    state = state,
-                    hosts = hosts,
-                    sessions = sessions,
-                    credentials = credentials,
-                    keyGenerator = keyGenerator,
-                    tunnels = tunnels,
-                    snippets = snippets,
-                    runbooks = runbooks,
-                    runbookRunner = runner,
-                    ai = ai,
-                    windowChrome = windowChrome,
-                )
+                WithTestLifecycle {
+                    DesktopDesignApp(
+                        state = state,
+                        hosts = hosts,
+                        sessions = sessions,
+                        credentials = credentials,
+                        keyGenerator = keyGenerator,
+                        tunnels = tunnels,
+                        snippets = snippets,
+                        runbooks = runbooks,
+                        runbookRunner = runner,
+                        ai = ai,
+                        windowChrome = windowChrome,
+                    )
+                }
             }
         }
         waitForIdle()
@@ -196,6 +203,22 @@ internal fun runDesktopShell(
         // A write already dispatched must not land in the next test's log.
         FakeShellInput.clear()
     }
+}
+
+/**
+ * A window-lifecycle owner for the test composition, pinned to STARTED. The real shell gets one
+ * from `Window`; `runComposeUiTest` provides none, and a connected remote desktop reads it
+ * ([app.skerry.ui.remote.ReportOutputVisibility]) — without an owner the first VNC frame throws.
+ * `createUnsafe` because there is no Android main thread to enforce here.
+ */
+@Composable
+private fun WithTestLifecycle(content: @Composable () -> Unit) {
+    val owner = remember {
+        object : LifecycleOwner {
+            override val lifecycle: LifecycleRegistry = LifecycleRegistry.createUnsafe(this)
+        }.also { it.lifecycle.currentState = Lifecycle.State.STARTED }
+    }
+    CompositionLocalProvider(LocalLifecycleOwner provides owner, content = content)
 }
 
 /** What a mobile test can reach behind the UI. */
@@ -242,16 +265,20 @@ internal fun runMobileShell(
                     CompositionLocalProvider(
                         LocalDensity provides Density(LocalDensity.current.density, fontScale),
                     ) {
-                        MobileDesignApp(
-                            deps = AppDependencies(
-                                hosts = hosts, snippets = snippets, tunnels = tunnels,
-                                runbooks = mobileRunbooks, runbookRunner = runner,
-                            ),
-                            state = state,
-                            sessions = sessions,
-                            // The AI screen draws only its header without a controller behind it.
-                            aiOverride = ai,
-                        )
+                        // Same lifecycle owner as the desktop shell: the mobile VNC screen reads it
+                        // too (MobileVncScreen -> ReportOutputVisibility).
+                        WithTestLifecycle {
+                            MobileDesignApp(
+                                deps = AppDependencies(
+                                    hosts = hosts, snippets = snippets, tunnels = tunnels,
+                                    runbooks = mobileRunbooks, runbookRunner = runner,
+                                ),
+                                state = state,
+                                sessions = sessions,
+                                // The AI screen draws only its header without a controller behind it.
+                                aiOverride = ai,
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #178.

## What

The Remote Desktops section had no control to collapse the left hosts panel — only a handle to *re*open it once hidden. The single collapse control in the app was the chevron in the terminal's work bar, so giving a desktop session the full width meant switching to the terminal, clicking the chevron there, and switching back.

The reopen-only strip (`SidebarReopenHandle`) is replaced by `SidebarToggleHandle`: a slim strip on the panel's own edge, present whether the panel is open or shut. The chevron points the way the panel will travel and the accessible name flips with it (`Hide hosts` / `Show hosts`, localized en/ru/zh). Full-window mode still takes the strip off screen together with the rest of the chrome; the floating bar remains the way back out of it. The handle drives the same shared `sidebarHidden` preference as the terminal's chevron, so the two sections stay in step. The orphaned `SidebarReopenHandle` is deleted in the same change.

Test-side, composing a *connected* remote desktop turned out to be impossible in the shell harness — `ReportOutputVisibility` reads `LocalLifecycleOwner`, which `runComposeUiTest` does not provide. The harness now pins a `STARTED` lifecycle owner around both shells, and the new tests cover: collapse/reopen from the empty-state screen, the same beside a live (fake) VNC framebuffer, and the handle disappearing/returning across full-window mode.

## How to verify

1. Open the Remote Desktops section with no session: a 16dp strip with a left chevron sits on the panel's right edge; clicking it collapses the panel, clicking the (now right-pointing) chevron brings it back.
2. Connect a VNC/RDP host and repeat — same behaviour beside the framebuffer.
3. Enter full-window mode from the floating bar: the strip disappears with the rest of the chrome and returns on exit.
4. Collapse the panel in the desktops section, switch to the terminal: the sidebar is collapsed there too (one shared preference, as before).

## Not verified

- Live on a real VNC/RDP server, real device — exercised only through the fake transport in tests.
- Windows/macOS: the code path is common; behaviour is expected to match Linux.