### PR TITLE
Scope the review fan-out to what each reviewer reads

### DIFF
--- a/.claude/hooks/record-review.py
+++ b/.claude/hooks/record-review.py
@@ -36,6 +36,20 @@ def note(text: str) -> None:
     sys.exit(0)
 
 
+def report_text(response) -> str:
+    """The reviewer's findings as text, whatever shape the harness handed them back in."""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        for key in ("content", "text", "output", "result"):
+            if key in response:
+                return report_text(response[key])
+        return ""
+    if isinstance(response, list):
+        return "\n".join(part for part in (report_text(item) for item in response) if part)
+    return ""
+
+
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
@@ -54,12 +68,16 @@ def main() -> None:
         }
         if subagent in known:
             st = state.load()
+            entries = policy.reviewer_entries(subagent)
             st.setdefault("reviews", {})[subagent] = {
-                "digest": state.tree_digest("all"),
+                # Scoped to what this reviewer reads, so an unrelated fix does not owe it again.
+                "digest": state.digest_of(entries),
+                "files": entries,
                 "branch": state.current_branch(),
                 "at": __import__("time").time(),
             }
             state.save(st)
+            state.save_review_report(subagent, report_text(payload.get("tool_response")))
         sys.exit(0)
 
     if tool == "Bash":

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,19 @@ Rules for the fan-out:
   Silent dismissal is not an option.
 - A fix that changes behaviour goes back through step 1 (test first).
 - Reviewers are fallible: verify each finding against the actual code before acting on it.
+- **Fix the whole round before re-reviewing.** Collect every finding, apply every fix, then run one
+  more pass — not a pass per finding. A fan-out per fix is how a branch ends up reviewed fifteen
+  times over the same code, and each of those passes re-reads the entire diff.
+- A reviewer that has already seen this branch gets **only what moved since** its last pass.
+  `gate.py reviewers` prints that delta per reviewer; hand it those files, not `main...HEAD` again.
+- Findings are kept in `.git/skerry-gate/reviews/<agent>.md` as each reviewer finishes, so what is
+  still owed survives a context compaction. Read them back rather than re-running the fan-out to
+  rediscover what a reviewer already said.
+
+Each reviewer is now owed again only when **its own scope** moves — the vault reviewer is not
+reopened by a Compose layout fix, and the server reviewer is not reopened by either. `skerry-reviewer`
+and `ecc:pr-test-analyzer` stay whole-change on purpose: parity, i18n and coverage are properties of
+the change, not of one directory. The scopes live in `REVIEWER_SCOPES` in `tools/harness/policy.py`.
 
 `/ecc:kotlin-review`, `/ecc:code-review` and `/ecc:review-pr` are the command shortcuts for the same
 agents when a single-angle pass is enough.

--- a/tools/harness/README.md
+++ b/tools/harness/README.md
@@ -14,6 +14,7 @@ tools/harness/gate.py status     # what this change is, and what it still owes
 tools/harness/gate.py run        # run the stages it owes
 tools/harness/gate.py red --tests '*Foo*' --file path/to/FooTest.kt
 tools/harness/gate.py reviewers  # which reviewers this change needs
+                                 # and, for each, what moved since its last pass
 tools/harness/gate.py checks     # the deterministic rules on their own
 tools/harness/gate.py task bug 133
 python3 tools/harness/selftest.py

--- a/tools/harness/gate.py
+++ b/tools/harness/gate.py
@@ -213,13 +213,28 @@ def cmd_checks(_: argparse.Namespace) -> int:
 
 def cmd_reviewers(_: argparse.Namespace) -> int:
     task = policy.classify()
-    digest = state.tree_digest("all")
-    missing = policy.missing_reviewers(state.load(), digest, task)
+    st = state.load()
+    missing = policy.missing_reviewers(st, task)
     base = state.merge_base()
     print(f"range: {base[:12]}...HEAD (worktree included)")
     for reviewer in policy.required_reviewers(task):
         mark = "MISSING" if reviewer in missing else "ok"
         print(f"  {mark:>11}  {policy.agent_id(reviewer)}")
