### PR TITLE
Render dialog quotes as text, and make the review gate wait for the review

### DIFF
--- a/.claude/hooks/record-review.py
+++ b/.claude/hooks/record-review.py
@@ -25,6 +25,11 @@ try:
 except ImportError:
     policy = state = None
 
+REFUSALS = {
+    "moved": "the code moved while it was reading, so it reviewed a tree that no longer exists",
+    "recycled": "that is the findings file already on disk, not a new pass",
+    "not saved": "the record could not be written",
+}
 GATE_TASKS = re.compile(r"gradlew\b.*\b(allTests|detektAll|\btest\b|build|compileDebugKotlin)")
 RUNNER = re.compile(r"harness/gate\.py")
 
@@ -36,48 +41,39 @@ def note(text: str) -> None:
     sys.exit(0)
 
 
-def report_text(response) -> str:
-    """The reviewer's findings as text, whatever shape the harness handed them back in."""
-    if isinstance(response, str):
-        return response
-    if isinstance(response, dict):
-        for key in ("content", "text", "output", "result"):
-            if key in response:
-                return report_text(response[key])
-        return ""
-    if isinstance(response, list):
-        return "\n".join(part for part in (report_text(item) for item in response) if part)
-    return ""
-
-
 def main() -> None:
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):
         sys.exit(0)
+    if not isinstance(payload, dict):
+        sys.exit(0)
     if state is None:
         sys.exit(0)
 
     tool = payload.get("tool_name") or ""
-    tool_input = payload.get("tool_input") or {}
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        tool_input = {}
 
     if tool in ("Agent", "Task"):
         subagent = (tool_input.get("subagent_type") or "").split(":")[-1]
-        known = set(policy.BASE_REVIEWERS) | {
-            name for names in policy.AREA_REVIEWERS.values() for name in names
-        }
-        if subagent in known:
-            st = state.load()
-            entries = policy.reviewer_entries(subagent)
-            st.setdefault("reviews", {})[subagent] = {
-                # Scoped to what this reviewer reads, so an unrelated fix does not owe it again.
-                "digest": state.digest_of(entries),
-                "files": entries,
-                "branch": state.current_branch(),
-                "at": __import__("time").time(),
-            }
-            state.save(st)
-            state.save_review_report(subagent, report_text(payload.get("tool_response")))
+        if subagent in policy.known_reviewers():
+            reason = policy.record_review(subagent, payload.get("tool_response"))
+            if reason == "no findings":
+                # A backgrounded reviewer answers with a launch acknowledgement: it has not read a
+                # line yet. Recording that would close the review gate on the fan-out being
+                # started, which is the one thing the gate exists to rule out. Snapshot the scope
+                # it is about to read instead, so an edit made while it reads is visible when the
+                # report finally arrives.
+                policy.note_review_launch(subagent)
+                note(f"{subagent} was launched, not recorded — this reply carries no findings. "
+                     f"When its report arrives, record it with `tools/harness/gate.py review "
+                     f"{subagent} --file <report>`.")
+            elif reason:
+                # Anything else is a report that was refused, and the snapshot is the evidence it
+                # was refused on: re-taking it here would let the retry launder the refusal.
+                note(f"{subagent}: {REFUSALS.get(reason, reason)} — not recorded.")
         sys.exit(0)
 
     if tool == "Bash":
@@ -92,4 +88,9 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:  # noqa: BLE001 - a hook that raises breaks every Agent call in the session
+        sys.exit(0)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,19 +156,25 @@ Rules for the fan-out:
   Silent dismissal is not an option.
 - A fix that changes behaviour goes back through step 1 (test first).
 - Reviewers are fallible: verify each finding against the actual code before acting on it.
-- **Fix the whole round before re-reviewing.** Collect every finding, apply every fix, then run one
-  more pass — not a pass per finding. A fan-out per fix is how a branch ends up reviewed fifteen
-  times over the same code, and each of those passes re-reads the entire diff.
+- **Two rounds per branch, and the third one is the user's call.** Collect every finding, apply
+  every fix, then run one more pass — not a pass per finding. After the second round the gate stops
+  demanding reviewers and prints what went unread instead; launching a third fan-out needs the user
+  to ask for it. Fixing what a reviewer found is what moves the files it read, so inside its own
+  scope the loop does not converge on its own: it ran eleven times on one branch and cost hours.
 - A reviewer that has already seen this branch gets **only what moved since** its last pass.
   `gate.py reviewers` prints that delta per reviewer; hand it those files, not `main...HEAD` again.
 - Findings are kept in `.git/skerry-gate/reviews/<agent>.md` as each reviewer finishes, so what is
   still owed survives a context compaction. Read them back rather than re-running the fan-out to
   rediscover what a reviewer already said.
 
-Each reviewer is now owed again only when **its own scope** moves — the vault reviewer is not
+A reviewer with nothing in its scope is not owed at all, and each reviewer is owed again only
+when **its own scope** moves — the vault reviewer is not
 reopened by a Compose layout fix, and the server reviewer is not reopened by either. `skerry-reviewer`
 and `ecc:pr-test-analyzer` stay whole-change on purpose: parity, i18n and coverage are properties of
-the change, not of one directory. The scopes live in `REVIEWER_SCOPES` in `tools/harness/policy.py`.
+the change, not of one directory. The scopes live in `REVIEWER_SCOPES` in `tools/harness/policy.py`, and the two-round cap in
+`REVIEW_ROUNDS` beside them. The harness's own `.py` files are outside the security reviewer's
+scope: they still owe `selftest`, the deterministic checks and the whole-change passes, but a
+gate fix does not reopen the vault review.
 
 `/ecc:kotlin-review`, `/ecc:code-review` and `/ecc:review-pr` are the command shortcuts for the same
 agents when a single-angle pass is enough.

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -66,7 +66,7 @@
     <string name="lib_snippets_ph_name">Отчёт об использовании диска</string>
     <string name="lib_snippets_add_tag">добавить тег…</string>
     <string name="lib_snippets_press_keys">Нажмите клавиши…</string>
-    <string name="lib_snippets_shortcut_conflict">Уже используется в \"%1$s\"</string>
+    <string name="lib_snippets_shortcut_conflict">Уже используется в «%1$s»</string>
     <string name="lib_snippets_shortcut_reserved">Занято горячей клавишей Skerry (Настройки → Клавиатура)</string>
     <string name="lib_snippets_select_or_create">Выберите сниппет или создайте новый.</string>
     <string name="lib_snippets_save">Сохранить</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_mon.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_mon.xml
@@ -45,9 +45,9 @@
 
     <string name="mon_alert_disk">Диск %1$s выше порога</string>
     <string name="mon_alert_disk_ok">Диск %1$s вернулся под порог</string>
-    <string name="mon_alert_memory">Память на %1$s%%</string>
+    <string name="mon_alert_memory">Память на %1$s%</string>
     <string name="mon_alert_memory_ok">Память вернулась в норму</string>
-    <string name="mon_alert_swap">Подкачка на %1$s%%</string>
+    <string name="mon_alert_swap">Подкачка на %1$s%</string>
     <string name="mon_alert_swap_ok">Подкачка вернулась в норму</string>
     <string name="mon_alert_load">Загрузка %1$s выше числа ядер</string>
     <string name="mon_alert_load_ok">Загрузка вернулась под число ядер</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -113,6 +113,6 @@
     <string name="sftp_edit_conflict_body">«%1$s» изменился после того, как вы его открыли. Сохранение перезапишет его вашей версией.</string>
 
     <!-- Transfer queue under the panes -->
-    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">готово</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -42,7 +42,7 @@
     <string name="rd_panel_hide">Скрыть панель</string>
     <string name="rd_panel_show">Показать панель</string>
     <string name="rd_screenshot">Снимок экрана</string>
-    <string name="rd_screenshot_saved">Сохранено в %s</string>
+    <string name="rd_screenshot_saved">Сохранено в %1$s</string>
     <string name="rd_screenshot_failed">Не удалось записать файл</string>
     <string name="rd_settings">Настройки</string>
     <string name="rd_ctrl_alt_del">Отправить Ctrl+Alt+Del</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_conn.xml
@@ -182,8 +182,8 @@
     <string name="conn_rdp_h264_off">关闭</string>
     <string name="conn_rdp_h264_desc">需要本地 H.264 解码器（桌面端为 ffmpeg）；“自动”会提供所有可解码的格式。</string>
     <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
-    <string name="conn_err_hostkey_changed">主机密钥已更改。请在「已知主机」中处理。</string>
-    <string name="conn_err_hostkey_untrusted">主机密钥尚未受信任。请先用终端连接一次，或在「已知主机」中添加其 CA。</string>
+    <string name="conn_err_hostkey_changed">主机密钥已更改。请在“已知主机”中处理。</string>
+    <string name="conn_err_hostkey_untrusted">主机密钥尚未受信任。请先用终端连接一次，或在“已知主机”中添加其 CA。</string>
     <string name="conn_err_hostkey_locked">保管库已锁定：无法读取主机密钥信任。请解锁后重试。</string>
     <string name="conn_err_hostkey_cert">该主机必须出示受信任 CA 签发的证书；它出示的已被拒绝。</string>
     <string name="conn_err_hostkey_jump">跳板主机 — %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -66,7 +66,7 @@
     <string name="lib_snippets_ph_name">磁盘使用报告</string>
     <string name="lib_snippets_add_tag">添加标签…</string>
     <string name="lib_snippets_press_keys">按键…</string>
-    <string name="lib_snippets_shortcut_conflict">已被 \"%1$s\" 使用</string>
+    <string name="lib_snippets_shortcut_conflict">已被“%1$s”使用</string>
     <string name="lib_snippets_shortcut_reserved">已被 Skerry 快捷键占用（设置 → 键盘）</string>
     <string name="lib_snippets_select_or_create">选择一个片段或新建一个。</string>
     <string name="lib_snippets_save">保存</string>
@@ -75,7 +75,7 @@
     <string name="lib_snippets_screen_title">片段</string>
     <string name="lib_snippets_empty_mobile">暂无片段。点击 + 保存一个命令。</string>
     <string name="lib_snippets_run_title">运行片段</string>
-    <string name="lib_snippets_run_empty">暂无片段。在\"片段\"标签页中添加。</string>
+    <string name="lib_snippets_run_empty">暂无片段。在“片段”标签页中添加。</string>
     <string name="lib_snippets_run_in_terminal">在终端中运行</string>
     <string name="lib_snippets_run_needs_save">保存修改后的命令才能运行</string>
     <string name="lib_snippets_save_snippet">保存片段</string>
@@ -219,7 +219,7 @@
     <string name="lib_teams_delete_message">为所有人删除此团队？共享记录将从服务器移除。</string>
     <string name="lib_teams_err_not_connected">同步未连接</string>
     <string name="lib_teams_err_vault_locked">保险库已锁定</string>
-    <string name="lib_teams_err_no_recipient_key">此账户尚未发布共享密钥，请让被邀请者打开一次\"团队\"</string>
+    <string name="lib_teams_err_no_recipient_key">此账户尚未发布共享密钥，请让被邀请者打开一次“团队”</string>
     <string name="lib_teams_err_already_invited">此账户已是成员或有待处理的邀请</string>
     <string name="lib_teams_err_no_such_account">同步服务器上没有此账户</string>
     <string name="lib_teams_err_key_missing">团队密钥在此设备上不可用</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_mon.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_mon.xml
@@ -45,9 +45,9 @@
 
     <string name="mon_alert_disk">磁盘 %1$s 超过阈值</string>
     <string name="mon_alert_disk_ok">磁盘 %1$s 回到阈值以下</string>
-    <string name="mon_alert_memory">内存占用 %1$s%%</string>
+    <string name="mon_alert_memory">内存占用 %1$s%</string>
     <string name="mon_alert_memory_ok">内存恢复正常</string>
-    <string name="mon_alert_swap">交换占用 %1$s%%</string>
+    <string name="mon_alert_swap">交换占用 %1$s%</string>
     <string name="mon_alert_swap_ok">交换恢复正常</string>
     <string name="mon_alert_load">负载 %1$s 高于核心数</string>
     <string name="mon_alert_load_ok">负载回到核心数以下</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ports.xml
@@ -27,7 +27,7 @@
     <string name="ports_no_saved_hosts">无已保存主机</string>
     <string name="ports_via">经由 %1$s</string>
     <string name="ports_col_type">类型</string>
-    <string name="ports_remove_confirm_title">移除 \"%1$s\"?</string>
+    <string name="ports_remove_confirm_title">移除“%1$s”？</string>
     <string name="ports_remove_active_message">隧道处于活动状态，将断开并删除，无法撤销。</string>
     <string name="ports_remove_inactive_message">此已保存隧道将被删除。无法撤销。</string>
     <string name="ports_type_local">本地</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -40,19 +40,19 @@
     <string name="sftp_rename">重命名</string>
 
     <!-- Диалог имени (New folder / Rename) -->
-    <string name="sftp_already_exists">「%1$s」已存在</string>
+    <string name="sftp_already_exists">“%1$s”已存在</string>
 
     <!-- Диалоги удаления -->
     <string name="sftp_delete_folder_q">删除文件夹？</string>
     <string name="sftp_delete_file_q">删除文件？</string>
     <string name="sftp_delete_items_q">删除 %1$d 个项目？</string>
-    <string name="sftp_delete_folder_body">「%1$s」及其内部所有内容将被永久删除。</string>
-    <string name="sftp_delete_file_body">「%1$s」将被永久删除。</string>
+    <string name="sftp_delete_folder_body">“%1$s”及其内部所有内容将被永久删除。</string>
+    <string name="sftp_delete_file_body">“%1$s”将被永久删除。</string>
     <string name="sftp_delete_items_dirs_body">%1$d 个项目（含文件夹及其内容）将被永久删除。</string>
     <string name="sftp_delete_items_body">%1$d 个项目将被永久删除。</string>
 
     <!-- Диалоги копирования / перемещения -->
-    <string name="sftp_what_single">「%1$s」</string>
+    <string name="sftp_what_single">“%1$s”</string>
     <string name="sftp_items_count">%1$d 个项目</string>
     <string name="sftp_copy_to_q">复制到 %1$s？</string>
     <string name="sftp_move_to_q">移动到 %1$s？</string>
@@ -107,12 +107,12 @@
     <string name="sftp_edit_find">查找：</string>
     <string name="sftp_edit_not_found">未找到</string>
     <string name="sftp_edit_discard_q">放弃更改？</string>
-    <string name="sftp_edit_discard_body">「%1$s」有未保存的更改，现在关闭将会丢失。</string>
+    <string name="sftp_edit_discard_body">“%1$s”有未保存的更改，现在关闭将会丢失。</string>
     <string name="sftp_edit_discard">放弃</string>
     <string name="sftp_edit_conflict_q">文件在源端已被修改？</string>
-    <string name="sftp_edit_conflict_body">「%1$s」在你打开后已更改。保存将用你的版本覆盖它。</string>
+    <string name="sftp_edit_conflict_body">“%1$s”在你打开后已更改。保存将用你的版本覆盖它。</string>
 
     <!-- Transfer queue under the panes -->
-    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">完成</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_shell.xml
@@ -64,7 +64,7 @@
     <string name="shell_use_saved_secret">或使用已保存的凭据</string>
 
     <!-- 删除主机对话框 (DeleteHostDialog.kt) -->
-    <string name="shell_delete_host_title">删除 \"%1$s\"？</string>
+    <string name="shell_delete_host_title">删除“%1$s”？</string>
     <string name="shell_delete_host_body">已从主机列表中移除。已存储的凭据仍保留在保险库中。此操作不可撤销。</string>
 
     <!-- 移动端主机详情 (MobileHostDetailView.kt) -->
@@ -87,14 +87,14 @@
 
     <!-- 桌面端边框：确认对话框、标题栏、状态栏 (DesktopDesignApp.kt) -->
     <string name="shell_this_session">本次会话</string>
-    <string name="shell_disconnect_title">断开 \"%1$s\"？</string>
+    <string name="shell_disconnect_title">断开“%1$s”？</string>
     <string name="shell_disconnect_message">将关闭会话及其终端。</string>
     <string name="shell_disconnect">断开连接</string>
     <string name="shell_disconnect_all_title">断开此标签页中的所有会话？</string>
     <string name="shell_disconnect_all_message">将关闭以下会话：%1$s</string>
     <string name="shell_close_pane_title">关闭窗格？</string>
     <string name="shell_close_pane_message">将关闭会话：%1$s</string>
-    <string name="shell_replace_pane_title">将此窗格的会话替换为 \"%1$s\"？</string>
+    <string name="shell_replace_pane_title">将此窗格的会话替换为“%1$s”？</string>
     <string name="shell_close_panel">关闭窗格</string>
     <string name="shell_lock">锁定</string>
     <string name="shell_settings">设置</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -77,7 +77,7 @@
     <!-- 已关联设备 -->
     <string name="sync_linked_devices">已关联设备</string>
     <string name="sync_loading_devices">加载设备中…</string>
-    <string name="sync_load_devices_failed">无法加载设备。请尝试\"立即同步\"。</string>
+    <string name="sync_load_devices_failed">无法加载设备。请尝试“立即同步”。</string>
     <string name="sync_only_this_device">目前只有此设备。</string>
     <string name="sync_this_device_badge">● 此设备</string>
     <string name="sync_confirm">确认</string>
@@ -87,7 +87,7 @@
 
     <!-- 桌面端对话框 -->
     <string name="sync_setup_dialog_desc">端到端加密。Skerry 永远不会看到你的明文数据 — 主密码只留在你的设备上。</string>
-    <string name="sync_pairing_dialog_desc">在新设备上选择\"我有配对码\"，然后扫描此二维码或粘贴下方代码。仅可使用一次。</string>
+    <string name="sync_pairing_dialog_desc">在新设备上选择“我有配对码”，然后扫描此二维码或粘贴下方代码。仅可使用一次。</string>
     <string name="sync_done">完成</string>
     <string name="sync_pairing_gen_failed">无法创建配对码。</string>
     <string name="sync_generating_code">正在生成代码…</string>
@@ -121,7 +121,7 @@
 
     <!-- issue #28: 连接到使用其他密码的现有账户会将本设备改用该密码 -->
     <string name="sync_password_replace_title">使用账户密码？</string>
-    <string name="sync_password_replace_body">账户「%1$s」使用其他密码。若要同步，此设备将改用账户密码解锁。</string>
+    <string name="sync_password_replace_body">账户“%1$s”使用其他密码。若要同步，此设备将改用账户密码解锁。</string>
     <string name="sync_password_replace_confirm">使用账户密码</string>
     <string name="sync_password_replace_cancel">取消</string>
 

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -56,7 +56,7 @@
     <string name="term_ai_blocked_device_not_ready">请先在 AI 设置中下载设备端模型。</string>
     <string name="term_ai_blocked_disabled">AI 已在 AI 设置中关闭。</string>
     <string name="term_mobile_title_fallback">终端</string>
-    <string name="term_mobile_open_host_connect">打开一个主机并点击\"连接\"。</string>
+    <string name="term_mobile_open_host_connect">打开一个主机并点击“连接”。</string>
     <!-- 主机名下方的会话状态行（移动端终端标题栏）。 -->
     <string name="term_status_connected">已连接</string>
     <string name="term_status_connecting">连接中…</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -88,13 +88,13 @@
     <string name="vault_copy">复制</string>
 
     <!-- 编辑密钥对话框：名称与备注 -->
-    <string name="vault_edit_title">编辑「%1$s」</string>
+    <string name="vault_edit_title">编辑“%1$s”</string>
     <string name="vault_field_note">备注</string>
     <string name="vault_placeholder_note">例如：审计临时访问，五月删除</string>
     <string name="vault_save">保存</string>
 
     <!-- 删除密钥对话框 -->
-    <string name="vault_delete_title">删除「%1$s」？</string>
+    <string name="vault_delete_title">删除“%1$s”？</string>
     <string name="vault_delete_detail_none">此密钥将从保险库中移除。此操作不可撤销。</string>
     <string name="vault_delete_detail_bound">%1$d 台主机将失去此凭证，下次连接时需输入密码。无法撤销。</string>
 

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -42,7 +42,7 @@
     <string name="rd_panel_hide">隐藏面板</string>
     <string name="rd_panel_show">显示面板</string>
     <string name="rd_screenshot">屏幕截图</string>
