### PR TITLE
Keep the profile intact when its credential is deleted

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/host/HostManagerController.kt
@@ -183,6 +183,24 @@ class HostManagerController(
         hosts = canonicalHosts()
     }
 
+    /**
+     * Drop every profile's reference to the vault secret [credentialId], which is about to be
+     * deleted. Written straight onto the stored hosts, not through a [HostDraft]: a draft carries
+     * the form's fields, so rebuilding one here would rewrite everything it does not name — the
+     * profile's type first of all — back to its default.
+     *
+     * One [HostStore.reorder] pass rather than a write per host: read-compute-write happens under
+     * the store's lock over the store's own snapshot, so a sync merge landing between the dialog's
+     * last recomposition and this call is not clobbered by a stale record, and a host the merge
+     * rebound to another secret keeps it — only the id being deleted is cleared.
+     */
+    fun unbindCredential(credentialId: String) {
+        store.reorder { all ->
+            all.map { if (it.credentialId == credentialId) it.copy(credentialId = null) else it }
+        }
+        hosts = canonicalHosts()
+    }
+
     fun delete(id: String) {
         store.remove(id)
         hosts = canonicalHosts()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -149,7 +149,6 @@ import app.skerry.ui.vault.mockSecrets
 import app.skerry.ui.vault.rememberCertInfo
 import app.skerry.ui.vault.rememberKeyInfo
 import app.skerry.ui.vault.secretMetaLine
-import app.skerry.ui.vault.unbindCredential
 import app.skerry.ui.theme.Skerry
 
 /**
@@ -348,9 +347,11 @@ private fun MobileVaultLive(state: MobileDesignState, credentials: CredentialMan
                 onConfirm = {
                     // The cascade is consistent only with a live hostsController (always present behind the
                     // gate): first unbind hosts so they don't reference the deleted secret, then delete it.
+                    // A vault known to be locked abandons the delete — see the desktop cascade for why the
+                    // check is `!= false`.
                     val hc = hostsController
-                    if (hc != null) {
-                        bound.forEach { host -> hc.save(host.unbindCredential()) }
+                    if (hc != null && vault?.isUnlocked != false) {
+                        hc.unbindCredential(victim.id)
                         credentials.delete(victim.id)
                         if (selectedId == victim.id) selectedId = null
                     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -63,7 +63,6 @@ import app.skerry.ui.generated.resources.vault_generate_key
 import app.skerry.ui.generated.resources.vault_import_certificate
 import app.skerry.ui.generated.resources.vault_link_key_file
 import app.skerry.ui.generated.resources.vault_sidebar_header
-import app.skerry.ui.host.HostDraft
 import app.skerry.ui.host.rowLabel
 import app.skerry.ui.identity.CredentialDraft
 import app.skerry.ui.identity.CredentialKind
@@ -315,7 +314,7 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                 onDismiss = { pendingEditCred = null },
                 onConfirm = { newLabel, newNote ->
                     // Abort on a lock race: idle auto-lock can fire while the dialog is open, and vault
-                    // CRUD throws once locked. Mirrors the delete guard just below.
+                    // CRUD throws once locked.
                     if (vault?.isUnlocked == true) credentials.edit(target.id, newLabel, newNote)
                     pendingEditCred = null
                 },
@@ -331,11 +330,13 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
                 onDismiss = { pendingDeleteCred = null },
                 onConfirm = {
                     // The cascade is only consistent with a live hostsController; otherwise hosts would keep
-                    // referencing a deleted secret. Always present past the gate; the guard protects against
-                    // a lock race while the dialog is open (in which case the whole delete is aborted).
+                    // referencing a deleted secret. Always present past the gate. Idle auto-lock can fire in
+                    // the same frame as this click and vault CRUD throws once locked, so a vault known to be
+                    // locked abandons the delete instead of throwing out of the click handler. `!= false`,
+                    // not `== true`: no vault at all is the design/preview wiring, which must still run.
                     val hc = hostsController
-                    if (hc != null) {
-                        bound.forEach { host -> hc.save(host.unbindCredential()) }
+                    if (hc != null && vault?.isUnlocked != false) {
+                        hc.unbindCredential(victim.id)
                         credentials.delete(victim.id)
                         if (selectedId == victim.id) selectedId = null
                     }
@@ -362,9 +363,6 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
         }
     }
 }
-
-internal fun Host.unbindCredential(): HostDraft =
-    HostDraft(id = id, label = label, address = address, port = port, username = username, group = group, credentialId = null)
 
 // Left category sidebar (live counters) + header with the category action.
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostManagerControllerTest.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.host
 
+import app.skerry.shared.container.ContainerRuntime
+import app.skerry.shared.container.ContainerSpec
 import app.skerry.shared.host.Host
 import app.skerry.shared.ssh.ConnectionType
 import app.skerry.shared.host.HostStore
@@ -203,6 +205,71 @@ class HostManagerControllerTest {
         )
 
         assertEquals(listOf("prod", "db"), controller.hosts.single().tags)
+    }
+
+    @Test
+    fun `unbinding a deleted secret changes nothing but the credential reference`() {
+        // Issue #280: deleting the password of an RDP host used to rewrite the profile as a plain
+        // SSH one, so it vanished from Remote Desktops along with its tags and notes.
+        val jump = Host("j", "bastion", "b.local", 22, "u")
+        val rdp = Host(
+            id = "1",
+            label = "win",
+            address = "w.local",
+            port = 3389,
+            username = "admin",
+            group = "Prod",
+            credentialId = "key-1",
+            interactiveAuth = false,
+            tags = listOf("prod", "win"),
+            aiPolicy = app.skerry.shared.ai.AiPolicy.Balanced,
+            connectionType = ConnectionType.RDP,
+            jumpHostId = "j",
+            keepAliveSeconds = 0,
+            vncResizeToWindow = true,
+            vncQuality = app.skerry.shared.graphics.RemoteDesktopQuality.High,
+            notes = "ask ops before reboot",
+            container = ContainerSpec(runtime = ContainerRuntime.DOCKER, target = "api"),
+            rdp = RdpSpec(loadBalanceInfo = "tsv://farm", audioOutput = true),
+        )
+        val store = FakeHostStore(jump, rdp)
+        val controller = HostManagerController(store) { error("must not be called") }
+
+        controller.unbindCredential("key-1")
+
+        assertEquals(rdp.copy(credentialId = null), controller.find("1"))
+        assertEquals(rdp.copy(credentialId = null), store.all().first { it.id == "1" })
+    }
+
+    @Test
+    fun `unbinding a secret reads the store, not the list the dialog was drawn from`() {
+        // The dialog is drawn from the controller's snapshot, but a sync merge writes HOST records
+        // straight into the vault and the reload lands afterwards. Matching on the snapshot would
+        // miss a host the merge bound to the victim, and would clear one it rebound to a live secret.
+        val store = FakeHostStore(
+            Host("1", "a", "a.local", 22, "u", credentialId = "key-1"),
+            Host("2", "b", "b.local", 22, "u", credentialId = "key-1"),
+        )
+        val controller = HostManagerController(store) { error("must not be called") }
+        // What the merge did behind the controller's back — no reload() before the click.
+        store.put(Host("1", "a", "a.local", 22, "u", credentialId = "key-2"))
+        store.reorder { all -> all.map { if (it.id == "2") it.copy(credentialId = "key-1") else it } }
+
+        controller.unbindCredential("key-1")
+
+        val stored = store.all().associateBy { it.id }
+        assertEquals("key-2", stored.getValue("1").credentialId, "a host rebound to a live secret keeps it")
+        assertNull(stored.getValue("2").credentialId, "a host the merge left on the victim is unbound")
+    }
+
+    @Test
+    fun `unbinding a secret nothing references is a no-op`() {
+        val store = FakeHostStore(Host("1", "a", "a.local", 22, "u", credentialId = "key-1"))
+        val controller = HostManagerController(store) { error("must not be called") }
+
+        controller.unbindCredential("gone")
+
+        assertEquals("key-1", controller.find("1")?.credentialId)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostTestSupport.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/host/HostTestSupport.kt
@@ -25,6 +25,11 @@ internal class FakeHostStore(initial: List<Host> = emptyList()) : HostStore {
 
     override fun reorder(transform: (List<Host>) -> List<Host>) {
         val updated = transform(entries.toList())
+        // The precondition VaultHostStore enforces: a fake that accepts anything lets a transform
+        // that drops or duplicates a profile pass every test and throw in production.
+        require(updated.size == entries.size && updated.map { it.id }.toSet() == entries.map { it.id }.toSet()) {
+            "reorder must preserve the id set (had ${entries.size}, got ${updated.size})"
+        }
         entries.clear()
         entries += updated
     }

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotSeeds.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotSeeds.kt
@@ -74,7 +74,8 @@ internal fun seedFakeHome() {
 
 /**
  * In-memory host catalog with demo profiles, for the offscreen render of a live sidebar only.
- * [boundCredentialId] (if given) is attached to a pair of hosts so Vault shows "Used by hosts".
+ * [boundCredentialId] (if given) is attached to a pair of shell hosts and one remote desktop, so Vault
+ * shows "Used by hosts" and the unbind cascade crosses connection types.
  */
 internal fun seededHosts(boundCredentialId: String? = null): HostManagerController {
     val store = object : HostStore {
@@ -94,7 +95,12 @@ internal fun seededHosts(boundCredentialId: String? = null): HostManagerControll
         Host("h3", "homelab-pi", "10.0.0.12", 22, "pi", "Homelab", tags = listOf("docker")),
         Host("h4", "vps-edge", "vps.example.com", 2222, "deploy", null, tags = listOf("edge")),
         // Remote desktops: their own section in the shell, so the demo catalog seeds both kinds.
-        Host("h5", "lab-desktop", "10.0.0.30", 5900, "", "Homelab", connectionType = ConnectionType.VNC),
+        // Bound like the pair above: a secret shared by a shell host and a remote desktop is what
+        // makes the vault's unbind cascade cross connection types (issue #280).
+        Host(
+            "h5", "lab-desktop", "10.0.0.30", 5900, "", "Homelab",
+            credentialId = boundCredentialId, connectionType = ConnectionType.VNC,
+        ),
         Host("h6", "win-bench", "10.0.0.31", 5901, "", null, connectionType = ConnectionType.VNC, tags = listOf("lab")),
     ).forEach(store::put)
     var seq = 0

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultSecretsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultSecretsTest.kt
@@ -49,7 +49,8 @@ class VaultSecretsTest {
     fun `deleting a secret unbinds the hosts that used it`() = runDesktopShell { shell ->
         openVault()
         val credential = shell.credentialId(KEY_SECRET)
-        assertTrue(shell.hosts.hosts.any { it.credentialId == credential })
+        val boundBefore = shell.hosts.hosts.filter { it.credentialId == credential }
+        assertTrue(boundBefore.isNotEmpty())
 
         onNodeWithText(KEY_SECRET).performClick()
         waitForIdle()
@@ -64,6 +65,13 @@ class VaultSecretsTest {
             emptyList(),
             shell.hosts.hosts.filter { it.credentialId == credential }.map { it.label },
             "a host left pointing at a deleted secret fails at connect time, not here",
+        )
+        // Issue #280: the cascade used to rebuild each bound host from a partial draft, so the
+        // profile came back as a plain SSH one without its tags. Only the binding may change.
+        assertEquals(
+            boundBefore.map { it.copy(credentialId = null) },
+            boundBefore.map { before -> shell.hosts.find(before.id) },
+            "unbinding must not rewrite anything else on the profile",
         )
         onNodeWithText(KEY_SECRET).assertDoesNotExist()
     }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/host/VaultHostStore.kt
@@ -86,6 +86,11 @@ class VaultHostStore(
         // group list, and writing the new host order over a record we could not read would replace
         // that list with an empty one. The profile changes above are already committed.
         val existing = layout.readOrNull() ?: return@transaction
-        layout.write(existing.copy(hostOrder = updated.map { it.id }))
+        // Only when the order actually moved: a content-only transform (renameGroup, unbinding a
+        // deleted secret) would otherwise bump the layout record on every call, and that record is
+        // the whole account's host order under LWW — a device still holding an older order would
+        // push it back over a reorder made elsewhere.
+        val order = updated.map { it.id }
+        if (order != existing.hostOrder) layout.write(existing.copy(hostOrder = order))
     }
 }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/host/VaultHostStoreTest.kt
@@ -143,6 +143,20 @@ class VaultHostStoreTest {
     }
 
     @Test
+    fun `a content-only reorder does not bump the layout record`() {
+        // The layout record is the whole account's host order under LWW: bumping it on a transform
+        // that only rewrote a field (renameGroup, unbinding a deleted secret) would let a device
+        // holding an older order push it back over a reorder made elsewhere.
+        val vault = FakeVault()
+        val store = VaultHostStore(vault)
+        store.put(host("a")); store.put(host("b"))
+        val before = vault.records().single { it.id == WorkspaceLayoutStore.LAYOUT_ID }.version
+        store.reorder { list -> list.map { if (it.id == "a") it.copy(group = "prod") else it } }
+        val after = vault.records().single { it.id == WorkspaceLayoutStore.LAYOUT_ID }.version
+        assertEquals(before, after)
+    }
+
+    @Test
     fun `jump host reference survives persist and reload`() {
         val vault = FakeVault()
         VaultHostStore(vault).put(host("web").copy(jumpHostId = "bastion"))


### PR DESCRIPTION
Deleting a stored password unbound every host that referenced it by rebuilding each one from a `HostDraft` carrying seven of the seventeen fields a `Host` has. The draft's defaults then took over: `connectionType` fell back to SSH, so an RDP or VNC profile disappeared from Remote Desktops, and `tags`, `notes`, `container`, `jumpHostId`, `aiPolicy`, `keepAliveSeconds` and `interactiveAuth` were reset. The lost tags also stripped the host of its production confirmation gate, and the lost `jumpHostId` turned a bastion-only profile into a direct dial.

## What changed

`HostManagerController.unbindCredential` takes the credential id and clears it in one `HostStore.reorder` pass: read-compute-write under the store's lock over the store's own snapshot, so a sync merge landing between the dialog's last recomposition and the click is not overwritten by a stale record, and a host that merge rebound to a surviving secret keeps it. The `Host.unbindCredential` draft extension is gone; `NewConnectionFormState.toDraft` is now the only `HostDraft` producer.

`VaultHostStore.reorder` writes the workspace layout record only when the order actually moved. That record is the whole account's host order under LWW, and a content-only transform — renaming a group or unbinding a secret — used to bump it on every call, letting a device holding an older order push it back over a reorder made elsewhere.

The delete cascade aborts on a vault known to be locked instead of throwing out of the click handler; no vault at all is the design wiring and still runs.

## Tests

- Three controller cases: whole-record equality on a maximally populated RDP profile, another secret left alone, the store read rather than the dialog's snapshot.
- A layout-version case in `VaultHostStoreTest`.
- `VaultSecretsTest` compares each survivor of the real delete dialog with `before.copy(credentialId = null)`, with a remote desktop bound to the seeded secret so `connectionType` is in the assertion.
- `FakeHostStore.reorder` enforces the id-set precondition the production store has.

## Verify

1. Remote Desktops: create an RDP host with a stored password, give it a tag and a note.
2. Vault: delete that password and confirm.
3. The host stays in Remote Desktops with its type, tag and note; connecting asks for a password.

Closes #280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)