### PR TITLE
Keep file-backed credentials off sync — the refs are device-local

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vault.xml
@@ -139,6 +139,7 @@
     <string name="vault_label_key_path">ФАЙЛ КЛЮЧА</string>
     <string name="vault_label_cert_path">ФАЙЛ СЕРТИФИКАТА</string>
     <string name="vault_key_file_missing">Недоступен с этого устройства</string>
+    <string name="vault_key_file_device_only">Секреты из файла не синхронизируются</string>
     <string name="vault_cert_from_file_unreadable">Файл сертификата не читается</string>
 
     <plurals name="vault_item_count">

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vault.xml
@@ -139,6 +139,7 @@
     <string name="vault_label_key_path">密钥文件</string>
     <string name="vault_label_cert_path">证书文件</string>
     <string name="vault_key_file_missing">此设备无法读取</string>
+    <string name="vault_key_file_device_only">存放在文件中的密钥不参与同步</string>
     <string name="vault_cert_from_file_unreadable">无法读取证书文件</string>
 
     <plurals name="vault_item_count">

--- a/composeApp/src/commonMain/composeResources/values/strings_vault.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vault.xml
@@ -139,6 +139,7 @@
     <string name="vault_label_key_path">KEY FILE</string>
     <string name="vault_label_cert_path">CERTIFICATE FILE</string>
     <string name="vault_key_file_missing">Not readable from this device</string>
+    <string name="vault_key_file_device_only">Secrets kept in a file are not synced</string>
     <string name="vault_cert_from_file_unreadable">Certificate file not readable</string>
 
     <!-- Section header: how much the vault holds and how it is protected. -->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVaultView.kt
@@ -672,7 +672,7 @@ private fun MobileSecretDetailSheet(
                     }
                 }
                 SecretSectionLabel(encryptionSectionTitle())
