### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.3.3
-skerry.versionCode=12
+skerry.versionName=0.3.4
+skerry.versionCode=13

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.3"
+version = "0.3.4"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.3"
+version = "0.3.4"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Version bump for the 0.3.4 release: `skerry.versionName` 0.3.4 / `skerry.versionCode` 13, plus `server` and `sync-wire`.