### PR TITLE
Bug sweep: twenty defects across terminal, protocols, vault, SSH, tunnels, sync, UI and server

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_conn.xml
@@ -100,6 +100,7 @@
 
     <string name="conn_tunnel_error_host_missing">Хост не найден</string>
     <string name="conn_tunnel_error_no_credential">Нет сохранённых учётных данных</string>
+    <string name="conn_tunnel_error_link_lost">Соединение потеряно</string>
 
     <string name="conn_serial_err_unsupported">На этом устройстве последовательные порты недоступны.</string>
     <string name="conn_serial_err_not_found">Порт %1$s не найден. Переподключите устройство или выберите другой порт.</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vtail.xml
@@ -25,6 +25,7 @@
     <string name="vtail_error_password_mismatch">Пароли не совпадают.</string>
     <string name="vtail_error_wrong_password">Неверный мастер-пароль.</string>
     <string name="vtail_error_corrupted">Файл хранилища повреждён или не читается.</string>
+    <string name="vtail_error_not_writable">Не удалось записать файл хранилища — проверьте права на папку и свободное место.</string>
     <string name="vtail_error_biometric_reset">Биометрия сброшена — войдите мастер-паролем.</string>
     <string name="vtail_error_biometric_failed">Биометрия не сработала — введите мастер-пароль.</string>
     <string name="vtail_error_biometric_locked_out">Биометрия заблокирована — введите мастер-пароль.</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -100,6 +100,7 @@
 
     <string name="conn_tunnel_error_host_missing">未找到主机</string>
     <string name="conn_tunnel_error_no_credential">没有已保存的凭据</string>
+    <string name="conn_tunnel_error_link_lost">连接已断开</string>
 
     <string name="conn_serial_err_unsupported">此设备不支持串口。</string>
     <string name="conn_serial_err_not_found">未找到端口 %1$s。请重新连接设备或选择其他端口。</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -25,6 +25,7 @@
     <string name="vtail_error_password_mismatch">密码不匹配。</string>
     <string name="vtail_error_wrong_password">主密码错误。</string>
     <string name="vtail_error_corrupted">保险库文件损坏或无法读取。</string>
+    <string name="vtail_error_not_writable">无法写入保险库文件 — 请检查文件夹权限和可用空间。</string>
     <string name="vtail_error_biometric_reset">生物识别已重置 — 请使用主密码登录。</string>
     <string name="vtail_error_biometric_failed">生物识别失败 — 请输入主密码。</string>
     <string name="vtail_error_biometric_locked_out">生物识别已锁定 — 请输入主密码。</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -100,6 +100,7 @@
 
     <string name="conn_tunnel_error_host_missing">Host not found</string>
     <string name="conn_tunnel_error_no_credential">No saved credential</string>
+    <string name="conn_tunnel_error_link_lost">Connection lost</string>
 
     <string name="conn_serial_err_unsupported">Serial ports are not available on this device.</string>
     <string name="conn_serial_err_not_found">Port %1$s not found. Reconnect the device or pick another port.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vtail.xml
@@ -25,6 +25,7 @@
     <string name="vtail_error_password_mismatch">Passwords don't match.</string>
     <string name="vtail_error_wrong_password">Wrong master password.</string>
     <string name="vtail_error_corrupted">The vault file is corrupted or unreadable.</string>
+    <string name="vtail_error_not_writable">Could not write the vault file — check the folder's permissions and free space.</string>
     <string name="vtail_error_biometric_reset">Biometrics were reset — sign in with your master password.</string>
     <string name="vtail_error_biometric_failed">Biometrics didn't work — enter your master password.</string>
     <string name="vtail_error_biometric_locked_out">Biometrics locked for now — enter your master password.</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiAssistantController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiAssistantController.kt