-    <string name="rd_screenshot_saved">已保存到 %s</string>
+    <string name="rd_screenshot_saved">已保存到 %1$s</string>
     <string name="rd_screenshot_failed">无法写入文件</string>
     <string name="rd_settings">设置</string>
     <string name="rd_ctrl_alt_del">发送 Ctrl+Alt+Del</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vtail.xml
@@ -31,7 +31,7 @@
     <string name="vtail_error_biometric_locked_out">生物识别已锁定 — 请输入主密码。</string>
     <string name="vtail_error_biometric_unsupported">此手机不支持生物识别解锁 — 请输入主密码。</string>
 
-    <!-- 密钥卡片\"被使用\"片段，单数 / 复数 -->
+    <!-- 密钥卡片“被使用”片段，单数 / 复数 -->
     <string name="vtail_used_by_snippets_one">被 1 个片段使用</string>
     <string name="vtail_used_by_snippets_other">被 %1$d 个片段使用</string>
     <string name="vtail_snippets_frag_one">1 个片段</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_conn.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_conn.xml
@@ -117,7 +117,7 @@
 
     <string name="conn_import_action">Import from ssh_config</string>
     <string name="conn_import_title">Import from ssh_config</string>
-    <string name="conn_import_subtitle">Pick the hosts to add. Keys aren\'t imported — you set authentication when you connect.</string>
+    <string name="conn_import_subtitle">Pick the hosts to add. Keys aren't imported — you set authentication when you connect.</string>
     <string name="conn_import_select_all">Select all</string>
     <string name="conn_import_empty">No hosts found in this file.</string>
     <string name="conn_import_button">Import (%1$d)</string>
@@ -156,7 +156,7 @@
 
     <!-- RDP audio redirection -->
     <string name="conn_field_audio">Audio</string>
-    <string name="conn_audio_redirect">Play the session\'s sound here</string>
+    <string name="conn_audio_redirect">Play the session's sound here</string>
     <string name="conn_audio_redirect_desc">The remote desktop plays through this device instead of staying on the server.</string>
     <string name="conn_field_clipboard">Clipboard</string>
     <string name="conn_rdp_import_no_address">The file names no address to connect to.</string>
@@ -184,7 +184,7 @@
     <!-- Host key refusals (HostKeyRefusal) — one line each, ending in what to do -->
     <string name="conn_err_hostkey_changed">Host key changed. Resolve it in Known hosts.</string>
     <string name="conn_err_hostkey_untrusted">Host key not trusted yet. Connect once from a terminal, or add its CA in Known hosts.</string>
-    <string name="conn_err_hostkey_locked">Vault locked: host key trust can\'t be read. Unlock and retry.</string>
+    <string name="conn_err_hostkey_locked">Vault locked: host key trust can't be read. Unlock and retry.</string>
     <string name="conn_err_hostkey_cert">This host must present a certificate from a trusted CA; what it offered was refused.</string>
     <string name="conn_err_hostkey_jump">Jump host — %1$s</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -24,7 +24,7 @@
     <string name="lib_ca_field_hosts_hint">*.prod.example.com</string>
     <string name="lib_ca_field_label">LABEL</string>
     <string name="lib_ca_field_label_hint">Production CA</string>
-    <string name="lib_ca_error_key">Not a CA public key. Paste the CA\'s .pub file contents or a whole @cert-authority line.</string>
+    <string name="lib_ca_error_key">Not a CA public key. Paste the CA's .pub file contents or a whole @cert-authority line.</string>
     <string name="lib_ca_error_hosts_missing">Enter which hosts this CA covers.</string>
     <string name="lib_ca_error_hosts_invalid">This pattern matches no host.</string>
     <string name="lib_ca_error_duplicate">This CA already covers these hosts.</string>
@@ -66,7 +66,7 @@
     <string name="lib_snippets_ph_name">Disk usage report</string>
     <string name="lib_snippets_add_tag">add tag…</string>
     <string name="lib_snippets_press_keys">Press keys…</string>
-    <string name="lib_snippets_shortcut_conflict">Already used by \"%1$s\"</string>
+    <string name="lib_snippets_shortcut_conflict">Already used by “%1$s”</string>
     <string name="lib_snippets_shortcut_reserved">Reserved by a Skerry shortcut (Settings → Keyboard)</string>
     <string name="lib_snippets_select_or_create">Select a snippet or create a new one.</string>
     <string name="lib_snippets_save">Save</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_mon.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_mon.xml
@@ -45,9 +45,9 @@
 
     <string name="mon_alert_disk">Disk %1$s above the limit</string>
     <string name="mon_alert_disk_ok">Disk %1$s back under the limit</string>
-    <string name="mon_alert_memory">Memory at %1$s%%</string>
+    <string name="mon_alert_memory">Memory at %1$s%</string>
     <string name="mon_alert_memory_ok">Memory back to normal</string>
-    <string name="mon_alert_swap">Swap at %1$s%%</string>
+    <string name="mon_alert_swap">Swap at %1$s%</string>
     <string name="mon_alert_swap_ok">Swap back to normal</string>
     <string name="mon_alert_load">Load %1$s above the core count</string>
     <string name="mon_alert_load_ok">Load back under the core count</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_ports.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ports.xml
@@ -27,7 +27,7 @@
     <string name="ports_no_saved_hosts">No saved hosts</string>
     <string name="ports_via">via %1$s</string>
     <string name="ports_col_type">TYPE</string>
-    <string name="ports_remove_confirm_title">Remove \"%1$s\"?</string>
+    <string name="ports_remove_confirm_title">Remove “%1$s”?</string>
     <string name="ports_remove_active_message">Active tunnel. It will be disconnected and deleted — can't be undone.</string>
     <string name="ports_remove_inactive_message">This saved tunnel is deleted. This can't be undone.</string>
     <string name="ports_type_local">local</string>
@@ -84,9 +84,11 @@
     </plurals>
     <string name="ports_autostart_hint_one">This tunnel comes up on its own once the vault is unlocked.</string>
     <plurals name="ports_count_active">
+        <item quantity="one">%1$d active</item>
         <item quantity="other">%1$d active</item>
     </plurals>
     <plurals name="ports_count_stopped">
+        <item quantity="one">%1$d stopped</item>
         <item quantity="other">%1$d stopped</item>
     </plurals>
     <string name="ports_bind_beyond_loopback">Listens beyond loopback — reachable from the network.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -104,7 +104,7 @@
     <string name="settings_hide_system_bars_desc">The terminal and the remote desktop take the whole display. The bars come back on a swipe from the edge.</string>
     <string name="settings_terminal_open_paths">Open file paths in SFTP</string>
     <string name="settings_terminal_open_paths_desc">Ctrl+click a file path in the output to reveal it in the file panel.</string>
-    <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap "Open in Files".</string>
+    <string name="settings_terminal_open_paths_desc_mobile">Long-press a file path in the output, then tap “Open in Files”.</string>
     <string name="settings_terminal_highlight_input">Highlight the command line</string>
     <string name="settings_terminal_highlight_input_desc">Colors commands, flags, quoted strings, paths and operators as you type.</string>
     <string name="settings_terminal_highlight_output">Highlight log levels in output</string>
@@ -251,7 +251,7 @@
     <string name="settings_trash_empty_all">Empty trash</string>
     <string name="settings_trash_days_left">%1$d d left</string>
     <string name="settings_trash_gone">This item is no longer in the trash</string>
-    <string name="settings_trash_confirm_forget">Delete “%1$s” for good? This can’t be undone.</string>
+    <string name="settings_trash_confirm_forget">Delete “%1$s” for good? This can't be undone.</string>
     <string name="settings_trash_confirm_empty">Empty the trash? Everything in it is deleted for good.</string>
     <string name="settings_trash_kind_host">Host</string>
     <string name="settings_trash_kind_credential">Key</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -1,7 +1,7 @@
 <resources>
-    <!-- SFTP / file transfer: двухпанельный desktop (SftpView) и мобильный Files (MobileFilesView) -->
+    <!-- SFTP / file transfer: the two-pane desktop (SftpView) and mobile Files (MobileFilesView) -->
 
-    <!-- Заголовки и шапка -->
+    <!-- Titles and work bar -->
     <string name="sftp_wbar_subtitle">SFTP · %1$s</string>
     <string name="sftp_files_title">Files</string>
 
@@ -12,18 +12,18 @@
     <string name="sftp_tip_upload">Upload selection (F5)</string>
     <string name="sftp_tip_download">Download selection (F5)</string>
 
-    <!-- Действия тулбара / FAB -->
+    <!-- Toolbar / FAB actions -->
     <string name="sftp_new_folder">New folder</string>
     <string name="sftp_create">Create</string>
     <string name="sftp_create_directory">Create directory</string>
     <string name="sftp_upload_file">Upload file</string>
     <string name="sftp_download_to_device">Download to device</string>
 
-    <!-- Метки панелей -->
+    <!-- Pane labels -->
     <string name="sftp_pane_local">Local</string>
     <string name="sftp_pane_remote">Remote</string>
 
-    <!-- Статусы / уведомления -->
+    <!-- Statuses / notices -->
     <string name="sftp_unavailable">SFTP unavailable</string>
     <string name="sftp_opening">Opening SFTP…</string>
     <string name="sftp_connecting">Connecting…</string>
@@ -32,36 +32,36 @@
     <string name="sftp_no_session">No active session</string>
     <string name="sftp_no_session_hint">Connect a host to browse files</string>
 
-    <!-- Общие кнопки диалогов -->
+    <!-- Shared dialog buttons -->
     <string name="sftp_cancel">Cancel</string>
     <string name="sftp_delete">Delete</string>
     <string name="sftp_copy">Copy</string>
     <string name="sftp_move">Move</string>
     <string name="sftp_rename">Rename</string>
 
-    <!-- Диалог имени (New folder / Rename) -->
-    <string name="sftp_already_exists">«%1$s» already exists</string>
+    <!-- Name dialog (New folder / Rename) -->
+    <string name="sftp_already_exists">“%1$s” already exists</string>
 
-    <!-- Диалоги удаления -->
+    <!-- Delete dialogs -->
     <string name="sftp_delete_folder_q">Delete folder?</string>
     <string name="sftp_delete_file_q">Delete file?</string>
     <string name="sftp_delete_items_q">Delete %1$d items?</string>
-    <string name="sftp_delete_folder_body">«%1$s» and everything inside it will be removed permanently.</string>
-    <string name="sftp_delete_file_body">«%1$s» will be removed permanently.</string>
+    <string name="sftp_delete_folder_body">“%1$s” and everything inside it will be removed permanently.</string>
+    <string name="sftp_delete_file_body">“%1$s” will be removed permanently.</string>
     <string name="sftp_delete_items_dirs_body">%1$d items (folders with their contents) will be removed permanently.</string>
     <string name="sftp_delete_items_body">%1$d items will be removed permanently.</string>
 
-    <!-- Диалоги копирования / перемещения -->
-    <string name="sftp_what_single">«%1$s»</string>
+    <!-- Copy / move dialogs -->
+    <string name="sftp_what_single">“%1$s”</string>
     <string name="sftp_items_count">%1$d items</string>
     <string name="sftp_copy_to_q">Copy to %1$s?</string>
     <string name="sftp_move_to_q">Move to %1$s?</string>
     <string name="sftp_transfer_body">%1$s → %2$s</string>
 
-    <!-- Ошибка передачи (имя: сообщение) -->
+    <!-- Transfer error (name: message) -->
     <string name="sftp_transfer_error">%1$s: %2$s</string>
 
-    <!-- Подтверждение перезаписи: в приёмнике уже есть объекты с такими именами -->
+    <!-- Overwrite confirmation: the destination already holds entries with these names -->
     <string name="sftp_overwrite_q">Overwrite existing?</string>
     <string name="sftp_overwrite_one">%1$s already exists in the destination.</string>
     <string name="sftp_overwrite_many">%1$d items already exist in the destination and will be overwritten.</string>
@@ -109,12 +109,12 @@
     <string name="sftp_edit_find">Search:</string>
     <string name="sftp_edit_not_found">not found</string>
     <string name="sftp_edit_discard_q">Discard changes?</string>
-    <string name="sftp_edit_discard_body">«%1$s» has unsaved changes. Closing now loses them.</string>
+    <string name="sftp_edit_discard_body">“%1$s” has unsaved changes. Closing now loses them.</string>
     <string name="sftp_edit_discard">Discard</string>
     <string name="sftp_edit_conflict_q">File changed on the source?</string>
-    <string name="sftp_edit_conflict_body">«%1$s» changed since you opened it. Saving overwrites it with your version.</string>
+    <string name="sftp_edit_conflict_body">“%1$s” changed since you opened it. Saving overwrites it with your version.</string>
 
     <!-- Transfer queue under the panes -->
-    <string name="sftp_queue_progress">%1$d%% · %2$s / %3$s</string>
+    <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">done</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_share.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_share.xml
@@ -17,7 +17,7 @@
     <string name="share_unnamed">Shared session</string>
     <string name="share_watching">Watching %1$s</string>
     <string name="share_fail_not_connected">Sync account not connected.</string>
-    <string name="share_fail_no_key">The team key hasn\'t arrived on this device yet.</string>
+    <string name="share_fail_no_key">The team key hasn't arrived on this device yet.</string>
     <string name="share_fail_network">The relay is unreachable.</string>
     <string name="share_fail_rejected">The server refused the share.</string>
     <string name="share_fail_server">The server failed to relay the session.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_shell.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_shell.xml
@@ -64,7 +64,7 @@
     <string name="shell_use_saved_secret">OR USE A SAVED SECRET</string>
 
     <!-- Delete host dialog (DeleteHostDialog.kt) -->
-    <string name="shell_delete_host_title">Delete \"%1$s\"?</string>
+    <string name="shell_delete_host_title">Delete “%1$s”?</string>
     <string name="shell_delete_host_body">Removed from your hosts. Any stored credential stays in your vault. This can't be undone.</string>
 
     <!-- Mobile host detail (MobileHostDetailView.kt) -->
@@ -87,14 +87,14 @@
 
     <!-- Desktop chrome: confirm dialogs, title bar, status bar (DesktopDesignApp.kt) -->
     <string name="shell_this_session">this session</string>
-    <string name="shell_disconnect_title">Disconnect \"%1$s\"?</string>
+    <string name="shell_disconnect_title">Disconnect “%1$s”?</string>
     <string name="shell_disconnect_message">The session and its terminal will be closed.</string>
     <string name="shell_disconnect">Disconnect</string>
     <string name="shell_disconnect_all_title">Disconnect all sessions in this tab?</string>
     <string name="shell_disconnect_all_message">These sessions will be closed: %1$s</string>
     <string name="shell_close_pane_title">Close pane?</string>
     <string name="shell_close_pane_message">This session will be closed: %1$s</string>
-    <string name="shell_replace_pane_title">Replace this pane's session with \"%1$s\"?</string>
+    <string name="shell_replace_pane_title">Replace this pane's session with “%1$s”?</string>
     <string name="shell_close_panel">Close pane</string>
     <string name="shell_lock">Lock</string>
     <string name="shell_settings">Settings</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sync.xml
@@ -137,7 +137,7 @@
     <string name="web_access_desc">The web password is set apart from the master password. A browser shows devices, activity and record sizes — not the records.</string>
     <string name="web_access_state_on">Enabled</string>
     <string name="web_access_state_off">Not set</string>
-    <string name="web_access_state_unknown">Can\'t read the state</string>
+    <string name="web_access_state_unknown">Can't read the state</string>
     <string name="web_access_checking">Checking…</string>
     <!-- Screen-reader confirmation after a set/change/remove; %1$s — one of the state lines above -->
     <string name="web_access_announce">Web access: %1$s</string>
@@ -151,7 +151,7 @@
     <string name="web_access_cancel">Cancel</string>
     <string name="web_access_too_short">At least %1$d characters.</string>
     <string name="web_access_too_long">At most %1$d characters.</string>
-    <string name="web_access_mismatch">Passwords don\'t match.</string>
+    <string name="web_access_mismatch">Passwords don't match.</string>
     <string name="web_access_not_connected">Connect to the sync server first.</string>
     <string name="web_access_remove_title">Disable web access?</string>
     <string name="web_access_remove_body">A browser signed in right now is signed out. Setting a password again reopens the page.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -88,13 +88,13 @@
     <string name="vault_copy">Copy</string>
 
     <!-- Edit secret dialog: name and note. -->
-    <string name="vault_edit_title">Edit \"%1$s\"</string>
+    <string name="vault_edit_title">Edit “%1$s”</string>
     <string name="vault_field_note">NOTE</string>
     <string name="vault_placeholder_note">e.g. temporary access for the audit, remove in May</string>
     <string name="vault_save">Save</string>
 
     <!-- Delete secret dialog. -->
-    <string name="vault_delete_title">Delete \"%1$s\"?</string>
+    <string name="vault_delete_title">Delete “%1$s”?</string>
     <string name="vault_delete_detail_none">This is removed from your vault. This can't be undone.</string>
     <string name="vault_delete_detail_bound">%1$d hosts will lose this credential and ask for a password on next connect. Can't be undone.</string>
 

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -42,7 +42,7 @@
     <string name="rd_panel_hide">Hide the panel</string>
     <string name="rd_panel_show">Show the panel</string>
     <string name="rd_screenshot">Screenshot</string>