+        if reviewer not in missing:
+            continue
+        delta = policy.reviewer_delta(st, reviewer)
+        if delta:
+            # A reviewer that has already seen this branch only needs what moved since. Handing it
+            # the whole diff again is what made a second round cost as much as the first.
+            print(f"{'':>13}re-run on the delta only — {len(delta)} file(s) changed since its "
+                  "last pass:")
+            for path in delta[:12]:
+                print(f"{'':>15}{path}")
+            if len(delta) > 12:
+                print(f"{'':>15}... and {len(delta) - 12} more")
+            report = state.review_report_path(reviewer)
+            if report and os.path.exists(report):
+                print(f"{'':>13}its previous findings: {os.path.relpath(report)}")
     for reviewer in policy.skipped_reviewers(task):
         print(f"  {'not installed':>11}  {policy.agent_id(reviewer)}")
     skipped = policy.skipped_reviewers(task)

--- a/tools/harness/policy.py
+++ b/tools/harness/policy.py
@@ -65,6 +65,75 @@ AREA_REVIEWERS = {
     "terminal": ("performance-optimizer",),
 }
 
+# Untrusted input reaches the client through more than the areas named above: every wire protocol
+# parses bytes a server chose. The security reviewer's scope is the vault and the sync boundary
+# plus those parsers, which is wider than the "security" area used for build stages.
+PROTOCOL_SEGMENTS = (
+    "/ssh/", "/sftp/", "/telnet/", "/serial/", "/mosh/", "/rdp/", "/vnc/", "/terminal/",
+    "/graphics/", "/audio/", "/tunnel/", "/container/",
+)
+
+
+def _area_matcher(*names: str):
+    rules = [predicate for area, predicate in AREA_RULES if area in names]
+    return lambda path: any(rule(path) for rule in rules)
+
+
+def _kotlin(path: str) -> bool:
+    return path.endswith((".kt", ".kts"))
+
+
+def _security_scope(path: str) -> bool:
+    return _area_matcher("security")(path) or any(seg in path for seg in PROTOCOL_SEGMENTS)
+
+
+# What each reviewer actually reads. A reviewer is owed again only when the files inside its own
+# scope have moved — fixing a Compose layout does not un-review the vault. None means everything,
+# and is the honest answer for the two passes that are about the change as a whole.
+REVIEWER_SCOPES = {
+    "skerry-reviewer": None,               # parity, i18n, the abstraction catalogue: the whole diff
+    "skerry-kotlin-reviewer": _kotlin,
+    "skerry-security-reviewer": _security_scope,
+    "silent-failure-hunter": _kotlin,
+    "pr-test-analyzer": None,              # coverage is a property of the change, not of a file
+    "a11y-architect": _area_matcher("ui", "android"),
+    "java-reviewer": _area_matcher("server"),
+    "performance-optimizer": _area_matcher("terminal"),
+}
+
+
+def reviewer_entries(reviewer: str, cwd: str | None = None) -> dict[str, str]:
+    """The files this reviewer's verdict depends on, as path -> content id.
+
+    A reviewer reads the diff, not the repository, so the set is the change itself narrowed to the
+    reviewer's own scope. Recording the whole tree instead would put thousands of untouched files
+    into the state file and make every reviewer depend on every other reviewer's fix.
+    """
+    keep = REVIEWER_SCOPES.get(reviewer, None)
+    changed = set(state.changed_paths(cwd=cwd))
+    if keep is None:
+        return state.scoped_entries(lambda path: path in changed, "all", cwd)
+    return state.scoped_entries(lambda path: path in changed and keep(path), "all", cwd)
+
+
+def reviewer_digest(reviewer: str, cwd: str | None = None) -> str:
+    return state.digest_of(reviewer_entries(reviewer, cwd))
+
+
+def reviewer_delta(st: dict, reviewer: str, cwd: str | None = None) -> list[str]:
+    """Which files inside a reviewer's scope moved since it last ran.
+
+    Empty when the reviewer never ran here: there is no delta to review, only the whole diff.
+    """
+    seen = ((st.get("reviews") or {}).get(reviewer) or {}).get("files")
+    if not isinstance(seen, dict):
+        return []
+    now = reviewer_entries(reviewer, cwd)
+    changed = {path for path, cid in now.items() if seen.get(path) != cid}
+    changed |= {path for path in seen if path not in now}
+    return sorted(changed)
+
+
 PLUGIN_GLOBS = (
     "~/.claude/plugins/cache/*/*/*/agents/{name}.md",
     "~/.claude/plugins/marketplaces/*/agents/{name}.md",
@@ -206,7 +275,7 @@ def gate_debt(cwd: str | None = None) -> tuple[dict, list[str]]:
                 debt.append(f"red — {why}")
             continue
         if stage == "review":
-            missing = missing_reviewers(st, digest, task, cwd)
+            missing = missing_reviewers(st, task, cwd)
             if missing:
                 debt.append("review — missing: " + ", ".join(missing))
             continue
@@ -218,10 +287,16 @@ def gate_debt(cwd: str | None = None) -> tuple[dict, list[str]]:
     return task, debt
 
 
-def missing_reviewers(st: dict, digest: str, task: dict, cwd: str | None = None) -> list[str]:
+def missing_reviewers(st: dict, task: dict, cwd: str | None = None) -> list[str]:
+    """Reviewers whose own scope has moved since they last ran.
+
+    Previously this compared one whole-tree digest, so a one-line Compose fix owed the vault, the
+    server and the terminal reviewer all over again — the fan-out ran ten to twenty times per
+    branch and each pass re-read the entire diff. Scoping the comparison is what stops that.
+    """
     seen = (st.get("reviews") or {})
     return [name for name in required_reviewers(task, cwd)
-            if (seen.get(name) or {}).get("digest") != digest]
+            if (seen.get(name) or {}).get("digest") != reviewer_digest(name, cwd)]
 
 
 def skipped_reviewers(task: dict, cwd: str | None = None) -> list[str]:

