### PR TITLE
Hold llamatik at 1.9.0 with a guard that can lift it, and take logback 1.6.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,7 @@
 # Dependabot keeps the supply chain patched: GitHub Actions and Gradle/Maven dependencies.
 # Actions pinned to a commit SHA (e.g. android-actions/setup-android) are bumped here too —
 # Dependabot rewrites the SHA and updates the trailing "# vX" comment, so pinning stays current
-# without manual tracking. This is the ongoing half of the dependency-verification hardening;
-# see docs/dependency-verification.md for the (separate) Gradle artifact-checksum file.
+# without manual tracking.
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -26,12 +25,17 @@ updates:
     # Newer stable CMP only pairs with -alpha material3. Revisit by hand if a stable material3 > 1.9.0 ships.
     ignore:
       - dependency-name: "org.jetbrains.compose*"
-      # llamatik 1.9.1 ships a Linux x86-64 native that runs AVX-512 unconditionally in
-      # ggml_cpu_init, before any CPU dispatch — an instant SIGILL on every CPU without AVX-512
-      # (all AMD Zen 1-3, Intel parts with E-cores). CI never loads the native, so only a live run
-      # catches it. Drop this entry once upstream rebuilds without AVX-512 on the init path.
+      # llamatik has shipped a Linux x86-64 native that runs AVX-512 unconditionally in
+      # ggml_cpu_init, before any CPU dispatch, since 1.9.1 — an instant SIGILL on every CPU
+      # without AVX-512 (all AMD Zen 1-3, Intel parts with E-cores). 1.10.0 still does (PR #268:
+      # `libllama_jni.so+0x758c06` = `ggml_cpu_init+0x246`). Listed version by version on purpose,
+      # not as a range: a new release must still reach a PR, because that is the only thing that
+      # will ever tell us the hold can be lifted. LlamatikNativeIsaTest then disassembles both
+      # shipped natives of that release whole and holds them at the counts 1.9.0 has, so AVX-512
+      # fails CI by name instead of by SIGILL — see the pin comment for what a bump still owes
+      # beyond that.
       - dependency-name: "com.llamatik:library"
-        versions: ["1.9.1"]
+        versions: ["1.9.1", "1.10.0"]
       # Micrometer follows ktor, not the other way round: ktor-server-metrics-micrometer is built
       # against a specific registry version and taking the registry ahead of it mixes versions.
       # Bump both together by hand.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,13 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
-      - name: Install ffmpeg
-        # The desktop H.264 decoder is an ffmpeg process, and the flags it drives one with were
-        # arrived at empirically (see FfmpegH264DecoderTest). Its test skips itself where there is no
-        # ffmpeg, so without this step a regression in those flags would go green here.
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Install test tools
+        # ffmpeg: the desktop H.264 decoder is an ffmpeg process, and the flags it drives one with
+        # were arrived at empirically (see FfmpegH264DecoderTest). binutils: LlamatikNativeIsaTest
+        # disassembles the shipped natives to prove they do not run AVX-512 before any CPU dispatch
+        # (see the llamatik pin in gradle/libs.versions.toml). Both tests skip themselves where the
+        # tool is missing, so without this step a regression in either would go green here.
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg binutils
 
       - name: Test
         # `allTests` as well as `test`: :shared and :composeApp are Kotlin Multiplatform modules
@@ -59,7 +61,11 @@ jobs:
         # Under xvfb-run because compose-resources asks AWT for the screen resolution when it loads
         # a string, which throws HeadlessException on a runner with no display — the failure lands
         # inside a coroutine and surfaces as a test that never reaches its final state.
-        run: xvfb-run --auto-servernum ./gradlew test allTests --stacktrace
+        #
+        # -PskerryCi: binutils are installed above, so LlamatikNativeIsaTest treats a guard it
+        # cannot run as a failure rather than a skip. A property, not an environment variable — see
+        # the comment on it in shared/build.gradle.kts.
+        run: xvfb-run --auto-servernum ./gradlew test allTests --stacktrace -PskerryCi=1
 
       # Static analysis. Runs after the tests so a red suite is reported first — detekt findings are
       # cheaper to read once the behaviour is known good. Existing findings sit in

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,9 +20,9 @@ material3 = "1.9.0"
 kotlinx-coroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 ktor = "3.5.2"
-logback = "1.6.1"
-# slf4j-nop: a no-op SLF4J provider for the app. sshj logs via slf4j-api (2.0.17 on the
-# classpath); without any binding SLF4J prints "No SLF4J providers were found" and goes NOP.
+logback = "1.6.2"
+# slf4j-nop: a no-op SLF4J provider for the app. sshj logs via slf4j-api (the version pinned on the
+# classpath, see below); without any binding SLF4J prints "No SLF4J providers were found" and goes NOP.
 # An explicit nop removes the warning while keeping current behavior (sshj logs are not needed in the client anyway).
 slf4j = "2.0.18"
 sshj = "0.40.0"
@@ -73,9 +73,18 @@ camerax = "1.4.1"
 # Llamatik — a KMP binding of llama.cpp (GGUF, streaming, chat template from GGUF): the only
 # maintained option with natives for both desktop JVM (Linux/Win/macOS) and Android arm64
 # (16KB pages aligned). MIT. java-llama.cpp (kherud) has been dead since 2025-06 and cannot load Qwen3.
-# Held back from 1.9.1: its Linux x86-64 native runs AVX-512 unconditionally in ggml_cpu_init,
-# before any CPU dispatch, so loading it is an instant SIGILL on every CPU without AVX-512
-# (all AMD Zen 1-3, Intel parts with E-cores). 1.9.0 has no AVX-512 on that path.
+# Held back at 1.9.0: every release since (1.9.1, 1.10.0) ships x86-64 natives whose ggml_cpu_init
+# runs AVX-512 unconditionally, before any CPU dispatch, so loading one is an instant SIGILL on
+# every CPU without AVX-512 (all AMD Zen 1-3, Intel parts with E-cores) — 25 such instructions in
+# that one function, 30437 in the whole Linux native, 14880 in the Windows one.
+# LlamatikNativeIsaTest checks a candidate automatically: it disassembles both shipped natives and
+# counts AVX-512 by encoding rather than by operand (AVX-512VL runs on ymm0-15 with a mask register
+# and the mask instructions are VEX-encoded, so a search for `zmm` or a high register finds 8 of
+# those 25). The counts must stay at what 1.9.0 has: 0 in `native/linux/libllama_jni.so`, and 2 in
+# `native/windows/llama_jni.dll` — an auto-vectorised `vpmullq` pair whose reachability on a CPU
+# without AVX-512 nobody has established. Which is why a bump still owes a live generation on such
+# a CPU, on Linux and on Windows, before the hold comes off. Cost of the hold: 1.9.0 keeps the
+# generateStream crash on emoji that upstream fixed in 1.9.1.
 llamatik = "1.9.0"
 # ML Kit barcode-scanning — QR recognition in the camera frame (Android, on-device, no network)
 mlkit-barcode = "17.3.0"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -21,6 +21,11 @@ kotlin {
             // A packaged app's JVM carries this jpackage restart marker; the tests prove it never
             // leaks into a spawned inference host (see LlmHostCommandLine.scrubEnvironment).
             environment("_JPACKAGE_LAUNCHER", "1")
+            // Read by LlamatikNativeIsaTest to decide whether a guard it cannot run is a failure or
+            // a skip. A Gradle property rather than an environment variable: workers inherit the
+            // daemon's environment, so a variable set on this invocation would not reach a daemon
+            // an earlier step already started, and the guard would quietly skip.
+            systemProperty("skerry.ci", providers.gradleProperty("skerryCi").getOrElse(""))
         }
     }
 