-                SecretEncryptionRows(syncing)
+                SecretEncryptionRows(syncing, credential.secret)
                 // Same rule as the desktop panel: audit shows for every secret whose material can
                 // leave the vault — password copies and private-key exports.
                 if (hasAuditTrail(credential)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -4,6 +4,7 @@ import app.skerry.shared.platformName
 import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.sync.MAX_ACCOUNT_ID_CHARS
 import app.skerry.shared.sync.DeviceInfo
+import app.skerry.shared.sync.DeviceLocalRecords
 import app.skerry.shared.sync.RemoteDevice
 import app.skerry.shared.sync.SyncClient
 import app.skerry.shared.sync.SyncEngine
@@ -200,6 +201,10 @@ class SyncCoordinator(
     // sync (see [SyncSettings]). Read lazily from the vault: on a locked vault the store returns default.
     private val settingsStore = SyncSettingsStore(vault)
 
+    // The payload-side half of the same filter: file-backed credentials name a location this device
+    // owns and no other one can resolve, so they never travel in either direction (issue #174).
+    private val deviceLocal = DeviceLocalRecords(vault)
+
     private val engineFactory: (SyncClient) -> SyncRunner = engineFactory
         // The engine knows only the session it syncs, and a session carries no server — so the cursor is
         // pinned to the link the cycle belongs to here, where it is known ([cursorKey], issue #242).
@@ -210,7 +215,13 @@ class SyncCoordinator(
                 // strand its progress silently and re-pull everything for good. The failure surfaces on
                 // the status like any other failed cycle.
                 val key = cursorKey() ?: error("no active link for a live session")
-                SyncEngine(c, vault, KeyedStateStore(syncState, key), settings = { settingsStore.load() }).sync(s)
+                SyncEngine(
+                    c,
+                    vault,
+                    KeyedStateStore(syncState, key),
+                    settings = { settingsStore.load() },
+                    deviceLocal = deviceLocal,
+                ).sync(s)
             }
         }
 
@@ -888,7 +899,8 @@ class SyncCoordinator(
      * disabled locally but enabled on the server would keep its stale record through the clear and then be
      * pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the maximal
      * (everything-on) filter covers any server settings; only never-synced, device-local types (terminal
-     * history) are kept.
+     * history) are kept — plus, record by record, the device-local ones the push filter already refuses
+     * ([DeviceLocalRecords]): nothing on the server would restore those.
      *
      * Throws whatever the clear throws — a vault locked at this moment ([Vault.clearRecords] needs an
      * unlocked one) leaves the debt standing over an un-cleared vault, which is what [reconcileOwed] reads.
@@ -912,7 +924,9 @@ class SyncCoordinator(
         configStore.save(config)
         recordDebt(link)
         val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
-        vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet())
+        // Device-local records are spared one at a time, not by type: they were never pushed, so the
+        // re-pull cannot bring them back and clearing them would simply destroy them (issue #174).
+        vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet(), deviceLocal::survivesClear)
         syncState.setCursor(link.cursorKey, 0) // reactivation always full-pulls to rebuild from the server
         armedFor = link // only now, and named — see [retireDischargedDebt]
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -682,6 +682,11 @@ class TeamsCoordinator(
         val spaceVault = spaces.vaultResettingStale(ref) ?: return
         syncMutex.withLock {
             try {
+                // No device-local filter (issue #174): a space vault cannot hold a credential at
+                // all — the share picker offers hosts, snippets and runbooks, and HOST_SHARE_STRIP
+                // drops `credentialId` on the way in. Offering credentials to a team would have to
+                // pass DeviceLocalRecords(spaceVault) here, or a file-backed ref would reach every
+                // member's device.
                 val engine = SyncEngine(
                     TeamScopedSyncClient(c, ref),
                     spaceVault,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultFacts.kt
@@ -99,11 +99,17 @@ fun SecretFactRows(
 
 /**
  * How the secret is protected and where its ciphertext goes. Static facts of this build's crypto
- * (see [VaultCrypto]) plus one live one: whether a sync account exists at all — without it
- * "stored on server" would be a claim about a server the user never connected to.
+ * (see [VaultCrypto]) plus one live one: whether the ciphertext reaches a server at all.
+ *
+ * That last answer takes the secret and not just [syncing] on purpose. An account existing is
+ * account-level; whether THIS secret is pushed is not — a file-backed one never is (issue #174,
+ * [app.skerry.shared.sync.DeviceLocalRecords]). Asking for both leaves no way to pass the
+ * account-level fact where the per-secret one belongs, which is how the row came to claim a server
+ * copy of a record that never left.
  */
 @Composable
-fun SecretEncryptionRows(syncing: Boolean, modifier: Modifier = Modifier) {
+fun SecretEncryptionRows(syncing: Boolean, secret: CredentialSecret, modifier: Modifier = Modifier) {
+    val onServer = syncing && secret !is CredentialSecret.KeyFile
     Column(modifier.fillMaxWidth()) {
         KeyValueRow(stringResource(Res.string.vault_kv_cipher), VAULT_CIPHER)
         KeyValueRow(
@@ -112,7 +118,7 @@ fun SecretEncryptionRows(syncing: Boolean, modifier: Modifier = Modifier) {
         )
         KeyValueRow(
             stringResource(Res.string.vault_kv_stored),
-            stringResource(if (syncing) Res.string.vault_stored_ciphertext else Res.string.vault_stored_local),
+            stringResource(if (onServer) Res.string.vault_stored_ciphertext else Res.string.vault_stored_local),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultMockView.kt
@@ -148,6 +148,6 @@ private fun MockSecretDetail(credential: Credential, mono: FontFamily) {
             }
         }
         SecretSectionLabel(encryptionSectionTitle())
-        SecretEncryptionRows(syncing = true)
+        SecretEncryptionRows(syncing = true, secret = credential.secret)
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -54,6 +54,7 @@ import app.skerry.ui.generated.resources.vault_delete
 import app.skerry.ui.generated.resources.vault_edit
 import app.skerry.ui.generated.resources.vault_export_key
 import app.skerry.ui.generated.resources.vault_export_certificate
+import app.skerry.ui.generated.resources.vault_key_file_device_only
 import app.skerry.ui.generated.resources.vault_key_unreadable
 import app.skerry.ui.generated.resources.vault_label_cert_path
 import app.skerry.ui.generated.resources.vault_label_key_path
@@ -229,7 +230,7 @@ internal fun LiveSecretDetail(
             }
         }
         SecretSectionLabel(encryptionSectionTitle())
-        SecretEncryptionRows(syncing)
+        SecretEncryptionRows(syncing, credential.secret)
         // Audit shows for every secret whose material can leave the vault: a password (clipboard
         // copies) and anything with an exportable private key (file exports). A file-backed secret
         // has neither — its material never entered the vault.
@@ -333,6 +334,11 @@ internal fun KeyFileBadges(state: KeyFileState?) {
  * Detail body for a file-backed secret: the refs themselves (that's the whole secret, as far as the
  * vault is concerned), whether each is readable here, and the certificate metadata parsed off disk —
  * the same [CertificateDetailBody] a vault-stored certificate gets, so both kinds read alike.
+ *
+ * It also states that this secret does not sync (issue #174) — a ref is a location, and a location
+ * means nothing on the next device. Said here rather than as a list badge: it is a permanent
+ * property of every file-backed secret, so a badge would be on every such row forever, including
+ * for the users who never connected an account.
  */
 @Composable
 internal fun KeyFileDetailBody(secret: CredentialSecret.KeyFile, state: KeyFileState?, mono: FontFamily) {
@@ -346,6 +352,7 @@ internal fun KeyFileDetailBody(secret: CredentialSecret.KeyFile, state: KeyFileS
     if (state?.certificateExpected == true && !state.certificateReadable) {
         Txt(stringResource(Res.string.vault_cert_from_file_unreadable), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(bottom = 16.dp))
     }
+    Txt(stringResource(Res.string.vault_key_file_device_only), color = Skerry.colors.dim, size = 11.sp, modifier = Modifier.padding(bottom = 16.dp))
     state?.certificate?.let { CertificateDetailBody(it, mono) }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultView.kt
@@ -307,7 +307,8 @@ private fun LiveVaultView(credentials: CredentialManagerController) {
         }
         pendingEditCred?.let { target ->
             // Editing touches only the name and the note; the id (which hosts reference) and the secret
-            // stay put, and the change propagates to sync on its own (see CredentialManagerController.edit).
+            // stay put, and the change propagates to sync on its own (see CredentialManagerController.edit)
+            // — except for a file-backed secret, whose whole record stays on this device (issue #174).
             EditSecretDialog(
                 currentLabel = target.label,
                 currentNote = target.note,

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
@@ -15,6 +15,7 @@ import app.skerry.shared.vault.FileVault
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
+import app.skerry.shared.vault.VaultRecord
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -144,12 +145,12 @@ internal class ClearFailingVault(
     /** How many clears were tried — the observable "the reconcile ran again" for a retry that fails too. */
     val clearAttempts: Int get() = attempts.get()
 
-    override fun clearRecords(types: Set<RecordType>) {
+    override fun clearRecords(types: Set<RecordType>, keep: (VaultRecord) -> Boolean) {
         val n = attempts.getAndIncrement()
         // `n - intact < failures`, not `n < intact + failures`: the default [failures] is Int.MAX_VALUE and
         // the sum would overflow, turning "every clear after the first" into "no clear at all".
         if (n >= intact && n - intact < failures) error("vault is locked")
-        delegate.clearRecords(types)
+        delegate.clearRecords(types, keep)
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -3,11 +3,16 @@ package app.skerry.ui.sync
 import app.skerry.shared.sync.InMemorySyncStateStore
 import app.skerry.shared.sync.SyncSettings
 import app.skerry.shared.sync.SyncSettingsStore
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialStore
 import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.TrashStore
 import app.skerry.shared.vault.UnlockResult
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.shared.vault.trashRecordId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -60,6 +65,90 @@ class SyncCoordinatorReactivationTest {
             assertFalse(client.pushed.any { it.id == "r1" }, "a reactivated device must not re-push a purged record")
             // The debt is retired once the reconcile's first sync succeeded.
             assertFalse(debts.owes(serverUrl, account), "a completed reconcile retires the debt")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #174: a file-backed credential is never pushed, so the reconcile's re-pull has nothing to
+     * restore it from — clearing it by type would destroy the only copy that exists.
+     */
+    @Test
+    fun `a reactivated device keeps the file-backed credential it never pushed`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        CredentialStore(vault).put(
+            Credential("cred-file", "tsh", CredentialSecret.KeyFile(privateKeyRef = "/home/maya/.tsh/keys/id")),
+        )
+        CredentialStore(vault).put(
+            Credential("cred-pem", "laptop", CredentialSecret.PrivateKey("-----BEGIN OPENSSH PRIVATE KEY-----")),
+        )
+        // Deleted, so the clear also has to spare its trash snapshot — that snapshot holds the ref.
+        val trashed = Credential("cred-gone", "old tsh", CredentialSecret.KeyFile("/home/maya/.ssh/old"))
+        CredentialStore(vault, TrashStore(vault)).also {
+            it.put(trashed)
+            it.remove(trashed.id)
+        }
+
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val debts = InMemoryReconcileDebtStore()
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault, debtStore = debts)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
+            assertTrue(
+                vault.records().any { it.id == "cred-file" },
+                "the reconcile must not drop a record the server was never given",
+            )
+            assertFalse(client.pushed.any { it.id == "cred-file" }, "and it still must not travel")
+            assertTrue(
+                vault.records().any { it.id == trashRecordId(RecordType.CREDENTIAL, "cred-gone") },
+                "the trash snapshot holds the same ref, so the clear must spare it too",
+            )
+            assertFalse(vault.records().any { it.id == "cred-pem" }, "a synced credential is rebuilt from the server")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * The other half of that rule: sparing has to be NARROWER than the push filter. A blob this device
+     * can no longer open — what [Vault.adoptDataKey] leaves behind when an account key replaces this
+     * vault's own — is not device-local, it is dead: the server may well hold a readable copy. The
+     * clear is the only thing that ever removed it, and a spared one squats on its id, so the copy the
+     * re-pull brings back arrives at a lower version and loses the LWW.
+     */
+    @Test
+    fun `a reactivated device drops the credentials it can no longer decrypt`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        CredentialStore(vault).put(
+            Credential("cred-stale", "old account", CredentialSecret.PrivateKey("-----BEGIN OPENSSH PRIVATE KEY-----")),
+        )
+        // Joining another account: what was written under the old key stays in the file, unreadable.
+        assertTrue(vault.adoptDataKey(crypto.newDataKey(), password.toCharArray()), "the adoption must take")
+        CredentialStore(vault).put(
+            Credential("cred-file", "tsh", CredentialSecret.KeyFile(privateKeyRef = "/home/maya/.tsh/keys/id")),
+        )
+
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(
+            clientFactory = { client }, crypto = crypto, vault = vault, debtStore = InMemoryReconcileDebtStore(),
+        )
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
+            assertFalse(
+                vault.records().any { it.id == "cred-stale" },
+                "an undecryptable leftover is not device-local and must not survive the clear",
+            )
+            assertTrue(
+                vault.records().any { it.id == "cred-file" },
+                "the file-backed credential still must",
+            )
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/KeyFileDetailBodyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/vault/KeyFileDetailBodyTest.kt
@@ -1,0 +1,81 @@
+package app.skerry.ui.vault
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.ui.desktop.drawnText
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.vault_key_file_device_only
+import app.skerry.ui.generated.resources.vault_key_file_missing
+import app.skerry.ui.generated.resources.vault_stored_ciphertext
+import app.skerry.ui.generated.resources.vault_stored_local
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The one thing issue #174 puts on screen. A file-backed secret is silently excluded from sync
+ * everywhere else — the pane is where the user finds out, so the line has to be there whether or not
+ * the file itself can be read from here (a record an older release synced in shows both).
+ */
+@OptIn(ExperimentalTestApi::class)
+class KeyFileDetailBodyTest {
+
+    private val secret = CredentialSecret.KeyFile(privateKeyRef = "/home/maya/.tsh/keys/id")
+
+    @Test
+    fun `a file-backed secret says it does not sync`() {
+        runForm({ KeyFileDetailBody(secret, state = null, mono = FontFamily.Monospace) }) {
+            val expected = string(Res.string.vault_key_file_device_only)
+            assertTrue(drawnText().any { it.contains(expected) }, "was ${drawnText()}")
+        }
+    }
+
+    @Test
+    fun `it says so about the kind, not about where this record came from`() {
+        // Inherited from a pre-fix release: the file is absent here, so the pane also draws "not
+        // readable from this device". The two lines must not read as one claim about provenance.
+        val absent = KeyFileState(
+            keyReadable = false,
+            certificateRef = null,
+            certificateExpected = false,
+            certificateReadable = false,
+            certificate = null,
+        )
+        runForm({ KeyFileDetailBody(secret, state = absent, mono = FontFamily.Monospace) }) {
+            val drawn = drawnText()
+            val missing = string(Res.string.vault_key_file_missing)
+            val kind = string(Res.string.vault_key_file_device_only)
+            assertTrue(drawn.any { it.contains(missing) }, "the pane still says the file is absent, was $drawn")
+            assertTrue(drawn.any { it.contains(kind) }, "and still states the kind does not sync, was $drawn")
+            // The order is the claim: where this record is readable comes first, what it is comes last.
+            assertTrue(
+                drawn.indexOfFirst { it.contains(missing) } < drawn.indexOfFirst { it.contains(kind) },
+                "was $drawn",
+            )
+        }
+    }
+
+    /**
+     * The claim the pane makes twice. "Stored on server" is an account-level fact everywhere else,
+     * and for a file-backed secret the account-level answer is wrong: the record never leaves, so the
+     * row a user reads to find out where the ciphertext is must say so too.
+     */
+    @Test
+    fun `a file-backed secret is stored on this device even with an account connected`() {
+        runForm({ SecretEncryptionRows(syncing = true, secret = secret) }) {
+            val drawn = drawnText()
+            assertTrue(drawn.any { it.contains(string(Res.string.vault_stored_local)) }, "was $drawn")
+            assertTrue(drawn.none { it.contains(string(Res.string.vault_stored_ciphertext)) }, "was $drawn")
+        }
+    }
+
+    @Test
+    fun `an ordinary secret still reports the server it is synced to`() {
+        val password = CredentialSecret.Password("hunter2")
+        runForm({ SecretEncryptionRows(syncing = true, secret = password) }) {
+            assertTrue(drawnText().any { it.contains(string(Res.string.vault_stored_ciphertext)) }, "was ${drawnText()}")
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/DeviceLocalRecords.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/DeviceLocalRecords.kt
@@ -1,0 +1,181 @@
+package app.skerry.shared.sync
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.TrashEntry
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+import app.skerry.shared.vault.VaultRecordCodec
+import kotlinx.serialization.KSerializer
+
+/**
+ * The half of the sync filter that has to open the payload. [SyncSettings] decides by plaintext
+ * metadata — type and id — which is all a zero-knowledge engine needs for a per-type switch; what
+ * makes a record device-local is inside the encrypted blob.
+ *
+ * The three questions are deliberately not one. Outgoing, the answer has to be safe when the payload
+ * cannot be read at all; incoming, it must not swallow a record [Vault.mergeRemote] would have
+ * counted as tampered; and what a reconcile spares is narrower than either. See [DeviceLocalRecords]
+ * for the rule itself.
+ */
+interface DeviceLocalFilter {
+
+    /** Whether [record] may not leave this device: what the push drops. */
+    fun blocksOutgoing(record: VaultRecord): Boolean
+
+    /** Whether [record], arriving from another device, must not be applied. */
+    fun blocksIncoming(record: VaultRecord): Boolean
+
+    /**
+     * Whether [record] must survive a reconcile's [Vault.clearRecords]. Narrower than
+     * [blocksOutgoing] on purpose, and not a synonym for it: the clear is followed by a full re-pull,
+     * so sparing is right only for a record the server can never hand back — one this device refuses
+     * to push because of what its payload holds. Everything else the push merely *could* not judge
+     * belongs in the clear, where it always was.
+     */
+    fun survivesClear(record: VaultRecord): Boolean
+
+    /** Nothing is device-local: engines over a vault that cannot hold such a record, and tests. */
+    object None : DeviceLocalFilter {
+        override fun blocksOutgoing(record: VaultRecord): Boolean = false
+        override fun blocksIncoming(record: VaultRecord): Boolean = false
+        override fun survivesClear(record: VaultRecord): Boolean = false
+    }
+}
+
+/**
+ * Records that must stay on the device that made them: today exactly one thing, a
+ * [CredentialSecret.KeyFile] credential. Its `privateKeyRef`/`certificateRef` are a *location* — a
+ * filesystem path on desktop, a `content://` document Uri on Android — and a location does not
+ * survive the trip: a desktop path means nothing on a phone, and a `content://` Uri is a per-app
+ * grant that resolves on no other device at all, not even another Android one. Pushed anyway, it
+ * lands in the other device's keychain as an entry that can never connect. So it never leaves, and
+ * one arriving from an older client is never applied (issue #174).
+ *
+ * The exclusion is hard, not a setting: the one layout where the ref would resolve — two desktops
+ * with the same `~/.ssh` — is a coincidence of paths, and on the far machine the same path may hold
+ * a different key. A switch offering that would be offering to authenticate with whatever is there.
+ *
+ * Deletion is unaffected: a tombstone carries no payload, travels as always, and is what clears a
+ * copy an older client already synced. The trash *snapshot* of such a credential holds the same ref
+ * in its payload, so it is excluded on the same grounds.
+ *
+ * Two things this does NOT do, both deliberate. A record a previous release already pushed stays on
+ * the server until the user deletes the credential — the same "off doesn't delete" semantics
+ * [SyncSettings] documents, and the only alternative would be tombstoning a record the user still
+ * has, which deletes it here too. And the tombstone of a credential whose live version never
+ * travelled tells a server operator that this id was file-backed; suppressing it would cost the
+ * cleanup path, which is worth more than hiding one bit from a server that already sees every id.
+ */
+class DeviceLocalRecords(private val vault: Vault) : DeviceLocalFilter {
+
+    /**
+     * Outgoing, an unreadable payload counts as device-local too. A blob this device cannot open is
+     * one no device can: it authenticates for nobody (a leftover sealed under the account key this
+     * one replaced), so pushing it can only add a record the server keeps for good and, through LWW,
+     * overwrite a copy elsewhere that still opens. "Cannot tell" must not resolve to "upload it" on
+     * the side where uploading is the irreversible move.
+     */
+    override fun blocksOutgoing(record: VaultRecord): Boolean = verdict(record) != Verdict.SHAREABLE
+
+    /**
+     * Incoming, only positive evidence counts. An incoming blob that does not open is a forged,
+     * replayed or foreign-key record, and [Vault.mergeRemote] rejects it *and reports it* — dropping
+     * it here instead would turn a tampering signal ([SyncOutcome.rejected]) into silence.
+     */
+    override fun blocksIncoming(record: VaultRecord): Boolean = verdict(record) == Verdict.DEVICE_LOCAL
+
+    /**
+     * The clear asks the third question, and it is not [blocksOutgoing]. A blob that does not open is
+     * not device-local, it is dead — a leftover of the account key this vault replaced
+     * ([Vault.adoptDataKey] keeps the records and drops the key that opened them), and the clear is
+     * the only thing that has ever removed one. Spared, it would keep its id and version and squat
+     * there: the server's readable copy comes back from the re-pull at a lower version, loses the LWW
+     * and never lands, so the account's credential is gone from this device for good.
+     */
+    override fun survivesClear(record: VaultRecord): Boolean = verdict(record) == Verdict.DEVICE_LOCAL
+
+    private enum class Verdict { DEVICE_LOCAL, SHAREABLE, UNREADABLE }
+
+    /**
+     * A record is judged on its payload, so the vault has to be open: [Vault.openRecordPayload]
+     * throws on a locked one and the throw is left alone. Swallowing it would answer "shareable" for
+     * a reason that says nothing about the record — the whole cycle failing is the honest outcome,
+     * and [SyncEngine] holds the vault for the length of the push filter so it cannot happen there.
+     */
+    private fun verdict(record: VaultRecord): Verdict {
+        // A tombstone carries no payload to judge, and is exactly what must keep travelling.
+        if (record.deleted) return Verdict.SHAREABLE
+        // Every trash record is opened, not just the ones whose id says CREDENTIAL: the id is
+        // plaintext metadata, and [TrashStore.restore] restores by the origin type inside the
+        // *entry*. A record filed under `skerry.trash:HOST:…` whose entry says CREDENTIAL would
+        // otherwise pass unopened and be restored as the very credential this refuses.
+        if (record.type != RecordType.CREDENTIAL && record.type != RecordType.TRASH) return Verdict.SHAREABLE
+        // Wiped on the way out: this is a full credential in the clear — password, PEM, passphrase —
+        // read to answer one bit, on a loop that runs unattended (FileVault.authenticates does the
+        // same). The String the parse makes is the accepted JVM limitation named in [Credential].
+        val payload = vault.openRecordPayload(record) ?: return Verdict.UNREADABLE
+        val credential = try {
+            // A sound negative first, on the bytes. Every [CredentialSecret.KeyFile] carries its
+            // `@SerialName` verbatim in the JSON, so a payload without those bytes cannot be one and
+            // is answered without ever building a String. That matters here and not elsewhere: this
+            // runs for every credential AND every credential trash snapshot on every push cycle, and
+            // a snapshot's payload is a *deleted* secret in full, which would otherwise be
+            // re-materialised as unwipeable Strings all through the retention window.
+            //
+            // Sound only against what the writer emits, and the reader accepts more: the lexer
+            // unescapes `\uXXXX` inside a string, discriminator included, so `\u006bey_file` parses
+            // as this very secret while spelling none of its bytes. A device holding the account key
+            // could seal exactly that. `\u` is the only way JSON can write an ASCII letter without
+            // writing it, so a payload carrying one is not answered by a scan at all — it goes the
+            // long way, like a real file-backed secret does.
+            if (!payload.holds(UNICODE_ESCAPE) && !payload.holds(KEY_FILE_MARK)) return Verdict.SHAREABLE
+            if (record.type == RecordType.TRASH) {
+                decode(payload, TrashEntry.serializer())
+                    ?.takeIf { it.originType == RecordType.CREDENTIAL }
+                    ?.let { parse(it.payload) }
+            } else {
+                decode(payload, Credential.serializer())
+            }
+        } finally {
+            payload.fill(0)
+        }
+        // A payload that opened but did not parse is a schema this build does not know, not evidence
+        // of a file-backed key: it keeps syncing, so a newer client's record is not stranded here.
+        return if (credential?.secret is CredentialSecret.KeyFile) Verdict.DEVICE_LOCAL else Verdict.SHAREABLE
+    }
+
+    /** [TrashEntry.payload] is already the deleted record's plaintext JSON — no byte round trip. */
+    private fun parse(payload: String): Credential? =
+        runCatching { VaultRecordCodec.json.decodeFromString(Credential.serializer(), payload) }.getOrNull()
+
+    private fun <T> decode(payload: ByteArray, serializer: KSerializer<T>): T? =
+        runCatching { VaultRecordCodec.json.decodeFromString(serializer, payload.decodeToString()) }.getOrNull()
+
+    /**
+     * [mark] is spelled out per call rather than held in a shared array: the one thing this file also
+     * does to a [ByteArray] is `fill(0)`, and a wiped needle would quietly answer "no payload holds
+     * it" — which is the whole filter saying yes to everything.
+     */
+    private fun ByteArray.holds(mark: String): Boolean {
+        val needle = mark.encodeToByteArray()
+        if (needle.size > size) return false
+        outer@ for (start in 0..size - needle.size) {
+            for (i in needle.indices) if (this[start + i] != needle[i]) continue@outer
+            return true
+        }
+        return false
+    }
+}
+
+/**
+ * The discriminator [CredentialSecret.KeyFile] is written under — a wire name fixed by `@SerialName`,
+ * so it survives package renames and R8 exactly as the payloads that carry it do. Present in the
+ * plaintext of every file-backed secret this build writes; a hit proves nothing on its own, since a
+ * label, a note or a PEM comment sits in the same blob.
+ */
+private const val KEY_FILE_MARK = "key_file"
+
+/** The one JSON spelling that hides an ASCII letter from a byte scan. */
+private const val UNICODE_ESCAPE = "\\u"

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
@@ -97,6 +97,14 @@ class SyncEngine(
      * configs without the feature). See [SyncSettings].
      */
     private val settings: () -> SyncSettings = { SyncSettings() },
+    /**
+     * The other half of the filter, decided on the payload rather than on plaintext metadata: a
+     * record that must stay on this device, neither pushed nor applied from another one. See
+     * [DeviceLocalRecords]. Defaults to [DeviceLocalFilter.None] — what the engine did before the
+     * rule existed, and the right answer for a vault that cannot hold such a record (a team space:
+     * credentials are not shareable).
+     */
+    private val deviceLocal: DeviceLocalFilter = DeviceLocalFilter.None,
 ) {
 
     suspend fun sync(session: SyncSession): SyncOutcome {
@@ -114,8 +122,16 @@ class SyncEngine(
         // type stays local and never reaches the server. The settings record itself always syncs
         // (shouldSync), otherwise a disable would never reach other devices. Push-all by type is
         // simple and correct at current vault sizes; fine-grained dirty tracking is a future optimization.
+        // Device-local records drop out on the same pass: they are excluded by what their payload
+        // holds rather than by their type, so no toggle can put them back (see [DeviceLocalRecords]).
         val filter = settings()
-        val local = vault.records().filter { filter.shouldSync(it.type, it.id) }
+        // Snapshot and decision under one hold of the vault: the device-local check has to open
+        // payloads, and an idle auto-lock landing between the listing and the check would leave the
+        // filter unable to read anything at all — with a push in flight carrying what it could not
+        // judge. Holding the vault makes the whole decision atomic against [Vault.lock].
+        val local = vault.transaction {
+            vault.records().filter { filter.shouldSync(it.type, it.id) && !deviceLocal.blocksOutgoing(it) }
+        }
         // Types a self-hosted server may not know yet go in a batch of their own: the server
         // rejects a whole push batch on an unknown type, and losing hosts/keys/settings sync
         // because a trash snapshot or a trusted CA can't be mirrored would be a far worse trade.
@@ -173,7 +189,11 @@ class SyncEngine(
                     onMerged(vault.mergeRemote(settingsRecords))
                     filter = settings()
                 }
-                val rest = incoming.filter { it.type != RecordType.SETTINGS && filter.shouldSync(it.type, it.id) }
+                val rest = incoming.filter {
+                    it.type != RecordType.SETTINGS &&
+                        filter.shouldSync(it.type, it.id) &&
+                        !deviceLocal.blocksIncoming(it)
+                }
                 if (rest.isNotEmpty()) onMerged(vault.mergeRemote(rest))
             }
             // Compact after merge: otherwise a tombstone just merged from this same page would

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Credential.kt
@@ -63,8 +63,11 @@ sealed interface CredentialSecret {
      *
      * The refs are locations, not secrets, but [passphrase] is one — and so is the fact of which
      * files a user keeps keys in, so `toString` redacts everything as the other secrets do. The
-     * refs are device-local by nature: synced to a device where that file doesn't exist, the
-     * profile fails to connect with "file not found" rather than silently authenticating as
+     * refs are device-local by nature — a desktop path means nothing on a phone, a `content://` Uri
+     * resolves on no other device at all — so a credential holding one is kept off sync entirely
+     * ([app.skerry.shared.sync.DeviceLocalRecords]) instead of arriving elsewhere as an entry that
+     * can never connect. On a device that received one from an older client the file is simply
+     * absent, and the connection fails with "file not found" rather than silently authenticating as
      * someone else.
      */
     @Serializable

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
@@ -304,6 +304,15 @@ class FileVault(
         openRecord(key, record)
     }
 
+    override fun openRecordPayload(record: VaultRecord): ByteArray? = synchronized(lock) {
+        val key = requireUnlocked()
+        if (record.deleted) return@synchronized null
+        // Not looked up by id on purpose: the point is to read a record this vault does not hold
+        // (or holds at another version). openRecord authenticates the blob against the metadata the
+        // record claims, so a forged or replayed one yields null exactly as it does in mergeRemote.
+        openRecord(key, record)
+    }
+
     override fun put(id: String, type: RecordType, payload: ByteArray): Unit = store(id, type, payload, minVersion = 0L)
 
     override fun putAtLeast(id: String, type: RecordType, payload: ByteArray, minVersion: Long): Unit =
@@ -361,13 +370,14 @@ class FileVault(
         commit(currentMeta, updated)
     }
 
-    override fun clearRecords(types: Set<RecordType>): Unit = synchronized(lock) {
+    override fun clearRecords(types: Set<RecordType>, keep: (VaultRecord) -> Boolean): Unit = synchronized(lock) {
         requireUnlocked()
         if (types.isEmpty()) return@synchronized
         val currentMeta = session()
         // Keep records of other types (device-local or currently not synced): they never resurrect a
-        // purged record because they're not pushed, and dropping them would lose local-only data.
-        val kept = records.filterNot { it.type in types }
+        // purged record because they're not pushed, and dropping them would lose local-only data. A
+        // record [keep] spares is kept on exactly that reasoning, one record at a time.
+        val kept = records.filterNot { it.type in types && !keep(it) }
         if (kept.size == records.size) return@synchronized // nothing of these types — leave the file untouched
         // Hard drop, no tombstone (see [Vault.clearRecords]) and no _localChanges: the caller re-pulls
         // the server snapshot, so records still on the server return and purged ones stay gone.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/Vault.kt
@@ -184,6 +184,24 @@ interface Vault {
     fun openPayload(id: String): ByteArray?
 
     /**
+     * [openPayload] for a record this vault does not (yet) hold — the incoming half of a sync
+     * cycle, inspected before [mergeRemote] decides anything. Same trial decryption as the merge:
+     * the blob is opened against the metadata [record] claims, so a payload only comes back when it
+     * authenticates. `null` for a tombstone (the same refusal as [openPayload]: a deleted record's
+     * blob is kept for sync but never exposed) and for a blob under another key; a locked vault
+     * throws, as every other read on this interface does.
+     *
+     * Exists so a sync policy can be decided on what a record *is* rather than on its plaintext
+     * metadata — [app.skerry.shared.sync.DeviceLocalRecords]. `null` there means "this blob did not
+     * open", which the caller reads as evidence and acts on; an implementation that simply cannot
+     * open anything must NOT answer it, or every credential silently stops being pushed with nothing
+     * logged and nothing on screen. So the default throws, as [rekeyRecords] does: only a vault that
+     * really encrypts can be asked, and a missing override is loud the first time it is.
+     */
+    fun openRecordPayload(record: VaultRecord): ByteArray? =
+        throw UnsupportedOperationException("openRecordPayload is only supported by vaults that encrypt")
+
+    /**
      * Upsert: seals [payload] under `dataKey` (AAD binds the full record metadata — see
      * [VaultRecord]) and stores a record with this [id]/[type], bumping `version` and updating
      * `updatedAt`.
@@ -240,8 +258,18 @@ interface Vault {
      * still holds it). That is the intended contract for reactivation: a revoked device could not push
      * anyway, so its unsynced edits — additions and deletions alike — are discarded in favor of the server
      * snapshot. No-op by default (fakes); the file vault overrides it. Requires an unlocked vault.
+     *
+     * [keep] spares individual records of those very types: scoping by type alone is not enough once
+     * a record can be device-local by what it *holds* rather than by what it is
+     * ([app.skerry.shared.sync.DeviceLocalFilter.survivesClear] — a file-backed credential is never
+     * pushed, so the re-pull would not bring it back and the clear would simply destroy it). It is
+     * deliberately NOT "everything the push refuses": a blob this vault can no longer open is refused
+     * by the push too, and sparing that one keeps a dead record squatting on an id the server holds a
+     * readable copy of. Anything less loses data, anything more keeps a record the re-pull cannot
+     * replace. [keep] runs under the vault's lock and may read the vault back (it has to, to judge a
+     * payload), so an implementation's lock must be reentrant — as [transaction] already requires.
      */
-    fun clearRecords(types: Set<RecordType>) {}
+    fun clearRecords(types: Set<RecordType>, keep: (VaultRecord) -> Boolean = { false }) {}
 
     /**
      * Changes the master password: rewraps the same `dataKey` under the new password (records aren't

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
@@ -980,6 +980,39 @@ class FileVaultTest {
     }
 
     @Test
+    fun `openRecordPayload opens a record this vault does not hold, and only an honest one`() = vaultTest {
+        val v = vault()
+        v.create("m".toCharArray())
+        v.put("h1", RecordType.HOST, "host".encodeToByteArray())
+        val record = v.records().first { it.id == "h1" }
+
+        // The point of the method: it reads what the RECORD carries, not what the file holds under
+        // that id — this is how an incoming sync record is judged before mergeRemote decides.
+        assertContentEquals("host".encodeToByteArray(), v.openRecordPayload(record.copy(id = "h1")))
+        // The AAD binds the metadata, so a replay with a bumped version does not open (same refusal
+        // mergeRemote rejects on), and a tombstone never yields its blob.
+        assertNull(v.openRecordPayload(record.copy(version = record.version + 1)))
+        assertNull(v.openRecordPayload(record.copy(type = RecordType.SNIPPET)))
+        assertNull(v.openRecordPayload(record.copy(deleted = true)))
+    }
+
+    @Test
+    fun `clearRecords spares the records the keep predicate names`() = vaultTest {
+        val v = vault()
+        v.create("m".toCharArray())
+        v.put("c1", RecordType.CREDENTIAL, "device-local".encodeToByteArray())
+        v.put("c2", RecordType.CREDENTIAL, "synced".encodeToByteArray())
+        v.put("h1", RecordType.HOST, "host".encodeToByteArray())
+
+        // Type scoping alone cannot express this: c1 and c2 are the same type, and only one of them
+        // is on the server to come back after the re-pull (see [Vault.clearRecords]).
+        v.clearRecords(setOf(RecordType.CREDENTIAL, RecordType.HOST)) { it.id == "c1" }
+
+        assertEquals(listOf("c1"), v.records().map { it.id })
+        assertContentEquals("device-local".encodeToByteArray(), v.openPayload("c1"))
+    }
+
+    @Test
     fun `clearRecords emits no local change`() = runTest {
         initializeVaultCrypto()
         val v = vault()

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sync/DeviceLocalCredentialSyncTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sync/DeviceLocalCredentialSyncTest.kt
@@ -1,0 +1,453 @@
+package app.skerry.shared.sync
+
+import app.skerry.shared.vault.Credential
+import app.skerry.shared.vault.CredentialSecret
+import app.skerry.shared.vault.CredentialStore
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.TrashEntry
+import app.skerry.shared.vault.TrashStore
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
+import app.skerry.shared.vault.VaultRecordCodec
+import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.shared.vault.trashRecordId
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * File-backed credentials stay on the device that made them (issue #174): [CredentialSecret.KeyFile]
+ * holds a *location* — a filesystem path on desktop, a `content://` Uri on Android — and a location
+ * is meaningless anywhere else. The rule lives in [DeviceLocalRecords], which opens the payload
+ * [SyncSettings] can't see, and applies to both directions plus the trash snapshot of such a record.
+ */
+class DeviceLocalCredentialSyncTest {
+
+    private val password = "correct horse battery staple"
+    private val session = SyncSession("acct", "access", "refresh")
+
+    private fun VaultRecord.toRemote() = RemoteRecord(id, type.name, version, updatedAt, deviceId, deleted, blob)
+
+    private fun newVault(deviceId: String) = FileVault(
+        path = Files.createTempDirectory("skerry-devlocal-$deviceId").resolve("vault.json").toString().toPath(),
+        crypto = IonspinVaultCrypto(),
+        deviceId = deviceId,
+        fileSystem = FileSystem.SYSTEM,
+        now = { "2026-06-30T00:00:00Z" },
+    )
+
+    private fun engine(client: SyncClient, vault: Vault) = SyncEngine(
+        client,
+        vault,
+        InMemorySyncStateStore(),
+        deviceLocal = DeviceLocalRecords(vault),
+    )
+
+    private val keyFile = Credential(
+        id = "cred-file",
+        label = "tsh",
+        secret = CredentialSecret.KeyFile(
+            privateKeyRef = "/home/user/.tsh/keys/id",
+            certificateRef = "/home/user/.tsh/keys/id-cert.pub",
+            passphrase = null,
+        ),
+    )
+    private val inVault = Credential(
+        id = "cred-pem",
+        label = "laptop",
+        secret = CredentialSecret.PrivateKey(privateKeyPem = "-----BEGIN OPENSSH PRIVATE KEY-----"),
+    )
+
+    @Test
+    fun `a file-backed credential is never pushed while the other secrets are`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        val credentials = CredentialStore(vault)
+        credentials.put(keyFile)
+        credentials.put(inVault)
+        credentials.put(
+            Credential("cred-pass", "prod", CredentialSecret.Password("hunter2")),
+        )
+        credentials.put(
+            Credential("cred-cert", "ca", CredentialSecret.Certificate("-----BEGIN-----", "ssh-ed25519-cert-v01@openssh.com AAAA")),
+        )
+
+        val client = FakeSyncClient()
+        engine(client, vault).sync(session)
+
+        val pushedIds = client.pushed.map { it.id }.toSet()
+        assertFalse("cred-file" in pushedIds, "a KeyFile credential must not reach the server")
+        assertTrue("cred-pem" in pushedIds, "a PrivateKey credential keeps syncing")
+        assertTrue("cred-pass" in pushedIds, "a Password credential keeps syncing")
+        assertTrue("cred-cert" in pushedIds, "a Certificate credential keeps syncing")
+    }
+
+    @Test
+    fun `an incoming file-backed credential is not applied`() = runBlocking {
+        initializeVaultCrypto()
+        // Source A is an older client that still pushes the ref; B unwraps with the same account key.
+        val source = newVault("devA")
+        source.create(password.toCharArray())
+        CredentialStore(source).put(keyFile)
+        CredentialStore(source).put(inVault)
+        val remote = source.records().filter { it.type == RecordType.CREDENTIAL }.map { it.toRemote() }
+
+        val receiver = newVault("devB")
+        receiver.create(password.toCharArray())
+        receiver.unlockWithDataKey(source.exportDataKey()!!)
+
+        engine(FakeSyncClient(serverRecords = remote), receiver).sync(session)
+
+        assertFalse(receiver.records().any { it.id == "cred-file" }, "an incoming KeyFile credential must not be merged")
+        assertTrue(receiver.records().any { it.id == "cred-pem" }, "an incoming PrivateKey credential still merges")
+    }
+
+    @Test
+    fun `the trash snapshot of a file-backed credential is not pushed`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        val credentials = CredentialStore(vault, TrashStore(vault))
+        credentials.put(keyFile)
+        credentials.put(inVault)
+        credentials.remove(keyFile.id)
+        credentials.remove(inVault.id)
+
+        val client = FakeSyncClient()
+        engine(client, vault).sync(session)
+
+        val pushedIds = client.pushed.map { it.id }.toSet()
+        assertFalse(
+            trashRecordId(RecordType.CREDENTIAL, "cred-file") in pushedIds,
+            "the snapshot carries the same ref and must not travel either",
+        )
+        assertTrue(
+            trashRecordId(RecordType.CREDENTIAL, "cred-pem") in pushedIds,
+            "the snapshot of a synced credential keeps syncing",
+        )
+        // The tombstone itself still travels: it is what clears an already-synced copy on device B.
+        assertTrue(
+            client.pushed.any { it.id == "cred-file" && it.deleted },
+            "the deletion must still propagate",
+        )
+    }
+
+    @Test
+    fun `an incoming trash snapshot of a file-backed credential is not applied either`() = runBlocking {
+        initializeVaultCrypto()
+        val source = newVault("devA")
+        source.create(password.toCharArray())
+        val sourceCredentials = CredentialStore(source, TrashStore(source))
+        sourceCredentials.put(keyFile)
+        sourceCredentials.put(inVault)
+        sourceCredentials.remove(keyFile.id)
+        sourceCredentials.remove(inVault.id)
+        val remote = source.records().filter { it.type == RecordType.TRASH }.map { it.toRemote() }
+
+        val receiver = newVault("devB")
+        receiver.create(password.toCharArray())
+        receiver.unlockWithDataKey(source.exportDataKey()!!)
+
+        engine(FakeSyncClient(serverRecords = remote), receiver).sync(session)
+
+        val landed = receiver.records().map { it.id }.toSet()
+        assertFalse(trashRecordId(RecordType.CREDENTIAL, "cred-file") in landed, "the ref must not arrive in the trash either")
+        assertTrue(trashRecordId(RecordType.CREDENTIAL, "cred-pem") in landed, "an ordinary snapshot still arrives")
+    }
+
+    /**
+     * A device that ran a release without this rule already holds the record. The newer version
+     * arriving from its origin must be dropped rather than merged — and the stale local copy must be
+     * left exactly as it is: an incoming record that is refused is not a deletion.
+     */
+    @Test
+    fun `an update to an already-synced file-backed credential is refused without touching the local copy`() = runBlocking {
+        initializeVaultCrypto()
+        val source = newVault("devA")
+        source.create(password.toCharArray())
+        CredentialStore(source).put(keyFile)
+        val first = source.records().first { it.id == "cred-file" }
+        CredentialStore(source).put(keyFile.copy(label = "renamed"))
+        val second = source.records().first { it.id == "cred-file" } // version 2 — wins LWW
+
+        val receiver = newVault("devB")
+        receiver.create(password.toCharArray())
+        receiver.unlockWithDataKey(source.exportDataKey()!!)
+        receiver.mergeRemote(listOf(first)) // what the older release already put here
+        assertEquals(first.version, receiver.records().first { it.id == "cred-file" }.version)
+
+        val client = FakeSyncClient(serverRecords = listOf(second.toRemote()))
+        engine(client, receiver).sync(session)
+
+        assertEquals(
+            first.version,
+            receiver.records().first { it.id == "cred-file" }.version,
+            "the refused update must not be applied",
+        )
+        assertFalse(client.pushed.any { it.id == "cred-file" }, "nor must the stale local copy be pushed back")
+    }
+
+    /**
+     * The two answers the payload cannot give. Outgoing they differ: a blob this device cannot open
+     * authenticates for nobody, so pushing it can only add server garbage or overwrite a readable
+     * copy elsewhere. Incoming they must not — [Vault.mergeRemote] rejects such a record and REPORTS
+     * it, and swallowing it here would turn a tampering signal into silence.
+     */
+    @Test
+    fun `an unreadable payload blocks the push but never the merge`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        CredentialStore(vault).put(inVault)
+        val readable = vault.records().first { it.id == "cred-pem" }
+        // What an adopted account key leaves behind: a live record whose blob no longer authenticates.
+        val unreadable = readable.copy(id = "cred-stale", blob = readable.blob.copyOf().also { it[0] = (it[0] + 1).toByte() })
+        val subject = DeviceLocalRecords(vault)
+
+        assertTrue(subject.blocksOutgoing(unreadable), "an unopenable payload must not be pushed")
+        assertFalse(subject.blocksIncoming(unreadable), "but the merge must still see it and reject it")
+        assertFalse(subject.blocksOutgoing(readable), "a readable ordinary credential is unaffected")
+    }
+
+    /**
+     * What a reconcile spares is a narrower question than what the push refuses. Only a record the
+     * server can never hand back — one held here because of what its payload says — may survive the
+     * clear; a blob that no longer opens is dead weight the clear has always been the one to remove.
+     */
+    @Test
+    fun `the clear spares only what is genuinely device-local, not what merely cannot be read`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        val credentials = CredentialStore(vault)
+        credentials.put(keyFile)
+        credentials.put(inVault)
+        val subject = DeviceLocalRecords(vault)
+        val fileBacked = vault.records().first { it.id == "cred-file" }
+        val ordinary = vault.records().first { it.id == "cred-pem" }
+        val unreadable = ordinary.copy(id = "cred-stale", blob = ordinary.blob.copyOf().also { it[0] = (it[0] + 1).toByte() })
+
+        assertTrue(subject.survivesClear(fileBacked), "nothing else holds this secret — the clear must spare it")
+        assertFalse(subject.survivesClear(ordinary), "a synced credential comes back from the re-pull")
+        assertTrue(subject.blocksOutgoing(unreadable), "an unopenable blob is still not pushed")
+        assertFalse(
+            subject.survivesClear(unreadable),
+            "but it must not survive the clear: the server may hold a readable copy of that id",
+        )
+    }
+
+    @Test
+    fun `a payload this build cannot parse keeps syncing`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        // A schema a newer client wrote: it decrypts, it does not parse as a Credential. That is not
+        // evidence of a file-backed key, so it must not be stranded here.
+        vault.put("cred-future", RecordType.CREDENTIAL, """{"id":"cred-future","shape":"unknown"}""".encodeToByteArray())
+        val subject = DeviceLocalRecords(vault)
+        val record = vault.records().first { it.id == "cred-future" }
+
+        assertFalse(subject.blocksOutgoing(record))
+        assertFalse(subject.blocksIncoming(record))
+    }
+
+    /**
+     * The byte scan that spares the parse is a NEGATIVE only: absent, the discriminator settles the
+     * question; present, it settles nothing. A label or a note is in the same payload, so treating a
+     * hit as the answer would strand an ordinary password whose owner named it after the file it
+     * replaced.
+     */
+    @Test
+    fun `a credential that merely mentions the wire name in its text still syncs`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        CredentialStore(vault).put(
+            Credential(
+                id = "cred-named",
+                label = "key_file",
+                secret = CredentialSecret.Password("hunter2"),
+                note = "replaced the key_file one",
+            ),
+        )
+        val subject = DeviceLocalRecords(vault)
+        val record = vault.records().first { it.id == "cred-named" }
+
+        assertFalse(subject.blocksOutgoing(record))
+        assertFalse(subject.blocksIncoming(record))
+        assertFalse(subject.survivesClear(record))
+    }
+
+    /**
+     * The byte scan reads what the encoder writes; the decoder reads more. `\u006bey_file` is the same
+     * discriminator to kotlinx-serialization and different bytes to a scan, so a device holding the
+     * account key could otherwise seal a record that passes the filter and decodes as file-backed —
+     * the exact direction the exclusion exists to defend.
+     */
+    @Test
+    fun `an incoming credential that spells the wire name in escapes is still not applied`() = runBlocking {
+        initializeVaultCrypto()
+        val source = newVault("devA")
+        source.create(password.toCharArray())
+        source.put(
+            "cred-craft",
+            RecordType.CREDENTIAL,
+            ("""{"id":"cred-craft","label":"prod","secret":{"type":"\u006bey_file",""" +
+                """"privateKeyRef":"/home/victim/.ssh/id_ed25519"}}""").encodeToByteArray(),
+        )
+        val remote = source.records().map { it.toRemote() }
+
+        val receiver = newVault("devB")
+        receiver.create(password.toCharArray())
+        receiver.unlockWithDataKey(source.exportDataKey()!!)
+
+        engine(FakeSyncClient(serverRecords = remote), receiver).sync(session)
+
+        assertFalse(
+            receiver.records().any { it.id == "cred-craft" },
+            "an escaped discriminator is the same secret to the parser and must be refused as one",
+        )
+    }
+
+    /**
+     * The id of a trash record is plaintext metadata; what [TrashStore] restores by is the origin
+     * type inside the entry. Judging on the id would let a record filed under `skerry.trash:HOST:…`
+     * carry a file-backed credential past the filter and be restored as one.
+     */
+    @Test
+    fun `an incoming trash record filed under another type is judged by what it holds`() = runBlocking {
+        initializeVaultCrypto()
+        val source = newVault("devA")
+        source.create(password.toCharArray())
+        val entry = TrashEntry(
+            originId = "cred-x",
+            originType = RecordType.CREDENTIAL,
+            label = "prod",
+            deletedAt = 0,
+            originVersion = 1,
+            payload = VaultRecordCodec.json.encodeToString(Credential.serializer(), keyFile),
+        )
+        // Filed under HOST on purpose — only a device holding the account key can write this.
+        val misfiled = trashRecordId(RecordType.HOST, "cred-x")
+        source.put(
+            misfiled,
+            RecordType.TRASH,
+            VaultRecordCodec.json.encodeToString(TrashEntry.serializer(), entry).encodeToByteArray(),
+        )
+        val remote = source.records().map { it.toRemote() }
+
+        val receiver = newVault("devB")
+        receiver.create(password.toCharArray())
+        receiver.unlockWithDataKey(source.exportDataKey()!!)
+
+        engine(FakeSyncClient(serverRecords = remote), receiver).sync(session)
+
+        assertFalse(
+            receiver.records().any { it.id == misfiled },
+            "the entry names a credential, so the snapshot is one whatever its id says",
+        )
+    }
+
+    @Test
+    fun `a trash snapshot this build cannot parse keeps syncing`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        // The snapshot opens and the entry parses; the credential it wrapped does not. Same reasoning
+        // as the live record: an unknown schema is not evidence of a file-backed key.
+        val entry = TrashEntry(
+            originId = "cred-future",
+            originType = RecordType.CREDENTIAL,
+            label = "x",
+            deletedAt = 0,
+            originVersion = 1,
+            payload = """{"id":"cred-future","shape":"unknown"}""",
+        )
+        val id = entry.recordId
+        vault.put(
+            id,
+            RecordType.TRASH,
+            VaultRecordCodec.json.encodeToString(TrashEntry.serializer(), entry).encodeToByteArray(),
+        )
+        val subject = DeviceLocalRecords(vault)
+        val record = vault.records().first { it.id == id }
+
+        assertFalse(subject.blocksOutgoing(record))
+        assertFalse(subject.blocksIncoming(record))
+        assertFalse(subject.survivesClear(record))
+    }
+
+    @Test
+    fun `the push filter reads the vault under one hold, so an auto-lock cannot land inside it`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        CredentialStore(vault).put(keyFile)
+        CredentialStore(vault).put(inVault)
+        val watched = TransactionWatchingVault(vault)
+
+        engine(FakeSyncClient(), watched).sync(session)
+
+        assertTrue(watched.sawRecords, "the engine must list the records")
+        assertTrue(
+            watched.readsOutsideTransaction.isEmpty(),
+            "every payload read must happen inside the transaction: ${watched.readsOutsideTransaction}",
+        )
+    }
+
+    /** Records whether each payload read happened while the engine held the vault. */
+    private class TransactionWatchingVault(private val delegate: Vault) : Vault by delegate {
+        private var depth = 0
+        var sawRecords = false
+            private set
+        val readsOutsideTransaction = mutableListOf<String>()
+
+        override fun <T> transaction(block: () -> T): T {
+            depth++
+            try {
+                return delegate.transaction(block)
+            } finally {
+                depth--
+            }
+        }
+
+        override fun records(): List<VaultRecord> {
+            sawRecords = true
+            return delegate.records()
+        }
+
+        override fun openRecordPayload(record: VaultRecord): ByteArray? {
+            if (depth == 0) readsOutsideTransaction += record.id
+            return delegate.openRecordPayload(record)
+        }
+    }
+
+    @Test
+    fun `the verdict is decided by the payload and leaves everything else alone`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newVault("devA")
+        vault.create(password.toCharArray())
+        CredentialStore(vault, TrashStore(vault)).also {
+            it.put(keyFile)
+            it.put(inVault)
+        }
+        vault.put("h1", RecordType.HOST, """{"id":"h1"}""".encodeToByteArray())
+        val subject = DeviceLocalRecords(vault)
+        val record = { id: String -> vault.records().first { it.id == id } }
+
+        assertTrue(subject.blocksOutgoing(record("cred-file")))
+        assertTrue(subject.blocksIncoming(record("cred-file")))
+        assertFalse(subject.blocksOutgoing(record("cred-pem")))
+        assertFalse(subject.blocksIncoming(record("cred-pem")))
+        assertFalse(subject.blocksOutgoing(record("h1")), "a host is never device-local, whatever its payload")
+        assertEquals(2, vault.records().count { it.type == RecordType.CREDENTIAL })
+    }
+}


### PR DESCRIPTION
Closes #174.

A `CredentialSecret.KeyFile` holds a *location*, not a secret: a filesystem path on desktop, a `content://` document Uri on Android. Neither resolves on another device — the Uri resolves on no other device at all, not even another Android one — so a synced copy lands in the other keychain as an entry that can never connect. Where the same path does happen to exist, it may hold a different key, which is worse than an entry that fails.

Such a credential is now kept off sync entirely, in both directions, together with its trash snapshot, which carries the same refs. The exclusion is hard rather than a setting: the one layout where the ref would resolve — two desktops sharing `~/.ssh` — is a coincidence of paths, and a switch offering it would be offering to authenticate with whatever is there.

Password, private-key and certificate credentials sync exactly as before. Deleting a file-backed credential still propagates: a tombstone carries no payload and travels as always, so it clears a copy an older release synced.

## How it works

`SyncSettings` filters by plaintext metadata — type and id — which is all a zero-knowledge engine needs for a per-type switch. What makes a record device-local is inside the encrypted blob, so the rule lives in `DeviceLocalRecords`, which opens the payload. It asks three separate questions rather than one:

- **Outgoing** — a payload that cannot be read at all counts as device-local too. A blob this device cannot open authenticates for nobody, so pushing it can only add a record the server keeps for good and, through LWW, overwrite a copy elsewhere that still opens.
- **Incoming** — only positive evidence counts. A blob that does not open is a forged, replayed or foreign-key record, and `mergeRemote` rejects it *and reports it*; dropping it here would turn a tampering signal into silence.
- **The reconcile clear** — narrower than the push. Only a record the server can never hand back is spared; a blob this vault can no longer open is dead, and sparing it would leave it squatting on an id whose readable server copy then loses the LWW and never lands.

Supporting changes:

- `Vault.openRecordPayload` opens a record the vault does not yet hold, under the same trial decryption the merge uses — `null` for a tombstone or a blob under another key, a throw for a locked vault. Its default throws rather than answering `null`: a vault that cannot open anything must not answer, or every credential would silently stop being pushed.
- The push snapshot and the filter run under one `Vault.transaction`, so an idle auto-lock cannot land between listing the records and judging them.
- The verdict takes a byte scan before any parse, so an ordinary secret's plaintext is never materialised as an unwipeable `String` on a loop that runs unattended. The scan is a negative only — a hit settles nothing, and a payload carrying a `\u` escape skips the scan and takes the long path, because the JSON reader unescapes what a byte scan cannot see.
- Trash records are judged by the origin type inside the entry — what `TrashStore.restore` actually restores by — not by the plaintext record id.
- The secret's detail pane states that a file-backed secret does not sync, and the "stored on server" row answers per secret instead of per account. Desktop and Android render the same composable.

## Known limitation

A file-backed credential that a previous release already pushed stays on the server until the user deletes the credential — the same "off doesn't delete" semantics `SyncSettings` documents. The alternative would be tombstoning a record the user still has, which deletes it here too. The detail pane therefore states a property of the kind ("secrets kept in a file are not synced"), not a claim about where this particular record has been.

## Verifying by eye

1. Connect two devices to the same sync account.
2. On A, add a key from a file (Vault → new secret → link a key file) and a normal private key pasted as text.
3. Sync both. On B the pasted key appears; the file-backed one does not.
4. Open the file-backed secret on A: the pane says it is not synced and that it is stored on this device only.
5. Delete it on A and sync: nothing about it appears on B, and A's trash snapshot stays local.

## Not verified

Android device, a live sync server and any OS other than Linux. Everything here was exercised through the desktop test suite against a real `FileVault`, real crypto and the real sync engine with only the network stubbed.