--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -300,7 +300,8 @@ class TestGateDebt(SandboxCase):
         st["stages"] = {stage: {"ok": True, "digest": digest}
                         for stage in policy.required_stages(task)
                         if stage not in ("red", "review")}
-        st["reviews"] = {name: {"digest": digest} for name in policy.required_reviewers(task)}
+        st["reviews"] = {name: {"digest": policy.reviewer_digest(name, self.cwd)}
+                         for name in policy.required_reviewers(task, self.cwd)}
         state.save(st, self.cwd)
 
     def test_untouched_branch_owes_every_stage(self):
@@ -344,9 +345,9 @@ class TestGateDebt(SandboxCase):
     def test_one_reviewer_does_not_close_the_fan_out(self):
         self.box.branch("feat/thing")
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
-        digest = state.tree_digest("all", self.cwd)
         st = state.load(self.cwd)
-        st["reviews"] = {"skerry-reviewer": {"digest": digest}}
+        st["reviews"] = {"skerry-reviewer": {
+            "digest": policy.reviewer_digest("skerry-reviewer", self.cwd)}}
         state.save(st, self.cwd)
         _, debt = policy.gate_debt(self.cwd)
         review = [item for item in debt if item.startswith("review")][0]
@@ -615,6 +616,107 @@ class TestChecks(SandboxCase):
         found = self._findings("i18n-parity")
         self.assertEqual(len(found), 1)
         self.assertIn("missing_key", found[0].message)
