### PR TITLE
Take the RDP certificate decision inside the TLS handshake

### DIFF
--- a/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpCertificate.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/rdp/RdpCertificate.kt
@@ -7,6 +7,14 @@ package app.skerry.shared.rdp
  * why the decision is delegated to a verifier (TOFU over a remembered fingerprint) instead of being
  * left to the default TLS trust store.
  *
+ * [subject], [issuer] and [host] are text the server authored: run them through
+ * `sanitizeServerText` before they reach a screen.
+ *
+ * [trustedByPlatform] and [hostnameMatches] describe the certificate; they do not decide anything.
+ * The only verifier wired in production is `FileRdpCertificateStore`, which judges by fingerprint
+ * alone — refusing on either flag would refuse nearly every Windows host, which names itself after
+ * the machine rather than the address dialled. They are here for the certificate dialog to show.
+ *
  * [publicKey] is the DER SubjectPublicKeyInfo of the leaf certificate: CredSSP binds the
  * authentication exchange to it, so the value the verifier saw is the value the NLA layer signs.
  * [derChain] is the chain as the server sent it, leaf first.
@@ -48,10 +56,28 @@ data class RdpCertificateOffer(
  * `HostKeyVerifier`, and synchronous for the same reason: it is called from the connect path, and
  * the store it consults is a local file.
  */
-fun interface RdpCertificateVerifier {
+interface RdpCertificateVerifier {
+    /**
+     * Whether this certificate may be talked to. Asked from inside the TLS handshake, which is
+     * before the server has proven it holds the matching private key — so this answers, and
+     * records nothing. Anyone able to answer the connection can reach it with a certificate
+     * copied from elsewhere.
+     */
     fun verify(offer: RdpCertificateOffer): Boolean
+
+    /**
+     * The handshake [offer] came from completed, so the server does hold the key. Trust on first
+     * use is committed here and nowhere else; called once per connection, and only after [verify]
+     * said yes.
+     *
+     * False means this host is now remembered by a different certificate — a second first-time
+     * connection settled between the two calls — and the connection is dropped. Abstract on
+     * purpose: an implementation that forwarded only [verify] would accept every certificate for
+     * ever without recording one, and nothing would say so.
+     */
+    fun remember(offer: RdpCertificateOffer): Boolean
 }
 
 /** The verifier refused the server's certificate; the socket is closed before any data is sent. */
-class RdpCertificateRejectedException(val offer: RdpCertificateOffer) :
-    Exception("server certificate rejected (${offer.fingerprintSha256})")
+class RdpCertificateRejectedException(val offer: RdpCertificateOffer, cause: Throwable? = null) :
+    Exception("server certificate rejected (${offer.fingerprintSha256})", cause)

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/FileRdpCertificateStoreTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/FileRdpCertificateStoreTest.kt
@@ -39,9 +39,37 @@ class FileRdpCertificateStoreTest {
     @Test
     fun `a fingerprint seen once is refused when it changes`() {
         assertTrue(store.verify(offer("desk", "aa")))
+        store.remember(offer("desk", "aa"))
         assertTrue(store.verify(offer("desk", "aa")))
 
         assertFalse(store.verify(offer("desk", "bb")), "a changed certificate was accepted")
+    }
+
+    @Test
+    fun `a certificate is only remembered once the connection it came from succeeded`() {
+        // verify() is asked from inside the TLS handshake, before the server has proven it holds
+        // the private key. A peer that presents a certificate lifted from somewhere else and then
+        // walks away must not get to write the entry every later connection is judged against.
+        assertTrue(store.verify(offer("desk", "aa")))
+
+        assertEquals(emptyMap(), store.entries(), "an unproven certificate was recorded")
+
+        store.remember(offer("desk", "aa"))
+        assertEquals(mapOf("desk:3389" to "aa"), store.entries())
+    }
+
+    @Test
+    fun `of two first connections racing, the one the host is not known by is refused`() {
+        // Both pass verify() against an empty store — the entry is written only once each
+        // handshake finishes, and between the two the certificate can differ.
+        val first = offer("desk", "aa")
+        val second = offer("desk", "bb")
+        assertTrue(store.verify(first))
+        assertTrue(store.verify(second))
+
+        assertTrue(store.remember(first))
+        assertFalse(store.remember(second), "a second certificate was accepted for the same host")
+        assertEquals(mapOf("desk:3389" to "aa"), store.entries())
     }
 
     @Test
@@ -54,7 +82,8 @@ class FileRdpCertificateStoreTest {
         hosts.map { host ->
             thread {
                 start.await()
-                store.verify(offer(host, "fp-$host"))
+                val candidate = offer(host, "fp-$host")
+                if (store.verify(candidate)) store.remember(candidate)
             }
         }.forEach { it.join() }
 

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpHostnameMatchTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpHostnameMatchTest.kt
@@ -1,0 +1,155 @@
+package app.skerry.shared.rdp
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The certificate/hostname check the connector runs from inside the TLS handshake, where no finished
+ * `SSLSession` exists yet to hand to the platform's verifier.
+ */
+class RdpHostnameMatchTest {
+
+    @Test
+    fun `a dNSName entry matches the host it names, whatever the case`() {
+        val certificate = RdpTestCertificates.certificate(
+            commonName = "irrelevant",
+            dnsNames = listOf("Rdp.Example.Com"),
+        )
+
+        assertTrue(certificateMatchesHost("rdp.example.com", certificate))
+        assertTrue(certificateMatchesHost("RDP.EXAMPLE.COM", certificate))
+        // A trailing root dot is the same name.
+        assertTrue(certificateMatchesHost("rdp.example.com.", certificate))
+        assertFalse(certificateMatchesHost("other.example.com", certificate))
+    }
+
+    @Test
+    fun `a wildcard covers one label and never the registry`() {
+        val wildcard = RdpTestCertificates.certificate(dnsNames = listOf("*.example.com"))
+
+        assertTrue(certificateMatchesHost("rdp.example.com", wildcard))
+        assertFalse(certificateMatchesHost("a.b.example.com", wildcard))
+        assertFalse(certificateMatchesHost("example.com", wildcard))
+
+        // "*.com" would otherwise match every host in the TLD.
+        val tooBroad = RdpTestCertificates.certificate(dnsNames = listOf("*.com"))
+        assertFalse(certificateMatchesHost("example.com", tooBroad))
+        assertFalse(certificateMatchesHost("rdp.com", tooBroad))
+    }
+
+    @Test
+    fun `the common name answers only when there is no dNSName entry`() {
+        val bare = RdpTestCertificates.certificate(commonName = "win-host")
+        assertTrue(certificateMatchesHost("win-host", bare))
+        assertFalse(certificateMatchesHost("other-host", bare))
+
+        // RFC 6125: once the certificate carries dNSName entries, they describe it completely.
+        val withSan = RdpTestCertificates.certificate(
+            commonName = "win-host",
+            dnsNames = listOf("rdp.example.com"),
+        )
+        assertFalse(certificateMatchesHost("win-host", withSan))
+    }
+
+    @Test
+    fun `an address matches an iPAddress entry and nothing else`() {
+        val certificate = RdpTestCertificates.certificate(
+            commonName = "10.0.0.5",
+            dnsNames = listOf("10.0.0.5"),
+            ipAddresses = listOf("10.0.0.5"),
+        )
+
+        assertTrue(certificateMatchesHost("10.0.0.5", certificate))
+        assertFalse(certificateMatchesHost("10.0.0.6", certificate))
+
+        // The same text as a name entry is not an address entry, and the common name never
+        // stands in for one.
+        val nameOnly = RdpTestCertificates.certificate(
+            commonName = "10.0.0.5",
+            dnsNames = listOf("10.0.0.5"),
+        )
+        assertFalse(certificateMatchesHost("10.0.0.5", nameOnly))
+    }
+
+    @Test
+    fun `an IPv6 address is compared as an address, not as text`() {
+        val certificate = RdpTestCertificates.certificate(ipAddresses = listOf("0:0:0:0:0:0:0:1"))
+
+        assertTrue(certificateMatchesHost("::1", certificate))
+        assertTrue(certificateMatchesHost("[::1]", certificate))
+        assertFalse(certificateMatchesHost("::2", certificate))
+    }
+
+    @Test
+    fun `a subjectAltName extension retires the common name, whatever it holds`() {
+        // RFC 6125: the extension describes the certificate completely once it is there. An
+        // iPAddress-only certificate names no host, even if its common name looks like one.
+        val addressOnly = RdpTestCertificates.certificate(
+            commonName = "win-host",
+            ipAddresses = listOf("10.0.0.5"),
+        )
+
+        assertFalse(certificateMatchesHost("win-host", addressOnly))
+        assertTrue(certificateMatchesHost("10.0.0.5", addressOnly))
+    }
+
+    @Test
+    fun `an unparseable subjectAltName names nothing and does not fall back to the common name`() {
+        val malformed = RdpTestCertificates.certificate(
+            commonName = "win-host",
+            malformedAlternativeNames = true,
+        )
+
+        assertFalse(certificateMatchesHost("win-host", malformed))
+    }
+
+    @Test
+    fun `an escaped comma inside another attribute is not an attribute separator`() {
+        // Renders as `O=\,CN=evil.example.com` — a subject with no common name at all.
+        val certificate = RdpTestCertificates.certificate(
+            distinguishedName = """O=\,CN=evil.example.com""",
+        )
+
+        assertFalse(certificateMatchesHost("evil.example.com", certificate))
+    }
+
+    @Test
+    fun `a multi-valued RDN still yields its common name`() {
+        val certificate = RdpTestCertificates.certificate(distinguishedName = "CN=win-host+OU=lab")
+
+        assertTrue(certificateMatchesHost("win-host", certificate))
+    }
+
+    @Test
+    fun `only a real IPv6 literal is handed to the resolver`() {
+        // Anything this lets through and InetAddress cannot parse becomes a DNS lookup on the
+        // handshake thread — and the host is attacker-influenced through Server Redirection.
+        assertTrue(isIpv6Literal("::1"))
+        assertTrue(isIpv6Literal("0:0:0:0:0:0:0:1"))
+        assertTrue(isIpv6Literal("fe80::1%eth0"))
+        assertTrue(isIpv6Literal("::ffff:10.0.0.5"))
+
+        assertFalse(isIpv6Literal("dead:beef"), "a two-group address is not a literal")
+        assertFalse(isIpv6Literal("rdp.example.com:3389"))
+        assertFalse(isIpv6Literal("1::2::3"))
+        assertFalse(isIpv6Literal("0:0:0:0:0:0:0:1:2"))
+    }
+
+    @Test
+    fun `a plus sign in the common name survives unescaping`() {
+        // RFC 2253 renders it `\+`, and `"+1".toIntOrNull(16)` is 1 — decoding it as a hex pair
+        // would turn the name into a control character.
+        val certificate = RdpTestCertificates.certificate(distinguishedName = """CN=win\+host""")
+
+        assertTrue(certificateMatchesHost("win+host", certificate))
+    }
+
+    @Test
+    fun `a certificate without a usable name matches nothing`() {
+        val certificate = RdpTestCertificates.certificate(dnsNames = listOf("rdp.example.com"))
+
+        assertFalse(certificateMatchesHost("", certificate))
+        assertFalse(certificateMatchesHost("   ", certificate))
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpLiveServerTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpLiveServerTest.kt
@@ -41,10 +41,10 @@ class RdpLiveServerTest {
         Assumptions.assumeTrue(serverIsListening(), "nothing listening on $host:$port")
 
         val fingerprints = mutableListOf<String>()
-        val transport = RdpTcpTransport(certificateVerifier = { offer ->
-            fingerprints += offer.fingerprintSha256
-            true // trust whatever the test server presents
-        })
+        // Trusts whatever the test server presents, and records nothing anywhere.
+        val transport = RdpTcpTransport(
+            certificateVerifier = RecordingVerifier(onVerify = { fingerprints += it.fingerprintSha256 }),
+        )
 
         val session = transport.connect(
             RdpTarget(host = host, port = port, desktopWidth = 1024, desktopHeight = 768),

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTcpConnectorTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTcpConnectorTest.kt
@@ -1,6 +1,7 @@
 package app.skerry.shared.rdp
 
 import java.io.DataInputStream
+import java.io.IOException
 import java.net.InetAddress
 import java.net.ServerSocket
 import java.net.Socket
@@ -16,6 +17,7 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 
@@ -78,7 +80,7 @@ class RdpTcpConnectorTest {
         assertFailsWith<SocketTimeoutException> {
             runBlocking {
                 RdpTcpConnector(
-                    certificateVerifier = RdpCertificateVerifier { true },
+                    certificateVerifier = RecordingVerifier(),
                     negotiationTimeoutMillis = 250,
                 ).connect(host = server.inetAddress.hostAddress, port = server.localPort)
             }
@@ -86,7 +88,7 @@ class RdpTcpConnectorTest {
     }
 
     private fun connect(
-        verifier: RdpCertificateVerifier = RdpCertificateVerifier { true },
+        verifier: RdpCertificateVerifier = RecordingVerifier(),
         cookie: String? = null,
         requestedProtocols: Int = RdpSecurityProtocol.SSL or RdpSecurityProtocol.HYBRID,
     ): RdpConnection = runBlocking {
@@ -147,7 +149,7 @@ class RdpTcpConnectorTest {
         }
         val offers = mutableListOf<RdpCertificateOffer>()
 
-        val connection = connect(verifier = { offer -> offers.add(offer); true })
+        val connection = connect(verifier = RecordingVerifier(onVerify = offers::add))
 
         try {
             assertEquals(1, offers.size)
@@ -166,7 +168,73 @@ class RdpTcpConnectorTest {
     }
 
     @Test
-    fun `a rejected certificate fails the connection and closes the socket`() {
+    fun `a certificate naming the address dialled is reported as a hostname match`() {
+        // The hostname check runs inside the handshake now, off the certificate itself — this is the
+        // test that says it still answers, rather than quietly reporting "no" for everything.
+        val tls = RdpTestCertificates.serverContext(ipAddresses = listOf(server.inetAddress.hostAddress))
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            val secure = tls.socketFactory.createSocket(socket, null, socket.port, false) as SSLSocket
+            secure.useClientMode = false
+            secure.startHandshake()
+        }
+        val offers = mutableListOf<RdpCertificateOffer>()
+
+        val connection = connect(verifier = RecordingVerifier(onVerify = offers::add))
+
+        try {
+            assertTrue(offers.single().hostnameMatches)
+        } finally {
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `a rejected certificate never completes the tls handshake`() {
+        // The trust decision belongs inside the handshake: a client that trusts every chain and only
+        // decides afterwards has already established a session with a server it refuses to talk to.
+        val tls = RdpTestCertificates.serverContext()
+        val serverHandshake = CompletableFuture<Boolean>()
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            val secure = tls.socketFactory.createSocket(socket, null, socket.port, false) as SSLSocket
+            secure.useClientMode = false
+            serverHandshake.complete(runCatching { secure.startHandshake() }.isSuccess)
+        }
+
+        assertFailsWith<RdpCertificateRejectedException> { connect(verifier = RecordingVerifier(answer = false)) }
+
+        assertFalse(serverHandshake.get(TIMEOUT_MS, TimeUnit.MILLISECONDS))
+    }
+
+    @Test
+    fun `a certificate is remembered only once the handshake it came from completed`() {
+        // The verifier is asked from inside the handshake, before the server has proven it holds
+        // the key. Trust on first use may only be committed the other side of that.
+        val tls = RdpTestCertificates.serverContext()
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            val secure = tls.socketFactory.createSocket(socket, null, socket.port, false) as SSLSocket
+            secure.useClientMode = false
+            secure.startHandshake()
+        }
+        val verifier = RecordingVerifier()
+
+        val connection = connect(verifier = verifier)
+
+        try {
+            assertEquals(1, verifier.verified.size)
+            assertEquals(verifier.verified, verifier.remembered)
+        } finally {
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `a refused certificate is never remembered`() {
         val tls = RdpTestCertificates.serverContext()
         serve { socket ->
             DataInputStream(socket.getInputStream()).let { readPacket(it) }
@@ -175,8 +243,70 @@ class RdpTcpConnectorTest {
             secure.useClientMode = false
             runCatching { secure.startHandshake() }
         }
+        val verifier = RecordingVerifier(answer = false)
 
-        assertFailsWith<RdpCertificateRejectedException> { connect(verifier = { false }) }
+        val failure = assertFailsWith<RdpCertificateRejectedException> { connect(verifier = verifier) }
+
+        assertEquals(verifier.verified.single(), failure.offer)
+        assertTrue(verifier.remembered.isEmpty())
+    }
+
+    @Test
+    fun `a certificate offered by a handshake that then fails is not remembered`() {
+        // The point of committing trust after the handshake: a peer that presents a certificate it
+        // does not hold the key for cannot finish, and so cannot take the host's entry.
+        val tls = RdpTestCertificates.serverContext()
+        val raw = CompletableFuture<Socket>()
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            val secure = tls.socketFactory.createSocket(socket, null, socket.port, false) as SSLSocket
+            secure.useClientMode = false
+            // TLS 1.2 so the client still has to read the server's Finished after this dies.
+            secure.enabledProtocols = arrayOf("TLSv1.2")
+            raw.complete(socket)
+            runCatching { secure.startHandshake() }
+        }
+        // Kills the connection the moment the certificate has been offered.
+        val verifier = RecordingVerifier { raw.get(TIMEOUT_MS, TimeUnit.MILLISECONDS).close() }
+
+        assertFailsWith<IOException> { connect(verifier = verifier) }
+
+        assertEquals(1, verifier.verified.size)
+        assertTrue(verifier.remembered.isEmpty(), "a failed handshake recorded its certificate")
+    }
+
+    @Test
+    fun `a certificate the store would not commit fails the connection`() {
+        // Another first connection to the same host settled on a different certificate while this
+        // handshake ran. One of the two is what the host is now known by; this one is not.
+        val tls = RdpTestCertificates.serverContext()
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            val secure = tls.socketFactory.createSocket(socket, null, socket.port, false) as SSLSocket
+            secure.useClientMode = false
+            runCatching { secure.startHandshake() }
+        }
+        val verifier = RecordingVerifier(committed = false)
+
+        val failure = assertFailsWith<RdpCertificateRejectedException> { connect(verifier = verifier) }
+
+        assertEquals(verifier.remembered.single(), failure.offer)
+    }
+
+    @Test
+    fun `a handshake that fails for its own reasons is not reported as a rejected certificate`() {
+        // Confirmed, then hung up on before TLS. The connector has to pass that failure through as
+        // it is — reporting a certificate problem would send the user looking at the wrong thing.
+        serve { socket ->
+            DataInputStream(socket.getInputStream()).let { readPacket(it) }
+            socket.getOutputStream().apply { write(connectionConfirm(RdpSecurityProtocol.SSL)); flush() }
+            socket.close()
+        }
+
+        // RdpCertificateRejectedException is not an IOException, so this pins both halves.
+        assertFailsWith<IOException> { connect() }
     }
 
     @Test

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTestCertificates.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTestCertificates.kt
@@ -3,12 +3,16 @@ package app.skerry.shared.rdp
 import java.math.BigInteger
 import java.security.KeyPairGenerator
 import java.security.KeyStore
+import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import java.util.Date
 import javax.net.ssl.KeyManagerFactory
 import javax.net.ssl.SSLContext
 import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.asn1.x509.GeneralName
+import org.bouncycastle.asn1.x509.GeneralNames
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
@@ -21,29 +25,80 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
 object RdpTestCertificates {
 
     /** A server-side [SSLContext] holding a fresh self-signed certificate for [commonName]. */
-    fun serverContext(commonName: String = "rdp-test"): SSLContext {
-        val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
-        val now = System.currentTimeMillis()
-        val name = X500Name("CN=$commonName")
-        val holder = JcaX509v3CertificateBuilder(
-            name,
-            BigInteger.valueOf(now),
-            Date(now - 60_000),
-            Date(now + 3_600_000),
-            name,
-            keyPair.public,
-        ).build(JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private))
-        val certificate: X509Certificate = JcaX509CertificateConverter().getCertificate(holder)
-
+    fun serverContext(
+        commonName: String = "rdp-test",
+        dnsNames: List<String> = emptyList(),
+        ipAddresses: List<String> = emptyList(),
+    ): SSLContext {
+        val issued = selfSigned(commonName, dnsNames, ipAddresses)
         val keyStore = KeyStore.getInstance("PKCS12").apply {
             load(null, null)
-            setKeyEntry("server", keyPair.private, PASSWORD, arrayOf(certificate))
+            setKeyEntry("server", issued.privateKey, PASSWORD, arrayOf(issued.certificate))
         }
         val managers = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
             .apply { init(keyStore, PASSWORD) }
         return SSLContext.getInstance("TLS").apply {
             init(managers.keyManagers, null, SecureRandom())
         }
+    }
+
+    /**
+     * The certificate alone, for the checks that never open a socket. [distinguishedName] replaces
+     * the whole subject when a DN more awkward than `CN=x` is the point, and
+     * [malformedAlternativeNames] writes a `subjectAltName` extension that cannot be parsed.
+     */
+    fun certificate(
+        commonName: String = "rdp-test",
+        dnsNames: List<String> = emptyList(),
+        ipAddresses: List<String> = emptyList(),
+        distinguishedName: String? = null,
+        malformedAlternativeNames: Boolean = false,
+    ): X509Certificate = selfSigned(
+        commonName,
+        dnsNames,
+        ipAddresses,
+        distinguishedName,
+        malformedAlternativeNames,
+    ).certificate
+
+    private class Issued(val certificate: X509Certificate, val privateKey: PrivateKey)
+
+    private fun selfSigned(
+        commonName: String,
+        dnsNames: List<String>,
+        ipAddresses: List<String>,
+        distinguishedName: String? = null,
+        malformedAlternativeNames: Boolean = false,
+    ): Issued {
+        val keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair()
+        val now = System.currentTimeMillis()
+        val name = X500Name(distinguishedName ?: "CN=$commonName")
+        val builder = JcaX509v3CertificateBuilder(
+            name,
+            BigInteger.valueOf(now),
+            Date(now - 60_000),
+            Date(now + 3_600_000),
+            name,
+            keyPair.public,
+        )
+        val alternatives = dnsNames.map { GeneralName(GeneralName.dNSName, it) } +
+            ipAddresses.map { GeneralName(GeneralName.iPAddress, it) }
+        if (malformedAlternativeNames) {
+            // A SEQUENCE whose dNSName entry claims three bytes and carries one.
+            builder.addExtension(
+                Extension.subjectAlternativeName,
+                false,
+                byteArrayOf(0x30, 0x05, 0x82.toByte(), 0x03, 0x61),
+            )
+        } else if (alternatives.isNotEmpty()) {
+            builder.addExtension(
+                Extension.subjectAlternativeName,
+                false,
+                GeneralNames(alternatives.toTypedArray()),
+            )
+        }
+        val holder = builder.build(JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private))
+        return Issued(JcaX509CertificateConverter().getCertificate(holder), keyPair.private)
     }
 
     private val PASSWORD = charArrayOf('x')

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTestVerifiers.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpTestVerifiers.kt
@@ -1,0 +1,27 @@
+package app.skerry.shared.rdp
+
+/**
+ * Records what the connector asked of it, so the two questions — may I talk to this, and is this
+ * what the host is now known by — can be told apart. [RdpCertificateVerifier] is deliberately not a
+ * SAM type: a verifier that answered only the first question would accept every certificate for
+ * ever without recording one.
+ */
+internal class RecordingVerifier(
+    private val answer: Boolean = true,
+    private val committed: Boolean = true,
+    private val onVerify: (RdpCertificateOffer) -> Unit = {},
+) : RdpCertificateVerifier {
+    val verified = mutableListOf<RdpCertificateOffer>()
+    val remembered = mutableListOf<RdpCertificateOffer>()
+
+    override fun verify(offer: RdpCertificateOffer): Boolean {
+        verified.add(offer)
+        onVerify(offer)
+        return answer
+    }
+
+    override fun remember(offer: RdpCertificateOffer): Boolean {
+        remembered.add(offer)
+        return committed
+    }
+}

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpVerifyingTrustManagerTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/rdp/RdpVerifyingTrustManagerTest.kt
@@ -1,0 +1,112 @@
+package app.skerry.shared.rdp
+
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * The trust manager the RDP connector installs. Driven directly rather than through a socket: a
+ * real TLS renegotiation is a thread race, and the branch it exercises is one comparison.
+ */
+class RdpVerifyingTrustManagerTest {
+
+    private class Answers(private val answer: Boolean) : RdpCertificateVerifier {
+        var asked = 0
+            private set
+
+        override fun verify(offer: RdpCertificateOffer): Boolean {
+            asked++
+            return answer
+        }
+
+        override fun remember(offer: RdpCertificateOffer) = true
+    }
+
+    private fun manager(verifier: RdpCertificateVerifier) =
+        RdpVerifyingTrustManager(verifier, platform = null, host = "10.0.0.5", port = 3389)
+
+    private fun chainOf(commonName: String): Array<X509Certificate> =
+        arrayOf(RdpTestCertificates.certificate(commonName = commonName))
+
+    @Test
+    fun `an accepted certificate is offered to the verifier once, whatever the handshake does after`() {
+        val verifier = Answers(answer = true)
+        val trust = manager(verifier)
+        val chain = chainOf("win-host")
+
+        trust.checkServerTrusted(chain, "RSA")
+        // Renegotiation on the same certificate: asking again would run the verifier from the read
+        // thread, long after the connection was reported as up.
+        trust.checkServerTrusted(chain, "RSA")
+
+        assertEquals(1, verifier.asked)
+        assertEquals(fingerprintOf(chain.first()), trust.accepted?.fingerprintSha256)
+    }
+
+    @Test
+    fun `a certificate swapped mid-session is refused`() {
+        val trust = manager(Answers(answer = true))
+        trust.checkServerTrusted(chainOf("win-host"), "RSA")
+
+        assertFailsWith<CertificateException> { trust.checkServerTrusted(chainOf("other-host"), "RSA") }
+    }
+
+    @Test
+    fun `a refused certificate is recorded so the failure can name it`() {
+        val trust = manager(Answers(answer = false))
+        val chain = chainOf("win-host")
+
+        assertFailsWith<CertificateException> { trust.checkServerTrusted(chain, "RSA") }
+
+        assertNull(trust.accepted)
+        assertEquals(fingerprintOf(chain.first()), trust.rejected?.fingerprintSha256)
+    }
+
+    @Test
+    fun `an empty chain is refused without asking the verifier`() {
+        val verifier = Answers(answer = true)
+        val trust = manager(verifier)
+
+        assertFailsWith<CertificateException> { trust.checkServerTrusted(emptyArray(), "RSA") }
+
+        assertEquals(0, verifier.asked)
+    }
+
+    @Test
+    fun `it will not vouch for a client certificate`() {
+        val trust = manager(Answers(answer = true))
+
+        assertFailsWith<CertificateException> { trust.checkClientTrusted(chainOf("someone"), "RSA") }
+        assertTrue(trust.acceptedIssuers.isEmpty())
+    }
+
+    @Test
+    fun `the offer carries what the verifier needs to judge`() {
+        val chain = chainOf("win-host")
+        var seen: RdpCertificateOffer? = null
+        val trust = manager(object : RdpCertificateVerifier {
+            override fun verify(offer: RdpCertificateOffer): Boolean {
+                seen = offer
+                return true
+            }
+
+            override fun remember(offer: RdpCertificateOffer) = true
+        })
+
+        trust.checkServerTrusted(chain, "RSA")
+
+        val offer = requireNotNull(seen)
+        assertSame(offer, trust.accepted)
+        assertEquals("10.0.0.5", offer.host)
+        assertEquals(3389, offer.port)
+        assertTrue(offer.subject.contains("win-host"))
+        // No platform trust manager was given, and the certificate names no address.
+        assertTrue(!offer.trustedByPlatform)
+        assertTrue(!offer.hostnameMatches)
+    }
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/FileRdpCertificateStore.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/FileRdpCertificateStore.kt
@@ -21,31 +21,37 @@ class FileRdpCertificateStore(
 ) : RdpCertificateVerifier {
 
     /**
-     * Whether [offer] is trusted, recording it on first sight.
-     *
-     * Serialized: one store answers every connection this client makes, and reading the file and
-     * writing it back is not one step. Two first connections at once would otherwise write over
-     * each other, and the host whose fingerprint was lost is trusted on first use a second time —
-     * which is the connection a swapped certificate would have been caught on.
+     * Whether [offer] matches what this host is remembered by. An unknown host is accepted here and
+     * recorded in [remember], not before: the question is asked while the handshake is still in
+     * flight, so at this point anyone who can answer the connection could have sent the chain.
      */
     @Synchronized
     override fun verify(offer: RdpCertificateOffer): Boolean {
+        val known = read()["${offer.host}:${offer.port}"]
+            // First sight. A platform-trusted, name-matching certificate is recorded too, so a
+            // later swap to a self-signed one still shows up as a change.
+            ?: return true
+        // The certificate changed. That is a server rebuild as often as an attack, and a client
+        // cannot tell them apart — accepting it quietly would make the store pointless.
+        return known == offer.fingerprintSha256
+    }
+
+    /**
+     * Commit trust on first use, now that the handshake has proven the server holds the key.
+     *
+     * Serialized, and the decision is re-taken here rather than trusted from [verify]: two first
+     * connections to the same host both pass [verify] against an empty store, and between them the
+     * certificate can differ. Whoever writes first owns the entry; the other is refused, which is
+     * what the single locked read-decide-write did before the two steps were split.
+     */
+    @Synchronized
+    override fun remember(offer: RdpCertificateOffer): Boolean {
         val key = "${offer.host}:${offer.port}"
         val entries = read()
         val known = entries[key]
-        return when (known) {
-            null -> {
-                // First sight: remember it. A platform-trusted, name-matching certificate is
-                // recorded too, so a later swap to a self-signed one still shows up as a change.
-                write(entries + (key to offer.fingerprintSha256))
-                true
-            }
-
-            offer.fingerprintSha256 -> true
-            // The certificate changed. That is a server rebuild as often as an attack, and a client
-            // cannot tell them apart — accepting it quietly would make the store pointless.
-            else -> false
-        }
+        if (known != null) return known == offer.fingerprintSha256
+        write(entries + (key to offer.fingerprintSha256))
+        return true
     }
 
     /** Forget the entry for [host]:[port], so the next connection trusts on first use again. */

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpHostnameMatch.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpHostnameMatch.kt
@@ -1,0 +1,174 @@
+package app.skerry.shared.rdp
+
+import java.io.ByteArrayOutputStream
+import java.net.InetAddress
+import java.security.cert.X509Certificate
+import javax.security.auth.x500.X500Principal
+
+/** `subjectAltName` entry tags from RFC 5280 §4.2.1.6, as `getSubjectAlternativeNames` reports them. */
+private const val SAN_DNS_NAME = 2
+private const val SAN_IP_ADDRESS = 7
+
+/** `id-ce-subjectAltName`, read raw to tell "no extension" from "an extension we could not parse". */
+private const val SUBJECT_ALT_NAME_OID = "2.5.29.17"
+
+/**
+ * Whether [certificate] was issued for [host], by the RFC 6125 rules: `subjectAltName` decides
+ * whenever the extension is present at all, the common name only when it is absent, and a literal
+ * address matches nothing but an `iPAddress` entry.
+ *
+ * Not the platform's hostname verifier, which needs a finished `SSLSession` — this answer is needed
+ * while the handshake is still running, so that the trust decision can be taken there. It feeds
+ * [RdpCertificateOffer.hostnameMatches], which describes the certificate rather than accepting or
+ * refusing it: an RDP host commonly names itself something other than the address dialled.
+ */
+internal fun certificateMatchesHost(host: String, certificate: X509Certificate): Boolean {
+    val name = host.trim().trimEnd('.')
+    if (name.isEmpty()) return false
+    // A subjectAltName we cannot parse is a certificate that names nothing usable, not one without
+    // the extension — falling back to the common name there would let a malformed extension pick
+    // which name is consulted.
+    val hasAlternativeNames = certificate.getExtensionValue(SUBJECT_ALT_NAME_OID) != null
+    val alternatives = runCatching { certificate.subjectAlternativeNames }.getOrNull().orEmpty()
+        .mapNotNull { entry ->
+            val tag = entry.getOrNull(0) as? Int ?: return@mapNotNull null
+            val value = entry.getOrNull(1) as? String ?: return@mapNotNull null
+            tag to value
+        }
+
+    val address = literalAddressOf(name)
+    if (address != null) {
+        return alternatives.any { (tag, value) ->
+            tag == SAN_IP_ADDRESS && literalAddressOf(value)?.contentEquals(address) == true
+        }
+    }
+
+    val dnsNames = alternatives.filter { it.first == SAN_DNS_NAME }.map { it.second }
+    val candidates = when {
+        hasAlternativeNames -> dnsNames
+        else -> listOfNotNull(commonNameOf(certificate))
+    }
+    return candidates.any { dnsNameMatches(it, name) }
+}
+
+/** One wildcard, leftmost label only, and never one that would cover a whole registry (`*.com`). */
+private fun dnsNameMatches(pattern: String, host: String): Boolean {
+    val candidate = pattern.trim().trimEnd('.').lowercase()
+    val target = host.lowercase()
+    if (candidate.isEmpty()) return false
+    if (!candidate.startsWith("*.")) return candidate == target
+    val suffix = candidate.substring(1)
+    if (suffix.count { it == '.' } < 2) return false
+    if (!target.endsWith(suffix)) return false
+    val label = target.dropLast(suffix.length)
+    return label.isNotEmpty() && !label.contains('.')
+}
+
+/**
+ * [host] as raw address bytes, or null when it is a name rather than a literal. The shape is
+ * checked first: `InetAddress.getByName` resolves anything it cannot parse, and a DNS lookup in
+ * the middle of a TLS handshake is not what this asks for.
+ */
+private fun literalAddressOf(host: String): ByteArray? {
+    val text = host.removeSurrounding("[", "]")
+    if (!IPV4.matches(text) && !isIpv6Literal(text)) return null
+    return runCatching { InetAddress.getByName(text).address }.getOrNull()
+}
+
+/**
+ * The subject's common name, or null when it has none. Hand-rolled because `javax.naming.ldap`
+ * does not exist on Android: the RFC 2253 rendering is split on unescaped separators, then the
+ * value is unescaped.
+ */
+private fun commonNameOf(certificate: X509Certificate): String? =
+    splitAttributes(certificate.subjectX500Principal.getName(X500Principal.RFC2253))
+        .firstNotNullOfOrNull { attribute ->
+            val separator = attribute.indexOf('=')
+            if (separator < 0) return@firstNotNullOfOrNull null
+            if (!attribute.take(separator).trim().equals("CN", ignoreCase = true)) {
+                return@firstNotNullOfOrNull null
+            }
+            // "#0c0477696e" is a DER-encoded value rather than a string; nothing to match against.
+            unescape(attribute.substring(separator + 1)).takeUnless { it.startsWith("#") }
+        }
+
+/** Split on the separators RFC 2253 gives meaning to — `,` between attributes, `+` within an RDN. */
+private fun splitAttributes(distinguishedName: String): List<String> {
+    val attributes = mutableListOf<String>()
+    val current = StringBuilder()
+    var escaped = false
+    for (character in distinguishedName) {
+        when {
+            escaped -> {
+                current.append(character)
+                escaped = false
+            }
+
+            character == '\\' -> {
+                current.append(character)
+                escaped = true
+            }
+
+            character == ',' || character == '+' -> {
+                attributes += current.toString()
+                current.clear()
+            }
+
+            else -> current.append(character)
+        }
+    }
+    attributes += current.toString()
+    return attributes
+}
+
+/** Undo RFC 2253 escaping: `\c` is the character itself, `\XX` a byte of the UTF-8 encoding. */
+private fun unescape(value: String): String {
+    if (!value.contains('\\')) return value.trim()
+    val bytes = ByteArrayOutputStream()
+    var index = 0
+    while (index < value.length) {
+        val character = value[index]
+        if (character != '\\' || index + 1 >= value.length) {
+            bytes.write(character.toString().toByteArray(Charsets.UTF_8))
+            index++
+            continue
+        }
+        val pair = value.substring(index + 1).take(2)
+        // `toIntOrNull` accepts a leading sign, so "\+1" would decode as the byte 0x01.
+        val byte = pair.takeIf { it.length == 2 && it.all(Char::isHexDigit) }?.toIntOrNull(radix = 16)
+        if (byte != null) {
+            bytes.write(byte)
+            index += 3
+        } else {
+            bytes.write(value[index + 1].toString().toByteArray(Charsets.UTF_8))
+            index += 2
+        }
+    }
+    return bytes.toByteArray().decodeToString().trim()
+}
+
+private val IPV4 = Regex("""(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}""")
+
+private fun Char.isHexDigit() = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+
+private fun Char.isIpv6Character() = isHexDigit() || this == ':' || this == '.'
+
+/**
+ * A real IPv6 literal: eight groups, or fewer with one `::` standing in for the rest, optionally
+ * ending in a dotted IPv4 form. Anything looser — "any hex and colons" — lets `dead:beef` through
+ * to `InetAddress.getByName`, which cannot parse it and falls back to a DNS lookup.
+ */
+internal fun isIpv6Literal(text: String): Boolean {
+    val body = text.substringBefore('%')
+    if (body.count { it == ':' } < 2) return false
+    if (!body.all(Char::isIpv6Character)) return false
+    val elided = body.split("::")
+    if (elided.size > 2) return false
+    val tail = elided.last()
+    val trailingIpv4 = IPV4.matches(tail.substringAfterLast(':', missingDelimiterValue = ""))
+    val groups = elided.sumOf { part ->
+        part.split(':').count { it.isNotEmpty() }
+    } + if (trailingIpv4) 1 else 0
+    if (elided.size == 2) return groups < 8
+    return groups == 8 && !body.startsWith(":") && !body.endsWith(":")
+}

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpConnector.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpTcpConnector.kt
@@ -2,12 +2,11 @@ package app.skerry.shared.rdp
 
 import java.io.BufferedOutputStream
 import java.io.DataInputStream
+import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
-import java.security.MessageDigest
 import java.security.cert.X509Certificate
 import java.util.concurrent.atomic.AtomicBoolean
-import javax.net.ssl.HttpsURLConnection
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLSocket
 import javax.net.ssl.TrustManagerFactory
@@ -155,42 +154,40 @@ class RdpTcpConnector(
     private class SecureSocket(val socket: SSLSocket, val publicKey: ByteArray)
 
     /**
-     * Wrap [plain] in TLS and put the server's certificate in front of [certificateVerifier].
+     * Wrap [plain] in TLS, with [certificateVerifier] taking the trust decision from inside the
+     * handshake. Refusing there rather than afterwards is the point: a client that trusts every
+     * chain and only makes up its mind once the session is up has already finished a handshake with
+     * a server it will not talk to, and any later slip leaks data over it.
      *
-     * The decision is taken after the handshake completes rather than inside the trust manager: the
-     * verifier's answer also depends on whether the platform trusted the chain and whether the name
-     * matched, and the hostname check needs the finished session. Nothing of ours has been written
-     * at that point, so a refusal costs the server a handshake and nothing else.
+     * Trust on first use is committed the other side of [SSLSocket.startHandshake], though. The
+     * verifier is asked when the server's certificate arrives, which is before the server has
+     * proven it holds the matching key — recording there would let anyone able to answer the
+     * connection register a certificate copied from elsewhere.
      */
     private fun upgradeToTls(plain: Socket, host: String, port: Int): SecureSocket {
-        val trust = CapturingTrustManager(platformTrustManager())
+        val trust = RdpVerifyingTrustManager(certificateVerifier, platformTrustManager(), host, port)
         val context = SSLContext.getInstance("TLS").apply { init(null, arrayOf(trust), null) }
         val secure = context.socketFactory.createSocket(plain, host, port, true) as SSLSocket
         secure.useClientMode = true
         // Not left to the platform's defaults: Android's lag behind the desktop JVM's, and the floor
         // a remote-desktop session is protected by should not depend on which one is running it.
         secure.enabledProtocols = secure.supportedProtocols.filter { it in TLS_FLOOR }.toTypedArray()
-        secure.startHandshake()
-
-        val chain = trust.chain
+        try {
+            secure.startHandshake()
+        } catch (e: IOException) {
+            runCatching { secure.close() }
+            // Our own refusal surfaces here as a generic TLS failure; the caller needs the
+            // certificate that was turned down, not the alert it produced. The alert stays as the
+            // cause — a rejection and a broken handshake read the same way in a bug report.
+            throw trust.rejected?.let { RdpCertificateRejectedException(it, cause = e) } ?: e
+        }
+        // Fails closed: null means the handshake completed without the trust manager being asked
+        // at all — an anonymous suite, or a resumed session (impossible here, the context is new).
+        val offer = trust.accepted
             ?: throw RdpProtocolException("TLS handshake produced no server certificate")
-        val leaf = chain.first()
-        val offer = RdpCertificateOffer(
-            host = host,
-            port = port,
-            fingerprintSha256 = fingerprintOf(leaf),
-            subject = leaf.subjectX500Principal.name,
-            issuer = leaf.issuerX500Principal.name,
-            notBeforeMillis = leaf.notBefore.time,
-            notAfterMillis = leaf.notAfter.time,
-            trustedByPlatform = trust.platformTrusted,
-            hostnameMatches = runCatching {
-                HttpsURLConnection.getDefaultHostnameVerifier().verify(host, secure.session)
-            }.getOrDefault(false),
-            publicKey = leaf.publicKey.encoded,
-            derChain = chain.map { it.encoded },
-        )
-        if (!certificateVerifier.verify(offer)) {
+        if (!certificateVerifier.remember(offer)) {
+            // Another first-time connection to this host settled on a different certificate while
+            // this handshake ran. One of the two is the one the host is now known by; this is not.
             runCatching { secure.close() }
             throw RdpCertificateRejectedException(offer)
         }
@@ -205,34 +202,6 @@ class RdpTcpConnector(
                 .filterIsInstance<X509TrustManager>()
                 .firstOrNull()
         }.getOrNull()
-
-    private fun fingerprintOf(certificate: X509Certificate): String =
-        MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
-            .joinToString(":") { byte -> (byte.toInt() and 0xFF).toString(16).padStart(2, '0').uppercase() }
-
-    /**
-     * Accepts every chain so the decision can be taken by [RdpCertificateVerifier], but records what
-     * the platform's own trust store thought of it — "my enterprise CA issued this" and "the machine
-     * signed it itself" are different answers, and the verifier is the one that gets to weigh them.
-     */
-    private class CapturingTrustManager(private val delegate: X509TrustManager?) : X509TrustManager {
-        @Volatile
-        var chain: Array<X509Certificate>? = null
-
-        @Volatile
-        var platformTrusted = false
-
-        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
-            this.chain = chain
-            val platform = delegate
-            platformTrusted = platform != null &&
-                runCatching { platform.checkServerTrusted(chain, authType) }.isSuccess
-        }
-
-        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) = Unit
-
-        override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
-    }
 
     private companion object {
         /** The only TLS versions this client offers; anything older is not negotiable. */

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpVerifyingTrustManager.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/rdp/RdpVerifyingTrustManager.kt
@@ -1,0 +1,82 @@
+package app.skerry.shared.rdp
+
+import java.security.MessageDigest
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+import javax.net.ssl.X509TrustManager
+
+/**
+ * Puts the server's chain in front of [RdpCertificateVerifier] while the handshake is still in
+ * flight, and fails it when the answer is no. The platform's own verdict is recorded rather than
+ * enforced — Windows signs its Remote Desktop certificate itself unless an enterprise CA issued
+ * one, so "the platform does not trust this" is the normal case, and "my enterprise CA issued
+ * it" and "the machine signed it itself" are answers the verifier gets to weigh.
+ */
+internal class RdpVerifyingTrustManager(
+    private val verifier: RdpCertificateVerifier,
+    private val platform: X509TrustManager?,
+    private val host: String,
+    private val port: Int,
+) : X509TrustManager {
+    /** The certificate the verifier accepted; its public key is what CredSSP binds to. */
+    @Volatile
+    var accepted: RdpCertificateOffer? = null
+        private set
+
+    /** The certificate the verifier turned down, so the failure can name it. */
+    @Volatile
+    var rejected: RdpCertificateOffer? = null
+        private set
+
+    override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+        val leaf = chain.firstOrNull()
+            ?: throw CertificateException("server sent an empty certificate chain")
+        val settled = accepted
+        if (settled != null) {
+            // Renegotiation. The session may not change the certificate under us: CredSSP is
+            // bound to the key captured on the first one, and asking the verifier again would
+            // run it from the read thread, long after the connection was reported as up.
+            if (settled.fingerprintSha256 != fingerprintOf(leaf)) {
+                throw CertificateException("server changed its certificate mid-session")
+            }
+            return
+        }
+        val offer = RdpCertificateOffer(
+            host = host,
+            port = port,
+            fingerprintSha256 = fingerprintOf(leaf),
+            subject = leaf.subjectX500Principal.name,
+            issuer = leaf.issuerX500Principal.name,
+            notBeforeMillis = leaf.notBefore.time,
+            notAfterMillis = leaf.notAfter.time,
+            trustedByPlatform = platformTrusts(chain, authType),
+            hostnameMatches = certificateMatchesHost(host, leaf),
+            publicKey = leaf.publicKey.encoded,
+            derChain = chain.map { it.encoded },
+        )
+        if (!verifier.verify(offer)) {
+            rejected = offer
+            throw CertificateException("server certificate rejected (${offer.fingerprintSha256})")
+        }
+        accepted = offer
+    }
+
+    /**
+     * What the platform's own trust store makes of [chain] — recorded for the verifier, never
+     * enforced here, so its refusal is an answer rather than a failure.
+     */
+    private fun platformTrusts(chain: Array<X509Certificate>, authType: String): Boolean {
+        val store = platform ?: return false
+        return runCatching { store.checkServerTrusted(chain, authType) }.isSuccess
+    }
+
+    /** Client-side only: nothing here ever authenticates a peer that dialled us. */
+    override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String): Unit =
+        throw CertificateException("RDP client trust manager cannot vouch for a client certificate")
+
+    override fun getAcceptedIssuers(): Array<X509Certificate> = emptyArray()
+}
+
+internal fun fingerprintOf(certificate: X509Certificate): String =
+    MessageDigest.getInstance("SHA-256").digest(certificate.encoded)
+        .joinToString(":") { byte -> (byte.toInt() and 0xFF).toString(16).padStart(2, '0').uppercase() }


### PR DESCRIPTION
Closes the `java/insecure-trustmanager` code-scanning alert (CWE-295) on `RdpTcpConnector`.

## What changed

The trust manager accepted every chain and the trust-on-first-use decision was taken after `startHandshake()` returned, so a handshake with a server we were about to refuse completed anyway.

- `RdpVerifyingTrustManager` answers from inside `checkServerTrusted`. A renegotiation that changes the certificate is refused — CredSSP is bound to the key captured on the first one.
- `RdpCertificateVerifier` is split into `verify` (asked in the handshake) and `remember` (called once the handshake completed). Trust on first use is committed only after the server has proven it holds the matching key; recording it earlier would let anyone able to answer the connection register a certificate copied from elsewhere. `remember` returns whether the entry it wrote is the one the host is now known by, so two first connections racing cannot both win.
- `RdpHostnameMatch` does the RFC 6125 check the platform verifier cannot: that one needs a finished `SSLSession`, and on the desktop JVM the default verifier returns `false` unconditionally — `hostnameMatches` was dead there while Android computed it.

`hostnameMatches` and `trustedByPlatform` stay descriptive rather than deciding: an RDP host commonly names itself something other than the address dialled, so refusing on either would refuse nearly every server.

## Tests

29 tests across the trust manager, the hostname matcher, the connector and the store, including the certificate swapped mid-session, a handshake that fails after the certificate was offered, and two first connections racing. Each new test was re-run with the fix reverted.

## Verification

Connect to a Windows RDP host: the first connection succeeds, a second one with the same certificate succeeds, and one after the certificate is regenerated on the server is refused.

Not verified live — no RDP server, Android device or other OS was available; the tests drive a local TLS server.