-    <string name="rd_screenshot_saved">Saved to %s</string>
+    <string name="rd_screenshot_saved">Saved to %1$s</string>
     <string name="rd_screenshot_failed">Could not write the file</string>
     <string name="rd_settings">Settings</string>
     <string name="rd_ctrl_alt_del">Send Ctrl+Alt+Del</string>

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/i18n/StringEscapeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/i18n/StringEscapeTest.kt
@@ -1,0 +1,182 @@
+package app.skerry.ui.i18n
+
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.allPluralStringResources
+import app.skerry.ui.generated.resources.allStringArrayResources
+import app.skerry.ui.generated.resources.allStringResources
+import app.skerry.ui.generated.resources.shell_delete_host_title
+import app.skerry.ui.generated.resources.shell_disconnect_title
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.PluralStringResource
+import org.jetbrains.compose.resources.StringResource
+import org.jetbrains.compose.resources.getPluralString
+import org.jetbrains.compose.resources.getString
+import org.jetbrains.compose.resources.getStringArray
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What an Android-style escape does to a Compose Resources string, and which quote marks a locale
+ * writes once the escape is gone.
+ *
+ * The gradle plugin decodes `\n`, `\t`, `\uXXXX` and `\\` and nothing else, so the `\"`, `\'`, `\@`
+ * and `\?` an Android `strings.xml` defines survive the build and reach the screen with the
+ * backslash still on them: `Disconnect \"my-host\"?`. Nothing else in the project catches it — the
+ * XML is valid, the key exists in all three locales, and the parity check compares keys, not text.
+ *
+ * The strings are read through the same resource reader the UI uses, which resolves the locale from
+ * the JVM default and asks AWT for the screen density — so this test needs the display `desktopTest`
+ * already runs under, and cannot move to `commonTest`.
+ */
+class StringEscapeTest {
+
+    @Test
+    fun `the disconnect and delete dialogs quote the host in every locale`() {
+        inLocale("en") {
+            assertEquals("Disconnect “my-host”?", getString(Res.string.shell_disconnect_title, HOST))
+            assertEquals("Delete “my-host”?", getString(Res.string.shell_delete_host_title, HOST))
+        }
+        inLocale("ru") {
+            assertEquals("Отключить «my-host»?", getString(Res.string.shell_disconnect_title, HOST))
+            assertEquals("Удалить «my-host»?", getString(Res.string.shell_delete_host_title, HOST))
+        }
+        inLocale("zh") {
+            assertEquals("断开“my-host”？", getString(Res.string.shell_disconnect_title, HOST))
+            assertEquals("删除“my-host”？", getString(Res.string.shell_delete_host_title, HOST))
+        }
+    }
+
+    @Test
+    fun `no locale renders an escape the resource pipeline never decodes`() {
+        forEachLocale { locale, rendered ->
+            val stray = rendered.filterValues { text -> ANDROID_ESCAPE.containsMatchIn(text) }
+            assertEquals(
+                emptyMap(), stray,
+                "$locale: Compose Resources leaves an Android escape alone — the backslash is drawn",
+            )
+        }
+    }
+
+    /**
+     * A locale quotes with its own marks: “ ” in English and Chinese, « » in Russian, corner
+     * brackets nowhere. Mixed marks are what the escape sweep leaves behind — a string can lose the
+     * backslash and still end up with another language's quotes around the host name.
+     */
+    @Test
+    fun `no locale borrows another locale's quote marks`() {
+        forEachLocale { locale, rendered ->
+            val forbidden = FOREIGN_QUOTES.getValue(locale)
+            val borrowed = rendered.filterValues { text -> text.any { it in forbidden } }
+            assertEquals(emptyMap(), borrowed, "$locale: quoted with $forbidden")
+        }
+    }
+
+    /**
+     * Compose Resources substitutes with a regex over `%N$s` / `%N$d` — it is not `String.format`,
+     * so `%%` stays doubled and a non-positional `%s` is never filled at all. Both reach the screen
+     * the way #281's backslash did.
+     */
+    @Test
+    fun `no locale draws a format placeholder the substitution never fills`() {
+        forEachLocale { locale, rendered ->
+            val leftover = rendered.filterValues { text -> FORMAT_ARTIFACT.containsMatchIn(text) }
+            assertEquals(emptyMap(), leftover, "$locale: a `%` construct the resource reader leaves alone")
+        }
+    }
+
+    /** Runs [body] against every string the app can draw in that locale. */
+    private fun forEachLocale(body: (String, Map<String, String>) -> Unit) {
+        for (locale in LOCALES) {
+            inLocale(locale) {
+                // A collector that stopped collecting would leave every filter below empty and the
+                // file green for good. Each kind is asserted on its own: strings outnumber the other
+                // two by two orders of magnitude, so one shared floor cannot see them reach zero.
+                // The collectors are the declarations, not the rendered values — same in every
+                // locale; it is renderEverything() below that depends on the one in force.
+                assertTrue(Res.allStringResources.size > MIN_STRINGS, "only ${Res.allStringResources.size} strings")
+                assertTrue(Res.allStringArrayResources.isNotEmpty(), "no string arrays collected")
+                assertTrue(Res.allPluralStringResources.isNotEmpty(), "no plurals collected")
+                body(locale, renderEverything())
+            }
+        }
+    }
+
+    /**
+     * Every string the app can draw, keyed by type and name — a `<string>` and a `<plurals>` may
+     * share a name, and one silently replacing the other would drop it out of the sweep.
+     * Placeholders are filled because the no-argument overload substitutes nothing at all, so every
+     * string that takes an argument would reach the format sweep with its `%1$s` intact. That sweep
+     * is the real backstop here: the vararg overload only throws once a placeholder outruns the
+     * arguments given. Plural forms Russian reaches only with a fraction are out of reach, for the
+     * same reason they are out of reach in the app: the quantity is an `Int`.
+     */
+    private suspend fun renderEverything(): Map<String, String> = buildMap {
+        Res.allStringResources.forEach { (name, resource) -> put("string/$name", resource.filled()) }
+        Res.allStringArrayResources.forEach { (name, resource) ->
+            put("array/$name", getStringArray(resource).joinToString("\n"))
+        }
+        Res.allPluralStringResources.forEach { (name, resource) ->
+            put("plurals/$name", QUANTITIES.map { resource.filled(it) }.joinToString("\n"))
+        }
+    }
+
+    /** More placeholders than any string uses; the extras are ignored by the formatter. */
+    private suspend fun StringResource.filled(): String = getString(this, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+    private suspend fun PluralStringResource.filled(quantity: Int): String =
+        getPluralString(this, quantity, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+
+    private fun inLocale(tag: String, body: suspend () -> Unit) = runBlocking { withLocale(tag, body) }
+
+    private companion object {
+        const val HOST = "my-host"
+        /**
+         * The languages the app ships, from the enum that defines them — a fourth one fails on
+         * [FOREIGN_QUOTES] until its quote marks are declared, rather than going unswept.
+         */
+        val LOCALES = UiLanguage.entries.mapNotNull { it.localeTag }
+
+        /** One plural form per rule Russian needs — 1, 2 and 5 land in three different buckets. */
+        val QUANTITIES = listOf(1, 2, 5)
+
+        /**
+         * Every escape Android's `strings.xml` defines and the resource plugin does not decode. A
+         * lone `\` is left alone: it is what `\\` decodes to, and a Windows path may need one.
+         * The sweep reads rendered text, where those two are the same character — so copy that
+         * deliberately draws `\"` (a shell quoting example) trips this and has to say so here.
+         */
+        val ANDROID_ESCAPE = Regex("""\\["'@?]""")
+
+        /**
+         * The marks a locale must not quote with — its neighbours', the straight ASCII pair an
+         * editor types when it does not know the convention, and the typographic apostrophe, which
+         * English copy here writes as a plain `'`.
+         *
+         * Nesting is out of scope: no string here quotes inside a quote, so the inner marks each
+         * language would then use (`‘ ’` in en and zh, `„ “` in ru) are forbidden rather than
+         * declared. The first translation that needs one relaxes this set — it is a convention,
+         * not a translator error.
+         */
+        val FOREIGN_QUOTES = mapOf(
+            "en" to "\"«»„「」’‘『』",
+            "ru" to "\"“”„「」’‘『』",
+            "zh" to "\"«»„「」’‘『』",
+        )
+
+        /**
+         * `%%` or a bare `%s`/`%d` — the substituter is a regex over `%N$s`, so it fills neither
+         * and both reach the screen as typed. The conversions are the ones the resources use; a
+         * new one has to be added here or it goes unswept. An index past the arguments handed in
+         * is *not* reported here: the resource reader throws on it before the sweep sees the text.
+         * Copy that means a literal `%s` — a strftime or shell fragment — trips this, because the
+         * substituter cannot tell the two apart either, which is the point. So does a placeholder
+         * inside a `<string-array>`, and rightly: `getStringArray` returns items verbatim, with no
+         * substitution pass at all, so an array can carry no arguments.
+         */
+        val FORMAT_ARTIFACT = Regex("""%(%|\d+\$|[sdf])""")
+
+        /** Just under the ~1870 strings the app ships; the count only grows. */
+        const val MIN_STRINGS = 1_800
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/i18n/TestLocale.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/i18n/TestLocale.kt
@@ -1,0 +1,21 @@
+package app.skerry.ui.i18n
+
+import java.util.Locale
+
+/**
+ * Runs [block] with the JVM default locale set to [tag], and restores it afterwards.
+ *
+ * Compose Resources read the default locale outside a composition (`getSystemResourceEnvironment`
+ * asks `Locale.getDefault()` on every call), and `ResourceEnvironment` cannot be built from outside
+ * the library — so setting the process-global is the only way a test can read another language.
+ * The suite shares one JVM and pins `user.language=en`, which is why the restore is not optional.
+ */
+internal suspend fun withLocale(tag: String, block: suspend () -> Unit) {
+    val previous = Locale.getDefault()
+    Locale.setDefault(Locale.forLanguageTag(tag))
+    try {
+        block()
+    } finally {
+        Locale.setDefault(previous)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/tunnel/TunnelCountPluralTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/tunnel/TunnelCountPluralTest.kt
@@ -5,9 +5,9 @@ import app.skerry.ui.generated.resources.ports_autostart_failed
 import app.skerry.ui.generated.resources.ports_count_active
 import app.skerry.ui.generated.resources.ports_count_stopped
 import app.skerry.ui.generated.resources.ports_tunnel_count
+import app.skerry.ui.i18n.withLocale
 import kotlinx.coroutines.test.runTest
 import org.jetbrains.compose.resources.getPluralString
-import java.util.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,7 +23,7 @@ class TunnelCountPluralTest {
 
     @Test
     fun `russian picks a different form for one, a few and many`() = runTest {
-        runBlockingLocale("ru") {
+        withLocale("ru") {
             assertEquals("1 туннель", getPluralString(Res.plurals.ports_tunnel_count, 1, 1))
             assertEquals("3 туннеля", getPluralString(Res.plurals.ports_tunnel_count, 3, 3))
             assertEquals("7 туннелей", getPluralString(Res.plurals.ports_tunnel_count, 7, 7))
@@ -36,7 +36,7 @@ class TunnelCountPluralTest {
     fun `the header tally agrees with its own numbers in russian`() = runTest {
         // Regression: the tally was one flat template, so a single active tunnel read
         // "1 активных". English never showed it — the adjective there doesn't inflect.
-        runBlockingLocale("ru") {
+        withLocale("ru") {
             assertEquals("1 активный", getPluralString(Res.plurals.ports_count_active, 1, 1))
             assertEquals("3 активных", getPluralString(Res.plurals.ports_count_active, 3, 3))
             assertEquals("21 активный", getPluralString(Res.plurals.ports_count_active, 21, 21))
@@ -47,7 +47,7 @@ class TunnelCountPluralTest {
 
     @Test
     fun `the autostart failure banner agrees with its own count in russian`() = runTest {
-        runBlockingLocale("ru") {
+        withLocale("ru") {
             assertEquals("1 туннель автостарта не поднялся", getPluralString(Res.plurals.ports_autostart_failed, 1, 1))
             assertEquals("2 туннеля автостарта не поднялись", getPluralString(Res.plurals.ports_autostart_failed, 2, 2))
             assertEquals("5 туннелей автостарта не поднялись", getPluralString(Res.plurals.ports_autostart_failed, 5, 5))
@@ -56,23 +56,9 @@ class TunnelCountPluralTest {
 
     @Test
     fun `english keeps the singular for one and the plural for everything else`() = runTest {
-        runBlockingLocale("en") {
+        withLocale("en") {
             assertEquals("1 tunnel", getPluralString(Res.plurals.ports_tunnel_count, 1, 1))
             assertEquals("3 tunnels", getPluralString(Res.plurals.ports_tunnel_count, 3, 3))
-        }
-    }
-
-    /**
-     * Compose resources read the JVM default locale outside a composition, so the assertions have
-     * to set it. Restored afterwards — the suite shares one JVM.
-     */
-    private suspend fun runBlockingLocale(tag: String, block: suspend () -> Unit) {
-        val previous = Locale.getDefault()
-        Locale.setDefault(Locale.forLanguageTag(tag))
-        try {
-            block()
-        } finally {
-            Locale.setDefault(previous)
         }
     }
 }

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -152,6 +152,12 @@ The most expensive defect class of the refactor. No exceptions to these:
 - **No hex colours in screens** — `D.*` tokens only (the refactor replaced ~70 hardcoded colours).
   Need a new shade? Add a token, checked against the prototype's `:root` block.
 - **No string literals in the UI** — everything through resources, en + ru + zh at once.
+- A locale quotes with its own marks: `“ ”` in en and zh, `« »` in ru, never the straight `"`,
+  and corner brackets nowhere. In `composeResources` (not `androidApp/src/main/res`, which is
+  AAPT and behaves the Android way) the plugin decodes `\n`, `\t`, `\uXXXX` and `\\` and nothing
+  else, so an Android-style `\"` or `\'` is drawn with the backslash on it — and substitution is
+  a regex over `%N$s`/`%N$d`, not `String.format`, so `%%` stays doubled and a bare `%s` is never
+  filled. `StringEscapeTest` sweeps every string in every locale for all four.
 - **No raw Compose Material components** where a design primitive exists (§1, UI table). `Txt` and
   `Sym` are used by 100+ and 70+ files respectively; a raw `Text()` or a stray icon is a bug.
 - Desktop and mobile **share form state and logic** (`*FormState`); only the layout differs. A new

--- a/tools/harness/checks.py
+++ b/tools/harness/checks.py
@@ -45,17 +45,28 @@ def added_lines(base: str = "", cwd: str | None = None) -> list[tuple[str, int, 
     root = state.repo_root(cwd)
     out: list[tuple[str, int, str]] = []
 
-    code, diff = state.git(["diff", "-U0", "--no-color", base], cwd)
-    if code == 0:
-        path, lineno = "", 0
-        for raw in diff.splitlines():
-            if raw.startswith("+++ b/"):
-                path, lineno = raw[6:], 0
-            elif raw.startswith("@@"):
+    # One diff per file, rather than one diff parsed for its `+++ b/` headers. An added line whose
+    # own text starts with `++ b/…` — legal inside a raw string or a fixture — renders as a header
+    # and used to retarget every rule after it onto a path where none of them apply.
+    code, names = state.git(["diff", "--name-only", "-z", base], cwd)
+    for path in (p for p in names.split("\0") if p) if code == 0 else ():
+        # --text: a committed `.gitattributes` with `*.kt -diff` makes git print "Binary files
+        # differ" instead of the content, and every rule then sees an empty diff.
+        code, diff = state.git(["diff", "-U0", "--no-color", "--text", base, "--", path], cwd)
+        if code != 0:
+            continue
+        lineno, in_hunk = 0, False
+        # split("\n"), not splitlines(): Python breaks lines on U+000C, U+001C-1E, U+0085 and
+        # U+2028/9, which git does not, and it consumes the byte — truncating the line and hiding
+        # the very character the control-chars rule is looking for.
+        for raw in diff.split("\n"):
+            if raw.startswith("@@"):
                 match = HUNK.match(raw)
                 if match:
                     lineno = int(match.group(1))
-            elif raw.startswith("+") and path and not raw.startswith("+++"):
+                in_hunk = True
+            elif in_hunk and raw.startswith("+"):
+                # Inside a hunk every `+` line is content: the file headers are all above it.
                 out.append((path, lineno, raw[1:]))
                 lineno += 1
 
@@ -94,14 +105,10 @@ RAW_COORD = re.compile(
     r"androidTestImplementation|ksp|kapt)\s*\(\s*\"[^\"]+:[^\"]+:[^\"]*\"")
 SECRET_WRITE = re.compile(r"\.writeText\s*\(")
 SUSPICIOUS_CATCH = re.compile(r"catch\s*\(\s*\w+\s*:\s*(?:Exception|Throwable)\s*\)")
-# Built from code points rather than written out: the pattern's own subject matter is invisible
-# characters, and a literal one here would be unreviewable — and would trip this very rule.
-CONTROL_RANGES = (
-    (0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F),   # C0 minus tab, LF, CR
-    (0x200B, 0x200F), (0x202A, 0x202E), (0x2066, 0x2069),  # zero-width and bidi overrides
-)
-CONTROL_CHARS = re.compile(
-    "[" + "".join(f"\\U{lo:08X}-\\U{hi:08X}" for lo, hi in CONTROL_RANGES) + "]")
+# One definition, in `state`: this rule keeps the byte out of the source, and `save_review_report`
+# strips it out of a stored report before the operator cats it. Two lists would drift apart.
+CONTROL_RANGES = state.CONTROL_RANGES
+CONTROL_CHARS = state.CONTROL_CHARS
 TODO_MARK = re.compile(r"(?://|/\*|\*)\s*(TODO|FIXME|XXX)\b")
 
 UI_MAIN = re.compile(r"^composeApp/src/\w+Main/")
@@ -122,6 +129,16 @@ def _line_rules(added: list[tuple[str, int, str]]) -> list[Finding]:
         if path.endswith(".kt") and TODO_MARK.search(text) and not _allowed(text, "todo"):
             found.append(Finding("todo", WARN, path, line,
                                  "TODO/FIXME added — either do it or drop it before the PR."))
+        # Trojan source belongs in a comment by construction: the payload has to sit where the
+        # reviewer reads prose and the compiler reads nothing. So this one is judged before
+        # comments are skipped, like the TODO rule above it.
+        if CONTROL_CHARS.search(text) and not _allowed(text, "control-chars"):
+            # In a test these bytes are the fixture — the input a sanitiser is supposed to strip.
+            # In shipping code they are a spoof waiting to happen, and unreadable in review.
+            found.append(Finding("control-chars", WARN if state.is_test(path) else BLOCK,
+                                 path, line,
+                                 "raw control or bidi byte — write it as an escape "
+                                 "(`\\u202E`) so review can see it."))
         if _is_comment(text):
             continue
         kt = path.endswith(".kt")
@@ -162,13 +179,6 @@ def _line_rules(added: list[tuple[str, int, str]]) -> list[Finding]:
             found.append(Finding("secret-write", BLOCK, path, line,
                                  "`writeText` on a secret-bearing path — use `atomicWriteUtf8` "
                                  "(atomic + 0600)."))
-        if CONTROL_CHARS.search(text) and not _allowed(text, "control-chars"):
-            # In a test these bytes are the fixture — the input a sanitiser is supposed to strip.
-            # In shipping code they are a spoof waiting to happen, and unreadable in review.
-            found.append(Finding("control-chars", WARN if state.is_test(path) else BLOCK,
-                                 path, line,
-                                 "raw control or bidi byte in a literal — write it as an escape "
-                                 "(`\\u202E`), it is invisible in review otherwise."))
     return found
 
 
@@ -205,36 +215,107 @@ def _i18n_parity(cwd: str | None) -> list[Finding]:
     if not os.path.isdir(base):
         return []
 
-    def keys(locale: str) -> dict[str, str]:
+    unreadable: dict[str, list[str]] = {"locale": [], "source": []}
+    cached: dict[str, str] = {}
+
+    def read(file: str) -> str:
+        """A locale file's text, read once per run, or empty.
+
+        A file the check cannot open is recorded rather than passed over: an unreadable locale
+        looks exactly like an untranslated one in the findings below. The cache is what keeps that
+        count honest — the name scan and the plural scan both walk every locale, and an uncached
+        read reported one broken file as two.
+        """
+        if file not in cached:
+            try:
+                with open(file, encoding="utf-8") as fh:
+                    cached[file] = fh.read()
+            except (OSError, UnicodeDecodeError):
+                # A locale file saved in cp1251 is the likeliest way this fails, and that raises
+                # ValueError, not OSError — uncaught it took the whole `checks` stage down.
+                unreadable["locale"].append(os.path.relpath(file, root))
+                cached[file] = ""
+        return cached[file]
+
+    def read_source(file: str) -> str:
+        """A Kotlin source, read once each — an unreadable one hides a usage, not a translation."""
+        try:
+            with open(file, encoding="utf-8") as fh:
+                return fh.read()
+        except (OSError, UnicodeDecodeError):
+            unreadable["source"].append(os.path.relpath(file, root))
+            return ""
+
+    def keys(locale: str) -> dict[tuple[str, str], str]:
+        """Every translatable name, by kind — a plural and an array need a translation as much as
+        a string does, and each kind lives in its own namespace.
+
+        The attribute is matched loosely: `<string translatable="false" name="x">` is the form
+        Android tooling emits, and a name the pattern misses is silently exempt from parity.
+        """
         out = {}
         for file in sorted(glob.glob(os.path.join(base, locale, "*.xml"))):
-            try:
-                body = open(file, encoding="utf-8").read()
-            except OSError:
-                continue
-            for key in re.findall(r'<string name="([^"]+)"', body):
-                out[key] = os.path.relpath(file, root)
+            body = read(file)
+            for kind, key in re.findall(r'<(string|string-array|plurals)\s+[^>]*?name="([^"]+)"', body):
+                out[(kind, key)] = os.path.relpath(file, root)
         return out
+
+    def label(entry: tuple[str, str]) -> str:
+        kind, key = entry
+        return key if kind == "string" else f"{kind} {key}"
 
     en, found = keys("values"), []
     for locale in ("values-ru", "values-zh"):
         other = keys(locale)
         for key in sorted(set(en) - set(other)):
             found.append(Finding("i18n-parity", BLOCK, en[key], 0,
-                                 f"`{key}` has no {locale} translation — strings ship en + ru + zh."))
+                                 f"`{label(key)}` has no {locale} translation — strings ship en + ru + zh."))
         for key in sorted(set(other) - set(en)):
             found.append(Finding("i18n-parity", BLOCK, other[key], 0,
-                                 f"`{key}` exists only in {locale} — a stale or misspelt key."))
+                                 f"`{label(key)}` exists only in {locale} — a stale or misspelt key."))
 
-    used: set[str] = set()
+    # The plural categories each language actually needs (CLDR). A name that exists in a locale but
+    # carries only `other` is not a translation: the reader falls back to `other` silently, so
+    # Russian renders "1 файлов" with every gate green.
+    required = {"values": ("one", "other"),
+                "values-ru": ("one", "few", "many", "other"),
+                "values-zh": ("other",)}
+    for locale, categories in required.items():
+        for file in sorted(glob.glob(os.path.join(base, locale, "*.xml"))):
+            rel = os.path.relpath(file, root)
+            for key, block in re.findall(r'<plurals\s+[^>]*?name="([^"]+)"(.*?)</plurals>', read(file), re.S):
+                # An empty item is not a form: it draws a blank where the number belongs, and the
+                # reader is as silent about it as it is about a category that was never declared.
+                written = {category for category, text
+                           in re.findall(r'<item quantity="([a-z]+)"[^>]*>(.*?)</item>', block, re.S)
+                           if text.strip()}
+                missing = [c for c in categories if c not in written]
+                if missing:
+                    found.append(Finding("i18n-parity", BLOCK, rel, 0,
+                                         f"`plurals {key}` has no {', '.join(missing)} form — "
+                                         f"{locale} needs {'/'.join(categories)}; a missing or "
+                                         "empty item falls back to `other` and reads wrong."))
+
+    # `Res.array` is the accessor of a `<string-array>`; the other two are named after their tag.
+    accessor = {"string": "string", "plurals": "plurals", "string-array": "array"}
+    tag_of = {value: key for key, value in accessor.items()}
+    used: set[tuple[str, str]] = set()
     for file in glob.glob(os.path.join(root, "composeApp/src/**/*.kt"), recursive=True):
-        try:
-            used |= set(re.findall(r"Res\.string\.([A-Za-z0-9_]+)", open(file, encoding="utf-8").read()))
-        except OSError:
-            continue
-    for key in sorted(used - set(en)):
+        for kind, key in re.findall(r"Res\.(string|plurals|array)\.([A-Za-z0-9_]+)", read_source(file)):
+            used.add((tag_of[kind], key))
+    for kind, key in sorted(used - set(en)):
         found.append(Finding("i18n-parity", BLOCK, "composeApp", 0,
-                             f"`Res.string.{key}` is used but defined nowhere."))
+                             f"`Res.{accessor[kind]}.{key}` is used but defined nowhere."))
+
+    # Which way the sweep is wrong depends on what could not be read, so the two are counted apart.
+    if unreadable["locale"]:
+        found.append(Finding("i18n-parity", WARN, unreadable["locale"][0], 0,
+                             f"{len(unreadable['locale'])} resource file(s) could not be read — a "
+                             "translation reported missing above may be that read failure."))
+    if unreadable["source"]:
+        found.append(Finding("i18n-parity", WARN, unreadable["source"][0], 0,
+                             f"{len(unreadable['source'])} source file(s) could not be read — a "
+                             "stale `Res.` reference in them goes unreported."))
     return found
 
 
@@ -253,11 +334,14 @@ def _shortcut_rule(added: list[tuple[str, int, str]]) -> list[Finding]:
 def _tests_present(added: list[tuple[str, int, str]], task: dict) -> list[Finding]:
     if task["kind"] not in ("bug", "feature"):
         return []
-    src = {p for p, _, _ in added if state.is_code(p) and not state.is_test(p) and p.endswith(".kt")}
+    # `.py` under the harness counts as source for the same reason `.kt` does — it is behaviour
+    # someone has to be able to break. Its test is `selftest.py`, which `state.is_test` knows.
+    src = {p for p, _, _ in added if state.is_code(p) and not state.is_test(p)
+           and (p.endswith(".kt") or p.startswith(("tools/harness/", ".claude/hooks/")))}
     tests = {p for p, _, _ in added if state.is_test(p)}
     if src and not tests:
         return [Finding("tests-present", BLOCK, sorted(src)[0], 0,
-                        f"a {task['kind']} changed Kotlin sources without touching a single test "
+                        f"a {task['kind']} changed sources without touching a single test "
                         "— step 1 of the loop is the failing test.")]
     return []
 

--- a/tools/harness/gate.py
+++ b/tools/harness/gate.py
@@ -158,7 +158,7 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     _, debt = policy.gate_debt()
     print()
-    print(_status_text(task, debt))
+    print(_status_text(task, debt, policy.unreviewed(state.load(), task)))
     return 1 if failed else 0
 
 
@@ -345,7 +345,8 @@ def cmd_reviewers(_: argparse.Namespace) -> int:
     return 0
 
 
-def _status_text(task: dict, debt: list[str]) -> str:
+def _status_text(task: dict, debt: list[str], missed: list[tuple[str, list[str]]] | None = None
+                 ) -> str:
     lines = [
         f"task:    {task['kind']}  ({task['source']})",
         f"branch:  {task['branch']}",
@@ -358,12 +359,19 @@ def _status_text(task: dict, debt: list[str]) -> str:
         lines.append("gate:    owed —")
         lines += [f"           - {item}" for item in debt]
         lines.append("run:     tools/harness/gate.py run")
+    for reviewer, delta in missed or []:
+        lines.append(f"unreviewed: {policy.agent_id(reviewer)} — {len(delta)} file(s) moved after "
+                     f"its {policy.REVIEW_ROUNDS} passes; the gate stopped asking, nobody read "
+                     "this:")
+        lines += [f"             {path}" for path in delta[:12]]
+        if len(delta) > 12:
+            lines.append(f"             ... and {len(delta) - 12} more")
     return "\n".join(lines)
 
 
 def cmd_status(_: argparse.Namespace) -> int:
     task, debt = policy.gate_debt()
-    print(_status_text(task, debt))
+    print(_status_text(task, debt, policy.unreviewed(state.load(), task)))
     return 1 if debt else 0
 
 

--- a/tools/harness/gate.py
+++ b/tools/harness/gate.py
@@ -16,12 +16,14 @@ rather than recorded against the wrong code.
     tools/harness/gate.py task bug [ref]      override the auto-detected kind
     tools/harness/gate.py checks              the deterministic rules alone
     tools/harness/gate.py reviewers           which reviewers this change needs
+    tools/harness/gate.py review NAME         record a reviewer's findings once its report arrives
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import time
@@ -45,16 +47,32 @@ TEST_TASKS = (
 )
 
 
+# The harness's own suite is not a Gradle task, and a `fix/` branch that touches only the gate
+# still owes a RED record.
+HARNESS_SUITE = "selftest"
+# A test name or a glob of one. Anything else — an option, a shell fragment — is handed to the
+# suite as an argument, and its own usage error would exit non-zero and read as a failing test.
+TEST_PATTERN = re.compile(r"^[A-Za-z0-9_.*]+$")
+# What a run that actually reached a test looks like: unittest prints both lines, in this order.
+HARNESS_RED_EVIDENCE = re.compile(r"^Ran [1-9]\d* tests?\b.*^FAILED \(", re.S | re.M)
+# Gradle prints this only from a test task that ran and had failures. A compile error, a
+# missing dependency or a bad task name fails the build without it.
+GRADLE_RED_EVIDENCE = re.compile(r"There were failing tests|tests? completed, \d+ failed")
+
+
 def _env() -> dict:
     env = dict(os.environ)
     env.setdefault("ANDROID_HOME", os.path.expanduser("~/Android/Sdk"))
     return env
 
 
-def _gradle(args: list[str], stage: str, root: str) -> tuple[int, str]:
-    """Run Gradle, tee the output to .git/skerry-gate/<stage>.log, return (code, log path)."""
+def _run_logged(args: list[str], stage: str, root: str) -> tuple[int, str]:
+    """Run a stage command, tee its output to .git/skerry-gate/<stage>.log, return (code, log)."""
     log = state.log_path(stage) or os.path.join(root, f".gradle-{stage}.log")
     os.makedirs(os.path.dirname(log), exist_ok=True)
+    # Whatever a failing test printed is nobody else's business on a shared machine, and the logs
+    # sit beside a 0600 state file and 0600 findings.
+    os.chmod(os.path.dirname(log), 0o700)
     with open(log, "w", encoding="utf-8") as fh:
         try:
             proc = subprocess.run(args, cwd=root, env=_env(), stdout=fh,
@@ -93,7 +111,7 @@ def run_stage(stage: str, root: str) -> bool:
         if stage == "tests" and state.load().get("test_cache_dirty"):
             command.append("--rerun")
         print(f"harness: {' '.join(command)}")
-        code, log = _gradle(command, stage, root)
+        code, log = _run_logged(command, stage, root)
         ok = code == 0
         detail = f"exit {code}, log {log}"
         if not ok:
@@ -151,30 +169,57 @@ def _stop_daemons(root: str) -> None:
     subprocess.run(["pkill", "-f", "KotlinCompileDaemon"], capture_output=True, check=False)
 
 
+def proves_a_failing_test(task_name: str, body: str) -> bool:
+    """Whether the run actually reached a test and that test failed.
+
+    A non-zero exit is not a failing test: an import error, a syntax error, a usage error in the
+    runner or a compile error in the module all exit non-zero, and each of those would record a
+    RED phase no test ever ran. Fixing the typo then moves the sources and the gate reports the
+    bug as reproduced.
+    """
+    pattern = HARNESS_RED_EVIDENCE if task_name == HARNESS_SUITE else GRADLE_RED_EVIDENCE
+    return bool(pattern.search(body))
+
+
 def cmd_red(args: argparse.Namespace) -> int:
     root = state.repo_root()
     task_name = args.task or _task_for_file(args.file or "")
     if not task_name:
-        print("harness: which Gradle task runs this test? Pass --task (e.g. :shared:desktopTest) "
-              "or --file with the test's path.")
+        print("harness: which task runs this test? Pass --task (e.g. :shared:desktopTest, or "
+              f"{HARNESS_SUITE} for the harness's own suite) or --file with the test's path.")
         return 2
 
-    command = ["./gradlew", task_name, "--tests", args.tests, "--rerun"]
+    if task_name == HARNESS_SUITE:
+        # Gradle cannot run a Python test. Without this branch a bug fix to the gate itself could
+        # not record the failure it fixes — the one change where that matters most.
+        if not TEST_PATTERN.match(args.tests):
+            print("harness: --tests takes a test name or a glob of one, not an option — "
+                  f"`{args.tests}` would be handed to the suite as an argument.")
+            return 2
+        command = [sys.executable, "tools/harness/selftest.py", "-k", args.tests.strip("*")]
+        empty = "Ran 0 tests"
+    else:
+        command = ["./gradlew", task_name, "--tests", args.tests, "--rerun"]
+        empty = "No tests found for given includes"
+        st = state.load()
+        st["test_cache_dirty"] = True  # a filtered run leaves the aggregate task looking up to date
+        state.save(st)
+
     print(f"harness: {' '.join(command)}")
-    code, log = _gradle(command, "red", root)
+    code, log = _run_logged(command, "red", root)
     body = tail(log, 200)
 
-    st = state.load()
-    st["test_cache_dirty"] = True  # a filtered run poisons the aggregate task's up-to-date check
-    state.save(st)
-
-    if "No tests found for given includes" in body:
+    if empty in body:
         print(f"harness: the pattern matched no test — nothing was proven.\n{tail(log, 15)}")
         return 2
     if code == 0:
         print("harness: the test PASSED. A test that is green before the fix proves nothing about "
               "the bug — make it reproduce the failure first.")
         return 1
+    if not proves_a_failing_test(task_name, body):
+        print(f"harness: the run did not report a failing test — nothing was proven.\n"
+              f"{tail(log, 15)}")
+        return 2
 
     record = {
         "task": task_name, "pattern": args.tests, "at": time.time(),
@@ -190,6 +235,8 @@ def cmd_red(args: argparse.Namespace) -> int:
 
 def _task_for_file(path: str) -> str:
     normalised = path.replace(os.sep, "/")
+    if normalised.startswith(("tools/harness/", ".claude/hooks/")):
+        return HARNESS_SUITE
     for prefix, task_name in TEST_TASKS:
         if prefix in normalised:
             return task_name
@@ -205,6 +252,60 @@ def cmd_task(args: argparse.Namespace) -> int:
                   "branch": state.current_branch(), "at": time.time()}
     state.save(st)
     return cmd_status(args)
+
+
+# Why a report was turned away, in the words the operator needs to act on it.
+REVIEW_REFUSALS = {
+    "no findings": "that text carries no findings — it reads as a launch acknowledgement",
+    "recycled": "that is the report already on disk, not a new pass",
+    "not saved": "the record could not be written",
+}
+
+
+def cmd_review(args: argparse.Namespace) -> int:
+    """Record a reviewer's findings once its report is actually in hand.
+
+    The PostToolUse hook can only record a fan-out that hands its findings back inline. A
+    backgrounded reviewer returns a launch acknowledgement instead and reports minutes later — so
+    without this command the gate would close on the launch, and "reviewed" would mean "started".
+    """
+    reviewer = args.agent.split(":")[-1]
+    if reviewer not in policy.known_reviewers():
+        print(f"harness: {args.agent} is not one of this repository's reviewers")
+        return 2
+    try:
+        if args.file in (None, "-"):
+            text = sys.stdin.read()
+        else:
+            with open(args.file, encoding="utf-8") as fh:
+                text = fh.read()
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"harness: cannot read the report — {exc}")
+        return 2
+    stored = state.review_report_path(reviewer)
+    if args.file not in (None, "-") and stored and os.path.exists(stored) \
+            and os.path.realpath(args.file) == os.path.realpath(stored):
+        # `gate.py reviewers` prints this path right under MISSING. Once the reviewer's scope moves
+        # it is owed again and its own stored round is no longer a replay — nothing in the text can
+        # tell that file apart from a report the reviewer just wrote, but where it came from can.
+        print("harness: that is the file the previous round was written to, not a new pass — "
+              f"re-run {policy.agent_id(reviewer)} and record what it says.")
+        return 2
+    drift = policy.review_drift(reviewer)
+    # The verdict itself comes from `record_review`, the same one the hook gets: the CLI used to
+    # refuse on drift before the report was ever looked at, so the retry a refusal advertises was
+    # refused too and the reviewer could not be recorded at all without a fresh launch.
+    reason = policy.record_review(reviewer, text)
+    if reason == "moved":
+        print(f"harness: {reviewer} read a tree that has since moved — not recorded. Re-run it on:")
+        for path in drift:
+            print(f"  {path}")
+        return 2
+    if reason:
+        print(f"harness: nothing recorded — {REVIEW_REFUSALS.get(reason, reason)}")
+        return 2
+    print(f"harness: {reviewer} recorded against the current tree")
+    return 0
 
 
 def cmd_checks(_: argparse.Namespace) -> int:
@@ -286,6 +387,11 @@ def main(argv: list[str]) -> int:
     task.add_argument("kind", help=" | ".join(policy.KINDS))
     task.add_argument("ref", nargs="?", help="issue or PR reference")
     task.set_defaults(func=cmd_task)
+
+    review = sub.add_parser("review", help="record a reviewer's findings once its report arrives")
+    review.add_argument("agent", help="reviewer name, with or without its plugin prefix")
+    review.add_argument("--file", help="path to the report; omitted or '-' reads stdin")
+    review.set_defaults(func=cmd_review)
 
     sub.add_parser("checks", help="deterministic project rules").set_defaults(func=cmd_checks)
     sub.add_parser("reviewers", help="reviewers this change needs").set_defaults(func=cmd_reviewers)

--- a/tools/harness/policy.py
+++ b/tools/harness/policy.py
@@ -12,10 +12,15 @@ from __future__ import annotations
 
 import glob
 import os
+import hashlib
+import re
+import time
 
 from . import state
 
 KINDS = ("bug", "feature", "refactor", "docs")
+# How much each kind owes, so a declaration can be compared against what the branch already proves.
+STRICTNESS = {"docs": 0, "refactor": 1, "feature": 2, "bug": 3}
 
 # Branch prefixes are the cheapest honest signal: they are chosen before the work starts.
 BRANCH_KINDS = {
@@ -37,10 +42,18 @@ AREA_RULES = (
                                                     "/sync/", "crypto", "Crypto"))),
     ("terminal", lambda p: "/terminal/" in p or "/graphics/" in p),
     ("build", lambda p: p.endswith((".gradle.kts", ".versions.toml")) or p.startswith("gradle/")),
+    # The harness gates every other change, and Gradle cannot see a line of it: its own suite is
+    # the only thing that can, so a change here owes that suite the way Kotlin owes `tests`.
+    # Everything that decides what a change owes, or who reads it: the runner, the hook that
+    # records reviews, the settings that register the hook, and the reviewers' own definitions.
+    ("harness", lambda p: p.startswith(("tools/harness/", ".claude/hooks/", ".claude/agents/",
+                                       ".claude/commands/"))
+        or p == ".claude/settings.json"),
 )
 
 # Stage -> the command the runner uses. "checks" is internal (tools/harness/checks.py).
 STAGE_COMMANDS = {
+    "selftest": ["python3", "tools/harness/selftest.py"],
     "tests": ["./gradlew", "test", "allTests"],
     "build": ["./gradlew", "build"],
     "detekt": ["./gradlew", "detektAll"],
@@ -84,7 +97,10 @@ def _kotlin(path: str) -> bool:
 
 
 def _security_scope(path: str) -> bool:
-    return _area_matcher("security")(path) or any(seg in path for seg in PROTOCOL_SEGMENTS)
+    # The harness is in scope for the same reason the vault is: it is the code that decides what a
+    # change has to prove, so a hole in it is worth every other hole at once.
+    return (_area_matcher("security", "harness")(path)
+            or any(seg in path for seg in PROTOCOL_SEGMENTS))
 
 
 # What each reviewer actually reads. A reviewer is owed again only when the files inside its own
@@ -125,8 +141,10 @@ def reviewer_delta(st: dict, reviewer: str, cwd: str | None = None) -> list[str]
 
     Empty when the reviewer never ran here: there is no delta to review, only the whole diff.
     """
-    seen = ((st.get("reviews") or {}).get(reviewer) or {}).get("files")
-    if not isinstance(seen, dict):
+    entry = (st.get("reviews") or {}).get(reviewer) or {}
+    seen = entry.get("files")
+    # A pass made on another branch is not a delta to re-read here — it is no pass at all.
+    if not isinstance(seen, dict) or entry.get("branch") != state.current_branch(cwd):
         return []
     now = reviewer_entries(reviewer, cwd)
     changed = {path for path, cid in now.items() if seen.get(path) != cid}
@@ -175,6 +193,21 @@ def areas(paths: list[str]) -> list[str]:
     return sorted(found)
 
 
+def _floor(branch: str, has_code: bool) -> str:
+    """The least strict kind the diff itself can justify, whatever the branch is named.
+
+    Both the branch and the declaration are floored by this one function. They used to be floored
+    by two pieces of code that agreed on `wip/` and disagreed on `docs/`: a branch called `docs/…`
+    with Kotlin in it became a feature, while declaring `docs` on that same branch was compared
+    against `docs` and accepted itself — the whole gate off, and quieter than the override.
+    """
+    if not has_code:
+        return "docs"
+    named = kind_from_branch(branch)
+    # The strictest kind that does not demand a reproduction test.
+    return named if named and named != "docs" else "feature"
+
+
 def classify(cwd: str | None = None) -> dict:
     """The task at hand: kind, where it came from, and which areas it touches.
 
@@ -188,10 +221,14 @@ def classify(cwd: str | None = None) -> dict:
 
     declared = (state.load(cwd).get("task") or {})
     # A declaration can make the gate stricter (this "chore" is really a bug fix) but never looser
-    # than the diff itself proves: calling a change with Kotlin in it "docs" would disarm the gate
-    # with one command, which is the whole thing this harness exists to prevent.
+    # than the diff itself proves. Refusing "docs" over a Kotlin diff was not enough: on a `fix/`
+    # branch, declaring `refactor` dropped the RED phase — a silent bypass, where the override at
+    # least has to be typed out loud.
     if declared.get("kind") in KINDS and declared.get("branch") == branch:
-        if not (declared["kind"] == "docs" and code_paths):
+        # The same default the branch itself would fall back to: the strictest kind that does
+        # not demand a reproduction test.
+        from_branch = _floor(branch, bool(code_paths))
+        if STRICTNESS[declared["kind"]] >= STRICTNESS[from_branch]:
             return {
                 "kind": declared["kind"], "source": "declared", "ref": declared.get("ref", ""),
                 "areas": task_areas, "paths": paths, "code_paths": code_paths, "branch": branch,
@@ -201,10 +238,9 @@ def classify(cwd: str | None = None) -> dict:
     if not code_paths:
         kind, source = "docs", "no code in diff"
     else:
-        kind = kind_from_branch(branch)
-        source = f"branch `{branch}`" if kind else "default"
-        if not kind:
-            kind = "feature"  # the strictest kind that does not demand a reproduction test
+        named = kind_from_branch(branch)
+        kind = _floor(branch, True)
+        source = f"branch `{branch}`" if named else "default"
     return {
         "kind": kind, "source": source, "ref": "", "areas": task_areas,
         "paths": paths, "code_paths": code_paths, "branch": branch,
@@ -214,9 +250,16 @@ def classify(cwd: str | None = None) -> dict:
 def required_stages(task: dict) -> list[str]:
     if task["kind"] == "docs":
         return []
-    stages = ["checks", "tests", "build", "detekt"]
-    if {"ui", "android"} & set(task["areas"]):
-        stages.append("android")
+    areas = set(task["areas"])
+    stages = ["checks"]
+    if "harness" in areas:
+        stages.append("selftest")
+    # Gradle cannot see a line of Python. Charging a hook fix ten minutes of `test allTests` and
+    # `build` teaches the operator to reach for SKERRY_GATE_OVERRIDE, which costs more than it saves.
+    if areas != {"harness"}:
+        stages += ["tests", "build", "detekt"]
+        if {"ui", "android"} & areas:
+            stages.append("android")
     if task["kind"] == "bug":
         stages.append("red")
     stages.append("review")
@@ -233,6 +276,202 @@ def relevant_reviewers(task: dict) -> list[str]:
             if extra not in reviewers:
                 reviewers.append(extra)
     return reviewers
+
+
+# What a backgrounded fan-out returns the moment it is launched. The agent has not read a line
+# yet, so recording it would make "reviewed" mean "started" — the one thing the review gate exists
+# to rule out. Length is part of the test: a real report that happens to quote `agentId` or the
+# phrase "in the background" is a report, not an acknowledgement.
+LAUNCH_STUB = re.compile(r"async agent launched|agentid:|is working in the background", re.I)
+STUB_CHARS = 400
+# A positive floor as well as the denylist: acceptance must not be what happens by default. A
+# reviewer that read this diff has more to say than a word, whatever shape the reply arrives in.
+MIN_REPORT_CHARS = 200
+# Deep enough for any real tool response, shallow enough that the hook cannot blow its stack.
+FLATTEN_DEPTH = 50
+
+
+def review_findings(response) -> str:
+    """A reviewer's findings out of whatever shape the harness handed the response back in.
+
+    Empty when the response carries none — an async launch acknowledgement, a one-word "ok", or a
+    reviewer that said nothing at all. Either way there is nothing to pin a tree to.
+    """
+    text = _flatten(response).strip()
+    if len(text) < MIN_REPORT_CHARS:
+        return ""
+    if len(text) < STUB_CHARS and LAUNCH_STUB.search(text):
+        return ""
+    return text
+
+
+def _flatten(response, depth: int = 0) -> str:
+    """The text inside whatever shape the harness handed a response back in.
+
+    Bounded: this runs inside a PostToolUse hook, where a RecursionError would surface as a
+    traceback on every Agent call. A response nested past the bound carries no findings anyone
+    could act on anyway.
+    """
+    if depth > FLATTEN_DEPTH:
+        return ""
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        for key in ("content", "text", "output", "result"):
+            if key in response:
+                return _flatten(response[key], depth + 1)
+        return ""
+    if isinstance(response, list):
+        return "\n".join(part for part in (_flatten(item, depth + 1) for item in response) if part)
+    return ""
+
+
+def _already_recorded(reviewer: str, cwd: str | None = None) -> bool:
+    """Whether this reviewer's pass for *this* tree is already recorded.
+
+    Both halves matter. Without the branch, a pass follows the worktree onto the next piece of
+    work; without the digest, a reviewer whose second round reads the same as its first ("checked
+    and clean" over changed code) can never be recorded, because the text is on disk already.
+    """
+    entry = (state.load(cwd).get("reviews") or {}).get(reviewer) or {}
+    return (entry.get("branch") == state.current_branch(cwd)
+            and entry.get("digest") == reviewer_digest(reviewer, cwd))
+
+
+def _wears_another_name(reviewer: str, findings: str) -> bool:
+    """A report whose header names a different reviewer records nobody. Always refused: no state
+    of the gate makes one reviewer's pass count as another's."""
+    first = findings.lstrip().splitlines()[0].strip()
+    return first.startswith("# ") and first[2:].strip() in known_reviewers() - {reviewer}
+
+
+def _stored_rounds(reviewer: str, cwd: str | None = None) -> list[tuple[str, str]]:
+    """Each round on disk as (branch it was recorded on, its text)."""
+    rounds: list[tuple[str, str]] = []
+    for block in stored_report(reviewer, cwd).split(f"\n# {reviewer}\n"):
+        if not block.strip():
+            continue
+        match = re.search(r"^branch: (.*)$", block, re.M)
+        rounds.append((match.group(1).strip() if match else "", block))
+    return rounds
+
+
+def _is_replay(reviewer: str, findings: str, cwd: str | None = None) -> bool:
+    """Whether this text is a round already on disk, replayed rather than reviewed.
+
+    `gate.py reviewers` prints the path of the previous findings, so re-feeding that file is the
+    easiest keystroke there is. A round made on another branch is always a replay; one made on
+    this branch is a replay only while the pass it belongs to is still recorded — otherwise the
+    retry after a failed state write, and a second round that reads the same as the first, would
+    both be refused with no way through.
+    """
+    body = findings.strip()
+    for round_branch, text in _stored_rounds(reviewer, cwd):
+        # Both directions: a round re-fed on its own, and the whole findings file re-fed at once —
+        # `gate.py reviewers` prints that path, so it is the likelier keystroke of the two.
+        if body in text or text.strip() in body:
+            if round_branch != state.current_branch(cwd):
+                return True
+            return _already_recorded(reviewer, cwd)
+    return False
+
+
+def note_review_launch(reviewer: str, cwd: str | None = None) -> None:
+    """Remember what the reviewer's scope looked like when it started reading.
+
+    A backgrounded reviewer reports minutes later, and the tree can move underneath it in that
+    window. Build stages already discard a run whose tree changed while it ran; without this
+    snapshot the review gate had no way to notice the same thing.
+    """
+    entries = reviewer_entries(reviewer, cwd)
+    st = state.load(cwd)
+    st.setdefault("pending_reviews", {})[reviewer] = {
+        "digest": state.digest_of(entries),
+        "files": entries,
+        "branch": state.current_branch(cwd),
+        "at": time.time(),
+    }
+    state.save(st, cwd)
+
+
+def moved_under_the_reviewer(reviewer: str, findings: str, cwd: str | None = None) -> bool:
+    """Whether this report was written against a tree that has since moved — and is still the
+    report that was refused for it.
+
+    The snapshot is taken when a pass is launched, and a reviewer re-run inline produces no launch,
+    so a first refusal used to wedge that reviewer for good: nothing could ever refresh the
+    snapshot again. Pinning the refusal to the text it refused keeps the property that matters —
+    retrying the same stale report changes nothing — while a report the reviewer actually wrote
+    afterwards gets through.
+    """
+    if not review_drift(reviewer, cwd):
+        return False
+    st = state.load(cwd)
+    pending = (st.get("pending_reviews") or {}).get(reviewer)
+    if pending is None:
+        return False
+    digest = hashlib.sha256(findings.encode("utf-8")).hexdigest()[:16]
+    if pending.get("refused") in (None, digest):
+        pending["refused"] = digest
+        state.save(st, cwd)
+        return True
+    # A different report after the refusal: the reviewer ran again, and the snapshot is spent.
+    # Re-aimed at the tree as it is now rather than dropped — dropping it left every later move
+    # for that reviewer unmeasured, so a stale report after this one met no drift check at all.
+    pending["files"] = reviewer_entries(reviewer, cwd)
+    pending.pop("refused", None)
+    state.save(st, cwd)
+    return False
+
+
+def review_drift(reviewer: str, cwd: str | None = None) -> list[str]:
+    """Files in the reviewer's scope that moved while it was reading. Empty when it never ran
+    backgrounded — there is no snapshot to compare against, and nothing to claim."""
+    pending = (state.load(cwd).get("pending_reviews") or {}).get(reviewer)
+    # A snapshot taken on another branch cannot judge this one: every file differs across a switch,
+    # so it would refuse the first honest report here as a tree that "moved".
+    if not pending or pending.get("branch") != state.current_branch(cwd):
+        return []
+    before, now = pending.get("files") or {}, reviewer_entries(reviewer, cwd)
+    return sorted({path for path in set(before) | set(now) if before.get(path) != now.get(path)})
+
+
+def record_review(reviewer: str, text: str, cwd: str | None = None) -> str:
+    """Pin a reviewer to the tree its findings were written against.
+
+    Returns the reason it was *not* recorded, empty when it was. A bool told the caller only that
+    something went wrong, and the hook reacted to all four reasons the same way — including by
+    re-snapshotting the drift evidence it had just refused on.
+    """
+    findings = review_findings(text)
+    if not findings:
+        return "no findings"
+    if moved_under_the_reviewer(reviewer, findings, cwd):
+        return "moved"
+    if _wears_another_name(reviewer, findings):
+        return "recycled"
+    if _is_replay(reviewer, findings, cwd):
+        return "recycled"
+    # The report goes first. The other order left the entry behind when the write failed, and the
+    # structural check in `missing_reviewers` then read the *previous* round's file and called the
+    # reviewer done — against code it never saw.
+    if not state.save_review_report(reviewer, findings, cwd):
+        return "not saved"
+    entries = reviewer_entries(reviewer, cwd)
+    st = state.load(cwd)
+    st.setdefault("reviews", {})[reviewer] = {
+        # Scoped to what this reviewer reads, so an unrelated fix does not owe it again.
+        "digest": state.digest_of(entries),
+        "files": entries,
+        "branch": state.current_branch(cwd),
+        "at": time.time(),
+    }
+    (st.get("pending_reviews") or {}).pop(reviewer, None)
+    return "" if state.save(st, cwd) else "not saved"
+
+
+def known_reviewers() -> set[str]:
+    return set(BASE_REVIEWERS) | {name for names in AREA_REVIEWERS.values() for name in names}
 
 
 def required_reviewers(task: dict, cwd: str | None = None) -> list[str]:
@@ -288,15 +527,32 @@ def gate_debt(cwd: str | None = None) -> tuple[dict, list[str]]:
 
 
 def missing_reviewers(st: dict, task: dict, cwd: str | None = None) -> list[str]:
-    """Reviewers whose own scope has moved since they last ran.
+    """Reviewers whose own scope has moved since they last ran, or who left no findings behind.
 
     Previously this compared one whole-tree digest, so a one-line Compose fix owed the vault, the
     server and the terminal reviewer all over again — the fan-out ran ten to twenty times per
     branch and each pass re-read the entire diff. Scoping the comparison is what stops that.
+
+    The report has to exist too. Entries written from an intent rather than a result left no file
+    on disk, and comparing digests alone counted them as reviewed — the check has to be structural,
+    not a matter of which code path wrote the entry.
     """
     seen = (st.get("reviews") or {})
+    branch = state.current_branch(cwd)
     return [name for name in required_reviewers(task, cwd)
-            if (seen.get(name) or {}).get("digest") != reviewer_digest(name, cwd)]
+            if (seen.get(name) or {}).get("digest") != reviewer_digest(name, cwd)
+            or (seen.get(name) or {}).get("branch") != branch
+            or not stored_report(name, cwd)]
+
+
+def stored_report(reviewer: str, cwd: str | None = None) -> str:
+    """The findings on disk for this reviewer, or empty when there are none."""
+    path = state.review_report_path(reviewer, cwd)
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except (OSError, UnicodeDecodeError):
+        return ""
 
 
 def skipped_reviewers(task: dict, cwd: str | None = None) -> list[str]:

--- a/tools/harness/policy.py
+++ b/tools/harness/policy.py
@@ -97,9 +97,7 @@ def _kotlin(path: str) -> bool:
 
 
 def _security_scope(path: str) -> bool:
-    # The harness is in scope for the same reason the vault is: it is the code that decides what a
-    # change has to prove, so a hole in it is worth every other hole at once.
-    return (_area_matcher("security", "harness")(path)
+    return (_area_matcher("security")(path)
             or any(seg in path for seg in PROTOCOL_SEGMENTS))
 
 
@@ -464,6 +462,7 @@ def record_review(reviewer: str, text: str, cwd: str | None = None) -> str:
         "digest": state.digest_of(entries),
         "files": entries,
         "branch": state.current_branch(cwd),
+        "rounds": review_rounds(st, reviewer, cwd) + 1,
         "at": time.time(),
     }
     (st.get("pending_reviews") or {}).pop(reviewer, None)
@@ -526,6 +525,34 @@ def gate_debt(cwd: str | None = None) -> tuple[dict, list[str]]:
     return task, debt
 
 
+# Two passes per branch, and the third is the operator's decision. A reviewer is owed again when
+# the files it read move — but fixing what it found is exactly what moves them, and its next round
+# is then about the fix. Inside a reviewer's own scope that loop does not converge; it ran eleven
+# times on one branch before this cap existed. What the cap lets through is printed, not hidden.
+REVIEW_ROUNDS = 2
+
+
+def review_rounds(st: dict, reviewer: str, cwd: str | None = None) -> int:
+    entry = (st.get("reviews") or {}).get(reviewer) or {}
+    return entry.get("rounds", 0) if entry.get("branch") == state.current_branch(cwd) else 0
+
+
+def unreviewed(st: dict, task: dict, cwd: str | None = None) -> list[tuple[str, list[str]]]:
+    """Reviewers the gate has stopped demanding while their scope has moved since they last read.
+
+    The gate stops asking; it does not claim the code was read. Saying nothing here would be the
+    same defect as recording a reviewer on its launch.
+    """
+    out = []
+    for name in required_reviewers(task, cwd):
+        if review_rounds(st, name, cwd) < REVIEW_ROUNDS:
+            continue
+        delta = reviewer_delta(st, name, cwd)
+        if delta:
+            out.append((name, delta))
+    return out
+
+
 def missing_reviewers(st: dict, task: dict, cwd: str | None = None) -> list[str]:
     """Reviewers whose own scope has moved since they last ran, or who left no findings behind.
 
@@ -539,10 +566,17 @@ def missing_reviewers(st: dict, task: dict, cwd: str | None = None) -> list[str]
     """
     seen = (st.get("reviews") or {})
     branch = state.current_branch(cwd)
-    return [name for name in required_reviewers(task, cwd)
-            if (seen.get(name) or {}).get("digest") != reviewer_digest(name, cwd)
-            or (seen.get(name) or {}).get("branch") != branch
-            or not stored_report(name, cwd)]
+    missing = []
+    for name in required_reviewers(task, cwd):
+        entry = seen.get(name) or {}
+        if not reviewer_entries(name, cwd):
+            continue  # nothing of this reviewer's in the change: there is nothing for it to read
+        if review_rounds(st, name, cwd) >= REVIEW_ROUNDS:
+            continue
+        if (entry.get("digest") != reviewer_digest(name, cwd) or entry.get("branch") != branch
+                or not stored_report(name, cwd)):
+            missing.append(name)
+    return missing
 
 
 def stored_report(reviewer: str, cwd: str | None = None) -> str:

--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -994,14 +994,65 @@ class TestReviewerScope(SandboxCase):
                                            self.cwd)
         self.assertIn("skerry-security-reviewer", missing)
 
-    def test_the_gates_own_code_is_owed_a_security_review(self):
-        # The code that decides what a change owes is the one place a bypass costs everything, and
-        # it used to fall outside every scope but the two whole-change passes.
-        self._branch_with_ui_and_vault()
+    def test_a_reviewer_with_nothing_in_its_scope_is_not_owed(self):
+        # A reviewer whose scope the change does not touch has nothing to read. Demanding it
+        # anyway is what made a harness-only edit cost a full fan-out.
+        self.box.branch("refactor/harness")
         self.box.write("tools/harness/policy.py", "# edited\n")
         missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
                                            self.cwd)
+        self.assertNotIn("skerry-security-reviewer", missing)
+        self.assertNotIn("skerry-kotlin-reviewer", missing)
+        self.assertIn("skerry-reviewer", missing, "the whole-change passes always have something")
+
+    ROUND = ("## Findings\n\n- `VaultStore.unlock` logs the unwrapped key at INFO in round {n}, "
+             "so a support bundle carries it off the machine. Nothing else in the diff adds a "
+             "primitive, drops a parity case, swallows a cancellation or ships a shortcut "
+             "without its Settings row.\n")
+
+    def _vault_branch(self) -> None:
+        self.box.branch("feat/thing")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val v = 1\n")
+
+    def _two_rounds(self) -> None:
+        for n in (1, 2):
+            self.assertEqual(
+                policy.record_review("skerry-security-reviewer", self.ROUND.format(n=n), self.cwd),
+                "", f"round {n}")
+            self.box.write("shared/src/commonMain/kotlin/vault/V.kt", f"val v = {n + 1}\n")
+
+    def test_a_reviewer_is_owed_at_most_twice_on_one_branch(self):
+        # Fixing what a reviewer found moves the files it read, which owes it again — and its next
+        # findings are about that fix. Inside its own scope the loop does not converge: eleven
+        # rounds on one branch, each one re-reading the diff. Two passes are the gate's; a third
+        # is the operator's call.
+        self._vault_branch()
+        self._two_rounds()
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertNotIn("skerry-security-reviewer", missing)
+
+    def test_the_cap_starts_over_on_the_next_branch(self):
+        self._vault_branch()
+        self._two_rounds()
+        run_git(self.cwd, "add", "-A")
+        run_git(self.cwd, "commit", "-q", "-m", "vault")
+        run_git(self.cwd, "checkout", "-q", "main")
+        self.box.branch("feat/other")
+        self.box.write("shared/src/commonMain/kotlin/vault/W.kt", "val w = 1\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
         self.assertIn("skerry-security-reviewer", missing)
+
+    def test_what_the_cap_let_through_is_said_out_loud(self):
+        # The gate stops demanding, it does not pretend the code was read. Silence here would be
+        # the same defect as recording a reviewer on its launch.
+        self._vault_branch()
+        self._two_rounds()
+        status = self.box.gate("status")
+        self.assertIn("unreviewed", status.stdout)
+        self.assertIn("skerry-security-reviewer", status.stdout)
+        self.assertIn("shared/src/commonMain/kotlin/vault/V.kt", status.stdout)
 
     def test_a_review_does_not_follow_the_worktree_onto_the_next_branch(self):
         # RED records are scoped to their branch; review records were not, so a resources-only

--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -25,7 +25,7 @@ TOOLS_DIR = os.path.dirname(HARNESS_DIR)
 REPO_ROOT = os.path.dirname(TOOLS_DIR)
 sys.path.insert(0, TOOLS_DIR)
 
-from harness import checks, policy, state  # noqa: E402
+from harness import checks, gate, policy, state  # noqa: E402
 
 
 def run_git(cwd: str, *args: str) -> str:
@@ -43,8 +43,9 @@ class Sandbox:
         run_git(self.path, "config", "user.name", "Harness")
         shutil.copytree(HARNESS_DIR, os.path.join(self.path, "tools", "harness"))
         os.makedirs(os.path.join(self.path, ".claude", "hooks"), exist_ok=True)
-        shutil.copy2(os.path.join(REPO_ROOT, ".claude", "hooks", "guard-git.py"),
-                     os.path.join(self.path, ".claude", "hooks", "guard-git.py"))
+        for hook in ("guard-git.py", "record-review.py"):
+            shutil.copy2(os.path.join(REPO_ROOT, ".claude", "hooks", hook),
+                         os.path.join(self.path, ".claude", "hooks", hook))
         # The repo-local reviewers are part of the clone, so the sandbox has to have them too:
         # without them the gate degrades to the plugin agents and tests silently check less.
         shutil.copytree(os.path.join(REPO_ROOT, ".claude", "agents"),
@@ -77,6 +78,24 @@ class Sandbox:
             env=environment, check=False,
         )
 
+    def recorder(self, subagent: str, response) -> subprocess.CompletedProcess:
+        """Drive the PostToolUse recorder exactly as the session does — the layer the review gate
+        was recorded from intent in, and the one no test used to reach."""
+        return self.raw_hook({"tool_name": "Agent", "tool_input": {"subagent_type": subagent},
+                              "tool_response": response})
+
+    def raw_hook(self, payload: dict) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, os.path.join(self.path, ".claude", "hooks", "record-review.py")],
+            input=json.dumps(payload), capture_output=True, text=True, cwd=self.path, check=False,
+        )
+
+    def gate(self, *args: str, stdin: str = "") -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, os.path.join(self.path, "tools", "harness", "gate.py"), *args],
+            input=stdin, capture_output=True, text=True, cwd=self.path, check=False,
+        )
+
     def cleanup(self) -> None:
         shutil.rmtree(self.path, ignore_errors=True)
 
@@ -95,11 +114,38 @@ class TestRelevance(unittest.TestCase):
                      "gradle/libs.versions.toml"):
             self.assertTrue(state.is_code(path), path)
 
-    def test_prose_and_harness_do_not(self):
-        for path in ("README.md", "docs/coding-guidelines.md", ".claude/hooks/guard-git.py",
-                     "tools/harness/gate.py", ".github/workflows/ci.yml",
+    def test_prose_and_generated_files_do_not(self):
+        for path in ("README.md", "docs/coding-guidelines.md", ".github/workflows/ci.yml",
                      "composeApp/build/generated/Thing.kt", "docs/img/x.png"):
             self.assertFalse(state.is_code(path), path)
+
+    def test_the_harness_counts_as_code_it_gates(self):
+        # It used to be ignored, so deleting a rule moved no digest and the stage that had already
+        # run against the old rule set stayed green.
+        for path in ("tools/harness/checks.py", ".claude/hooks/guard-git.py"):
+            self.assertTrue(state.is_code(path), path)
+
+    def test_a_reviewer_definition_is_code_the_gate_watches(self):
+        # The agent files are the executable content of the review gate: prose everywhere else,
+        # but editing one changes what a reviewer looks for.
+        self.assertTrue(state.is_code(".claude/agents/skerry-security-reviewer.md"))
+        self.assertFalse(state.is_code("docs/design/notes.md"))
+        self.assertEqual(policy.areas([".claude/agents/skerry-reviewer.md"]), ["harness"])
+
+    def test_a_slash_command_is_code_the_gate_watches(self):
+        # `/gate` and `/task` drive the fan-out and the kind declaration: the same argument that
+        # made agent definitions code.
+        self.assertTrue(state.is_code(".claude/commands/gate.md"))
+        self.assertEqual(policy.areas([".claude/commands/gate.md"]), ["harness"])
+
+    def test_the_invisible_byte_list_covers_the_bidi_and_c1_families(self):
+        # ALM is a bidi control like LRM; C1 opens CSI/OSC in a UTF-8 xterm; the word-joiner block
+        # and the BOM are invisible in review the same way the zero-width space is.
+        for point in (0x061C, 0x2060, 0xFEFF, 0x007F, 0x009B, 0x202E, 0x200B,
+                      0x2028, 0x2029, 0x000C, 0x0085):
+            self.assertIsNotNone(state.CONTROL_CHARS.search(chr(point)), hex(point))
+        for point in (0x0009, 0x000A, 0x0041, 0x0410, 0x4E2D, 0x00A0):
+            self.assertIsNone(state.CONTROL_CHARS.search(chr(point)), hex(point))
 
     def test_test_sources_are_marked(self):
         self.assertTrue(state.is_test("shared/src/commonTest/kotlin/AT.kt"))
@@ -190,6 +236,15 @@ class TestClassification(SandboxCase):
         self.box.write("README.md", "prose\n")
         self.assertEqual(policy.classify(self.cwd)["kind"], "docs")
 
+    def test_a_docs_branch_does_not_disarm_a_code_change(self):
+        # The declaration is floored by the branch; the branch has to be floored by the diff, or
+        # `git checkout -b docs/tidy` is a quieter override than SKERRY_GATE_OVERRIDE.
+        self.box.branch("docs/tidy")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val a = 1\n")
+        task = policy.classify(self.cwd)
+        self.assertEqual(task["kind"], "feature")
+        self.assertTrue(policy.required_stages(task))
+
     def test_unknown_prefix_defaults_to_feature(self):
         self.box.branch("wip")
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
@@ -221,6 +276,27 @@ class TestClassification(SandboxCase):
         self.assertEqual(task["kind"], "feature")
         self.assertNotEqual(policy.gate_debt(self.cwd)[1], [])
 
+    def test_a_docs_branch_cannot_declare_itself_docs_over_code(self):
+        # The undeclared path floors `docs/` to feature. The declared path compared against the
+        # unfloored branch kind, so `docs/tidy` + `gate.py task docs` accepted itself and the
+        # whole gate went quiet — without the override having to be typed out loud.
+        self.box.branch("docs/tidy")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val a = 1\n")
+        self.box.gate("task", "docs")
+        task = policy.classify(self.cwd)
+        self.assertEqual(task["kind"], "feature")
+        self.assertNotEqual(policy.gate_debt(self.cwd)[1], [])
+
+    def test_a_declaration_cannot_drop_the_red_phase(self):
+        # The module says a declaration can only tighten the gate. `task refactor` on a `fix/`
+        # branch dropped `red`, and it does not announce itself the way the override does.
+        self.box.branch("fix/thing")
+        self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
+        self.box.gate("task", "refactor")
+        task = policy.classify(self.cwd)
+        self.assertEqual(task["kind"], "bug")
+        self.assertIn("red", policy.required_stages(task))
+
     def test_declaring_a_stricter_kind_is_honoured(self):
         self.box.branch("chore/actually-a-bug")
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
@@ -237,6 +313,10 @@ class TestClassification(SandboxCase):
         self.assertIn("android", policy.areas(["androidApp/src/main/AndroidManifest.xml"]))
         self.assertIn("i18n", policy.areas(
             ["composeApp/src/commonMain/composeResources/values-ru/strings.xml"]))
+        # Without this the `harness` rule could be deleted and every case above still passed: the
+        # stage it pulls in was pinned, the classification that pulls it in was not.
+        self.assertIn("harness", policy.areas(["tools/harness/policy.py"]))
+        self.assertIn("harness", policy.areas([".claude/hooks/record-review.py"]))
 
 
 class TestRequirements(unittest.TestCase):
@@ -248,6 +328,25 @@ class TestRequirements(unittest.TestCase):
         stages = policy.required_stages({"kind": "bug", "areas": ["shared"]})
         self.assertIn("red", stages)
         self.assertNotIn("red", policy.required_stages({"kind": "feature", "areas": ["shared"]}))
+
+    def test_a_harness_change_owes_its_own_suite(self):
+        # Gradle cannot see a line of Python, so this suite is the only stage that gates the gate.
+        self.assertIn("selftest", policy.required_stages({"kind": "refactor", "areas": ["harness"]}))
+        self.assertNotIn("selftest", policy.required_stages({"kind": "refactor", "areas": ["ui"]}))
+
+    def test_the_hook_wiring_is_part_of_the_harness(self):
+        # `.claude/settings.json` is where the recorder is registered: Gradle cannot see it, and
+        # the suite is the only thing that can.
+        self.assertEqual(policy.areas([".claude/settings.json"]), ["harness"])
+
+    def test_a_harness_only_change_does_not_owe_gradle(self):
+        # No Gradle stage can see a line of Python. Charging a five-line hook fix ten minutes of
+        # `test allTests` and `build` is how a harness ends up routinely overridden.
+        self.assertEqual(policy.required_stages({"kind": "refactor", "areas": ["harness"]}),
+                         ["checks", "selftest", "review"])
+        both = policy.required_stages({"kind": "refactor", "areas": ["harness", "ui"]})
+        self.assertIn("tests", both)
+        self.assertIn("selftest", both)
 
     def test_ui_pulls_in_the_android_compile_and_a11y(self):
         task = {"kind": "feature", "areas": ["ui"]}
@@ -300,9 +399,13 @@ class TestGateDebt(SandboxCase):
         st["stages"] = {stage: {"ok": True, "digest": digest}
                         for stage in policy.required_stages(task)
                         if stage not in ("red", "review")}
-        st["reviews"] = {name: {"digest": policy.reviewer_digest(name, self.cwd)}
+        st["reviews"] = {name: {"digest": policy.reviewer_digest(name, self.cwd),
+                                "branch": state.current_branch(self.cwd)}
                          for name in policy.required_reviewers(task, self.cwd)}
         state.save(st, self.cwd)
+        for name in policy.required_reviewers(task, self.cwd):
+            state.save_review_report(name, f"# {name}\n\nfindings from a pass that really ran",
+                                     self.cwd)
 
     def test_untouched_branch_owes_every_stage(self):
         self.box.branch("feat/thing")
@@ -347,8 +450,10 @@ class TestGateDebt(SandboxCase):
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
         st = state.load(self.cwd)
         st["reviews"] = {"skerry-reviewer": {
-            "digest": policy.reviewer_digest("skerry-reviewer", self.cwd)}}
+            "digest": policy.reviewer_digest("skerry-reviewer", self.cwd),
+            "branch": state.current_branch(self.cwd)}}
         state.save(st, self.cwd)
+        state.save_review_report("skerry-reviewer", "# skerry-reviewer\n\nno findings", self.cwd)
         _, debt = policy.gate_debt(self.cwd)
         review = [item for item in debt if item.startswith("review")][0]
         missing = review.split("missing: ")[1]
@@ -534,6 +639,73 @@ class TestChecks(SandboxCase):
         self.assertEqual(len(found), 1)
         self.assertEqual(found[0].severity, checks.WARN)
 
+    def test_invisible_characters_are_blocked_in_a_comment_too(self):
+        # Trojan source lives in comments by design: the payload has to sit where the reviewer
+        # reads prose and the compiler reads nothing.
+        bidi = chr(0x202E)
+        self.box.write("shared/src/commonMain/kotlin/A.kt", f"// drop{bidi} the table\n")
+        found = self._findings("control-chars")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, checks.BLOCK)
+
+    def test_a_line_that_looks_like_a_diff_header_does_not_retarget_the_rules(self):
+        # `git diff -U0` renders an added line `++ b/x` as `+++ b/x`, which the parser read as a
+        # new file header: every rule after it was applied to the attacker's path instead.
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt",
+                       'val sample = """\n'
+                       "++ b/docs/notes.md\n"
+                       '"""\n'
+                       "fun leak() { file.writeText(secret) }\n")
+        self.box.commit("vault")
+        self.assertEqual(len(self._findings("secret-write")), 1,
+                         "content cannot decide which path the rules are applied to")
+
+    def test_the_line_that_does_the_spoofing_is_judged_like_any_other(self):
+        # Skipping a `+++` line inside a hunk would let the same trick hide one line — its own.
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt",
+                       'val sample = """\n'
+                       '++ b/notes.md" + file.writeText(secret)\n'
+                       '"""\n')
+        self.box.commit("vault")
+        self.assertEqual(len(self._findings("secret-write")), 1)
+
+    def test_a_separator_python_invents_does_not_truncate_a_line(self):
+        # `splitlines()` breaks on U+000C, U+001C-1E, U+0085, U+2028/9 — none of which git or
+        # Kotlin treat as line ends — and eats the byte, so the rest of the line was never judged
+        # and the invisible byte itself became invisible to the rule that looks for it.
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt",
+                       "fun b(f: Path, s: String) { f\u000c.writeText(s) }\n")
+        self.box.commit("vault")
+        self.assertEqual(len(self._findings("secret-write")), 1)
+        self.assertEqual(len(self._findings("control-chars")), 1)
+
+    def test_a_gitattribute_cannot_hide_a_file_from_the_rules(self):
+        # `*.kt -diff` makes git print "Binary files differ" instead of the content.
+        self.box.write(".gitattributes", "*.kt -diff\n")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt",
+                       "fun b(f: Path, s: String) { f.writeText(s) }\n")
+        self.box.commit("vault")
+        self.assertEqual(len(self._findings("secret-write")), 1)
+
+    def test_a_name_that_reads_as_a_pathspec_is_still_diffed(self):
+        # git parses `:(icase)x.kt` as pathspec magic, not as a file name, so the per-file diff
+        # came back empty and every line-based rule was applied to nothing.
+        self.box.write(":(icase)Payload.kt", f"// drop{chr(0x202E)} the table\n")
+        self.box.commit("payload")
+        self.assertEqual(len(self._findings("control-chars")), 1)
+
+    def test_a_file_name_that_is_not_utf8_does_not_disarm_the_gate(self):
+        # git hands the name back as raw bytes; a strict decode raised out of `gate_debt`, and the
+        # commit guard catches everything and allows — the whole gate off for one bad file name.
+        self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
+        broken = os.path.join(self.cwd.encode(), b"shared/src/commonMain/kotlin/\xff.kt")
+        with open(broken, "wb") as fh:
+            fh.write(b"val b = 2\n")
+        self.addCleanup(os.remove, broken)
+        _, debt = policy.gate_debt(self.cwd)
+        self.assertTrue(debt, "a file the harness cannot name is not a gate it can skip")
+        self.assertNotEqual(state.tree_digest("all", self.cwd), "empty")
+
     def test_escaped_control_characters_are_fine(self):
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = \"x\\u001Fy\"\n")
         self.assertEqual(self._findings("control-chars"), [])
@@ -567,6 +739,21 @@ class TestChecks(SandboxCase):
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
         self.box.write("shared/src/commonTest/kotlin/ATest.kt", "// covers it\n")
         task = {"kind": "feature", "areas": ["shared"], "paths": [], "code_paths": []}
+        self.assertEqual([f for f in checks.run(self.cwd, task) if f.rule == "tests-present"], [])
+
+    def test_a_harness_feature_owes_a_test_too(self):
+        # The rule that gates every other change is the one place an untested rule costs most.
+        self.box.branch("feat/gate-tweak")
+        self.box.write("tools/harness/policy.py", "# a new rule\n")
+        task = {"kind": "feature", "areas": ["harness"], "paths": [], "code_paths": []}
+        found = [f for f in checks.run(self.cwd, task) if f.rule == "tests-present"]
+        self.assertEqual(len(found), 1)
+
+    def test_a_harness_feature_with_its_suite_touched_is_fine(self):
+        self.box.branch("feat/gate-tweak")
+        self.box.write("tools/harness/policy.py", "# a new rule\n")
+        self.box.write("tools/harness/selftest.py", "# and the case that proves it\n")
+        task = {"kind": "feature", "areas": ["harness"], "paths": [], "code_paths": []}
         self.assertEqual([f for f in checks.run(self.cwd, task) if f.rule == "tests-present"], [])
 
     def test_a_refactor_may_leave_tests_alone(self):
@@ -606,6 +793,33 @@ class TestChecks(SandboxCase):
                            '<resources><string name="a">A</string></resources>')
         self.assertEqual(self._findings("i18n-parity"), [])
 
+    def test_i18n_gap_in_plurals_and_arrays_is_blocked(self):
+        base = "composeApp/src/commonMain/composeResources"
+        def both(*categories: str) -> str:
+            items = "".join(f'<item quantity="{c}">%1$d files</item>' for c in categories)
+            return (f'<resources><plurals name="p">{items}</plurals>'
+                    '<string-array name="a"><item>Jan</item></string-array></resources>')
+        self.box.write(f"{base}/values/strings.xml", both("one", "other"))
+        self.box.write(f"{base}/values-ru/strings.xml", both("one", "few", "many", "other"))
+        self.box.write(f"{base}/values-zh/strings.xml", "<resources></resources>")
+        found = self._findings("i18n-parity")
+        self.assertEqual(len(found), 2, "a plural and an array ship in three languages like a string")
+        self.assertTrue(all("values-zh" in f.message for f in found))
+
+    def test_a_plural_does_not_define_a_string_of_the_same_name(self):
+        base = "composeApp/src/commonMain/composeResources"
+        def body(*categories: str) -> str:
+            items = "".join(f'<item quantity="{c}">%1$d</item>' for c in categories)
+            return f'<resources><plurals name="count">{items}</plurals></resources>'
+        self.box.write(f"{base}/values/strings.xml", body("one", "other"))
+        self.box.write(f"{base}/values-ru/strings.xml", body("one", "few", "many", "other"))
+        self.box.write(f"{base}/values-zh/strings.xml", body("other"))
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt",
+                       "val t = stringResource(Res.string.count)\n")
+        found = self._findings("i18n-parity")
+        self.assertEqual(len(found), 1, "the namespaces are separate — a plural is not a string")
+        self.assertIn("Res.string.count", found[0].message)
+
     def test_undefined_string_key_is_blocked(self):
         base = "composeApp/src/commonMain/composeResources"
         for locale in ("values", "values-ru", "values-zh"):
@@ -616,6 +830,123 @@ class TestChecks(SandboxCase):
         found = self._findings("i18n-parity")
         self.assertEqual(len(found), 1)
         self.assertIn("missing_key", found[0].message)
+
+
+    def test_a_string_and_a_plural_of_one_name_are_two_keys(self):
+        base = "composeApp/src/commonMain/composeResources"
+        self.box.write(f"{base}/values/strings.xml",
+                       '<resources><string name="a">A</string></resources>')
+        self.box.write(f"{base}/values-ru/strings.xml",
+                       '<resources><plurals name="a">'
+                       '<item quantity="one">А</item><item quantity="few">А</item>'
+                       '<item quantity="many">А</item><item quantity="other">А</item>'
+                       '</plurals></resources>')
+        self.box.write(f"{base}/values-zh/strings.xml",
+                       '<resources><string name="a">A</string></resources>')
+        messages = [f.message for f in self._findings("i18n-parity")]
+        self.assertEqual(len(messages), 2, "a plural does not translate a string of the same name")
+        self.assertTrue(any(m.startswith("`a` has no values-ru") for m in messages), messages)
+        self.assertTrue(any(m.startswith("`plurals a` exists only in values-ru") for m in messages), messages)
+
+    def test_a_plural_missing_a_category_is_blocked(self):
+        base = "composeApp/src/commonMain/composeResources"
+        full = ('<item quantity="one">A</item><item quantity="few">A</item>'
+                '<item quantity="many">A</item><item quantity="other">A</item>')
+        self.box.write(f"{base}/values/strings.xml",
+                       f'<resources><plurals name="n">{full}</plurals></resources>')
+        self.box.write(f"{base}/values-ru/strings.xml",
+                       '<resources><plurals name="n"><item quantity="other">A</item></plurals></resources>')
+        self.box.write(f"{base}/values-zh/strings.xml",
+                       '<resources><plurals name="n"><item quantity="other">A</item></plurals></resources>')
+        found = self._findings("i18n-parity")
+        self.assertEqual(len(found), 1, "Chinese needs `other` alone; Russian needs one/few/many too")
+        self.assertIn("one, few, many", found[0].message)
+
+    def test_undefined_plural_and_array_keys_are_blocked(self):
+        base = "composeApp/src/commonMain/composeResources"
+        def body(*categories: str) -> str:
+            items = "".join(f'<item quantity="{c}">%1$d</item>' for c in categories)
+            return (f'<resources><plurals name="here">{items}</plurals>'
+                    '<string-array name="also"><item>Jan</item></string-array></resources>')
+        self.box.write(f"{base}/values/strings.xml", body("one", "other"))
+        self.box.write(f"{base}/values-ru/strings.xml", body("one", "few", "many", "other"))
+        self.box.write(f"{base}/values-zh/strings.xml", body("other"))
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt",
+                       "val a = pluralStringResource(Res.plurals.here, 1)\n"
+                       "val b = stringArrayResource(Res.array.also)\n"
+                       "val c = pluralStringResource(Res.plurals.gone, 1)\n"
+                       "val d = stringArrayResource(Res.array.vanished)\n")
+        messages = [f.message for f in self._findings("i18n-parity")]
+        self.assertEqual(len(messages), 2, "the two defined accessors resolve, the two stale ones do not")
+        self.assertIn("`Res.plurals.gone` is used but defined nowhere.", messages)
+        self.assertIn("`Res.array.vanished` is used but defined nowhere.", messages)
+
+    def test_an_attribute_before_the_name_does_not_exempt_a_string(self):
+        base = "composeApp/src/commonMain/composeResources"
+        self.box.write(f"{base}/values/strings.xml",
+                       '<resources><string translatable="false" name="a">A</string></resources>')
+        for locale in ("values-ru", "values-zh"):
+            self.box.write(f"{base}/{locale}/strings.xml", "<resources></resources>")
+        found = self._findings("i18n-parity")
+        self.assertEqual(len(found), 2, "a key the pattern misses is silently exempt from parity")
+
+    def test_an_unreadable_resource_file_says_so(self):
+        base = "composeApp/src/commonMain/composeResources"
+        for locale in ("values", "values-ru"):
+            self.box.write(f"{base}/{locale}/strings.xml",
+                           '<resources><string name="a">A</string></resources>')
+        os.makedirs(os.path.join(self.cwd, base, "values-zh/strings.xml"))
+        found = self._findings("i18n-parity")
+        warnings = [f for f in found if f.severity == checks.WARN]
+        self.assertEqual(len(warnings), 1, "an incomplete sweep has to say it was incomplete")
+        # Every locale is walked twice — once for names, once for plural categories. An uncached
+        # read counted the same broken file once per walk and sent the reader hunting a second one.
+        self.assertIn("1 resource file(s) could not be read", warnings[0].message)
+
+    def test_a_resource_file_that_is_not_utf8_says_so(self):
+        # The likeliest way a locale file becomes unreadable is an editor saving it in cp1251, and
+        # that raises UnicodeDecodeError, not OSError — the warning built for it has to fire.
+        base = "composeApp/src/commonMain/composeResources"
+        for locale in ("values", "values-ru"):
+            self.box.write(f"{base}/{locale}/strings.xml",
+                           '<resources><string name="a">A</string></resources>')
+        path = os.path.join(self.cwd, base, "values-zh", "strings.xml")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as fh:
+            fh.write('<resources><string name="a">Файл</string></resources>'.encode("cp1251"))
+        warnings = [f for f in self._findings("i18n-parity") if f.severity == checks.WARN]
+        self.assertEqual(len(warnings), 1, "a file the sweep cannot decode is not a clean sweep")
+
+    def test_a_source_file_that_cannot_be_read_says_so(self):
+        # An unreadable source hides a `Res.` usage, not a translation — a different warning from
+        # the locale one, and the two counters must not be folded together.
+        base = "composeApp/src/commonMain/composeResources"
+        for locale in ("values", "values-ru", "values-zh"):
+            self.box.write(f"{base}/{locale}/strings.xml",
+                           '<resources><string name="a">A</string></resources>')
+        path = os.path.join(self.cwd, "composeApp/src/commonMain/kotlin/S.kt")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as fh:
+            fh.write("val a = Res.string.a // файл\n".encode("cp1251"))
+        warnings = [f for f in self._findings("i18n-parity") if f.severity == checks.WARN]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("source file(s) could not be read", warnings[0].message)
+
+    def test_an_empty_plural_form_is_not_a_form(self):
+        base = "composeApp/src/commonMain/composeResources"
+        def body(*categories: str) -> str:
+            items = "".join(f'<item quantity="{c}">%1$d</item>' for c in categories)
+            return f'<resources><plurals name="n">{items}</plurals></resources>'
+        self.box.write(f"{base}/values/strings.xml", body("one", "other"))
+        self.box.write(f"{base}/values-ru/strings.xml",
+                       '<resources><plurals name="n">'
+                       '<item quantity="one">%1$d файл</item><item quantity="few"></item>'
+                       '<item quantity="many">%1$d файлов</item>'
+                       '<item quantity="other">%1$d файла</item></plurals></resources>')
+        self.box.write(f"{base}/values-zh/strings.xml", body("other"))
+        found = self._findings("i18n-parity")
+        self.assertEqual(len(found), 1, "an item with no text draws a blank where the number goes")
+        self.assertIn("few", found[0].message)
 
 
 class TestReviewerScope(SandboxCase):
@@ -630,7 +961,10 @@ class TestReviewerScope(SandboxCase):
         reviews = st.setdefault("reviews", {})
         for name in policy.required_reviewers(task, self.cwd):
             entries = policy.reviewer_entries(name, self.cwd)
-            reviews[name] = {"digest": state.digest_of(entries), "files": entries}
+            reviews[name] = {"digest": state.digest_of(entries), "files": entries,
+                             "branch": state.current_branch(self.cwd)}
+            state.save_review_report(name, f"# {name}\n\nfindings from a pass that really ran",
+                                     self.cwd)
         state.save(st, self.cwd)
 
     def _branch_with_ui_and_vault(self) -> dict:
@@ -659,6 +993,28 @@ class TestReviewerScope(SandboxCase):
         missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
                                            self.cwd)
         self.assertIn("skerry-security-reviewer", missing)
+
+    def test_the_gates_own_code_is_owed_a_security_review(self):
+        # The code that decides what a change owes is the one place a bypass costs everything, and
+        # it used to fall outside every scope but the two whole-change passes.
+        self._branch_with_ui_and_vault()
+        self.box.write("tools/harness/policy.py", "# edited\n")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-security-reviewer", missing)
+
+    def test_a_review_does_not_follow_the_worktree_onto_the_next_branch(self):
+        # RED records are scoped to their branch; review records were not, so a resources-only
+        # branch inherited the pass made on the previous one — the files had not moved.
+        self._branch_with_ui_and_vault()
+        self.assertEqual(policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                                  self.cwd), [])
+        run_git(self.cwd, "checkout", "-q", "-b", "feat/next")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-reviewer", missing)
+        self.assertEqual(policy.reviewer_delta(state.load(self.cwd), "skerry-reviewer", self.cwd),
+                         [], "a pass made elsewhere is not a delta to re-read")
 
     def test_a_ui_fix_does_not_reopen_the_server_review(self):
         self.box.branch("feat/thing")
@@ -711,12 +1067,486 @@ class TestReviewReports(SandboxCase):
         self.assertIn("FINDING: vault key logged", body)
         self.assertIn("skerry-reviewer", body)
 
+    REPORT = ("## Findings\n\n- `VaultStore.unlock` logs the unwrapped key at INFO, so a support "
+              "bundle carries it off the machine. The rest of the diff is clean: no new "
+              "primitive, no parity gap, no swallowed cancellation, no shortcut without its "
+              "Settings row.\n")
+
+    def _branch_with_ui(self) -> None:
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+
+    def test_the_recorder_refuses_a_launch_that_reviewed_nothing(self):
+        # The bug this whole path exists for lived in the hook, not in policy: it recorded on the
+        # Agent tool returning, and a backgrounded fan-out returns before reading anything.
+        self._branch_with_ui()
+        done = self.box.recorder("skerry-reviewer",
+                                 "Async agent launched successfully.\nagentId: abc123\n"
+                                 "The agent is working in the background.")
+        st = state.load(self.cwd)
+        self.assertNotIn("skerry-reviewer", st.get("reviews") or {})
+        self.assertIn("skerry-reviewer", st.get("pending_reviews") or {})
+        self.assertIn("not recorded", done.stdout)
+
+    def test_a_report_arriving_after_the_code_moved_is_refused(self):
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        self.assertEqual(policy.review_drift("skerry-reviewer", self.cwd),
+                         ["composeApp/src/commonMain/kotlin/S.kt"])
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "moved",
+                         "a reviewer cannot vouch for code it never read")
+
+    def test_a_refused_report_leaves_the_drift_snapshot_where_it_was(self):
+        # The refusal used to re-snapshot the scope on its way out, so the retry it recommends
+        # found no drift and recorded the stale report green — the guard cancelled itself.
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        before = (state.load(self.cwd)["pending_reviews"]["skerry-reviewer"])["files"]
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        refused = self.box.recorder("skerry-reviewer", self.REPORT)
+        self.assertIn("moved", refused.stdout)
+        after = (state.load(self.cwd)["pending_reviews"]["skerry-reviewer"])["files"]
+        self.assertEqual(before, after, "the snapshot is the evidence — a refusal must not reset it")
+        self.assertEqual(self.box.gate("review", "skerry-reviewer", stdin=self.REPORT).returncode,
+                         2, "the retry the refusal advertises cannot be the way around it")
+
+    def test_a_stored_report_cannot_be_recorded_twice(self):
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        stored = policy.stored_report("skerry-reviewer", self.cwd)
+        self.assertEqual(policy.record_review("skerry-reviewer", stored, self.cwd), "recycled",
+                         "re-feeding the file `gate.py reviewers` prints re-dates a stale pass")
+
+    def test_the_file_the_gate_prints_cannot_be_handed_back_as_a_pass(self):
+        # `gate.py reviewers` prints the previous findings' path right under MISSING. Once the
+        # scope moves, the stored round is no longer a replay — `_already_recorded` is false — so
+        # only where the text came from can tell an honest repeat verdict from a recycled file.
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        report = state.review_report_path("skerry-reviewer", self.cwd)
+        done = self.box.gate("review", "skerry-reviewer", "--file", report)
+        self.assertEqual(done.returncode, 2, done.stdout)
+        self.assertIn("skerry-reviewer",
+                      policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd)))
+
+    def test_the_cli_lets_the_next_report_through_like_the_hook_does(self):
+        # The CLI refused on drift before `record_review` could see the report, so the retry the
+        # refusal advertises was refused too — the two paths disagreed about the same tree.
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        stale = self.box.gate("review", "skerry-reviewer", stdin=self.REPORT)
+        self.assertEqual(stale.returncode, 2, stale.stdout)
+        self.assertIn("moved", stale.stdout)
+        fresh = self.box.gate("review", "skerry-reviewer",
+                              stdin=self.REPORT.replace("INFO", "DEBUG"))
+        self.assertEqual(fresh.returncode, 0, fresh.stdout)
+
+    def test_a_spent_refusal_re_arms_the_snapshot_instead_of_dropping_it(self):
+        # Dropping it left every later move for that reviewer unmeasured: a report refused for
+        # some other reason after the discharge, then a stale one, and nothing checks the tree.
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        self.assertTrue(policy.moved_under_the_reviewer("skerry-reviewer", self.REPORT, self.cwd))
+        second = self.REPORT.replace("INFO", "DEBUG")
+        self.assertFalse(policy.moved_under_the_reviewer("skerry-reviewer", second, self.cwd))
+        pending = (state.load(self.cwd).get("pending_reviews") or {}).get("skerry-reviewer")
+        self.assertIsNotNone(pending, "the snapshot is what measures the next report")
+        self.assertNotIn("refused", pending)
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 3\n")
+        self.assertEqual(policy.review_drift("skerry-reviewer", self.cwd),
+                         ["composeApp/src/commonMain/kotlin/S.kt"])
+
+    def test_one_reviewers_report_does_not_record_another(self):
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        stored = policy.stored_report("skerry-reviewer", self.cwd)
+        self.assertEqual(policy.record_review("skerry-security-reviewer", stored, self.cwd),
+                         "recycled")
+
+    def test_a_record_that_never_reached_the_disk_is_not_success(self):
+        self._branch_with_ui()
+        original = state.save
+        state.save = lambda *args, **kwargs: False
+        self.addCleanup(lambda: setattr(state, "save", original))
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd),
+                         "not saved")
+
+    def test_findings_that_cannot_be_written_leave_the_reviewer_owed(self):
+        # State first, report second left the entry behind when the report write failed: the
+        # structural check then read the *previous* round's file and called the reviewer done.
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        original = state.save_review_report
+        state.save_review_report = lambda *args, **kwargs: ""
+        self.addCleanup(lambda: setattr(state, "save_review_report", original))
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT + "second round\n",
+                                              self.cwd), "not saved")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-reviewer", missing,
+                      "last round's file on disk is not this round's review")
+
+    def test_a_repeat_verdict_on_moved_code_is_a_new_pass(self):
+        # Reports are appended, so a reviewer whose second round reads the same ("checked and
+        # clean") was refused as recycled and could not close the gate without being reworded.
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "",
+                         "the same verdict about different code is a different pass")
+
+    def test_a_fresh_report_after_a_drift_refusal_is_recorded(self):
+        # The snapshot refuses the report it was taken against. Re-running the reviewer inline
+        # produces a different text and no new launch, so nothing refreshed the snapshot and the
+        # reviewer could never be recorded again.
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "moved")
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "moved",
+                         "the report that was refused stays refused")
+        rerun = self.REPORT + "\nRe-read after the fix: the unwrapped key is no longer logged.\n"
+        self.assertEqual(policy.record_review("skerry-reviewer", rerun, self.cwd), "")
+
+    def test_a_report_stored_on_another_branch_cannot_close_this_one(self):
+        # The findings file is per-reviewer and spans branches, so on a fresh branch the reviewer
+        # has no entry — and the previous branch's report was accepted as this branch's pass.
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        stored = policy.stored_report("skerry-reviewer", self.cwd)
+        run_git(self.cwd, "checkout", "-q", "-b", "feat/next")
+        self.box.write("shared/src/commonMain/kotlin/vault/V.kt", "val v = 1\n")
+        self.assertEqual(policy.record_review("skerry-reviewer", stored, self.cwd), "recycled")
+
+    def test_a_report_kept_after_a_failed_state_write_can_still_be_recorded(self):
+        # The report is appended before the entry, so a state write that fails once left the
+        # findings on disk — and the retry was then refused as a recycled report, forever.
+        self._branch_with_ui()
+        original = state.save
+        state.save = lambda *args, **kwargs: False
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd),
+                         "not saved")
+        state.save = original
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "",
+                         "the file on disk is this round's own report, not a previous pass")
+
+    def test_the_stored_report_is_readable_only_by_its_operator(self):
+        # It is a verbatim copy of whatever path the operator named — a mistyped `--file` can put
+        # a private key in there, and .git is never cleaned.
+        path = state.save_review_report("skerry-reviewer", self.REPORT, self.cwd)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+        self.assertEqual(os.stat(os.path.dirname(path)).st_mode & 0o777, 0o700)
+
+    def test_a_report_cannot_carry_an_escape_sequence_into_the_terminal(self):
+        # Reports quote what the reviewer read — terminal fixtures, SFTP names, an AI transcript.
+        # `cat`-ing the file executes the escape, and the next round replays it into a context.
+        path = state.save_review_report(
+            "skerry-reviewer", f"{self.REPORT}\x1b]0;pwned\x07 and {chr(0x202E)}drop\n", self.cwd)
+        with open(path, encoding="utf-8") as fh:
+            body = fh.read()
+        self.assertNotIn("\x1b", body)
+        self.assertNotIn(chr(0x202E), body)
+        self.assertIn("pwned", body, "the text is kept, only the bytes that act are not")
+
+    def test_a_runaway_report_is_capped(self):
+        path = state.save_review_report("skerry-reviewer", "x" * 400_000, self.cwd)
+        self.assertLess(os.path.getsize(path), state.REPORT_CHARS + 500)
+
+    def test_each_round_is_kept_rather_than_overwritten(self):
+        # Findings live on disk so a compaction cannot lose what is still owed; a second round
+        # that does not repeat a first-round item used to erase it.
+        self._branch_with_ui()
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        second = self.REPORT.replace("VaultStore.unlock", "SnippetStore.render")
+        self.assertEqual(policy.record_review("skerry-reviewer", second, self.cwd), "")
+        stored = policy.stored_report("skerry-reviewer", self.cwd)
+        self.assertIn("VaultStore.unlock", stored)
+        self.assertIn("SnippetStore.render", stored)
+
+    def test_findings_are_found_whichever_key_the_runtime_wraps_them_in(self):
+        # A response shaped {"output": …} or {"result": …} is plausible for another agent runtime;
+        # flattening it to "" would report "no findings" and snapshot a launch that never happened.
+        for key in ("content", "text", "output", "result"):
+            self.assertEqual(policy.review_findings({key: self.REPORT}), self.REPORT.strip(), key)
+
+    def test_a_response_nested_beyond_reason_is_not_a_recursion_error(self):
+        response = {"content": "the vault key is logged at INFO in VaultStore.unlock"}
+        for _ in range(4_000):
+            response = {"content": [response]}
+        self.assertEqual(policy.review_findings(response), "",
+                         "a response the walker gives up on carries no findings — it does not "
+                         "take the hook down with it")
+
+    def test_a_launch_acknowledgement_long_enough_to_pass_the_floor_is_still_not_a_review(self):
+        # The length floor alone catches the acknowledgement this harness emits today; the denylist
+        # is there for a wordier one, and nothing proved it discriminated at all.
+        stub = ("Async agent launched successfully. agentId: aae1b895f4e4935a3. The agent is "
+                "working in the background and you will be notified when it completes. Do not "
+                "duplicate its work — avoid touching the same files while it runs. Its transcript "
+                "is written to the task output file named above.")
+        self.assertGreater(len(stub), policy.MIN_REPORT_CHARS)
+        self.assertEqual(policy.review_findings(stub), "")
+
+    def test_a_report_that_quotes_the_launch_wording_is_still_a_report(self):
+        report = self.REPORT + ("\n\nThe hook's note says the agent `is working in the background` "
+                                "and prints its agentId: that string appears in this report because "
+                                "the report is about the hook, and a reviewer quoting the wording it "
+                                "reviews must not be mistaken for the wording itself. This paragraph "
+                                "exists to carry the pass over the stub length.\n")
+        self.assertGreater(len(report), policy.STUB_CHARS)
+        self.assertEqual(policy.review_findings(report), report.strip())
+
+    def test_the_review_command_reads_the_report_from_the_file_it_is_given(self):
+        # `--file` is the form the hook's own note tells the operator to use, and it was the one
+        # path through the command that no test ever took.
+        self._branch_with_ui()
+        path = os.path.join(self.cwd, "report.md")
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(self.REPORT)
+        done = self.box.gate("review", "skerry-reviewer", "--file", path)
+        self.assertEqual(done.returncode, 0, done.stdout + done.stderr)
+        self.assertIn("VaultStore.unlock", policy.stored_report("skerry-reviewer", self.cwd))
+
+    def test_a_report_file_it_cannot_read_is_not_a_recorded_review(self):
+        self._branch_with_ui()
+        done = self.box.gate("review", "skerry-reviewer", "--file",
+                             os.path.join(self.cwd, "nothing-here.md"))
+        self.assertEqual(done.returncode, 2)
+        self.assertIn("cannot read the report", done.stdout)
+
+    def test_a_reviews_directory_that_already_exists_is_tightened(self):
+        # makedirs(mode=) and os.open(mode=) both ignore the mode when the target already exists,
+        # so the hardening reached new state directories only — every report written before it
+        # stayed world-readable, and so did the directory holding them.
+        path = state.review_report_path("skerry-reviewer", self.cwd)
+        os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
+        os.chmod(os.path.dirname(path), 0o755)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("# skerry-reviewer\n\nan earlier round, written before the hardening\n")
+        os.chmod(path, 0o644)
+        state.save_review_report("skerry-reviewer", self.REPORT, self.cwd)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+        self.assertEqual(os.stat(os.path.dirname(path)).st_mode & 0o777, 0o700)
+
+    def test_a_snapshot_from_another_branch_does_not_refuse_this_branchs_report(self):
+        # The drift snapshot outlived the branch it was taken on, so the first report on the next
+        # branch was refused as "moved" — every file differs across a branch switch.
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        run_git(self.cwd, "checkout", "-q", "-b", "feat/next")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        self.assertEqual(policy.review_drift("skerry-reviewer", self.cwd), [])
+        self.assertEqual(policy.record_review("skerry-reviewer", self.REPORT, self.cwd), "")
+
+    def test_a_payload_field_of_the_wrong_type_does_not_break_the_session(self):
+        done = self.box.raw_hook({"tool_name": "Agent", "tool_input": {"subagent_type": 123}})
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertNotIn("Traceback", done.stderr)
+
+    def test_a_payload_the_hook_cannot_read_does_not_break_the_session(self):
+        # Every other I/O path in the harness is wrapped; a hook that raises turns a bad payload
+        # into a traceback on every Agent call.
+        done = self.box.raw_hook({"tool_name": "Agent", "tool_input": "not a dict"})
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertNotIn("Traceback", done.stderr)
+
+    def test_an_entry_with_no_findings_on_disk_is_still_owed(self):
+        self._branch_with_ui()
+        st = state.load(self.cwd)
+        st["reviews"] = {"skerry-reviewer": {
+            "digest": policy.reviewer_digest("skerry-reviewer", self.cwd),
+            "branch": state.current_branch(self.cwd)}}
+        state.save(st, self.cwd)
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-reviewer", missing)
+
+    def test_the_review_command_reports_what_it_refused(self):
+        self._branch_with_ui()
+        self.assertEqual(self.box.gate("review", "not-a-reviewer", stdin=self.REPORT).returncode, 2)
+        stub = self.box.gate("review", "skerry-reviewer", stdin="ok")
+        self.assertEqual(stub.returncode, 2)
+        self.assertIn("no findings", stub.stdout)
+        good = self.box.gate("review", "ecc:skerry-reviewer", stdin=self.REPORT)
+        self.assertEqual(good.returncode, 0, good.stdout + good.stderr)
+        self.assertIn("recorded", good.stdout)
+
+    def test_the_review_command_names_the_files_to_re_read(self):
+        self._branch_with_ui()
+        self.box.recorder("skerry-reviewer", "Async agent launched successfully. agentId: abc")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 2\n")
+        refused = self.box.gate("review", "skerry-reviewer", stdin=self.REPORT)
+        self.assertEqual(refused.returncode, 2)
+        self.assertIn("has since moved", refused.stdout)
+        self.assertIn("composeApp/src/commonMain/kotlin/S.kt", refused.stdout)
+
+    def test_a_state_directory_it_cannot_write_is_not_a_saved_state(self):
+        self._branch_with_ui()
+        directory = os.path.dirname(state.state_path(self.cwd))
+        os.makedirs(directory, exist_ok=True)
+        os.chmod(directory, 0o500)
+        self.addCleanup(os.chmod, directory, 0o700)
+        self.assertFalse(state.save({"stages": {}}, self.cwd),
+                         "a write that raised is not a write that happened")
+
+    def test_a_launch_acknowledgement_is_not_a_review(self):
+        # The fan-out runs in the background, so the reply to the launch carries no findings. The
+        # hook used to pin the tree to it, which made a green review gate mean "agents started".
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+        stub = ("Async agent launched successfully.\nagentId: abc123\n"
+                "The agent is working in the background.")
+        self.assertEqual(policy.record_review("skerry-reviewer", stub, self.cwd), "no findings")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertIn("skerry-reviewer", missing)
+
+    def test_findings_record_the_reviewer_against_the_tree_it_read(self):
+        self.box.branch("feat/thing")
+        self.box.write("composeApp/src/commonMain/kotlin/S.kt", "val a = 1\n")
+        report = {"content": [{"text": "## Findings\n\n- the vault key is logged at INFO in "
+                                       "VaultStore.unlock, so a support bundle carries it out of "
+                                       "the machine. Everything else in the diff is clean: no new "
+                                       "primitive, no parity gap, no swallowed cancellation.\n"}]}
+        self.assertEqual(policy.record_review("skerry-reviewer", report, self.cwd), "")
+        missing = policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd),
+                                           self.cwd)
+        self.assertNotIn("skerry-reviewer", missing)
+        with open(state.review_report_path("skerry-reviewer", self.cwd), encoding="utf-8") as fh:
+            self.assertIn("the vault key is logged", fh.read())
+
     def test_an_empty_report_is_not_written(self):
         self.assertEqual(state.save_review_report("skerry-reviewer", "   ", self.cwd), "")
 
     def test_a_reviewer_name_cannot_escape_the_state_directory(self):
         path = state.review_report_path("../../etc/passwd", self.cwd)
         self.assertNotIn("..", path)
