### PR TITLE
Fix the harness selftest sandbox and cheapen the Kotlin review pass

### DIFF
--- a/.claude/agents/skerry-kotlin-reviewer.md
+++ b/.claude/agents/skerry-kotlin-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: skerry-kotlin-reviewer
 description: Kotlin reviewer for this repository's actual stack — Kotlin Multiplatform with Compose Multiplatform, coroutines and Flow, no Android architecture components. Reviews idiomatic Kotlin, structured concurrency and recomposition. Runs alongside skerry-reviewer, which owns the project's own rules.
+model: sonnet
 tools: ["Read", "Grep", "Glob", "Bash"]
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 .idea/
 *.iml
 .vscode/
+.zed/
 local.properties
 
 # Xcode / iOS

--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -1180,7 +1180,8 @@ class TestReviewReports(SandboxCase):
         done = self.box.gate("review", "skerry-reviewer", "--file", report)
         self.assertEqual(done.returncode, 2, done.stdout)
         self.assertIn("skerry-reviewer",
-                      policy.missing_reviewers(state.load(self.cwd), policy.classify(self.cwd)))
+                      policy.missing_reviewers(state.load(self.cwd),
+                                               policy.classify(self.cwd), self.cwd))
 
     def test_the_cli_lets_the_next_report_through_like_the_hook_does(self):
         # The CLI refused on drift before `record_review` could see the report, so the retry the


### PR DESCRIPTION
`test_the_file_the_gate_prints_cannot_be_handed_back_as_a_pass` called `policy.missing_reviewers`
without the sandbox `cwd`, so it read the real repository instead of the fixture. On a clean `main`
that list is empty, so the guard against handing a stored report back as a fresh pass was never
actually exercised. Passing the sandbox `cwd` restores the check; the suite is 165/165.

The Kotlin reviewer now runs on Sonnet. `silent-failure-hunter` and `pr-test-analyzer` beside it
already do; `skerry-reviewer` and `skerry-security-reviewer` keep the inherited model.

`.zed/` is ignored.

Not verified: no reviewer has been run on the Sonnet setting yet, so the quality of that pass on
this codebase is an assumption.