### PR TITLE
feat(snippet): add optional notes field and hover tooltip preview

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -61,9 +61,11 @@
     <string name="lib_snippets_untitled">Без названия</string>
     <string name="lib_snippets_field_name">Название</string>
     <string name="lib_snippets_field_command">Команда</string>
+    <string name="lib_snippets_field_notes">Заметки</string>
     <string name="lib_snippets_field_tags">Теги</string>
     <string name="lib_snippets_field_shortcut">Горячая клавиша</string>
     <string name="lib_snippets_ph_name">Отчёт об использовании диска</string>
+    <string name="lib_snippets_ph_notes">Необязательные заметки, инструкции или параметры</string>
     <string name="lib_snippets_add_tag">добавить тег…</string>
     <string name="lib_snippets_press_keys">Нажмите клавиши…</string>
     <string name="lib_snippets_shortcut_conflict">Уже используется в «%1$s»</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -61,9 +61,11 @@
     <string name="lib_snippets_untitled">未命名</string>
     <string name="lib_snippets_field_name">名称</string>
     <string name="lib_snippets_field_command">命令</string>
+    <string name="lib_snippets_field_notes">备注</string>
     <string name="lib_snippets_field_tags">标签</string>
     <string name="lib_snippets_field_shortcut">快捷键</string>
     <string name="lib_snippets_ph_name">磁盘使用报告</string>
+    <string name="lib_snippets_ph_notes">可选，记录此片段的用法、参数说明与注意事项</string>
     <string name="lib_snippets_add_tag">添加标签…</string>
     <string name="lib_snippets_press_keys">按键…</string>
     <string name="lib_snippets_shortcut_conflict">已被“%1$s”使用</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -61,9 +61,11 @@
     <string name="lib_snippets_untitled">Untitled</string>
     <string name="lib_snippets_field_name">Name</string>
     <string name="lib_snippets_field_command">Command</string>
+    <string name="lib_snippets_field_notes">Notes</string>
     <string name="lib_snippets_field_tags">Tags</string>
     <string name="lib_snippets_field_shortcut">Shortcut</string>
     <string name="lib_snippets_ph_name">Disk usage report</string>
+    <string name="lib_snippets_ph_notes">Optional notes, usage instructions, or parameters</string>
     <string name="lib_snippets_add_tag">add tag…</string>
     <string name="lib_snippets_press_keys">Press keys…</string>
     <string name="lib_snippets_shortcut_conflict">Already used by “%1$s”</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/RowNote.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/RowNote.kt