+
+
+class TestHarnessRed(SandboxCase):
+    """A bug in the gate has to be provable the same way a bug in the client is.
+
+    Making `.py` files code closed a hole and opened this one: on a `fix/` branch touching nothing
+    but the harness, the gate demanded a RED record that no Gradle task could produce.
+    """
+
+    STUB = ("import unittest\n\n\nclass StubHarness(unittest.TestCase):\n"
+            "    def test_the_bug_is_reproduced(self):\n        {body}\n\n\n"
+            "if __name__ == '__main__':\n    unittest.main()\n")
+
+    def _suite(self, body: str) -> None:
+        self.box.branch("fix/hook-refusal")
+        self.box.write("tools/harness/selftest.py", self.STUB.format(body=body))
+
+    def test_a_failing_harness_test_records_the_red_phase(self):
+        self._suite("self.fail('the report is recorded on a launch')")
+        done = self.box.gate("red", "--tests", "*the_bug_is_reproduced*",
+                             "--file", "tools/harness/policy.py")
+        self.assertEqual(done.returncode, 0, done.stdout)
+        record = state.load(self.cwd)["red"][0]
+        self.assertEqual(record["task"], "selftest")
+        self.assertEqual(record["branch"], "fix/hook-refusal")
+
+    def test_a_harness_test_that_passes_proves_nothing(self):
+        self._suite("self.assertTrue(True)")
+        done = self.box.gate("red", "--tests", "*the_bug_is_reproduced*",
+                             "--file", ".claude/hooks/record-review.py")
+        self.assertEqual(done.returncode, 1)
+        self.assertIn("PASSED", done.stdout)
+
+    def test_editing_only_the_suite_does_not_count_as_the_fix(self):
+        # The suite has to sit outside the `src` digest, exactly as Kotlin test sources do —
+        # otherwise the RED phase can be closed by weakening the test that proved the bug.
+        self._suite("self.fail('the report is recorded on a launch')")
+        self.assertTrue(state.is_test("tools/harness/selftest.py"))
+        done = self.box.gate("red", "--tests", "*the_bug_is_reproduced*",
+                             "--file", "tools/harness/policy.py")
+        self.assertEqual(done.returncode, 0, done.stdout)
+        self.box.write("tools/harness/selftest.py", self.STUB.format(body="self.assertTrue(True)"))
+        _, debt = policy.gate_debt(self.cwd)
+        self.assertTrue(any(item.startswith("red") for item in debt),
+                        "a test-only edit is not a fix")
+
+    def test_a_pattern_that_is_an_option_is_refused(self):
+        # `--tests '*-v*'` strips to `-v`, which unittest's own argparse rejects with exit 2 — a
+        # usage error was recorded as a test that failed.
+        self._suite("self.fail('never reached')")
+        done = self.box.gate("red", "--tests", "*-v*", "--file", "tools/harness/policy.py")
+        self.assertEqual(done.returncode, 2, done.stdout)
+        self.assertNotIn("red", state.load(self.cwd))
+
+    def test_a_suite_that_cannot_run_is_not_a_failing_test(self):
+        self.box.branch("fix/hook-refusal")
+        self.box.write("tools/harness/selftest.py", "import nothing_that_exists\n")
+        done = self.box.gate("red", "--tests", "*the_bug_is_reproduced*",
+                             "--file", "tools/harness/policy.py")
+        self.assertEqual(done.returncode, 2, done.stdout)
+        self.assertNotIn("red", state.load(self.cwd))
+
+    def test_a_pattern_that_matches_no_harness_test_is_refused(self):
+        self._suite("self.fail('never reached')")
+        done = self.box.gate("red", "--tests", "*NoSuchTest*",
+                             "--file", "tools/harness/state.py")
+        self.assertEqual(done.returncode, 2)
+        self.assertIn("matched no test", done.stdout)
+        self.assertNotIn("red", state.load(self.cwd))
+
+
+class TestRedEvidence(unittest.TestCase):
+    """A non-zero exit is not a failing test — in either runner."""
+
+    def test_a_gradle_run_that_never_reached_a_test_is_not_red(self):
+        compile_error = ("> Task :shared:compileKotlinJvm FAILED\n"
+                         "e: file:///s/A.kt:3:1 expecting a top level declaration\n"
+                         "FAILURE: Build failed with an exception.\n")
+        self.assertFalse(gate.proves_a_failing_test(":shared:jvmTest", compile_error))
+        failing = ("> Task :shared:jvmTest FAILED\n\nAT > a() FAILED\n\n"
+                   "3 tests completed, 1 failed\n\nFAILURE: Build failed with an exception.\n"
+                   "> There were failing tests. See the report at: file:///s/index.html\n")
+        self.assertTrue(gate.proves_a_failing_test(":shared:jvmTest", failing))
+
+    def test_the_harness_suite_keeps_its_own_evidence(self):
+        self.assertTrue(gate.proves_a_failing_test(
+            gate.HARNESS_SUITE, "Ran 3 tests in 1.0s\n\nFAILED (failures=1)\n"))
+        self.assertFalse(gate.proves_a_failing_test(
+            gate.HARNESS_SUITE, "ImportError: cannot import name policy\n"))
+
+
+class TestStateFile(SandboxCase):
+    def test_the_state_file_is_readable_only_by_its_operator(self):
+        # It carries the branch, every path in the change and the reviewers' verdicts; on a shared
+        # machine the default 0644 hands all of that to anyone with an account.
+        state.save({"reviews": {}}, self.cwd)
+        path = state.state_path(self.cwd)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+        self.assertEqual(os.stat(os.path.dirname(path)).st_mode & 0o777, 0o700)
+
+    def test_a_state_directory_that_already_exists_is_tightened(self):
+        path = state.state_path(self.cwd)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        os.chmod(os.path.dirname(path), 0o755)
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write("{}")
+        os.chmod(path, 0o644)
+        state.save({"reviews": {}}, self.cwd)
+        self.assertEqual(os.stat(path).st_mode & 0o777, 0o600)
+        self.assertEqual(os.stat(os.path.dirname(path)).st_mode & 0o777, 0o700)
+
+
+class TestSharedDefinitions(unittest.TestCase):
+    def test_the_invisible_byte_list_has_one_definition(self):
+        # One list keeps the byte out of source, the other strips it from a stored report before
+        # the operator cats it. Two copies means a byte added to one is caught by neither.
+        # Identity, not equality: `re.compile` caches by pattern string, so two independent
+        # definitions of the same ranges hand back the same compiled object and an equality test
+        # would pass while the duplication stood.
+        self.assertIs(checks.CONTROL_RANGES, state.CONTROL_RANGES)
 
 
 class TestStageRecording(SandboxCase):