--- a/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
+++ b/shared/src/androidMain/kotlin/app/skerry/shared/ai/local/ServiceLlmHostLauncher.kt
@@ -13,8 +13,10 @@ import android.os.Message
 import android.os.Messenger
 import android.os.ParcelFileDescriptor
 import app.skerry.shared.ai.AiException
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -30,7 +32,20 @@ class ServiceLlmHostLauncher(
 
     private val appContext = context.applicationContext
 
-    override suspend fun launch(): LlmHostLink = withContext(Dispatchers.IO) {
+    override suspend fun launch(): LlmHostLink {
+        // The desktop launcher's window, and here it costs more: `withContext` discards what it
+        // produced when a cancellation lands as it completes, and an unbound service keeps the
+        // `:llm` process alive with the model still mapped for the rest of the app's life.
+        val built = AtomicReference<LlmHostLink?>()
+        try {
+            return bind(built)
+        } catch (e: Throwable) {
+            runCatching { built.getAndSet(null)?.let { withContext(NonCancellable) { it.close() } } }
+            throw e
+        }
+    }
+
+    private suspend fun bind(built: AtomicReference<LlmHostLink?>): LlmHostLink = withContext(Dispatchers.IO) {
         val binder = CompletableDeferred<IBinder?>()
         val connection = object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
@@ -49,10 +64,13 @@ class ServiceLlmHostLauncher(
             runCatching { appContext.unbindService(connection) }
             fail("could not start the inference service")
         }
+        // Owns the descriptor from the moment it exists until the link takes it: `dup()` below can
+        // fail on a full fd table, and the reply can arrive as this call is giving up.
+        val opened = AtomicReference<ParcelFileDescriptor?>()
         try {
             val service = withTimeoutOrNull(BIND_TIMEOUT_MILLIS) { binder.await() }
                 ?: fail("the inference service did not start")
-            val channel = openChannel(Messenger(service)) ?: fail("the inference service gave no channel")
+            val channel = openChannel(Messenger(service), opened) ?: fail("the inference service gave no channel")
             StreamLlmHostLink(
                 // One descriptor per stream (see LlmHostService): the socket is full duplex, but a
                 // ParcelFileDescriptor must not be closed twice.
@@ -60,21 +78,29 @@ class ServiceLlmHostLauncher(
                 output = ParcelFileDescriptor.AutoCloseOutputStream(channel.dup()),
             ) {
                 runCatching { appContext.unbindService(connection) }
-            }
+            }.also(built::set)
         } catch (e: Throwable) {
+            opened.getAndSet(null)?.let { runCatching { it.close() } }
             runCatching { appContext.unbindService(connection) }
             throw e
         }
     }
 
-    /** Asks the service for a socket pair and waits for the descriptor to come back. */
-    private suspend fun openChannel(service: Messenger): ParcelFileDescriptor? {
+    /**
+     * Asks the service for a socket pair and waits for the descriptor to come back. What comes back
+     * is published into [held] before it is handed over, so that a reply and a caller that stopped
+     * waiting cannot each assume the other owns it — see [deliverOrClose].
+     */
+    private suspend fun openChannel(
+        service: Messenger,
+        held: AtomicReference<ParcelFileDescriptor?>,
+    ): ParcelFileDescriptor? {
         val answer = CompletableDeferred<ParcelFileDescriptor?>()
         val thread = HandlerThread("llm-host-reply").also { it.start() }
         try {
             val replyTo = Messenger(
                 Handler(thread.looper) { message ->
-                    answer.complete(message.data?.channel())
+                    deliverOrClose(answer, held, message.data?.channel()) { it.close() }
                     true
                 },
             )
@@ -85,6 +111,9 @@ class ServiceLlmHostLauncher(
             service.send(request)
             return withTimeoutOrNull(BIND_TIMEOUT_MILLIS) { answer.await() }
         } finally {
+            // Shut on every exit, a cancellation included: past this point a reply reaches nobody,
+            // and the handler closes it rather than leaving it in a deferred no one reads.
+            answer.complete(null)
             thread.quitSafely()
         }
     }

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncher.kt
@@ -1,22 +1,26 @@
 package app.skerry.shared.ai.local
 
 import app.skerry.shared.ai.AiException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runInterruptible
-import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
+import app.skerry.shared.process.isWindows
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
+import java.nio.channels.ClosedChannelException
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.deleteIfExists
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Starts the desktop inference host: a second process running [LlmHostMain] — a plain JVM on this
@@ -34,17 +38,40 @@ class ProcessLlmHostLauncher(
     private val selfCommand: String? = ProcessHandle.current().info().command().orElse(null),
     private val classpath: String = System.getProperty("java.class.path").orEmpty(),
     private val heapMegabytes: Int = DEFAULT_HEAP_MB,
+    /** How long the child gets to connect back. A parameter so the give-up path is testable. */
+    private val startTimeoutMillis: Long = START_TIMEOUT_MILLIS,
 ) : LlmHostLauncher {
 
-    override suspend fun launch(): LlmHostLink = withContext(Dispatchers.IO) {
+    override suspend fun launch(): LlmHostLink {
+        // Written inside the block below, read here if that block never hands its value over:
+        // `withContext` discards what it produced when a cancellation lands as it completes, and the
+        // link is the only handle on a child process that is by then alive and holding a model.
+        val built = AtomicReference<LlmHostLink?>()
+        try {
+            return start(built)
+        } catch (e: Throwable) {
+            // The whole teardown, not just close(): nothing here may replace the exception that says
+            // why the start failed — least of all a cancellation the caller branches on. The
+            // cancellation test reaches this arm with nothing built; what nothing drives is the
+            // close itself, which needs accept() to succeed and the cancel to land together — a
+            // seam in this class that would exist only to be faked.
+            runCatching { built.getAndSet(null)?.let { withContext(NonCancellable) { it.close() } } }
+            throw e
+        }
+    }
+
+    private suspend fun start(built: AtomicReference<LlmHostLink?>): LlmHostLink = withContext(Dispatchers.IO) {
         val directory = Files.createTempDirectory("skerry-llm-")
         val socketPath = directory.resolve(SOCKET_NAME)
         val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        // Held here rather than inside accept(): the catch below is the one place every failing path
+        // passes through, including a cancellation that discards a connection already made.
+        val accepted = AtomicReference<SocketChannel?>()
         var process: Process? = null
         try {
             server.bind(UnixDomainSocketAddress.of(socketPath))
             process = startChild(socketPath)
-            val channel = accept(server, process) ?: fail("the inference host did not start")
+            val channel = accept(server, process, accepted) ?: fail(startFailure(process))
             StreamLlmHostLink(
                 input = Channels.newInputStream(channel),
                 output = Channels.newOutputStream(channel),
@@ -54,9 +81,12 @@ class ProcessLlmHostLauncher(
                 process.destroy()
                 if (!process.waitFor(EXIT_GRACE_MILLIS, TimeUnit.MILLISECONDS)) process.destroyForcibly()
                 cleanUp(server, socketPath, directory)
-            }
+            }.also(built::set)
         } catch (e: Throwable) {
-            process?.destroyForcibly()
+            // runCatching like the rest of the teardown: a failure to kill the child must not
+            // replace the exception that says why the start failed.
+            closeUnclaimed(accepted)
+            runCatching { process?.destroyForcibly() }
             cleanUp(server, socketPath, directory)
             throw e
         }
@@ -70,19 +100,38 @@ class ProcessLlmHostLauncher(
         .also { LlmHostCommandLine.scrubEnvironment(it.environment()) }
         .start()
 
-    /** Waits for the child to connect back; gives up early if it died instead. */
-    private suspend fun accept(server: ServerSocketChannel, process: Process): SocketChannel? = coroutineScope {
-        withTimeoutOrNull(START_TIMEOUT_MILLIS.milliseconds) {
+    /**
+     * Waits for the child to connect back; gives up early if it died instead. Publishes what it
+     * accepted into [accepted] before returning it, because every way this can end without the
+     * caller receiving it — the timeout, a cancellation discarding the value at either coroutine
+     * boundary — leaves the socket open with no other reference to close it.
+     */
+    private suspend fun accept(
+        server: ServerSocketChannel,
+        process: Process,
+        accepted: AtomicReference<SocketChannel?>,
+    ): SocketChannel? = coroutineScope {
+        withTimeoutOrNull(startTimeoutMillis.milliseconds) {
             val watchdog = launch {
                 runInterruptible(Dispatchers.IO) { process.waitFor() }
                 runCatching { server.close() } // unblocks accept()
             }
             try {
-                runCatching { runInterruptible(Dispatchers.IO) { server.accept() } }.getOrNull()
+                runCatching { runInterruptible(Dispatchers.IO) { server.accept().also(accepted::set) } }
+                    // The watchdog closes the socket to unblock this when the child dies, and the
+                    // timeout closes it by interrupting — those are the two ways out. Anything else
+                    // is a fault of ours (no descriptors left, a temp dir we may not write) and must
+                    // not be reported as a host that answered too slowly. Nothing drives that arm
+                    // either — provoking it means exhausting the fd table, not writing a test.
+                    .getOrElse { if (it is ClosedChannelException) null else throw it }
             } finally {
                 watchdog.cancel()
             }
         }
+    }
+
+    private fun closeUnclaimed(channel: AtomicReference<SocketChannel?>) {
+        channel.getAndSet(null)?.let { runCatching { it.close() } }
     }
 
     private fun cleanUp(server: ServerSocketChannel, socketPath: Path, directory: Path) {
@@ -94,10 +143,30 @@ class ProcessLlmHostLauncher(
     private fun fail(reason: String): Nothing =
         throw AiException(AiException.Kind.ENGINE_CRASHED, "Local inference host: $reason")
 
+    /**
+     * Why the child never connected. Died on a signal and timed out are different faults with the
+     * same [AiException.Kind], and a native that meets an instruction this CPU has not got
+     * (llamatik's AVX-512 build — see the pin in `gradle/libs.versions.toml`) shows up here as
+     * `signal 4`. The UI renders the kind, not this text, so it reaches a run from a terminal, a
+     * stack trace and the tests; making it reachable from a packaged build needs a log sink that
+     * this app does not have.
+     */
+    private fun startFailure(process: Process): String {
+        if (process.isAlive) return "the inference host did not answer in ${startTimeoutMillis}ms"
+        val code = process.exitValue()
+        // A child killed by a signal exits as 128 + the signal number — a Unix shell convention, and
+        // only for real signal numbers: Windows exit codes and an ordinary `exit 130` land in the
+        // same range without anything having signalled the process.
+        val signal = (code - SIGNAL_EXIT_BASE).takeIf { !isWindows && code in SIGNAL_EXIT_RANGE }
+        return "the inference host died on start-up, exit code $code" + signal?.let { " (signal $it)" }.orEmpty()
+    }
+
     private companion object {
         const val SOCKET_NAME = "host.sock"
         const val START_TIMEOUT_MILLIS = 60_000L
         const val EXIT_GRACE_MILLIS = 2_000L
+        const val SIGNAL_EXIT_BASE = 128
+        val SIGNAL_EXIT_RANGE = (SIGNAL_EXIT_BASE + 1)..(SIGNAL_EXIT_BASE + 64)
 
         /** The host holds protocol strings only; the model itself is native, mmapped memory. */
         const val DEFAULT_HEAP_MB = 256

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/local/LocalShell.desktop.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/local/LocalShell.desktop.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.local
 
 import app.skerry.shared.ai.local.LlmHostCommandLine
+import app.skerry.shared.process.isWindows
 import com.pty4j.PtyProcess
 import com.pty4j.PtyProcessBuilder
 import com.pty4j.WinSize
@@ -36,11 +37,9 @@ actual object LocalShell {
         return Pty4jHandle(process)
     }
 
-    private fun defaultShell(): String {
-        val windows = System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
-        return if (windows) System.getenv("COMSPEC") ?: "cmd.exe"
+    private fun defaultShell(): String =
+        if (isWindows) System.getenv("COMSPEC") ?: "cmd.exe"
         else System.getenv("SHELL") ?: "/bin/sh"
-    }
 }
 
 private class Pty4jHandle(private val process: PtyProcess) : LocalShellHandle {

--- a/shared/src/desktopMain/kotlin/app/skerry/shared/process/Executables.kt
+++ b/shared/src/desktopMain/kotlin/app/skerry/shared/process/Executables.kt
@@ -21,8 +21,13 @@ fun resolveExecutableOnPath(name: String): String? {
         ?.absolutePath
 }
 
-private val isWindows: Boolean =
-    System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+private val osName: String = System.getProperty("os.name").orEmpty()
+
+/** Desktop host is Windows. One definition: three copies of this expression drifted apart once. */
+internal val isWindows: Boolean = osName.startsWith("Windows", ignoreCase = true)
+
+/** Desktop host is Linux. Same reason as [isWindows]. */
+internal val isLinux: Boolean = osName.startsWith("Linux", ignoreCase = true)
 
 private val windowsExtensions: List<String> =
     (System.getenv("PATHEXT") ?: ".EXE;.BAT;.CMD").split(';').filter { it.startsWith('.') }

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LateAnswerTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LateAnswerTest.kt
@@ -1,0 +1,112 @@
+package app.skerry.shared.ai.local
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.InternalForInheritanceCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The rule this pins is the one the Android launcher's reply handler lives by, and it is plain
+ * Kotlin rather than framework plumbing — which is the only reason it can be tested at all: the
+ * `Messenger`/`Looper` round trip around it cannot be driven from a JVM test.
+ *
+ * One case implements [CompletableDeferred] by delegation, which the library asks to be opted into:
+ * it is the only way to stand in the middle of the hand-over without racing two threads and hoping.
+ */
+@OptIn(InternalForInheritanceCoroutinesApi::class)
+class LateAnswerTest {
+
+    private class Handle {
+        var closes = 0
+            private set
+
+        val closed: Boolean get() = closes > 0
+
+        fun close() {
+            closes++
+        }
+    }
+
+    @Test
+    fun `a reply that is waited for is handed over, not closed`() = runBlocking {
+        val answer = CompletableDeferred<Handle?>()
+        val held = AtomicReference<Handle?>()
+        val handle = Handle()
+
+        deliverOrClose(answer, held, handle) { it.close() }
+
+        assertSame(handle, answer.await(), "the waiter did not receive it")
+        assertFalse(handle.closed, "handed over and closed at once")
+        // Left behind on purpose: the caller may still be cancelled before it takes ownership.
+        assertSame(handle, held.get())
+    }
+
+    @Test
+    fun `a reply nobody waits for any more is closed`() = runBlocking {
+        val answer = CompletableDeferred<Handle?>()
+        val held = AtomicReference<Handle?>()
+        answer.complete(null) // the caller gave up and shut the door
+        val late = Handle()
+
+        deliverOrClose(answer, held, late) { it.close() }
+
+        assertTrue(late.closed, "the late reply was dropped instead of closed")
+        assertNull(held.get(), "a closed handle must not be left for the caller to close again")
+        assertNull(answer.await())
+    }
+
+    @Test
+    fun `an empty reply only shuts the door`() = runBlocking {
+        val answer = CompletableDeferred<Handle?>()
+        val held = AtomicReference<Handle?>()
+
+        deliverOrClose(answer, held, null) { it.close() }
+
+        assertNull(answer.await())
+        assertNull(held.get())
+    }
+
+    @Test
+    fun `a reply the caller reclaims mid-handover is closed once, not twice`() = runBlocking {
+        val answer = CompletableDeferred<Handle?>()
+        answer.complete(null) // the caller already gave up, so this delivery will lose
+        val held = AtomicReference<Handle?>()
+        val late = Handle()
+        var taken: Handle? = null
+        // Fires at the one instant that matters: the value is published and the delivery is about
+        // to learn it lost. That is the window in which the launcher's teardown does
+        // `opened.getAndSet(null)?.close()`, and both sides used to close the same descriptor.
+        val racing = object : CompletableDeferred<Handle?> by answer {
+            override fun complete(value: Handle?): Boolean {
+                taken = held.getAndSet(null)?.also { it.close() }
+                return answer.complete(value)
+            }
+        }
+
+        deliverOrClose(racing, held, late) { it.close() }
+
+        assertSame(late, taken, "the caller never got to reclaim it")
+        assertEquals(1, late.closes, "the descriptor was closed by both sides")
+    }
+
+    @Test
+    fun `only one of two replies survives, and the other is closed`() = runBlocking {
+        val answer = CompletableDeferred<Handle?>()
+        val held = AtomicReference<Handle?>()
+        val first = Handle()
+        val second = Handle()
+
+        deliverOrClose(answer, held, first) { it.close() }
+        deliverOrClose(answer, held, second) { it.close() }
+
+        assertSame(first, answer.await())
+        assertEquals(false to true, first.closed to second.closed)
+        assertSame(first, held.get(), "the surviving handle was taken from the caller")
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlamatikNativeIsaTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/LlamatikNativeIsaTest.kt
@@ -1,0 +1,255 @@
+package app.skerry.shared.ai.local
+
+import app.skerry.shared.process.isLinux
+import app.skerry.shared.process.resolveExecutableOnPath
+import java.net.JarURLConnection
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.bufferedReader
+import kotlin.io.path.deleteIfExists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import org.opentest4j.TestAbortedException
+
+/**
+ * llamatik's x86-64 natives must carry no more AVX-512 than the pinned version already does.
+ *
+ * `ggml_cpu_init` runs before any CPU dispatch, so one AVX-512 instruction there is an instant
+ * `SIGILL` on every processor without it (all AMD Zen 1-3, Intel parts with E-cores), and the
+ * library is loaded the moment a generation starts. Upstream has shipped that build twice — 1.9.1
+ * and 1.10.0, which put 25 of them in that one function. See the pin in `gradle/libs.versions.toml`.
+ *
+ * Whole binary rather than that one function: a rebuild can move inlined code into a callee or an
+ * ELF constructor without changing anything about the defect, and the pinned Linux native has a flat
+ * zero, so there is no reason to look through a keyhole. The Windows DLL exports no symbol table at
+ * all — a function-scoped check could not reach it, and it is the half that would otherwise ship
+ * unchecked when upstream fixes only Linux.
+ *
+ * Reading the shipped binary answers the same on every machine rather than only on hardware that
+ * happens to lack AVX-512 — which is how 1.9.1 got past review once. What it cannot answer is
+ * whether an instruction is reachable: 1.9.0's DLL has two, an auto-vectorised `vpmullq` pair in a
+ * popcount with no dispatch inside the function, and nothing here says whether a caller guards them.
+ * So a bump still owes a live generation on a CPU without AVX-512, on Linux and on Windows.
+ */
+class LlamatikNativeIsaTest {
+
+    @Test
+    fun `the natives carry no AVX-512 beyond the pinned baseline`() {
+        for ((resource, baseline) in BASELINE) {
+            val native = javaClass.classLoader.getResource(resource)
+                ?: fail("llamatik's native is not on the test classpath as $resource")
+            val copy = Files.createTempFile("llama-jni-", ".bin")
+            try {
+                native.openStream().use { input -> Files.newOutputStream(copy).use(input::copyTo) }
+                val counts = disassemble(
+                    // Wide enough for the longest x86 instruction, so nothing wraps: a wrapped tail
+                    // keeps the `address:` shape without a mnemonic, and a 0x62 byte in a string
+                    // constant would then read as an EVEX prefix (`62 65 64` is "bed").
+                    listOf(tool("objdump"), "-d", "--insn-width=$MAX_INSTRUCTION_BYTES", "$copy"),
+                )
+
+                // Positive control first: matching the baseline proves nothing if nothing was
+                // decoded, and every way this check can break — a different objdump, a changed
+                // column layout, a truncated copy — produces an empty result that reads as clean.
+                if (counts.decoded < MIN_INSTRUCTIONS) {
+                    unusable("only ${counts.decoded} instructions decoded in $resource")
+                }
+
+                assertEquals(baseline, counts.avx512, "AVX-512 in $resource — it will SIGILL without AVX-512")
+                // Undecodable bytes are excluded from the count above, and an EVEX-shaped one is
+                // ambiguous: data in a code section, or an encoding this binutils is older than.
+                // Only growth is a signal, and only growth is checked — a newer disassembler that
+                // decodes more of them is an improvement, and where the sweep resynchronises after
+                // invalid bytes differs between binutils versions. If this trips on an unchanged
+                // llamatik, compare `objdump --version` before touching the number.
+                assertTrue(
+                    counts.undecodableEvex <= UNDECODABLE_EVEX.getValue(resource),
+                    "${counts.undecodableEvex} EVEX-shaped bytes this objdump cannot decode in " +
+                        "$resource, was ${UNDECODABLE_EVEX.getValue(resource)}",
+                )
+            } finally {
+                copy.deleteIfExists()
+            }
+        }
+    }
+
+    @Test
+    fun `the jar ships the natives this checks and no others`() {
+        // Iterating the baselines would silently pass over a native upstream added — a second Linux
+        // variant, an x86-64 macOS slice — and that one would reach users unscanned.
+        assertEquals(BASELINE.keys + MACOS_NATIVE, shippedNatives(), "the set of shipped natives moved")
+    }
+
+    /** Every binary under `native/` in the jar the natives come from. */
+    private fun shippedNatives(): Set<String> {
+        val url = javaClass.classLoader.getResource(BASELINE.keys.first())
+            ?: fail("llamatik's native is not on the test classpath as ${BASELINE.keys.first()}")
+        // Through the connection, not by slicing the URL: that string is percent-encoded, and a
+        // Gradle cache under a path with a space or a non-ASCII character then names no file.
+        val connection = url.openConnection() as? JarURLConnection
+            ?: unusable("the natives are not in a jar, so there is nothing to enumerate")
+        connection.useCaches = false
+        return connection.jarFile.use { jar ->
+            jar.entries().asSequence()
+                .map { it.name }
+                .filterNot { it.endsWith("/") || it.endsWith(".txt") }
+                .filter { it.startsWith("native/") }
+                .toSet()
+        }
+    }
+
+    @Test
+    fun `the search knows an AVX-512 encoding from an ordinary one`() {
+        // Real objdump lines, tabs and all. The binaries under test are whatever version is pinned,
+        // and the pinned one sits at its baseline by definition — so without this, deleting half the
+        // disjunction or mistyping a prefix byte still leaves the guard green.
+        val avx512 = listOf(
+            "  758c06:\t62 e2 7d 28 7c ca   \tvpbroadcastd %edx,%ymm17",
+            "  758c86:\t62 a3 6d 20 25 d2 ff\tvpternlogd \$0xff,%ymm18,%ymm18,%ymm18",
+            "  758cd8:\t62 f2 5d 29 47 d8   \tvpsllvd %ymm0,%ymm4,%ymm3{%k1}",
+            // VEX, not EVEX: the mask registers are what make it AVX-512, and no operand says so.
+            "  758cfc:\tc4 e3 79 31 d1 10   \tkshiftrd \$0x10,%k1,%k2",
+            "  64758cfc:\t64 62 e2 7d 28 7c ca\tvpbroadcastd %edx,%ymm17",
+        )
+        val ordinary = listOf(
+            "  7589c0:\tf3 0f 1e fa         \tendbr64",
+            "  7589c4:\t41 55               \tpush   %r13",
+            // AVX-2 on the same encoding as the kshift above, without a mask register.
+            "  7589f8:\tc5 f9 6f 7d b0      \tvmovdqa -0x50(%rbp),%xmm7",
+            // Only the byte column decides: those operand bytes read "el.em" and the immediate
+            // spells "el.embed" in memory order, but none of that is where a prefix can be.
+            "  6821b0:\t48 ba 65 6c 2e 65 6d 62 65 64\tmovabs \$0x6465626d652e6c65,%rdx",
+            // Data in an executable section. Ten of these sit in the pinned Windows DLL; counting
+            // them would put its baseline at 12 and bury the two real instructions among them.
+            "  180086080:\t62                  \t(bad)",
+        )
+
+        for (line in avx512) assertTrue(isAvx512(line), "not recognised: $line")
+        for (line in ordinary) assertFalse(isAvx512(line), "recognised as AVX-512: $line")
+        for (line in avx512 + ordinary) assertTrue(INSTRUCTION.containsMatchIn(line), "not an instruction: $line")
+    }
+
+    /** Whether an objdump line is an AVX-512 instruction: EVEX, or VEX touching a mask register. */
+    private fun isAvx512(line: String): Boolean {
+        if (line.endsWith(UNDECODABLE)) return false
+        return EVEX_INSTRUCTION.containsMatchIn(line) ||
+            (VEX_INSTRUCTION.containsMatchIn(line) && MASK_REGISTER.containsMatchIn(line))
+    }
+
+    private fun tool(name: String): String = resolveExecutableOnPath(name) ?: unusable("no $name on PATH")
+
+    /** What one pass over a disassembly found. */
+    private data class Counts(val decoded: Int, val avx512: Int, val undecodableEvex: Int)
+
+    /**
+     * Runs [command] and counts, in one streaming pass, the instructions it decoded, the AVX-512
+     * among them, and the EVEX-shaped bytes it could not decode. Streamed rather than held: a whole
+     * native disassembles to over a million lines, which is a heap the test JVM does not have.
+     */
+    private fun disassemble(command: List<String>): Counts {
+        val output = Files.createTempFile("skerry-binutils-", ".txt")
+        try {
+            val process = ProcessBuilder(command)
+                .redirectErrorStream(true)
+                .redirectOutput(output.toFile())
+                .start()
+            if (!process.waitFor(TOOL_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                unusable("${command.first()} did not finish in ${TOOL_TIMEOUT_SECONDS}s")
+            }
+            if (process.exitValue() != 0) {
+                unusable("${command.first()} failed: ${output.bufferedReader().use { it.readLine() }}")
+            }
+            var decoded = 0
+            var avx512 = 0
+            var undecodableEvex = 0
+            output.bufferedReader().useLines { lines ->
+                for (line in lines) {
+                    if (!INSTRUCTION.containsMatchIn(line)) continue
+                    when {
+                        // Not counted as decoded: the positive control asks whether objdump read
+                        // real code, and a sweep over data produces these by the thousand.
+                        line.endsWith(UNDECODABLE) -> if (EVEX_INSTRUCTION.containsMatchIn(line)) undecodableEvex++
+                        else -> {
+                            decoded++
+                            if (isAvx512(line)) avx512++
+                        }
+                    }
+                }
+            }
+            return Counts(decoded, avx512, undecodableEvex)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    /**
+     * Skipped where binutils cannot read an x86-64 binary — an arm64 workstation, a JDK image
+     * without them — and **failed** where `-PskerryCi=1` says the tools were installed on purpose
+     * and a green tick from a run that disassembled nothing is how the next AVX-512 build would
+     * ship. A second workflow that runs the tests owes the same flag, or the guard skips there.
+     */
+    private fun unusable(reason: String): Nothing {
+        // Blank, not absent: the Gradle test task always sets the property, empty when unasked.
+        if (!System.getProperty("skerry.ci").isNullOrBlank() && isLinux) {
+            fail("the AVX-512 guard cannot run where it is needed: $reason")
+        }
+        // What Assumptions.abort throws; thrown directly because a Java generic method is not
+        // `Nothing`-returning to Kotlin, and this function has to be.
+        throw TestAbortedException(reason)
+    }
+
+    private companion object {
+        /**
+         * What each shipped x86-64 native holds today. Zero is the only defensible number for a
+         * binary that has none; the Windows two are the `vpmullq` pair described above, held as a
+         * baseline rather than waved through, so a bump that changes either number stops for a
+         * person to look. The macOS dylib is arm64-only and cannot carry AVX-512 at all.
+         */
+        val BASELINE: Map<String, Int> = mapOf(
+            "native/linux/libllama_jni.so" to 0,
+            "native/windows/llama_jni.dll" to 2,
+        )
+
+        /**
+         * EVEX-shaped bytes objdump reports as `(bad)` in each pinned native: ten data bytes in the
+         * Windows one, none in the Linux one. Measured with binutils 2.46 and cross-checked with
+         * 2.42, the version CI runs — identical, so where the sweep resynchronises after invalid
+         * bytes is not version-sensitive for these two binaries. Counted separately from real instructions so that a
+         * candidate built with an encoding this binutils predates cannot read as clean.
+         */
+        val UNDECODABLE_EVEX: Map<String, Int> = mapOf(
+            "native/linux/libllama_jni.so" to 0,
+            "native/windows/llama_jni.dll" to 10,
+        )
+
+        /** Arm64 only in every release so far, so AVX-512 cannot apply — listed, not scanned. */
+        const val MACOS_NATIVE = "native/macos/libllama_jni.dylib"
+
+        const val TOOL_TIMEOUT_SECONDS = 120L
+        const val MAX_INSTRUCTION_BYTES = 15
+
+        /** Both natives decode over a million instructions; this only has to rule out "almost none". */
+        const val MIN_INSTRUCTIONS = 100_000
+
+        const val LEGACY_PREFIXES = "((26|2e|36|3e|64|65|66|67|f0|f2|f3) )*"
+
+        /** Bytes objdump could not decode. They keep the shape of an instruction and are not one. */
+        const val UNDECODABLE = "(bad)"
+
+        /** An objdump line, by its `address:` column and the first byte of the instruction. */
+        val INSTRUCTION = Regex("^\\s+[0-9a-f]+:\\s+[0-9a-f]{2}")
+
+        /** The same, where the instruction carries the EVEX prefix — behind legacy prefixes if any. */
+        val EVEX_INSTRUCTION = Regex("^\\s+[0-9a-f]+:\\s+$LEGACY_PREFIXES(62) ")
+
+        /** VEX, two- or three-byte form. Ordinary AVX uses it too — only a mask operand makes it 512. */
+        val VEX_INSTRUCTION = Regex("^\\s+[0-9a-f]+:\\s+$LEGACY_PREFIXES(c4|c5) ")
+
+        /** An AVX-512 mask register: `kshiftrd %k1,%k2` is VEX-encoded and mentions no vector width. */
+        val MASK_REGISTER = Regex("%k[0-7]")
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/ai/local/ProcessLlmHostLauncherTest.kt
@@ -4,24 +4,47 @@ import app.skerry.shared.ai.AiChatRequest
 import app.skerry.shared.ai.AiException
 import app.skerry.shared.ai.AiMessage
 import app.skerry.shared.ai.AiRole
+import app.skerry.shared.process.isWindows
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import okio.Path.Companion.toPath
 import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * The real desktop host: a child JVM is started, connects back over its Unix socket and answers.
  * Deliberately uses a model path that does not exist — the answer travels the full pipeline
- * (spawn -> socket -> protocol -> typed failure) without needing multi-gigabyte weights, and the
- * native library never has to load.
+ * (spawn -> socket -> protocol -> typed failure) without needing multi-gigabyte weights. The native
+ * library itself is loaded (`LlamaBridge` pulls it in before the model path is ever checked), only
+ * the weights are not, which is why this is also what catches a native that cannot be loaded at
+ * all: llamatik 1.10.0 died here with SIGILL on CI (dependabot PR #268).
  */
 class ProcessLlmHostLauncherTest {
+
+    /**
+     * A stand-in for the app's own launcher. `sh` forks rather than execs its last command, and the
+     * child inherits this JVM's stdout — an orphaned `sleep` outlives destroyForcibly() and holds
+     * that pipe open until Gradle gives up on the worker, so a script that waits must `exec`.
+     */
+    private fun writeLauncher(path: Path, body: String) {
+        Files.writeString(path, "#!/bin/sh\n$body\n")
+        path.toFile().setExecutable(true)
+    }
 
     private val request = AiChatRequest("local-it", listOf(AiMessage(AiRole.USER, "Say OK.")), maxOutputTokens = 8)
 
@@ -29,19 +52,24 @@ class ProcessLlmHostLauncherTest {
     fun `reports a missing model through a real child process`() = runBlocking {
         val runtime = IsolatedLlmRuntime(ProcessLlmHostLauncher(contextLength = 512))
 
-        val error = withTimeout(2.minutes) {
-            assertFailsWith<AiException> {
-                runtime.generate("/nonexistent/model.gguf".toPath(), request).toList()
+        try {
+            val error = withTimeout(2.minutes) {
+                assertFailsWith<AiException> {
+                    runtime.generate("/nonexistent/model.gguf".toPath(), request).toList()
+                }
             }
-        }
 
-        assertEquals(AiException.Kind.INVALID_REQUEST, error.kind)
-        runtime.close()
+            assertEquals(AiException.Kind.INVALID_REQUEST, error.kind)
+        } finally {
+            // Not after the assertion: a failing one would leave the child JVM holding this worker's
+            // inherited stdout until Gradle gave up on it.
+            runtime.close()
+        }
     }
 
     @Test
     fun `the jpackage restart marker does not leak into the child`() = runBlocking {
-        if (System.getProperty("os.name").startsWith("Windows")) return@runBlocking
+        assumeTrue(!isWindows, "POSIX shell and signals only")
         // Planted by the Gradle test task to mimic a packaged app's JVM. A child launcher that
         // inherits it feeds our --llm-host flag to the JVM and dies before reaching main.
         assertEquals("1", System.getenv("_JPACKAGE_LAUNCHER"), "the test task must plant the marker")
@@ -49,8 +77,7 @@ class ProcessLlmHostLauncherTest {
         val recorded = Files.createTempFile("skerry-llm-env", ".txt")
         val launcher = Files.createTempFile("skerry-fake-launcher", ".sh")
         try {
-            Files.writeString(launcher, "#!/bin/sh\nprintenv > '$recorded'\n")
-            launcher.toFile().setExecutable(true)
+            writeLauncher(launcher, "printenv > '$recorded'")
             val runtime = IsolatedLlmRuntime(
                 ProcessLlmHostLauncher(contextLength = 512, selfCommand = launcher.toString()),
             )
@@ -71,6 +98,113 @@ class ProcessLlmHostLauncherTest {
     }
 
     @Test
+    fun `a child that dies before connecting reports how it died`() = runBlocking {
+        assumeTrue(!isWindows, "POSIX shell and signals only")
+        val launcher = Files.createTempFile("skerry-fake-launcher", ".sh")
+        try {
+            // Kills itself the way the native does when it meets an instruction this CPU has not
+            // got — the AVX-512 crash class llamatik is pinned against (see libs.versions.toml).
+            writeLauncher(launcher, "kill -ILL $$")
+            val runtime = IsolatedLlmRuntime(
+                ProcessLlmHostLauncher(contextLength = 512, selfCommand = launcher.toString()),
+            )
+
+            val error = assertFailsWith<AiException> { runtime.generate("/m.gguf".toPath(), request).toList() }
+
+            assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+            // 128 + SIGILL. Without it, a host killed by an instruction the CPU has not got and a
+            // host started with a broken classpath are the same sentence in a stack trace.
+            assertContains(error.message.orEmpty(), "exit code 132 (signal 4)", message = error.message.orEmpty())
+        } finally {
+            Files.deleteIfExists(launcher)
+        }
+    }
+
+    @Test
+    fun `a child that never connects is given up on, not waited for`() = runBlocking {
+        assumeTrue(!isWindows, "POSIX shell and signals only")
+        val launcher = Files.createTempFile("skerry-fake-launcher", ".sh")
+        try {
+            writeLauncher(launcher, "exec sleep 30")
+            val runtime = IsolatedLlmRuntime(
+                ProcessLlmHostLauncher(contextLength = 512, selfCommand = launcher.toString(), startTimeoutMillis = 500),
+            )
+
+            val error = assertFailsWith<AiException> { runtime.generate("/m.gguf".toPath(), request).toList() }
+
+            // A live child that never connects is a different fault from one that died, and saying
+            // so is the whole reason the give-up path has its own branch.
+            assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+            assertContains(error.message.orEmpty(), "did not answer in 500ms", message = error.message.orEmpty())
+        } finally {
+            Files.deleteIfExists(launcher)
+        }
+    }
+
+    @Test
+    fun `cancelling a start is a cancellation, not a crashed engine`() = runBlocking {
+        assumeTrue(!isWindows, "POSIX shell and signals only")
+        val launcher = Files.createTempFile("skerry-fake-launcher", ".sh")
+        try {
+            writeLauncher(launcher, "exec sleep 30")
+            val runtime = IsolatedLlmRuntime(
+                ProcessLlmHostLauncher(contextLength = 512, selfCommand = launcher.toString()),
+            )
+
+            // The sibling test execs the same `sleep`, and destroyForcibly() does not wait — one of
+            // its corpses can still be in `descendants()` here. Anything already running is not
+            // this test's child and must not be mistaken for it.
+            val strangers = sleepers().map { it.pid() }.toSet()
+            var caught: Throwable? = null
+            val job = launch(Dispatchers.Default) {
+                runCatching { runtime.generate("/m.gguf".toPath(), request).toList() }
+                    .onFailure { caught = it }
+            }
+            // Captured before the cancel, and watched by handle afterwards: a process leaves
+            // `descendants()` both when it is killed and when it is orphaned onto init, so asking
+            // the set again would call a leak a success. Polled rather than slept on: how long a
+            // loaded runner takes to fork and exec is not something to guess at.
+            val started = withTimeout(10.seconds) {
+                var live = ours(strangers)
+                while (live.isEmpty()) {
+                    delay(POLL_MILLIS)
+                    live = ours(strangers)
+                }
+                live
+            }
+            withTimeout(10.seconds) { job.cancelAndJoin() }
+
+            // Abandoning a request is not the engine dying: a caller that branches on
+            // CancellationException (IsolatedLlmRuntime does) must not be handed a failure instead.
+            // Pins behaviour that already held — the coroutine machinery, not this file's own
+            // handling of a dead child, is what makes it hold.
+            assertIs<CancellationException>(caught, "cancelling the start produced $caught")
+            // And the child goes with it. Without this the test passes on a launcher that leaks the
+            // inference host on every abandoned answer — the exception type above is the coroutine
+            // machinery's doing, the teardown is this file's.
+            withTimeout(10.seconds) {
+                while (started.any { it.isAlive }) delay(POLL_MILLIS)
+            }
+        } finally {
+            Files.deleteIfExists(launcher)
+        }
+    }
+
+    /** [sleepers] minus the ones that were already running, i.e. the child this test started. */
+    private fun ours(strangers: Set<Long>): List<ProcessHandle> = sleepers().filterNot { it.pid() in strangers }
+
+    /**
+     * Live descendants of this JVM that are the `sleep` a fake launcher exec'd into. Matched by
+     * command rather than by the script's path: `exec` replaces the process image, which is the
+     * point of it — the launcher then holds the sleeper itself and can kill it. An empty result is
+     * therefore evidence of nothing, and the caller checks that before it means anything.
+     */
+    private fun sleepers(): List<ProcessHandle> =
+        ProcessHandle.current().descendants()
+            .filter { it.info().command().orElse("").endsWith("/sleep") }
+            .toList()
+
+    @Test
     fun `a missing runtime fails as an engine error instead of hanging`() = runBlocking {
         val runtime = IsolatedLlmRuntime(
             ProcessLlmHostLauncher(contextLength = 512, selfCommand = "/nonexistent/bin/java"),
@@ -79,5 +213,9 @@ class ProcessLlmHostLauncherTest {
         val error = assertFailsWith<AiException> { runtime.generate("/m.gguf".toPath(), request).toList() }
 
         assertEquals(AiException.Kind.ENGINE_CRASHED, error.kind)
+    }
+
+    private companion object {
+        const val POLL_MILLIS = 50L
     }
 }

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LateAnswer.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/ai/local/LateAnswer.kt
@@ -1,0 +1,37 @@
+package app.skerry.shared.ai.local
+
+import kotlinx.coroutines.CompletableDeferred
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Hands [value] to whoever waits on [answer], and leaves it in [held] so it can still be closed.
+ *
+ * A reply and the deadline its caller set are two independent things, and which lands first is a
+ * race nobody arbitrates — so the loser must not be the resource. One that arrives after the caller
+ * gave up belongs to nobody and is closed here; one that wins the completion is left in [held],
+ * because the caller can be cancelled between being handed the value and taking ownership of it.
+ * The caller closes whatever is still there once it knows it never received it.
+ *
+ * A `null` [value] only closes the door: there is nothing to own and nothing to leak.
+ */
+internal fun <T : Any> deliverOrClose(
+    answer: CompletableDeferred<T?>,
+    held: AtomicReference<T?>,
+    value: T?,
+    close: (T) -> Unit,
+) {
+    if (value == null) {
+        answer.complete(null)
+        return
+    }
+    // Published before the completion, not after: a waiter can resume and be cancelled while this
+    // thread is still between the two statements. On losing the race the previous occupant goes
+    // back — it is the one that was handed over, and the caller still has to be able to close it.
+    val previous = held.getAndSet(value)
+    if (!answer.complete(value)) {
+        // Closed only if the restore reclaimed it. A failed exchange means the caller took the
+        // value out in the meantime and is closing it itself, and closing an fd twice can land on
+        // a number something else has since reopened.
+        if (held.compareAndSet(value, previous)) runCatching { close(value) }
+    }
+}


### PR DESCRIPTION
Dependabot PR #268 bundled two updates. One is fine, the other cannot ship.

## The hold

Since 1.9.1, llamatik's x86-64 natives run AVX-512 unconditionally in `ggml_cpu_init` — before any CPU dispatch — so loading one is an instant `SIGILL` on every processor without it (all AMD Zen 1-3, Intel parts with E-cores). 1.10.0 still does: 25 such instructions in that function, 30437 in the whole Linux native, 14880 in the Windows one. CI caught it on #268 at `libllama_jni.so+0x758c06` = `ggml_cpu_init+0x246`.

The previous ignore entry named 1.9.1 exactly, which is why 1.10.0 got through. It now lists both versions individually rather than a range, so a future release still reaches a PR — that is the only signal that upstream has rebuilt.

## What decides the next one

`LlamatikNativeIsaTest` disassembles both shipped x86-64 natives and holds their AVX-512 count at what 1.9.0 has: **0** in `native/linux/libllama_jni.so`, **2** in `native/windows/llama_jni.dll` — an auto-vectorised `vpmullq` pair whose reachability on a CPU without AVX-512 nobody has established, which is why a live generation on both platforms is still owed before the hold comes off.

Counting is by encoding, not operand names: AVX-512VL runs on `ymm0-15` with a mask register, and the mask instructions are VEX-encoded, so a search for `zmm` or a high register finds 8 of the 25. A second test feeds real objdump lines through the same predicate, because the pinned binary is clean by definition and could never exercise the "found something" branch.

The guard fails rather than skips where the tools were installed on purpose (`-PskerryCi=1`), so it cannot go quietly green.

## Found while reading the code the guard runs against

- **A start that fails now says how.** The child's exit code and POSIX signal reach the exception, so a native killed by an instruction the CPU has not got is no longer the same sentence as a wrong classpath.
- **A cancellation landing as `withContext` completes discards what it produced.** That left an accepted socket unclosed, and on Android a whole `:llm` process with the model still mapped and nobody holding the handle to stop it. Both platforms now publish into a reference that the teardown drains.
- **`accept()` no longer reports a descriptor exhaustion as a host that answered too slowly.**
- **`isWindows` had three copies** in `shared/desktopMain`; one definition now, with `isLinux` beside it.

## Verification

| Check | Result |
|---|---|
| Guard on the pinned 1.9.0 | passes |
| Guard on 1.10.0 | fails, `expected: <0> but was: <30437>` |
| Detection regexes with half the disjunction removed | fails on `kshiftrd $0x10,%k1,%k2` |
| Guard with binutils missing under `-PskerryCi=1` | fails; without the flag, reports skipped |
| Teardown assertion with `destroyForcibly()` removed | fails |
| `deliverOrClose` without its close guard | fails, the descriptor is closed twice |
| binutils 2.42 (what CI runs) vs 2.46 (local) | identical counts on all four natives |

Not verified live: local AI has not been run on either platform from this branch.

## Accepted, not fixed

`LateAnswer` sits in `jvmSharedMain` though its only caller is Android — that placement is what makes the rule testable at all, since the repo has no Android unit-test infrastructure. Four `os.name` reads remain in `composeApp`, a module that cannot see a `shared` `internal`. Two narrow arms — the `withContext`-discard close and the non-`ClosedChannelException` rethrow — have no test, and say so in the code: reaching them needs a seam that would exist only to be faked.