@@ -1,0 +1,119 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.theme.Skerry
+import kotlinx.coroutines.delay
+
+/** How much of a note a tooltip or a detail row will draw. */
+internal const val MAX_NOTE_CHARS = 600
+
+/**
+ * Lines of a note a card peeks at before it ellipsizes — the terminal palette and both phone cards,
+ * the surfaces that put a note next to a Run button. One number across them, because the platform
+ * without a hover fallback must not be the one showing less. A dense desktop list row draws a single
+ * line and leaves the rest to the panel beside it.
+ */
+internal const val NOTE_PEEK_LINES = 2
+
+/**
+ * Dwell before a row's note pops up, so sweeping the pointer down a list doesn't flash a tooltip
+ * over every row on the way.
+ */
+private const val NOTE_TOOLTIP_DELAY_MS = 450L
+
+/** A row's note as the list shows it: what may be drawn, and whether the pointer has earned it. */
+@Stable
+internal data class RowNote(
+    /** Hand this to the row's `hoverable`; it is what the dwell watches. */
+    val interaction: MutableInteractionSource,
+    /** The filtered note, or `null` when there is nothing left to show. */
+    val text: String?,
+    /** True once the pointer has rested on the row long enough. */
+    val visible: Boolean,
+)
+
+/**
+ * The note a hovered row shows, filtered and timed. Host rows in the sidebar, snippets in the
+ * library and snippets in the terminal palette all reveal a note this way; the filter and the dwell
+ * live here so the three agree on both.
+ *
+ * A note can arrive from a peer (a shared profile): it keeps its lines — it is prose — but not the
+ * characters that would let it draw as something else, and not more of them than a tooltip can
+ * hold, since the field has no cap of its own.
+ */
+@Composable
+internal fun rememberRowNote(note: String?): RowNote {
+    val interaction = remember { MutableInteractionSource() }
+    val hovered by interaction.collectIsHoveredAsState()
+    val text = remember(note) {
+        note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) }?.takeIf { it.isNotBlank() }
+    }
+    var visible by remember { mutableStateOf(false) }
+    LaunchedEffect(hovered, text) {
+        visible = false
+        if (hovered && text != null) {
+            delay(NOTE_TOOLTIP_DELAY_MS)
+            visible = true
+        }
+    }
+    return RowNote(interaction, text, visible && text != null)
+}
+
+/**
+ * Draws [note] once its dwell has elapsed. Render it inside the hovered row's [androidx.compose.foundation.layout.Box],
+ * as a sibling of the row rather than a child — see [HoverTooltip].
+ *
+ * [suppressed] is for a row that opens popups of its own: the note would land on top of them.
+ */
+@Composable
+internal fun RowNoteTooltip(note: RowNote, suppressed: Boolean = false) {
+    val text = note.text
+    if (note.visible && !suppressed && text != null) HoverTooltip(text)
+}
+
+/**
+ * A stored note drawn under the thing it belongs to — a secret in the keychain, a snippet in the
+ * run panel, a runbook's description on its card, a note under a row in a list. Filtered like the
+ * hover variant above, and named: sighted readers know this line is the note from where it sits and
+ * how dim it is, a screen reader gets neither, so the block would otherwise read as an unlabelled
+ * sentence between two facts.
+ *
+ * Safe inside a row that merges its children, contrary to the rule [Modifier.fieldValueName] is
+ * built around: that one is about a description put *on* the merging node, which does replace the
+ * text under it. Android reads `contentDescription` off each node's own unmerged config and skips it
+ * entirely on a node that merges descendants, so a named leaf keeps its siblings audible.
+ *
+ * [maxLines] is for the surfaces that show a peek rather than the whole note (a list card).
+ */
+@Composable
+internal fun NoteBlock(
+    note: String?,
+    label: String,
+    modifier: Modifier = Modifier,
+    size: TextUnit = 12.sp,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    val shown = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+    if (shown.isNullOrBlank()) return
+    Txt(
+        shown,
+        color = Skerry.colors.dim, size = size, lineHeight = 17.sp,
+        maxLines = maxLines, overflow = TextOverflow.Ellipsis,
+        // Comma-joined, the way Compose joins the texts it merges (see design/fieldValueName).
+        modifier = modifier.semantics { contentDescription = "$label, $shown" },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileHostDetailView.kt
@@ -55,7 +55,7 @@ import app.skerry.ui.generated.resources.shell_details
 import app.skerry.ui.generated.resources.shell_edit_host
 import app.skerry.ui.generated.resources.shell_duplicate_host
 import app.skerry.ui.generated.resources.shell_delete_host
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import app.skerry.ui.design.MAX_NOTE_CHARS
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.LocalConnectHost
 import app.skerry.ui.design.HLine

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileRunbooksView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileRunbooksView.kt
@@ -60,6 +60,7 @@ import app.skerry.ui.generated.resources.runbook_run_needs_session
 import app.skerry.ui.generated.resources.runbook_run_no_steps
 import app.skerry.ui.generated.resources.runbook_save
 import app.skerry.ui.generated.resources.runbook_section
+import app.skerry.ui.generated.resources.runbook_field_description
 import app.skerry.ui.generated.resources.runbook_step_count
 import app.skerry.ui.generated.resources.runbook_untitled
 import app.skerry.ui.runbook.RunbookEditorFields
@@ -69,8 +70,8 @@ import app.skerry.ui.runbook.RunbookFormState
 import app.skerry.ui.runbook.RunbookManager
 import app.skerry.ui.runbook.runbookTarget
 import app.skerry.ui.design.untrustedLabel
-import app.skerry.ui.design.sanitizeServerText
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import app.skerry.ui.design.NOTE_PEEK_LINES
+import app.skerry.ui.design.NoteBlock
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.platform.testTag
@@ -195,7 +196,7 @@ fun MobileRunbooksScreen(state: MobileDesignState) {
 }
 
 @Composable
-private fun RunbookCard(entry: RunbookEntry, mono: FontFamily, onClick: () -> Unit) {
+internal fun RunbookCard(entry: RunbookEntry, mono: FontFamily, onClick: () -> Unit) {
     val runbook = entry.runbook
     Column(
         Modifier
@@ -219,13 +220,10 @@ private fun RunbookCard(entry: RunbookEntry, mono: FontFamily, onClick: () -> Un
             color = Skerry.colors.faint, size = 11.sp, font = mono,
             modifier = Modifier.padding(top = 6.dp),
         )
-        if (runbook.description.isNotBlank()) {
-            Txt(
-                remember(runbook) { sanitizeServerText(runbook.description, MAX_NOTE_CHARS, allowNewlines = true) },
-                color = Skerry.colors.dim, size = 12.sp, maxLines = 2,
-                overflow = TextOverflow.Ellipsis, modifier = Modifier.padding(top = 6.dp),
-            )
-        }
+        NoteBlock(
+            runbook.description, stringResource(Res.string.runbook_field_description),
+            Modifier.padding(top = 6.dp), maxLines = NOTE_PEEK_LINES,
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -51,10 +51,15 @@ import app.skerry.ui.generated.resources.lib_snippets_empty_mobile
 import app.skerry.ui.generated.resources.lib_snippets_starter_pack
 import app.skerry.ui.generated.resources.lib_snippets_field_command
 import app.skerry.ui.generated.resources.lib_snippets_field_name
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_field_tags
 import app.skerry.ui.generated.resources.lib_snippets_new
 import app.skerry.ui.generated.resources.lib_snippets_no_matches
 import app.skerry.ui.generated.resources.lib_snippets_ph_name
+import app.skerry.ui.generated.resources.lib_snippets_ph_notes
+import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import androidx.compose.ui.text.style.TextOverflow
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_placeholder
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_subtitle
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_title
@@ -234,6 +239,18 @@ internal fun MobileSnippetCard(snippet: Snippet, onClick: () -> Unit) {
             Sym("code_blocks", size = 18.sp, color = Skerry.colors.cyanBright)
             Txt(remember(snippet) { untrustedLabel(snippet.label) }.ifBlank { stringResource(Res.string.lib_snippets_untitled) }, color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
         }
+        val note = snippet.notes
+        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+        if (!shownNote.isNullOrBlank()) {
+            Txt(
+                shownNote,
+                color = Skerry.colors.dim,
+                size = 11.5.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
         if (snippet.command.isNotBlank()) {
             Box(
                 Modifier.fillMaxWidth().padding(top = 8.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.terminalBg).padding(horizontal = 11.dp, vertical = 9.dp),
@@ -322,6 +339,9 @@ private fun MobileSnippetEditSheet(
             }
             MobileFormField(stringResource(Res.string.lib_snippets_field_command)) {
                 MobileFormInput(form.command, { form.command = it }, "df -h | sort -k5 -r", mono = true, background = Skerry.colors.terminalBg, singleLine = false, minHeightDp = 88)
+            }
+            MobileFormField(stringResource(Res.string.lib_snippets_field_notes)) {
+                MobileFormInput(form.notes, { form.notes = it }, stringResource(Res.string.lib_snippets_ph_notes), singleLine = false, minHeightDp = 64)
             }
             MobileFormField(stringResource(Res.string.lib_snippets_field_tags)) {
                 // Own tags are excluded via selected; suggestions come from all snippets (including the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileSnippetsView.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.text.capNotes
 import app.skerry.shared.snippet.Snippet
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.snippet.SnippetHelpDialog
@@ -57,9 +58,8 @@ import app.skerry.ui.generated.resources.lib_snippets_new
 import app.skerry.ui.generated.resources.lib_snippets_no_matches
 import app.skerry.ui.generated.resources.lib_snippets_ph_name
 import app.skerry.ui.generated.resources.lib_snippets_ph_notes
-import app.skerry.ui.design.sanitizeServerText
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
-import androidx.compose.ui.text.style.TextOverflow
+import app.skerry.ui.design.NOTE_PEEK_LINES
+import app.skerry.ui.design.NoteBlock
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_placeholder
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_subtitle
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_title
@@ -239,18 +239,12 @@ internal fun MobileSnippetCard(snippet: Snippet, onClick: () -> Unit) {
             Sym("code_blocks", size = 18.sp, color = Skerry.colors.cyanBright)
             Txt(remember(snippet) { untrustedLabel(snippet.label) }.ifBlank { stringResource(Res.string.lib_snippets_untitled) }, color = Skerry.colors.text, size = 14.5.sp, weight = FontWeight.SemiBold)
         }
-        val note = snippet.notes
-        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
-        if (!shownNote.isNullOrBlank()) {
-            Txt(
-                shownNote,
-                color = Skerry.colors.dim,
-                size = 11.5.sp,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = 4.dp),
-            )
-        }
+        // A peek at the note, not the whole of it: the card is a row in a list, and the full text is
+        // in the editor.
+        NoteBlock(
+            snippet.notes, stringResource(Res.string.lib_snippets_field_notes),
+            Modifier.padding(top = 4.dp), size = 11.5.sp, maxLines = NOTE_PEEK_LINES,
+        )
         if (snippet.command.isNotBlank()) {
             Box(
                 Modifier.fillMaxWidth().padding(top = 8.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.terminalBg).padding(horizontal = 11.dp, vertical = 9.dp),
@@ -341,7 +335,7 @@ private fun MobileSnippetEditSheet(
                 MobileFormInput(form.command, { form.command = it }, "df -h | sort -k5 -r", mono = true, background = Skerry.colors.terminalBg, singleLine = false, minHeightDp = 88)
             }
             MobileFormField(stringResource(Res.string.lib_snippets_field_notes)) {
-                MobileFormInput(form.notes, { form.notes = it }, stringResource(Res.string.lib_snippets_ph_notes), singleLine = false, minHeightDp = 64)
+                MobileFormInput(form.notes, { form.notes = capNotes(it) }, stringResource(Res.string.lib_snippets_ph_notes), singleLine = false, minHeightDp = 64)
             }
             MobileFormField(stringResource(Res.string.lib_snippets_field_tags)) {
                 // Own tags are excluded via selected; suggestions come from all snippets (including the

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunCard.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookRunCard.kt
@@ -45,7 +45,7 @@ import app.skerry.ui.design.Txt
 import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.design.CommandLine
 import app.skerry.ui.design.untrustedLabel
-import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.design.NoteBlock
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_runs_on
 import app.skerry.ui.generated.resources.lib_snippets_variables
@@ -64,13 +64,13 @@ import app.skerry.ui.generated.resources.runbook_run_no_steps
 import app.skerry.ui.generated.resources.runbook_step_confirm
 import app.skerry.ui.generated.resources.runbook_step_continue_on_error
 import app.skerry.ui.generated.resources.runbook_step_n
+import app.skerry.ui.generated.resources.runbook_field_description
 import app.skerry.ui.generated.resources.runbook_steps
 import app.skerry.ui.generated.resources.runbook_untitled
 import app.skerry.ui.host.HostSection
 import app.skerry.ui.sftp.fileDateText
 import app.skerry.ui.design.tagChipLabel
 import app.skerry.ui.theme.Skerry
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
 import org.jetbrains.compose.resources.stringResource
 
 /** Width of the runbook panel — wider than the snippet one: its rows are whole step lines. */
@@ -130,12 +130,10 @@ internal fun RunbookRunCard(
                 runbook.tags.forEach { tag -> key(tag) { Chip(remember(tag) { tagChipLabel(tag) }) } }
             }
         }
-        if (runbook.description.isNotBlank()) {
-            Txt(
-                remember(runbook) { sanitizeServerText(runbook.description, MAX_NOTE_CHARS, allowNewlines = true) }, color = Skerry.colors.dim, size = 12.sp,
-                lineHeight = 17.sp, modifier = Modifier.padding(bottom = 14.dp),
-            )
-        }
+        NoteBlock(
+            runbook.description, stringResource(Res.string.runbook_field_description),
+            Modifier.padding(bottom = 14.dp),
+        )
 
         FieldLabel(labelUppercase(stringResource(Res.string.runbook_steps)), top = 0.dp, bottom = 7.dp)
         runbook.steps.forEachIndexed { index, step ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookStartDialog.kt
@@ -52,7 +52,7 @@ import app.skerry.ui.design.CommandQuote
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.sanitizedFits
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import app.skerry.ui.design.MAX_NOTE_CHARS
 
 /**
  * Confirmation shown before a runbook starts: prompts for the `${{…}}` values its steps need and

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbooksView.kt
@@ -41,6 +41,7 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.SidebarSearchField
+import app.skerry.ui.design.NoteBlock
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
@@ -56,6 +57,7 @@ import app.skerry.ui.generated.resources.runbook_no_matches
 import app.skerry.ui.generated.resources.runbook_section
 import app.skerry.ui.generated.resources.runbook_search
 import app.skerry.ui.generated.resources.runbook_select_or_create
+import app.skerry.ui.generated.resources.runbook_field_description
 import app.skerry.ui.generated.resources.runbook_step_count
 import app.skerry.ui.generated.resources.runbook_steps_total
 import app.skerry.ui.generated.resources.runbook_untitled
@@ -245,7 +247,7 @@ private fun RunbooksHeader(
 /** One runbook row: name and its first steps on the left, tags on the right. */
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun RunbookListRow(entry: RunbookEntry, selected: Boolean, mono: FontFamily, onClick: () -> Unit) {
+internal fun RunbookListRow(entry: RunbookEntry, selected: Boolean, mono: FontFamily, onClick: () -> Unit) {
     val runbook = entry.runbook
     Row(
         Modifier
@@ -274,6 +276,12 @@ private fun RunbookListRow(entry: RunbookEntry, selected: Boolean, mono: FontFam
                     },
                 color = Skerry.colors.faint, size = 11.sp, font = mono,
                 maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.padding(top = 3.dp),
+            )
+            // The search matches on the description, and a hit whose only match is invisible reads
+            // as a stray row — the same reason the snippet library row draws its note.
+            NoteBlock(
+                runbook.description, stringResource(Res.string.runbook_field_description),
+                Modifier.padding(top = 3.dp), size = 11.sp, maxLines = 1,
             )
         }
         if (runbook.tags.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
@@ -67,10 +67,12 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_add_tag
 import app.skerry.ui.generated.resources.lib_snippets_field_command
 import app.skerry.ui.generated.resources.lib_snippets_field_name
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_field_shortcut
 import app.skerry.ui.generated.resources.lib_snippets_field_tags
 import app.skerry.ui.generated.resources.lib_snippets_new
 import app.skerry.ui.generated.resources.lib_snippets_ph_name
+import app.skerry.ui.generated.resources.lib_snippets_ph_notes
 import app.skerry.ui.generated.resources.lib_snippets_press_keys
 import app.skerry.ui.generated.resources.lib_snippets_save
 import app.skerry.ui.generated.resources.lib_snippets_shortcut_conflict
@@ -116,6 +118,11 @@ internal fun SnippetEditor(
         Column(Modifier.padding(top = 20.dp)) {
             FormField(stringResource(Res.string.lib_snippets_field_command), top = 0.dp, bottom = 8.dp) {
                 CommandField(form.command, { form.command = it }, "df -h | sort -k5 -r", mono)
+            }
+        }
+        Column(Modifier.padding(top = 20.dp)) {
+            FormField(stringResource(Res.string.lib_snippets_field_notes), top = 0.dp, bottom = 8.dp) {
+                NotesField(form.notes, { form.notes = it }, stringResource(Res.string.lib_snippets_ph_notes), LocalFonts.current.ui)
             }
         }
         Column(Modifier.padding(top = 20.dp)) {
@@ -350,6 +357,27 @@ private fun CommandField(value: String, onValueChange: (String) -> Unit, placeho
         decorationBox = { inner ->
             Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).padding(horizontal = 16.dp, vertical = 14.dp)) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = mono)
+                inner()
+            }
+        },
+    )
+}
+
+/** Multiline notes field (UI font, standard card background). */
+@Composable
+private fun NotesField(value: String, onValueChange: (String) -> Unit, placeholder: String, font: FontFamily) {
+    val textColor = Skerry.colors.text
+    val textStyle = remember(font, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = font) }
+    val draft = rememberFieldDraft(value, singleLine = false)
+    BasicTextField(
+        value = draft.textFieldValue(value),
+        onValueChange = { draft.accept(it, value, onValueChange) },
+        textStyle = textStyle,
+        cursorBrush = SolidColor(Skerry.colors.cyan),
+        modifier = Modifier.fillMaxWidth().fieldFocus(draft).fieldName(),
+        decorationBox = { inner ->
+            Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).padding(horizontal = 14.dp, vertical = 10.dp)) {
+                if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = font)
                 inner()
             }
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetEditor.kt
@@ -49,8 +49,10 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import app.skerry.shared.text.capNotes
 import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.FieldLabel
@@ -122,7 +124,12 @@ internal fun SnippetEditor(
         }
         Column(Modifier.padding(top = 20.dp)) {
             FormField(stringResource(Res.string.lib_snippets_field_notes), top = 0.dp, bottom = 8.dp) {
-                NotesField(form.notes, { form.notes = it }, stringResource(Res.string.lib_snippets_ph_notes), LocalFonts.current.ui)
+                // Capped per keystroke, the way a host's note is: the store caps too, but a field
+                // that keeps accepting text it will not save lies about what was written.
+                EditField(
+                    form.notes, { form.notes = capNotes(it) }, stringResource(Res.string.lib_snippets_ph_notes),
+                    LocalFonts.current.ui, singleLine = false, minHeight = 52.dp,
+                )
             }
         }
         Column(Modifier.padding(top = 20.dp)) {
@@ -316,21 +323,31 @@ private fun ShortcutField(value: String?, mono: FontFamily, conflictText: String
 
 // --- Editor fields ---
 
-/** Single-line editable field. */
+/**
+ * Editable field in the UI font. Single-line by default; [minHeight] turns it into a prose box (the
+ * notes field), which is the only thing that separated the two.
+ */
 @Composable
-private fun EditField(value: String, onValueChange: (String) -> Unit, placeholder: String, font: FontFamily) {
+private fun EditField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    font: FontFamily,
+    singleLine: Boolean = true,
+    minHeight: Dp = Dp.Unspecified,
+) {
     val textColor = Skerry.colors.text
     val textStyle = remember(font, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = font) }
-    val draft = rememberFieldDraft(value)
+    val draft = rememberFieldDraft(value, singleLine = singleLine)
     BasicTextField(
         value = draft.textFieldValue(value),
         onValueChange = { draft.accept(it, value, onValueChange) },
-        singleLine = true,
+        singleLine = singleLine,
         textStyle = textStyle,
         cursorBrush = SolidColor(Skerry.colors.cyan),
         modifier = Modifier.fillMaxWidth().fieldFocus(draft).fieldName(),
         decorationBox = { inner ->
-            Box(Modifier.fillMaxWidth().clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp)) {
+            Box(Modifier.fillMaxWidth().heightIn(min = minHeight).clip(RoundedCornerShape(7.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp)).padding(horizontal = 11.dp, vertical = 9.dp)) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = font)
                 inner()
             }
@@ -357,27 +374,6 @@ private fun CommandField(value: String, onValueChange: (String) -> Unit, placeho
         decorationBox = { inner ->
             Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.terminalBg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).padding(horizontal = 16.dp, vertical = 14.dp)) {
                 if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = mono)
-                inner()
-            }
-        },
-    )
-}
-
-/** Multiline notes field (UI font, standard card background). */
-@Composable
-private fun NotesField(value: String, onValueChange: (String) -> Unit, placeholder: String, font: FontFamily) {
-    val textColor = Skerry.colors.text
-    val textStyle = remember(font, textColor) { TextStyle(color = textColor, fontSize = 13.sp, fontFamily = font) }
-    val draft = rememberFieldDraft(value, singleLine = false)
-    BasicTextField(
-        value = draft.textFieldValue(value),
-        onValueChange = { draft.accept(it, value, onValueChange) },
-        textStyle = textStyle,
-        cursorBrush = SolidColor(Skerry.colors.cyan),
-        modifier = Modifier.fillMaxWidth().fieldFocus(draft).fieldName(),
-        decorationBox = { inner ->
-            Box(Modifier.fillMaxWidth().heightIn(min = 52.dp).clip(RoundedCornerShape(8.dp)).background(Skerry.colors.bg).border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)).padding(horizontal = 14.dp, vertical = 10.dp)) {
-                if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = font)
                 inner()
             }
         },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetFormState.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.setValue
 class SnippetFormState private constructor(private val editingId: String?) {
     var label: String by mutableStateOf("")
     var command: String by mutableStateOf("")
+    var notes: String by mutableStateOf("")
 
     /** Committed tags (pills); edited via [addTags]/[removeTag]/[pickTag]. */
     var tags: List<String> by mutableStateOf(emptyList())
@@ -61,6 +62,7 @@ class SnippetFormState private constructor(private val editingId: String?) {
         command = command,
         tags = (tags + parseSnippetTags(tagDraft)).distinct(),
         shortcut = shortcut,
+        notes = notes.trim().ifEmpty { null },
     )
 
     companion object {
@@ -72,6 +74,7 @@ class SnippetFormState private constructor(private val editingId: String?) {
                     command = s.command
                     tags = s.tags
                     shortcut = s.shortcut
+                    notes = s.notes.orEmpty()
                 }
             }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetFormState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetFormState.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.snippet
 
+import app.skerry.shared.text.normalizeNotes
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -62,7 +63,7 @@ class SnippetFormState private constructor(private val editingId: String?) {
         command = command,
         tags = (tags + parseSnippetTags(tagDraft)).distinct(),
         shortcut = shortcut,
-        notes = notes.trim().ifEmpty { null },
+        notes = normalizeNotes(notes),
     )
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetGrouping.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetGrouping.kt
@@ -69,17 +69,18 @@ fun hasCategories(snippets: List<SnippetEntry>): Boolean = snippets.any { it.sni
 fun snippetCategoryChips(snippets: List<SnippetEntry>): List<String> =
     listOf(ALL_SNIPPETS_CHIP) + groupSnippetsByCategory(snippets).map { it.name }
 
-/** Case-insensitive search across a snippet's name, command and tags. */
+/** Case-insensitive search across a snippet's name, command, tags and notes. */
 fun SnippetEntry.matches(query: String): Boolean {
     val q = query.trim().lowercase()
     return snippet.label.lowercase().contains(q) ||
         snippet.command.lowercase().contains(q) ||
+        snippet.notes?.lowercase()?.contains(q) == true ||
         snippet.tags.any { it.lowercase().contains(q) }
 }
 
 /**
  * Narrow [snippets] by the active chip ([activeChip] = category, `All` = no filter) and [query] (AND).
- * Search is case-insensitive across label/command/tags (see [SnippetEntry.matches]).
+ * Search is case-insensitive across label/command/tags/notes (see [SnippetEntry.matches]).
  */
 fun filterSnippets(
     snippets: List<SnippetEntry>,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
@@ -3,6 +3,9 @@ package app.skerry.ui.snippet
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.Chip
 import app.skerry.ui.design.FilterChipRow
+import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.fieldFocus
@@ -47,6 +51,9 @@ import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import kotlinx.coroutines.delay
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_placeholder
@@ -119,37 +126,54 @@ internal fun SnippetListRow(
     onClick: () -> Unit,
 ) {
     val s = entry.snippet
-    Row(
-        Modifier
-            .fillMaxWidth()
-            .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-            .clickable(onClick = onClick)
-            .padding(horizontal = 18.dp, vertical = 11.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Box(
-            Modifier.size(30.dp).clip(RoundedCornerShape(7.dp))
-                .background(if (selected) Skerry.colors.cyan.copy(alpha = 0.14f) else Skerry.colors.overlayMed),
-            contentAlignment = Alignment.Center,
+    val hoverInteraction = remember { MutableInteractionSource() }
+    val hovered by hoverInteraction.collectIsHoveredAsState()
+    var noteVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(hovered) {
+        noteVisible = false
+        if (hovered) {
+            delay(450L)
+            noteVisible = true
+        }
+    }
+    val note = s.notes
+    val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+
+    Box(Modifier.fillMaxWidth()) {
+        if (noteVisible && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
+                .hoverable(hoverInteraction)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 18.dp, vertical = 11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
-            Sym("code_blocks", size = 16.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim)
-        }
-        Column(Modifier.weight(1f)) {
-            Txt(
-                remember(s) { untrustedLabel(s.label) }.ifBlank { stringResource(Res.string.lib_snippets_untitled) },
-                color = if (selected) Skerry.colors.cyanBright else Skerry.colors.textBright,
-                size = 12.5.sp,
-                weight = FontWeight.Medium,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            CommandLine(s.command, modifier = Modifier.padding(top = 3.dp))
-        }
-        // Tags are metadata, not the row's subject: they get whatever width is left after the command.
-        if (s.tags.isNotEmpty()) {
-            Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
-                s.tags.take(MAX_ROW_TAGS).forEach { tag -> key(tag) { Chip(remember(tag) { tagChipLabel(tag) }) } }
+            Box(
+                Modifier.size(30.dp).clip(RoundedCornerShape(7.dp))
+                    .background(if (selected) Skerry.colors.cyan.copy(alpha = 0.14f) else Skerry.colors.overlayMed),
+                contentAlignment = Alignment.Center,
+            ) {
+                Sym("code_blocks", size = 16.sp, color = if (selected) Skerry.colors.cyanBright else Skerry.colors.dim)
+            }
+            Column(Modifier.weight(1f)) {
+                Txt(
+                    remember(s) { untrustedLabel(s.label) }.ifBlank { stringResource(Res.string.lib_snippets_untitled) },
+                    color = if (selected) Skerry.colors.cyanBright else Skerry.colors.textBright,
+                    size = 12.5.sp,
+                    weight = FontWeight.Medium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                CommandLine(s.command, modifier = Modifier.padding(top = 3.dp))
+            }
+            // Tags are metadata, not the row's subject: they get whatever width is left after the command.
+            if (s.tags.isNotEmpty()) {
+                Row(horizontalArrangement = Arrangement.spacedBy(5.dp)) {
+                    s.tags.take(MAX_ROW_TAGS).forEach { tag -> key(tag) { Chip(remember(tag) { tagChipLabel(tag) }) } }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetLibraryList.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.Chip
 import app.skerry.ui.design.FilterChipRow
-import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.fieldFocus
@@ -48,17 +45,18 @@ import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.RowNoteTooltip
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
-import app.skerry.ui.design.sanitizeServerText
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
-import kotlinx.coroutines.delay
+import app.skerry.ui.design.NoteBlock
+import app.skerry.ui.design.rememberRowNote
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_placeholder
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_subtitle
 import app.skerry.ui.generated.resources.lib_snippets_rename_tag_title
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_untitled
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.generated.resources.shell_save
@@ -126,26 +124,16 @@ internal fun SnippetListRow(
     onClick: () -> Unit,
 ) {
     val s = entry.snippet
-    val hoverInteraction = remember { MutableInteractionSource() }
-    val hovered by hoverInteraction.collectIsHoveredAsState()
-    var noteVisible by remember { mutableStateOf(false) }
-    LaunchedEffect(hovered) {
-        noteVisible = false
-        if (hovered) {
-            delay(450L)
-            noteVisible = true
-        }
-    }
-    val note = s.notes
-    val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
-
+    // Hovering gives the whole note, the way a host row does. A line of it is drawn either way:
+    // the search matches on the note, and a hit whose only match is invisible reads as a stray row.
+    val note = rememberRowNote(s.notes)
     Box(Modifier.fillMaxWidth()) {
-        if (noteVisible && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
+        RowNoteTooltip(note)
         Row(
             Modifier
                 .fillMaxWidth()
                 .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-                .hoverable(hoverInteraction)
+                .hoverable(note.interaction)
                 .clickable(onClick = onClick)
                 .padding(horizontal = 18.dp, vertical = 11.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -168,6 +156,10 @@ internal fun SnippetListRow(
                     overflow = TextOverflow.Ellipsis,
                 )
                 CommandLine(s.command, modifier = Modifier.padding(top = 3.dp))
+                NoteBlock(
+                    s.notes, stringResource(Res.string.lib_snippets_field_notes),
+                    Modifier.padding(top = 3.dp), size = 11.sp, maxLines = 1,
+                )
             }
             // Tags are metadata, not the row's subject: they get whatever width is left after the command.
             if (s.tags.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
@@ -25,6 +25,7 @@ data class SnippetDraft(
     val command: String,
     val tags: List<String> = emptyList(),
     val shortcut: String? = null,
+    val notes: String? = null,
 )
 
 /**
@@ -132,6 +133,7 @@ class SnippetManager(
             command = draft.command,
             tags = normalizeTags(draft.tags),
             shortcut = draft.shortcut?.takeIf { it.isNotBlank() },
+            notes = draft.notes?.takeIf { it.isNotBlank() },
         )
         store.put(snippet)
         val existing = find(id)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetManager.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import app.skerry.shared.text.normalizeNotes
 import app.skerry.shared.snippet.Snippet
 import app.skerry.shared.snippet.SnippetRunEnvironment
 import app.skerry.shared.snippet.SnippetSegment
@@ -133,7 +134,7 @@ class SnippetManager(
             command = draft.command,
             tags = normalizeTags(draft.tags),
             shortcut = draft.shortcut?.takeIf { it.isNotBlank() },
-            notes = draft.notes?.takeIf { it.isNotBlank() },
+            notes = draft.notes?.let(::normalizeNotes),
         )
         store.put(snippet)
         val existing = find(id)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
@@ -72,7 +72,9 @@ import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.ClippedNotice
 import app.skerry.ui.design.CommandQuote
+import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.tagChipLabel
+import app.skerry.ui.terminal.MAX_NOTE_CHARS
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
@@ -137,6 +139,17 @@ internal fun SnippetRunPanel(
             color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold,
             modifier = Modifier.padding(bottom = 10.dp),
         )
+        val note = snippet.notes
+        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+        if (!shownNote.isNullOrBlank()) {
+            Txt(
+                shownNote,
+                color = Skerry.colors.dim,
+                size = 12.sp,
+                lineHeight = 17.sp,
+                modifier = Modifier.padding(bottom = 10.dp),
+            )
+        }
         if (snippet.tags.isNotEmpty()) {
             FlowRow(
                 Modifier.fillMaxWidth().padding(bottom = 12.dp),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/snippet/SnippetRunPanel.kt
@@ -56,6 +56,7 @@ import app.skerry.ui.generated.resources.lib_snippets_copy
 import app.skerry.ui.generated.resources.lib_snippets_delete
 import app.skerry.ui.generated.resources.lib_snippets_edit_action
 import app.skerry.ui.generated.resources.lib_snippets_field_command
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_no_session
 import app.skerry.ui.generated.resources.lib_snippets_preview_runs
 import app.skerry.ui.generated.resources.lib_snippets_run
@@ -72,9 +73,8 @@ import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.ClippedNotice
 import app.skerry.ui.design.CommandQuote
-import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.tagChipLabel
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import app.skerry.ui.design.NoteBlock
 import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.semantics
@@ -139,17 +139,7 @@ internal fun SnippetRunPanel(
             color = Skerry.colors.text, size = 15.sp, weight = FontWeight.SemiBold,
             modifier = Modifier.padding(bottom = 10.dp),
         )
-        val note = snippet.notes
-        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
-        if (!shownNote.isNullOrBlank()) {
-            Txt(
-                shownNote,
-                color = Skerry.colors.dim,
-                size = 12.sp,
-                lineHeight = 17.sp,
-                modifier = Modifier.padding(bottom = 10.dp),
-            )
-        }
+        SnippetNote(snippet.notes)
         if (snippet.tags.isNotEmpty()) {
             FlowRow(
                 Modifier.fillMaxWidth().padding(bottom = 12.dp),
@@ -360,3 +350,8 @@ private fun ParamInput(
     )
 }
 
+/** The snippet's note, under its name — the shared [NoteBlock], named and filtered like every other. */
+@Composable
+internal fun SnippetNote(note: String?) {
+    NoteBlock(note, stringResource(Res.string.lib_snippets_field_notes), Modifier.padding(bottom = 10.dp))
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/HostRows.kt
@@ -2,8 +2,6 @@ package app.skerry.ui.terminal
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -45,13 +42,13 @@ import app.skerry.ui.app.LocalRunSnippetOnHost
 import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.design.Badge
 import app.skerry.ui.design.Dot
-import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.MenuItem
 import app.skerry.ui.design.MenuPanel
+import app.skerry.ui.design.RowNoteTooltip
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
-import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.design.rememberRowNote
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_menu_delete
@@ -72,7 +69,6 @@ import app.skerry.ui.host.icon
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.sessionDotColor
-import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.generated.resources.shell_tip_more_actions
@@ -237,9 +233,6 @@ internal fun HostRow(host: MockHost, state: DesktopDesignState, mono: FontFamily
     )
 }
 
-/** How long the pointer must rest on a host row before its note pops up. */
-private const val NOTE_TOOLTIP_DELAY_MS = 450L
-
 /**
  * Shared host row for the sidebar (mock and live catalog): status dot + protocol icon + name +
  * optional badge. [icon] is the profile's [app.skerry.ui.host.icon] and stays [Skerry.colors.faint] — the two
@@ -283,35 +276,18 @@ internal fun HostEntryRow(
     var snippetPickerOpen by remember { mutableStateOf(false) }
     // The profile's note is shown on hover — mouse-only by nature; on Android the same code simply
     // never reports a hover (the note lives in the host detail screen there).
-    val hoverInteraction = remember { MutableInteractionSource() }
-    val hovered by hoverInteraction.collectIsHoveredAsState()
-    // Dwell before the note pops up, so sweeping the pointer down the list doesn't flash a tooltip
-    // over every row on the way.
-    var noteVisible by remember { mutableStateOf(false) }
-    LaunchedEffect(hovered) {
-        noteVisible = false
-        if (hovered) {
-            delay(NOTE_TOOLTIP_DELAY_MS)
-            noteVisible = true
-        }
-    }
+    val note = rememberRowNote(host?.notes)
     // The tooltip is a sibling of the row, not a child: inside the row its (zero-sized) popup node
     // would still collect the row's 8dp item spacing and shift the label sideways on hover.
     Box(Modifier.fillMaxWidth()) {
-        val note = host?.notes
-        // A shared profile's note is its author's text; it keeps its lines (prose), but not the
-        // characters that would let it draw as something else, and not more of them than a tooltip
-        // can hold — the field has no cap of its own.
-        val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
         // Suppressed while the row's own popups are up, so the note doesn't land on top of them.
-        val popupOpen = menuOpen || snippetPickerOpen
-        if (noteVisible && !popupOpen && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
+        RowNoteTooltip(note, suppressed = menuOpen || snippetPickerOpen)
         Row(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(5.dp))
                 .background(if (selected) Skerry.colors.cyan10 else Color.Transparent)
-                .hoverable(hoverInteraction)
+                .hoverable(note.interaction)
                 .hostConnectClick(
                     onClick = {
                         // Connecting also marks the row selected (single-click mode too — it reads as
@@ -395,5 +371,3 @@ internal fun HostEntryRow(
     }
 }
 
-/** How much of a profile's note a tooltip or a detail row will draw. */
-internal const val MAX_NOTE_CHARS = 600

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -3,6 +3,9 @@ package app.skerry.ui.terminal
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,11 +41,14 @@ import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.LocalSnippets
 import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.rememberModalPresence
+import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import kotlinx.coroutines.delay
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.generated.resources.term_no_matches
@@ -155,21 +161,42 @@ private const val ROW_PREVIEW_LINES = 2
 @Composable
 private fun PaletteRow(entry: SnippetEntry, mono: FontFamily, onClick: () -> Unit) {
     val s = entry.snippet
-    Column(
-        Modifier.fillMaxWidth().clip(RoundedCornerShape(6.dp)).clickable(onClick = onClick).padding(horizontal = 9.dp, vertical = 7.dp),
-    ) {
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
-            Sym("code_blocks", size = 14.sp, color = Skerry.colors.dim)
-            Txt(remember(s) { untrustedLabel(s.label) }.ifBlank { stringResource(Res.string.term_untitled) }, color = Skerry.colors.textBright, size = 12.5.sp, weight = FontWeight.Medium)
-            // Gated on the filtered chord, not the raw one: a chip drawn around nothing is a stray
-            // pill next to the row.
-            val chord = remember(s) { s.shortcut?.let { untrustedLabel(it) }.orEmpty() }
-            if (chord.isNotBlank()) {
-                Box(Modifier.clip(RoundedCornerShape(4.dp)).background(Skerry.colors.bg).padding(horizontal = 5.dp, vertical = 1.dp)) {
-                    Txt(chord, color = Skerry.colors.faint, size = 10.sp, font = mono)
+    val hoverInteraction = remember { MutableInteractionSource() }
+    val hovered by hoverInteraction.collectIsHoveredAsState()
+    var noteVisible by remember { mutableStateOf(false) }
+    LaunchedEffect(hovered) {
+        noteVisible = false
+        if (hovered) {
+            delay(450L)
+            noteVisible = true
+        }
+    }
+    val note = s.notes
+    val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
+
+    Box(Modifier.fillMaxWidth()) {
+        if (noteVisible && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
+        Column(
+            Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(6.dp))
+                .hoverable(hoverInteraction)
+                .clickable(onClick = onClick)
+                .padding(horizontal = 9.dp, vertical = 7.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+                Sym("code_blocks", size = 14.sp, color = Skerry.colors.dim)
+                Txt(remember(s) { untrustedLabel(s.label) }.ifBlank { stringResource(Res.string.term_untitled) }, color = Skerry.colors.textBright, size = 12.5.sp, weight = FontWeight.Medium)
+                // Gated on the filtered chord, not the raw one: a chip drawn around nothing is a stray
+                // pill next to the row.
+                val chord = remember(s) { s.shortcut?.let { untrustedLabel(it) }.orEmpty() }
+                if (chord.isNotBlank()) {
+                    Box(Modifier.clip(RoundedCornerShape(4.dp)).background(Skerry.colors.bg).padding(horizontal = 5.dp, vertical = 1.dp)) {
+                        Txt(chord, color = Skerry.colors.faint, size = 10.sp, font = mono)
+                    }
                 }
             }
+            CommandLine(s.command, maxLines = ROW_PREVIEW_LINES, modifier = Modifier.padding(top = 3.dp))
         }
-        CommandLine(s.command, maxLines = ROW_PREVIEW_LINES, modifier = Modifier.padding(top = 3.dp))
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,15 +39,17 @@ import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.LocalSnippets
 import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
-import app.skerry.ui.design.HoverTooltip
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.NOTE_PEEK_LINES
+import app.skerry.ui.design.NoteBlock
+import app.skerry.ui.design.RowNoteTooltip
 import app.skerry.ui.design.rememberModalPresence
-import app.skerry.ui.design.sanitizeServerText
+import app.skerry.ui.design.rememberRowNote
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
-import kotlinx.coroutines.delay
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.generated.resources.term_no_matches
 import app.skerry.ui.generated.resources.term_no_snippets_yet
@@ -161,26 +161,17 @@ private const val ROW_PREVIEW_LINES = 2
 @Composable
 private fun PaletteRow(entry: SnippetEntry, mono: FontFamily, onClick: () -> Unit) {
     val s = entry.snippet
-    val hoverInteraction = remember { MutableInteractionSource() }
-    val hovered by hoverInteraction.collectIsHoveredAsState()
-    var noteVisible by remember { mutableStateOf(false) }
-    LaunchedEffect(hovered) {
-        noteVisible = false
-        if (hovered) {
-            delay(450L)
-            noteVisible = true
-        }
-    }
-    val note = s.notes
-    val shownNote = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
-
+    // The hover tooltip carries the whole note; the row itself carries the opening of it, because
+    // this palette runs a fitting command on one click with no confirmation — a warning only a
+    // pointer can reveal is no warning for whoever drives it from the keyboard.
+    val note = rememberRowNote(s.notes)
     Box(Modifier.fillMaxWidth()) {
-        if (noteVisible && !shownNote.isNullOrBlank()) HoverTooltip(shownNote)
+        RowNoteTooltip(note)
         Column(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(6.dp))
-                .hoverable(hoverInteraction)
+                .hoverable(note.interaction)
                 .clickable(onClick = onClick)
                 .padding(horizontal = 9.dp, vertical = 7.dp),
         ) {
@@ -197,6 +188,10 @@ private fun PaletteRow(entry: SnippetEntry, mono: FontFamily, onClick: () -> Uni
                 }
             }
             CommandLine(s.command, maxLines = ROW_PREVIEW_LINES, modifier = Modifier.padding(top = 3.dp))
+            NoteBlock(
+                s.notes, stringResource(Res.string.lib_snippets_field_notes),
+                Modifier.padding(top = 3.dp), size = 11.sp, maxLines = NOTE_PEEK_LINES,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultSecretDetail.kt
@@ -25,8 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -77,7 +75,7 @@ import app.skerry.ui.generated.resources.vault_used_by_snippets
 import app.skerry.ui.generated.resources.vault_used_by_snippets_one
 import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.host.rowLabel
-import app.skerry.ui.terminal.MAX_NOTE_CHARS
+import app.skerry.ui.design.NoteBlock
 import app.skerry.ui.known.shortFingerprint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -372,15 +370,7 @@ internal fun KeyFileDetailBody(secret: CredentialSecret.KeyFile, state: KeyFileS
  */
 @Composable
 internal fun SecretNote(note: String?) {
-    val shown = remember(note) { note?.let { sanitizeServerText(it, MAX_NOTE_CHARS, allowNewlines = true) } }
-    if (shown.isNullOrBlank()) return
-    val label = stringResource(Res.string.vault_label_note)
-    Txt(
-        shown,
-        color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 17.sp,
-        // Comma-joined, the way Compose joins the texts it merges (see design/fieldValueName).
-        modifier = Modifier.padding(bottom = 14.dp).semantics { contentDescription = "$label, $shown" },
-    )
+    NoteBlock(note, stringResource(Res.string.vault_label_note), Modifier.padding(bottom = 14.dp), size = 11.5.sp)
 }
 
 @Composable

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetFormStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetFormStateTest.kt
@@ -1,0 +1,57 @@
+package app.skerry.ui.snippet
+
+import app.skerry.shared.snippet.Snippet
+import app.skerry.shared.text.MAX_NOTES_LENGTH
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SnippetFormStateTest {
+
+    private fun entry(notes: String? = null) =
+        SnippetEntry(Snippet(id = "s1", label = "Rollout", command = "kubectl apply -f -", notes = notes))
+
+    /** Editing a snippet and saving it unchanged must not drop the note it already carried. */
+    @Test
+    fun `an edited snippet keeps the note it arrived with`() {
+        val form = SnippetFormState.fromEntry(entry(notes = "Drains the canary pool first"))
+
+        assertEquals("Drains the canary pool first", form.notes)
+        assertEquals("Drains the canary pool first", form.toDraft().notes)
+    }
+
+    /** A note is optional: an empty field is no note at all, not an empty one. */
+    @Test
+    fun `a blank note saves as none`() {
+        val form = SnippetFormState.fromEntry(entry(notes = "gone"))
+        form.notes = "   \n  "
+
+        assertNull(form.toDraft().notes)
+    }
+
+    @Test
+    fun `a note is trimmed before it is stored`() {
+        val form = SnippetFormState.fromEntry(null)
+        form.notes = "  runs as root  "
+
+        assertEquals("runs as root", form.toDraft().notes)
+    }
+
+    @Test
+    fun `a snippet without a note stays without one`() {
+        assertEquals("", SnippetFormState.fromEntry(entry()).notes)
+        assertNull(SnippetFormState.fromEntry(entry()).toDraft().notes)
+    }
+
+    /**
+     * A note is stored the way every other note is (shared/text/Notes.kt): capped, so a pasted log
+     * cannot bloat the vault record the whole sync pushes in one body.
+     */
+    @Test
+    fun `a note longer than the cap is cut on the way to the store`() {
+        val form = SnippetFormState.fromEntry(null)
+        form.notes = "a".repeat(MAX_NOTES_LENGTH + 400)
+
+        assertEquals(MAX_NOTES_LENGTH, form.toDraft().notes?.length)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetGroupingTest.kt
@@ -7,8 +7,12 @@ import kotlin.test.assertTrue
 
 class SnippetGroupingTest {
 
-    private fun entry(label: String, tags: List<String> = emptyList(), command: String = "cmd") =
-        SnippetEntry(Snippet(id = label, label = label, command = command, tags = tags))
+    private fun entry(
+        label: String,
+        tags: List<String> = emptyList(),
+        command: String = "cmd",
+        notes: String? = null,
+    ) = SnippetEntry(Snippet(id = label, label = label, command = command, tags = tags, notes = notes))
 
     @Test
     fun groups_by_tag_in_alphabetical_order() {
@@ -88,5 +92,16 @@ class SnippetGroupingTest {
 
         assertEquals(listOf("Disk usage"), filterSnippets(all, activeChip = "disk", query = "disk").map { it.snippet.label })
         assertTrue(filterSnippets(all, activeChip = "disk", query = "iostat").isEmpty())
+    }
+
+    @Test
+    fun search_reaches_the_notes() {
+        val all = listOf(
+            entry("Rollout", command = "kubectl apply -f -", notes = "Drains the canary pool first"),
+            entry("Disk", command = "df -h"),
+        )
+
+        assertEquals(listOf("Rollout"), filterSnippets(all, query = "canary").map { it.snippet.label })
+        assertEquals(listOf("Rollout"), filterSnippets(all, query = "DRAINS").map { it.snippet.label })
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/snippet/SnippetManagerTest.kt
@@ -44,6 +44,18 @@ class SnippetManagerTest {
     }
 
     @Test
+    fun `save persists notes on snippet`() {
+        val store = FakeSnippetStore()
+        val manager = managerWith(store)
+
+        val id = manager.save(SnippetDraft(label = "Disk", command = "df -h", notes = "Show human-readable disk usage"))
+
+        val entry = manager.snippets.single()
+        assertEquals("Show human-readable disk usage", entry.snippet.notes)
+        assertEquals("Show human-readable disk usage", store.all().single().notes)
+    }
+
+    @Test
     fun `save with existing id updates in place`() {
         val manager = managerWith()
         val id = manager.save(draft(label = "old"))

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/RowNoteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/RowNoteTest.kt
@@ -1,0 +1,106 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import app.skerry.ui.desktop.allText
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The hover note a list row shows: the host sidebar, the snippet library and the terminal snippet
+ * palette all reach it through [rememberRowNote], so what it does is asserted once, here, rather
+ * than three times over three rows.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RowNoteTest {
+
+    private val note = "drains the canary pool first"
+
+    @Composable
+    private fun Row(text: String?, suppressed: Boolean = false) {
+        val row = rememberRowNote(text)
+        Box {
+            RowNoteTooltip(row, suppressed = suppressed)
+            Box(Modifier.testTag(ROW).size(60.dp).hoverable(row.interaction))
+        }
+    }
+
+    @Test
+    fun `the note waits for the pointer to rest before it pops up`() {
+        runForm({ Row(note) }) {
+            hoverTheRow()
+            // Straight after the pointer arrives: sweeping down a list must not flash a tooltip over
+            // every row on the way.
+            assertFalse(drawsNote(), "the tooltip appeared without a dwell, was ${allDrawnText()}")
+            mainClock.advanceTimeBy(DWELL_MS)
+            waitForIdle()
+            assertTrue(drawsNote(), "the tooltip never appeared, was ${allDrawnText()}")
+        }
+    }
+
+    @Test
+    fun `no pointer, no note`() {
+        runForm({ Row(note) }) {
+            mainClock.advanceTimeBy(DWELL_MS)
+            waitForIdle()
+            assertFalse(drawsNote(), "was ${allDrawnText()}")
+        }
+    }
+
+    @Test
+    fun `a note that filters away to nothing never pops up an empty box`() {
+        // Escapes, not the raw glyphs: an invisible character in source is unreviewable.
+        runForm({ Row("\u200B\u202E") }) {
+            hoverTheRow()
+            mainClock.advanceTimeBy(DWELL_MS)
+            waitForIdle()
+            // By root count, not by drawn text: an empty tooltip is a popup drawing an empty string,
+            // which reads as "nothing" to any text assertion.
+            assertEquals(1, roots(), "an empty tooltip popped up, drew ${allDrawnText()}")
+        }
+    }
+
+    @Test
+    fun `a row with its own popup up keeps the note out of the way`() {
+        runForm({ Row(note, suppressed = true) }) {
+            hoverTheRow()
+            mainClock.advanceTimeBy(DWELL_MS)
+            waitForIdle()
+            assertFalse(drawsNote(), "the note landed on top of the row's own popup, was ${allDrawnText()}")
+        }
+    }
+
+    private fun ComposeUiTest.hoverTheRow() {
+        onNodeWithTag(ROW).performMouseInput { moveTo(Offset(30f, 30f)) }
+        waitForIdle()
+    }
+
+    /** Every root, not the first: the tooltip is a Popup, and a popup is a root of its own. */
+    private fun ComposeUiTest.allDrawnText(): List<String> =
+        onAllNodes(isRoot(), useUnmergedTree = true).fetchSemanticsNodes().flatMap { it.allText() }
+
+    private fun ComposeUiTest.roots(): Int = onAllNodes(isRoot(), useUnmergedTree = true).fetchSemanticsNodes().size
+
+    private fun ComposeUiTest.drawsNote(): Boolean = allDrawnText().any { it.contains(note) }
+
+    private companion object {
+        const val ROW = "row-note-test-row"
+
+        /** Longer than the dwell in [rememberRowNote], so the test asserts "it came up", not "when". */
+        const val DWELL_MS = 900L
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSnippetFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSnippetFormTest.kt
@@ -15,6 +15,7 @@ import app.skerry.ui.desktop.runMobileShell
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_field_command
 import app.skerry.ui.generated.resources.lib_snippets_field_name
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -52,7 +53,22 @@ class MobileSnippetFormTest {
         assertEquals(COMMAND, saved?.command, "the phone editor saved nothing or lost the command")
     }
 
-    /** Same rule as the desktop editor: a snippet with no command has nothing to run. */
+    @Test
+    fun `a snippet with notes typed on the phone lands in the library`() = runMobileShell { shell ->
+        shell.state.push(MobileRoute.Snippets)
+        waitForIdle()
+        openEditor()
+        onField(Res.string.lib_snippets_field_name).performTextInput(NAME)
+        onField(Res.string.lib_snippets_field_command).performTextInput(COMMAND)
+        onField(Res.string.lib_snippets_field_notes).performTextInput("Mobile test notes")
+        onNodeWithTag(UiTags.FORM_SAVE).performClick()
+        waitForIdle()
+
+        val saved = shell.snippets.snippets.map { it.snippet }.singleOrNull { it.label == NAME }
+        assertEquals("Mobile test notes", saved?.notes)
+    }
+
+    /** Same rule as the desktop editor: a snippet with no command is not saved. */
     @Test
     fun `a snippet with no command is not saved`() = runMobileShell { shell ->
         shell.state.push(MobileRoute.Snippets)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookDescriptionNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookDescriptionNameTest.kt
@@ -1,0 +1,56 @@
+package app.skerry.ui.runbook
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.runbook.Runbook
+import app.skerry.shared.runbook.RunbookStep
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_field_description
+import app.skerry.ui.mobile.RunbookCard
+import kotlin.test.Test
+
+/**
+ * A runbook's description is the line that says when not to run the thing, and every surface that
+ * draws it does so in the same dim grey a screen reader cannot see. Named on each, or it reads as an
+ * unlabelled sentence wedged between the runbook's name and its step count.
+ *
+ * The list row draws it at all because the list searches on it: a hit whose only match is invisible
+ * reads as a stray row.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RunbookDescriptionNameTest {
+
+    private val runbook = Runbook(
+        id = "rb",
+        label = "Rollout",
+        description = "Aborts the canary first.",
+        steps = listOf(RunbookStep.Command(id = "s1", command = "uptime", confirm = false)),
+    )
+
+    @Test
+    fun `the desktop card names the description`() {
+        runForm({ RunbookRunCard(RunbookEntry(runbook), DesktopDesignState(), {}, {}) }) {
+            onNodeWithContentDescription(named, useUnmergedTree = true).assertExists()
+        }
+    }
+
+    @Test
+    fun `the desktop list row names the description`() {
+        runForm({ RunbookListRow(RunbookEntry(runbook), selected = false, mono = FontFamily.Monospace) {} }) {
+            onNodeWithContentDescription(named, useUnmergedTree = true).assertExists()
+        }
+    }
+
+    @Test
+    fun `the phone's card names the description`() {
+        runForm({ RunbookCard(RunbookEntry(runbook), FontFamily.Monospace) {} }) {
+            onNodeWithContentDescription(named, useUnmergedTree = true).assertExists()
+        }
+    }
+
+    private val named get() = string(Res.string.runbook_field_description) + ", " + runbook.description
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetEditorFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetEditorFormTest.kt
@@ -14,6 +14,7 @@ import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_snippets_field_command
 import app.skerry.ui.generated.resources.lib_snippets_field_name
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -66,6 +67,20 @@ class SnippetEditorFormTest {
 
         assertEquals(before, shell.snippets.snippets.size)
         assertTrue(shell.snippets.snippets.none { it.snippet.label == NAME })
+    }
+
+    @Test
+    fun `a snippet with notes saves notes into the library`() = runDesktopShell { shell ->
+        openEditor()
+        onField(Res.string.lib_snippets_field_name).performTextInput(NAME)
+        onField(Res.string.lib_snippets_field_command).performTextInput(COMMAND)
+        onField(Res.string.lib_snippets_field_notes).performTextInput("Sorts partitions by space used")
+        onNodeWithTag(UiTags.FORM_SAVE).performClick()
+        waitForIdle()
+
+        val saved = shell.snippets.snippets.singleOrNull { it.snippet.label == NAME }
+        assertNotNull(saved, "the editor saved nothing")
+        assertEquals("Sorts partitions by space used", saved.snippet.notes)
     }
 
     private fun ComposeUiTest.openEditor() {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetNoteTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetNoteTest.kt
@@ -1,0 +1,58 @@
+package app.skerry.ui.snippet
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import app.skerry.ui.desktop.drawnText
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The note under a snippet's name in the run panel: the same filtered, self-naming block the vault
+ * gives a secret's note. A snippet crosses devices over sync and can arrive from a peer.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SnippetNoteTest {
+
+    @Test
+    fun `a snippet without a note draws nothing at all`() {
+        runForm({ SnippetNote(null) }) {
+            assertEquals(emptyList(), drawnText())
+        }
+    }
+
+    @Test
+    fun `a note that filters away to nothing draws nothing`() {
+        // Escapes, not the raw glyphs: an invisible character in source is unreviewable.
+        runForm({ SnippetNote("\u200B\u202E") }) {
+            assertTrue(drawnText().all { it.isBlank() }, "was ${drawnText()}")
+        }
+    }
+
+    @Test
+    fun `a note keeps its own line breaks — it is prose, not a label`() {
+        runForm({ SnippetNote("drains the canary pool\nsafe to re-run") }) {
+            assertTrue(drawnText().any { it.contains("drains the canary pool\nsafe to re-run") }, "was ${drawnText()}")
+        }
+    }
+
+    @Test
+    fun `a note drops the characters that would let it draw as something else`() {
+        runForm({ SnippetNote("stop\u202Edb first") }) {
+            val drawn = drawnText()
+            assertTrue(drawn.any { it.contains("stopdb first") }, "the text still reads, was $drawn")
+            assertTrue(drawn.none { it.any { c -> c.category == CharCategory.FORMAT } }, "was $drawn")
+        }
+    }
+
+    @Test
+    fun `the note names itself for a reader who cannot see where it sits`() {
+        runForm({ SnippetNote("drains the canary pool") }) {
+            onNodeWithContentDescription(string(Res.string.lib_snippets_field_notes) + ", drains the canary pool").assertExists()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
@@ -15,7 +15,9 @@ import app.skerry.ui.teams.ShareItem
 import app.skerry.ui.teams.SharePickerDialog
 import app.skerry.shared.snippet.SnippetMoment
 import app.skerry.shared.snippet.SnippetRunEnvironment
+import app.skerry.ui.design.MAX_NOTE_CHARS
 import app.skerry.ui.design.boundedVisibleText
+import app.skerry.ui.design.sanitizeServerText
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.desktop.drawnText
 import app.skerry.ui.desktop.allText
@@ -39,6 +41,7 @@ import kotlinx.coroutines.cancel
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import androidx.compose.ui.test.onNodeWithContentDescription
+import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_run_title
 import app.skerry.ui.app.DesktopView
 import app.skerry.ui.desktop.runDesktopShell
@@ -63,6 +66,8 @@ class UntrustedSnippetTextTest {
     // the tail of the line, so what is drawn reads as a comment and what runs is the command.
     private val label = "Rollout\u202Etuollor"
     private val command = "echo ok \u202E# rm -rf /"
+    private val note = "safe to re-run\u202Enur-er ot efasnu"
+    private val drawnNote = sanitizeServerText(note, MAX_NOTE_CHARS, allowNewlines = true)
 
     // Every peer-authored field of the record, not just the two the row is named after.
     private val snippet = Snippet(
@@ -71,6 +76,7 @@ class UntrustedSnippetTextTest {
         command = command,
         tags = listOf("pro\u202Ed"),
         shortcut = "Ctrl+\u202EK",
+        notes = note,
     )
 
     @Test
@@ -81,6 +87,7 @@ class UntrustedSnippetTextTest {
             // drawn is the line that runs — a filter that deleted it would pass the check above.
             onNodeWithText(boundedVisibleText(command), useUnmergedTree = true).assertExists()
             onNodeWithText(untrustedLabel(label), useUnmergedTree = true).assertExists()
+            assertNoteDrawn()
         }
     }
 
@@ -98,17 +105,19 @@ class UntrustedSnippetTextTest {
         }) {
             assertNothingReordered()
             onNodeWithText(boundedVisibleText(command), useUnmergedTree = true).assertExists()
+            assertNoteDrawn()
         }
     }
 
     @Test
     fun `the terminal palette draws neither the label nor the command raw`() {
         val manager = seededSnippets().apply {
-            save(SnippetDraft(label = label, command = command, shortcut = "Ctrl+\u202EK"))
+            save(SnippetDraft(label = label, command = command, shortcut = "Ctrl+\u202EK", notes = snippet.notes))
         }
         runForm({ SnippetPalette(manager) {} }) {
             assertNothingReordered()
             onNodeWithText(boundedVisibleText(command), useUnmergedTree = true).assertExists()
+            assertNoteDrawn()
         }
     }
 
@@ -117,6 +126,7 @@ class UntrustedSnippetTextTest {
         runForm({ MobileSnippetCard(snippet) {} }) {
             assertNothingReordered()
             onNodeWithText(boundedVisibleText(command), useUnmergedTree = true).assertExists()
+            assertNoteDrawn()
         }
     }
 
@@ -371,6 +381,19 @@ class UntrustedSnippetTextTest {
             runner.close()
             scope.cancel()
         }
+    }
+
+    /**
+     * The note is drawn, filtered, and named — on the four surfaces that show it without a pointer.
+     * The negative check above passes just as well when the note was dropped altogether, and the note
+     * is the whole point on two of them: the palette row runs its command on one click, and the
+     * library row can be in the list because the search matched a note and nothing else.
+     */
+    private fun ComposeUiTest.assertNoteDrawn() {
+        onNodeWithContentDescription(
+            string(Res.string.lib_snippets_field_notes) + ", " + drawnNote,
+            useUnmergedTree = true,
+        ).assertExists()
     }
 
     private fun ComposeUiTest.assertNothingReordered() {

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -69,7 +69,8 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Any icon | `ui/design/Sym` (Material Symbols glyph) + `DesignFonts` |
 | Fonts | `ui/design/DesignFoundation`: `rememberUiFont`, `rememberMono`, `rememberMaterialSymbols` |
 | Buttons | `PrimaryButton`, `GhostButton`, `CancelButton`, `IconBtn` (hover/tooltip chrome); `ui/design/GlyphButton` for a touch glyph box — square tap target, `Role.Button`, optional long-press — don't hand-roll the `Box`+`Sym`+`clickable` shape again |
-| Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` |
+| Small controls | `Toggle`, `Badge`, `Dot`, `MeterBar`, `NumberStepper`, `HoverTooltip` (raw popup — a *row's* note goes through `RowNote` below) |
+| A stored note on a row or in a panel | `ui/design/RowNote`: `rememberRowNote` + `RowNoteTooltip` for the hover variant (the dwell, the filter and the popup-suppression the host sidebar, the snippet library and the terminal palette all share), `NoteBlock` for the static one (keychain secret, run panel, list row, card) — it names itself for a screen reader, which a bare dim `Txt` does not. `MAX_NOTE_CHARS` is how much of a note any of them draws, `NOTE_PEEK_LINES` how many lines a row in a list peeks at; what is *stored* is capped by `shared/text/normalizeNotes` |
 | A setting as a label + switch row | `ToggleRow` (optional second line); `SettingToggleRow` / `MobileSyncToggleRow` are its settings and sync scales and should converge onto it |
 | A fact as a label + value row in a detail panel | `KeyValueRow`; `InfoRow` (session info panel) and `CardRow` (tunnel dashboard) are the same shape and should converge onto it |
 | Chips | `Chip` (label, active/inactive) vs `ChipButton` (action chip: colour, outline/filled, enabled) — pick one, don't add a third |

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/Snippet.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/Snippet.kt
@@ -22,4 +22,5 @@ data class Snippet(
     val command: String,
     val tags: List<String> = emptyList(),
     val shortcut: String? = null,
+    val notes: String? = null,
 )

--- a/shared/src/commonMain/kotlin/app/skerry/shared/snippet/Snippet.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/snippet/Snippet.kt
@@ -9,11 +9,16 @@ import kotlinx.serialization.Serializable
  * active terminal and executed (with a newline). [tags] are user labels for grouping/search
  * (#monitoring, #disk).
  *
+ * [notes] is an optional free-form remark about the snippet (what it does to the box, which
+ * parameters it expects, when not to run it), stored the way every other note is
+ * ([app.skerry.shared.text.normalizeNotes]): trimmed, capped, blank collapsed to `null`. It is
+ * never sent to the shell — only the [command] is.
+ *
  * [shortcut] is the global launch hotkey in canonical form (`Ctrl+Shift+D`), `null` for none.
- * Defaulted field; older `snippets.json` without it reads as-is (backward-compat). The launch
- * target (active terminal or a specific host) isn't stored on the snippet — it's chosen at launch
- * time: the terminal palette targets the active session, while "Run snippet…" in a host's context
- * menu runs it on that host.
+ * Defaulted fields, [notes] included; older `snippets.json` without them reads as-is
+ * (backward-compat). The launch target (active terminal or a specific host) isn't stored on the
+ * snippet — it's chosen at launch time: the terminal palette targets the active session, while
+ * "Run snippet…" in a host's context menu runs it on that host.
  */
 @Serializable
 data class Snippet(

--- a/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/snippet/VaultSnippetStoreTest.kt
@@ -33,4 +33,11 @@ class VaultSnippetStoreTest {
         VaultSnippetStore(vault).put(snippet("s1"))
         assertEquals(listOf("s1"), VaultSnippetStore(vault).all().map { it.id })
     }
+
+    @Test
+    fun `put preserves notes`() {
+        val store = VaultSnippetStore(FakeVault())
+        store.put(Snippet(id = "s1", label = "Disk", command = "df -h", notes = "Check root partition usage"))
+        assertEquals("Check root partition usage", store.all().single().notes)
+    }
 }


### PR DESCRIPTION
### Summary

During my normal daily use of Skerry to manage various server commands and maintenance routines, I found that it can be difficult to recall the specific purpose, parameters, or caveats of complex snippets without opening them in the editor.

This PR adds an optional `notes` field to snippets and integrates a lightweight hover tooltip preview across the snippet library and the terminal snippet palette.

---

### What's Changed

1. **Core Data Model (`shared`)**:
   - Added `notes: String? = null` to `Snippet` and `SnippetDraft`.
   - Backward-compatible: existing vaults and sync payloads without the `notes` field continue to parse and serialize seamlessly.

2. **Desktop & Mobile UI (`composeApp`)**:
   - **Snippet Editor**: Added a dedicated multiline notes field in `SnippetEditor` (Desktop) and `MobileSnippetEditSheet` (Mobile).
   - **Run Panels & Cards**: Displays the notes in `SnippetRunPanel` and `MobileSnippetCard`.
   - **Hover Tooltip**: Added hover tooltip support to `SnippetLibraryList` and the terminal `SnippetPalette`, allowing quick preview of notes before executing a command.

3. **Localization**:
   - Added string resources for English, Chinese, and Russian (`values`, `values-zh`, `values-ru`).

4. **Testing**:
   - Added unit and form tests covering serialization, draft conversions, and UI state handling (`VaultSnippetStoreTest`, `SnippetManagerTest`, `SnippetEditorFormTest`, `MobileSnippetFormTest`).

---

### Verification

- All tests pass: `./gradlew test allTests`
- Detekt & Gate checks clean.
- Verified on Desktop (Linux / macOS / Windows) and Android.