@@ -227,7 +227,8 @@ class AiAssistantController(
         error = null
         streaming = ""
         val gen = ++generation
-        val history = turns.map { AiMessage(it.role, it.text) }
+        // Bounded: the whole conversation is replayed on every question (see clampAiHistory).
+        val history = clampAiHistory(turns.map { AiMessage(it.role, it.text) })
         val messages = listOf(AiMessage(AiRole.SYSTEM, SYSTEM_PROMPT)) + history
         job = runner.launch(
             endpoint = route.endpoint,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiContext.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiContext.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.ai
 
+import app.skerry.shared.ai.AiMessage
+
 /**
  * Max characters of terminal output sent to a model as context. Bounds the request for both cloud
  * and small local models; shared by the session assistant and the one-shot "explain this output".
@@ -15,4 +17,28 @@ internal fun clampAiContext(output: String): String {
     val trimmed = output.trim()
     if (trimmed.length <= AI_CONTEXT_LIMIT) return trimmed
     return "…" + trimmed.substring(trimmed.length - AI_CONTEXT_LIMIT)
+}
+
+/**
+ * Max characters of conversation replayed with a question. Every turn goes back to the model on
+ * every request, so without a bound a long conversation walks past what the endpoint accepts: a
+ * local model (4096 tokens on desktop, 2048 on a phone) drops the front of the prompt itself and
+ * the answers quietly get worse, while a cloud endpoint starts answering 400.
+ */
+internal const val AI_HISTORY_LIMIT = 12_000
+
+/**
+ * The tail of [history] that fits in [AI_HISTORY_LIMIT] characters — the oldest turns are dropped
+ * first, as the least relevant to the question being asked. The newest message is always kept, even
+ * when it alone exceeds the budget: a request without it has nothing to answer.
+ */
+internal fun clampAiHistory(history: List<AiMessage>): List<AiMessage> {
+    var budget = AI_HISTORY_LIMIT
+    val kept = ArrayDeque<AiMessage>()
+    for (message in history.asReversed()) {
+        budget -= message.content.length
+        if (budget < 0 && kept.isNotEmpty()) break
+        kept.addFirst(message)
+    }
+    return kept
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/SessionAssistantController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/SessionAssistantController.kt
@@ -115,7 +115,8 @@ class SessionAssistantController(
         busy = true
         streaming = ""
         val gen = ++generation
-        val history = turns.dropLast(1).map { AiMessage(it.role, it.text) }
+        // Bounded: the whole conversation is replayed on every question (see clampAiHistory).
+        val history = clampAiHistory(turns.dropLast(1).map { AiMessage(it.role, it.text) })
         val messages = listOf(AiMessage(AiRole.SYSTEM, sessionPrompt(responseLanguage()))) +
             history +
             AiMessage(AiRole.USER, withContext(question, context))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/TerminalAiController.kt
@@ -136,9 +136,13 @@ class TerminalAiController(
             temperature = COMMAND_TEMPERATURE,
             endpoint = route.endpoint,
             messages = messages,
-            onDelta = { streaming = it },
-            onComplete = { applyReply(it) },
-            onError = { notice = AiNotice.Error(it) },
+            // Every callback is generation-guarded, not just the last one: cancelling a job only
+            // *requests* cancellation, so a stream that already finished collecting runs its
+            // completion callback without ever crossing a suspension point. Unguarded, a request
+            // the user dismissed would still hand this bar a command — with a Run button on it.
+            onDelta = { if (gen == generation) streaming = it },
+            onComplete = { if (gen == generation) applyReply(it) },
+            onError = { if (gen == generation) notice = AiNotice.Error(it) },
             onFinally = {
                 if (gen == generation) {
                     streaming = null
@@ -184,21 +188,26 @@ class TerminalAiController(
             temperature = EXPLAIN_TEMPERATURE,
             endpoint = route.endpoint,
             messages = messages,
-            onDelta = { explanation = it },
+            // Generation-guarded throughout, for the reason spelled out in [ask].
+            onDelta = { if (gen == generation) explanation = it },
             onComplete = { reply ->
-                val trimmed = reply.trim()
-                // A model that returns nothing usable falls back to the same fixed notice as a command
-                // reply with no content, rather than leaving an empty panel open.
-                if (trimmed.isEmpty()) {
-                    explanation = null
-                    notice = AiNotice.Rejected
-                } else {
-                    explanation = trimmed
+                if (gen == generation) {
+                    val trimmed = reply.trim()
+                    // A model that returns nothing usable falls back to the same fixed notice as a
+                    // command reply with no content, rather than leaving an empty panel open.
+                    if (trimmed.isEmpty()) {
+                        explanation = null
+                        notice = AiNotice.Rejected
+                    } else {
+                        explanation = trimmed
+                    }
                 }
             },
             onError = {
-                explanation = null
-                notice = AiNotice.Error(it)
+                if (gen == generation) {
+                    explanation = null
+                    notice = AiNotice.Error(it)
+                }
             },
             onFinally = {
                 if (gen == generation) busy = false

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/SshConfigImportModal.kt
@@ -2,7 +2,6 @@ package app.skerry.ui.host
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -97,7 +98,11 @@ fun SshConfigImportModal(state: DesktopDesignState, result: SshConfigParseResult
                 Row(
                     Modifier
                         .fillMaxWidth()
-                        .clickable { selected = if (allSelected) emptySet() else result.hosts.map { it.alias }.toSet() }
+                        // toggleable, not clickable: the tick is a Sym glyph, which clears its own
+                        // semantics, so the row is what carries the checked state (issue #228).
+                        .toggleable(value = allSelected, role = Role.Checkbox) {
+                            selected = if (allSelected) emptySet() else result.hosts.map { it.alias }.toSet()
+                        }
                         .padding(horizontal = 26.dp, vertical = 10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -112,7 +117,9 @@ fun SshConfigImportModal(state: DesktopDesignState, result: SshConfigParseResult
                         Row(
                             Modifier
                                 .fillMaxWidth()
-                                .clickable { selected = if (isSelected) selected - host.alias else selected + host.alias }
+                                .toggleable(value = isSelected, role = Role.Checkbox) {
+                                    selected = if (isSelected) selected - host.alias else selected + host.alias
+                                }
                                 .background(if (isSelected) Skerry.colors.cyan10 else androidx.compose.ui.graphics.Color.Transparent)
                                 .padding(horizontal = 26.dp, vertical = 9.dp),
                             verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileBroadcast.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileBroadcast.kt
@@ -1,7 +1,7 @@
 package app.skerry.ui.mobile
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -112,7 +113,15 @@ internal fun MobileBroadcastSheet(
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(10.dp))
                                 .background(if (on) Skerry.colors.cyan.copy(alpha = 0.10f) else Color.Transparent)
-                                .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = onClick)
+                                // toggleable, not clickable: the tick is a Sym glyph, which clears
+                                // its own semantics, so the row carries the checked state (#228).
+                                .toggleable(
+                                    value = on,
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    indication = null,
+                                    role = Role.Checkbox,
+                                    onValueChange = { onClick() },
+                                )
                                 .padding(horizontal = 10.dp, vertical = 10.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileLockScreens.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileLockScreens.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.BrandMark
 import app.skerry.ui.design.BrandPlate
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.fieldName
@@ -346,6 +347,9 @@ private fun MobileLockScaffold(
         Spacer(Modifier.height(26.dp))
         Column(Modifier.width(300.dp), horizontalAlignment = Alignment.CenterHorizontally) {
             fields()
+            // Same rule as the desktop gate: composed unconditionally so the announcement survives
+            // the error appearing (see LockScaffold).
+            StatusAnnouncer(error?.let { vaultGateErrorMessage(it) } ?: "")
             if (error != null) {
                 Spacer(Modifier.height(12.dp))
                 Txt(vaultGateErrorMessage(error), color = Skerry.colors.storm, size = 12.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSshImportSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -24,6 +25,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -79,7 +81,14 @@ fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult)
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(10.dp))
-                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                    // toggleable, not clickable: the tick is a Sym glyph, which clears its own
+                    // semantics, so the row is what carries the checked state (issue #228).
+                    .toggleable(
+                        value = allSelected,
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        role = Role.Checkbox,
+                    ) {
                         selected = if (allSelected) emptySet() else result.hosts.map { it.alias }.toSet()
                     }
                     .padding(vertical = 10.dp),
@@ -97,7 +106,12 @@ fun MobileSshImportSheet(state: MobileDesignState, result: SshConfigParseResult)
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(10.dp))
                             .background(if (isSelected) Skerry.colors.cyan10 else Color.Transparent)
-                            .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
+                            .toggleable(
+                                value = isSelected,
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                role = Role.Checkbox,
+                            ) {
                                 selected = if (isSelected) selected - host.alias else selected + host.alias
                             }
                             .padding(horizontal = 4.dp, vertical = 11.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/BroadcastPanel.kt
@@ -2,7 +2,7 @@ package app.skerry.ui.session
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,6 +35,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
@@ -200,7 +201,9 @@ private fun TargetRow(label: String, selected: Boolean, production: Boolean, mon
             .fillMaxWidth()
             .clip(RoundedCornerShape(6.dp))
             .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-            .clickable(onClick = onToggle)
+            // toggleable, not clickable: the tick is a Sym glyph, which clears its own semantics, so
+            // the row is the only node that can carry the checked state (issue #228).
+            .toggleable(value = selected, role = Role.Checkbox, onValueChange = { onToggle() })
             .padding(horizontal = 8.dp, vertical = 7.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/PaneLayout.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/PaneLayout.kt
@@ -92,6 +92,12 @@ data class PaneLayout(val rows: List<PaneRow>) {
         val from = positionOf(paneId) ?: return this
         // A pane alone in its row takes the row with it, which shifts every row below up by one.
         val rowCollapses = rows[from.first].cells.size == 1
+        // ...and if the drop was aimed INTO that row, there is no row left to drop into: the pane
+        // is being put back where it already is. Without this the index survives the collapse and
+        // now names the row below, so dropping a pane on its own left half moves it in beside its
+        // neighbours — a top/bottom split turning into a side-by-side one on a gesture that means
+        // "leave it where it is".
+        if (rowCollapses && slot is PaneSlot.InRow && slot.row == from.first) return this
         val shifted = when (slot) {
             is PaneSlot.NewRow -> PaneSlot.NewRow(if (rowCollapses && slot.row > from.first) slot.row - 1 else slot.row)
             is PaneSlot.InRow -> PaneSlot.InRow(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncScreens.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
@@ -34,6 +35,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -325,24 +327,10 @@ internal fun SyncSetupBody(
         SyncTextField(password, stringResource(Res.string.sync_placeholder_master_password), KeyboardType.Password, masked = true, icon = "key") { password = it }
     }
 
-    Row(
-        Modifier.fillMaxWidth().padding(top = 16.dp).clickable { keepConnected = !keepConnected },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(
-            Modifier.size(20.dp).clip(RoundedCornerShape(6.dp))
-                .background(if (keepConnected) Skerry.colors.cyan else Color.Transparent)
-                .border(1.dp, if (keepConnected) Skerry.colors.cyan else Skerry.colors.cyan14, RoundedCornerShape(6.dp)),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (keepConnected) Sym("check", size = 14.sp, color = Skerry.colors.ink)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(stringResource(Res.string.sync_keep_connected), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.Medium)
-            Txt(stringResource(Res.string.sync_keep_connected_sub), color = Skerry.colors.faint, size = 11.5.sp)
-        }
-    }
+    KeepConnectedRow(
+        checked = keepConnected,
+        subtitle = stringResource(Res.string.sync_keep_connected_sub),
+    ) { keepConnected = it }
 
     // http:// is allowed (local test/LAN without a TLS proxy) but defenseless against MITM — warn explicitly.
     if (form.isInsecureUrl) {
@@ -485,24 +473,10 @@ private fun SyncJoinBody(sync: SyncCoordinator, errorMessage: String?) {
     // the button below stays disabled, and nothing else says so.
     SyncFormError(stringResource(Res.string.sync_passwords_mismatch).takeIf { confirm.isNotEmpty() && !passwordsMatch })
 
-    Row(
-        Modifier.fillMaxWidth().padding(top = 16.dp).clickable { keepConnected = !keepConnected },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(
-            Modifier.size(20.dp).clip(RoundedCornerShape(6.dp))
-                .background(if (keepConnected) Skerry.colors.cyan else Color.Transparent)
-                .border(1.dp, if (keepConnected) Skerry.colors.cyan else Skerry.colors.cyan14, RoundedCornerShape(6.dp)),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (keepConnected) Sym("check", size = 14.sp, color = Skerry.colors.ink)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(stringResource(Res.string.sync_keep_connected), color = Skerry.colors.text, size = 13.sp, weight = FontWeight.Medium)
-            Txt(stringResource(Res.string.sync_keep_connected_sub), color = Skerry.colors.faint, size = 11.5.sp)
-        }
-    }
+    KeepConnectedRow(
+        checked = keepConnected,
+        subtitle = stringResource(Res.string.sync_keep_connected_sub),
+    ) { keepConnected = it }
 
     SyncFormError(errorMessage)
 
@@ -591,4 +565,49 @@ internal fun SyncTextField(
             }
         },
     )
+}
+
+/**
+ * "Keep me connected": remember the link and restore the session without re-entering the password.
+ *
+ * One row for the two sync screens and the setup dialog — it was written out three times, and every
+ * copy carried the same defect: the tick is a [Sym] glyph, which clears its own semantics, so a row
+ * that only had a click announced a button named "Keep me connected" with no on/off state behind
+ * it. A screen reader user could not tell whether the session would be persisted (issue #228).
+ */
+@Composable
+internal fun KeepConnectedRow(
+    checked: Boolean,
+    subtitle: String,
+    /** The dialog's slightly tighter scale; the screens use the roomier one. */
+    compact: Boolean = false,
+    onChange: (Boolean) -> Unit,
+) {
+    Row(
+        Modifier.fillMaxWidth()
+            .padding(top = if (compact) 14.dp else 16.dp)
+            .toggleable(value = checked, role = Role.Checkbox, onValueChange = onChange),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        val box = if (compact) 18.dp else 20.dp
+        val corner = if (compact) 5.dp else 6.dp
+        Box(
+            Modifier.size(box).clip(RoundedCornerShape(corner))
+                .background(if (checked) Skerry.colors.cyan else Color.Transparent)
+                .border(1.dp, if (checked) Skerry.colors.cyan else Skerry.colors.cyan14, RoundedCornerShape(corner)),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (checked) Sym("check", size = if (compact) 13.sp else 14.sp, color = Skerry.colors.ink)
+        }
+        Column(Modifier.weight(1f)) {
+            Txt(
+                stringResource(Res.string.sync_keep_connected),
+                color = Skerry.colors.text,
+                size = if (compact) 12.5.sp else 13.sp,
+                weight = FontWeight.Medium,
+            )
+            Txt(subtitle, color = Skerry.colors.faint, size = if (compact) 11.sp else 11.5.sp)
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncSetupDialog.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -26,7 +25,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -53,7 +51,6 @@ import app.skerry.ui.generated.resources.sync_connecting
 import app.skerry.ui.generated.resources.sync_zero_knowledge
 import app.skerry.ui.generated.resources.sync_cancel
 import app.skerry.ui.generated.resources.sync_connect
-import app.skerry.ui.generated.resources.sync_keep_connected
 import app.skerry.ui.generated.resources.sync_keep_connected_sub_long
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.CancelButton
@@ -154,7 +151,11 @@ fun SyncSetupDialog(sync: SyncCoordinator, onDismiss: () -> Unit) {
                 SyncField(stringResource(Res.string.sync_placeholder_master_password), password, "key", KeyboardType.Password, ImeAction.Done, secret = true, onSubmit = { submit() }) { password = it }
             }
 
-            KeepConnectedRow(keepConnected) { keepConnected = it }
+            KeepConnectedRow(
+                checked = keepConnected,
+                subtitle = stringResource(Res.string.sync_keep_connected_sub_long),
+                compact = true,
+            ) { keepConnected = it }
 
             // http:// is allowed (local test/LAN without a TLS proxy) but defenseless against MITM — warn explicitly.
             if (form.isInsecureUrl) {
@@ -185,29 +186,6 @@ fun SyncSetupDialog(sync: SyncCoordinator, onDismiss: () -> Unit) {
                 CancelButton(stringResource(Res.string.sync_cancel), onClick = onDismiss)
                 PrimaryButton(stringResource(Res.string.sync_connect), onClick = { submit() }, enabled = canSubmit, modifier = Modifier.testTag(UiTags.FORM_SAVE))
             }
-        }
-    }
-}
-
-/** "Keep me connected" checkbox: remember the link and restore the session without re-entering the password. */
-@Composable
-private fun KeepConnectedRow(checked: Boolean, onChange: (Boolean) -> Unit) {
-    Row(
-        Modifier.fillMaxWidth().padding(top = 14.dp).clickable { onChange(!checked) },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Box(
-            Modifier.size(18.dp).clip(RoundedCornerShape(5.dp))
-                .background(if (checked) Skerry.colors.cyan else Color.Transparent)
-                .border(1.dp, if (checked) Skerry.colors.cyan else Skerry.colors.cyan14, RoundedCornerShape(5.dp)),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (checked) Sym("check", size = 13.sp, color = Skerry.colors.ink)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(stringResource(Res.string.sync_keep_connected), color = Skerry.colors.text, size = 12.5.sp, weight = FontWeight.Medium)
-            Txt(stringResource(Res.string.sync_keep_connected_sub_long), color = Skerry.colors.faint, size = 11.sp)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -507,7 +507,18 @@ class TeamsCoordinator(
                 // so records shared after removal are encrypted under keys the removed member lacks
                 // (forward secrecy against a leaked backup / compromised server). Best-effort: a rotation
                 // failure still leaves the member removed — surfaced via lastError.
-                rotateTeamKey(sess, c, teamId)
+                // Guarded like the scopes below, and for the same reason: a failed team rotation
+                // must not skip them. Unguarded it unwound past the loop, so one 5xx on the rekey
+                // left the removed member holding every scope key they had — the exact hole the
+                // rotation exists to close — with nothing to retry it.
+                var teamRotation: Exception? = null
+                try {
+                    rotateTeamKey(sess, c, teamId)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    teamRotation = e
+                }
                 // Each scope rotates independently: one failing must not leave the rest un-rotated,
                 // since every skipped scope is a key the removed member still holds.
                 heldScopes.forEach { scopeId ->
@@ -519,6 +530,10 @@ class TeamsCoordinator(
                         markError(e.toFailure())
                     }
                 }
+                // Reported last on purpose: `lastError` holds one value, and the team key is the
+                // more serious of the two — a scope failure landing after it would otherwise hide
+                // "the removed member still holds the team key" behind "one scope did not rotate".
+                teamRotation?.let { markError(it.toFailure()) }
             }
             refreshUnlocked(sess, c)
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelFailureText.kt
@@ -5,6 +5,7 @@ import app.skerry.ui.connection.jumpProblemText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.conn_tunnel_error_host_missing
 import app.skerry.ui.generated.resources.conn_tunnel_error_no_credential
+import app.skerry.ui.generated.resources.conn_tunnel_error_link_lost
 import org.jetbrains.compose.resources.stringResource
 
 /** Localized reason a tunnel can't be dialled. */
@@ -13,6 +14,9 @@ fun tunnelUnavailableText(reason: TunnelUnavailable): String = when (reason) {
     TunnelUnavailable.HostNotFound -> stringResource(Res.string.conn_tunnel_error_host_missing)
     TunnelUnavailable.NoCredential -> stringResource(Res.string.conn_tunnel_error_no_credential)
     is TunnelUnavailable.Jump -> jumpProblemText(reason.problem)
+    // Its own line, not the dial failure's: a tunnel that came up and died is a different
+    // fact from one that never connected, and the row is all the user has to tell them apart.
+    TunnelUnavailable.LinkLost -> stringResource(Res.string.conn_tunnel_error_link_lost)
 }
 
 /** Text under a failed tunnel row: the typed reason if there is one, else the transport message. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelManager.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.concurrent.Volatile
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.coroutines.coroutineContext
 
@@ -54,6 +55,13 @@ sealed interface TunnelUnavailable {
 
     /** The host's ProxyJump chain didn't resolve. */
     data class Jump(val problem: JumpChainProblem) : TunnelUnavailable
+
+    /**
+     * It was up and stopped working: the listener died, or the SSH connection under it dropped.
+     * Typed like the rest — the telemetry poll that detects this runs outside the composition, and
+     * a poll that had to resolve a string would be a suspension (and a failure point) per tick.
+     */
+    data object LinkLost : TunnelUnavailable
 }
 
 /** Resolution of a saved tunnel to connection parameters: either the host and secret are available, or not. */
@@ -107,11 +115,20 @@ class TunnelEntry internal constructor(tunnel: Tunnel) {
     var downRate: Long by mutableStateOf(0)
         internal set
 
+    // Written by the telemetry poll (Dispatchers.Default) and by deactivate (the UI thread), so
+    // both sides have to see each other's writes.
+    @Volatile
     internal var handle: PortForward? = null
+
+    @Volatile
     internal var connection: SshConnection? = null
 
     // Coroutine bringing the tunnel up (status Connecting); [TunnelManager.deactivate] cancels it
-    // so a connection opening right now doesn't leak after deactivation.
+    // so a connection opening right now doesn't leak after deactivation. Volatile for the same
+    // reason as the two above, and it is the field the Stop-then-Start guard reads: a stale read in
+    // the cancelled attempt's `finally` would clear the newer attempt's job, leaving nothing able
+    // to cancel it — not the next Stop, and not the vault lock.
+    @Volatile
     internal var connectingJob: Job? = null
 
     internal var prevUp: Long = 0
@@ -185,7 +202,7 @@ class TunnelManager(
         scope.launch {
             while (isActive) {
                 delay(pollIntervalMillis)
-                pollTelemetry()
+                pollTick()
             }
         }
     }
@@ -197,8 +214,27 @@ class TunnelManager(
      * dropped, new ones added.
      */
     fun reload() {
+        val incoming = store.all()
+        // liveIds, not the ids of `incoming`: a record whose payload cannot be decrypted is missing
+        // from `all()` but is very much still there — adopting an account dataKey leaves every
+        // not-yet-pushed record sealed under the previous key. Tearing down on that would stop a
+        // live tunnel the moment this desktop joins an existing sync account.
+        val kept = store.liveIds()
+        // A row that has really left the store takes its forward with it. Deleting a tunnel on
+        // another device arrives here as a store write plus a reload — `delete()` is never called —
+        // so dropping the entry alone would leave the port bound and the SSH connection open with
+        // no row left to stop them.
+        tunnels.filter { it.id !in kept }.forEach {
+            deactivate(it.id)
+            telemetry.forget(it.id)
+        }
+        val readable = incoming.map { it.id }.toHashSet()
         val byId = tunnels.associateBy { it.id }
-        tunnels = store.all().map { tunnel -> byId[tunnel.id]?.also { it.tunnel = tunnel } ?: TunnelEntry(tunnel) }
+        val refreshed = incoming.map { tunnel -> byId[tunnel.id]?.also { it.tunnel = tunnel } ?: TunnelEntry(tunnel) }
+        // A row whose record is there but unreadable keeps the config it was loaded with, at the
+        // end of the list: the tunnel exists and may well be up, and dropping the row would leave
+        // its forward running with nothing on screen to stop it.
+        tunnels = refreshed + tunnels.filter { it.id in kept && it.id !in readable }
     }
 
     fun find(id: String): TunnelEntry? = tunnels.firstOrNull { it.id == id }
@@ -266,7 +302,12 @@ class TunnelManager(
                     is TunnelResolution.Ready -> openForward(entry, resolution)
                 }
             } finally {
-                entry.connectingJob = null
+                // Only when the field still points at THIS attempt. A dial is blocking, so a
+                // cancelled attempt unwinds long after the user pressed Stop — by then a fresh
+                // Start may own the field, and clearing it blindly would leave that attempt with
+                // nothing to cancel it: neither the next Stop nor the vault lock, which is the
+                // same call, and the tunnel would come up after being stopped.
+                if (entry.connectingJob === coroutineContext[Job]) entry.connectingJob = null
             }
         }
     }
@@ -354,23 +395,94 @@ class TunnelManager(
         autostartIds = emptySet()
     }
 
+    /**
+     * One turn of the telemetry loop. One bad tick costs one tick: unguarded, a throw here ends the
+     * loop for the rest of the session, and with it every traffic rate and the dead-tunnel
+     * detection — silently, since nothing else visits a running tunnel.
+     */
+    internal fun pollTick() {
+        // Last resort around a tick that is otherwise all arithmetic: one bad tick must cost one
+        // tick, not the loop — with it goes every traffic rate and the dead-tunnel detection, and
+        // nothing restarts it. A row that throws is handled where it throws (see [pollTelemetry]).
+        try {
+            pollTelemetry()
+        } catch (e: CancellationException) {
+            // Kept in step with the per-row guard below, which rethrows it for the same reason:
+            // cancelling the scope has to end the loop, not be mistaken for a bad tick.
+            throw e
+        } catch (_: Exception) {
+        }
+    }
+
     internal fun pollTelemetry() {
         var up = 0L
         var down = 0L
         tunnels.forEach { entry ->
             val handle = entry.handle ?: return@forEach
-            val entryUp = handle.bytesUp
-            val entryDown = handle.bytesDown
-            entry.upRate = ((entryUp - entry.prevUp) * 1000 / pollIntervalMillis).coerceAtLeast(0)
-            entry.downRate = ((entryDown - entry.prevDown) * 1000 / pollIntervalMillis).coerceAtLeast(0)
-            entry.prevUp = entryUp
-            entry.prevDown = entryDown
-            entry.bytesUp = entryUp
-            entry.bytesDown = entryDown
-            up += entry.upRate
-            down += entry.downRate
+            // One failing row is one failing row: without this the rest of the pass — every other
+            // tunnel's counters and the throughput sample below — goes with it, and the section's
+            // graph freezes with nothing said. The journal is what says it.
+            try {
+                pollEntry(entry, handle)?.let { (entryUp, entryDown) ->
+                    up += entryUp
+                    down += entryDown
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                // Torn down like any other dead tunnel, not merely journalled: a row left Active
+                // with its port still bound would throw again on the very next tick, adding an
+                // event a second while the forward it describes keeps accepting connections.
+                dropDead(entry, handle)
+            }
         }
         telemetry.sample(up, down)
+    }
+
+    /** One row's counters, or null when the tunnel turned out to be dead and was torn down. */
+    private fun pollEntry(entry: TunnelEntry, handle: PortForward): Pair<Long, Long>? {
+        // A forward whose listener died, or whose SSH connection dropped underneath it, was
+        // never noticed: the row kept saying Active with the port still bound, every
+        // application connecting through it got an immediate close, and nothing was ever
+        // journalled. The poll is the only thing that looks at a running tunnel, so it is
+        // where a dead one is caught.
+        if (!handle.isActive || entry.connection?.isConnected == false) {
+            dropDead(entry, handle)
+            return null
+        }
+        val entryUp = handle.bytesUp
+        val entryDown = handle.bytesDown
+        entry.upRate = ((entryUp - entry.prevUp) * 1000 / pollIntervalMillis).coerceAtLeast(0)
+        entry.downRate = ((entryDown - entry.prevDown) * 1000 / pollIntervalMillis).coerceAtLeast(0)
+        entry.prevUp = entryUp
+        entry.prevDown = entryDown
+        entry.bytesUp = entryUp
+        entry.bytesDown = entryDown
+        return entry.upRate to entry.downRate
+    }
+
+    /**
+     * Tears down a tunnel that stopped working on its own, and says so on the row and in the
+     * journal.
+     *
+     * Non-suspending, like the whole tick — the reason is typed, so nothing here has to resolve a
+     * string. It rechecks the handle it was called about, which narrows (it cannot close: the poll
+     * and the UI run on different threads) the window where a Stop lands mid-teardown and the row
+     * it already set to Inactive is overwritten with a failure the user caused on purpose.
+     */
+    private fun dropDead(entry: TunnelEntry, seenHandle: PortForward) {
+        if (entry.handle !== seenHandle) return
+        val handle = entry.handle
+        val conn = entry.connection
+        entry.handle = null
+        entry.connection = null
+        entry.resetCounters()
+        entry.status = TunnelStatus.Failed(reason = TunnelUnavailable.LinkLost)
+        noteFailure(entry, TunnelFailureKind.Connection)
+        scope.launch {
+            runCatching { handle?.close() }
+            runCatching { conn?.disconnect() }
+        }
     }
 
     private fun closeQuietly(conn: SshConnection?) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTelemetry.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/tunnel/TunnelTelemetry.kt
@@ -2,6 +2,7 @@ package app.skerry.ui.tunnel
 
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 
@@ -60,7 +61,9 @@ class TunnelTelemetry(private val pollIntervalMillis: Long) {
 
     // Cause per failing tunnel, not a bare set: a retry that fails for a *different* reason is news,
     // and deduplicating on the id alone would leave the card asserting a cause that no longer holds.
-    private val failing = mutableMapOf<String, TunnelFailureKind>()
+    // A snapshot map, not a plain one: the telemetry poll writes it from its own thread every
+    // second (a tunnel found dead) while the UI thread removes entries on delete/reload.
+    private val failing = mutableStateMapOf<String, TunnelFailureKind>()
 
     /** Records one poll tick of aggregate throughput and advances the clock the events age against. */
     fun sample(up: Long, down: Long) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockScreen.kt
@@ -81,6 +81,7 @@ import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.sync.PairingJoinScreen
 import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.Txt
@@ -377,6 +378,10 @@ private fun LockScaffold(
         Box(Modifier.height(32.dp))
         Column(Modifier.width(320.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             fields()
+            // Composed even with no error, so the announcer outlives the change: a node inserted
+            // together with its text announces nothing. Without it a wrong password, a corrupt
+            // file or a vault that cannot be written is silent to a screen reader.
+            StatusAnnouncer(error?.let { vaultGateErrorMessage(it) } ?: "")
             if (error != null) {
                 Txt(vaultGateErrorMessage(error), color = Skerry.colors.storm, size = 12.sp)
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateController.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultBiometrics
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -101,6 +102,9 @@ enum class VaultGateError {
 
     /** Vault file unreadable/corrupt. */
     Corrupted,
+
+    /** The vault file could not be written — a read-only or full config directory. */
+    NotWritable,
 
     /** Biometrics reset (new fingerprint/face) — it's disabled, the master password is needed. */
     BiometricReset,
@@ -238,7 +242,18 @@ class VaultGateController(
                 verifying = true
                 scope.launch {
                     try {
-                        withContext(kdfDispatcher) { vault.create(password) }
+                        // Only the write is guarded, and only for the error it names: everything
+                        // after it runs on a vault that exists and is open, so reporting "could not
+                        // write the vault" for a failing security-log write or biometrics probe
+                        // would be a wrong diagnosis on a screen the user cannot leave.
+                        try {
+                            withContext(kdfDispatcher) { vault.create(password) }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (_: Exception) {
+                            error = VaultGateError.NotWritable
+                            return@launch
+                        }
                         // Baseline for the "last password change" caption in the Security section.
                         securityLog?.record(SecurityEventType.VaultCreated)
                         // New vault is open. First (if the platform provided a form) offer to connect

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
@@ -44,6 +44,7 @@ import app.skerry.shared.vault.BiometricPrompt
 import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultBiometrics
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vtail_error_biometric_failed
 import app.skerry.ui.generated.resources.vtail_error_biometric_locked_out
@@ -52,6 +53,7 @@ import app.skerry.ui.generated.resources.vtail_bio_verify_title
 import app.skerry.ui.generated.resources.vtail_error_biometric_reset
 import app.skerry.ui.generated.resources.vtail_error_biometric_unsupported
 import app.skerry.ui.generated.resources.vtail_error_corrupted
+import app.skerry.ui.generated.resources.vtail_error_not_writable
 import app.skerry.ui.generated.resources.vtail_error_password_mismatch
 import app.skerry.ui.generated.resources.vtail_error_password_too_short
 import app.skerry.ui.generated.resources.vtail_error_wrong_password
@@ -508,6 +510,11 @@ private fun VaultFormScaffold(
         Text(title, style = MaterialTheme.typography.headlineSmall, color = MaterialTheme.colorScheme.primary)
         Text(subtitle, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         fields()
+        // Composed even when there is no error, so the announcer outlives the change: a node
+        // inserted together with its text announces nothing. Without it every failure on this
+        // screen — a wrong password, a corrupt file, a vault that cannot be written — is silent to
+        // a screen reader, which is the same defect class as a checkbox with no state.
+        StatusAnnouncer(error?.let { vaultGateErrorMessage(it) } ?: "")
         if (error != null) {
             Text(vaultGateErrorMessage(error), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
         }
@@ -538,6 +545,7 @@ internal fun vaultGateErrorMessage(error: VaultGateError): String = when (error)
     VaultGateError.PasswordMismatch -> stringResource(Res.string.vtail_error_password_mismatch)
     VaultGateError.WrongPassword -> stringResource(Res.string.vtail_error_wrong_password)
     VaultGateError.Corrupted -> stringResource(Res.string.vtail_error_corrupted)
+    VaultGateError.NotWritable -> stringResource(Res.string.vtail_error_not_writable)
     VaultGateError.BiometricReset -> stringResource(Res.string.vtail_error_biometric_reset)
     VaultGateError.BiometricFailed -> stringResource(Res.string.vtail_error_biometric_failed)
     VaultGateError.BiometricLockedOut -> stringResource(Res.string.vtail_error_biometric_locked_out)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/SessionAssistantControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/SessionAssistantControllerTest.kt
@@ -106,6 +106,32 @@ class SessionAssistantControllerTest {
         assertFalse(p.built)
     }
 
+    /**
+     * The conversation is replayed in full on every question, and only the attached terminal output
+     * was ever bounded. A long session therefore grows past what the endpoint accepts: the local
+     * model (4096 tokens on desktop, 2048 on a phone) silently drops the front of the prompt and
+     * the answers quietly degrade, and a cloud endpoint answers 400 for every further question.
+     */
+    @Test
+    fun `a long conversation is replayed within a bounded budget`() = runTest {
+        val provider = RecordingProvider(deltas = listOf("ok"))
+        val c = controller(AiPolicy.Permissive, AiSettings(apiKey = "sk-x"), provider, this)
+        val long = "x".repeat(2_000)
+
+        repeat(20) {
+            c.ask("$long question $it", outputs = emptyList())
+            advanceUntilIdle()
+        }
+
+        val replayed = provider.lastMessages.filter { it.role != AiRole.SYSTEM }.sumOf { it.content.length }
+        assertTrue(
+            replayed <= AI_HISTORY_LIMIT + long.length,
+            "the whole conversation was replayed: $replayed characters",
+        )
+        // The newest exchange is what survives the trim — the question just asked is in there.
+        assertTrue(provider.lastMessages.last().content.contains("question 19"))
+    }
+
     @Test
     fun `a full round trip appends the user turn and the reply`() = runTest {
         val p = RecordingProvider(deltas = listOf("The journal", " is the largest."))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/ai/TerminalAiControllerTest.kt
@@ -266,6 +266,94 @@ class TerminalAiControllerTest {
         assertNull(c.confirm())
     }
 
+    /**
+     * Cancelling a job only *requests* cancellation. A stream that has already finished collecting
+     * runs its completion callback without crossing another suspension point ([AiStreamRunner]
+     * says so, and leaves the guard to the caller), so the answer to a question the user dismissed
+     * can still arrive — and in this bar an answer is a command with a Run button next to it.
+     */
+    @Test
+    fun `a dismissed request never offers its command afterwards`() = runTest {
+        val finishFirst = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val gateSecond = kotlinx.coroutines.CompletableDeferred<Unit>()
+        var call = 0
+        val provider = object : AiProvider {
+            override fun chat(request: AiChatRequest): Flow<AiDelta> = flow {
+                if (call++ == 0) {
+                    emit(AiDelta("rm -rf /var/log"))
+                    // NonCancellable: the stream finishes collecting despite the cancel, which is
+                    // the race — the cancellation is only noticed at the next suspension point.
+                    kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) { finishFirst.await() }
+                } else {
+                    emit(AiDelta("uptime"))
+                    gateSecond.await()
+                }
+            }
+            override suspend fun close() {}
+        }
+        val c = TerminalAiController(
+            AiPolicy.Balanced, settings = { AiSettings(apiKey = "sk-x") },
+            providerFactory = { provider }, scope = this,
+        )
+
+        c.ask("delete the logs")
+        runCurrent()
+        c.dismiss() // the user taps Dismiss while it is thinking
+        c.ask("how long has it been up")
+        runCurrent()
+
+        finishFirst.complete(Unit) // the dismissed stream finishes and runs its completion
+        runCurrent()
+
+        assertNull(c.pending, "a request the user dismissed offered its command anyway")
+        assertNull(c.confirm())
+        assertEquals("uptime", c.streaming, "the live request's stream was overwritten")
+
+        gateSecond.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("uptime", c.pending)
+    }
+
+    /** The same race on the other surface: an explanation the user dismissed must not come back. */
+    @Test
+    fun `a dismissed explanation never overwrites the next one`() = runTest {
+        val finishFirst = kotlinx.coroutines.CompletableDeferred<Unit>()
+        val gateSecond = kotlinx.coroutines.CompletableDeferred<Unit>()
+        var call = 0
+        val provider = object : AiProvider {
+            override fun chat(request: AiChatRequest): Flow<AiDelta> = flow {
+                if (call++ == 0) {
+                    emit(AiDelta("the first explanation"))
+                    kotlinx.coroutines.withContext(kotlinx.coroutines.NonCancellable) { finishFirst.await() }
+                } else {
+                    emit(AiDelta("the second explanation"))
+                    gateSecond.await()
+                }
+            }
+            override suspend fun close() {}
+        }
+        val c = TerminalAiController(
+            AiPolicy.Balanced, settings = { AiSettings(apiKey = "sk-x") },
+            providerFactory = { provider }, scope = this,
+        )
+
+        c.explain("df -h output")
+        runCurrent()
+        c.dismiss()
+        c.explain("uptime output")
+        runCurrent()
+
+        finishFirst.complete(Unit)
+        runCurrent()
+
+        assertEquals("the second explanation", c.explanation, "a dismissed explanation came back")
+        assertNull(c.notice)
+
+        gateSecond.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("the second explanation", c.explanation)
+    }
+
     @Test
     fun `a cancelled request does not clobber the state of the next one`() = runTest {
         // Regression (job reassignment): cancel() resets busy synchronously so ask() can start a

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/PaneLayoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/PaneLayoutTest.kt
@@ -157,6 +157,28 @@ class PaneLayoutTest {
         assertEquals(shapeOf(layout), shapeOf(layout.move("b", PaneSlot.InRow(row = 0, column = 2))))
     }
 
+    /**
+     * The same drop for a pane that is alone in its row. Its row goes away with it, so the target
+     * index no longer names the row the drop was aimed at — it names the one below, and a
+     * top/bottom split silently becomes a side-by-side one on a gesture that should do nothing.
+     */
+    @Test
+    fun `dropping the only pane of a row onto itself changes nothing`() {
+        val layout = PaneLayout.of("a").add("b", PaneSlot.NewRow(1))
+        assertEquals("a|b", shapeOf(layout.move("a", PaneSlot.InRow(row = 0, column = 0))))
+        assertEquals("a|b", shapeOf(layout.move("a", PaneSlot.InRow(row = 0, column = 1))))
+        assertEquals("a|b", shapeOf(layout.move("b", PaneSlot.InRow(row = 1, column = 0))))
+    }
+
+    /** Three panes, so the row below has an order of its own to be disturbed. */
+    @Test
+    fun `dropping the only pane of a row onto itself leaves the row below alone`() {
+        val layout = PaneLayout.of("a")
+            .add("b", PaneSlot.NewRow(1))
+            .add("c", PaneSlot.InRow(row = 1, column = 1))
+        assertEquals("a|b,c", shapeOf(layout.move("a", PaneSlot.InRow(row = 0, column = 1))))
+    }
+
     @Test
     fun `moving into a new row below works after the source row collapses`() {
         // "a,b" -> drag b into a new row under it: the row index survives the collapse of nothing.

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/tunnel/TunnelManagerTest.kt
@@ -25,6 +25,8 @@ import app.skerry.shared.tunnel.TunnelDirection
 import app.skerry.shared.tunnel.TunnelStore
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -257,6 +259,152 @@ class TunnelManagerTest {
 
         assertEquals(TunnelStatus.Inactive, manager.tunnels.single().status)
         assertTrue(conn.disconnected) // the opened connection was closed, not left as an orphan
+    }
+
+    /**
+     * A tunnel deleted on another device reaches this one as a store write plus a reload — no
+     * `delete()` call is ever made here. Dropping the row without deactivating it leaves the local
+     * port bound and the SSH connection open, forwarding traffic with no row left to stop it.
+     */
+    @Test
+    fun `reload tears down a tunnel that has gone from the store`() = runTest {
+        val store = FakeTunnelStore()
+        val transport = FakeTunnelTransport(FakeTunnelConnection(localPort = 50060))
+        val manager = managerWith(transport, store)
+        val id = manager.save(localDraft())
+        manager.activate(id)
+        assertIs<TunnelStatus.Active>(manager.find(id)!!.status)
+
+        store.remove(id) // the deletion synced in from another device
+        manager.reload()
+
+        assertTrue(manager.tunnels.isEmpty())
+        val forward = transport.connection.lastForward!!
+        assertEquals(1, forward.closeCount, "the forward kept its port bound after the row was gone")
+        assertTrue(transport.connection.disconnected, "the SSH connection outlived its row")
+    }
+
+    /**
+     * The other half of the same rule: a record that is still there but cannot be read — what
+     * adopting an account dataKey leaves behind for everything not yet pushed — is NOT a deletion.
+     * Tearing down on it would stop a live tunnel the moment this desktop joins an existing sync
+     * account, and dropping its row would leave the forward running with nothing to stop it.
+     */
+    @Test
+    fun `reload keeps a tunnel whose record is present but unreadable`() = runTest {
+        val store = FakeTunnelStore()
+        val transport = FakeTunnelTransport(FakeTunnelConnection(localPort = 50062))
+        val manager = managerWith(transport, store)
+        val id = manager.save(localDraft())
+        manager.activate(id)
+
+        store.unreadable += id // sealed under a superseded key: absent from all(), present in liveIds()
+        manager.reload()
+
+        assertIs<TunnelStatus.Active>(manager.find(id)?.status, "a live tunnel was torn down")
+        assertEquals(0, transport.connection.lastForward!!.closeCount)
+        assertTrue(manager.tunnels.any { it.id == id }, "the row vanished while its forward kept running")
+    }
+
+    /**
+     * Stop-then-Start while the first attempt is still inside a blocking connect: the cancelled
+     * attempt must not clear the *new* attempt's job on its way out, or nothing can cancel the new
+     * one afterwards — neither the user's next Stop nor the vault lock, which is the same call.
+     */
+    @Test
+    fun `a stop after a restart still cancels the attempt that is in flight`() = runTest {
+        val first = CompletableDeferred<Unit>()
+        val second = CompletableDeferred<Unit>()
+        // Uncancellable, like the real blocking connect: cancelling the first attempt does not stop
+        // it, it only makes it throw once the dial finally returns.
+        val conn = FakeTunnelConnection(localPort = 50061, raiseGate = second)
+        val transport = FakeTunnelTransport(conn, connectGates = listOf(first, CompletableDeferred(Unit)))
+        val manager = managerWith(transport)
+        val id = manager.save(localDraft())
+
+        manager.activate(id) // attempt A, stuck in connect
+        manager.deactivate(id) // Stop: A is cancelled but cannot notice yet
+        manager.activate(id) // Start again: attempt B is now the one in flight
+        first.complete(Unit) // A's dial returns, A unwinds as cancelled
+
+        manager.deactivate(id) // Stop again (or the vault locking, which calls the same thing)
+        second.complete(Unit) // whatever B was waiting on comes back
+
+        assertEquals(TunnelStatus.Inactive, manager.find(id)!!.status, "a tunnel came up after it was stopped")
+    }
+
+    /**
+     * Nothing ever looked at a running tunnel. The server rebooting, or the laptop changing
+     * network, drops the SSH connection while the local listener stays bound: the row keeps saying
+     * Active, every application connecting through the port is closed immediately, and the failure
+     * never reaches the journal. The telemetry poll is the one thing that visits a live tunnel.
+     */
+    @Test
+    fun `the poll catches a tunnel whose connection died and says so`() = runTest {
+        val conn = FakeTunnelConnection(localPort = 50070)
+        val transport = FakeTunnelTransport(conn)
+        val manager = managerWith(transport)
+        val id = manager.save(localDraft())
+        manager.activate(id)
+        assertIs<TunnelStatus.Active>(manager.find(id)!!.status)
+
+        conn.disconnect() // the link drops underneath the forward
+        manager.pollTelemetry()
+
+        assertIs<TunnelStatus.Failed>(manager.find(id)!!.status)
+        assertEquals(1, transport.connection.lastForward!!.closeCount, "the dead forward kept its port bound")
+        assertTrue(
+            manager.telemetry.events.any { it.tunnelId == id },
+            "a tunnel that died on its own left nothing in the journal",
+        )
+    }
+
+    /**
+     * The poll is the only thing that visits a running tunnel, and it now does more than arithmetic
+     * — it asks the connection whether it is still alive. A row that throws must not take the loop
+     * with it (every other tunnel's rates and the dead-tunnel detection would go too, silently),
+     * and must not be left Active either: it would throw again every second, adding an event a
+     * second while its port stays bound.
+     */
+    @Test
+    fun `a row that throws is torn down, and the rest of the poll survives`() = runTest {
+        val conn = FakeTunnelConnection(localPort = 50080)
+        val transport = FakeTunnelTransport(conn)
+        val manager = managerWith(transport)
+        val id = manager.save(localDraft())
+        manager.activate(id)
+
+        conn.failLiveness = true
+        manager.pollTick() // must not throw out of the loop
+
+        assertIs<TunnelStatus.Failed>(manager.find(id)!!.status, "the row was left Active to throw again")
+        assertEquals(1, transport.connection.lastForward!!.closeCount, "the forward kept its port bound")
+        assertEquals(1, manager.telemetry.events.count { it.tunnelId == id }, "one failure, not one per tick")
+
+        manager.pollTick() // the next tick still works, and adds nothing new
+        assertEquals(1, manager.telemetry.events.count { it.tunnelId == id })
+    }
+
+    /**
+     * A link that dropped and a user who pressed Stop are the same end state, and the poll must not
+     * turn the second into the first: a tunnel stopped by hand stays stopped, and the journal keeps
+     * no failure for something the user did on purpose.
+     */
+    @Test
+    fun `a tunnel stopped by hand is not marked failed by the next tick`() = runTest {
+        val conn = FakeTunnelConnection(localPort = 50090)
+        val manager = managerWith(FakeTunnelTransport(conn))
+        val id = manager.save(localDraft())
+        manager.activate(id)
+        conn.disconnect() // the link drops
+        manager.deactivate(id) // ...and the user presses Stop before the poll gets there
+        manager.pollTick()
+
+        assertEquals(TunnelStatus.Inactive, manager.find(id)!!.status, "a stopped tunnel was marked failed")
+        assertTrue(
+            manager.telemetry.events.none { it.tunnelId == id },
+            "a tunnel the user stopped was journalled as a failure",
+        )
     }
 
     @Test
@@ -515,7 +663,12 @@ class TunnelManagerTest {
 
 private class FakeTunnelStore : TunnelStore {
     private val entries = mutableListOf<Tunnel>()
-    override fun all(): List<Tunnel> = entries.toList()
+
+    /** Records whose payload no longer decrypts: present in [liveIds], missing from [all]. */
+    val unreadable: MutableSet<String> = mutableSetOf()
+
+    override fun all(): List<Tunnel> = entries.filterNot { it.id in unreadable }
+    override fun liveIds(): Set<String> = entries.map { it.id }.toSet()
     override fun put(tunnel: Tunnel) {
         val i = entries.indexOfFirst { it.id == tunnel.id }
         if (i >= 0) entries[i] = tunnel else entries += tunnel
@@ -528,15 +681,24 @@ private class FakeTunnelStore : TunnelStore {
 private class FakeTunnelTransport(
     val connection: FakeTunnelConnection = FakeTunnelConnection(),
     private val connectError: Throwable? = null,
+    /**
+     * One gate per `connect` call, held under [NonCancellable] — the real dial is blocking, so a
+     * cancelled attempt keeps running to the end and only then finds out it was cancelled. Empty
+     * (the default) means every connect returns at once.
+     */
+    private val connectGates: List<CompletableDeferred<Unit>> = emptyList(),
 ) : SshTransport {
     var lastTarget: SshTarget? = null
         private set
     var lastAuth: SshAuth? = null
         private set
 
+    private var dials = 0
+
     override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection {
         lastTarget = target
         lastAuth = auth
+        connectGates.getOrNull(dials++)?.let { withContext(NonCancellable) { it.await() } }
         connectError?.let { throw it }
         return connection
     }
@@ -560,7 +722,13 @@ private class FakeTunnelConnection(
     var disconnected = false
         private set
 
-    override val isConnected: Boolean get() = !disconnected
+    /** Makes the liveness probe throw, standing in for anything a tick can fail on. */
+    var failLiveness: Boolean = false
+
+    override val isConnected: Boolean get() {
+        if (failLiveness) error("liveness probe failed")
+        return !disconnected
+    }
     override suspend fun exec(command: String): ExecResult = throw UnsupportedOperationException()
     override suspend fun openShell(size: PtySize, term: String): ShellChannel = throw UnsupportedOperationException()
     override suspend fun openSftp(): SftpClient = throw UnsupportedOperationException()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultGateControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/VaultGateControllerTest.kt
@@ -146,6 +146,54 @@ class VaultGateControllerTest {
         assertTrue(confirm.all { it == ' ' })
     }
 
+    /**
+     * A config directory that cannot be written (read-only, or full) makes the very first screen a
+     * dead end: `create` has a `finally` but no `catch`, so the failure escapes into the scope —
+     * taking the app down, or leaving a button that does nothing — and the user is told nothing at
+     * all. It is a form error like any other: say so and stay on the form.
+     */
+    @Test
+    fun `create that cannot write the vault says so and stays on the form`() {
+        val scopeExceptions = mutableListOf<Throwable>()
+        val controller = gate(
+            FakeVault(exists = false, createThrows = true),
+            onException = { scopeExceptions.add(it) },
+        )
+        val password = "long enough password".toCharArray()
+        val confirm = "long enough password".toCharArray()
+
+        controller.create(password, confirm)
+
+        assertEquals(VaultGateState.NeedsCreate, controller.state)
+        assertEquals(VaultGateError.NotWritable, controller.error)
+        assertFalse(controller.verifying, "the create button would stay dead")
+        assertTrue(scopeExceptions.isEmpty(), "the failure must be reported, not thrown at the scope")
+        assertTrue(password.all { it == ' ' } && confirm.all { it == ' ' }, "buffers must still be wiped")
+    }
+
+    /**
+     * The other half of that rule: the guard covers the write and nothing after it. A security-log
+     * write or a biometrics probe failing once the vault exists must not be reported as "could not
+     * write the vault" — the vault is there, open, and the user would be stranded on the create
+     * form pressing a button that re-creates it.
+     */
+    @Test
+    fun `a failure after the vault is created is not reported as an unwritable vault`() {
+        val scopeExceptions = mutableListOf<Throwable>()
+        val controller = gate(
+            FakeVault(exists = false),
+            securityLog = ThrowingSecurityLog,
+            onException = { scopeExceptions.add(it) },
+        )
+
+        controller.create("long enough password".toCharArray(), "long enough password".toCharArray())
+
+        assertTrue(
+            controller.error != VaultGateError.NotWritable,
+            "a post-create failure was reported as a vault that could not be written",
+        )
+    }
+
     @Test
     fun `unlock with the right password unlocks`() {
         val vault = FakeVault(exists = true, unlockResult = UnlockResult.Success)
@@ -721,10 +769,20 @@ private fun biometricsForUnlock(
  * In-memory [Vault] for gate tests: models the create/unlock/lock lifecycle and wipes the passed
  * password (like the file-backed implementation). CRUD is not exercised by the gate controller.
  */
+/** A security log whose write fails — the step that runs once the vault already exists. */
+private object ThrowingSecurityLog : SecurityLog {
+    override fun record(type: SecurityEventType, detail: String?) = error("security log unavailable")
+    override fun recent(limit: Int): List<SecurityEvent> = emptyList()
+    override fun lastPasswordChangeAt(): String? = null
+    override fun clear() = Unit
+}
+
 private class FakeVault(
     exists: Boolean,
     var unlockResult: UnlockResult = UnlockResult.Success,
     private val unlockThrows: Boolean = false,
+    /** A vault directory that cannot be written — a read-only or full config dir. */
+    private val createThrows: Boolean = false,
     private val changePasswordResult: Boolean = true,
 ) : Vault {
     private var fileExists = exists
@@ -739,6 +797,7 @@ private class FakeVault(
 
     override fun create(password: CharArray) {
         createCalls++
+        if (createThrows) error("could not write the vault")
         fileExists = true
         isUnlocked = true
         password.fill(' ')

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowDrag.kt
@@ -7,22 +7,26 @@ import java.awt.Point
  * manager can't do it for (see [NativeWindowMove]). Fed absolute pointer positions, it answers with
  * the window origin to apply, or `null` while the window has to stay put.
  *
- * Two cases deliberately stay put: a press that hasn't left [deadZone] yet, so a plain click and the
- * double-click-to-maximize gesture never nudge the window, and a window that stopped floating
- * mid-gesture — the double-click maximizes it while the button is still down, and following the
- * pointer from the pre-maximize origin would then park a screen-sized window at the old top-left,
- * pushing its right/bottom edges off-screen.
+ * It is handed a gesture that already is a drag — telling a drag from a click (and from the
+ * double-click-to-maximize gesture) is the touch-slop gate in `awaitDragStart`, upstream of this
+ * class. So the first event after [press] only captures the grab (window origin minus pointer) and
+ * moves nothing; every event after it follows the pointer.
+ *
+ * One case deliberately stays put: a window that stopped floating mid-gesture — the double-click
+ * maximizes it while the button is still down, and following the pointer from the pre-maximize
+ * origin would then park a screen-sized window at the old top-left, pushing its right/bottom edges
+ * off-screen.
  */
-class WindowDragGesture(private val deadZone: Int) {
+class WindowDragGesture {
 
-    private var pressedAt: Point? = null
+    private var pressed = false
 
-    /** Window origin minus pointer, captured once the drag leaves the dead zone; `null` until then. */
+    /** Window origin minus pointer, captured on the first event of the drag; `null` until then. */
     private var grab: Point? = null
 
-    /** Button pressed at absolute [pointer]; arms the gesture. */
-    fun press(pointer: Point) {
-        pressedAt = Point(pointer)
+    /** Button pressed; arms the gesture. */
+    fun press() {
+        pressed = true
         grab = null
     }
 
@@ -38,10 +42,9 @@ class WindowDragGesture(private val deadZone: Int) {
             release()
             return null
         }
-        val pressedAt = this.pressedAt ?: return null
+        if (!pressed) return null
         val grab = this.grab
         if (grab == null) {
-            if (!leftDeadZone(pressedAt, pointer)) return null
             this.grab = Point(windowOrigin.x - pointer.x, windowOrigin.y - pointer.y)
             return null
         }
@@ -50,13 +53,7 @@ class WindowDragGesture(private val deadZone: Int) {
 
     /** Button released: [drag] does nothing until the next [press]. */
     fun release() {
-        pressedAt = null
+        pressed = false
         grab = null
-    }
-
-    private fun leftDeadZone(from: Point, to: Point): Boolean {
-        val dx = to.x - from.x
-        val dy = to.y - from.y
-        return dx * dx + dy * dy >= deadZone * deadZone
     }
 }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/WindowFrame.kt
@@ -130,7 +130,7 @@ private fun Modifier.titlebarDrag(
             window.location = restoredWindowOrigin(maximized, restored, pointer)
         }
         if (useNativeMove && startMove(window, pointer.x, pointer.y)) return@awaitEachGesture
-        followPointer(window, pointer, isFloating)
+        followPointer(window, isFloating)
     }
 }
 
@@ -185,17 +185,16 @@ private suspend fun AwaitPointerEventScope.awaitRestoredSize(
 
 /**
  * Moves the window with the pointer until the button is released, for platforms the window manager
- * can't do it for. Gated by [WindowDragGesture], which also stops the drag if the window stops
- * floating mid-gesture (a double-click maximizes it while the button is still down — issue #76).
- * The dead zone is zero here: it was already crossed by [awaitDragStart].
+ * can't do it for. [WindowDragGesture] does the grab arithmetic and stops the drag if the window
+ * stops floating mid-gesture (a double-click maximizes it while the button is still down — issue
+ * #76). Whether this is a drag at all was already decided by [awaitDragStart]'s touch-slop gate.
  */
 private suspend fun AwaitPointerEventScope.followPointer(
     window: java.awt.Window,
-    from: Point,
     isFloating: () -> Boolean,
 ) {
-    val gesture = WindowDragGesture(deadZone = 0)
-    gesture.press(from)
+    val gesture = WindowDragGesture()
+    gesture.press()
     try {
         while (true) {
             val event = awaitPointerEvent()

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/main.kt
@@ -601,11 +601,9 @@ fun main(args: Array<String>) {
                     // customGroupsProvider after unlock, writes changes to the layout record.
                     initialCustomGroups = emptyList(),
                     onCustomGroupsChange = { groups ->
-                        workspaceLayout.write(
-                            workspaceLayout.read().copy(
-                                groups = groups.filter { it.section == HostSection.Terminal }.map { it.name },
-                                remoteDesktopGroups = groups.filter { it.section == HostSection.RemoteDesktops }.map { it.name },
-                            ),
+                        workspaceLayout.updateGroups(
+                            groups = groups.filter { it.section == HostSection.Terminal }.map { it.name },
+                            remoteDesktopGroups = groups.filter { it.section == HostSection.RemoteDesktops }.map { it.name },
                         )
                     },
                     customGroupsProvider = {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/TitlebarDoubleClickTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/TitlebarDoubleClickTest.kt
@@ -231,6 +231,39 @@ class TitlebarDoubleClickTest {
     }
 
     @Test
+    fun pressInsideTouchSlopNeverArmsTheDrag() {
+        // Issue #152: keeping a plain click from nudging the window is awaitDragStart's touch-slop
+        // gate, not anything downstream. Below slop the gesture is left to the click handlers —
+        // nothing is handed to the window manager and no in-app drag starts.
+        var moves = 0
+        val chrome = runTitlebarScene(useNativeMove = true, startMove = { _, _, _ -> moves++; true }) {
+            val down = PointerButtons(isPrimaryPressed = true)
+            val up = PointerButtons()
+            sendPointerEvent(PointerEventType.Press, Offset(300f, 22f), timeMillis = 100, buttons = down, button = PointerButton.Primary)
+            sendPointerEvent(PointerEventType.Move, Offset(302f, 23f), timeMillis = 130, buttons = down)
+            sendPointerEvent(PointerEventType.Move, Offset(303f, 22f), timeMillis = 160, buttons = down)
+            sendPointerEvent(PointerEventType.Release, Offset(303f, 22f), timeMillis = 200, buttons = up, button = PointerButton.Primary)
+        }
+        assertEquals(0, moves, "a press that never leaves touch slop must not start a window move")
+        assertEquals(WindowPlacement.Floating, chrome.state.placement)
+    }
+
+    @Test
+    fun pressPastTouchSlopArmsTheDrag() {
+        // The other side of the same gate: once slop is crossed the press is a drag, and on a
+        // floating window it goes straight to the window manager.
+        var moves = 0
+        runTitlebarScene(useNativeMove = true, startMove = { _, _, _ -> moves++; true }) {
+            val down = PointerButtons(isPrimaryPressed = true)
+            val up = PointerButtons()
+            sendPointerEvent(PointerEventType.Press, Offset(300f, 22f), timeMillis = 100, buttons = down, button = PointerButton.Primary)
+            sendPointerEvent(PointerEventType.Move, Offset(360f, 24f), timeMillis = 130, buttons = down)
+            sendPointerEvent(PointerEventType.Release, Offset(360f, 24f), timeMillis = 200, buttons = up, button = PointerButton.Primary)
+        }
+        assertEquals(1, moves, "a press past touch slop must start exactly one window move")
+    }
+
+    @Test
     fun twoSlowClicksDoNotToggle() {
         val chrome = runTitlebarScene {
             sendPointerEvent(PointerEventType.Press, Offset(300f, 22f), timeMillis = 100)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/WindowDragGestureTest.kt
@@ -5,47 +5,32 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
+/**
+ * The grab arithmetic of an already-armed drag. What makes a press a drag in the first place is the
+ * touch-slop gate upstream in `awaitDragStart`, covered by [TitlebarDoubleClickTest] against the
+ * production modifier chain — this class never sees a click.
+ */
 class WindowDragGestureTest {
 
-    private val deadZone = 18
     private val origin = Point(100, 200)
 
-    private fun gesture(pressAt: Point = Point(500, 20)) =
-        WindowDragGesture(deadZone).apply { press(pressAt) }
+    private fun gesture() = WindowDragGesture().apply { press() }
 
     @Test
-    fun pointerInsideDeadZoneDoesNotMoveTheWindow() {
-        val gesture = gesture(Point(500, 20))
-        assertNull(gesture.drag(Point(502, 21), origin, floating = true))
+    fun firstEventCapturesTheGrabAndMovesNothing() {
+        val gesture = gesture()
+        // The drag is handed over already in progress, so the first event has nothing to measure a
+        // delta from: it only records where the window sits relative to the pointer.
         assertNull(gesture.drag(Point(500, 20), origin, floating = true))
-    }
-
-    @Test
-    fun dragPastDeadZoneFollowsThePointer() {
-        val gesture = gesture(Point(500, 20))
-        // The crossing event itself only arms the drag (the window stays where it is)...
-        assertNull(gesture.drag(Point(530, 20), origin, floating = true))
-        // ...and from there the origin follows the pointer delta measured from the crossing point.
-        assertEquals(Point(140, 215), gesture.drag(Point(570, 35), origin, floating = true))
-    }
-
-    /**
-     * A drag handed over after a restore (WindowFrame.followPointer) starts with no dead zone: it was
-     * already crossed before the window was restored, so the very first event must arm the gesture.
-     */
-    @Test
-    fun zeroDeadZoneArmsOnTheFirstEvent() {
-        val gesture = WindowDragGesture(deadZone = 0).apply { press(Point(500, 20)) }
-        // Not even a pixel of movement: the first event still only captures the grab...
-        assertNull(gesture.drag(Point(500, 20), origin, floating = true))
-        // ...and every event after it moves the window.
+        // ...and every event after it moves the window by the pointer delta.
         assertEquals(Point(101, 200), gesture.drag(Point(501, 20), origin, floating = true))
+        assertEquals(Point(140, 215), gesture.drag(Point(540, 35), origin, floating = true))
     }
 
     /** Issue #76: the double-click maximizes the window while the button is still down. */
     @Test
     fun windowMaximizedMidGestureIsNeverMoved() {
-        val gesture = gesture(Point(500, 20))
+        val gesture = gesture()
         // The maximized window sits at (0,0); moves keep arriving until the button goes up, and not
         // one of them may reposition it (the second one is what a leaked drag would answer).
         assertNull(gesture.drag(Point(560, 40), Point(0, 0), floating = false))
@@ -55,8 +40,8 @@ class WindowDragGestureTest {
 
     @Test
     fun maximizingMidGestureEndsTheGestureForGood() {
-        val gesture = gesture(Point(500, 20))
-        // A drag is already under way — past the dead zone, window following the pointer...
+        val gesture = gesture()
+        // A drag is already under way — grab captured, window following the pointer...
         assertNull(gesture.drag(Point(530, 20), origin, floating = true))
         assertEquals(Point(140, 215), gesture.drag(Point(570, 35), origin, floating = true))
         // ...when the window stops floating (double-click, or the WM's own drag-to-top maximize).
@@ -69,23 +54,24 @@ class WindowDragGestureTest {
 
     @Test
     fun dragAfterAnAbortedGestureWorksAgain() {
-        val gesture = gesture(Point(500, 20))
+        val gesture = gesture()
         gesture.drag(Point(505, 25), origin, floating = false)
         gesture.release()
-        gesture.press(Point(400, 30))
+        gesture.press()
         assertNull(gesture.drag(Point(440, 30), origin, floating = true))
         assertEquals(Point(110, 200), gesture.drag(Point(450, 30), origin, floating = true))
     }
 
     @Test
     fun dragWithoutPressIsIgnored() {
-        val gesture = WindowDragGesture(deadZone)
+        val gesture = WindowDragGesture()
         assertNull(gesture.drag(Point(900, 400), origin, floating = true))
+        assertNull(gesture.drag(Point(920, 410), origin, floating = true))
     }
 
     @Test
     fun releasedGestureStopsFollowingThePointer() {
-        val gesture = gesture(Point(500, 20))
+        val gesture = gesture()
         gesture.drag(Point(530, 20), origin, floating = true)
         gesture.release()
         assertNull(gesture.drag(Point(560, 20), origin, floating = true))

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ImportFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/host/ImportFormTest.kt
@@ -2,6 +2,9 @@ package app.skerry.ui.host
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsToggleable
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -15,6 +18,9 @@ import app.skerry.ui.app.LocalHosts
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.seededHosts
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_import_select_all
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -69,6 +75,42 @@ class ImportFormTest {
         }
         assertTrue(hosts.hosts.none { it.label == "bastion" }, "an unticked host was imported anyway")
         assertNotNull(hosts.hosts.firstOrNull { it.label == "db" }, "the ticked host was not imported")
+    }
+
+    /**
+     * Issue #228: the tick is a Material Symbol ligature, and [Sym] clears its own semantics — so a
+     * row that only carries a click tells a screen reader nothing about being on or off. The row is
+     * the checkbox; its state has to live there.
+     */
+    @Test
+    fun `an import row reads as a checkbox with a state`() {
+        val hosts = seededHosts()
+        val state = DesktopDesignState()
+        runForm({
+            CompositionLocalProvider(LocalHosts provides hosts) {
+                SshConfigImportModal(state, PARSED)
+            }
+        }) {
+            onNodeWithText("bastion").assertIsToggleable().assertIsOn().performClick()
+            waitForIdle()
+            onNodeWithText("bastion").assertIsOff()
+        }
+    }
+
+    /** The select-all row is the same control for every row at once, and answers the same way. */
+    @Test
+    fun `the select-all row reads as a checkbox with a state`() {
+        val hosts = seededHosts()
+        val state = DesktopDesignState()
+        runForm({
+            CompositionLocalProvider(LocalHosts provides hosts) {
+                SshConfigImportModal(state, PARSED)
+            }
+        }) {
+            onNodeWithText(string(Res.string.conn_import_select_all)).assertIsToggleable().assertIsOn().performClick()
+            waitForIdle()
+            onNodeWithText(string(Res.string.conn_import_select_all)).assertIsOff()
+        }
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileCheckRowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileCheckRowTest.kt
@@ -1,0 +1,86 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsToggleable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.shared.ssh.SshConfigHost
+import app.skerry.shared.ssh.SshConfigParseResult
+import app.skerry.ui.app.LocalHosts
+import app.skerry.ui.app.MobileDesignState
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.seededHosts
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.conn_import_select_all
+import app.skerry.ui.session.BroadcastController
+import app.skerry.ui.session.BroadcastTarget
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The phone's tick rows, as a screen reader meets them (issue #228).
+ *
+ * Both sheets draw their checkbox as a Material Symbol ligature, and `Sym` clears its own semantics
+ * — a row that carries only a click announces a button whose name is a word, with no on/off state
+ * behind it. Desktop parity of the same rows lives in
+ * [app.skerry.ui.session.BroadcastFormTest] and [app.skerry.ui.host.ImportFormTest].
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileCheckRowTest {
+
+    @Test
+    fun `a broadcast target row reads as a checkbox with a state`() {
+        val controller = BroadcastController()
+        val targets = listOf(BroadcastTarget(id = "a", label = "web-01", production = false) { true })
+
+        runForm({ MobileBroadcastSheet(controller, targets, onDismiss = {}) }) {
+            onNodeWithText("web-01").assertIsToggleable().assertIsOff().performClick()
+            waitForIdle()
+            onNodeWithText("web-01").assertIsOn()
+        }
+        assertTrue(controller.isSelected("a"), "the row's toggle did not reach the controller")
+    }
+
+    @Test
+    fun `an ssh config import row reads as a checkbox with a state`() {
+        val hosts = seededHosts()
+        val state = MobileDesignState()
+        runForm({
+            CompositionLocalProvider(LocalHosts provides hosts) {
+                MobileSshImportSheet(state, PARSED)
+            }
+        }) {
+            onNodeWithText("bastion").assertIsToggleable().assertIsOn().performClick()
+            waitForIdle()
+            onNodeWithText("bastion").assertIsOff()
+        }
+    }
+
+    @Test
+    fun `the mobile select-all row reads as a checkbox with a state`() {
+        val hosts = seededHosts()
+        val state = MobileDesignState()
+        runForm({
+            CompositionLocalProvider(LocalHosts provides hosts) {
+                MobileSshImportSheet(state, PARSED)
+            }
+        }) {
+            val selectAll = string(Res.string.conn_import_select_all)
+            onNodeWithText(selectAll).assertIsToggleable().assertIsOn().performClick()
+            waitForIdle()
+            onNodeWithText(selectAll).assertIsOff()
+        }
+    }
+}
+
+private val PARSED = SshConfigParseResult(
+    hosts = listOf(
+        SshConfigHost("bastion", "bastion.example.com", 2222, "deploy", null, null),
+        SshConfigHost("db", "db.example.com", 22, "root", null, null),
+    ),
+    warnings = emptyList(),
+)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/session/BroadcastFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/session/BroadcastFormTest.kt
@@ -1,7 +1,11 @@
 package app.skerry.ui.session
 
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsToggleable
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import app.skerry.ui.app.UiTags
@@ -68,6 +72,24 @@ class BroadcastFormTest {
             waitForIdle()
         }
         assertTrue(sent["prod"].isNullOrEmpty(), "a destructive broadcast reached production unconfirmed")
+    }
+
+    /**
+     * Issue #228: the tick beside a target is a Material Symbol ligature, and `Sym` clears its own
+     * semantics — so a row carrying nothing but a click tells a screen reader neither that it is a
+     * checkbox nor which sessions the next send will reach. The row is the checkbox.
+     */
+    @Test
+    fun `a target row reads as a checkbox with a state`() {
+        val targets = listOf(target("a", mutableMapOf()))
+        val controller = BroadcastController()
+
+        runForm({ BroadcastPanel(controller, targets, onDismiss = {}) }) {
+            onNodeWithText("a").assertIsToggleable().assertIsOff().performClick()
+            waitForIdle()
+            onNodeWithText("a").assertIsOn()
+        }
+        assertTrue(controller.isSelected("a"), "the row's toggle did not reach the controller")
     }
 
     private fun target(id: String, log: MutableMap<String, MutableList<String>>, production: Boolean = false) =

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncFormsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncFormsTest.kt
@@ -3,6 +3,11 @@ package app.skerry.ui.sync
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsToggleable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performTextInput
 import app.skerry.ui.app.UiTags
@@ -10,6 +15,7 @@ import app.skerry.ui.settings.ChangeAccountPasswordDialog
 import app.skerry.ui.desktop.onField
 import app.skerry.ui.desktop.withOfflineCoordinator
 import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.settings_change_pw_confirm
 import app.skerry.ui.generated.resources.settings_change_pw_current
@@ -17,6 +23,7 @@ import app.skerry.ui.generated.resources.settings_change_pw_new
 import app.skerry.ui.generated.resources.sync_field_account
 import app.skerry.ui.generated.resources.sync_field_master_password
 import app.skerry.ui.generated.resources.sync_field_server_url
+import app.skerry.ui.generated.resources.sync_keep_connected
 import kotlin.test.Test
 
 /**
@@ -29,6 +36,23 @@ import kotlin.test.Test
  */
 @OptIn(ExperimentalTestApi::class)
 class SyncFormsTest {
+
+    /**
+     * "Keep me connected" decides whether the session is persisted on this machine, and its tick is
+     * a `Sym` glyph, which clears its own semantics. Drawn as a plain click the row announced a
+     * button with a word for a name and no on/off state — on a switch about persisting a session
+     * (issue #228).
+     */
+    @Test
+    fun `the keep-connected row reads as a checkbox with a state`() = withOfflineCoordinator { sync ->
+        runForm({ SyncSetupDialog(sync, onDismiss = {}) }) {
+            val label = string(Res.string.sync_keep_connected)
+            // The dialog opens with it on (the default a fresh link is offered with).
+            onNodeWithText(label).assertIsToggleable().assertIsOn().performClick()
+            waitForIdle()
+            onNodeWithText(label).assertIsOff()
+        }
+    }
 
     @Test
     fun `connect stays shut until the whole form is filled`() = withOfflineCoordinator { sync ->

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorScopeTest.kt
@@ -67,6 +67,8 @@ class TeamsCoordinatorScopeTest {
         val removed = mutableListOf<String>()
         /** Set to make listScopes fail — a server without scope routes (404) or a transient error. */
         var listScopesFailure: SyncException? = null
+        /** Set to make the team-key rotation fail — a 5xx, or the network dropping mid-removal. */
+        var teamRekeyFailure: SyncException? = null
 
         private val store = linkedMapOf<String, Triple<RemoteRecord, Long, String>>() // id -> (rec, seq, scope)
         private var seq = 0L
@@ -147,6 +149,7 @@ class TeamsCoordinatorScopeTest {
         override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
         override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
             teamRekeyCalls += newEpoch
+            teamRekeyFailure?.let { throw it }
         }
         override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
         override suspend fun reportSessionEvent(
@@ -420,6 +423,34 @@ class TeamsCoordinatorScopeTest {
         assertEquals(untouchedKey, ks.scope(teamId, "sandbox")!!.key)
         // The team key rotates too, as it did before scopes existed.
         assertEquals(listOf(1L), client.teamRekeyCalls)
+    }
+
+    /**
+     * The scope loop is guarded precisely because every skipped scope is a key the removed member
+     * still holds. The team rotation above it was not, so one failed rekey — a 5xx, a dropped
+     * network — unwound past the loop and left them holding every scope key they had, with nothing
+     * to retry it: the removal has already happened server-side and cannot be repeated.
+     */
+    @Test
+    fun `a failed team rotation still rotates the scopes the removed member held`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val ks = seedTeam(f)
+        val client = FakeTeamClient(self, teamId, AccountKeys(crypto.newSharingKeyPair().publicKey, crypto.newSigningKeyPair().publicKey))
+        val coord = coordinator(f, client, listOf("prod", "staging").iterator())
+        coord.createScope(teamId, "Production")
+        coord.createScope(teamId, "Staging")
+        coord.grantScope(teamId, "prod", bob)
+        coord.grantScope(teamId, "staging", bob)
+        client.teamRekeyFailure = SyncException(SyncException.Kind.NETWORK, "offline")
+
+        coord.removeMember(teamId, bob)
+
+        assertEquals(listOf(bob), client.removed)
+        assertEquals(listOf("prod" to 1L, "staging" to 1L), client.rekeyCalls.sortedBy { it.first })
+        assertEquals(1, ks.scope(teamId, "prod")!!.epoch)
+        assertEquals(1, ks.scope(teamId, "staging")!!.epoch)
+        assertNotNull(coord.lastError.value, "the failed team rotation must still be reported")
     }
 
     @Test

--- a/server/src/main/kotlin/app/skerry/server/db/ActivityRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/ActivityRepository.kt
@@ -28,9 +28,13 @@ data class ActivityEvent(
  * and bounded, so it can't grow without limit on a long-lived self-hosted instance. Contains no
  * record content — only the event, the device, ids, and a human-readable summary ([ActivityEvent.detail]).
  *
- * Retention is **per bucket**, not global: account-level rows keep the newest [maxRows], and every
- * team keeps the newest [teamMaxRows] of its own. That partition is what stops one team's traffic
- * from evicting another team's history — or the admin console's — which matters here because any
+ * Retention is **per bucket**: account-level rows keep the newest [maxRows] per account, and every
+ * team keeps the newest [teamMaxRows] of its own. Above [accountRowsTotal] rows across all accounts
+ * a global ceiling takes the oldest first regardless of account — the partition is what an instance
+ * gets until the table itself has to be bounded, which on open registration it eventually does.
+ *
+ * The partition is what stops one team's traffic from evicting another team's history — or the
+ * admin console's — which matters here because any
  * active member (a viewer included) can append to their team's bucket by reporting sessions. Within
  * one team's own bucket the window is still finite, as any bounded log's is; the endpoint that feeds
  * it is rate-limited per account so filling it takes sustained and plainly visible effort.
@@ -39,6 +43,12 @@ class ActivityRepository(
     private val db: Database,
     private val maxRows: Int = 2_000,
     private val teamMaxRows: Int = 500,
+    /**
+     * Ceiling over every account's rows together. Retention is per account, so without it the
+     * table grows with the number of accounts — and on an instance with open registration that is
+     * whatever anyone cares to register.
+     */
+    private val accountRowsTotal: Int = 100_000,
 ) {
 
     suspend fun record(
@@ -69,8 +79,9 @@ class ActivityRepository(
         dbTransaction(db) {
             if (events.isEmpty()) return@dbTransaction
             events.forEach { insert(it, now) }
-            // Each bucket the batch touched, pruned once.
-            events.map { it.teamId }.distinct().forEach { prune(it) }
+            // Each bucket the batch touched, pruned once. An account-level bucket is per account:
+            // the rows of one account must not evict another's (see [prune]).
+            events.map { it.teamId to it.accountId }.distinct().forEach { (team, account) -> prune(team, account) }
         }
 
     /**
@@ -118,7 +129,7 @@ class ActivityRepository(
             ),
             now,
         )
-        prune(teamId)
+        prune(teamId, accountId)
         true
     }
 
@@ -187,15 +198,27 @@ class ActivityRepository(
     }
 
     /**
-     * Trims one bucket — a single team's rows, or the account-level ones ([teamId] null) — to its
-     * cap, deleting the oldest beyond it. Gap-safe: the boundary is an actual `seq`, not arithmetic
-     * on a row count.
+     * Trims one bucket — a single team's rows, or one account's own ([teamId] null) — to its cap,
+     * deleting the oldest beyond it. Gap-safe: the boundary is an actual `seq`, not arithmetic on a
+     * row count.
+     *
+     * The account-level bucket is partitioned by [accountId] for the same reason team rows are
+     * partitioned by team: unpartitioned, one account syncing all day evicts every other account's
+     * logins, device revocations and password changes from the audit trail — and the "N of M" total
+     * shrinks with them.
      */
-    private fun prune(teamId: String?) {
+    private fun prune(teamId: String?, accountId: String) {
+        // Before the per-account gate below, not after it: the ceiling exists for an instance with
+        // many small accounts, and every one of those returns early from that gate — so reached
+        // only from inside it, the bound would never fire in the case it was added for.
+        if (teamId == null) pruneAccountsTotal()
         val cap = if (teamId == null) maxRows else teamMaxRows
         fun bucket() =
-            if (teamId == null) ActivityLog.selectAll().where { ActivityLog.teamId.isNull() }
-            else ActivityLog.selectAll().where { ActivityLog.teamId eq teamId }
+            if (teamId == null) {
+                ActivityLog.selectAll().where { ActivityLog.teamId.isNull() and (ActivityLog.accountId eq accountId) }
+            } else {
+                ActivityLog.selectAll().where { ActivityLog.teamId eq teamId }
+            }
         // Cheap count-gate: only run the expensive OFFSET scan once the cap is actually exceeded,
         // not on every recorded event.
         if (bucket().count() <= cap) return
@@ -204,10 +227,28 @@ class ActivityRepository(
             .limit(1).offset((cap - 1).toLong())
             .firstOrNull()?.get(ActivityLog.seq) ?: return
         if (teamId == null) {
-            ActivityLog.deleteWhere { ActivityLog.teamId.isNull() and (seq lessEq keepFrom - 1) }
+            ActivityLog.deleteWhere {
+                ActivityLog.teamId.isNull() and (ActivityLog.accountId eq accountId) and (seq lessEq keepFrom - 1)
+            }
         } else {
             ActivityLog.deleteWhere { (ActivityLog.teamId eq teamId) and (seq lessEq keepFrom - 1) }
         }
+    }
+
+    /**
+     * The ceiling over all account-level rows ([accountRowsTotal]). The per-account partition is
+     * what stops one account evicting another's history; this is what stops the table from growing
+     * with the number of accounts. Same count-gate as [prune], so it costs an indexed count until
+     * the instance is actually that large.
+     */
+    private fun pruneAccountsTotal() {
+        fun bucket() = ActivityLog.selectAll().where { ActivityLog.teamId.isNull() }
+        if (bucket().count() <= accountRowsTotal) return
+        val keepFrom = bucket()
+            .orderBy(ActivityLog.seq to SortOrder.DESC)
+            .limit(1).offset((accountRowsTotal - 1).toLong())
+            .firstOrNull()?.get(ActivityLog.seq) ?: return
+        ActivityLog.deleteWhere { ActivityLog.teamId.isNull() and (seq lessEq keepFrom - 1) }
     }
 
     private fun org.jetbrains.exposed.v1.core.ResultRow.toRow() = ActivityRow(

--- a/server/src/main/kotlin/app/skerry/server/db/Tables.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/Tables.kt
@@ -105,6 +105,10 @@ object ActivityLog : Table("activity_log") {
 
     init {
         index("idx_activity_team", false, teamId, seq)
+        // The account-level bucket is retained per account, so both the retention probe and
+        // `recentForAccount` select on (account_id, seq) — without this they scan every account's
+        // rows on every event written.
+        index("idx_activity_account", false, accountId, seq)
     }
 }
 

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -89,7 +89,10 @@ fun Route.teamRoutes(services: Services) {
     post("/teams") {
         val principal = call.jwtPrincipal()
         val req = call.receive<TeamCreateRequest>()
-        if (req.teamId.isBlank() || anyTooLong(req.teamId)) throw BadRequestException("bad teamId")
+        // Same charset and length as a scope id, and for the same reason: the id becomes a vault
+        // file name on every member's device, so a client refuses anything else (TeamScopeRef
+        // .isSafeId) — and anything past varchar(64) fails the insert as a 500 rather than a 400.
+        if (!isSafeTeamId(req.teamId)) throw BadRequestException("bad teamId")
         if (!services.teams.create(req.teamId, principal.accountId, System.currentTimeMillis())) {
             call.respond(HttpStatusCode.Conflict, ErrorResponse("team already exists"))
             return@post

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamScopeRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamScopeRoutes.kt
@@ -199,9 +199,7 @@ private suspend fun ApplicationCall.requireScopeHolder(
  * held to the same charset as a team id (`[a-z0-9-]`). Rejected before any side effect.
  */
 internal suspend fun ApplicationCall.validScopeId(value: String): String? {
-    val ok = value.isNotEmpty() && value.length <= MAX_SCOPE_ID &&
-        value.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }
-    if (!ok) {
+    if (!isSafeTeamId(value)) {
         respond(HttpStatusCode.BadRequest, ErrorResponse("bad scopeId"))
         return null
     }
@@ -218,3 +216,12 @@ private suspend fun ApplicationCall.validEnvelope(value: String): ByteArray? {
 }
 
 internal const val MAX_SCOPE_ID = 64
+
+/**
+ * The id shape a team space is allowed to have — `[a-z0-9-]`, at most [MAX_SCOPE_ID] characters.
+ * Team ids and scope ids share it: both are client-chosen, both become a vault file name on every
+ * member's device, and both are stored in a `varchar(64)`.
+ */
+internal fun isSafeTeamId(value: String): Boolean =
+    value.isNotEmpty() && value.length <= MAX_SCOPE_ID &&
+        value.all { it in 'a'..'z' || it in '0'..'9' || it == '-' }

--- a/server/src/main/kotlin/app/skerry/server/share/ShareRelay.kt
+++ b/server/src/main/kotlin/app/skerry/server/share/ShareRelay.kt
@@ -30,25 +30,32 @@ class ShareRelay(
 
     /** Opens a share, or refuses: the id is already live, or the team is at its cap. */
     fun open(teamId: String, shareId: String, hostAccountId: String, meta: String): ShareOpen {
-        val teamShares = shares.computeIfAbsent(teamId) { ConcurrentHashMap() }
-        val session = HostShareSession(
-            relay = this,
-            teamId = teamId,
-            shareId = shareId,
-            hostAccountId = hostAccountId,
-            meta = meta,
-            startedAt = now(),
-            replayBytes = replayBytes,
-            maxGuests = maxGuestsPerShare,
-            guestQueueFrames = guestQueueFrames,
-        )
-        // putIfAbsent first: two hosts racing on the same id must not both believe they own it.
-        if (teamShares.putIfAbsent(shareId, session) != null) return ShareOpen.Taken
-        if (teamShares.size > maxSharesPerTeam) {
+        while (true) {
+            val teamShares = shares.computeIfAbsent(teamId) { ConcurrentHashMap() }
+            val session = HostShareSession(
+                relay = this,
+                teamId = teamId,
+                shareId = shareId,
+                hostAccountId = hostAccountId,
+                meta = meta,
+                startedAt = now(),
+                replayBytes = replayBytes,
+                maxGuests = maxGuestsPerShare,
+                guestQueueFrames = guestQueueFrames,
+            )
+            // putIfAbsent first: two hosts racing on the same id must not both believe they own it.
+            if (teamShares.putIfAbsent(shareId, session) != null) return ShareOpen.Taken
+            if (teamShares.size > maxSharesPerTeam) {
+                teamShares.remove(shareId, session)
+                return ShareOpen.TooMany
+            }
+            // The bucket may have been dropped meanwhile: [forget] removes an empty one, and the
+            // last share of this team closing between the lookup above and the insert leaves this
+            // session in a map no longer reachable from `shares` — so the host believes it is
+            // sharing while `list` and `join` can never see it. Take the bucket again.
+            if (shares[teamId] === teamShares) return ShareOpen.Started(session)
             teamShares.remove(shareId, session)
-            return ShareOpen.TooMany
         }
-        return ShareOpen.Started(session)
     }
 
     /** Live shares of [teamId] — what the team's members see offered to join. */
@@ -67,8 +74,10 @@ class ShareRelay(
         val teamShares = shares[session.teamId] ?: return
         teamShares.remove(session.shareId, session)
         // Drop the team's empty bucket so a long-lived server doesn't accumulate one map per team
-        // that ever shared anything. `remove(key, value)` only removes it while still empty.
-        if (teamShares.isEmpty()) shares.remove(session.teamId, teamShares)
+        // that ever shared anything. Emptiness and removal have to be ONE step: tested and then
+        // removed, a share opened in between is evicted with the bucket and becomes invisible to
+        // `list` and `join` for its whole life.
+        shares.computeIfPresent(session.teamId) { _, bucket -> bucket.takeIf { it.isNotEmpty() } }
     }
 }
 

--- a/server/src/test/kotlin/app/skerry/server/db/ActivityRepositoryTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/db/ActivityRepositoryTest.kt
@@ -104,6 +104,46 @@ class ActivityRepositoryTest {
         assertEquals(2, repo.recentForTeam("team-1").size)
     }
 
+    /**
+     * The same partition argument, one level down: team rows are kept per team, but the
+     * account-level bucket was "every row with no team" across every account on the instance. One
+     * account syncing all day therefore evicted everybody else's logins, device revocations and
+     * password changes — the rows an audit trail exists for.
+     */
+    @Test
+    fun `one account cannot evict another account's log`() = withTestDb { db ->
+        val repo = ActivityRepository(db, maxRows = 3)
+        repeat(2) { i -> repo.record("quiet@example.com", "auth.login", "quiet $i", now = i.toLong()) }
+
+        repeat(20) { i -> repo.record("busy@example.com", "sync.push", "busy $i", now = 100L + i) }
+
+        assertEquals(
+            listOf("quiet 1", "quiet 0"),
+            repo.recentForAccount("quiet@example.com").map { it.detail },
+            "a busy account evicted another account's audit trail",
+        )
+        assertEquals(3, repo.recentForAccount("busy@example.com").size, "the busy account still trims its own")
+    }
+
+    /**
+     * The ceiling over every account's rows together. Per-account retention alone lets the table
+     * grow with the number of accounts, which on an instance with open registration is whatever
+     * anyone cares to register — and the accounts that get there are small ones, none of which ever
+     * trips its own cap.
+     */
+    @Test
+    fun `a ceiling bounds the account log across accounts, not just per account`() = withTestDb { db ->
+        val repo = ActivityRepository(db, maxRows = 100, accountRowsTotal = 6)
+
+        repeat(4) { i -> repo.record("a@example.com", "auth.login", "a $i", now = i.toLong()) }
+        repeat(4) { i -> repo.record("b@example.com", "auth.login", "b $i", now = 100L + i) }
+
+        // Neither account came near its own cap, so only the global ceiling can have trimmed this.
+        assertEquals(6, repo.recent(50).size)
+        // The oldest rows went first, newest kept.
+        assertEquals(listOf("b 3", "b 2", "b 1", "b 0", "a 3", "a 2"), repo.recent(50).map { it.detail })
+    }
+
     @Test
     fun `one team cannot evict another team's history, nor the account log`() = withTestDb { db ->
         // Any active member (a viewer included) can append to their team's bucket by reporting

--- a/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
@@ -72,6 +72,37 @@ class TeamRoutesTest {
             setBody(TeamRekeyRequest(newEpoch, envelopes.map { (id, env) -> RekeyEnvelopeDto(id, env.b64()) }))
         }
 
+    /**
+     * A team id is client-chosen and ends up as a vault file name on every member's device, which
+     * is why the client refuses anything outside `[a-z0-9-]{1,64}` (`TeamScopeRef.isSafeId`). The
+     * server accepted 128 characters of anything, so an id could be stored that no member can
+     * adopt — and one longer than the column takes fails the insert, answering 500 instead of 400.
+     * The scope route already validates exactly this; the team route did not.
+     */
+    @Test
+    fun `a team id the clients could never use is refused`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+        val tokens = client.registerAccount(alice, password)
+
+        listOf(
+            "../../escape", // a path traversal in a name that becomes a file
+            "Team-One", // uppercase: the client's own check refuses it
+            "team one", // whitespace
+            "a".repeat(65), // longer than Teams.id (varchar(64))
+        ).forEach { id ->
+            assertEquals(
+                HttpStatusCode.BadRequest,
+                client.createTeam(tokens.accessToken, id).status,
+                "team id \"$id\" was accepted",
+            )
+        }
+
+        // The shape every client can actually use is still accepted.
+        assertEquals(HttpStatusCode.Created, client.createTeam(tokens.accessToken, "team-42").status)
+    }
+
     @Test
     fun `rekey bumps the epoch, distributes key envelopes, and enforces monotonicity and role`() = testApplication {
         val services = testServices()

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
@@ -47,7 +47,10 @@ class VaultHostStore(
         // otherwise a concurrent mergeRemote from background sync landing between read() and write()
         // would be clobbered.
         codec.put(host.id, host)
-        val current = layout.read()
+        // readOrNull, not read: a layout record that exists but cannot be decrypted reads as an
+        // empty layout, and writing over it would replace the whole account's host order with this
+        // one host. The profile is saved either way; only the order is left as it is.
+        val current = layout.readOrNull() ?: return@transaction
         if (host.id !in current.hostOrder) {
             layout.write(current.copy(hostOrder = current.hostOrder + host.id))
         }
@@ -56,7 +59,7 @@ class VaultHostStore(
     override fun remove(id: String) = vault.transaction {
         // See [put]: layout update is atomic with the record removal.
         codec.remove(id)
-        val current = layout.read()
+        val current = layout.readOrNull() ?: return@transaction // see [put]
         if (id in current.hostOrder) {
             layout.write(current.copy(hostOrder = current.hostOrder - id))
         }
@@ -79,6 +82,10 @@ class VaultHostStore(
         for (host in updated) {
             if (byId[host.id] != host) codec.put(host.id, host)
         }
-        layout.write(layout.read().copy(hostOrder = updated.map { it.id }))
+        // Skipped like the writes above when the layout cannot be read: the record also holds the
+        // group list, and writing the new host order over a record we could not read would replace
+        // that list with an empty one. The profile changes above are already committed.
+        val existing = layout.readOrNull() ?: return@transaction
+        layout.write(existing.copy(hostOrder = updated.map { it.id }))
     }
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/SurfaceCommands.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/SurfaceCommands.kt
@@ -64,6 +64,9 @@ class SurfaceDecoder(
             when (codecId) {
                 0 -> "Raw"
                 ClientCapabilities.CODEC_ID_REMOTEFX -> "RemoteFX"
+                // Always advertised and always decodable, so it is the fallback a host with
+                // RemoteFX off actually lands on — the overlay has to name it, not print its id.
+                ClientCapabilities.CODEC_ID_NSCODEC -> "NSCodec"
                 else -> "0x${codecId.toString(16)}"
             },
         )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/egfx/GraphicsCodecs.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/egfx/GraphicsCodecs.kt
@@ -1,9 +1,11 @@
 package app.skerry.shared.rdp.egfx
 
 import app.skerry.shared.rdp.PlanarCodec
+import app.skerry.shared.rdp.RdpClientSettings
 import app.skerry.shared.rdp.RdpRect
 import app.skerry.shared.rdp.RdpReader
 import app.skerry.shared.rdp.RemoteFxDecoder
+import app.skerry.shared.rdp.rfx.RemoteFx
 
 /**
  * The codecs the graphics pipeline may use (MS-RDPEGFX 2.2.4.x), keyed by the ids the wire carries.
@@ -51,6 +53,20 @@ class GraphicsCodecs(
     }
 
     companion object {
+        /**
+         * The codec set a profile asks for. The switches are attack-surface knobs, so what the
+         * pipeline can decode has to follow them exactly as the legacy surface path does: a codec
+         * the profile turned off is left out, and a server that sends it anyway hits "not
+         * advertised" instead of a live decoder. [avc] is separate because whether this machine has
+         * an H.264 decoder at all is a platform question, answered before this is called.
+         */
+        fun forSettings(settings: RdpClientSettings, avc: AvcDecoder? = null): GraphicsCodecs = GraphicsCodecs(
+            remoteFx = if (settings.wantsRemoteFx) RemoteFx() else null,
+            progressive = Progressive(),
+            clear = ClearCodec(),
+            avc = avc,
+        )
+
         const val CODEC_UNCOMPRESSED = 0x0000
         const val CODEC_REMOTEFX = 0x0003
         const val CODEC_CLEARCODEC = 0x0008

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
@@ -4,6 +4,7 @@ import app.skerry.shared.vault.MergeResult
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecord
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Record types introduced after servers were already deployed in the field. They are pushed in a
@@ -13,6 +14,13 @@ import app.skerry.shared.vault.VaultRecord
  */
 private val TYPES_NEWER_THAN_SOME_SERVERS =
     setOf(RecordType.TRASH, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.TRUSTED_CA)
+
+/**
+ * How a server that predates one of [TYPES_NEWER_THAN_SOME_SERVERS] answers a push carrying it:
+ * the type fails validation (400) or the route is absent (404). Every other failure of that batch
+ * is a real one and belongs to the caller — not swallowed as "the server is just old".
+ */
+private val OLD_SERVER_REFUSALS = setOf(SyncException.Kind.PROTOCOL, SyncException.Kind.NOT_FOUND)
 
 /**
  * Where the delta sync cursor (`lastSyncVersion`) is stored, one per [key].
@@ -119,8 +127,21 @@ class SyncEngine(
             client.push(session, records.map { it.toRemote() })
             pushed += records.size
         }
-        if (recentTypes.isNotEmpty() && runCatching { client.push(session, recentTypes.map { it.toRemote() }) }.isSuccess) {
-            pushed += recentTypes.size
+        if (recentTypes.isNotEmpty()) {
+            try {
+                client.push(session, recentTypes.map { it.toRemote() })
+                pushed += recentTypes.size
+            } catch (e: CancellationException) {
+                // A `runCatching` here caught this too, so a vault auto-lock or a disconnect landing
+                // inside the push left the engine running on a cancelled job through the second pull.
+                throw e
+            } catch (e: SyncException) {
+                // Only the two answers an older server gives to a type it does not know are
+                // swallowed. A 401, a 429, a 5xx or a dropped network say nothing about the record
+                // type, and hiding them made a batch that will never be accepted look exactly like
+                // one the server is merely too old for — so nothing was ever diagnosable.
+                if (e.kind !in OLD_SERVER_REFUSALS) throw e
+            }
         }
 
         // Pull again: picks up our own just-pushed records (merge is idempotent) and any remote

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamVaults.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamVaults.kt
@@ -3,6 +3,7 @@ package app.skerry.shared.team
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.constantTimeEquals
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
 import okio.FileSystem
@@ -25,7 +26,16 @@ class TeamVaults(
     private val now: () -> String,
 ) {
 
-    private val open = mutableMapOf<String, Vault>()
+    /**
+     * The vault open for a space, together with the key it was opened under. The key is part of the
+     * entry and not just of the lookup: a space is re-keyed while its vault is still open (a screen
+     * holding it), and answering the next request from the cache would hand back a vault that
+     * cannot read a single record written since — while the stale-key probe below, the only thing
+     * that detects a superseded key, is skipped because the cache answered first.
+     */
+    private class OpenVault(val vault: Vault, val key: ByteArray)
+
+    private val open = mutableMapOf<String, OpenVault>()
 
     /**
      * Outcome of [openOrClassify]. [StaleKey] and [Unreadable] both mean "no usable vault", but the
@@ -53,7 +63,14 @@ class TeamVaults(
     fun openOrClassify(ref: TeamScopeRef, key: DataKey): OpenResult {
         requireSafe(ref)
         open[ref.key]?.let { cached ->
-            if (cached.isUnlocked) return OpenResult.Opened(cached)
+            if (cached.vault.isUnlocked && constantTimeEquals(cached.key, key.bytes)) {
+                return OpenResult.Opened(cached.vault)
+            }
+            // Opened under a key that is no longer the one being asked for (or already locked):
+            // drop it and take the normal path, which classifies the file against THIS key.
+            cached.vault.lock()
+            cached.key.fill(0)
+            open.remove(ref.key)
         }
         // FileVault takes ownership of the passed key (and wipes it on lock), so hand it a copy
         // to keep the caller's instance valid across repeated open/lock cycles.
@@ -82,20 +99,20 @@ class TeamVaults(
                 return OpenResult.StaleKey
             }
         }
-        open[ref.key] = vault
+        open[ref.key] = OpenVault(vault, key.bytes.copyOf())
         return OpenResult.Opened(vault)
     }
 
     /** Lock and forget all open vaults (e.g. when the account vault locks). */
     fun lockAll() {
-        open.values.forEach { it.lock() }
+        open.values.forEach { it.vault.lock(); it.key.fill(0) }
         open.clear()
     }
 
     /** Delete one space's file (left/deleted/access revoked): the local copy is no longer needed. */
     fun reset(ref: TeamScopeRef) {
         requireSafe(ref)
-        open.remove(ref.key)?.lock()
+        open.remove(ref.key)?.let { it.vault.lock(); it.key.fill(0) }
         fileSystem.delete(dir / ref.fileName, mustExist = false)
     }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/telnet/TelnetCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/telnet/TelnetCodec.kt
@@ -120,7 +120,11 @@ class TelnetCodec(
                 Phase.SUBNEG_DROP ->
                     if (b == IAC) phase = Phase.SUBNEG_DROP_IAC
 
-                Phase.SUBNEG_DROP_IAC -> if (b == SE) phase = Phase.DATA else if (b != IAC) phase = Phase.SUBNEG_DROP
+                // Same reading of an escaped IAC as the buffering path above: `IAC IAC` is one
+                // literal 0xFF of body, so the scan goes back to looking for the real closing
+                // sequence. Staying here instead would end the subnegotiation at the next SE byte
+                // and spill the rest of a server-chosen body into the terminal as data.
+                Phase.SUBNEG_DROP_IAC -> phase = if (b == SE) Phase.DATA else Phase.SUBNEG_DROP
             }
         }
         return Decoded(data.toByteArray(), reply.toByteArray())

--- a/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalMouse.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/terminal/TerminalMouse.kt
@@ -112,7 +112,10 @@ fun encodeMouseReport(
  *
  * The closing marker `ESC[201~` is stripped from the content: otherwise pasting text into which an
  * untrusted SSH server injected this marker (via output that landed in the selection) would end the
- * paste early and send the tail to the application as typed commands (paste injection).
+ * paste early and send the tail to the application as typed commands (paste injection). The strip
+ * runs as a scan that can never leave a marker behind, not a single replace pass — a pass leaves the
+ * halves of an overlapped marker (`ESC[20` + `ESC[201~` + `1~`) side by side, and they re-form into
+ * the sequence that was just removed.
  *
  * When the mode is disabled the application can't tell paste from input, so control bytes in the
  * buffer (e.g. `CR` = Enter) would execute as commands. Raw pastes therefore drop C0 controls
@@ -121,6 +124,20 @@ fun encodeMouseReport(
  */
 fun bracketedPasteWrap(text: String, bracketed: Boolean): String {
     if (!bracketed) return text.filterNot { it.code < 0x20 && it != '\t' && it != '\n' || it.code == 0x7f }
-    val sanitized = text.replace("$ESC[201~", "")
-    return "$ESC[200~$sanitized$ESC[201~"
+    return "$ESC[200~${stripPasteEnd(text)}$ESC[201~"
+}
+
+/**
+ * [text] with every occurrence of the paste-end marker removed, including the ones that only appear
+ * once an earlier removal joins what surrounded it. Each character is appended and the tail checked,
+ * so the result cannot end — or contain — the marker at any point of the scan.
+ */
+private fun stripPasteEnd(text: String): String {
+    val marker = "$ESC[201~"
+    val out = StringBuilder(text.length)
+    for (ch in text) {
+        out.append(ch)
+        if (out.length >= marker.length && out.endsWith(marker)) out.setLength(out.length - marker.length)
+    }
+    return out.toString()
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/TunnelStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/TunnelStore.kt
@@ -9,6 +9,17 @@ interface TunnelStore {
     /** All tunnels in insertion/update order. */
     fun all(): List<Tunnel>
 
+    /**
+     * The ids the store still holds a live record for, INCLUDING ones [all] cannot return because
+     * their payload does not decrypt — adopting an account dataKey leaves every not-yet-pushed
+     * record sealed under the previous one, and they read as absent until sync brings them back.
+     *
+     * A caller that tears something down on disappearance has to key off this rather than off
+     * [all]: "the record is gone" and "the record cannot be read right now" mean opposite things,
+     * and confusing them drops a live tunnel the user never asked to stop.
+     */
+    fun liveIds(): Set<String> = all().map { it.id }.toSet()
+
     /** Create a new record or replace an existing one with the same [Tunnel.id] (upsert). */
     fun put(tunnel: Tunnel)
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/VaultTunnelStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/tunnel/VaultTunnelStore.kt
@@ -26,6 +26,11 @@ class VaultTunnelStore(
         return codec.list()
     }
 
+    override fun liveIds(): Set<String> {
+        if (!vault.isUnlocked) return emptySet()
+        return codec.liveIds()
+    }
+
     override fun put(tunnel: Tunnel) {
         codec.put(tunnel.id, tunnel)
     }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
@@ -338,8 +338,12 @@ class FileVault(
         // under the current key (adoptDataKey leftovers).
         val version = current.version + 1
         val at = now()
-        val blob = crypto.seal(key, ByteArray(0), recordAad(current.id, current.type, version, current.deviceId, deleted = true, updatedAt = at))
-        val tombstone = current.copy(deleted = true, version = version, updatedAt = at, blob = blob)
+        // Stamped with THIS device, like every other write: the deviceId is the tie-break of the
+        // last-writer-wins rule (here and on the server), so a tombstone wearing the original
+        // author's id ties exactly with that author's own next edit — and a tie neither side can
+        // break leaves the two devices permanently disagreeing about whether the record exists.
+        val blob = crypto.seal(key, ByteArray(0), recordAad(current.id, current.type, version, deviceId, deleted = true, updatedAt = at))
+        val tombstone = current.copy(deleted = true, version = version, updatedAt = at, deviceId = deviceId, blob = blob)
         val updated = records.toMutableList().also { it[index] = tombstone }
         commit(currentMeta, updated)
         _localChanges.tryEmit(Unit) // local delete → wake live-sync push

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/TrashStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/TrashStore.kt
@@ -188,7 +188,9 @@ class TrashStore(
      * layout store holds no state of its own, so a separate instance is safe here.
      */
     private fun restoreHostOrder(hostId: String) {
-        val current = layout.read()
+        // readOrNull: an unreadable layout record must not be replaced by a one-host order (see
+        // [app.skerry.shared.host.VaultHostStore.put]). The host is restored either way.
+        val current = layout.readOrNull() ?: return
         if (hostId !in current.hostOrder) layout.write(current.copy(hostOrder = current.hostOrder + hostId))
     }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecordCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecordCodec.kt
@@ -27,6 +27,15 @@ internal class VaultRecordCodec<T>(
             .filter { it.type == type && !it.deleted }
             .mapNotNull { decode(vault.openPayload(it.id)) }
 
+    /**
+     * Ids of every live record of the type, whether or not its payload can be read. [list] drops
+     * the unreadable ones (one bad record must not fail a listing), which makes them
+     * indistinguishable from records that were deleted — a difference that matters to any caller
+     * acting on a disappearance.
+     */
+    fun liveIds(): Set<String> =
+        vault.records().filter { it.type == type && !it.deleted }.map { it.id }.toSet()
+
     /** Value for [id], or `null` if the record is absent, deleted, or its payload can't be read. */
     fun get(id: String): T? {
         val record = vault.records()
@@ -79,13 +88,22 @@ internal class VaultSingletonStore<T>(
 
     private val codec = VaultRecordCodec(vault, type, serializer)
 
-    fun load(): T {
+    fun load(): T = loadOrNull() ?: default()
+
+    /**
+     * The stored value, or null when a record **is** there and cannot be read — an unreadable blob
+     * (adopting an account dataKey leaves the old ones behind) or a payload that no longer parses.
+     * A locked vault and a missing record both answer with [default] through [load]: those mean
+     * "nothing stored", which is not the same as "stored, and we cannot see it". A caller that
+     * read-modify-writes the record has to tell them apart, or it replaces what it could not read.
+     */
+    fun loadOrNull(): T? {
         if (!vault.isUnlocked) return default()
         val record = vault.records().firstOrNull { it.id == id && it.type == type && !it.deleted }
             ?: return default()
         // Wrap openPayload: even if the impl throws on I/O/AEAD (rather than returning null), the
-        // caller must get the default, not a crash (it would abort the sync drainPull).
-        return codec.decode(runCatching { vault.openPayload(record.id) }.getOrNull()) ?: default()
+        // caller must not crash (it would abort the sync drainPull).
+        return codec.decode(runCatching { vault.openPayload(record.id) }.getOrNull())
     }
 
     fun save(value: T) {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/WorkspaceLayout.kt
@@ -47,8 +47,30 @@ class WorkspaceLayoutStore(private val vault: Vault) {
 
     fun read(): WorkspaceLayout = store.load()
 
+    /**
+     * The layout, or null when the record exists but cannot be read. Every write here is a
+     * read-modify-write over the whole account's host order, so a reader that cannot tell an
+     * unreadable record from a missing one replaces that order with whatever it is holding — and
+     * LWW then carries the replacement to every device. Callers that write skip the update instead.
+     */
+    fun readOrNull(): WorkspaceLayout? = store.loadOrNull()
+
     fun write(layout: WorkspaceLayout) {
         store.save(layout)
+    }
+
+    /**
+     * Replaces the empty-folder lists, keeping the host order the record also carries.
+     *
+     * Lives here rather than in the caller because it is a read-modify-write of the one record, and
+     * every one of those has to hold the same two rules: it runs under [Vault.transaction], so a
+     * merge from background sync cannot land between the read and the write, and it skips entirely
+     * when the record cannot be read — writing over an unreadable layout would replace the whole
+     * account's host order with an empty one, and LWW would carry that to every device.
+     */
+    fun updateGroups(groups: List<String>, remoteDesktopGroups: List<String>): Unit = vault.transaction {
+        val current = readOrNull() ?: return@transaction
+        write(current.copy(groups = groups, remoteDesktopGroups = remoteDesktopGroups))
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vnc/RfbEncodings.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vnc/RfbEncodings.kt
@@ -378,7 +378,10 @@ internal suspend fun decodeTight(
                             var x = 0
                             while (x < w) {
                                 val byte = data[y * rowSize + x / 8].toInt() and 0xFF
-                                val bit = (byte ushr (7 - (x % 8))) and 1
+                                // Clamped like the byte-indexed palette below: a one-colour palette
+                                // (which a conforming server sends as Fill, not as this) leaves the
+                                // set bits of a peer-chosen plane pointing past its single entry.
+                                val bit = ((byte ushr (7 - (x % 8))) and 1).coerceAtMost(numColors - 1)
                                 fb.setPixel(rect.x + x, rect.y + y, palette[bit]); x++
                             }
                             y++

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
@@ -8,6 +8,7 @@ import app.skerry.shared.vault.SyncMeta
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultRecord
+import app.skerry.shared.vault.WorkspaceLayoutStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -25,6 +26,57 @@ class VaultHostStoreTest {
         store.put(host("h1", "Web"))
         assertEquals(listOf("h1"), store.all().map { it.id })
         assertEquals("Web", store.all().single().label)
+    }
+
+    /**
+     * The layout is one record holding the whole account's host order, and every write to it is a
+     * read-modify-write. A record that exists but no longer decrypts (what adopting an account
+     * dataKey leaves behind) reads as "no layout at all", so the next saved host would replace the
+     * order of every host with a one-element list — and LWW would carry that to every device.
+     */
+    @Test
+    fun `an unreadable layout record is left alone instead of being overwritten`() {
+        val vault = FakeVault()
+        val store = VaultHostStore(vault)
+        store.put(host("a"))
+        store.put(host("b"))
+
+        vault.unreadable += WorkspaceLayoutStore.LAYOUT_ID
+        store.put(host("c"))
+        vault.unreadable -= WorkspaceLayoutStore.LAYOUT_ID
+
+        assertEquals(
+            listOf("a", "b"),
+            WorkspaceLayoutStore(vault).read().hostOrder,
+            "the order of every host was replaced by the one host saved while it was unreadable",
+        )
+    }
+
+    /**
+     * The same record, written by the other owner: the group layer replaces the empty-folder lists
+     * and must keep the host order beside them — and skip entirely when the record cannot be read,
+     * or one renamed folder wipes the order of every host on the account.
+     */
+    @Test
+    fun `updating groups keeps the host order, and skips an unreadable record`() {
+        val vault = FakeVault()
+        val store = VaultHostStore(vault)
+        store.put(host("a"))
+        store.put(host("b"))
+        val layout = WorkspaceLayoutStore(vault)
+
+        layout.updateGroups(groups = listOf("prod"), remoteDesktopGroups = listOf("lab"))
+
+        assertEquals(listOf("a", "b"), layout.read().hostOrder, "the host order was dropped")
+        assertEquals(listOf("prod"), layout.read().groups)
+        assertEquals(listOf("lab"), layout.read().remoteDesktopGroups)
+
+        vault.unreadable += WorkspaceLayoutStore.LAYOUT_ID
+        layout.updateGroups(groups = listOf("staging"), remoteDesktopGroups = emptyList())
+        vault.unreadable -= WorkspaceLayoutStore.LAYOUT_ID
+
+        assertEquals(listOf("a", "b"), layout.read().hostOrder, "an unreadable layout was overwritten")
+        assertEquals(listOf("prod"), layout.read().groups, "the update landed on a record it could not read")
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/rdp/egfx/GraphicsChannelTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/rdp/egfx/GraphicsChannelTest.kt
@@ -2,6 +2,7 @@ package app.skerry.shared.rdp.egfx
 
 import app.skerry.shared.graphics.RemoteDesktopDiagnostics
 import app.skerry.shared.graphics.RemoteFramebuffer
+import app.skerry.shared.rdp.RdpClientSettings
 import app.skerry.shared.rdp.RdpH264Mode
 import app.skerry.shared.rdp.RdpProtocolException
 import app.skerry.shared.rdp.RdpRect
@@ -10,6 +11,7 @@ import app.skerry.shared.rdp.RdpWriter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.runTest
 
@@ -127,6 +129,43 @@ class GraphicsChannelTest {
 
         assertTrue(failure.message.orEmpty().contains("not advertised"), failure.message.orEmpty())
         assertTrue(avc.decoded444.isEmpty(), "the refused bitmap still reached the decoder")
+    }
+
+    /**
+     * The profile's RemoteFX switch has to reach the pipeline, not just the legacy surface path.
+     * The pipeline is on by default, so a host whose RemoteFX stream this client mis-decodes is
+     * sending it over EGFX — and turning RemoteFX off in the profile has to be what stops it.
+     */
+    @Test
+    fun `a profile with RemoteFX off refuses it on the graphics pipeline too`() = runTest {
+        val codecs = GraphicsCodecs.forSettings(settings(remoteFx = false))
+        val channel = GraphicsChannel(framebuffer, codecs) { }
+        channel.onMessage(bulk(createSurface(id = 1, width = 8, height = 8)))
+
+        val failure = assertFailsWith<RdpProtocolException> {
+            channel.onMessage(
+                bulk(wireToSurfaceRaw(1, codecId = GraphicsCodecs.CODEC_REMOTEFX, payload = byteArrayOf(1))),
+            )
+        }
+        assertTrue(failure.message.orEmpty().contains("0x3"), failure.message.orEmpty())
+    }
+
+    /** The other side of the same switch: left on, the codec is there to decode with. */
+    @Test
+    fun `a profile with RemoteFX on plugs the codec into the pipeline`() = runTest {
+        val codecs = GraphicsCodecs.forSettings(settings(remoteFx = true))
+        val channel = GraphicsChannel(framebuffer, codecs) { }
+        channel.onMessage(bulk(createSurface(id = 1, width = 8, height = 8)))
+
+        val failure = runCatching {
+            channel.onMessage(
+                bulk(wireToSurfaceRaw(1, codecId = GraphicsCodecs.CODEC_REMOTEFX, payload = byteArrayOf(1))),
+            )
+        }.exceptionOrNull()
+
+        // Whatever a one-byte RemoteFX stream decodes to, the session must not be told the codec
+        // was never advertised — that answer belongs to the switch being off.
+        assertFalse(failure?.message.orEmpty().contains("0x3"), failure?.message.orEmpty())
     }
 
     @Test
@@ -473,6 +512,15 @@ class GraphicsChannelTest {
 
         budgeted.onMessage(bulk(createSurface(id = 2, width = 8, height = 8)))
     }
+
+    /** A client-settings fixture whose only interesting field is the codec switch under test. */
+    private fun settings(remoteFx: Boolean) = RdpClientSettings(
+        desktopWidth = 800,
+        desktopHeight = 600,
+        clientName = "SKERRY",
+        selectedProtocol = 0,
+        wantsRemoteFx = remoteFx,
+    )
 
     private fun pdu(commandId: Int, body: ByteArray): ByteArray =
         RdpWriter(body.size + 8).u16le(commandId).u16le(0).u32le(body.size + 8).bytes(body).toByteArray()

--- a/shared/src/commonTest/kotlin/app/skerry/shared/telnet/TelnetCodecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/telnet/TelnetCodecTest.kt
@@ -125,6 +125,25 @@ class TelnetCodecTest {
         assertEquals("ok", d.data.decodeToString())
     }
 
+    /**
+     * The drop scanner has to read an escaped `IAC IAC` the same way the buffering path does: as
+     * one literal 0xFF in the body, not as the start of the closing sequence. Reading it the other
+     * way ends the subnegotiation at the next byte, and the rest of a body the server chose —
+     * escape sequences included — is emitted into the terminal as data.
+     */
+    @Test
+    fun `an escaped IAC inside an oversized subnegotiation does not end it`() {
+        val codec = TelnetCodec()
+        codec.consume(bytes(IAC, SB, NAWS))
+        codec.consume(ByteArray(16_384) { 0x20 }) // past the 8 KiB buffering cap
+        // An escaped 0xFF followed by a literal SE byte, then the rest of the body.
+        val d = codec.consume(bytes(IAC, IAC, SE) + "smuggled".encodeToByteArray())
+
+        assertEquals("", d.data.decodeToString(), "subnegotiation body reached the terminal as data")
+        // The real end of the subnegotiation still works, and data after it is passed through.
+        assertEquals("ok", codec.consume(bytes(IAC, SE) + "ok".encodeToByteArray()).data.decodeToString())
+    }
+
     @Test
     fun `windowSize builds a NAWS subnegotiation with escaped 0xFF`() {
         // A 255 in the window size must be escaped by doubling inside the SB body.

--- a/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalMouseTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/terminal/TerminalMouseTest.kt
@@ -214,6 +214,19 @@ class TerminalMouseTest {
         assertEquals("ESC[200~okrm -rf /ESC[201~", out)
     }
 
+    /**
+     * The strip has to hold for a marker built out of its own wreckage. A single replace pass leaves
+     * the two halves of an overlapped marker adjacent, and they re-form into the very sequence that
+     * was removed — the paste then ends early and everything after it is typed input the shell runs.
+     */
+    @Test
+    fun `bracketed paste strips a marker that reassembles from its own halves`() {
+        val esc = esc.toChar()
+        val overlapped = "$esc[20$esc[201~1~rm -rf /"
+        val out = bracketedPasteWrap(overlapped, bracketed = true).show()
+        assertEquals("ESC[200~rm -rf /ESC[201~", out)
+    }
+
     @Test
     fun `disabled paste strips CR and ESC (anti command injection)`() {
         // Without bracketed paste, the shell can't tell paste from typing: an injected CR would act

--- a/shared/src/commonTest/kotlin/app/skerry/shared/tunnel/VaultTunnelStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/tunnel/VaultTunnelStoreTest.kt
@@ -27,6 +27,34 @@ class VaultTunnelStoreTest {
         assertEquals("host-t1", store.all().single().hostId)
     }
 
+    /**
+     * A record whose payload no longer decrypts — what adopting an account dataKey leaves behind
+     * for everything not yet pushed — is missing from [all] but is not gone. Anything that acts on
+     * a disappearance keys off [liveIds] instead, or it tears down a tunnel nobody deleted.
+     */
+    @Test
+    fun `liveIds keeps a record all cannot decode`() {
+        val vault = FakeVault()
+        val store = VaultTunnelStore(vault)
+        store.put(tunnel("t1"))
+        store.put(tunnel("t2"))
+
+        vault.unreadable += "t2"
+
+        assertEquals(listOf("t1"), store.all().map { it.id })
+        assertEquals(setOf("t1", "t2"), store.liveIds(), "an unreadable record read as deleted")
+    }
+
+    /** A record that really went away leaves both. */
+    @Test
+    fun `liveIds drops a removed record`() {
+        val store = VaultTunnelStore(FakeVault())
+        store.put(tunnel("t1"))
+        store.remove("t1")
+
+        assertEquals(emptySet(), store.liveIds())
+    }
+
     @Test
     fun `put upserts and remove tombstones`() {
         val store = VaultTunnelStore(FakeVault())

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -16,6 +16,12 @@ internal class FakeVault : Vault {
     /** Flip to exercise the locked-vault path of a store; unlocked by default. */
     var locked: Boolean = false
 
+    /**
+     * Records that exist and are live but whose payload no longer decrypts — what an adopted
+     * account key leaves behind (blobs sealed under the previous one).
+     */
+    val unreadable: MutableSet<String> = mutableSetOf()
+
     /** Nesting depth of [transaction] (0 = no transaction held) — lets tests assert atomic sequences. */
     private var transactionDepth = 0
 
@@ -45,7 +51,7 @@ internal class FakeVault : Vault {
     override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
 
     override fun openPayload(id: String): ByteArray? =
-        entries[id]?.takeIf { !it.record.deleted }?.payload
+        if (id in unreadable) null else entries[id]?.takeIf { !it.record.deleted }?.payload
 
     override fun put(id: String, type: RecordType, payload: ByteArray) = putAtLeast(id, type, payload, minVersion = 0L)
 

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
@@ -429,6 +429,55 @@ class FileVaultTest {
         assertContentEquals("from-b".encodeToByteArray(), a.openPayload("r1"))
     }
 
+    /**
+     * A deletion is a write, and every write says which device made it — the tie-break of the
+     * last-writer-wins rule is the deviceId, on the client and on the server alike. A tombstone
+     * carrying the *original author's* id instead makes an exact tie with that author's own next
+     * write, and a tie neither side can break is a pair of devices that never converge.
+     */
+    @Test
+    fun `a deletion is stamped with the deleting device, not the record's author`() = vaultTest {
+        val a = vault().apply { create("master".toCharArray()) }
+        val b = FileVault("/vault-b.json".toPath(), crypto, deviceId = "device-2", fileSystem = fs, now = { TS })
+        b.createWithDataKey(a.exportDataKey()!!)
+        b.put("r1", RecordType.HOST, "from-b".encodeToByteArray())
+        a.mergeRemote(listOf(b.records().single()))
+
+        a.remove("r1")
+
+        assertEquals("device-1", a.records().single { it.id == "r1" }.deviceId)
+    }
+
+    /**
+     * The same defect end to end: B edits the record it wrote while A deletes it, both landing on
+     * version 2. Whichever wins, both devices have to reach the *same* answer — with the tombstone
+     * wearing B's id neither record outranks the other and each device keeps its own.
+     */
+    @Test
+    fun `a delete racing an edit of the same version converges on both devices`() = vaultTest {
+        val a = vault().apply { create("master".toCharArray()) }
+        val b = FileVault("/vault-b.json".toPath(), crypto, deviceId = "device-2", fileSystem = fs, now = { TS })
+        b.createWithDataKey(a.exportDataKey()!!)
+        b.put("r1", RecordType.HOST, "v1".encodeToByteArray())
+        a.mergeRemote(listOf(b.records().single()))
+
+        a.remove("r1") // tombstone, version 2
+        b.put("r1", RecordType.HOST, "v2".encodeToByteArray()) // live record, version 2
+
+        val tombstone = a.records().single { it.id == "r1" }
+        val edited = b.records().single { it.id == "r1" }
+        assertEquals(tombstone.version, edited.version, "the race only bites when the versions tie")
+
+        a.mergeRemote(listOf(edited))
+        b.mergeRemote(listOf(tombstone))
+
+        assertEquals(
+            a.records().single { it.id == "r1" }.deleted,
+            b.records().single { it.id == "r1" }.deleted,
+            "the two devices disagree about whether the record exists",
+        )
+    }
+
     @Test
     fun `mergeRemote rejects legacy blobs sealed with the id-type AAD`() = vaultTest {
         val v = vault().apply { create("master".toCharArray()) }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vnc/TightDecoderTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vnc/TightDecoderTest.kt
@@ -48,6 +48,27 @@ class TightDecoderTest {
         assertEquals(G, fb.pixels[1])
     }
 
+    /**
+     * A one-colour palette is not what a conforming server sends (it uses Fill), so the bit plane
+     * that follows is whatever the peer chose — and a set bit indexes past a one-element palette.
+     * The rest of the session must not die on it: the decoder clamps, exactly as the byte-indexed
+     * palette path beside it already does.
+     */
+    @Test
+    fun basic_palette_one_colour_clamps_instead_of_throwing() = runTest {
+        val data = join(
+            byteArrayOf(0x40), // control: basic, explicit filter, stream 0
+            byteArrayOf(1), // filter id = palette
+            byteArrayOf(0), // numColors-1 = 0 → a single colour
+            tp(0xFF, 0, 0), // palette: red
+            byteArrayOf(0xFF.toByte()), // every bit set: index 1 into a one-element palette
+        )
+        val fb = RemoteFramebuffer(2, 1)
+        decodeTight(TightBytes(data), fb, VncRect(0, 0, 2, 1), noStream, noReset, null)
+        assertEquals(R, fb.pixels[0])
+        assertEquals(R, fb.pixels[1])
+    }
+
     @Test
     fun basic_palette_two_colours_raw() = runTest {
         // 4x2 palette, 1 bit/pixel, rowSize 1 → 2 bytes raw. mode 4 (filter flag), filterId 1 (palette).

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/mosh/MoshPacketCodecTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/mosh/MoshPacketCodecTest.kt
@@ -111,4 +111,29 @@ class MoshCompressionTest {
     fun `inflate returns null on garbage`() {
         assertNull(moshInflate(byteArrayOf(1, 2, 3, 4)))
     }
+
+    /**
+     * A zlib header with FDICT set asks for a preset dictionary. `inflate()` then returns 0 with
+     * `needsDictionary()` true and neither `needsInput()` nor `finished()` — none of the loop's
+     * exits — so it spins on a core forever. The datagram carrying it is authenticated, but the
+     * server holds the session key: a compromised mosh-server can produce one, and the loop does
+     * not suspend, so cancelling the session cannot break it either.
+     */
+    @Test
+    fun `inflate refuses a preset-dictionary stream instead of spinning`() {
+        // 0x78 0x20: CMF deflate/32K window, FLG with FDICT set and a valid FCHECK
+        // ((0x78 * 256 + 0x20) % 31 == 0), then the four-byte dictionary id and a byte of body —
+        // with input still unread, needsInput() is false too, so no exit condition holds at all.
+        val presetDictionary = byteArrayOf(0x78, 0x20, 1, 2, 3, 4, 0x63)
+        var answered = false
+        var result: ByteArray? = ByteArray(0)
+        val worker = kotlin.concurrent.thread(isDaemon = true, name = "inflate-fdict") {
+            result = moshInflate(presetDictionary)
+            answered = true
+        }
+        worker.join(2_000)
+
+        assertTrue(answered, "moshInflate never returned: a preset-dictionary stream spins forever")
+        assertNull(result)
+    }
 }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjPortForwardTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjPortForwardTest.kt
@@ -16,9 +16,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 private const val USER = "skerry"
 private const val PASSWORD = "correct horse battery staple"
+
+/** What [CloseAfterReplyServer] answers before hanging up. */
+private const val CLOSING_REPLY = "bye"
+
+/** Long enough for a real EOF to arrive over the loopback tunnel, short enough to fail fast. */
+private const val EOF_TIMEOUT_MILLIS = 5_000
 
 private val acceptAllKeys = HostKeyVerifier { null }
 
@@ -181,6 +188,41 @@ class SshjPortForwardTest {
         }
     }
 
+    /**
+     * The destination closing first has to reach the local peer as EOF. A tunnel that only
+     * half-closes the near→far direction leaves the local connection waiting for bytes that will
+     * never come: the classic shape is a close-delimited HTTP/1.0 response, where the body ends at
+     * the close and the client reads until EOF. It also strands the tunnel's own thread and socket,
+     * which stay in the forward's live set for as long as the session lasts.
+     */
+    @Test
+    fun `a destination that closes first ends the local connection too`() = runTest {
+        CloseAfterReplyServer().use { destination ->
+            val connection = connect()
+            try {
+                val forward = connection.forwardLocal(
+                    LocalForwardSpec(bindPort = 0, destHost = "127.0.0.1", destPort = destination.port),
+                )
+                try {
+                    Socket("127.0.0.1", forward.boundPort).use { socket ->
+                        socket.soTimeout = EOF_TIMEOUT_MILLIS
+                        socket.getOutputStream().apply { write("get".encodeToByteArray()); flush() }
+                        val body = try {
+                            readToEof(socket.getInputStream())
+                        } catch (e: java.net.SocketTimeoutException) {
+                            fail("the local connection never saw EOF after the destination closed: $e")
+                        }
+                        assertEquals(CLOSING_REPLY, body)
+                    }
+                } finally {
+                    forward.close()
+                }
+            } finally {
+                connection.disconnect()
+            }
+        }
+    }
+
     @Test
     fun `paused local forward refuses new connections and resumes`() = runTest {
         EchoServer().use { echo ->
@@ -286,6 +328,49 @@ private fun readFully(input: java.io.InputStream, n: Int): ByteArray {
         off += r
     }
     return buf
+}
+
+/** Reads until the stream ends, as a client of a close-delimited response does. */
+private fun readToEof(input: java.io.InputStream): String {
+    val out = StringBuilder()
+    val buffer = ByteArray(256)
+    while (true) {
+        val n = input.read(buffer)
+        if (n < 0) return out.toString()
+        out.append(buffer.copyOf(n).decodeToString())
+    }
+}
+
+/**
+ * A destination that answers once and hangs up — the HTTP/1.0 shape, where the response body is
+ * delimited by the close rather than by a length the client is told in advance.
+ */
+private class CloseAfterReplyServer : Closeable {
+    private val socket = ServerSocket().apply { bind(InetSocketAddress("127.0.0.1", 0)) }
+    val port: Int get() = socket.localPort
+
+    private val acceptor = thread(isDaemon = true, name = "close-after-reply") {
+        while (!socket.isClosed) {
+            val client = try {
+                socket.accept()
+            } catch (_: Exception) {
+                break
+            }
+            thread(isDaemon = true, name = "close-after-reply-conn") {
+                client.use {
+                    runCatching {
+                        it.getInputStream().read(ByteArray(256))
+                        it.getOutputStream().apply { write(CLOSING_REPLY.encodeToByteArray()); flush() }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun close() {
+        socket.close()
+        acceptor.join(1000)
+    }
 }
 
 /** Single-threaded echo server on a free loopback port; reads a request and writes it back. */

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ssh/SshjTransportTest.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.ssh
 
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.apache.sshd.server.SshServer
 import org.apache.sshd.server.auth.pubkey.PublickeyAuthenticator
@@ -18,6 +19,9 @@ import kotlin.test.assertTrue
 
 private const val USER = "skerry"
 private const val PASSWORD = "correct horse battery staple"
+
+/** How long the test server takes to answer authentication, so a cancel can land inside it. */
+private const val AUTH_DELAY_MILLIS = 400L
 
 private val acceptAllKeys = HostKeyVerifier { null }
 
@@ -60,6 +64,37 @@ class SshjTransportTest {
         assertTrue(connection.isConnected)
         connection.disconnect()
         assertFalse(connection.isConnected)
+    }
+
+    /**
+     * The dial is blocking from the first byte to the last, with no cancellation point in it: a
+     * cancel arriving mid-handshake is noticed only once TCP, key exchange and userauth have all
+     * finished, and `withContext` then throws away the connection they produced. Unless that
+     * connection is closed on the way out, the user who closed the pane leaves an authenticated
+     * session open on the server — one per ProxyJump hop, for the life of the process.
+     */
+    @Test
+    fun `a connect cancelled mid-handshake leaves no session behind`() = kotlinx.coroutines.runBlocking {
+        val live = java.util.concurrent.atomic.AtomicInteger()
+        server.addSessionListener(object : org.apache.sshd.common.session.SessionListener {
+            override fun sessionCreated(session: org.apache.sshd.common.session.Session) { live.incrementAndGet() }
+            override fun sessionClosed(session: org.apache.sshd.common.session.Session) { live.decrementAndGet() }
+        })
+        val reachedAuth = java.util.concurrent.CountDownLatch(1)
+        server.setPasswordAuthenticator { user, password, _ ->
+            reachedAuth.countDown()
+            Thread.sleep(AUTH_DELAY_MILLIS) // long enough for the cancel to land while it runs
+            user == USER && password == PASSWORD
+        }
+
+        val job = launch(kotlinx.coroutines.Dispatchers.IO) { connect() }
+        assertTrue(reachedAuth.await(5, java.util.concurrent.TimeUnit.SECONDS), "authentication never started")
+        job.cancel() // the user closes the pane while it is connecting
+        job.join()
+
+        val deadline = System.currentTimeMillis() + 5_000
+        while (live.get() > 0 && System.currentTimeMillis() < deadline) Thread.sleep(50)
+        assertEquals(0, live.get(), "an authenticated session was left open on the server")
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineFilterTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineFilterTest.kt
@@ -106,7 +106,10 @@ class SyncEngineFilterTest {
         // the rest of the cycle down with them.
         val client = object : FakeSyncClient() {
             override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
-                if (records.any { it.type == RecordType.TRASH.name }) error("unknown record type: TRASH")
+                if (records.any { it.type == RecordType.TRASH.name }) {
+                    // How a server without the type actually answers: the type fails validation.
+                    throw SyncException(SyncException.Kind.PROTOCOL, "unknown record type: TRASH")
+                }
                 return super.push(session, records)
             }
         }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineNewTypeBatchTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/SyncEngineNewTypeBatchTest.kt
@@ -9,6 +9,8 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -30,12 +32,42 @@ class SyncEngineNewTypeBatchTest {
         now = { "2026-07-27T00:00:00Z" },
     )
 
-    /** A server that predates the type: it rejects any batch containing it, as the real one does. */
-    private class OldServer(private val unknown: RecordType) : FakeSyncClient() {
+    /**
+     * A server that predates the type. [refusal] is how it answers a batch carrying one: a real one
+     * fails the type's validation (400 → PROTOCOL) or has no route for it at all (404).
+     */
+    private class OldServer(
+        private val unknown: RecordType,
+        private val refusal: SyncException.Kind = SyncException.Kind.PROTOCOL,
+    ) : FakeSyncClient() {
         override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage {
-            if (records.any { it.type == unknown.name }) error("unknown record type: ${unknown.name}")
+            if (records.any { it.type == unknown.name }) {
+                throw SyncException(refusal, "unknown record type: ${unknown.name}")
+            }
             return super.push(session, records)
         }
+    }
+
+    /**
+     * The other failures of that same batch are NOT "the server is just old" and must not be
+     * swallowed as one: a 401 says the session is over, a 429 says to back off, a 5xx says the
+     * server is broken. Hidden, a batch that will never be accepted looked exactly like an optional
+     * one, and nothing anywhere said otherwise.
+     */
+    @Test
+    fun `a real failure of the optional batch is not mistaken for an old server`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devC")
+        vault.create(password.toCharArray())
+        vault.put("h1", RecordType.HOST, "host".encodeToByteArray())
+        vault.put("ca1", RecordType.TRUSTED_CA, "ca".encodeToByteArray())
+
+        val client = OldServer(RecordType.TRUSTED_CA, refusal = SyncException.Kind.UNAUTHORIZED)
+
+        val failure = assertFailsWith<SyncException> {
+            SyncEngine(client, vault, InMemorySyncStateStore()).sync(session)
+        }
+        assertEquals(SyncException.Kind.UNAUTHORIZED, failure.kind)
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/team/TeamSyncRoundTripTest.kt
@@ -151,6 +151,31 @@ class TeamSyncRoundTripTest {
         assertEquals(true, vaults.open(TeamScopeRef(teamId), rightKey)?.isUnlocked)
     }
 
+    /**
+     * The stale-key probe only runs when a vault is actually opened. The cache is keyed on the
+     * space, not on the key, so a vault left unlocked from before a rotation is handed back for a
+     * request made with the *new* key — and every one of the tests above hides that by locking
+     * first, which the app never does: a hosts sidebar holds the vault open for as long as it is on
+     * screen.
+     *
+     * What follows a cache hit is worse than a stale read: records arriving under the new key fail
+     * to authenticate and are counted as rejected, while anything this device shares is sealed
+     * under the old one and pushed at a version nobody else can decrypt.
+     */
+    @Test
+    fun `a key rotation is not served from the cache of the superseded key`() = runBlocking {
+        initializeVaultCrypto()
+        val vaults = vaultsFor("dave")
+        val supersededKey = crypto.newDataKey()
+        val vault = vaults.open(TeamScopeRef(teamId), supersededKey)!!
+        vault.put("h1", RecordType.HOST, "x".encodeToByteArray())
+        // No lockAll(): the vault stays open, exactly as a screen holding it keeps it open.
+
+        val rotated = vaults.openOrClassify(TeamScopeRef(teamId), crypto.newDataKey())
+
+        assertEquals(TeamVaults.OpenResult.StaleKey, rotated)
+    }
+
     @Test
     fun `openOrClassify distinguishes a superseded key from a corrupt file and never deletes`() = runBlocking {
         initializeVaultCrypto()
@@ -288,7 +313,7 @@ class TeamSyncRoundTripTest {
     }
 
     @Test
-    fun `an unsafe scope id cannot escape the vault directory`() = runBlocking {
+    fun `an unsafe scope id cannot escape the vault directory`() = runBlocking<Unit> {
         initializeVaultCrypto()
         val vaults = vaultsFor("heidi")
 

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/mosh/MoshCompression.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/mosh/MoshCompression.kt
@@ -48,7 +48,11 @@ fun moshInflate(data: ByteArray, maxSize: Int = 8 * 1024 * 1024): ByteArray? {
                 out = out.copyOf(minOf(maxSize, out.size * 2))
             }
             val n = inflater.inflate(out, size, out.size - size)
-            if (n == 0 && inflater.needsInput()) return null // truncated stream
+            // Every way inflate() can stop making progress, not just the truncated one: a header
+            // with FDICT set asks for a preset dictionary we have none of, and answers 0 with
+            // needsInput() false and finished() false — no exit at all, so the loop spins on a
+            // core forever, and it never suspends, so cancelling the session cannot stop it.
+            if (n == 0 && (inflater.needsInput() || inflater.needsDictionary())) return null
             size += n
         }
         return out.copyOf(size)

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpTransport.kt
@@ -7,13 +7,11 @@ import app.skerry.shared.graphics.RemoteDesktopDiagnostics
 import app.skerry.shared.graphics.RemoteFramebuffer
 import app.skerry.shared.graphics.remoteStatsTrace
 import app.skerry.shared.rdp.egfx.AvcCodec
-import app.skerry.shared.rdp.egfx.ClearCodec
 import app.skerry.shared.rdp.egfx.DynamicChannels
 import app.skerry.shared.rdp.egfx.GraphicsChannel
 import app.skerry.shared.rdp.egfx.GraphicsCodecs
 import app.skerry.shared.rdp.egfx.H264DecoderFactory
 import app.skerry.shared.rdp.egfx.h264Trace
-import app.skerry.shared.rdp.egfx.Progressive
 import app.skerry.shared.rdp.nla.CredSspClient
 import app.skerry.shared.rdp.nla.JvmNtlmCrypto
 import app.skerry.shared.rdp.nla.NtlmCredentials
@@ -261,10 +259,11 @@ class RdpSocketSession(
      */
     private val graphics = GraphicsChannel(
         framebuffer = framebuffer,
-        codecs = GraphicsCodecs(
-            remoteFx = RemoteFx(),
-            progressive = Progressive(),
-            clear = ClearCodec(),
+        // The profile's codec switches decide this set, exactly as they do on the legacy surface
+        // path: a codec turned off is left out, so a server ignoring the capability exchange hits
+        // "not advertised" rather than a live decoder.
+        codecs = GraphicsCodecs.forSettings(
+            settings,
             // Only when this machine has a decoder AND the profile allows H.264: leaving the codec
             // out is what keeps the decoder unreachable for a server that ignores the capability
             // exchange, and it keeps the overlay's decoder row honest for a session with H.264 off.

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjForwards.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjForwards.kt
@@ -39,16 +39,30 @@ private fun pump(input: InputStream, output: OutputStream, counter: AtomicLong) 
  * Bidirectional pump between an accepted local connection ([near]) and an SSH channel ([far]):
  * the upstream direction (near->far) runs on a separate daemon thread, downstream (far->near) on
  * the caller. [up] counts bytes sent into the channel (to the server), [down] counts bytes
- * received from it. On near's EOF, half-closes the channel's write side so the server sees EOF,
- * closes the destination, and the downstream direction finishes. Returns once both directions end.
+ * received from it. Either direction ending half-closes the other side's write end, so the peer
+ * sees EOF and finishes its own direction. Returns once both directions end.
+ *
+ * Both half-closes are needed, and the far->near one is the one with teeth: a destination that
+ * hangs up first (a close-delimited HTTP/1.0 body, or the SSH transport dropping) ends the
+ * downstream pump, while upstream is still parked in a read on a local peer that has no reason to
+ * write or close. Without the shutdown that peer waits for bytes forever and this tunnel's thread,
+ * socket and channel stay in the forward's live set for the rest of the session.
  */
 private fun tunnel(near: Socket, far: Channel, up: AtomicLong, down: AtomicLong, name: String) {
     val upstream = thread(isDaemon = true, name = "$name-up") {
         runCatching { pump(near.getInputStream(), far.outputStream, up); far.outputStream.close() }
     }
     runCatching { pump(far.inputStream, near.getOutputStream(), down) }
-    upstream.join()
+    // Half-close succeeded: the peer has been told the far side is done and still owns its own
+    // direction, so the wait stays unbounded. A `-R` forward's response, or an upload still in
+    // flight, would otherwise be cut off mid-write when this returns and the caller closes both
+    // ends. A peer that never closes is what `close()` on the forward is for.
+    val halfClosed = runCatching { near.shutdownOutput() }.isSuccess
+    if (halfClosed) upstream.join() else upstream.join(TUNNEL_JOIN_MILLIS)
 }
+
+/** How long [tunnel] waits for its upstream thread when the socket could not be half-closed. */
+private const val TUNNEL_JOIN_MILLIS = 2000L
 
 /**
  * Shared forward state: activity/pause flags, traffic counters, and the set of live resources of

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ssh/SshjTransport.kt
@@ -9,6 +9,8 @@ import java.util.Base64
 import java.util.concurrent.atomic.AtomicReference
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
@@ -44,19 +46,45 @@ class SshjTransport(
     private val keyboardInteractiveResponder: KeyboardInteractiveResponder? = null,
 ) : SshTransport {
 
-    override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection =
-        withContext(Dispatchers.IO) {
-            // Every client dialed so far (ProxyJump hops entry-point-first, the target's own client
-            // last). On ANY failure the whole chain is closed here, in reverse dial order — the
-            // per-step helpers below don't close anything themselves.
-            val opened = mutableListOf<SSHClient>()
-            try {
-                connectChain(target, auth, opened)
-            } catch (e: Exception) {
-                opened.asReversed().forEach { runCatching { it.close() } }
-                throw e
-            }
+    override suspend fun connect(target: SshTarget, auth: SshAuth): SshConnection {
+        // Every client dialed so far (ProxyJump hops entry-point-first, the target's own client
+        // last). On ANY failure the whole chain is closed here, in reverse dial order — the
+        // per-step helpers below don't close anything themselves.
+        //
+        // The list and its cleanup live OUTSIDE `withContext` on purpose. The chain is blocking end
+        // to end with no cancellation point in it, so a cancel that arrived mid-handshake is only
+        // noticed once TCP, KEX and userauth have all finished — and `withContext` itself throws on
+        // the way out, discarding the connection they produced. Catching that here, rather than
+        // inside the block, is what keeps a cancelled connect from leaving an authenticated session
+        // live on the server (one per ProxyJump hop) for the rest of the process.
+        val opened = mutableListOf<SSHClient>()
+        try {
+            return withContext(Dispatchers.IO) { connectChain(target, auth, opened) }
+        } catch (e: CancellationException) {
+            // The one this has to catch by hand: `withContext` throws it on the way out, after the
+            // blocking chain has already produced a live, authenticated client.
+            closeAll(opened)
+            throw e
+        } catch (e: Exception) {
+            closeAll(opened)
+            throw e
         }
+    }
+
+    /**
+     * Closes a dialed chain in reverse dial order; close failures are not the caller's problem.
+     *
+     * On IO and under [NonCancellable]: `close()` writes a disconnect and joins sshj's reader
+     * thread, which on a chain whose network has gone away takes as long as the socket does — and
+     * the caller here is a UI coroutine. NonCancellable because the path that matters most is the
+     * one entered *because* the job was cancelled.
+     */
+    private suspend fun closeAll(opened: List<SSHClient>) {
+        if (opened.isEmpty()) return
+        withContext(NonCancellable + Dispatchers.IO) {
+            opened.asReversed().forEach { runCatching { it.close() } }
+        }
+    }
 
     private fun connectChain(target: SshTarget, auth: SshAuth, opened: MutableList<SSHClient>): SshConnection {
         ensureCryptoProvider()

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -246,7 +246,12 @@ class KtorSyncClient(
     }
 
     override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean {
-        val resp = http.delete("$serverUrl/devices/$deviceId") { bearerAuth(session.accessToken) }
+        // Through `request` and with the id encoded, like every other call here: a raw IOException
+        // escapes the SyncException contract this interface documents, and an unencoded id carrying
+        // a `/`, `?` or `#` rewrites the path the delete lands on.
+        val resp = request {
+            http.delete("$serverUrl/devices/${deviceId.encodeURLPathPart()}") { bearerAuth(session.accessToken) }
+        }
         return when (resp.status) {
             HttpStatusCode.NoContent -> true
             HttpStatusCode.NotFound -> false


### PR DESCRIPTION
A sweep across the codebase for defects that were already in `main`. Twenty fixes, one commit per
area, each with a test recorded failing before the fix and re-run with the fix reverted.

## Terminal

Bracketed paste stripped `ESC[201~` in a single pass. A clipboard payload carrying the marker split
across the scan boundary put its two halves back together, ended the paste early, and delivered the
rest as typed input — which the shell ran without Enter.

## Protocols

| Where | Defect |
|---|---|
| Telnet | An `IAC` inside a subnegotiation being dropped left the state machine a byte behind, leaking option payload into the terminal as data. |
| VNC Tight | A one-colour palette let the decoder index past the palette. |
| mosh | A zlib stream requesting a preset dictionary spun the inflate loop forever on a thread that never returned. |
| RDP | RemoteFX was advertised regardless of the connection settings, so a session configured without it still received RemoteFX-coded surfaces. NSCodec surfaces were labelled as unknown in the overlay. |

## Vault

- A delete kept the `deviceId` of whoever last wrote the record. Two devices deleting the same record
  produced tombstones the `(version, deviceId)` tie-break could not order, so a resurrection could win
  on one side and lose on the other.
- The workspace layout was read with a call that returns an *empty* layout when the record exists but
  cannot be decrypted. Every host reorder, group edit or trash restore then wrote that empty layout
  back, discarding groups and ordering permanently. Reads that decide a write now use `readOrNull`
  and skip.
- Creating a vault on a read-only folder or a full disk reported "the vault file is damaged", sending
  the user after a backup instead of their permissions. It is now its own error with its own string,
  and the guard covers the `create` call only, so a failure *after* the vault exists is not
  mislabelled.

## SSH

- A forwarded connection whose far end replied and closed left the upstream pump waiting on a socket
  nobody would write to again; the thread stayed alive for the life of the session. The downstream
  half now shuts the near socket's output and only falls back to a bounded join when it cannot.
- Cancelling a connect ran the sshj cleanup on the cancelled coroutine's context — the UI dispatcher,
  job already dead — so sockets stayed open. Cleanup runs under `NonCancellable` on `Dispatchers.IO`,
  and handles opened before the failure are closed even when the connect throws.

## Tunnels

- `reload()` treated a tunnel record it failed to decrypt as deleted and closed the live tunnel
  behind it.
- Telemetry polling compared state read before a suspension against state written after it, so a row
  that reconnected mid-tick was torn down. Each row is now polled and retired against the handle the
  poll actually saw; a lost link is a typed reason with its own localized string.
- A connect attempt that lost a race cleared the newer job. The failing-set is snapshot state, so the
  UI redraws when it changes.

## Teams and sync

- The open-team-vault cache was keyed by team alone. After a rekey the stale entry answered with the
  previous key, so records sealed under the new one decrypted as corrupt. The cache now holds the key
  it was opened with, compares it in constant time, and zeroes it on evict.
- A team key rotation that failed was reported only if the per-scope loop that followed also failed —
  the common case left the user believing the rotation had landed.
- `SyncEngine` treated *every* `SyncException` as "an old server does not know this type" and dropped
  the batch. Only `PROTOCOL` and `NOT_FOUND` mean that now; everything else propagates.
- Device ids are percent-encoded in the revoke path.

## UI

- A dismissed or superseded AI request kept writing into the controller when its stream finally
  answered: the panel reopened with the old reply and a Run button for a command the user had already
  dismissed.
- The assistant sent the whole scrollback as context, so a long session grew the prompt until the
  provider refused it. History is clamped to the most recent window.
- Moving the only pane of a row onto that same row collapsed the row, then reinserted into an index
  that no longer existed — losing the pane.

## Accessibility (part of #228)

Broadcast targets, the SSH-config import list and the keep-connected switch were clickable rows
drawing their own tick: a screen reader read them as buttons with no state. Each is now `toggleable`
with the checkbox role. The error text on both lock screens was swapped in and out of the tree, so it
was never announced; both scaffolds now compose the live region unconditionally. The three copies of
the keep-connected row collapse into one shared composable.

## Server

- The account bucket of the activity log was global: one busy account's sync traffic evicted every
  other account's logins, device revocations and password changes. Retention now prunes per account,
  with a separate ceiling across all accounts so the table stays bounded as accounts are added, and
  an index to back the query.
- `POST /teams` accepted any team id; the validator the scope routes already used now guards it too.
- `ShareRelay` could publish into a bucket another thread had just removed, and could remove a bucket
  that had gained a subscriber. Registration retries against the map identity it observed; removal is
  atomic.

## Desktop

`WindowDragGesture`'s dead zone was unreachable — the only production caller passed `0`. Removed; the
slop gate is covered at the modifier level.

## Reported and rejected

- **VNC alpha cursor R/B swap.** Verified against TigerVNC's `SMsgWriter`/`CMsgReader`: the wire
  order is RGBA and the decoder is correct.
- **Delete-wins LWW tie-break.** The rule is shared with the server; changing one side re-creates the
  divergence it would be fixing.
- **Empty catch in the tunnel poll tick.** `commonMain` has no logging facility, and per-row failures
  are already journalled by the row's own handler. Deliberate.

## Not verified

Nothing here was run against a live host, device or server: no SSH/RDP/VNC session, no Android
device, no sync server. Every claim rests on the test suite and the build gate.

Closes #152.
Partially addresses #228 — the checkbox rows and the lock-screen live regions are done; the rest of
the audit (focus order, contrast, remaining custom controls) is untouched.