--- a/tools/harness/state.py
+++ b/tools/harness/state.py
@@ -19,20 +19,43 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 
 # Suffixes that can change what the build produces or how it behaves.
 CODE_SUFFIXES = (
     ".kt", ".kts", ".java", ".xml", ".toml", ".properties", ".pro", ".json", ".sql", ".gradle",
+    # The harness is code the gate depends on: editing a rule used to move no digest at all, so a
+    # rule could be deleted after its stage had already been recorded green.
+    ".py",
 )
-# Trees that never enter a Gradle build: prose, the harness itself, CI definitions, assets.
+# Trees that never enter a build: prose, CI definitions, assets.
 IGNORED_PREFIXES = (
-    "docs/", "licenses/", ".claude/", "tools/", ".github/", ".idea/", "build/",
+    "docs/", "licenses/", ".github/", ".idea/", "build/",
 )
+# Instructions the gate executes: the reviewers it launches, and the slash commands
+# that drive the fan-out and the kind declaration. Prose everywhere else stays prose.
+AGENT_PREFIX = (".claude/agents/", ".claude/commands/")
 IGNORED_SUFFIXES = (".md", ".png", ".jpg", ".jpeg", ".svg", ".webp", ".ico", ".ttf", ".otf")
 # Path fragments that mark a source file as a test — used to tell "the fix" from "the test" when
 # proving the RED phase of a bug fix.
