### PR TITLE
Count every kind of user input against the idle auto-lock

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_settings.xml
@@ -151,7 +151,7 @@
     <string name="settings_security_biometric_recheck">Проверить снова</string>
     <string name="settings_security_biometric_weak_binding">Включено с ослабленной привязкой ключа — биометрия по-прежнему нужна.</string>
     <string name="settings_security_auto_lock">Автоблокировка</string>
-    <string name="settings_security_auto_lock_desc">Блокировка после простоя.</string>
+    <string name="settings_security_auto_lock_desc">Блокировка, когда прекращается ввод. Передача файлов или идущий сценарий откладывают её не более чем на десять интервалов; блокировка закрывает открытые сессии.</string>
     <string name="settings_autolock_1m">Через 1 минуту</string>
     <string name="settings_autolock_5m">Через 5 минут</string>
     <string name="settings_autolock_15m">Через 15 минут</string>
@@ -170,6 +170,7 @@
     <string name="settings_event_unlocked_biometric">Разблокировка биометрией</string>
     <string name="settings_event_device_paired">Привязано новое устройство</string>
     <string name="settings_event_key_exported">Ключ экспортирован в файл</string>
+    <string name="settings_event_lock_incomplete">Автоблокировка завершилась не полностью</string>
     <string name="settings_event_with_detail">%1$s: %2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">сегодня %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_settings.xml
@@ -151,7 +151,7 @@
     <string name="settings_security_biometric_recheck">重新检查</string>
     <string name="settings_security_biometric_weak_binding">已启用，但密钥绑定较弱 — 仍需生物识别。</string>
     <string name="settings_security_auto_lock">自动锁定</string>
-    <string name="settings_security_auto_lock_desc">空闲后锁定。</string>
+    <string name="settings_security_auto_lock_desc">停止输入后锁定。文件传输或正在运行的脚本最多可将其推迟十个间隔；锁定会关闭已打开的会话。</string>
     <string name="settings_autolock_1m">1 分钟后</string>
     <string name="settings_autolock_5m">5 分钟后</string>
     <string name="settings_autolock_15m">15 分钟后</string>
@@ -170,6 +170,7 @@
     <string name="settings_event_unlocked_biometric">通过生物识别解锁</string>
     <string name="settings_event_device_paired">新设备已配对</string>
     <string name="settings_event_key_exported">密钥已导出到文件</string>
+    <string name="settings_event_lock_incomplete">自动锁定未完全完成</string>
     <string name="settings_event_with_detail">%1$s：%2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">今天 %1$s</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_settings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_settings.xml
@@ -151,7 +151,7 @@
     <string name="settings_security_biometric_recheck">Check again</string>
     <string name="settings_security_biometric_weak_binding">On with a weaker key binding — biometrics still required.</string>
     <string name="settings_security_auto_lock">Auto-lock</string>
-    <string name="settings_security_auto_lock_desc">Lock after idle.</string>
+    <string name="settings_security_auto_lock_desc">Locks when your input stops. A transfer or a running script defers it by up to ten intervals; locking closes open sessions.</string>
     <string name="settings_autolock_1m">After 1 minute</string>
     <string name="settings_autolock_5m">After 5 minutes</string>
     <string name="settings_autolock_15m">After 15 minutes</string>
@@ -170,6 +170,7 @@
     <string name="settings_event_unlocked_biometric">Unlocked with biometrics</string>
     <string name="settings_event_device_paired">New device paired</string>
     <string name="settings_event_key_exported">Key exported to file</string>
+    <string name="settings_event_lock_incomplete">Auto-lock did not finish cleanly</string>
     <string name="settings_event_with_detail">%1$s: %2$s</string>
     <string name="settings_event_line">%1$s · %2$s</string>
     <string name="settings_time_today">today %1$s</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/AppLocals.kt
@@ -229,6 +229,14 @@ val LocalRunbooks: ProvidableCompositionLocal<RunbookManager?> = staticCompositi
 val LocalRunbookRunner: ProvidableCompositionLocal<RunbookRunner?> = staticCompositionLocalOf { null }
 
 /**
+ * Reports user input to the vault's idle auto-lock timer from the places the gate's own
+ * [app.skerry.ui.vault.idleActivity] modifier cannot see it: a soft keyboard delivers no key event
+ * to the composition, so on Android text is the only trace the user is still there. Provided by
+ * [app.skerry.ui.vault.VaultGate]; a no-op wherever there is no gate (mock path, previews).
+ */
+val LocalUserActivity: ProvidableCompositionLocal<() -> Unit> = staticCompositionLocalOf { {} }
+
+/**
  * Log of past runs, per runbook — what the run screen's "previous runs" card and the library's
  * "last run" line read. `null` on the mock path and wherever no vault is behind the section.
  */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -513,6 +513,13 @@ class ConnectionController(
         }
 
     /**
+     * Whether this session is writing a file right now — a transfer or an editor save; `false` when
+     * the SFTP channel was never opened. Cheap enough for the vault's idle auto-lock to poll (see
+     * [VaultGate]'s `workInFlight`).
+     */
+    val writeInFlight: Boolean get() = transferCoordinator?.writeInFlight == true
+
+    /**
      * This session's live host-metrics controller — one per connection, created lazily and cached
      * (like [openPortForwards]/[openTransferCoordinator]); polling runs on the session's [scope]
      * and starts immediately. Stopped by [disconnect] along with the session.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/FieldDraft.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -13,6 +14,7 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import app.skerry.ui.app.LocalUserActivity
 
 /**
  * Caret state for a text field whose value lives outside it as a plain [String].
@@ -48,6 +50,14 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
      * `Left` is how a screen reader reads a field it has just landed on.
      */
     private var gestureCaret: Int? = null
+
+    /**
+     * Reports typing to the vault's idle auto-lock ([app.skerry.ui.app.LocalUserActivity]). Set from
+     * [rememberFieldDraft] on every composition, because the field outlives the value the local had
+     * when it was created. On Android a soft keyboard sends no key event to the composition, so the
+     * text arriving here is the only sign the user is present.
+     */
+    internal var onActivity: () -> Unit = {}
 
     /** Written by [fieldFocus]; read by [rememberFieldDraft] to drive the select-on-focus rule. */
     internal var focused by mutableStateOf(false)
@@ -122,7 +132,10 @@ internal class FieldDraft(private val masked: Boolean = false, private val singl
         // it was, so the retyped character would match the text this field last emitted and the key
         // would go dead for good.
         emitted = next.text != previous || next.text != current
-        if (emitted) onText(next.text)
+        if (emitted) {
+            onActivity()
+            onText(next.text)
+        }
     }
 
     /**
@@ -173,6 +186,10 @@ internal fun rememberFieldDraft(
     singleLine: Boolean = true,
 ): FieldDraft {
     val draft = remember(masked, singleLine) { FieldDraft(masked, singleLine) }
+    // SideEffect, not a bare write: a composition attempt Compose discards must not leave the field
+    // holding a callback from it.
+    val activity = LocalUserActivity.current
+    SideEffect { draft.onActivity = activity }
     // An effect rather than the focus callback: a tap requests focus and then drops the caret at
     // the tapped offset inside the same gesture, so a selection made while the focus is being
     // granted is undone by the very click that asked for it. Applying it once the gesture is over

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -403,8 +403,14 @@ fun DesktopDesignApp(
                 // Idle auto-lock threshold from settings: changing it in the UI recomposes VaultGate
                 // and restarts the idle timer; Never (idleMs == null) turns it off.
                 autoLockIdleMs = state.settings.autoLock.idleMs,
+                // Unattended work the user started defers the idle lock — see [IdleLockPolicy]. Read
+                // on every tick of the idle timer, so both getters stay O(open sessions).
+                workInFlight = { liveSessions?.writeInFlight == true || runbookRunner?.stepInFlight == true },
                 // Runs on EVERY lock, including the two automatic ones that bypass the lock action.
-                onBeforeLock = { tearDownForLock(tunnels, sessions, sync, snippets, runbookRunner, keyboardInteractive) },
+                // liveSessions, not the `sessions` parameter: the desktop entry point passes none and
+                // lets this composable build one, so the parameter is null in the shipped app and the
+                // reconnect credentials survived every automatic lock.
+                onBeforeLock = { tearDownForLock(tunnels, liveSessions, sync, snippets, runbookRunner, keyboardInteractive) },
                 onReset = onVaultReset,
                 // onPairingComplete != null (sync is present) — the create screen offers "I have a code":
                 // the coordinator creates the vault under the chosen password itself and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.ui.app.LocalUserActivity
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
@@ -290,6 +291,10 @@ private fun EditorBuffer(
     focusEditor: Boolean,
 ) {
     val focus = remember(controller) { FocusRequester() }
+    // A soft keyboard sends no key event to the vault gate's input modifier, and an editor buffer is
+    // not a transfer either — without this, editing a remote file on Android for the idle window
+    // locks the vault and takes the unsaved text with it.
+    val userActivity = LocalUserActivity.current
     // The controller can replace the content on its own (initial load, an edit rejected while a
     // conflict is pending): adopt it, but never on the echo of our own keystroke.
     LaunchedEffect(state.text) {
@@ -302,6 +307,7 @@ private fun EditorBuffer(
     BasicTextField(
         value = value,
         onValueChange = { next ->
+            if (next.text != value.text) userActivity()
             onValueChange(next)
             controller.edit(next.text)
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -115,6 +115,16 @@ class TransferCoordinator(
     val transfer: TransferState get() = transfers.latest
 
     /**
+     * Whether bytes are moving right now — a transfer, or an editor save ([openEditor]; the same
+     * [editorWrites] lock session teardown waits on). Read by the vault's idle auto-lock, which
+     * defers locking while it is true: a lock closes the session this runs on, and a half-written
+     * file is not what a timeout should leave behind — a save is open-truncate-write, so cutting it
+     * loses the file. [busy] itself stays private: it is the serialization latch, held across the
+     * overwrite prompt too, which is the user being asked something, not work in flight.
+     */
+    val writeInFlight: Boolean get() = transfer is TransferState.Active || editorWrites.isLocked
+
+    /**
      * Overwrite conflict awaiting confirmation: the destination directory already has entries
      * named [OverwriteConflict.names]. While non-null, the UI shows an "Overwrite?" dialog;
      * [resolveOverwrite] either runs the deferred transfer or cancels it.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileDesignApp.kt
@@ -313,6 +313,10 @@ fun MobileDesignApp(
                     // Auto-lock threshold from settings: changing it recomposes VaultGate and restarts
                     // the idle timer; Never (idleMs == null) disables it.
                     autoLockIdleMs = state.autoLock.idleMs,
+                    // Unattended work the user started defers the idle lock — see [IdleLockPolicy].
+                    workInFlight = {
+                        liveSessions?.writeInFlight == true || deps.runbookRunner?.stepInFlight == true
+                    },
                     // Runs on EVERY lock, including the two automatic ones that bypass the lock
                     // action — Android had no teardown at all before (only onVaultReset did).
                     onBeforeLock = { tearDownForLock(deps.tunnels, liveSessions, deps.sync, deps.snippets, deps.runbookRunner, keyboardInteractive) },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunner.kt
@@ -103,6 +103,35 @@ class RunbookRunner(
     /** Whether a run is in flight (sending or waiting for a confirmation). */
     val active: Boolean get() = phase == RunbookPhase.RUNNING || phase == RunbookPhase.AWAITING_CONFIRM
 
+    /**
+     * Whether a step is executing right now — the run is sending or waiting on the host, and nobody
+     * is waiting on the user. The vault's idle auto-lock defers while this is true, so every state
+     * that is really "waiting for a human" has to be excluded: [RunbookPhase.RUNNING] alone is not
+     * that, because an interactive step ([RunbookStepStatus.AWAITING_COMPLETE]) and a confirmation
+     * pause ([RunbookPhase.AWAITING_CONFIRM]) both leave the run running while the click that ends
+     * them never comes — which is exactly the idleness the timer exists to catch.
+     *
+     * A silent step is excluded too, and that is not the same as a slow one: a step is marked RUNNING
+     * before its line is sent, and the terminal's production guard holds that line back behind a
+     * confirmation of its own. Dismiss that dialog and the step stays RUNNING for the rest of the
+     * session — an unattended desk deferring every later lock. Past [SILENT_STEP_MS] of no output the
+     * run cannot tell whether anything is executing at all, so it stops speaking for the user. The
+     * floor is not [RunbookPolicy.watchdogMinutes]: a runbook's author may switch that off, and how
+     * long a vault stays unlocked is not theirs to set. [RunbookStepState.stalled] counts as well,
+     * for the runbooks that ask to be judged sooner.
+     */
+    val stepInFlight: Boolean
+        get() = phase == RunbookPhase.RUNNING && stepQuietMillis < SILENT_STEP_MS &&
+            run?.let { it.steps.getOrNull(it.currentIndex) }
+                ?.let { it.status == RunbookStepStatus.RUNNING && !it.stalled } == true
+
+    /**
+     * How long the current step has produced no output. Tracked whatever the watchdog is set to,
+     * because [stepInFlight] holds the vault's auto-lock off and cannot depend on a runbook's own
+     * settings. A transfer step never touches the terminal, so it stays at zero and keeps deferring.
+     */
+    private var stepQuietMillis: Long by mutableStateOf(0L)
+
     /** Whether any step failed, including ones the runbook tolerates. */
     val hadFailures: Boolean get() = run?.hadFailures == true
 
