### PR TITLE
Stop the silent session restore from swallowing what the user does

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopDesignApp.kt
@@ -412,7 +412,14 @@ fun DesktopDesignApp(
                 // liveSessions, not the `sessions` parameter: the desktop entry point passes none and
                 // lets this composable build one, so the parameter is null in the shipped app and the
                 // reconnect credentials survived every automatic lock.
-                onBeforeLock = { tearDownForLock(tunnels, liveSessions, sync, snippets, runbookRunner, keyboardInteractive, hostTrust) },
+                onBeforeLock = {
+                    tearDownForLock(
+                        tunnels, liveSessions, sync, snippets, runbookRunner, keyboardInteractive, hostTrust,
+                        // The modal's own flag lives here, above the gate, so it outlives the lock — the
+                        // question inside it does not.
+                        closeSyncSetup = state::closeSyncSetup,
+                    )
+                },
                 onReset = onVaultReset,
                 // onPairingComplete != null (sync is present) — the create screen offers "I have a code":
                 // the coordinator creates the vault under the chosen password itself and accepts the account key.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -24,6 +24,8 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -121,10 +123,77 @@ class SyncCoordinator(
     @Volatile
     private var pendingReplace: PendingReplace? = null
 
-    /** Stash the pending replace, wiping any superseded one's password first. */
-    private fun stashPendingReplace(next: PendingReplace) {
+    /**
+     * A user-initiated linking operation ([connect]/[claimPairing]/[confirmPasswordReplace]) is in flight.
+     * What the double-submit guard reads — not [SyncStatus.Busy], which the silent keep-connected restore
+     * ([restoreSession]) raises just the same: a restore that happened to start first turned the user's own
+     * connect into a no-op, with nothing on screen to say the tap did anything (issue #278). Set on the
+     * calling (main) thread before the launch, cleared when the launched operation returns — @Volatile
+     * because that clear runs on [scope] and the guard reads it without the lock.
+     */
+    @Volatile
+    private var linkingInFlight = false
+
+    /**
+     * Which linking operation [linkingInFlight] currently stands for. A connect that pauses on the
+     * confirmation publishes [SyncStatus.NeedsPasswordReplaceConfirm] and only then unwinds to its own
+     * clear, so the user can confirm inside that window: without a token the confirmed re-run would raise
+     * the flag and the paused connect's clear would drop it again, leaving the re-run running with the
+     * guard down.
+     */
+    @Volatile
+    private var linkingGeneration = 0
+
+    // Both halves are read-modify-write across two threads (taken on the main thread, released on
+    // [scope]), so the token check and the clear have to be one step: a whole beginLinking landing between
+    // endLinking's read and its write would otherwise clear the guard for the operation that just took it.
+    private val linkingLock = SynchronizedObject()
+
+    /** Take the linking guard for a new operation; the token identifies it to [endLinking]. */
+    private fun beginLinking(): Int = synchronized(linkingLock) {
+        linkingInFlight = true
+        linkingGeneration += 1
+        linkingGeneration
+    }
+
+    /** Release the linking guard, unless another operation has taken it over since [beginLinking]. */
+    private fun endLinking(generation: Int) = synchronized(linkingLock) {
+        if (linkingGeneration == generation) linkingInFlight = false
+    }
+
+    // Guards the pending replace together with the status that advertises it. [pauseForLock] declines from
+    // the main thread while [doConnect] is publishing from [scope], and the two orders in between are both
+    // wrong: a decline that lands first leaves the ACCOUNT password stashed behind an already-locked vault,
+    // and one that lands between the stash and the status puts the question on screen with nothing left
+    // able to answer it (both buttons no-op on a null stash).
+    private val pendingLock = SynchronizedObject()
+
+    /**
+     * Publish the pause: stash the connect's params under an owned copy of the password and put the
+     * question on screen, as one step. Returns false when the vault locked first — there is nobody behind
+     * the lock screen to ask, and nothing is stashed, so the caller resolves the connect itself.
+     */
+    private fun publishPendingReplace(
+        serverUrl: String,
+        accountId: String,
+        password: CharArray,
+        keepConnected: Boolean,
+    ): Boolean = synchronized(pendingLock) {
+        if (lockPaused) return false
+        clearPendingReplace() // a superseded pause's password is not left behind
+        pendingReplace = PendingReplace(serverUrl, accountId, password.copyOf(), keepConnected)
+        _status.value = SyncStatus.NeedsPasswordReplaceConfirm(serverUrl, accountId)
+        true
+    }
+
+    /**
+     * Drop the pending replace, wiping the ACCOUNT password it kept. The wipe and the clear are one step
+     * on purpose: a site that does only the second leaves that password in the heap with nothing left
+     * pointing at it.
+     */
+    private fun clearPendingReplace() = synchronized(pendingLock) {
         pendingReplace?.password?.fill(' ')
-        pendingReplace = next
+        pendingReplace = null
     }
 
     // "What to sync" (account level) — stored as a SETTINGS record in the vault, synced by the same
@@ -370,8 +439,7 @@ class SyncCoordinator(
      * process/test teardown. Does not touch the saved link (that's [disconnect]).
      */
     fun close() {
-        pendingReplace?.password?.fill(' ')
-        pendingReplace = null
+        clearPendingReplace()
         scope.cancel()
     }
 
@@ -389,24 +457,31 @@ class SyncCoordinator(
         // Guard against a double launch: a repeat click while the previous connect/claim is in flight
         // would spawn a second Ktor client (pool/socket leak) and a status race. Calls come from UI
         // handlers on the main thread, so check-then-set without CAS is enough (like panel busy flags).
-        if (_status.value == SyncStatus.Busy) {
+        if (linkingInFlight) {
             masterPassword.fill(' ')
             return
         }
+        val linking = beginLinking()
         // Set Busy synchronously, before launch: the onboarding form disables "Skip" on Busy. If we set
         // Busy only in doConnect's first line, a dispatch window would remain where the status is still
         // Disabled and Skip is active: proceeding to biometric enroll, the user would wrap it under a key
         // that connect then replaces (account-key adoption race).
         _status.value = SyncStatus.Busy
         // A fresh connect supersedes any pending vault-password-replace confirmation: wipe its kept password.
-        pendingReplace?.let { it.password.fill(' '); pendingReplace = null }
+        clearPendingReplace()
         // Copy synchronously and wipe the original before launch: the coroutine starts on
         // Dispatchers.Default not immediately, and the caller may wipe the array first — otherwise
         // deriveMasterKey would get an empty password (TOCTOU). The copy is owned by [doConnect] and
         // wiped in its finally.
         val owned = masterPassword.copyOf()
         masterPassword.fill(' ')
-        scope.launch { opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected) } }
+        scope.launch {
+            try {
+                opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected) }
+            } finally {
+                endLinking(linking)
+            }
+        }
     }
 
     // Under [opMutex] (see connect): session activation must not race with disconnect.
@@ -525,8 +600,14 @@ class SyncCoordinator(
                 // password is an answer about the password, not about the revocation ([cancelPasswordReplace]).
                 // After the close, not before: a refused write throws, and it must not strand the client.
                 if (s.reactivated) rememberReactivation(link)
-                stashPendingReplace(PendingReplace(serverUrl, accountId, masterPassword.copyOf(), keepConnected))
-                _status.value = SyncStatus.NeedsPasswordReplaceConfirm(serverUrl, accountId)
+                if (!publishPendingReplace(serverUrl, accountId, masterPassword, keepConnected)) {
+                    // The vault locked while this connect was on the network (the lock has no idea one is
+                    // in flight, and a sync connect does not defer the idle timer). Fall back to the saved
+                    // state rather than asking a question nobody can see — the reactivation debt above is
+                    // already recorded, and the user reconnects after unlocking.
+                    _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) }
+                        ?: SyncStatus.Disabled
+                }
                 return
             } else {
                 // Confirmed ([confirmPasswordReplace]): log into the existing account and adopt its key,
@@ -883,10 +964,15 @@ class SyncCoordinator(
     fun confirmPasswordReplace() {
         val pending = pendingReplace ?: return
         pendingReplace = null
+        val linking = beginLinking() // the re-run is the same user action as the connect it resumes
         _status.value = SyncStatus.Busy
         scope.launch {
-            opMutex.withLock {
-                doConnect(pending.serverUrl, pending.accountId, pending.password, pending.keepConnected, allowPasswordReplace = true)
+            try {
+                opMutex.withLock {
+                    doConnect(pending.serverUrl, pending.accountId, pending.password, pending.keepConnected, allowPasswordReplace = true)
+                }
+            } finally {
+                endLinking(linking)
             }
         }
     }
@@ -901,10 +987,9 @@ class SyncCoordinator(
      * that account a rebuild whenever it does connect. Declining is an answer about the password, not about
      * the revocation.
      */
-    fun cancelPasswordReplace() {
-        val pending = pendingReplace ?: return
-        pendingReplace = null
-        pending.password.fill(' ')
+    fun cancelPasswordReplace() = synchronized(pendingLock) {
+        if (pendingReplace == null) return
+        clearPendingReplace()
         _status.value = configStore.load()?.let { SyncStatus.Configured(it.serverUrl, it.accountId) } ?: SyncStatus.Disabled
     }
 
@@ -1099,17 +1184,28 @@ class SyncCoordinator(
      */
     fun claimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean = false) {
         // Guard against a double launch — as in [connect] (a double submit would leak a Ktor client).
-        if (_status.value == SyncStatus.Busy) {
+        if (linkingInFlight) {
             localPassword.fill(' ')
             return
         }
+        val linking = beginLinking()
         // Busy synchronously (like connect): the onboarding form disables "Skip"/double-submit on Busy.
         _status.value = SyncStatus.Busy
         // Copy and wipe the original before launch (TOCTOU): the coroutine doesn't start immediately, and
         // the caller could wipe the array before vault.create/unlock reads it. The copy is owned by doClaimPairing.
         val owned = localPassword.copyOf()
         localPassword.fill(' ')
-        scope.launch { opMutex.withLock { doClaimPairing(payload, owned, keepConnected) } }
+        // A fresh linking attempt supersedes any pending vault-password-replace confirmation, exactly as in
+        // [connect]: leaving it stashed keeps a password copy in memory for an answer that can no longer be
+        // given (the dialog is gone), and its pause stands the keep-connected restore down for as long.
+        clearPendingReplace()
+        scope.launch {
+            try {
+                opMutex.withLock { doClaimPairing(payload, owned, keepConnected) }
+            } finally {
+                endLinking(linking)
+            }
+        }
     }
 
     // Under [opMutex] (see claimPairing): session activation must not race with disconnect.
@@ -1945,6 +2041,15 @@ class SyncCoordinator(
         // this coroutine to opMutex (a long connect holding the lock across lock+unlock) cancels the
         // pause instead of tearing down the session the resume just kept.
         lockPaused = true
+        // The lock drops every other decrypted secret ([tearDownForLock]); the password kept for a pending
+        // confirmation is the ACCOUNT password, and behind the lock screen nobody can answer the question
+        // it belongs to. So the lock declines on the user's behalf — the alternative is that password
+        // sitting in the heap for the whole locked period, which is the state the lock exists to prevent.
+        //
+        // After the flag, not before: a connect still on the network publishes its pause under the same
+        // [pendingLock] this reads. Setting the flag first means that publish is either refused (it sees
+        // the flag) or already done (and this finds the stash) — never lands in between and survives.
+        cancelPasswordReplace()
         // No early return on a null session: a connect in flight holds opMutex and would publish its
         // subscriptions after the lock, with nothing left to stop them. Queueing behind it stops them.
         scope.launch {
@@ -2053,54 +2158,78 @@ class SyncCoordinator(
      * (dataKey needed) — usually from `onVaultUnlocked`. Vault locked / no token → no-op (stays
      * [SyncStatus.Configured]); token expired / no connection → fall back to Configured (link not
      * erased, user reconnects by password). Already connected → no-op.
+     *
+     * A connect paused on [SyncStatus.NeedsPasswordReplaceConfirm] is a no-op too: that pause owns the
+     * status, and a restore writing over it takes the dialog off the screen while the stashed password
+     * stays in memory — nothing but that dialog can confirm or decline it (issue #278).
+     *
+     * The pause defers the restore rather than replacing it: confirming makes a session of its own, which
+     * is what this would have restored. Declining deliberately does NOT call this — a restore that owes a
+     * reactivation rebuild clears the vault and re-pulls it ([reconcileLocked]), and "no, don't change my
+     * password" must not be the button that empties the host list. What releases it afterwards is the next
+     * ordinary trigger: a vault unlock, or an UNREACHABLE→REACHABLE edge if the server was down. On a
+     * server that never went down neither fires, so a declined device stays on [SyncStatus.Configured]
+     * ("reconnect with your password") until the next unlock or app start — visibly offline, not silently.
      */
     fun restoreSession() {
         // Cheap pre-check only — the authoritative copy is re-loaded under the lock below.
         val quick = configStore.load() ?: return
         if (!quick.keepConnected || quick.sealedRefreshToken == null || session != null) return
-        scope.launch {
-            opMutex.withLock {
-                // Re-load and re-check under the lock: while this coroutine waited for opMutex, a
-                // parallel connect/claim may have activated a session (nothing to restore), or a
-                // disconnect may have erased the link — restoring from the stale pre-check copy would
-                // silently re-link a device the user just disconnected (the refresh token is still
-                // valid server-side; disconnect doesn't revoke it).
-                val cfg = configStore.load() ?: return@withLock
-                if (!cfg.keepConnected || cfg.sealedRefreshToken == null || session != null) return@withLock
-                val dataKey = vault.exportDataKey() ?: return@withLock
-                _status.value = SyncStatus.Busy
-                try {
-                    val refreshToken = tokens.open(dataKey, cfg.sealedRefreshToken)
-                    if (refreshToken == null) {
-                        _status.value = SyncStatus.Configured(cfg.serverUrl, cfg.accountId)
-                        return@withLock
-                    }
-                    val syncClient = clientFactory(cfg.serverUrl)
-                    val newSession = syncClient.refresh(SyncSession(cfg.accountId, "", refreshToken))
-                    // A reconcile interrupted before it finished must still run on this silent restore —
-                    // refresh carries no `reactivated` signal, so a standing debt is the only thing that
-                    // redoes it before the first push, whether it was recorded by this launch or an
-                    // earlier one.
-                    val reconcile = ServerLink(cfg.serverUrl, cfg.accountId) in reconcileDebts
-                    // refresh rotates the token — re-save it sealed under the dataKey (inside activation).
-                    activateSession(
-                        syncClient,
-                        newSession,
-                        cfg.copy(sealedRefreshToken = tokens.seal(dataKey, newSession.refreshToken)),
-                        resetCursor = reconcile,
-                        clearLocalRecords = reconcile,
-                    )
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Any restore failure (expired token, no connection, other) — fall back to Configured,
-                    // don't erase the link (reconnect by password). Catch Exception, not just SyncException:
-                    // otherwise something unexpected would stick on Busy (eternal spinner).
-                    _status.value = SyncStatus.Configured(cfg.serverUrl, cfg.accountId)
-                } finally {
-                    dataKey.zeroize() // dataKey copy — wipe it, the live key stays with the vault
-                }
+        if (pendingReplace != null) return
+        scope.launch { opMutex.withLock { doRestoreSession() } }
+    }
+
+    // Under [opMutex] (see restoreSession): activating the restored session must not race with a
+    // disconnect or a concurrent connect.
+    private suspend fun doRestoreSession() {
+        // Re-load and re-check under the lock: while this coroutine waited for opMutex, a parallel
+        // connect/claim may have activated a session (nothing to restore), a disconnect may have erased
+        // the link — restoring from the stale pre-check copy would silently re-link a device the user just
+        // disconnected (the refresh token is still valid server-side; disconnect doesn't revoke it) — or a
+        // connect may have paused on the password-replace confirmation, which owns the status from then on.
+        val cfg = configStore.load() ?: return
+        if (!cfg.keepConnected || cfg.sealedRefreshToken == null || session != null) return
+        if (pendingReplace != null) return
+        val dataKey = vault.exportDataKey() ?: return
+        _status.value = SyncStatus.Busy
+        // A client we opened but haven't handed to [activateSession] yet — close it on any exit, as
+        // [doConnect] and [doClaimPairing] do. A failing refresh (dead token, 5xx, a server that flaps its
+        // health ping) would otherwise strand a Ktor engine and its pool once per attempt.
+        var openedClient: SyncClient? = null
+        try {
+            val refreshToken = tokens.open(dataKey, cfg.sealedRefreshToken)
+            if (refreshToken == null) {
+                _status.value = SyncStatus.Configured(cfg.serverUrl, cfg.accountId)
+                return
             }
+            val syncClient = clientFactory(cfg.serverUrl).also { openedClient = it }
+            val newSession = syncClient.refresh(SyncSession(cfg.accountId, "", refreshToken))
+            // A reconcile interrupted before it finished must still run on this silent restore — refresh
+            // carries no `reactivated` signal, so a standing debt is the only thing that redoes it before
+            // the first push, whether it was recorded by this launch or an earlier one.
+            val reconcile = ServerLink(cfg.serverUrl, cfg.accountId) in reconcileDebts
+            // refresh rotates the token — re-save it sealed under the dataKey (inside activation). Sealed
+            // BEFORE the hand-off below, as in [doChangeAccountPassword]: a throw here with the field
+            // already nulled would leave the client open and unowned, which is the leak this tracks.
+            val sealed = tokens.seal(dataKey, newSession.refreshToken)
+            openedClient = null // ownership passes to activateSession (it closes any superseded client)
+            activateSession(
+                syncClient,
+                newSession,
+                cfg.copy(sealedRefreshToken = sealed),
+                resetCursor = reconcile,
+                clearLocalRecords = reconcile,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Any restore failure (expired token, no connection, other) — fall back to Configured, don't
+            // erase the link (reconnect by password). Catch Exception, not just SyncException: otherwise
+            // something unexpected would stick on Busy (eternal spinner).
+            _status.value = SyncStatus.Configured(cfg.serverUrl, cfg.accountId)
+        } finally {
+            runCatching { openedClient?.close() } // opened but never activated
+            dataKey.zeroize() // dataKey copy — wipe it, the live key stays with the vault
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/LockTeardown.kt
@@ -40,6 +40,12 @@ import kotlinx.coroutines.CancellationException
  * connection would go on waiting behind the lock screen for a code nobody can see — and then fail on
  * its own timeout minutes later, looking like the credentials were wrong.
  *
+ * The desktop sync-setup modal is closed too, for a reason the others don't have: its open flag lives
+ * above the vault gate, so the modal survives the lock and comes back on unlock — but the question inside
+ * it does not, because [SyncCoordinator.pauseForLock] declines it. Left open it would return as a plain
+ * connect form standing where the user's question was, with nothing said about the question being answered
+ * for them. Android passes nothing here: its confirmation is a screen, and it releases itself on dispose.
+ *
  * Shared by desktop and Android so the two can't drift apart on which of these gets forgotten.
  */
 fun tearDownForLock(
@@ -50,6 +56,7 @@ fun tearDownForLock(
     runbooks: RunbookRunner? = null,
     keyboardInteractive: KeyboardInteractivePromptController? = null,
     hostTrust: HostTrustPromptController? = null,
+    closeSyncSetup: (() -> Unit)? = null,
 ) {
     val failures = TeardownFailures()
     failures.run { tunnels?.closeAll() }
@@ -63,6 +70,7 @@ fun tearDownForLock(
     failures.run { runbooks?.close() }
     failures.run { keyboardInteractive?.cancelPending() }
     failures.run { hostTrust?.cancelPending() }
+    failures.run { closeSyncSetup?.invoke() }
     failures.rethrowFirst()
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/vault/LockTeardownTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 private fun hostKey() = HostTrustRequest(
     kind = HostTrustKind.SshHostKey,
@@ -100,5 +101,23 @@ class LockTeardownTest {
             runbooks.close()
             scope.cancel()
         }
+    }
+
+    /**
+     * The desktop sync-setup modal outlives the lock — its open flag is held above the vault gate — while
+     * the password-replace question inside it does not. Closed here, it does not come back after the
+     * unlock as a plain connect form standing where the user's question was.
+     */
+    @Test
+    fun `the lock closes the sync setup modal it would otherwise bring back empty`() {
+        var closed = false
+        tearDownForLock(
+            tunnels = null,
+            sessions = null,
+            sync = null,
+            snippets = null,
+            closeSyncSetup = { closed = true },
+        )
+        assertTrue(closed, "the modal survives the lock and would reopen with its question already answered")
     }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/AccountServerFake.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/AccountServerFake.kt
@@ -1,0 +1,175 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.AccountSummary
+import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.PairingResult
+import app.skerry.shared.sync.PairingTicket
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteDevice
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncClient
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.sync.SyncSignal
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.VaultCrypto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+
+/**
+ * Network stub modelling one account. [existingAccountPassword] = the password the account already
+ * exists under, or `null` if there's no account yet (so `register` creates it). `login` succeeds only
+ * for the matching authKey; `register` collides when the account exists. The wrapped account dataKey is
+ * a DIFFERENT key wrapped under the account password (adopting it re-keys the joining vault).
+ */
+internal class FakeAccountClient(
+    private val crypto: VaultCrypto,
+    private val account: String,
+    existingAccountPassword: String?,
+    /** The account key to publish. `null` = a fresh random one (a genuinely foreign account). */
+    accountDataKey: DataKey? = null,
+    /** Serve a wrap that can't be unwrapped, modelling a corrupted/mismatched server record. */
+    private val corruptWrap: Boolean = false,
+    /** This device is revoked on the account: the first successful login reactivates it and says so once. */
+    revoked: Boolean = false,
+    /** Holds `refresh` until completed, so a test can drive what happens while a silent restore is in flight. */
+    private val refreshGate: CompletableDeferred<Unit>? = null,
+    /** Holds `login` until completed, parking a connect mid-flight for a second one to race. */
+    private val loginGate: CompletableDeferred<Unit>? = null,
+    /** Holds the account-key fetch — only the confirmed re-run gets that far, so it parks that one. */
+    private val fetchGate: CompletableDeferred<Unit>? = null,
+) : SyncClient {
+    // var: a password rotation ([changePassword]) swaps both to the new password's material.
+    private var expectedAuthKey: ByteArray?
+    private var wrappedAccountKey: ByteArray?
+
+    init {
+        if (existingAccountPassword == null) {
+            expectedAuthKey = null
+            wrappedAccountKey = null
+        } else {
+            // Shared cache, not zeroized here: this class builds a client per test and the Argon2id
+            // derivation is what makes the class the slowest in the suite (issue #141).
+            val mk = syncAccountKey(crypto, existingAccountPassword, account)
+            expectedAuthKey = crypto.deriveAuthKey(mk)
+            val key = accountDataKey ?: crypto.newDataKey()
+            wrappedAccountKey = crypto.wrapDataKey(mk, key)
+            key.zeroize()
+        }
+    }
+
+    var registered = false; private set
+
+    // Cleared by the verify that reports it, exactly as the server does it (re-authentication
+    // reactivates the device), so a later login of the same device carries nothing.
+    private val revoked = AtomicBoolean(revoked)
+
+    override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
+        if (expectedAuthKey != null) throw SyncException(SyncException.Kind.CONFLICT, "account exists")
+        registered = true
+        return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
+    }
+
+    /** Completed once a connect has reached the login. */
+    val loggingIn = CompletableDeferred<Unit>()
+    private val loginCalls = AtomicInteger(0)
+
+    /** How many connects got as far as the login. */
+    val logins: Int get() = loginCalls.get()
+
+    override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
+        loginCalls.incrementAndGet()
+        loggingIn.complete(Unit)
+        loginGate?.await()
+        if (expectedAuthKey != null && authKey.contentEquals(expectedAuthKey)) {
+            return SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
+        }
+        throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong password") // server hides "no such account"
+    }
+
+    /** Completed once a connect has reached the account-key fetch. */
+    val fetching = CompletableDeferred<Unit>()
+
+    override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
+        fetching.complete(Unit)
+        fetchGate?.await()
+        val wrap = wrappedAccountKey?.copyOf() ?: throw NotImplementedError("no account")
+        if (corruptWrap) wrap.indices.forEach { wrap[it] = 0 }
+        return wrap
+    }
+
+    /**
+     * Models the server rotation (issue #32): the SRP proof is only accepted for the CURRENT
+     * authKey, then the verifier (authKey) and the wrapped dataKey are swapped to the new ones.
+     * Other-device revocation isn't observable through this stub, so it's not modelled.
+     */
+    override suspend fun changePassword(
+        accountId: String,
+        currentAuthKey: ByteArray,
+        newAuthKey: ByteArray,
+        newWrappedDataKey: ByteArray,
+        device: DeviceInfo,
+    ): SyncSession {
+        if (expectedAuthKey == null || !currentAuthKey.contentEquals(expectedAuthKey)) {
+            throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong current password")
+        }
+        expectedAuthKey = newAuthKey.copyOf()
+        wrappedAccountKey = newWrappedDataKey.copyOf()
+        return SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
+    }
+
+    var closeCalls = 0; private set
+
+    override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
+
+    // Unreachable on purpose, as in [ReactivatingClient]: a health ping that comes up drives the
+    // coordinator's own self-heal ([SyncCoordinator]'s init — no session, so `restoreSession`), and a
+    // restore racing the connects these tests drive is what made this class flake (issue #278). The
+    // restore is driven explicitly where a test is about it.
+    override suspend fun ping(): Boolean = false
+    override suspend fun close() {
+        closeCalls++
+    }
+    override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
+    override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
+    override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
+    override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
+    override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
+    /** Completed once a silent restore has reached the token exchange (and is holding `opMutex`). */
+    val refreshing = CompletableDeferred<Unit>()
+    private val refreshCalls = AtomicInteger(0)
+
+    /** How many silent restores got as far as the token exchange. */
+    val refreshes: Int get() = refreshCalls.get()
+
+    override suspend fun refresh(session: SyncSession): SyncSession {
+        refreshCalls.incrementAndGet()
+        refreshing.complete(Unit)
+        refreshGate?.await()
+        // What the restore does next isn't what these tests are about — fail it, so the status falls
+        // back to Configured and only what the connect does is left to look at.
+        //
+        // This used to be a loud `nope()`, which doubled as a tripwire for the tests that never meant to
+        // restore at all. Together with `ping()` returning unreachable, an unexpected restore in those now
+        // parks on Configured instead of failing the run — deliberate: what the tripwire kept catching was
+        // the coordinator's own self-heal, and that is what made this package flake (issue #278).
+        throw SyncException(SyncException.Kind.NETWORK, "unreachable")
+    }
+    override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
+    private val claimCalls = AtomicInteger(0)
+
+    /** How many pairing claims reached the server. */
+    val claims: Int get() = claimCalls.get()
+
+    // The envelope opens under no transfer key, so the claim fails on the step right after this one.
+    // What these tests need is that it got as far as the server, not that pairing succeeds.
+    override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult {
+        claimCalls.incrementAndGet()
+        return PairingResult(account, ByteArray(64), SyncSession(account, "access", "refresh"))
+    }
+    private fun nope(): Nothing = throw NotImplementedError("the connect flow should not call this")
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
@@ -203,6 +203,29 @@ internal class DebtClearFailingStore(private val delegate: ReconcileDebtStore) :
 /** Whether the store records a rebuild owed to [url]/[id]. */
 internal fun ReconcileDebtStore.owes(url: String, id: String): Boolean = ServerLink(url, id) in load()
 
+/**
+ * A saved keep-connected link whose refresh token really opens under [vault]'s dataKey — what a device
+ * that restores silently has on disk, and the only shape [SyncCoordinator.restoreSession] gets past its
+ * pre-checks.
+ */
+internal fun keepConnectedLink(
+    vault: Vault,
+    crypto: VaultCrypto,
+    serverUrl: String,
+    account: String,
+    deviceId: String,
+): SyncConfig {
+    val dk = vault.exportDataKey()!!
+    return try {
+        SyncConfig(
+            serverUrl, account, deviceId = deviceId, keepConnected = true,
+            sealedRefreshToken = SealedTokenCodec(crypto).seal(dk, "refresh"),
+        )
+    } finally {
+        dk.zeroize()
+    }
+}
+
 /** A fresh unlocked account vault under [password], with its own random dataKey. */
 internal fun newAccountVault(crypto: VaultCrypto, password: String): Vault {
     val file = Files.createTempFile("skerry-reactivate", ".json").toString().toPath()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLinkingGuardTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorLinkingGuardTest.kt
@@ -1,0 +1,349 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.SyncOutcome
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Issue #278 — who owns the status. Two things write it without the user asking: the silent
+ * keep-connected restore ([SyncCoordinator.restoreSession]) and the vault's idle lock. Neither may run
+ * over what the user is doing, and neither may make a tap of the user's into a no-op:
+ *
+ *  - a restore in flight must not swallow a connect or a pairing (the flake this class is named after:
+ *    the double-submit guard read [SyncStatus.Busy], which a restore raises just the same);
+ *  - a restore must not write over a connect paused on [SyncStatus.NeedsPasswordReplaceConfirm] — that
+ *    would take the dialog off the screen while the password it stashed stays in memory;
+ *  - a real double submit must still be refused, including the confirmed re-run of a paused connect;
+ *  - the lock declines a pending confirmation rather than leaving the ACCOUNT password in the heap.
+ *
+ * The vault and the crypto are real (Argon2id), as in [SyncCoordinatorPasswordReplaceTest]; only the
+ * network is the shared [FakeAccountClient], whose gates park an operation mid-flight so the racing one
+ * has a deterministic window to run in.
+ */
+class SyncCoordinatorLinkingGuardTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val serverUrl = "https://sync.test"
+    private val account = "maya"
+    private val vaultPassword = "vault-A"
+    private val accountPassword = "account-B"
+
+    /** A local vault created under [vaultPassword] (unlocked, with its own random dataKey). */
+    private fun localVault(): Vault {
+        val file = Files.createTempFile("skerry-issue278", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(file) // FileVault creates it
+        return FileVault(file, crypto, deviceId = "dev-local", fileSystem = FileSystem.SYSTEM, now = { "2026-07-18T00:00:00Z" })
+            .also { it.create(vaultPassword.toCharArray()) }
+    }
+
+    private fun coordinator(
+        vault: Vault,
+        client: FakeAccountClient,
+        configStore: SyncConfigStore = InMemorySyncConfigStore(),
+    ): SyncCoordinator = SyncCoordinator(
+        clientFactory = { client },
+        crypto = crypto,
+        vault = vault,
+        configStore = configStore,
+        debtStore = InMemoryReconcileDebtStore(),
+        deviceIdProvider = { "dev-local" },
+        engineFactory = { _ -> SyncRunner { _ -> SyncOutcome(pulled = 0, pushed = 0, cursor = 0L) } },
+    )
+
+    /** Sync already configured for [account] on [serverUrl], without the keep-connected token. */
+    private fun configuredStore(): SyncConfigStore = InMemorySyncConfigStore().apply {
+        save(SyncConfig(serverUrl, account, deviceId = "dev-local"))
+    }
+
+    /**
+     * The bug under the flake in issue #278. The silent keep-connected restore raises [SyncStatus.Busy]
+     * exactly like a connect does, and [SyncCoordinator.connect]'s double-submit guard read that status —
+     * so a restore that happened to start first turned the user's own connect into a no-op, with nothing
+     * on screen to say the tap did anything. A double submit is what that guard is for; a background
+     * restore is not one, and the connect must queue behind it instead of vanishing.
+     */
+    @Test
+    fun `a silent restore in flight does not swallow a user connect`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, refreshGate = gate)
+        val store = InMemorySyncConfigStore().apply { save(keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.restoreSession()
+            awaitSync("the silent restore to reach the token exchange") { client.refreshing.await() }
+            // The restore holds opMutex and the status is Busy because of it — the connect must still land.
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            gate.complete(Unit) // the restore fails and parks on Configured; the connect is next in the queue
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The other half of the same race. A connect paused on the confirmation owns the status: a silent
+     * restore running over [SyncStatus.NeedsPasswordReplaceConfirm] takes the dialog off the screen while
+     * the stashed password stays in memory, and nothing but that dialog can confirm or decline it. The
+     * restore is deferred, not dropped — declining hands it back.
+     */
+    @Test
+    fun `a silent restore does not run over a connect paused on the confirmation`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword)
+        val linked = keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")
+        val store = InMemorySyncConfigStore().apply { save(linked) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.restoreSession()
+            delay(700) // give the restore its chance to (wrongly) take the confirmation off the screen
+            assertTrue(sut.status.value is SyncStatus.NeedsPasswordReplaceConfirm, "was ${sut.status.value}")
+            assertEquals(0, client.refreshes, "the paused connect owns the status — nothing restores under it")
+            assertEquals(linked, store.load(), "and the saved link is untouched")
+            // Deferred, not dropped: the answer releases the stand-down, and the next ordinary trigger (an
+            // unlock, a reachability edge) is what restores. The decline itself must not — a restore that
+            // owes a reactivation rebuild clears the vault, and Cancel is not the button for that.
+            sut.cancelPasswordReplace()
+            sut.status.awaitStatus("the declined connect to fall back to the saved link") { it is SyncStatus.Configured }
+            assertEquals(0, client.refreshes, "declining is not itself a restore")
+            sut.restoreSession()
+            awaitSync("the released restore to reach the token exchange") { client.refreshing.await() }
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The deeper half of the same guard. A restore that passed its pre-check and then queued behind the
+     * connect on `opMutex` learns about the pause only when it gets the lock — by which time the dialog is
+     * already up. The re-check under the lock is what stands it down; without it the pre-check alone would
+     * let exactly the interleaving that flaked through.
+     */
+    @Test
+    fun `a restore queued behind the connect stands down once the connect pauses`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, loginGate = gate)
+        val linked = keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")
+        val store = InMemorySyncConfigStore().apply { save(linked) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            awaitSync("the connect to reach the login") { client.loggingIn.await() }
+            // Nothing is stashed yet, so the restore passes its pre-check and queues on the held opMutex.
+            sut.restoreSession()
+            delay(200) // keep the queue order deterministic: the restore enters the mutex queue behind the connect
+            gate.complete(Unit)
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            delay(700) // the queued restore now has the lock — it must find the pause and stand down
+            assertTrue(sut.status.value is SyncStatus.NeedsPasswordReplaceConfirm, "was ${sut.status.value}")
+            assertEquals(0, client.refreshes, "the queued restore must stand down on the pause it found")
+            assertEquals(linked, store.load(), "and leave the saved link alone")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The confirmed re-run is a linking operation like the connect it resumes, and the paused connect's own
+     * unwind must not hand the guard back while it runs — the user can confirm in the window between the
+     * status going up and that unwind finishing.
+     */
+    @Test
+    fun `a connect during the confirmed re-run is refused`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, fetchGate = gate)
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.confirmPasswordReplace()
+            awaitSync("the re-run to reach the account-key fetch") { client.fetching.await() }
+            sut.connect(serverUrl, account, accountPassword.toCharArray()) // must not start a connect of its own
+            // Not a sleep: opMutex is fair, so a connect the guard let through is already ahead of this
+            // disconnect in the queue and would have logged in by the time the disconnect settles. A fixed
+            // window would instead have to outlast two Argon2id derivations on a loaded machine. What the
+            // proof rests on is launch order, not lock order — a leaked connect dispatched onto a slower
+            // worker could in principle reach opMutex after this disconnect — so it is a head start, not
+            // an interlock. Still strictly better than the wall clock it replaced.
+            sut.disconnect()
+            gate.complete(Unit)
+            sut.status.awaitStatus("the disconnect to settle") { it is SyncStatus.Disabled }
+            assertEquals(2, client.logins, "the verify and the confirmed re-run — nothing else")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * What the guard in [SyncCoordinator.connect] is actually for, now that it no longer reads the status:
+     * a double submit must not start a second connect — it would open a second Ktor client and race the
+     * first one's status. Characterisation, not proof of the swap: the status is Busy here either way, so
+     * the old guard refused this too. What proves the swap is the pair of silent-restore tests above.
+     */
+    @Test
+    fun `a second connect while the first is in flight is refused`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, loginGate = gate)
+        val sut = coordinator(vault, client)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            awaitSync("the first connect to reach the login") { client.loggingIn.await() }
+            sut.connect(serverUrl, account, accountPassword.toCharArray()) // the double submit
+            gate.complete(Unit)
+            sut.status.awaitStatus("the connect to pause on the confirmation") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            // Same reason as above, including the same residual: the head start is launch order, so this
+            // is a strong probabilistic proof rather than an interlock.
+            sut.disconnect()
+            sut.status.awaitStatus("the disconnect to settle") { it is SyncStatus.Disabled }
+            assertEquals(1, client.logins, "the double submit must not have started a connect of its own")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /** A well-formed pairing code for [serverUrl] whose envelope opens under no key — the claim fails after the call. */
+    private fun pairingPayload() = PairingPayload(serverUrl, "code-1", ByteArray(32) { 7 }).encode()
+
+    /**
+     * The pairing entry point carries the same guard as [SyncCoordinator.connect], for the same reason: a
+     * silent restore is Busy too, so a guard reading the status would turn "Link a device" into a no-op
+     * with nothing on screen to say the tap did anything (issue #278).
+     */
+    @Test
+    fun `a silent restore in flight does not swallow a device pairing`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, refreshGate = gate)
+        val store = InMemorySyncConfigStore().apply { save(keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.restoreSession()
+            awaitSync("the silent restore to reach the token exchange") { client.refreshing.await() }
+            sut.claimPairing(pairingPayload(), vaultPassword.toCharArray())
+            gate.complete(Unit) // the restore fails and parks; the claim is next in the queue
+            sut.status.awaitStatus("the claim to settle") { it is SyncStatus.Failed }
+            assertEquals(1, client.claims, "the claim must reach the server, not be swallowed by the restore")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * A pairing supersedes a connect paused on the confirmation, exactly as a fresh connect does. The kept
+     * ACCOUNT password is wiped, and the stand-down it put on the silent restore goes with it — otherwise
+     * the password stays in memory for an answer the dialog can no longer give, and a keep-connected device
+     * never restores again for the rest of the process.
+     */
+    @Test
+    fun `a pairing supersedes a connect paused on the confirmation`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword)
+        val store = InMemorySyncConfigStore().apply { save(keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.claimPairing(pairingPayload(), vaultPassword.toCharArray())
+            sut.status.awaitStatus("the claim to settle") { it is SyncStatus.Failed }
+            assertEquals(1, client.claims, "the pairing was refused instead of superseding the pause")
+            // Nothing is stashed any more, so the restore the pause stood down runs when next triggered.
+            sut.restoreSession()
+            awaitSync("the released restore to reach the token exchange") { client.refreshing.await() }
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The client a failed restore opened is closed on the way out. A dead token, a 5xx or a server that
+     * flaps its health ping would otherwise strand a Ktor engine and its pool once per attempt.
+     */
+    @Test
+    fun `a failed silent restore closes the client it opened`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword)
+        val store = InMemorySyncConfigStore().apply { save(keepConnectedLink(vault, crypto, serverUrl, account, "dev-local")) }
+        val sut = coordinator(vault, client, store)
+        try {
+            sut.restoreSession()
+            awaitSync("the restore to reach the token exchange") { client.refreshing.await() }
+            sut.status.awaitStatus("the failed restore to fall back to the saved link") { it is SyncStatus.Configured }
+            assertEquals(1, client.closeCalls, "the client must be closed on the way out")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The same decline, but the lock fires while the connect is still on its way to the pause — after the
+     * login, before the stash. The synchronous decline finds nothing to drop and the password lands in
+     * memory a moment later, behind an already-locked vault. What catches it is the second decline, the
+     * one ordered after the connect by `opMutex`.
+     */
+    @Test
+    fun `a lock that fires before the connect pauses still drops the password`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val gate = CompletableDeferred<Unit>()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, loginGate = gate)
+        val sut = coordinator(vault, client, configuredStore())
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            awaitSync("the connect to reach the login") { client.loggingIn.await() }
+            sut.pauseForLock() // nothing is stashed yet — this one finds nothing
+            gate.complete(Unit)
+            sut.status.awaitStatus("the lock to take the question down") { it is SyncStatus.Configured }
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The idle lock drops every other decrypted secret; the password kept for the confirmation is the
+     * ACCOUNT password, and behind the lock screen nobody can answer the question it belongs to. So the
+     * lock declines on the user's behalf: the stash is wiped and the status stops claiming a dialog is up.
+     */
+    @Test
+    fun `an auto-lock drops the password kept for the confirmation`() = runBlocking<Unit> {
+        initializeVaultCrypto()
+        val vault = localVault()
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword)
+        val sut = coordinator(vault, client, configuredStore())
+        try {
+            sut.connect(serverUrl, account, accountPassword.toCharArray())
+            sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
+            sut.pauseForLock()
+            sut.status.awaitStatus("the lock to take the question down") { it is SyncStatus.Configured }
+            sut.confirmPasswordReplace() // nothing is stashed — this must not re-run the connect
+            sut.disconnect() // queues on opMutex behind any re-run the confirmation would have started
+            sut.status.awaitStatus("the disconnect to settle") { it is SyncStatus.Disabled }
+            assertEquals(1, client.logins, "the stash was dropped — there is nothing left to confirm")
+        } finally {
+            sut.close()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorNetworkRecoveryTest.kt
@@ -232,17 +232,7 @@ class SyncCoordinatorNetworkRecoveryTest {
         val vault = localVault()
         val configStore = InMemorySyncConfigStore()
         // Seed a keep-connected link (token sealed under the live vault dataKey) so restoreSession applies.
-        val dk = vault.exportDataKey()!!
-        try {
-            configStore.save(
-                SyncConfig(
-                    serverUrl, account, deviceId = "dev-1", keepConnected = true,
-                    sealedRefreshToken = SealedTokenCodec(crypto).seal(dk, "refresh"),
-                ),
-            )
-        } finally {
-            dk.zeroize()
-        }
+        configStore.save(keepConnectedLink(vault, crypto, serverUrl, account, deviceId = "dev-1"))
         val gate = CompletableDeferred<Unit>()
         val client = SwitchableServerClient(registerGate = gate)
         val sut = coordinator(vault, client, configStore)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorPasswordReplaceTest.kt
@@ -1,30 +1,19 @@
 package app.skerry.ui.sync
 
-import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.DeviceInfo
-import app.skerry.shared.sync.PairingResult
-import app.skerry.shared.sync.PairingTicket
-import app.skerry.shared.sync.RecordPage
-import app.skerry.shared.sync.RemoteDevice
-import app.skerry.shared.sync.RemoteRecord
 import app.skerry.shared.sync.SyncClient
 import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncOutcome
 import app.skerry.shared.sync.SyncSession
-import app.skerry.shared.sync.SyncSignal
-import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.runBlocking
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -54,103 +43,6 @@ class SyncCoordinatorPasswordReplaceTest {
     private val account = "maya"
     private val vaultPassword = "vault-A"
     private val accountPassword = "account-B"
-
-    /**
-     * Network stub modelling one account. [existingAccountPassword] = the password the account already
-     * exists under, or `null` if there's no account yet (so `register` creates it). `login` succeeds only
-     * for the matching authKey; `register` collides when the account exists. The wrapped account dataKey is
-     * a DIFFERENT key wrapped under the account password (adopting it re-keys the joining vault).
-     */
-    private inner class FakeAccountClient(
-        existingAccountPassword: String?,
-        /** The account key to publish. `null` = a fresh random one (a genuinely foreign account). */
-        accountDataKey: DataKey? = null,
-        /** Serve a wrap that can't be unwrapped, modelling a corrupted/mismatched server record. */
-        private val corruptWrap: Boolean = false,
-        /** This device is revoked on the account: the first successful login reactivates it and says so once. */
-        revoked: Boolean = false,
-    ) : SyncClient {
-        // var: a password rotation ([changePassword]) swaps both to the new password's material.
-        private var expectedAuthKey: ByteArray?
-        private var wrappedAccountKey: ByteArray?
-
-        init {
-            if (existingAccountPassword == null) {
-                expectedAuthKey = null
-                wrappedAccountKey = null
-            } else {
-                // Shared cache, not zeroized here: this class builds a client per test and the Argon2id
-                // derivation is what makes the class the slowest in the suite (issue #141).
-                val mk = syncAccountKey(crypto, existingAccountPassword, account)
-                expectedAuthKey = crypto.deriveAuthKey(mk)
-                val key = accountDataKey ?: crypto.newDataKey()
-                wrappedAccountKey = crypto.wrapDataKey(mk, key)
-                key.zeroize()
-            }
-        }
-
-        var registered = false; private set
-
-        // Cleared by the verify that reports it, exactly as the server does it (re-authentication
-        // reactivates the device), so a later login of the same device carries nothing.
-        private val revoked = AtomicBoolean(revoked)
-
-        override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession {
-            if (expectedAuthKey != null) throw SyncException(SyncException.Kind.CONFLICT, "account exists")
-            registered = true
-            return SyncSession(accountId, accessToken = "access", refreshToken = "refresh")
-        }
-
-        override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
-            if (expectedAuthKey != null && authKey.contentEquals(expectedAuthKey)) {
-                return SyncSession(accountId, accessToken = "access", refreshToken = "refresh", reactivated = revoked.getAndSet(false))
-            }
-            throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong password") // server hides "no such account"
-        }
-
-        override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
-            val wrap = wrappedAccountKey?.copyOf() ?: throw NotImplementedError("no account")
-            if (corruptWrap) wrap.indices.forEach { wrap[it] = 0 }
-            return wrap
-        }
-
-        /**
-         * Models the server rotation (issue #32): the SRP proof is only accepted for the CURRENT
-         * authKey, then the verifier (authKey) and the wrapped dataKey are swapped to the new ones.
-         * Other-device revocation isn't observable through this stub, so it's not modelled.
-         */
-        override suspend fun changePassword(
-            accountId: String,
-            currentAuthKey: ByteArray,
-            newAuthKey: ByteArray,
-            newWrappedDataKey: ByteArray,
-            device: DeviceInfo,
-        ): SyncSession {
-            if (expectedAuthKey == null || !currentAuthKey.contentEquals(expectedAuthKey)) {
-                throw SyncException(SyncException.Kind.UNAUTHORIZED, "wrong current password")
-            }
-            expectedAuthKey = newAuthKey.copyOf()
-            wrappedAccountKey = newWrappedDataKey.copyOf()
-            return SyncSession(accountId, accessToken = "access2", refreshToken = "refresh2")
-        }
-
-        var closeCalls = 0; private set
-
-        override fun changes(session: SyncSession): Flow<SyncSignal> = emptyFlow()
-        override suspend fun ping(): Boolean = true
-        override suspend fun close() {
-            closeCalls++
-        }
-        override suspend fun pull(session: SyncSession, since: Long): RecordPage = nope()
-        override suspend fun push(session: SyncSession, records: List<RemoteRecord>): RecordPage = nope()
-        override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = nope()
-        override suspend fun accountSummary(session: SyncSession): AccountSummary = nope()
-        override suspend fun revokeDevice(session: SyncSession, deviceId: String): Boolean = nope()
-        override suspend fun refresh(session: SyncSession): SyncSession = nope()
-        override suspend fun startPairing(session: SyncSession, encryptedDataKey: ByteArray): PairingTicket = nope()
-        override suspend fun claimPairing(code: String, device: DeviceInfo): PairingResult = nope()
-        private fun nope(): Nothing = throw NotImplementedError("the connect flow should not call this")
-    }
 
     /** A local vault created under [vaultPassword] (unlocked, with its own random dataKey). */
     private fun localVault(): Vault {
@@ -193,7 +85,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `joining an existing account under a different password pauses without changing the vault password`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        val sut = coordinator(vault, FakeAccountClient(crypto, account, existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
@@ -209,7 +101,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `confirming re-keys the vault to the account password`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        val sut = coordinator(vault, FakeAccountClient(crypto, account, existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
@@ -226,7 +118,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `cancelling keeps the vault password and returns to the prior state`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        val sut = coordinator(vault, FakeAccountClient(crypto, account, existingAccountPassword = accountPassword))
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
             sut.status.awaitStatus("the password-replace confirmation to be asked") { it is SyncStatus.NeedsPasswordReplaceConfirm }
@@ -243,7 +135,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `dismissing the confirmation resolves the paused connect instead of only hiding it`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val sut = coordinator(vault, FakeAccountClient(existingAccountPassword = accountPassword))
+        val sut = coordinator(vault, FakeAccountClient(crypto, account, existingAccountPassword = accountPassword))
         var closed = false
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
@@ -276,7 +168,7 @@ class SyncCoordinatorPasswordReplaceTest {
         initializeVaultCrypto()
         val vault = localVault()
         val ourKey = vault.exportDataKey()!!
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, accountDataKey = ourKey)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, accountDataKey = ourKey)
         val sut = coordinator(vault, client)
         try {
             // The vault password drifts away from the account password (Settings → Security).
@@ -302,7 +194,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `confirming fails loudly when the account key cannot be adopted`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, corruptWrap = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, corruptWrap = true)
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, accountPassword.toCharArray())
@@ -331,7 +223,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `reconnecting fails loudly when the account key cannot be adopted`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, corruptWrap = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, corruptWrap = true)
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, vaultPassword.toCharArray())
@@ -364,7 +256,7 @@ class SyncCoordinatorPasswordReplaceTest {
         val vault = localVault()
         // Held LIVE through the revocation — the server purged it in the meantime.
         vault.put("r1", RecordType.HOST, "stale".encodeToByteArray())
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, revoked = true)
         val store = InMemorySyncConfigStore()
         val debts = InMemoryReconcileDebtStore()
         val sut = coordinator(vault, client, store, debts)
@@ -394,7 +286,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `declining the confirmation leaves no link behind after a reactivating verify`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, revoked = true)
         val store = InMemorySyncConfigStore()
         val sut = coordinator(vault, client, store)
         try {
@@ -418,7 +310,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `a reactivating verify records the debt without touching the saved link`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, revoked = true)
         val linked = SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed")
         val store = InMemorySyncConfigStore().apply { save(linked) }
         val debts = InMemoryReconcileDebtStore()
@@ -453,7 +345,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `a confirmed replace that fails on the re-key keeps the reactivation`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, accountDataKey = vault.exportDataKey(), revoked = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, accountDataKey = vault.exportDataKey(), revoked = true)
         val store = configuredStore()
         val debts = InMemoryReconcileDebtStore()
         val sut = coordinator(RewrapUnderFailingVault(vault), client, store, debts)
@@ -482,7 +374,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `a refused reactivation write still closes the client the verify opened`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = accountPassword, revoked = true)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword, revoked = true)
         val linked = InMemorySyncConfigStore().apply { save(SyncConfig(serverUrl, account, deviceId = "dev-local")) }
         val debts = object : ReconcileDebtStore {
             override fun load(): Set<ServerLink> = emptySet()
@@ -502,7 +394,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `connecting with the vault password creates the account without prompting`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = null) // no account yet → register
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = null) // no account yet → register
         val sut = coordinator(vault, client)
         try {
             sut.connect(serverUrl, account, vaultPassword.toCharArray())
@@ -518,7 +410,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `connecting with a non-vault password and no matching account is rejected without registering`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = null) // no account exists
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = null) // no account exists
         val sut = coordinator(vault, client)
         try {
             // "wrong-C" is neither the vault password nor a real account password.
@@ -541,7 +433,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `changing the account password rotates it and re-keys the local vault`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault() // on a synced device the vault password IS the account password
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val sut = coordinator(vault, client, configuredStore())
         try {
             val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
@@ -558,7 +450,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `changing the account password with a wrong current password changes nothing`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val sut = coordinator(vault, client, configuredStore())
         try {
             val result = sut.changeAccountPassword("not-the-password".toCharArray(), rotated.toCharArray())
@@ -574,7 +466,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `changing the account password without sync configured is a no-op`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword)
         val sut = coordinator(vault, client) // no configStore → not configured
         try {
             val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())
@@ -595,7 +487,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `an interrupted rotation leaves the account on the new password and heals on reconnect`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val store = configuredStore()
 
         // The server rotates, but the local re-wrap fails (client "dies" between step 3 and 4).
@@ -632,7 +524,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `an interrupted rotation on a keep-connected device clears the auto-restore token`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val store = InMemorySyncConfigStore().apply {
             save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
         }
@@ -670,7 +562,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `a throttled rotation keeps the auto-restore token and is named as throttling`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val store = InMemorySyncConfigStore().apply {
             save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
         }
@@ -697,7 +589,7 @@ class SyncCoordinatorPasswordReplaceTest {
     fun `a rotation against a broken server is named as a server failure`() = runBlocking {
         initializeVaultCrypto()
         val vault = localVault()
-        val client = FakeAccountClient(existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = vaultPassword, accountDataKey = vault.exportDataKey())
         val store = InMemorySyncConfigStore().apply {
             save(SyncConfig(serverUrl, account, deviceId = "dev-local", keepConnected = true, sealedRefreshToken = "sealed-old"))
         }
@@ -725,7 +617,7 @@ class SyncCoordinatorPasswordReplaceTest {
         val vault = localVault()
         // Account exists under a DIFFERENT password than this vault's: local verifyPassword passes,
         // but the server's SRP proof of the current password fails.
-        val client = FakeAccountClient(existingAccountPassword = accountPassword)
+        val client = FakeAccountClient(crypto, account, existingAccountPassword = accountPassword)
         val sut = coordinator(vault, client, configuredStore())
         try {
             val result = sut.changeAccountPassword(vaultPassword.toCharArray(), rotated.toCharArray())

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -189,10 +189,8 @@ class SyncCoordinatorReactivationTest {
 
         // The link a keep-connected device already has — the failed connect below never reaches a session,
         // so it seals no token of its own.
-        val dataKey = vault.exportDataKey()!!
-        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
         val config = InMemorySyncConfigStore().also {
-            it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
+            it.save(keepConnectedLink(vault, crypto, serverUrl, account, deviceId = "devA"))
         }
         val debts = InMemoryReconcileDebtStore()
         val client = ReactivatingClient(ownWrap(vault), reactivated = true, corruptWraps = 1)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReconcileDebtTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReconcileDebtTest.kt
@@ -326,10 +326,8 @@ class SyncCoordinatorReconcileDebtTest {
         val vault = freshVault()
         vault.put("r1", RecordType.HOST, "secret".encodeToByteArray())
 
-        val dataKey = vault.exportDataKey()!!
-        val sealed = SealedTokenCodec(crypto).seal(dataKey, "refresh").also { dataKey.zeroize() }
         val config = InMemorySyncConfigStore().also {
-            it.save(SyncConfig(serverUrl, account, deviceId = "devA", keepConnected = true, sealedRefreshToken = sealed))
+            it.save(keepConnectedLink(vault, crypto, serverUrl, account, deviceId = "devA"))
         }
         val debts = DebtRaiseFailingStore(InMemoryReconcileDebtStore())
         val client = ReactivatingClient(ownWrap(vault), reactivated = true)


### PR DESCRIPTION
The double-submit guard in `connect()` and `claimPairing()` read `SyncStatus.Busy`, which the silent keep-connected session restore raises exactly as a user connect does. A restore that happened to start first turned the user's own tap into a no-op, with nothing on screen to say anything had happened.

The guard now reads a dedicated in-flight flag carrying a generation token, taken and released under one lock, so neither a paused connect's own unwind nor a worker preempted mid-release can drop the guard for the operation that currently holds it.

The same ownership rule applies the other way: a silent restore no longer writes over a connect paused on `NeedsPasswordReplaceConfirm`. That took the dialog off the screen while the password it stashed stayed in memory, with nothing left able to answer it. The stand-down is re-checked under `opMutex`, since a restore that passed its pre-check learns about the pause only when it gets the lock.

## The vault lock answers the question instead of walking away from it

The password stashed for a pending confirmation is the **account** password, and behind the lock screen nobody can answer the question it belongs to. The idle lock now declines on the user's behalf rather than leaving that password resident for the whole locked period.

The decline and the connect that publishes the pause take the same lock: a connect still on the network is either refused outright or has already stashed and is found — it can no longer land in between and leave the password behind a locked vault, nor put the question on screen with nothing able to answer it.

The desktop sync-setup modal is closed with it. Its open flag lives above the vault gate, so it would otherwise come back after the unlock as a plain connect form standing where the user's question was.

## Also in the same field's lifecycle

- `claimPairing` supersedes a pending confirmation, as `connect` already did.
- A failed restore closes the client it opened — previously one stranded Ktor engine and its connection pool per attempt — and seals the rotated refresh token before handing that client over, so a throw there cannot leak it.
- The wipe-and-clear idiom for the stashed password is one helper rather than four copies.

## Tests

The flaky test that exposed this (#278) had a fake whose health ping came up, driving the coordinator's own self-heal into a race with the connects the tests drive. It now reports unreachable, and the restore is driven explicitly where a test is about it. The tests about who owns the status moved into `SyncCoordinatorLinkingGuardTest`, and the account-server fake into `AccountServerFake.kt`.

Ten new tests cover the ownership rules and the lock's decline, including the two orders in which the lock and a connect on the network can meet.

## Verification

Desktop only. Not exercised on Android, against a live sync server, or with a real idle lock on a device.

Fixes #278