+
+
+class TestReviewerScope(SandboxCase):
+    """A reviewer is owed again only when its own scope moved.
+
+    The whole-tree comparison this replaces made every fix owe every reviewer, so a branch with
+    ten review findings ran the full fan-out ten times over the same unchanged code.
+    """
+
+    def _reviewed(self, task: dict) -> None:
+        st = state.load(self.cwd)
+        reviews = st.setdefault("reviews", {})
+        for name in policy.required_reviewers(task, self.cwd):
+            entries = policy.reviewer_entries(name, self.cwd)
+            reviews[name] = {"digest": state.digest_of(entries), "files": entries}
+        state.save(st, self.cwd)
+
+    def _branch_with_ui_and_vault(self) -> dict:
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val v = 1\n")
+        task = policy.classify(self.cwd)
+        self._reviewed(task)
+        return task
+
+    def test_a_reviewed_branch_owes_nobody(self):
+        task = self._branch_with_ui_and_vault()
+        self.assertEqual(policy.missing_reviewers(state.load(self.cwd), task, self.cwd), [])
+
+    def test_a_ui_fix_does_not_reopen_the_security_review(self):
+        self._branch_with_ui_and_vault()
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertNotIn("skerry-security-reviewer", missing)
+        self.assertIn("skerry-reviewer", missing)
+
+    def test_a_vault_fix_does_reopen_it(self):
+        self._branch_with_ui_and_vault()
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val v = 2\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-security-reviewer", missing)
+
+    def test_a_ui_fix_does_not_reopen_the_server_review(self):
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+        self.box.write("server/src/main/kotlin/S.kt", "val s = 1\n")
+        task = policy.classify(self.cwd)
+        self._reviewed(task)
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertNotIn("java-reviewer", missing)
+
+    def test_the_whole_change_reviewers_see_every_edit(self):
+        # Parity, i18n and coverage are properties of the change, not of one directory: those two
+        # passes stay global on purpose, and scoping must not quietly narrow them.
+        self._branch_with_ui_and_vault()
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-reviewer", missing)
+        self.assertIn("pr-test-analyzer", missing)
+
+    def test_the_delta_names_only_what_moved(self):
+        self._branch_with_ui_and_vault()
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        delta = policy.reviewer_delta(state.load(self.cwd), "skerry-reviewer", self.cwd)
+        self.assertEqual(delta, ["composeApp/src/commonMain/kotlin/S.kt"])
+
+    def test_a_reviewer_that_never_ran_has_no_delta(self):
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+        self.assertEqual(policy.reviewer_delta(state.load(self.cwd), "skerry-reviewer", self.cwd),
+                         [])
+
+    def test_a_deleted_file_is_part_of_the_delta(self):
+        self._branch_with_ui_and_vault()
+        os.remove(os.path.join(self.cwd, "composeApp/src/commonMain/kotlin/S.kt"))
+        delta = policy.reviewer_delta(state.load(self.cwd), "skerry-reviewer", self.cwd)
+        self.assertIn("composeApp/src/commonMain/kotlin/S.kt", delta)
+
+
+class TestReviewReports(SandboxCase):
+    """Findings on disk — the one thing a context compaction must not be able to lose."""
+
+    def test_findings_are_written_where_the_next_round_can_read_them(self):
+        path = state.save_review_report("skerry-reviewer", "FINDING: vault key logged", self.cwd)
+        self.assertTrue(path and os.path.exists(path))
+        with open(path, encoding="utf-8") as fh:
+            body = fh.read()
+        self.assertIn("FINDING: vault key logged", body)
+        self.assertIn("skerry-reviewer", body)
+
+    def test_an_empty_report_is_not_written(self):
+        self.assertEqual(state.save_review_report("skerry-reviewer", "   ", self.cwd), "")
+
+    def test_a_reviewer_name_cannot_escape_the_state_directory(self):
+        path = state.review_report_path("../../etc/passwd", self.cwd)
+        self.assertNotIn("..", path)
 
 
 class TestStageRecording(SandboxCase):