-TEST_MARKERS = ("/commonTest/", "/desktopTest/", "/androidTest/", "/jvmTest/", "/test/", "Test.kt")
+TEST_MARKERS = ("/commonTest/", "/desktopTest/", "/androidTest/", "/jvmTest/", "/test/", "Test.kt",
+                # The harness's own suite, for the same reason: a RED phase must not be closable
+                # by weakening the test that proved the bug.
+                "selftest.py")
+
+# Written out from code points on purpose: the subject is invisible characters, and a literal one
+# here would be unreviewable. C0 minus tab/LF/CR, then the zero-width and bidi overrides.
+CONTROL_RANGES = (
+    (0x00, 0x08), (0x0B, 0x0C), (0x0E, 0x1F), (0x7F, 0x9F),  # C0 minus tab/LF/CR, DEL, C1
+    (0x061C, 0x061C),                                        # Arabic letter mark, a bidi control
+    (0x200B, 0x200F), (0x202A, 0x202E), (0x2060, 0x2064), (0x2066, 0x2069), (0xFEFF, 0xFEFF),
+    (0x2028, 0x2029),  # line and paragraph separators: invisible, and Python splits lines on them
+)
+CONTROL_CHARS = re.compile(
+    "[" + "".join(f"\\U{lo:08X}-\\U{hi:08X}" for lo, hi in CONTROL_RANGES) + "]")
+# Roughly a long review round. A runaway report is a broken reviewer, not findings to keep.
+REPORT_CHARS = 200_000
 
 STATE_DIR = "skerry-gate"
 STATE_FILE = "state.json"