@@ -304,10 +333,22 @@ class RunbookRunner(
 
     /** Dismisses the run entirely (stopping it first if needed) and forgets its resolved values. */
     fun close() {
-        stop()
-        // A record parked by a run that ended without anyone flushing it (a phase settled while the
-        // screen was gone) is written now — after this the run it describes no longer exists.
-        flushReport()
+        try {
+            stop()
+            // A record parked by a run that ended without anyone flushing it (a phase settled while
+            // the screen was gone) is written now — after this the run it describes no longer exists.
+            flushReport()
+        } finally {
+            dropRun()
+        }
+    }
+
+    /**
+     * Everything this run still holds in memory. In a `finally`, because [close] is what a vault lock
+     * calls: a report that fails to write (a full disk) must not leave the step output, the resolved
+     * `${{vault:…}}` values and the context closure alive behind a locked vault.
+     */
+    private fun dropRun() {
         synchronized(lock) {
             generation++
             watchJob?.cancel()
@@ -351,6 +392,7 @@ class RunbookRunner(
         val resolved = script?.resolve(index, contextValue) ?: return
         state.status = RunbookStepStatus.RUNNING
         state.startedAtMillis = now()
+        stepQuietMillis = 0
         run.phase = RunbookPhase.RUNNING
         run.currentIndex = index
         phase = RunbookPhase.RUNNING
@@ -429,6 +471,7 @@ class RunbookRunner(
                     val version = target.outputVersion()
                     if (version == lastVersion) quietMillis += pollIntervalMillis else quietMillis = 0
                     lastVersion = version
+                    stepQuietMillis = quietMillis
                     val watchdog = policy.watchdogMinutes
                     markStalled(run, index, generationAtStart, watchdog > 0 && quietMillis >= watchdog * MILLIS_PER_MINUTE)
                     continue
@@ -621,6 +664,14 @@ class RunbookRunner(
 
 /** How long a watchdog minute is; the policy is in minutes, the poll loop counts milliseconds. */
 private const val MILLIS_PER_MINUTE = 60_000L
+
+/**
+ * Silence after which a running step stops counting as work in flight for the vault's idle auto-lock
+ * ([RunbookRunner.stepInFlight]). Matches the default watchdog: long enough for an ordinary command
+ * that prints only when it finishes, short enough that a step parked behind a dialog nobody answered
+ * cannot hold a vault open.
+ */
+private const val SILENT_STEP_MS = 2 * MILLIS_PER_MINUTE
 
 /** Raised in place of opening a channel the session doesn't have — reported, never surfaced raw. */
 private class NoSftpChannelException : Exception("This session has no SFTP channel")

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -287,6 +287,12 @@ class SessionsController(
     val allSessions: List<Session> get() = tabs.flatMap { it.panes }
 
     /**
+     * Whether any open session is writing a file right now — what the vault's idle auto-lock asks
+     * before locking, since locking would close the session the write runs on.
+     */
+    val writeInFlight: Boolean get() = allSessions.any { it.controller.writeInFlight }
+
+    /**
      * The session being worked in: the focused pane of the active tab. What every single-session
      * read-site wants (the status bar, the info panel, the mobile screens, which have no panes).
      */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/settings/SecuritySection.kt
@@ -66,6 +66,7 @@ import app.skerry.ui.generated.resources.settings_event_biometric_disabled
 import app.skerry.ui.generated.resources.settings_event_biometric_enabled
 import app.skerry.ui.generated.resources.settings_event_device_paired
 import app.skerry.ui.generated.resources.settings_event_key_exported
+import app.skerry.ui.generated.resources.settings_event_lock_incomplete
 import app.skerry.ui.generated.resources.settings_event_line
 import app.skerry.ui.generated.resources.settings_event_password_changed
 import app.skerry.ui.generated.resources.settings_event_unlocked_biometric
@@ -328,6 +329,7 @@ private fun SecurityEventType.eventLabel(): String = stringResource(
         SecurityEventType.UnlockedBiometric -> Res.string.settings_event_unlocked_biometric
         SecurityEventType.DevicePaired -> Res.string.settings_event_device_paired
         SecurityEventType.KeyExported -> Res.string.settings_event_key_exported
+        SecurityEventType.LockIncomplete -> Res.string.settings_event_lock_incomplete
     },
 )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -96,6 +96,7 @@ import app.skerry.shared.terminal.highlight.applyTo
 import app.skerry.shared.terminal.TerminalPos
 import app.skerry.shared.terminal.searchTerminal
 import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.app.LocalUserActivity
 import app.skerry.ui.design.ClaimKeyboard
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
@@ -194,6 +195,8 @@ fun TerminalScreen(
     val handleColor = termTheme.cursor
     val mono = rememberTerminalFontFamily(appearance.font)
     val density = LocalDensity.current
+    // Soft-keyboard input is invisible to the vault gate's own input modifier — reported here.
+    val userActivity = LocalUserActivity.current
     // A full TUI screen redraws hundreds of distinct glyph runs per frame; the default layout cache
     // (8 entries) thrashes and re-lays-out every run every frame. Sized to hold a busy screen's runs.
     // Color is passed at draw time (see drawGlyphText), so cache hits stay theme-safe.
@@ -1349,6 +1352,10 @@ fun TerminalScreen(
                   // sticky-ctrl etc. apply only to real input (not to an empty delta).
                   val out = if (raw.isEmpty()) raw else imeTransform?.invoke(raw) ?: raw
                   if (out.isNotEmpty()) {
+                      // The vault's idle auto-lock sees no key event for this path (the soft keyboard
+                      // is its own window), and typing into a session is the plainest evidence there
+                      // is that the user is still here.
+                      userActivity()
                       state.clearSelection()
                       textToolbar.hide()
                       // While reverse-search is open — the soft keyboard edits the query, not the PTY:

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/IdleLockPolicy.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/IdleLockPolicy.kt
@@ -1,0 +1,180 @@
+package app.skerry.ui.vault
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerType
+import androidx.compose.ui.input.pointer.pointerInput
+
+/** Floor under [IdleLockPolicy.tickMs]: a shorter tick would poll for nothing. */
+private const val MIN_TICK_MS = 1_000L
+
+/** [IdleLockPolicy.tickMs] is this fraction of the threshold, so the lock is at most 10% late. */
+private const val TICKS_PER_WINDOW = 10
+
+/**
+ * How long work in flight may hold the lock off with nobody at the keyboard, counted in idle
+ * windows. Proportional rather than flat, because the threshold *is* the user's answer to how long
+ * this desk may stand unattended and unlocked: a flat allowance would turn "After 1 minute" into an
+ * hour, and the setting would be off by sixty.
+ */
+private const val MAX_DEFERRAL_WINDOWS = 10
+
+/**
+ * Absolute ceiling on that allowance, whatever the threshold. Long enough for the transfers and
+ * procedures this exists for, short enough that it cannot be forever: what "in flight" means is
+ * decided at the far end of the wire, and a host that never finishes a step — or never answers a
+ * read — must not be able to keep a vault open on an unattended desk all night.
+ */
+private const val MAX_DEFERRAL_MS = 60 * 60_000L
+
+/**
+ * When an unlocked vault may lock itself again: the idle auto-lock rule, apart from the gate that
+ * runs it ([VaultGate]).
+ *
+ * Driven by ticks rather than by a wall clock. [touch] is called from input handlers — a pointer
+ * moving across the window produces hundreds of events a second — and a timer restarted per event
+ * would cancel and relaunch a coroutine just as often, or worse, recompose. Here an event is one
+ * boolean write and the timer is a plain loop of [tickMs] delays. The cost is quantization: the
+ * lock lands within one tick of the threshold, which is why [tickMs] is a fraction of it rather
+ * than a fixed interval.
+ *
+ * The policy, in full — what the Settings → Security caption has to match:
+ *  - any user input (keys, pointer movement, wheel, presses, text from a soft keyboard) restarts
+ *    the countdown;
+ *  - unattended work the user started — an SFTP transfer, a runbook step — defers the lock while it
+ *    runs, because locking closes sessions and would take the work with it, but for at most
+ *    [MAX_DEFERRAL_WINDOWS] idle windows of continuous absence, and never past [MAX_DEFERRAL_MS].
+ *    Worst case is therefore one countdown plus the allowance — eleven intervals, not ten — which
+ *    is why the Settings caption states the bound instead of leaving the threshold to imply it;
+ *  - nothing else holds the lock off. Output streaming from a session, a framebuffer repainting or
+ *    a tunnel carrying traffic are the remote end being busy, not the user being present.
+ */
+class IdleLockPolicy(private val idleMs: Long) {
+
+    init {
+        require(idleMs > 0) { "idle threshold must be positive; 'no auto-lock' is a null policy, not a zero one" }
+    }
+
+    /** How often [onTick] must be called. */
+    val tickMs: Long = (idleMs / TICKS_PER_WINDOW).coerceIn(minOf(MIN_TICK_MS, idleMs), idleMs)
+
+    /** Input seen since the last tick. Plain field: written from input handlers, read on the tick. */
+    private var touched = false
+
+    private var quietMs = 0L
+
+    /**
+     * How long work in flight may hold the lock off for this threshold: [MAX_DEFERRAL_WINDOWS] of
+     * the user's own windows, and never past the absolute [MAX_DEFERRAL_MS].
+     */
+    private val maxDeferralMs: Long = (idleMs * MAX_DEFERRAL_WINDOWS).coerceAtMost(MAX_DEFERRAL_MS)
+
+    /** How long work in flight has already held the lock off since the last sign of the user. */
+    private var deferredMs = 0L
+
+    /**
+     * Start the countdown from now. Called when the timer starts running rather than on every tick:
+     * a policy outlives the unlocked session it was made for (the threshold it was built from hasn't
+     * changed), and one that locked once already stands at the threshold — without this, the vault
+     * unlocked again would lock a tick later, mid-password-still-warm.
+     */
+    fun restart() {
+        touched = false
+        quietMs = 0
+        deferredMs = 0
+    }
+
+    /** Record user activity — restarts the countdown at the next tick. */
+    fun touch() {
+        touched = true
+    }
+
+    /**
+     * One step of the countdown.
+     *
+     * @param workInFlight whether unattended work the user started is running right now.
+     * @return whether the vault must lock now.
+     */
+    fun onTick(workInFlight: Boolean): Boolean {
+        if (touched) {
+            touched = false
+            quietMs = 0
+            deferredMs = 0
+            return false
+        }
+        quietMs += tickMs
+        if (quietMs < idleMs) return false
+        // Deferred, not cancelled: the countdown starts over, so the vault locks a full idle window
+        // after the work ends rather than the instant it does. Bounded by [maxDeferralMs], since
+        // "still working" is a claim made by the other end of the connection.
+        if (workInFlight && deferredMs < maxDeferralMs) {
+            deferredMs += quietMs
+            quietMs = 0
+            return false
+        }
+        return true
+    }
+}
+
+/**
+ * Tells pointer events made by a hand from the ones Compose makes up.
+ *
+ * After a relayout Compose re-sends the last mouse event as a [PointerEventType.Move] at its
+ * unchanged position, so that a control sliding under a resting cursor still gets its hover
+ * (`SyntheticEventSender.updatePointerPosition`). A session printing output relayouts on every
+ * batch: counting those would let a chatty host answer "still here" for an empty desk, and the
+ * vault would never lock again.
+ *
+ * The re-sent move is recognised by its position — it carries the one the previous event had.
+ * `positionChanged()` cannot be used for this: a pointer with no button down is not tracked between
+ * events (`PointerInputChangeEventProducer.produce`), so every hover move reports its own position
+ * as the previous one and claims nothing moved. Only mouse pointers are re-sent, so only they are
+ * compared; a finger reporting the same position twice is a finger held still on the glass, which
+ * is a person.
+ */
+internal class PointerActivity {
+
+    private var lastMouseAt: Offset? = null
+
+    fun isFromUser(event: PointerEvent): Boolean {
+        // Nothing but a lone mouse pointer is ever re-sent, and the remembered position survives
+        // everything else: forgetting it on a stray touch event would hand the next re-sent move
+        // through as a person.
+        val at = event.changes.singleOrNull()?.takeIf { it.type == PointerType.Mouse }?.position ?: return true
+        val resent = event.type == PointerEventType.Move && at == lastMouseAt
+        lastMouseAt = at
+        return !resent
+    }
+}
+
+/**
+ * Feeds user input in this subtree to [policy] — keys on the way down, and pointer events (press,
+ * movement, wheel) observed on [PointerEventPass.Initial] without consuming them, so children still
+ * receive both.
+ *
+ * Presses alone are not activity: typing into a terminal for five minutes without touching the
+ * pointer used to be indistinguishable from an empty desk, and the vault locked on top of a live
+ * session (issue #291). A soft keyboard sends neither — that input arrives through
+ * [app.skerry.ui.app.LocalUserActivity].
+ *
+ * [policy] `null` (auto-lock off) makes this a no-op modifier.
+ */
+fun Modifier.idleActivity(policy: IdleLockPolicy?): Modifier =
+    if (policy == null) {
+        this
+    } else {
+        this
+            .onPreviewKeyEvent { policy.touch(); false }
+            .pointerInput(policy) {
+                val pointer = PointerActivity()
+                awaitPointerEventScope {
+                    while (true) {
+                        if (pointer.isFromUser(awaitPointerEvent(PointerEventPass.Initial))) policy.touch()
+                    }
+                }
+            }
+    }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -6,6 +6,7 @@ import app.skerry.ui.session.SessionsController
 import app.skerry.ui.snippet.SnippetManager
 import app.skerry.ui.sync.SyncCoordinator
 import app.skerry.ui.tunnel.TunnelManager
+import kotlinx.coroutines.CancellationException
 
 /**
  * Drops everything that still holds a decrypted secret when the vault locks. Passed to
@@ -44,12 +45,40 @@ fun tearDownForLock(
     runbooks: RunbookRunner? = null,
     keyboardInteractive: KeyboardInteractivePromptController? = null,
 ) {
-    tunnels?.closeAll()
+    val failures = TeardownFailures()
+    failures.run { tunnels?.closeAll() }
+    // Guarded per pane, not per step: each pane holds its own decrypted credential, so one that
+    // refuses to let go must not leave the panes after it holding theirs behind a locked vault.
     sessions?.tabs?.forEach { tab ->
-        tab.panes.forEach { it.controller.clearReconnectCredentials() }
+        tab.panes.forEach { pane -> failures.run { pane.controller.clearReconnectCredentials() } }
     }
-    sync?.pauseForLock()
-    snippets?.dismissRun()
-    runbooks?.close()
-    keyboardInteractive?.cancelPending()
+    failures.run { sync?.pauseForLock() }
+    failures.run { snippets?.dismissRun() }
+    failures.run { runbooks?.close() }
+    failures.run { keyboardInteractive?.cancelPending() }
+    failures.rethrowFirst()
+}
+
+/**
+ * Keeps a failed cleanup from cancelling the ones after it. Each step here drops a different secret,
+ * and they are independent: a tunnel that refuses to close must not leave a runbook's resolved
+ * `${{vault:…}}` values in memory behind a locked vault. The first failure is still raised once
+ * everything has had its turn, so the manual lock reports it as before.
+ */
+private class TeardownFailures {
+    private var first: Throwable? = null
+
+    fun run(step: () -> Unit) {
+        try {
+            step()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (first == null) first = e
+        }
+    }
+
+    fun rethrowFirst() {
+        first?.let { throw it }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateController.kt
@@ -202,10 +202,6 @@ class VaultGateController(
     var biometricReducedBinding: Boolean by mutableStateOf(biometrics?.reducedBinding() == true)
         private set
 
-    /** User activity counter — idle auto-lock restarts when it changes. */
-    var activityTick: Int by mutableStateOf(0)
-        private set
-
     /**
      * Whether a biometric prompt is currently in flight. Background auto-lock must skip it: the system
      * prompt may send `ON_STOP`, and locking mid-authentication would leave the user having successfully
@@ -377,11 +373,6 @@ class VaultGateController(
             error = null
             state = VaultGateState.NeedsCreate
         }
-    }
-
-    /** Record user activity — restarts the idle auto-lock timer. */
-    fun touch() {
-        activityTick++
     }
 
     /** Whether biometric unlock can be offered on the unlock form (available and enabled). */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultGateScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.ui.input.pointer.PointerEventPass
-import androidx.compose.ui.input.pointer.PointerEventType
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -22,6 +19,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -41,9 +39,11 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import app.skerry.shared.vault.BiometricPrompt
+import app.skerry.shared.vault.SecurityEventType
 import app.skerry.shared.vault.SecurityLog
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultBiometrics
+import app.skerry.ui.app.LocalUserActivity
 import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vtail_error_biometric_failed
@@ -89,6 +89,7 @@ import app.skerry.ui.generated.resources.vtail_bio_unlock_cancel
 import app.skerry.ui.generated.resources.vtail_bio_unlock_subtitle
 import app.skerry.ui.generated.resources.vtail_bio_unlock_title
 import app.skerry.ui.nav.PlatformBackHandler
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
@@ -111,7 +112,7 @@ expect fun deviceMandatesAutoLock(): Boolean
  *
  * If [biometrics] is passed, the unlock form offers biometric unlock (the prompt fires automatically
  * when biometrics is enabled). Auto-lock: the vault locks on background (lifecycle `ON_STOP`) and on
- * idle ([AUTO_LOCK_IDLE_MS], timer restarted by touches).
+ * idle ([AUTO_LOCK_IDLE_MS] by default, [IdleLockPolicy] for what counts as idle).
  *
  * Compose input fields work with [String], so the password is converted to [CharArray] only on submit
  * and wiped immediately by the controller; the field's string buffer lives until recomposition — a
@@ -128,6 +129,12 @@ fun VaultGate(
     // restarts the idle timer. `null` — idle timer off ([AutoLockDuration.Never]); background lock remains
     // (deviceMandatesAutoLock).
     autoLockIdleMs: Long? = AUTO_LOCK_IDLE_MS,
+    // Whether unattended work the user started is running right now — an SFTP transfer, a runbook
+    // run. While it is, the idle timer defers the lock instead of firing it: locking closes the
+    // sessions the work lives on, and losing a half-finished transfer to a timeout is not a
+    // security win. Read on every tick, so it must be cheap. Default `false` — mock path/previews,
+    // where nothing is running. See [IdleLockPolicy] for the policy in full.
+    workInFlight: () -> Boolean = { false },
     modifier: Modifier = Modifier,
     // Teardown of everything holding the decrypted secret, run immediately before EVERY transition to
     // locked — manual lock, background (`ON_STOP`) and the idle timer alike. It lives here rather than
@@ -239,7 +246,34 @@ fun VaultGate(
     // Single door into the locked state: every path goes through the teardown first. Kept fresh via
     // rememberUpdatedState so the DisposableEffect observer below doesn't capture a stale lambda.
     val currentOnBeforeLock by rememberUpdatedState(onBeforeLock)
-    val lockNow = { currentOnBeforeLock(); controller.lock() }
+    // finally, not a plain sequence: a teardown that throws must not leave the vault open — the
+    // idle timer's only other exit is to stop running, and a gate that fails open is not a gate.
+    // The exception still propagates; it just no longer decides whether the vault locks.
+    val lockNow = {
+        try {
+            currentOnBeforeLock()
+        } finally {
+            controller.lock()
+        }
+    }
+
+    // The automatic locks — idle and background — fire on an empty desk, so a cleanup that refuses
+    // must not take the app down with it. It must not vanish either: the vault is locked, but
+    // whatever failed to close is still holding a secret, and the lock screen looks exactly like a
+    // clean lock. The log is the only place left to say otherwise. The manual lock keeps
+    // propagating: there the user is watching, and the crash is the report.
+    val lockAutomatically = {
+        try {
+            lockNow()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
+            // No detail: an exception's text carries host names, and this log is plaintext on disk.
+            // runCatching because the log is a file: on a full disk the write throws, and a record
+            // that cannot be made must not undo the containment it was added to report on.
+            runCatching { securityLog?.record(SecurityEventType.LockIncomplete) }
+        }
+    }
 
     // Background auto-lock: other hands on an unlocked device must not get an open vault after minimizing.
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -252,19 +286,46 @@ fun VaultGate(
                 !controller.biometricInFlight &&
                 deviceMandatesAutoLock()
             ) {
-                lockNow()
+                lockAutomatically()
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    // Idle auto-lock: the delay restarts on activityTick change (user touch) and on [autoLockIdleMs]
-    // threshold change from settings. null (AutoLockDuration.Never) — timer off.
-    if (controller.state == VaultGateState.Unlocked && autoLockIdleMs != null) {
-        LaunchedEffect(controller.activityTick, autoLockIdleMs) {
-            delay(autoLockIdleMs)
-            lockNow()
+    // Idle auto-lock: [IdleLockPolicy] owns the rule, this only runs its clock. Input reaches it
+    // through [idleActivity] on the content below and through [LocalUserActivity]; a new threshold
+    // from settings (or null — AutoLockDuration.Never, timer off) makes a new policy, which
+    // restarts the loop. Kept out of the composition otherwise: a policy tick is a plain field,
+    // deliberately not snapshot state, so pointer movement doesn't recompose the whole app.
+    val idlePolicy = remember(autoLockIdleMs) { autoLockIdleMs?.let { IdleLockPolicy(it) } }
+    val currentWorkInFlight by rememberUpdatedState(workInFlight)
+    // Stable per policy: a fresh lambda every recomposition would invalidate every reader of the
+    // static local below.
+    val userActivity: () -> Unit = remember(idlePolicy) { { idlePolicy?.touch() } }
+    if (controller.state == VaultGateState.Unlocked && idlePolicy != null) {
+        LaunchedEffect(idlePolicy) {
+            idlePolicy.restart()
+            while (true) {
+                delay(idlePolicy.tickMs)
+                // A predicate supplied from outside decides only whether to *defer*; if it throws,
+                // the tick proceeds as if nothing were running. The loop has no other restart —
+                // activity is a plain field write, not a state change — so letting an exception out
+                // of here would disable the auto-lock for the rest of the session, silently.
+                val busy = try {
+                    currentWorkInFlight()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {
+                    false
+                }
+                if (idlePolicy.onTick(busy)) {
+                    // The vault is locked by lockNow's own `finally` even when the teardown throws;
+                    // nothing here can repair one that did, so the loop ends either way.
+                    lockAutomatically()
+                    break
+                }
+            }
         }
     }
 
@@ -316,19 +377,10 @@ fun VaultGate(
 
             // lock() moves the gate to NeedsUnlock; key(state) tears down the content subtree, whose
             // DisposableEffect drops the live SSH session — locking closes sessions too.
-            VaultGateState.Unlocked -> Box(
-                Modifier.fillMaxSize().pointerInput(Unit) {
-                    // Observe presses on the Initial pass without consuming — children still get events,
-                    // and the idle timer restarts on each touch.
-                    awaitPointerEventScope {
-                        while (true) {
-                            val event = awaitPointerEvent(PointerEventPass.Initial)
-                            if (event.type == PointerEventType.Press) controller.touch()
-                        }
-                    }
-                },
-            ) {
-                content { lockNow() }
+            VaultGateState.Unlocked -> Box(Modifier.fillMaxSize().idleActivity(idlePolicy)) {
+                CompositionLocalProvider(LocalUserActivity provides userActivity) {
+                    content { lockNow() }
+                }
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -283,6 +283,21 @@ class ConnectionControllerTest {
         scope.cancel()
     }
 
+    /** What the vault's idle auto-lock polls: a session that never opened SFTP writes nothing. */
+    @Test
+    fun `writeInFlight is false while no transfer channel was ever opened`() = runTest {
+        val conn = FakeSshConnection(FakeShellChannel(), sftp = RecordingSftpClient())
+        val (controller, scope) = controllerWith(FakeSshTransport(conn))
+        controller.connect(testTarget, SshAuth.Password("pw"))
+
+        assertFalse(controller.writeInFlight)
+
+        // Opening the channel is not writing either — bytes have to be moving.
+        controller.openTransferCoordinator(FakeFileBrowser(), "host")
+        assertFalse(controller.writeInFlight)
+        scope.cancel()
+    }
+
     @Test
     fun `openTransferCoordinator without a live connection fails`() = runTest {
         val (controller, scope) = controllerWith(FakeSshTransport(FakeSshConnection(FakeShellChannel())))

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/design/FieldDraftTest.kt
@@ -24,6 +24,24 @@ class FieldDraftTest {
         assertEquals(TextRange(10), draft.textFieldValue("report.log").selection)
     }
 
+    /**
+     * The soft-keyboard half of the vault's idle auto-lock: on Android nothing about this typing
+     * reaches the gate's key handler, so the field is what reports the user is still there.
+     */
+    @Test
+    fun typing_reports_activity_to_the_idle_lock() {
+        val draft = FieldDraft()
+        var reported = 0
+        draft.onActivity = { reported++ }
+
+        draft.accept(TextFieldValue("22", TextRange(2)), "2") {}
+        assertEquals(1, reported)
+
+        // A caret move is not typing — and it arrives as a touch, which the gate sees on its own.
+        draft.accept(TextFieldValue("22", TextRange(1)), "22") {}
+        assertEquals(1, reported, "a caret move was reported as typing")
+    }
+
     @Test
     fun focus_selects_the_whole_value_when_armed() {
         val draft = FieldDraft()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -23,9 +23,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.cancel
 
-private const val LHOME = "/local/home"
-private const val RHOME = "/remote/app"
-
 /**
  * Transfer coordinator tests. The local pane runs over a "local" [FakeSftpClient] (an FS stand-in
  * that only sees transfers through its own tree); the remote pane and the transfer channel run
@@ -33,44 +30,6 @@ private const val RHOME = "/remote/app"
  * `upload` seeds the file), and the re-listed remote pane shows it.
  */
 class TransferCoordinatorTest {
-
-    private fun TestScope.scope() = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-
-    private fun localFake() = FakeSftpClient(startDir = LHOME).apply {
-        seedFile("$LHOME/a.txt", size = 10)
-        seedFile("$LHOME/b.txt", size = 20)
-        seedDir("$LHOME/sub")
-        seedFile("$LHOME/sub/inner.txt", size = 7)
-    }
-
-    private fun remoteFake() = FakeSftpClient(startDir = RHOME).apply {
-        seedFile("$RHOME/r.txt", size = 30)
-    }
-
-    private class Rig(
-        val local: FilePaneController,
-        val remote: FilePaneController,
-        val localFake: FakeSftpClient,
-        val remoteFake: FakeSftpClient,
-        val coordinator: TransferCoordinator,
-    )
-
-    private fun TestScope.rig(
-        local: FakeSftpClient = localFake(),
-        remote: FakeSftpClient = remoteFake(),
-        now: () -> Long = { 0L },
-    ): Rig {
-        val localBrowser = SftpFileBrowser(local, "This Mac")
-        val remoteBrowser = SftpFileBrowser(remote, "prod-web-01")
-        val localCtl = FilePaneController(localBrowser, scope())
-        val remoteCtl = FilePaneController(remoteBrowser, scope())
-        localCtl.start(); remoteCtl.start(); advanceUntilIdle()
-        val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope(), now)
-        return Rig(localCtl, remoteCtl, local, remote, coordinator)
-    }
-
-    private fun FilePaneController.entry(name: String) =
-        (state as FilePaneState.Loaded).entries.first { it.name == name }
 
     @Test
     fun `uploadSelection sends selected local files into the remote directory and refreshes it`() = runTest {
@@ -251,6 +210,8 @@ class TransferCoordinatorTest {
         advanceUntilIdle()
         assertEquals(TransferState.Idle, r.coordinator.transfer)
     }
+
+
 
     @Test
     fun `uploadSource uploads a picked file into the remote directory and refreshes it`() = runTest {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRig.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRig.kt
@@ -1,0 +1,56 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.ui.sftp.FakeSftpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+
+internal const val LHOME = "/local/home"
+internal const val RHOME = "/remote/app"
+
+/*
+ * The rig the transfer tests stand on: a "local" [FakeSftpClient] (an FS stand-in that only sees
+ * transfers through its own tree) and a "remote" one carrying the transfer channel. An upload really
+ * creates the file in the remote fake, and the re-listed pane shows it. Split out of
+ * `TransferCoordinatorTest` so a second suite can use it.
+ */
+
+internal fun TestScope.scope() = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+
+internal fun localFake() = FakeSftpClient(startDir = LHOME).apply {
+    seedFile("$LHOME/a.txt", size = 10)
+    seedFile("$LHOME/b.txt", size = 20)
+    seedDir("$LHOME/sub")
+    seedFile("$LHOME/sub/inner.txt", size = 7)
+}
+
+internal fun remoteFake() = FakeSftpClient(startDir = RHOME).apply {
+    seedFile("$RHOME/r.txt", size = 30)
+}
+
+internal class Rig(
+    val local: FilePaneController,
+    val remote: FilePaneController,
+    val localFake: FakeSftpClient,
+    val remoteFake: FakeSftpClient,
+    val coordinator: TransferCoordinator,
+)
+
+internal fun TestScope.rig(
+    local: FakeSftpClient = localFake(),
+    remote: FakeSftpClient = remoteFake(),
+    now: () -> Long = { 0L },
+): Rig {
+    val localBrowser = SftpFileBrowser(local, "This Mac")
+    val remoteBrowser = SftpFileBrowser(remote, "prod-web-01")
+    val localCtl = FilePaneController(localBrowser, scope())
+    val remoteCtl = FilePaneController(remoteBrowser, scope())
+    localCtl.start(); remoteCtl.start(); advanceUntilIdle()
+    val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope(), now)
+    return Rig(localCtl, remoteCtl, local, remote, coordinator)
+}
+
+internal fun FilePaneController.entry(name: String) =
+    (state as FilePaneState.Loaded).entries.first { it.name == name }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferWriteInFlightTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferWriteInFlightTest.kt
@@ -1,0 +1,65 @@
+package app.skerry.ui.files
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * What the vault's idle auto-lock reads off a session's files: the lock closes the channel the write
+ * runs on, and both a transfer and an editor save are open-truncate-write at the far end (issue
+ * #291). A question put to the user — an "Overwrite?" dialog — is not work in flight.
+ */
+class TransferWriteInFlightTest {
+
+    @Test
+    fun `writeInFlight is true only while bytes are moving`() = runTest {
+        val remote = remoteFake().apply {
+            seedFile("$RHOME/a.txt", size = 3)
+            uploadSize = 10
+        }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+
+        r.coordinator.uploadSelection()
+        assertNotNull(r.coordinator.overwrite, "expected an Overwrite dialog")
+        assertFalse(r.coordinator.writeInFlight, "a question for the user is not work in flight")
+
+        r.coordinator.resolveOverwrite(true)
+        advanceUntilIdle() // blocked on the gate, inside the file
+
+        assertTrue(r.coordinator.writeInFlight, "a running transfer must defer the lock")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(r.coordinator.writeInFlight, "a finished transfer still deferred the lock")
+    }
+
+    /** The buffer dies with the subtree the lock drops, so a cut save loses the file both ways. */
+    @Test
+    fun `writeInFlight covers an editor save`() = runTest {
+        val remote = remoteFake().apply { seedContent("$RHOME/nginx.conf", "before\n") }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+        val editor = r.coordinator.openEditor(fromLocal = false, item = r.remote.entry("nginx.conf"), readOnly = false)!!
+        advanceUntilIdle()
+        editor.edit("after\n")
+        remote.writeGate = CompletableDeferred()
+
+        editor.save()
+        advanceUntilIdle() // blocked inside the write
+
+        assertTrue(r.coordinator.writeInFlight, "a save in flight must defer the lock that would cut it")
+
+        remote.writeGate!!.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(r.coordinator.writeInFlight, "a finished save still deferred the lock")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerRig.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerRig.kt
@@ -1,0 +1,157 @@
+package app.skerry.ui.runbook
+
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.RunbookMarker
+import app.skerry.shared.runbook.RunbookPolicy
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.shared.runbook.RunbookTransferDirection
+import app.skerry.shared.sftp.SftpClient
+import app.skerry.shared.snippet.SnippetMoment
+import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.shared.snippet.SnippetSegment
+import app.skerry.shared.terminal.TerminalStepMark
+import app.skerry.ui.sftp.FakeSftpClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+
+/**
+ * The rig every runbook-run test stands on: a terminal faked as a byte sink plus the two things the
+ * runner reads from a real one (the step report its probe emitted, parked until taken as
+ * `TerminalScreenState` parks it, and a counter of host output), the runbook builders, and the
+ * shared teardown. Split out of `RunbookRunnerTest` so a second suite can use it.
+ */
+
+internal const val RUN_ID = "run"
+
+internal const val POLL = 100L
+
+/** The runbooks under test carry a one-minute watchdog; time is virtual, so the wait is free. */
+internal const val STALL_AFTER = 60_000L
+
+/**
+ * The runner's own silence floor (`SILENT_STEP_MS`, private to the production file), past which a
+ * step stops counting as work in flight. Duplicated rather than exposed: the point of the constant
+ * is that a runbook cannot move it, so a test that read it from the policy would prove nothing.
+ */
+internal const val SILENT_FLOOR = 120_000L
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class FakeTerminal {
+    val sent = mutableListOf<String>()
+    var live: Boolean = true
+    var polls: Int = 0
+
+    /** Bytes the host has produced — the echo of what was typed counts, a step report does too. */
+    var outputVersion: Long = 0L
+
+    /** The report parked by the terminal, waiting for the runner to take it. */
+    private var mark: TerminalStepMark? = null
+
+    /** Every token the runner declared, in order; `null` means it stopped expecting one. */
+    val expected = mutableListOf<String?>()
+
+    /** Fragments of the last declared step that the terminal was told to hide from the echo. */
+    var hiddenEcho: List<String> = emptyList()
+
+    /** What the terminal was expecting at the moment each line was sent. */
+    val declaredWhenSent = mutableListOf<String?>()
+
+    /** SFTP side of the same session; `null` stands for a connection without one. */
+    var sftp: FakeSftpClient? = null
+
+    fun target(sessionId: String = "tab-1") = RunbookTarget(
+        sessionId = sessionId,
+        // The PTY echoes the typed line; what the terminal was told to expect is captured with it.
+        send = { line, _ -> sent += line; declaredWhenSent += expected.lastOrNull(); outputVersion++ },
+        expectStep = { token, hidden -> expected += token; hiddenEcho = hidden },
+        // Consuming, and a report of another step is dropped — as TerminalScreenState does it.
+        takeMark = { token ->
+            polls++
+            val parked = mark
+            mark = null
+            parked?.takeIf { it.token == token }
+        },
+        outputVersion = { outputVersion },
+        isLive = { live },
+        openSftp = sftp?.let { client -> suspend { client as SftpClient } },
+    )
+
+    /** The host wrote something to the terminal — the only thing the watchdog looks at. */
+    fun printed() {
+        outputVersion++
+    }
+
+    /** The shell finished the step and its closing probe emitted the mark. */
+    fun complete(stepIndex: Int, exitCode: Int, output: String? = "", runId: String = RUN_ID) {
+        mark = TerminalStepMark(RunbookMarker.token(runId, stepIndex), exitCode, output)
+        outputVersion++
+    }
+}
+
+internal fun environment() = SnippetRunEnvironment(
+    moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
+    newUuid = { "uuid" },
+    randomChars = { n, _ -> "r".repeat(n) },
+)
+
+internal fun runbook(vararg steps: RunbookStep, policy: RunbookPolicy = RunbookPolicy(watchdogMinutes = 1)) =
+    Runbook(id = "rb", label = "Deploy", steps = steps.toList(), policy = policy)
+
+internal fun step(id: String, command: String, confirm: Boolean = false, continueOnError: Boolean = false) =
+    RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, continueOnError = continueOnError)
+
+internal fun interactive(id: String, command: String, confirm: Boolean = false) =
+    RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, interactive = true)
+
+internal fun transfer(
+    id: String,
+    localPath: String = "/tmp/release.tgz",
+    remotePath: String = "/srv/incoming/release.tgz",
+    direction: RunbookTransferDirection = RunbookTransferDirection.UPLOAD,
+    confirm: Boolean = false,
+    continueOnError: Boolean = false,
+) = RunbookStep.Transfer(
+    id = id,
+    title = id,
+    localPath = localPath,
+    remotePath = remotePath,
+    direction = direction,
+    confirm = confirm,
+    continueOnError = continueOnError,
+)
+
+/**
+ * Shared setup and — the point of the helper — shared teardown: a watcher still polling on the
+ * test scheduler makes a *failing* assertion hang runTest's cleanup instead of reporting it, so
+ * the runner is closed and the scope cancelled even when the body throws.
+ */
+internal fun runnerTest(body: TestScope.(RunbookRunner, FakeTerminal) -> Unit) = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val term = FakeTerminal()
+    val runner = RunbookRunner(
+        scope = scope,
+        newId = { RUN_ID },
+        environment = ::environment,
+        pollIntervalMillis = POLL,
+    )
+    try {
+        body(runner, term)
+    } finally {
+        runner.close()
+        scope.cancel()
+    }
+}
+
+/** The run in hand — every run here has exactly one session. */
+internal val RunbookRunner.only: RunbookSessionRun get() = run!!
+
+/** Prepare + confirm in one call: the dialog step has its own coverage in the UI layer. */
+internal fun RunbookRunner.startNow(
+    runbook: Runbook,
+    target: RunbookTarget,
+    contextValue: (SnippetSegment.Variable) -> String,
+): Boolean = requestStart(runbook, target) && confirmStart(contextValue = contextValue)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/runbook/RunbookRunnerTest.kt
@@ -3,20 +3,15 @@ package app.skerry.ui.runbook
 import app.skerry.shared.runbook.Runbook
 import app.skerry.shared.runbook.RunbookMarker
 import app.skerry.shared.runbook.RunbookPolicy
-import app.skerry.shared.runbook.RunbookStep
 import app.skerry.shared.runbook.RunbookTransferDirection
-import app.skerry.shared.sftp.SftpClient
-import app.skerry.shared.snippet.SnippetMoment
-import app.skerry.ui.sftp.FakeSftpClient
-import app.skerry.shared.snippet.SnippetRunEnvironment
 import app.skerry.shared.snippet.SnippetSegment
 import app.skerry.shared.terminal.TerminalStepMark
 import app.skerry.shared.terminal.UNREADABLE_STATUS
+import app.skerry.ui.sftp.FakeSftpClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -28,133 +23,11 @@ import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
- * Runbook run state machine. The terminal is faked as a byte sink plus the two things the runner
- * reads from a real one: the step report its probe emitted (parked until taken, as
- * `TerminalScreenState` parks it) and a counter of host output. Time is virtual.
+ * Runbook run state machine. The rig — the faked terminal, the runbook builders and the shared
+ * teardown — lives in [RunbookRunnerRig.kt]; time is virtual.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 class RunbookRunnerTest {
-
-    private val poll = 100L
-
-    /** The runbooks under test carry a one-minute watchdog; time is virtual, so the wait is free. */
-    private val stallAfter = 60_000L
-
-    private class FakeTerminal {
-        val sent = mutableListOf<String>()
-        var live: Boolean = true
-        var polls: Int = 0
-
-        /** Bytes the host has produced — the echo of what was typed counts, a step report does too. */
-        var outputVersion: Long = 0L
-
-        /** The report parked by the terminal, waiting for the runner to take it. */
-        private var mark: TerminalStepMark? = null
-
-        /** Every token the runner declared, in order; `null` means it stopped expecting one. */
-        val expected = mutableListOf<String?>()
-
-        /** Fragments of the last declared step that the terminal was told to hide from the echo. */
-        var hiddenEcho: List<String> = emptyList()
-
-        /** What the terminal was expecting at the moment each line was sent. */
-        val declaredWhenSent = mutableListOf<String?>()
-
-        /** SFTP side of the same session; `null` stands for a connection without one. */
-        var sftp: FakeSftpClient? = null
-
-        fun target(sessionId: String = "tab-1") = RunbookTarget(
-            sessionId = sessionId,
-            // The PTY echoes the typed line; what the terminal was told to expect is captured with it.
-            send = { line, _ -> sent += line; declaredWhenSent += expected.lastOrNull(); outputVersion++ },
-            expectStep = { token, hidden -> expected += token; hiddenEcho = hidden },
-            // Consuming, and a report of another step is dropped — as TerminalScreenState does it.
-            takeMark = { token ->
-                polls++
-                val parked = mark
-                mark = null
-                parked?.takeIf { it.token == token }
-            },
-            outputVersion = { outputVersion },
-            isLive = { live },
-            openSftp = sftp?.let { client -> suspend { client as SftpClient } },
-        )
-
-        /** The host wrote something to the terminal — the only thing the watchdog looks at. */
-        fun printed() {
-            outputVersion++
-        }
-
-        /** The shell finished the step and its closing probe emitted the mark. */
-        fun complete(stepIndex: Int, exitCode: Int, output: String? = "", runId: String = RUN_ID) {
-            mark = TerminalStepMark(RunbookMarker.token(runId, stepIndex), exitCode, output)
-            outputVersion++
-        }
-    }
-
-    private fun environment() = SnippetRunEnvironment(
-        moment = SnippetMoment(2026, 7, 26, 14, 5, 9, epochSeconds = 1_784_000_000L),
-        newUuid = { "uuid" },
-        randomChars = { n, _ -> "r".repeat(n) },
-    )
-
-    private fun runbook(vararg steps: RunbookStep, policy: RunbookPolicy = RunbookPolicy(watchdogMinutes = 1)) =
-        Runbook(id = "rb", label = "Deploy", steps = steps.toList(), policy = policy)
-
-    private fun step(id: String, command: String, confirm: Boolean = false, continueOnError: Boolean = false) =
-        RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, continueOnError = continueOnError)
-
-    private fun interactive(id: String, command: String, confirm: Boolean = false) =
-        RunbookStep.Command(id = id, title = id, command = command, confirm = confirm, interactive = true)
-
-    private fun transfer(
-        id: String,
-        localPath: String = "/tmp/release.tgz",
-        remotePath: String = "/srv/incoming/release.tgz",
-        direction: RunbookTransferDirection = RunbookTransferDirection.UPLOAD,
-        confirm: Boolean = false,
-        continueOnError: Boolean = false,
-    ) = RunbookStep.Transfer(
-        id = id,
-        title = id,
-        localPath = localPath,
-        remotePath = remotePath,
-        direction = direction,
-        confirm = confirm,
-        continueOnError = continueOnError,
-    )
-
-    /**
-     * Shared setup and — the point of the helper — shared teardown: a watcher still polling on the
-     * test scheduler makes a *failing* assertion hang runTest's cleanup instead of reporting it, so
-     * the runner is closed and the scope cancelled even when the body throws.
-     */
-    private fun runnerTest(body: TestScope.(RunbookRunner, FakeTerminal) -> Unit) = runTest {
-        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val term = FakeTerminal()
-        val runner = RunbookRunner(
-            scope = scope,
-            newId = { RUN_ID },
-            environment = ::environment,
-            pollIntervalMillis = poll,
-        )
-        try {
-            body(runner, term)
-        } finally {
-            runner.close()
-            scope.cancel()
-        }
-    }
-
-    /** The run in hand — every run here has exactly one session. */
-    private val RunbookRunner.only: RunbookSessionRun get() = run!!
-
-    /** Prepare + confirm in one call: the dialog step has its own coverage in the UI layer. */
-    private fun RunbookRunner.startNow(
-        runbook: Runbook,
-        target: RunbookTarget,
-        contextValue: (SnippetSegment.Variable) -> String,
-    ): Boolean = requestStart(runbook, target) && confirmStart(contextValue = contextValue)
 
     @Test
     fun a_step_that_goes_quiet_without_reporting_is_flagged() = runnerTest { r, term ->
@@ -164,7 +37,7 @@ class RunbookRunnerTest {
         r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
         assertFalse(r.only.steps[0].stalled)
 
-        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
 
         assertTrue(r.only.steps[0].stalled)
         // Not killed: `sleep 3600` and a silent migration look exactly the same from here, so the
@@ -178,10 +51,10 @@ class RunbookRunnerTest {
         r.startNow(runbook(step("s1", "apt upgrade")), term.target()) { "" }
 
         repeat(6) {
-            testScheduler.advanceTimeBy(stallAfter / 2); testScheduler.runCurrent()
+            testScheduler.advanceTimeBy(STALL_AFTER / 2); testScheduler.runCurrent()
             term.printed()
         }
-        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 2); testScheduler.runCurrent()
 
         assertFalse(r.only.steps[0].stalled, "a long step that talks is not a stuck one")
     }
@@ -189,11 +62,11 @@ class RunbookRunnerTest {
     @Test
     fun output_after_a_quiet_spell_clears_the_flag() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "./migrate.sh")), term.target()) { "" }
-        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
         assertTrue(r.only.steps[0].stalled)
 
         term.printed()
-        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 2); testScheduler.runCurrent()
 
         assertFalse(r.only.steps[0].stalled)
     }
@@ -201,11 +74,11 @@ class RunbookRunnerTest {
     @Test
     fun a_step_that_reports_after_a_quiet_spell_does_not_stay_flagged() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "sleep 300")), term.target()) { "" }
-        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
         assertTrue(r.only.steps[0].stalled)
 
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 2); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
         assertFalse(r.only.steps[0].stalled)
@@ -214,13 +87,13 @@ class RunbookRunnerTest {
     @Test
     fun stopping_a_flagged_step_clears_the_flag_and_a_late_poll_cannot_bring_it_back() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
-        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
         assertTrue(r.only.steps[0].stalled)
 
         r.stop()
         // A poll that passed its staleness check just before Stop must not re-flag a run that is
         // over — the same race the generation guard exists for, now on this flag too.
-        testScheduler.advanceTimeBy(stallAfter * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER * 2); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
         assertFalse(r.only.steps[0].stalled)
@@ -229,7 +102,7 @@ class RunbookRunnerTest {
     @Test
     fun a_new_run_after_a_stalled_one_starts_unflagged() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
-        testScheduler.advanceTimeBy(stallAfter + poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
         assertTrue(r.only.steps[0].stalled)
         r.stop()
 
@@ -250,7 +123,7 @@ class RunbookRunnerTest {
     @Test
     fun the_echoed_line_alone_never_finishes_a_step() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime"), step("s2", "df -h")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll * 20); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 20); testScheduler.runCurrent()
 
         // Only the first step was ever sent: the echo of its own line is output, not a report.
         assertEquals(1, term.sent.size)
@@ -282,7 +155,7 @@ class RunbookRunnerTest {
     fun the_step_keeps_what_the_terminal_cut_out_for_it() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "curl -fsS localhost/healthz")), term.target()) { "" }
         term.complete(0, 0, output = "healthz 200 OK")
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals("healthz 200 OK", r.only.steps[0].output)
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
@@ -294,7 +167,7 @@ class RunbookRunnerTest {
         // "Nothing printed" would be a claim about the command; this is a fact about the terminal.
         r.startNow(runbook(step("s1", "make build")), term.target()) { "" }
         term.complete(0, 0, output = null)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertNull(r.only.steps[0].output)
         assertTrue(r.only.steps[0].outputLost)
@@ -308,7 +181,7 @@ class RunbookRunnerTest {
         // success the operator would trust.
         r.startNow(runbook(step("s1", "deploy")), term.target()) { "" }
         term.complete(0, UNREADABLE_STATUS)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(UNREADABLE_STATUS, r.only.steps[0].exitCode)
@@ -318,7 +191,7 @@ class RunbookRunnerTest {
     fun a_step_that_printed_nothing_is_not_flagged_as_lost() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "true")), term.target()) { "" }
         term.complete(0, 0, output = "")
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertFalse(r.only.steps[0].outputLost)
     }
@@ -329,7 +202,7 @@ class RunbookRunnerTest {
         // Its token is another step's, and a status is not something to attribute by proximity.
         r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
         term.complete(stepIndex = 4, exitCode = 0, runId = "older-run")
-        testScheduler.advanceTimeBy(poll * 5); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 5); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.RUNNING, r.only.steps[0].status)
         assertNull(r.only.steps[0].exitCode)
@@ -339,14 +212,14 @@ class RunbookRunnerTest {
     fun walks_the_steps_as_each_exit_code_arrives() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime"), step("s2", "df -h")), term.target()) { "" }
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
         assertEquals(0, r.only.steps[0].exitCode)
         assertEquals(RunbookStepStatus.RUNNING, r.only.steps[1].status)
 
         term.complete(1, 0)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[1].status)
         assertEquals(RunbookPhase.DONE, r.phase)
@@ -357,7 +230,7 @@ class RunbookRunnerTest {
     @Test
     fun a_confirm_step_waits_until_the_user_says_go() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "reboot", confirm = true)), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll * 10); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 10); testScheduler.runCurrent()
 
         assertEquals(RunbookPhase.AWAITING_CONFIRM, r.phase)
         assertEquals(RunbookStepStatus.AWAITING_CONFIRM, r.only.steps[0].status)
@@ -372,7 +245,7 @@ class RunbookRunnerTest {
     fun a_failing_step_stops_the_run_and_leaves_the_rest_untouched() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "migrate"), step("s2", "restart")), term.target()) { "" }
         term.complete(0, 1)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(1, r.only.steps[0].exitCode)
@@ -388,14 +261,14 @@ class RunbookRunnerTest {
             term.target(),
         ) { "" }
         term.complete(0, 1)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(RunbookStepStatus.RUNNING, r.only.steps[1].status)
         assertEquals(RunbookPhase.RUNNING, r.phase)
 
         term.complete(1, 0)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
         // A tolerated failure still colours the run: it finished, but not cleanly.
         assertEquals(RunbookPhase.DONE, r.phase)
         assertTrue(r.hadFailures)
@@ -421,7 +294,7 @@ class RunbookRunnerTest {
 
         // Even if the step's marker turns up afterwards, the run is over.
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll * 20); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 20); testScheduler.runCurrent()
         assertEquals(1, term.sent.size)
         assertEquals(RunbookPhase.STOPPED, r.phase)
     }
@@ -429,10 +302,10 @@ class RunbookRunnerTest {
     @Test
     fun a_stopped_run_stops_reading_the_terminal() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll * 3); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 3); testScheduler.runCurrent()
         r.stop()
         val after = term.polls
-        testScheduler.advanceTimeBy(poll * 20); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 20); testScheduler.runCurrent()
 
         assertEquals(after, term.polls, "a stopped run must not keep polling the terminal")
     }
@@ -440,7 +313,7 @@ class RunbookRunnerTest {
     @Test
     fun a_stop_landing_during_the_poll_does_not_send_the_next_step() = runTest {
         // Single-threaded stand-in for the cross-thread race (same trick as PingControllerTest): the
-        // poll is where Stop lands, so the watcher holds a finished step's exit code that is no
+        // the poll is where Stop lands, so the watcher holds a finished step's exit code that is no
         // longer allowed to advance the run.
         val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
         val term = FakeTerminal()
@@ -453,12 +326,12 @@ class RunbookRunnerTest {
             outputVersion = { 0L },
             isLive = { true },
         )
-        val r = RunbookRunner(scope, newId = { RUN_ID }, environment = ::environment, pollIntervalMillis = poll)
+        val r = RunbookRunner(scope, newId = { RUN_ID }, environment = ::environment, pollIntervalMillis = POLL)
         runner = r
         try {
             r.requestStart(runbook(step("s1", "uptime"), step("s2", "df -h")), target)
             r.confirmStart { "" }
-            testScheduler.advanceTimeBy(poll * 5); testScheduler.runCurrent()
+            testScheduler.advanceTimeBy(POLL * 5); testScheduler.runCurrent()
 
             assertEquals(RunbookPhase.STOPPED, r.phase)
             assertEquals(1, term.sent.size, "the next step must not be typed after Stop")
@@ -472,7 +345,7 @@ class RunbookRunnerTest {
     fun losing_the_session_aborts_the_run() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime"), step("s2", "df -h")), term.target()) { "" }
         term.live = false
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookPhase.STOPPED, r.phase)
         assertEquals(1, term.sent.size)
@@ -489,7 +362,7 @@ class RunbookRunnerTest {
     fun a_finished_run_can_be_replaced_by_a_new_one() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertTrue(r.startNow(runbook(step("s2", "df -h")), term.target()) { "" })
         assertEquals(RunbookPhase.RUNNING, r.phase)
@@ -513,7 +386,7 @@ class RunbookRunnerTest {
     fun closing_a_finished_run_clears_it() = runnerTest { r, term ->
         r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
         assertEquals(RunbookPhase.DONE, r.phase)
 
         r.close()
@@ -529,7 +402,7 @@ class RunbookRunnerTest {
             term.target(),
         ) { "" }
 
-        testScheduler.advanceTimeBy(stallAfter * 10); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER * 10); testScheduler.runCurrent()
 
         assertFalse(r.only.steps[0].stalled)
         assertEquals(RunbookStepStatus.RUNNING, r.only.steps[0].status)
@@ -542,7 +415,7 @@ class RunbookRunnerTest {
             term.target(),
         ) { "" }
         term.complete(0, 1)
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(RunbookStepStatus.RUNNING, r.only.steps[1].status)
@@ -557,7 +430,7 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals("/tmp/release.tgz" to "/srv/incoming/release.tgz", sftp.lastUpload)
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
@@ -574,7 +447,7 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(4096L, r.only.steps[0].transferredBytes)
         assertEquals(4096L, r.only.steps[0].totalBytes)
@@ -598,7 +471,7 @@ class RunbookRunnerTest {
             ),
             term.target(),
         ) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals("/var/log/app/last.log" to "/tmp/last.log", sftp.lastDownload)
         assertEquals(RunbookStepStatus.SUCCEEDED, r.only.steps[0].status)
@@ -612,7 +485,7 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1"), step("s2", "systemctl restart app")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         val failure = assertIs<RunbookStepFailure.Transfer>(r.only.steps[0].failure)
@@ -630,7 +503,7 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1"), transfer("s2")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookPhase.DONE, r.phase)
         assertEquals(2, sftp.closeCount, "every transfer closes the channel it opened")
@@ -644,7 +517,7 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(1, sftp.closeCount, "a throw must not leak the channel")
@@ -680,7 +553,7 @@ class RunbookRunnerTest {
         term.sftp = null
 
         r.startNow(runbook(transfer("s1")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.FAILED, r.only.steps[0].status)
         assertEquals(RunbookStepFailure.NoSftpChannel, r.only.steps[0].failure)
@@ -697,7 +570,7 @@ class RunbookRunnerTest {
             runbook(transfer("s1", localPath = "/tmp/\${{tag}}.tgz", remotePath = "/srv/releases/\${{tag}}.tgz")),
             term.target(),
         ) { "0.2.1" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals("/tmp/0.2.1.tgz" to "/srv/releases/0.2.1.tgz", sftp.lastUpload)
     }
@@ -711,14 +584,90 @@ class RunbookRunnerTest {
         term.sftp = sftp
 
         r.startNow(runbook(transfer("s1"), step("s2", "uptime")), term.target()) { "" }
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
         r.stop()
         sftp.transferGate?.complete(Unit)
-        testScheduler.advanceTimeBy(poll * 5); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 5); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
         assertEquals(RunbookPhase.STOPPED, r.phase)
         assertTrue(term.sent.isEmpty(), "the step after a stopped transfer must not be sent")
+    }
+
+    // --- what the vault's idle auto-lock reads ---
+
+    @Test
+    fun a_step_running_on_the_host_is_work_in_flight() = runnerTest { r, term ->
+        assertFalse(r.stepInFlight, "nothing runs before a run starts")
+
+        r.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
+
+        assertTrue(r.stepInFlight, "a step on the host must defer the lock that would close it")
+
+        term.complete(0, 0)
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
+
+        assertEquals(RunbookPhase.DONE, r.phase)
+        assertFalse(r.stepInFlight, "a finished run still deferred the lock")
+    }
+
+    /**
+     * The distinction the property exists for: a run stopped on the user's turn is exactly the
+     * idleness the timer is meant to catch, and [RunbookRunner.active] is true through both.
+     */
+    @Test
+    fun a_step_waiting_on_the_user_is_not_work_in_flight() = runnerTest { r, term ->
+        r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
+        testScheduler.advanceTimeBy(STALL_AFTER); testScheduler.runCurrent()
+
+        assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
+        assertTrue(r.active)
+        assertFalse(r.stepInFlight, "an interactive step held the vault open on an empty desk")
+    }
+
+    /**
+     * A step is marked RUNNING before its line is sent, and the terminal's production guard holds
+     * that line back behind a confirmation of its own. Dismiss that dialog and the step stays
+     * RUNNING for the rest of the session — silence past the watchdog is the run itself saying it
+     * cannot tell whether anything is executing.
+     */
+    @Test
+    fun a_step_the_watchdog_flagged_is_not_work_in_flight() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "cat <<EOF")), term.target()) { "" }
+        testScheduler.advanceTimeBy(STALL_AFTER + POLL * 2); testScheduler.runCurrent()
+
+        assertTrue(r.only.steps[0].stalled)
+        assertEquals(RunbookStepStatus.RUNNING, r.only.steps[0].status, "the step is still nominally running")
+        assertFalse(r.stepInFlight, "a step flagged as stuck deferred the lock anyway")
+    }
+
+    /**
+     * The floor is the runner's own, not the runbook's. With the watchdog switched off nothing ever
+     * flags the step, so `stalled` cannot be what excludes it — and a step parked behind a guard
+     * dialog nobody answered would otherwise defer every later lock for the rest of the session.
+     */
+    @Test
+    fun a_silent_step_stops_deferring_with_the_watchdog_off() = runnerTest { r, term ->
+        val rb = runbook(step("s1", "cat <<EOF"), policy = RunbookPolicy(watchdogMinutes = 0))
+        r.startNow(rb, term.target()) { "" }
+
+        assertTrue(r.stepInFlight, "the step was just sent")
+
+        testScheduler.advanceTimeBy(SILENT_FLOOR + POLL); testScheduler.runCurrent()
+
+        assertFalse(r.only.steps[0].stalled, "the watchdog is off — nothing may flag this step")
+        assertEquals(RunbookStepStatus.RUNNING, r.only.steps[0].status, "the step is still nominally running")
+        assertFalse(r.stepInFlight, "silence past the floor deferred the lock anyway")
+    }
+
+    @Test
+    fun a_confirmation_pause_is_not_work_in_flight() = runnerTest { r, term ->
+        r.startNow(runbook(step("s1", "reboot", confirm = true)), term.target()) { "" }
+        testScheduler.advanceTimeBy(STALL_AFTER); testScheduler.runCurrent()
+
+        assertEquals(RunbookPhase.AWAITING_CONFIRM, r.phase)
+        assertTrue(r.active)
+        assertFalse(r.stepInFlight, "a confirmation pause held the vault open on an empty desk")
     }
 
     // --- interactive steps: the command is sent bare and the user decides when it is done ---
@@ -736,7 +685,7 @@ class RunbookRunnerTest {
 
         // However long it runs, only the user finishes it — and the terminal is never polled for a
         // mark that cannot come.
-        testScheduler.advanceTimeBy(stallAfter * 5); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(STALL_AFTER * 5); testScheduler.runCurrent()
         assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
         assertEquals(0, term.polls, "an interactive step has no mark to poll for")
         assertFalse(r.only.steps[0].stalled, "the watchdog has no meaning without a probe")
@@ -800,7 +749,7 @@ class RunbookRunnerTest {
     fun losing_the_session_ends_an_interactive_run() = runnerTest { r, term ->
         r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
         term.live = false
-        testScheduler.advanceTimeBy(poll * 2); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 2); testScheduler.runCurrent()
 
         assertEquals(RunbookPhase.STOPPED, r.phase)
         assertEquals(RunbookStepStatus.STOPPED, r.only.steps[0].status)
@@ -864,7 +813,7 @@ class RunbookRunnerTest {
 
         r.startNow(runbook(interactive("s1", "mc"), transfer("s2")), term.target()) { "" }
         r.skipStep()
-        testScheduler.advanceTimeBy(poll); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.SKIPPED, r.only.steps[0].status)
         assertEquals("/tmp/release.tgz" to "/srv/incoming/release.tgz", sftp.lastUpload)
@@ -878,12 +827,8 @@ class RunbookRunnerTest {
         // parked in the terminal. The user's click is the only way this step ends.
         r.startNow(runbook(interactive("s1", "htop")), term.target()) { "" }
         term.complete(0, 0)
-        testScheduler.advanceTimeBy(poll * 5); testScheduler.runCurrent()
+        testScheduler.advanceTimeBy(POLL * 5); testScheduler.runCurrent()
 
         assertEquals(RunbookStepStatus.AWAITING_COMPLETE, r.only.steps[0].status)
-    }
-
-    private companion object {
-        const val RUN_ID = "run"
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/IdleLockPolicyTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/IdleLockPolicyTest.kt
@@ -1,0 +1,157 @@
+package app.skerry.ui.vault
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rule behind the idle auto-lock, driven a tick at a time. Both directions matter: a vault that
+ * never locks is a security setting that lies, and one that locks over live work drops SSH sessions
+ * and tunnels (issue #291).
+ */
+class IdleLockPolicyTest {
+
+    @Test
+    fun `locks after a full quiet window`() {
+        val policy = IdleLockPolicy(IDLE)
+
+        assertFalse(policy.runQuietly(IDLE - policy.tickMs), "locked before the window was over")
+        assertTrue(policy.onTick(workInFlight = false))
+    }
+
+    @Test
+    fun `input restarts the countdown`() {
+        val policy = IdleLockPolicy(IDLE)
+
+        // Nearly the whole window quiet, then one keystroke — the countdown starts over.
+        policy.runQuietly(IDLE - policy.tickMs)
+        policy.touch()
+        assertFalse(policy.onTick(workInFlight = false))
+
+        assertFalse(policy.runQuietly(IDLE - policy.tickMs), "the keystroke didn't reset the window")
+        assertTrue(policy.onTick(workInFlight = false))
+    }
+
+    /** A transfer or a runbook step is the user's work: locking would close the session it runs on. */
+    @Test
+    fun `work in flight defers the lock`() {
+        val policy = IdleLockPolicy(IDLE)
+        policy.runQuietly(IDLE - policy.tickMs)
+
+        assertFalse(policy.onTick(workInFlight = true), "locked on top of running work")
+        // Deferred, not cancelled: nothing further is owed to the timer once the work ends.
+        assertFalse(policy.runQuietly(IDLE - policy.tickMs))
+        assertTrue(policy.onTick(workInFlight = false))
+    }
+
+    /**
+     * A policy outlives the session it locked: the gate keeps it while the threshold stands, so the
+     * vault unlocked again must get a whole window, not the tail of the one that locked it.
+     */
+    @Test
+    fun `restart gives back the whole window`() {
+        val policy = IdleLockPolicy(IDLE)
+        assertTrue(policy.runQuietly(IDLE + policy.tickMs), "the window never ran out")
+
+        policy.restart()
+
+        assertFalse(policy.runQuietly(IDLE - policy.tickMs), "locked on the tail of the old window")
+        assertTrue(policy.onTick(workInFlight = false))
+    }
+
+    /**
+     * "Work in flight" is a claim the far end of the wire gets to make, so it cannot be open-ended:
+     * a host that never finishes a transfer must not keep the vault open on an empty desk all night.
+     */
+    @Test
+    fun `deferral is bounded`() {
+        val policy = IdleLockPolicy(IDLE)
+
+        assertFalse(policy.runQuietly(IDLE * DEFERRAL_WINDOWS, workInFlight = true), "locked inside the allowance")
+        assertTrue(
+            policy.runQuietly(IDLE + policy.tickMs, workInFlight = true),
+            "work held the lock off past the cap",
+        )
+    }
+
+    /**
+     * The allowance is measured in the user's own windows, not in a flat hour. Someone who asked for
+     * "After 1 minute" said how long this desk may stand unattended and unlocked; a fixed cap would
+     * answer that with an hour, and the setting would be off by sixty.
+     */
+    @Test
+    fun `the cap scales with the threshold`() {
+        val impatient = IdleLockPolicy(60_000L)
+
+        assertFalse(impatient.runQuietly(10 * 60_000L, workInFlight = true), "locked inside the allowance")
+        assertTrue(
+            impatient.runQuietly(60_000L + impatient.tickMs, workInFlight = true),
+            "a one-minute threshold bought an hour of deferral",
+        )
+    }
+
+    /** And never past the absolute ceiling, however patient the threshold is. */
+    @Test
+    fun `the cap never exceeds the ceiling`() {
+        val patient = IdleLockPolicy(30 * 60_000L)
+
+        assertTrue(
+            patient.runQuietly(MAX_DEFERRAL + 30 * 60_000L + patient.tickMs, workInFlight = true),
+            "work held the lock off past the absolute ceiling",
+        )
+    }
+
+    /** The cap is on absence, not on the work: someone at the keyboard buys the whole allowance back. */
+    @Test
+    fun `the user's return lifts the cap`() {
+        val policy = IdleLockPolicy(IDLE)
+        policy.runQuietly(MAX_DEFERRAL, workInFlight = true)
+
+        policy.touch()
+
+        assertFalse(
+            policy.runQuietly(IDLE + policy.tickMs, workInFlight = true),
+            "the cap survived the user's return",
+        )
+    }
+
+    /** The tick is a fraction of the threshold, so the lock is late by at most that fraction. */
+    @Test
+    fun `the tick scales with the threshold`() {
+        assertEquals(6_000L, IdleLockPolicy(60_000L).tickMs)
+        assertEquals(180_000L, IdleLockPolicy(30 * 60_000L).tickMs)
+        // Never below the floor, and never longer than the window it divides.
+        assertEquals(500L, IdleLockPolicy(500L).tickMs)
+        // A tenth of the window under the floor is raised to it, not left to poll every 500ms.
+        assertEquals(1_000L, IdleLockPolicy(5_000L).tickMs)
+    }
+
+    /** "No auto-lock" is a null policy in [VaultGate], never a zero threshold that spins the timer. */
+    @Test
+    fun `a non-positive threshold is refused`() {
+        assertFailsWith<IllegalArgumentException> { IdleLockPolicy(0) }
+    }
+
+    /**
+     * Ticks [duration] worth of silence — no user input, [workInFlight] as given.
+     * @return whether the vault locked during it.
+     */
+    private fun IdleLockPolicy.runQuietly(duration: Long, workInFlight: Boolean = false): Boolean {
+        var elapsed = 0L
+        while (elapsed < duration) {
+            if (onTick(workInFlight)) return true
+            elapsed += tickMs
+        }
+        return false
+    }
+}
+
+private const val IDLE = 5 * 60_000L
+
+/** Mirrors `MAX_DEFERRAL_WINDOWS`, which is private to the policy. */
+private const val DEFERRAL_WINDOWS = 10
+
+/** Mirrors `MAX_DEFERRAL_MS`, the absolute ceiling, which is private to the policy. */
+private const val MAX_DEFERRAL = 60 * 60_000L

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
@@ -1,0 +1,83 @@
+package app.skerry.ui.vault
+
+import app.skerry.shared.ssh.KeyboardInteractiveChallenge
+import app.skerry.shared.ssh.KeyboardInteractivePrompt
+import app.skerry.ui.connection.KeyboardInteractivePromptController
+import app.skerry.ui.runbook.FakeTerminal
+import app.skerry.ui.runbook.POLL
+import app.skerry.ui.runbook.RUN_ID
+import app.skerry.ui.runbook.RunbookRunner
+import app.skerry.ui.runbook.environment
+import app.skerry.ui.runbook.runbook
+import app.skerry.ui.runbook.startNow
+import app.skerry.ui.runbook.step
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private fun challenge() = KeyboardInteractiveChallenge(
+    name = "Two-factor authentication",
+    instruction = "",
+    prompts = listOf(KeyboardInteractivePrompt("Verification code:", echo = false)),
+)
+
+/**
+ * What the lock owes when one of its cleanups fails. Each step here drops a different secret and
+ * they are independent, so the failure of one may not become an excuse to keep the rest — while the
+ * caller still has to hear that something went wrong.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LockTeardownTest {
+
+    @Test
+    fun `a cleanup that throws does not cancel the ones after it`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val term = FakeTerminal()
+        // The history log refusing the record is the realistic failure: a full disk, a read-only home.
+        val runbooks = RunbookRunner(
+            scope = scope,
+            newId = { RUN_ID },
+            environment = ::environment,
+            pollIntervalMillis = POLL,
+            onFinished = { throw IllegalStateException("history log is full") },
+        )
+        val prompts = KeyboardInteractivePromptController()
+        try {
+            runbooks.startNow(runbook(step("s1", "uptime")), term.target()) { "" }
+            val answering = async { prompts.responder.respond(challenge()) }
+            yield()
+            assertNotNull(prompts.pending.value, "the prompt should be showing before the lock")
+
+            val failure = assertFailsWith<IllegalStateException> {
+                tearDownForLock(
+                    tunnels = null,
+                    sessions = null,
+                    sync = null,
+                    snippets = null,
+                    runbooks = runbooks,
+                    keyboardInteractive = prompts,
+                )
+            }
+
+            assertEquals("history log is full", failure.message, "the caller must still hear the failure")
+            assertNull(runbooks.run, "the run's resolved values outlived a report that failed to write")
+            // No time is advanced here on purpose: the prompt has a timeout of its own, and letting
+            // the clock run would let that timeout stand in for the cancellation being tested.
+            yield()
+            assertNull(prompts.pending.value, "the prompt after the failing step was never cancelled")
+            assertNull(answering.await(), "a cancelled prompt must abort authentication, not answer")
+        } finally {
+            runbooks.close()
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/PointerActivityTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/PointerActivityTest.kt
@@ -1,0 +1,116 @@
+package app.skerry.ui.vault
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.PointerId
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.PointerType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Which pointer events count as a person at the desk.
+ *
+ * Compose re-sends the last mouse event as a [PointerEventType.Move] at its old position after a
+ * relayout, so that a control sliding under a resting cursor still gets its hover. A terminal
+ * printing output relayouts on every batch: if those counted, a chatty host would answer "still
+ * here" on the user's behalf and the vault would never lock (issue #291's fix, reviewed).
+ */
+class PointerActivityTest {
+
+    private val activity = PointerActivity()
+
+    @Test
+    fun `a mouse that moved is the user`() {
+        activity.isFromUser(mouseMove(at = Offset(4f, 4f)))
+
+        assertTrue(activity.isFromUser(mouseMove(at = Offset(10f, 10f))))
+    }
+
+    @Test
+    fun `a mouse move repeating the last position is Compose talking to itself`() {
+        activity.isFromUser(mouseMove(at = Offset(10f, 10f)))
+
+        assertFalse(
+            activity.isFromUser(mouseMove(at = Offset(10f, 10f))),
+            "a relayout's re-sent move counted as activity",
+        )
+    }
+
+    /** The move Compose re-sends after a press repeats that press's position, not a move's. */
+    @Test
+    fun `the position a press left behind is remembered too`() {
+        activity.isFromUser(mousePress(at = Offset(10f, 10f)))
+
+        assertFalse(activity.isFromUser(mouseMove(at = Offset(10f, 10f))))
+    }
+
+    /** Nothing but a Move is ever fabricated: a press or a wheel notch is always a hand. */
+    @Test
+    fun `a press at the same position is still the user`() {
+        activity.isFromUser(mouseMove(at = Offset(10f, 10f)))
+
+        assertTrue(activity.isFromUser(mousePress(at = Offset(10f, 10f))))
+    }
+
+    /**
+     * Only mouse pointers are re-sent. A finger reporting the same position twice is a finger held
+     * on the glass — Compose has no reason to invent it, and it is a person.
+     */
+    @Test
+    fun `a finger repeating its position is the user`() {
+        activity.isFromUser(move(at = Offset(10f, 10f), pointer = PointerType.Touch))
+
+        assertTrue(activity.isFromUser(move(at = Offset(10f, 10f), pointer = PointerType.Touch)))
+    }
+
+    /**
+     * The remembered position has to survive everything that is not a mouse: a hybrid device
+     * interleaving a finger with the mouse must not hand the next re-sent move through as a person.
+     */
+    @Test
+    fun `a touch in between does not make the mouse forget where it was`() {
+        activity.isFromUser(mouseMove(at = Offset(10f, 10f)))
+        activity.isFromUser(move(at = Offset(80f, 80f), pointer = PointerType.Touch))
+
+        assertFalse(
+            activity.isFromUser(mouseMove(at = Offset(10f, 10f))),
+            "a re-sent move counted as activity after a touch event",
+        )
+    }
+
+    /** Guards the assumption the filter is built on: these events really do report no movement. */
+    @Test
+    fun `a hover move claims nothing moved, whether it did or not`() {
+        val event = mouseMove(at = Offset(10f, 10f))
+
+        assertEquals(PointerEventType.Move, event.type)
+        assertEquals(event.changes.single().position, event.changes.single().previousPosition)
+    }
+
+    private fun mouseMove(at: Offset) = move(at, PointerType.Mouse)
+
+    private fun move(at: Offset, pointer: PointerType) = PointerEvent(listOf(change(at, pointer, pressed = false)))
+
+    private fun mousePress(at: Offset) =
+        PointerEvent(listOf(change(at, PointerType.Mouse, pressed = true)))
+
+    /**
+     * A change as the framework builds it for a pointer that is not being tracked between events —
+     * which is every pointer with no button down (`PointerInputChangeEventProducer.produce`).
+     */
+    private fun change(at: Offset, pointer: PointerType, pressed: Boolean) = PointerInputChange(
+        id = PointerId(1L),
+        uptimeMillis = 2L,
+        position = at,
+        pressed = pressed,
+        previousUptimeMillis = 1L,
+        previousPosition = at,
+        previousPressed = false,
+        isInitiallyConsumed = false,
+        type = pointer,
+    )
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -245,10 +245,12 @@ internal fun WithWindowInfo(info: WindowInfo?, content: @Composable () -> Unit) 
  * A window-lifecycle owner for the test composition, pinned to STARTED. The real shell gets one
  * from `Window`; `runComposeUiTest` provides none, and a connected remote desktop reads it
  * ([app.skerry.ui.remote.ReportOutputVisibility]) — without an owner the first VNC frame throws.
- * `createUnsafe` because there is no Android main thread to enforce here.
+ * `createUnsafe` because there is no Android main thread to enforce here. Shared with the tests
+ * that stand a single screen up rather than the whole shell ([app.skerry.ui.vault.VaultGate] reads
+ * the owner too, for background auto-lock).
  */
 @Composable
-private fun WithTestLifecycle(content: @Composable () -> Unit) {
+internal fun WithTestLifecycle(content: @Composable () -> Unit) {
     val owner = remember {
         object : LifecycleOwner {
             override val lifecycle: LifecycleRegistry = LifecycleRegistry.createUnsafe(this)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalImeActivityTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalImeActivityTest.kt
@@ -1,0 +1,74 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.ssh.PtySize
+import app.skerry.shared.terminal.TerminalSession
+import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.app.LocalUserActivity
+import app.skerry.ui.design.DesignFonts
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.theme.SkerryTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The soft keyboard's own funnel into the PTY reports typing to the vault's idle auto-lock.
+ *
+ * On Android nothing about this path produces a key event the gate's modifier could see: the
+ * keyboard is its own window and the characters arrive as text into an invisible field. Without
+ * this report, typing in a session for the idle window locks the vault on top of it — issue #291's
+ * bug, in the one place the fix cannot rely on key events.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TerminalImeActivityTest {
+
+    @Test
+    fun `text from a soft keyboard is reported as user activity`() = runComposeUiTest {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val state = TerminalScreenState(SilentSession(), scope)
+        var reported = false
+
+        setContent {
+            SkerryTheme {
+                CompositionLocalProvider(
+                    LocalFonts provides DesignFonts(FontFamily.Default, FontFamily.Monospace, FontFamily.Default),
+                    LocalUserActivity provides { reported = true },
+                ) {
+                    Box(Modifier.fillMaxSize()) {
+                        TerminalScreen(state, Modifier.fillMaxSize(), imeInput = true)
+                    }
+                }
+            }
+        }
+
+        onNode(hasSetTextAction()).performTextInput("l")
+
+        assertTrue(reported, "typing through the soft keyboard never reached the idle timer")
+        scope.cancel()
+    }
+}
+
+/** A session that never speaks: the terminal only has to render for the funnel to exist. */
+private class SilentSession : TerminalSession {
+    override val state: StateFlow<TerminalState> = MutableStateFlow(TerminalState.Open)
+    override val output: Flow<ByteArray> = MutableSharedFlow()
+    override suspend fun send(data: ByteArray) = Unit
+    override suspend fun resize(size: PtySize) = Unit
+    override suspend fun close() = Unit
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultGateIdleLockTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/VaultGateIdleLockTest.kt
@@ -1,0 +1,415 @@
+package app.skerry.ui.vault
+
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.MergeResult
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SecurityEvent
+import app.skerry.shared.vault.SecurityEventType
+import app.skerry.shared.vault.SecurityLog
+import app.skerry.shared.vault.SyncMeta
+import app.skerry.shared.vault.UnlockResult
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+import app.skerry.ui.app.LocalUserActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import app.skerry.ui.desktop.WithTestLifecycle
+import kotlinx.coroutines.delay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Idle auto-lock counted from user activity. The gate is what decides when the vault locks, and
+ * locking here is not a screensaver: `key(state)` drops the content subtree, so a live session dies
+ * with it. Which inputs count as "the user is here" is therefore a correctness property, and it is
+ * asserted through the real composable — the modifier that feeds the timer is exactly the piece
+ * that was wrong (issue #291: presses only, so typing locked the vault mid-session).
+ */
+@OptIn(ExperimentalTestApi::class)
+class VaultGateIdleLockTest {
+
+    /** The reported bug: five minutes of typing without a single click locked the vault. */
+    @Test
+    fun `typing holds the idle timer off`() = runComposeUiTest {
+        unlockedGate()
+
+        mainClock.autoAdvance = false
+        // Four half-windows of typing: more than twice the threshold in total, never a quiet window.
+        repeat(4) {
+            mainClock.advanceTimeBy(IDLE_MS / 2)
+            onRoot().performKeyInput { pressKey(Key.A) }
+        }
+        mainClock.advanceTimeBy(IDLE_MS / 2)
+
+        onNodeWithText(UNLOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * The same bug from the other input device: reading a long file with the wheel, or dragging a
+     * pane divider, is a person at the desk even though nothing was ever pressed.
+     */
+    @Test
+    fun `a moving pointer holds the idle timer off`() = runComposeUiTest {
+        unlockedGate()
+
+        mainClock.autoAdvance = false
+        var x = 1f
+        repeat(4) {
+            mainClock.advanceTimeBy(IDLE_MS / 2)
+            x += 3f
+            onRoot().performMouseInput { moveTo(Offset(x, x)) }
+        }
+        mainClock.advanceTimeBy(IDLE_MS / 2)
+
+        onNodeWithText(UNLOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * The inverse: a session repainting under a parked cursor is the remote end being busy, not the
+     * user being present. (What Compose itself re-sends over a relayout — a Move at the unchanged
+     * position — cannot be reproduced here: the test input dispatcher drops a move that goes
+     * nowhere. That half is `PointerActivityTest`.)
+     */
+    @Test
+    fun `a repainting session does not hold the idle timer off`() = runComposeUiTest {
+        unlockedGate(content = { RepaintingContent() })
+        onRoot().performMouseInput { moveTo(Offset(5f, 5f)) }
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * A soft keyboard sends neither key events nor pointer events into the composition, so on
+     * Android typing is invisible to the modifier; the text fields report it themselves.
+     */
+    @Test
+    fun `text arriving without key events holds the idle timer off`() = runComposeUiTest {
+        unlockedGate(content = { TypingContent() })
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(UNLOCKED).assertIsDisplayed()
+    }
+
+    /** Work the user started runs unattended; locking on top of it would close the session it needs. */
+    @Test
+    fun `work in flight defers the lock`() = runComposeUiTest {
+        var busy = true
+        unlockedGate(workInFlight = { busy })
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+        onNodeWithText(UNLOCKED).assertIsDisplayed()
+
+        // Deferred, not cancelled: the window starts over when the work ends, and then it locks.
+        busy = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /** A wheel notch is a person reading, with nothing pressed and the cursor never moving. */
+    @Test
+    fun `the wheel holds the idle timer off`() = runComposeUiTest {
+        unlockedGate()
+        onRoot().performMouseInput { moveTo(Offset(5f, 5f)) }
+
+        mainClock.autoAdvance = false
+        repeat(4) {
+            mainClock.advanceTimeBy(IDLE_MS / 2)
+            onRoot().performMouseInput { scroll(1f) }
+        }
+        mainClock.advanceTimeBy(IDLE_MS / 2)
+
+        onNodeWithText(UNLOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * Whether work is running is a claim the timer cannot verify, so a predicate that throws fails
+     * closed. The two sources wired today are plain state reads; this pins the direction for the next.
+     */
+    @Test
+    fun `a workInFlight that throws still locks the vault`() = runComposeUiTest {
+        unlockedGate(workInFlight = { error("the predicate broke") })
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * The teardown that drops decrypted secrets runs before the lock. If it throws, the lock still
+     * has to happen — a vault left open because closing a tunnel failed is the worst of both — and
+     * the failure must not travel out of a timer nobody asked for and take the app down.
+     */
+    @Test
+    fun `a teardown that throws still locks the vault`() = runComposeUiTest {
+        unlockedGate(onBeforeLock = { error("a tunnel refused to close") })
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * Locked but not cleaned up is a state the user has to be able to find out about: the lock screen
+     * looks exactly like a clean lock, while a tunnel that refused to close still holds an SSH
+     * connection opened with the vault secret. The failure is contained, so the log is the only place
+     * left to say so.
+     */
+    @Test
+    fun `an incomplete automatic lock is recorded`() = runComposeUiTest {
+        val log = IdleLockSecurityLog()
+        unlockedGate(onBeforeLock = { error("a tunnel refused to close") }, securityLog = log)
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+        onNodeWithText(LOCKED).assertIsDisplayed()
+
+        assertEquals(
+            listOf(SecurityEventType.LockIncomplete),
+            log.events.map { it.type }.filter { it == SecurityEventType.LockIncomplete },
+            "a lock that did not finish left no trace",
+        )
+        assertEquals(
+            listOf(null),
+            log.events.filter { it.type == SecurityEventType.LockIncomplete }.map { it.detail },
+            "the exception text carries host names and must not reach a plaintext log",
+        )
+    }
+
+    /**
+     * The report is a file write, so it can fail for the same reason the teardown did — a full disk
+     * takes both. A log that cannot be written must not undo the containment it was added to report
+     * on: the exception would leave the idle LaunchedEffect and reach the recomposer.
+     */
+    @Test
+    fun `a log that cannot be written does not undo the containment`() = runComposeUiTest {
+        unlockedGate(
+            onBeforeLock = { error("a tunnel refused to close") },
+            securityLog = FullDiskSecurityLog,
+        )
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * The background lock takes the same contained path. It is the one that used to throw straight
+     * into lifecycle dispatch: `ON_STOP` arrives on the platform's own callback, so a teardown
+     * failure there took the app down while it was being minimised. The idle timer is off here on
+     * purpose — nothing but the lifecycle event may do the locking.
+     */
+    @Test
+    fun `a teardown that throws on the background lock is contained and recorded`() = runComposeUiTest {
+        val log = IdleLockSecurityLog()
+        val owner = object : LifecycleOwner {
+            override val lifecycle: LifecycleRegistry = LifecycleRegistry.createUnsafe(this)
+        }.also { it.lifecycle.currentState = Lifecycle.State.STARTED }
+        setContent {
+            CompositionLocalProvider(LocalLifecycleOwner provides owner) {
+                VaultGate(
+                    vault = FakeFreshVault(),
+                    securityLog = log,
+                    autoLockIdleMs = null,
+                    onBeforeLock = { error("a tunnel refused to close") },
+                    createForm = { _, onCreate, _ ->
+                        LaunchedEffect(Unit) { onCreate(PASSWORD.toCharArray(), PASSWORD.toCharArray()) }
+                    },
+                    unlockForm = { _, _, _, _, _ -> Text(LOCKED) },
+                ) { FocusedContent() }
+            }
+        }
+        waitUntil { onAllNodesWithText(UNLOCKED).fetchSemanticsNodes().isNotEmpty() }
+
+        owner.lifecycle.currentState = Lifecycle.State.CREATED
+        waitForIdle()
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+        // VaultCreated is in the log too — the gate walked through the creation form to get here.
+        assertEquals(
+            listOf(SecurityEventType.LockIncomplete),
+            log.events.map { it.type }.filter { it == SecurityEventType.LockIncomplete },
+            "the background lock did not finish and left no trace",
+        )
+    }
+
+    /** The other half of the property: silence still locks, or the timeout would be decoration. */
+    @Test
+    fun `silence locks the vault`() = runComposeUiTest {
+        unlockedGate()
+
+        mainClock.autoAdvance = false
+        mainClock.advanceTimeBy(IDLE_MS * 2)
+
+        onNodeWithText(LOCKED).assertIsDisplayed()
+    }
+
+    /**
+     * Stands the gate up on a fresh vault and walks it to [VaultGateState.Unlocked] through the
+     * creation form (no biometrics, no sync form — creation leads straight into the app). Leaves the
+     * clock on autoAdvance; the caller takes it over.
+     */
+    private fun ComposeUiTest.unlockedGate(
+        workInFlight: () -> Boolean = { false },
+        onBeforeLock: () -> Unit = {},
+        securityLog: SecurityLog? = null,
+        content: @Composable () -> Unit = { FocusedContent() },
+    ) {
+        setContent {
+            WithTestLifecycle {
+                VaultGate(
+                    vault = FakeFreshVault(),
+                    securityLog = securityLog,
+                    autoLockIdleMs = IDLE_MS,
+                    workInFlight = workInFlight,
+                    onBeforeLock = onBeforeLock,
+                    createForm = { _, onCreate, _ ->
+                        LaunchedEffect(Unit) { onCreate(PASSWORD.toCharArray(), PASSWORD.toCharArray()) }
+                    },
+                    unlockForm = { _, _, _, _, _ -> Text(LOCKED) },
+                ) { content() }
+            }
+        }
+        waitUntil { onAllNodesWithText(UNLOCKED).fetchSemanticsNodes().isNotEmpty() }
+    }
+}
+
+/**
+ * A log on a full disk, as `FileSecurityLog.record` fails through okio. Only the lock event throws:
+ * the gate walks through the creation form to reach an unlocked vault, and that path records
+ * `VaultCreated` while the user is watching — a different call site with a different answer.
+ */
+private object FullDiskSecurityLog : SecurityLog {
+    override fun record(type: SecurityEventType, detail: String?) {
+        if (type == SecurityEventType.LockIncomplete) error("no space left on device")
+    }
+
+    override fun recent(limit: Int): List<SecurityEvent> = emptyList()
+
+    override fun lastPasswordChangeAt(): String? = null
+
+    override fun clear() = Unit
+}
+
+/** In-memory [SecurityLog]: this suite only ever asks what was written, never when. */
+private class IdleLockSecurityLog : SecurityLog {
+    val events = mutableListOf<SecurityEvent>()
+    override fun record(type: SecurityEventType, detail: String?) {
+        events += SecurityEvent(type, "t${events.size}", detail)
+    }
+
+    override fun recent(limit: Int): List<SecurityEvent> = events.asReversed().take(limit)
+
+    override fun lastPasswordChangeAt(): String? = null
+
+    override fun clear() = events.clear()
+}
+
+/**
+ * Stands in for the app behind the gate: something that holds the keyboard, the way a terminal does
+ * whenever it is being typed into. Key events reach the gate's modifier on their way down to the
+ * focused node, so a composition where nothing has focus would prove nothing about typing.
+ */
+@Composable
+private fun FocusedContent() {
+    val focus = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focus.requestFocus() }
+    Box(Modifier.focusRequester(focus).focusable()) { Text(UNLOCKED) }
+}
+
+/**
+ * Stands in for a session printing output: it relayouts on a timer and never touches the vault.
+ * Nothing here is user input, however many pointer events Compose manufactures over it.
+ */
+@Composable
+private fun RepaintingContent() {
+    var side by remember { mutableStateOf(10) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(REPAINT_MS)
+            side = if (side == 10) 40 else 10
+        }
+    }
+    Box(Modifier.size(side.dp)) { Text(UNLOCKED) }
+}
+
+/** Stands in for a text field fed by a soft keyboard: it reports typing itself, without key events. */
+@Composable
+private fun TypingContent() {
+    val activity = LocalUserActivity.current
+    LaunchedEffect(activity) {
+        while (true) {
+            delay(IDLE_MS / 2)
+            activity()
+        }
+    }
+    Text(UNLOCKED)
+}
+
+private const val IDLE_MS = 60_000L
+private const val REPAINT_MS = 100L
+private const val PASSWORD = "correct horse battery"
+private const val UNLOCKED = "session"
+private const val LOCKED = "locked"
+
+/** Vault with no file yet: [create] opens it, which is all the gate needs to reach `Unlocked`. */
+private class FakeFreshVault : Vault {
+    private var created = false
+    private var open = false
+
+    override fun exists(): Boolean = created
+    override val isUnlocked: Boolean get() = open
+    override fun create(password: CharArray) { created = true; open = true }
+    override fun verifyPassword(password: CharArray): Boolean = true
+    override fun unlock(password: CharArray): UnlockResult = UnlockResult.Success
+    override fun unlockWithDataKey(dataKey: DataKey): UnlockResult = UnlockResult.Success
+    override fun exportDataKey(): DataKey? = null
+    override fun adoptDataKey(newDataKey: DataKey, password: CharArray): Boolean = false
+    override fun lock() { open = false }
+    override fun reset() = Unit
+    override fun records(): List<VaultRecord> = emptyList()
+    override fun syncMeta(): SyncMeta? = null
+    override fun mergeRemote(remote: List<VaultRecord>): MergeResult = MergeResult.EMPTY
+    override fun openPayload(id: String): ByteArray? = null
+    override fun put(id: String, type: RecordType, payload: ByteArray) = Unit
+    override fun remove(id: String) = Unit
+    override fun changePassword(oldPassword: CharArray, newPassword: CharArray): Boolean = true
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecurityLog.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/SecurityLog.kt
@@ -4,6 +4,8 @@ import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
 import okio.FileSystem
 import okio.Path
 
@@ -37,6 +39,14 @@ enum class SecurityEventType {
      * ([Credential.toString] redacts them), and this log is plaintext on disk.
      */
     KeyExported,
+
+    /**
+     * An automatic lock ran but one of its cleanups failed — the vault is locked, yet something it
+     * was supposed to drop is still holding a secret (a tunnel that refused to close, say). Recorded
+     * with no [SecurityEvent.detail]: the exception's own text carries host names, and this log is
+     * plaintext on disk.
+     */
+    LockIncomplete,
 }
 
 /**
@@ -118,11 +128,21 @@ class FileSecurityLog(
         if (fileSystem.exists(path)) fileSystem.delete(path)
     }
 
-    /** Read the log in chronological order; any error (missing file/corrupt JSON) → empty. */
+    /**
+     * Read the log in chronological order; any error (missing file/corrupt JSON) → empty.
+     *
+     * Entry by entry, not the array in one piece: an event written by a newer build carries a
+     * [SecurityEventType] this one has no name for, and `ignoreUnknownKeys` does not cover unknown
+     * enum *values*. A strict decode would throw for the whole file, which reads as an empty log and
+     * is then overwritten by the next [record] — the device's audit trail destroyed by a downgrade,
+     * looking exactly like a wipe someone did on purpose. One unrecognised entry is dropped instead.
+     */
     private fun read(): List<SecurityEvent> = runCatching {
         if (!fileSystem.exists(path)) return emptyList()
         val text = fileSystem.read(path) { readUtf8() }
-        json.decodeFromString<List<SecurityEvent>>(text)
+        json.decodeFromString<JsonArray>(text).mapNotNull { entry ->
+            runCatching { json.decodeFromJsonElement<SecurityEvent>(entry) }.getOrNull()
+        }
     }.getOrDefault(emptyList())
 
     // Atomic write + harden on tmp before move — see [atomicWriteUtf8].

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileSecurityLogTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileSecurityLogTest.kt
@@ -37,6 +37,32 @@ class FileSecurityLogTest {
         assertEquals(SecurityEventType.VaultCreated, recent[2].type)
     }
 
+    /**
+     * An event this build has no name for is a downgrade, a second installed build, or a portable
+     * copy run beside the current one. Decoding the array in one piece would throw, the whole file
+     * would read as empty, and the next record would overwrite the audit trail — including the
+     * VaultCreated anchor [lastPasswordChangeAt] reads. One unrecognised line is dropped instead.
+     */
+    @Test
+    fun anEventFromANewerBuildDropsItsOwnLineNotTheFile() {
+        val l = log()
+        clock = 1; l.record(SecurityEventType.VaultCreated)
+        clock = 2; l.record(SecurityEventType.BiometricEnabled)
+        fs.write(path) {
+            writeUtf8(
+                """[{"type":"VaultCreated","at":"2026-01-01T00:00:01Z"},""" +
+                    """{"type":"SomethingFromTheFuture","at":"2026-01-01T00:00:02Z"},""" +
+                    """{"type":"BiometricEnabled","at":"2026-01-01T00:00:03Z"}]""",
+            )
+        }
+
+        val recent = l.recent(limit = 100)
+
+        assertEquals(2, recent.size, "an unknown event type took the rest of the log with it")
+        assertEquals(SecurityEventType.BiometricEnabled, recent[0].type)
+        assertEquals("2026-01-01T00:00:01Z", l.lastPasswordChangeAt(), "the password-change anchor was lost")
+    }
+
     @Test
     fun recentRespectsLimit() {
         val l = log()


### PR DESCRIPTION
The vault's idle timer only counted pointer presses as activity, so a session spent typing locked itself mid-work. Keystrokes, pointer movement, the wheel and text from a soft keyboard were all invisible to it.

## What counts as activity

`IdleLockPolicy` owns the rule and `Modifier.idleActivity` feeds it — keys through `onPreviewKeyEvent`, pointer events on the `Initial` pass, neither consumed. Two things needed care:

- After a relayout Compose re-sends the last mouse event as a `Move` at its unchanged position, so a session printing output would answer "still here" for an empty desk. `PointerActivity` recognises those by their position and drops them. `positionChanged()` cannot be used for this: a pointer with no button down is not tracked between events, so every hover move claims nothing moved.
- Android's soft keyboard produces no key events. The terminal's IME funnel, `FieldDraft` and the SFTP file editor report typing through `LocalUserActivity`.

## What an active session means

Decided rather than implied:

- Any user input restarts the countdown.
- Unattended work the user started — an SFTP transfer, a runbook step executing on the host — defers the lock while it runs, because locking closes sessions and would take the work with it. Bounded: at most ten idle windows of continuous absence, and never past an hour. "Still working" is a claim the far end of the wire gets to make, so a step silent for two minutes stops counting, on a floor a runbook's own `watchdogMinutes` cannot move.
- Nothing else holds the lock off. A session streaming output, a repainting framebuffer and a tunnel carrying traffic are the remote end being busy, not the user being present.

Settings → Security states that policy, bound included.

## Locking finishes what it can

- Each cleanup in `tearDownForLock` runs independently, guarded per pane as well as per step; the first failure is raised once every step has had its turn.
- `RunbookRunner.close` drops the run in a `finally`, so a report that fails to write cannot leave resolved `${{vault:…}}` values and captured step output alive behind a locked vault.
- Both automatic locks (idle and background) contain a failed teardown instead of taking the app down on an empty desk, and record `SecurityEventType.LockIncomplete` — an incomplete lock looks exactly like a clean one otherwise.
- `FileSecurityLog` decodes its entries one at a time: an event type an older build has no name for drops its own line instead of making the whole audit log read as empty and be overwritten by the next write.

## Tests

`IdleLockPolicyTest` and `PointerActivityTest` pin the rule and the synthetic-move filter; `VaultGateIdleLockTest` drives the real composable for typing, pointer movement, the wheel, a repainting session, soft-keyboard text, work in flight, a throwing predicate, a throwing teardown on both automatic paths and a log that cannot be written; `TerminalImeActivityTest` types into the real `TerminalScreen`; `LockTeardownTest` covers the independent cleanups; `RunbookRunnerTest` and `TransferWriteInFlightTest` cover what feeds `workInFlight`.

Not verified live: Android device, other operating systems.

Closes #291