--- a/tools/harness/state.py
+++ b/tools/harness/state.py
@@ -36,6 +36,7 @@ TEST_MARKERS = ("/commonTest/", "/desktopTest/", "/androidTest/", "/jvmTest/", "
 
 STATE_DIR = "skerry-gate"
 STATE_FILE = "state.json"
+REVIEWS_DIR = "reviews"
 
 
 def git(args: list[str], cwd: str | None = None) -> tuple[int, str]:
@@ -93,6 +94,32 @@ def save(state: dict, cwd: str | None = None) -> None:
 def log_path(stage: str, cwd: str | None = None) -> str:
     gd = git_dir(cwd)
     return os.path.join(gd, STATE_DIR, f"{stage}.log") if gd else ""
+
+
+def review_report_path(reviewer: str, cwd: str | None = None) -> str:
+    gd = git_dir(cwd)
+    safe = "".join(ch for ch in reviewer if ch.isalnum() or ch in "-_")
+    return os.path.join(gd, STATE_DIR, REVIEWS_DIR, f"{safe}.md") if gd and safe else ""
+
+
+def save_review_report(reviewer: str, text: str, cwd: str | None = None) -> str:
+    """Keep a reviewer's findings on disk.
+
+    Findings used to live only in the session context, so a compaction silently dropped the list
+    of what still had to be fixed. On disk they survive it, and the next round can be scoped to
+    what is actually left instead of running the whole fan-out again to rediscover it.
+    """
+    path = review_report_path(reviewer, cwd)
+    if not path or not text.strip():
+        return ""
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        header = f"# {reviewer}\n\nbranch: {current_branch(cwd)}\nat: {_now():.0f}\n\n"
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(header + text.strip() + "\n")
+        return path
+    except OSError:
+        return ""  # the harness must never break the session it guards
 
 
 def is_code(path: str) -> bool:
@@ -169,22 +196,38 @@ def worktree_entries(cwd: str | None = None) -> dict[str, str]:
     return entries
 
 
+def scoped_entries(keep=None, scope: str = "all", cwd: str | None = None) -> dict[str, str]:
+    """The build-relevant files a predicate keeps, as path -> content id.
+
+    `keep` narrows the set to what one consumer actually looks at, so a reviewer of the vault is
+    not invalidated by a Compose layout edit. None means every build-relevant file.
+    """
+    selected = {}
+    for path, content_id in worktree_entries(cwd).items():
+        if not is_code(path):
+            continue
+        if scope == "src" and is_test(path):
+            continue
+        if keep is not None and not keep(path):
+            continue
+        selected[path] = content_id
+    return selected
+
+
+def digest_of(entries: dict[str, str]) -> str:
+    """The digest of an already-selected set — the one place the hash is defined."""
+    if not entries:
+        return "empty"
+    joined = "\n".join(f"{path}\0{content_id}" for path, content_id in sorted(entries.items()))
+    return hashlib.sha256(joined.encode()).hexdigest()[:16]
+
+
 def tree_digest(scope: str = "all", cwd: str | None = None) -> str:
     """Digest of the build-relevant content of the worktree.
 
     scope="src" excludes test sources, so a bug fix can be told apart from the test that proves it.
     """
-    entries = worktree_entries(cwd)
-    selected = []
-    for path, content_id in sorted(entries.items()):
-        if not is_code(path):
-            continue
-        if scope == "src" and is_test(path):
-            continue
-        selected.append(f"{path}\0{content_id}")
-    if not selected:
-        return "empty"
-    return hashlib.sha256("\n".join(selected).encode()).hexdigest()[:16]
+    return digest_of(scoped_entries(None, scope, cwd))
 
 
 def current_branch(cwd: str | None = None) -> str:


### PR DESCRIPTION
The gate pinned every reviewer to a single whole-tree digest, so any edit invalidated all of them. A branch with a dozen review findings ran the full five-to-eight agent fan-out a dozen times over code most of those agents had already cleared, and every pass re-read the entire diff.

## What changes

**Reviewers are scoped.** `REVIEWER_SCOPES` in `tools/harness/policy.py` says what each reviewer actually reads, and a reviewer is owed again only when files inside its own scope have moved. A Compose layout fix no longer reopens the vault review or the server review.

| Reviewer | Scope |
|---|---|
| `skerry-reviewer` | the whole change — parity, i18n, the abstraction catalogue |
| `ecc:pr-test-analyzer` | the whole change — coverage is not a property of one directory |
| `skerry-kotlin-reviewer`, `ecc:silent-failure-hunter` | Kotlin sources |
| `skerry-security-reviewer` | vault, guard, team, share, sync, crypto, and every wire protocol parser |
| `ecc:a11y-architect` | UI and Android |
| `ecc:java-reviewer` | server |
| `ecc:performance-optimizer` | terminal |

**Second rounds get the delta.** `gate.py reviewers` prints, per reviewer, which files moved since its last pass:

```
      MISSING  skerry-security-reviewer
             re-run on the delta only — 1 file(s) changed since its last pass:
               shared/src/commonMain/kotlin/app/skerry/vault/VaultStore.kt
             its previous findings: .git/skerry-gate/reviews/skerry-security-reviewer.md
```

**Findings persist.** `record-review.py` writes each reviewer's report to `.git/skerry-gate/reviews/<agent>.md` as it finishes. They previously lived only in the session context, where a compaction dropped them and the fan-out had to run again to rediscover what was already said.

`CLAUDE.md` adds the matching process rule: collect every finding, apply every fix, then run one more pass — not a pass per finding.

## Tests

`python3 tools/harness/selftest.py` — 86 cases, 11 new: a UI fix not reopening the security or server review, a vault fix reopening the security review, the whole-change reviewers still seeing every edit, delta contents including deletions, report persistence, and a path-traversal guard on the report filename. Verified negatively: restoring the whole-tree comparison fails three of the new cases.

No Kotlin changes, so the harness classifies this as `docs` and no Gradle stage applies.