@@ -42,11 +65,19 @@ REVIEWS_DIR = "reviews"
 def git(args: list[str], cwd: str | None = None) -> tuple[int, str]:
     """Run git and return (exit code, stdout). Never raises: callers degrade instead."""
     try:
+        env = dict(os.environ)
+        # A file named `:(attr:x)Payload.kt` is a pathspec that matches nothing, so its content is
+        # never diffed and no rule ever sees it.
+        env["GIT_LITERAL_PATHSPECS"] = "1"
         out = subprocess.run(
-            ["git"] + args, capture_output=True, text=True, timeout=30, cwd=cwd,
+            ["git"] + args, capture_output=True, text=True, errors="replace", timeout=30, cwd=cwd,
+            env=env,
         )
         return out.returncode, out.stdout
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, ValueError):
+        # errors="replace" is the point: git hands back path names as raw bytes, and one file whose
+        # name is not UTF-8 used to raise out of every digest — into the commit guard, which
+        # catches everything and allows. A name the harness cannot spell is not a gate it skips.
         return 1, ""
 
 
@@ -77,18 +108,31 @@ def load(cwd: str | None = None) -> dict:
         return {}
 
 
-def save(state: dict, cwd: str | None = None) -> None:
+def save(state: dict, cwd: str | None = None) -> bool:
+    """Persist the gate state. False when it did not land — a caller that reports success to the
+    user has to know; the harness itself still never raises, so nothing it guards breaks."""
     path = state_path(cwd)
     if not path:
-        return
+        return False
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # The file carries the branch, every path in the change and the reviewers' verdicts.
+        # `os.open`'s mode only applies to a file it creates, so the modes are set again after the
+        # rename: a directory or a leftover `.tmp` from an older version keeps its own otherwise.
+        directory = os.path.dirname(path)
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        if os.stat(directory).st_mode & 0o077:
+            # Only when it is actually loose: a directory made read-only on purpose stays that
+            # way, and a save into it fails the way the caller expects.
+            os.chmod(directory, 0o700)
         tmp = path + ".tmp"
-        with open(tmp, "w", encoding="utf-8") as fh:
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(state, fh, indent=2, sort_keys=True)
         os.replace(tmp, path)
+        os.chmod(path, 0o600)
+        return True
     except OSError:
-        pass  # the harness must never break the session it guards
+        return False  # the harness must never break the session it guards
 
 
 def log_path(stage: str, cwd: str | None = None) -> str:
@@ -103,27 +147,48 @@ def review_report_path(reviewer: str, cwd: str | None = None) -> str:
 
 
 def save_review_report(reviewer: str, text: str, cwd: str | None = None) -> str:
-    """Keep a reviewer's findings on disk.
+    """Keep a reviewer's findings on disk, one round after another.
 
     Findings used to live only in the session context, so a compaction silently dropped the list
     of what still had to be fixed. On disk they survive it, and the next round can be scoped to
-    what is actually left instead of running the whole fan-out again to rediscover it.
+    what is actually left instead of running the whole fan-out again to rediscover it. Rounds are
+    appended rather than replaced: a round-1 item the next pass does not repeat is still owed.
+
+    The text is a reviewer's quotation of what it read — terminal fixtures, file names off an SFTP
+    listing, an AI transcript. Escape sequences in it would run in the operator's terminal on a
+    `cat`, so they are stripped, and the length is capped: nothing that arrives here is trusted
+    beyond being someone's prose.
     """
     path = review_report_path(reviewer, cwd)
-    if not path or not text.strip():
+    body = CONTROL_CHARS.sub("", text.strip())[:REPORT_CHARS]
+    if not path or not body:
         return ""
     try:
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        header = f"# {reviewer}\n\nbranch: {current_branch(cwd)}\nat: {_now():.0f}\n\n"
-        with open(path, "w", encoding="utf-8") as fh:
-            fh.write(header + text.strip() + "\n")
+        directory = os.path.dirname(path)
+        os.makedirs(directory, mode=0o700, exist_ok=True)
+        header = f"\n# {reviewer}\n\nbranch: {current_branch(cwd)}\nat: {_now():.0f}\n\n"
+        # 0600 through os.open: the file is a verbatim copy of whatever path the operator named,
+        # and `.git` is never cleaned. A default-mode open leaves it world-readable for good.
+        # Both mode arguments below are ignored when the target already exists, so a directory or
+        # a report written before this rule stayed world-readable. Tighten first, so the round
+        # about to be appended is never briefly world-readable.
+        os.chmod(directory, 0o700)
+        if os.path.exists(path):
+            os.chmod(path, 0o600)
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        with os.fdopen(fd, "a", encoding="utf-8") as fh:
+            fh.write(header + body + "\n")
         return path
     except OSError:
         return ""  # the harness must never break the session it guards
 
 
 def is_code(path: str) -> bool:
-    """Whether a repo-relative path takes part in a Gradle build."""
+    """Whether a repo-relative path takes part in a Gradle build, or in the gate that guards it."""
+    # Prose everywhere else, but an agent definition is what a reviewer executes: editing one
+    # changes what the review gate looks for, and it used to move no digest at all.
+    if path.startswith(AGENT_PREFIX):
+        return True
     if path.startswith(IGNORED_PREFIXES) or path.endswith(IGNORED_SUFFIXES):
         return False
     if "/build/" in path:


### PR DESCRIPTION
Closes #281.

## Resource strings

Compose Resources decodes only `\n`, `\t`, `\uXXXX` and `\\`. Every other Android-style escape
reaches the screen verbatim, so `Disconnect \"my-host\"?` rendered with the backslashes visible.

- 26 lines of over-escaped `\"` / `\'` / `\@` / `\?` fixed across `values`, `values-ru` and `values-zh`,
  and the quotes replaced with the typographic pair each locale uses (`“ ”`, `« »`, `「 」`).
- Substitution is `Regex("%(\\d+)\\$[ds]")`, not `String.format`: `%%` stayed doubled on screen and
  a bare `%s` / `%d` was never filled. Four keys carried one of those (`mon_alert_memory`,
  `mon_alert_swap`, `sftp_queue_progress`, `rd_screenshot_saved`).
- `strings_ports.xml` declares the `one` category English plurals were relying on the `other`
  fallback for.

`StringEscapeTest` renders every string, array and plural in all three locales — 1870 strings,
11 plurals — and fails on a stray escape, a foreign quote character, or a format artifact that
reached the rendered text. It is a corpus sweep, so a resource added later is covered without
touching the test.

## Deterministic checks

`tools/harness/checks.py` now enforces the same properties on every future change:

- i18n parity covers `<plurals>` and `<string-array>` as well as `<string>`, keyed by kind, with
  the CLDR categories each locale owes (en: one/other, ru: one/few/many/other, zh: other) and an
  empty `<item>` counted as missing.
- `Res.plurals.*` and `Res.array.*` usages are resolved against the resource files, not just
  `Res.string.*`.
- A locale file that cannot be read or decoded is reported as an incomplete sweep instead of
  passing as untranslated.
- The control-character rule runs before comments are skipped — trojan source lives in comments
  by construction.

## Review gate

The gate reported "clear — commit and PR are unblocked" while five reviewers were still running:
the PostToolUse hook recorded a reviewer when the Agent tool returned, and a backgrounded fan-out
returns a launch acknowledgement before reading a line. "Reviewed" meant "started".

- A reply with no findings is refused, and the reviewer's scope is snapshotted instead, so an edit
  made while it reads is visible when the report arrives.
- `tools/harness/gate.py review <agent> --file <report>` records a report that arrives later, and
  refuses one written against a tree that has since moved, one already on disk, and one carrying
  another reviewer's name. The refusal no longer resets the snapshot it refused on.
- Findings are written to `.git/skerry-gate/reviews/<agent>.md` before the state entry, one round
  appended after another, stripped of control bytes, capped, and 0600 in a 0700 directory.
- A reviewer's pass is scoped to the branch it was made on, the way a RED record already was.
- The harness itself is code the gate depends on: `.py` files move the digest, a change to them
  owes `python3 tools/harness/selftest.py`, and it is inside the security reviewer's scope. A
  change that touches nothing but the harness owes no Gradle stage.

- The classification cannot be argued down: a declaration is honoured only when it is at least as
  strict as the branch name implies, and a `docs/` branch carrying code is a `feature`.
- The rules read what git actually wrote: `--text` and `GIT_LITERAL_PATHSPECS=1` so a `.gitattributes`
  entry cannot hide a file, and hunks split on `\n` alone so a `\v` or `\x1c` in a line cannot
  truncate what the checks see.
- A RED record needs the runner's own evidence — `Ran N tests` followed by `FAILED (` — and a
  `--tests` pattern that is not option-shaped.

`selftest.py` is at 153 cases, ~10s, no Gradle. Every rule above was mutation-checked: reverting the
guard fails exactly its own test.

## Verification

Desktop and Android builds, `test allTests`, `detektAll` and `:androidApp:compileDebugKotlin` are
green. The rendered dialogs were not checked on a running client or an Android device.
