### PR TITLE
Name the inputs and the toggles a screen reader lands on (#228)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -115,4 +115,6 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">готово</string>
+    <string name="sftp_path_field">Перейти к пути</string>
+    <string name="sftp_edit_buffer">Содержимое файла</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_term.xml
@@ -127,4 +127,5 @@
     <string name="term_autofit_shrink">Уменьшить шрифт терминала</string>
     <string name="term_autofit_grow">Увеличить шрифт терминала</string>
     <string name="term_autofit_restore">Вернуть размер шрифта</string>
+    <string name="term_keyboard_input">Ввод в терминал</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_vnc.xml
@@ -70,4 +70,5 @@
     <string name="rd_clipboard_failed">Системный буфер обмена недоступен</string>
     <string name="rd_surface">Удалённый рабочий стол: %1$s. %2$s</string>
     <string name="rd_surface_release">%1$s отпускает клавиатуру</string>
+    <string name="rd_keyboard_input">Ввод в удалённый рабочий стол</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -115,4 +115,6 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">完成</string>
+    <string name="sftp_path_field">跳转到路径</string>
+    <string name="sftp_edit_buffer">文件内容</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_term.xml
@@ -124,4 +124,5 @@
     <string name="term_autofit_shrink">缩小终端字体</string>
     <string name="term_autofit_grow">放大终端字体</string>
     <string name="term_autofit_restore">恢复字体大小</string>
+    <string name="term_keyboard_input">终端输入</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_vnc.xml
@@ -70,4 +70,5 @@
     <string name="rd_clipboard_failed">系统剪贴板拒绝访问</string>
     <string name="rd_surface">远程桌面：%1$s。%2$s</string>
     <string name="rd_surface_release">%1$s 释放键盘</string>
+    <string name="rd_keyboard_input">远程桌面输入</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -117,4 +117,7 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">done</string>
+    <!-- Accessible names for the two inputs the panes draw without a caption (issue #228) -->
+    <string name="sftp_path_field">Jump to path</string>
+    <string name="sftp_edit_buffer">File contents</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_term.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_term.xml
@@ -125,4 +125,6 @@
     <string name="term_autofit_shrink">Shrink terminal font</string>
     <string name="term_autofit_grow">Enlarge terminal font</string>
     <string name="term_autofit_restore">Restore font size</string>
+    <!-- Accessible name of the invisible field the soft keyboard types into (issue #228) -->
+    <string name="term_keyboard_input">Terminal input</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_vnc.xml
@@ -70,4 +70,6 @@
     <string name="rd_clipboard_failed">The system clipboard refused</string>
     <string name="rd_surface">Remote desktop: %1$s. %2$s</string>
     <string name="rd_surface_release">%1$s releases the keyboard</string>
+    <!-- Same funnel on the remote-desktop screen (issue #228) -->
+    <string name="rd_keyboard_input">Remote desktop input</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiModelPicker.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AiModelPicker.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,9 +42,11 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.HLine
+import app.skerry.ui.design.LocalFieldLabel
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.theme.Skerry
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.settings_ai_models_count
@@ -81,6 +84,14 @@ fun ModelPickerMenu(
             .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(8.dp)),
     ) {
         // Search row: fixed at the top, filters the list below as you type.
+        //
+        // Under a reset [LocalFieldLabel]: desktop composes this menu inside `FormField("Model")`
+        // and a popup is a subcomposition, so that caption reaches the search box and outranks its
+        // placeholder — naming it after the combo it dropped out of, while the phone (which draws
+        // the menu in the page flow, with no caption over it) called the same field "Search
+        // models…". The menu is a surface of its own: a caption above the trigger names the
+        // trigger, not what is inside the menu it opens.
+        CompositionLocalProvider(LocalFieldLabel provides null) {
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -100,7 +111,8 @@ fun ModelPickerMenu(
                 // Enter picks the first match, as in the command palette — otherwise the only way
                 // out of the search field is a pointer.
                 keyboardActions = KeyboardActions(onSearch = { filtered.firstOrNull()?.let(onSelect) }),
-                modifier = Modifier.weight(1f),
+                // The placeholder is the only label this field draws (see fieldName).
+                modifier = Modifier.weight(1f).fieldName(searchPlaceholder),
                 decorationBox = { inner ->
                     Box(Modifier.fillMaxWidth()) {
                         if (query.isEmpty()) {
@@ -121,6 +133,7 @@ fun ModelPickerMenu(
                     contentAlignment = Alignment.Center,
                 ) { Sym("close", size = 13.sp, color = Skerry.colors.faint) }
             }
+        }
         }
         // Catalog size, so a refresh's result is visible at a glance (e.g. "321 models"); with a
         // query typed it counts what is actually listed, or it would contradict the rows below.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/ai/AssistantPanel.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.sp
 import app.skerry.shared.ai.AiProviderKind
 import app.skerry.shared.ai.AiRole
 import app.skerry.shared.ai.local.LocalModelCatalog
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.handsKeyboardBack
 import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.HLine
@@ -308,9 +309,10 @@ private fun AssistantAskRow(
                 )
             }
         }
+        val placeholder = stringResource(Res.string.assistant_ask_placeholder)
         Box(Modifier.weight(1f).padding(bottom = 4.dp)) {
             if (prompt.isEmpty()) {
-                Txt(stringResource(Res.string.assistant_ask_placeholder), color = Skerry.colors.faint, size = 12.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, maxLines = 1, overflow = TextOverflow.Ellipsis)
             }
             // Wraps and grows up to ASK_MAX_LINES, then scrolls: a pasted error or a long question
             // has to be readable before it is sent, not hidden past the right edge of one line.
@@ -323,7 +325,8 @@ private fun AssistantAskRow(
                 cursorBrush = SolidColor(Skerry.colors.cyan),
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
                 keyboardActions = KeyboardActions(onSend = { submit() }),
-                modifier = Modifier.fillMaxWidth().focusRequester(focus).onPreviewKeyEvent { event ->
+                // The placeholder is the only label this field draws (see fieldName).
+                modifier = Modifier.fillMaxWidth().focusRequester(focus).fieldName(placeholder).onPreviewKeyEvent { event ->
                     // Enter sends, Shift+Enter breaks the line — the field is multi-line now, so the
                     // key has to be claimed here or it would only ever insert a newline.
                     if (event.type == KeyEventType.KeyDown && event.key == Key.Enter && !event.isShiftPressed) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditor.kt
@@ -44,6 +44,7 @@ import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.fieldFocus
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.rememberSeededDraft
 import app.skerry.ui.design.Txt
 import app.skerry.ui.generated.resources.Res
@@ -51,6 +52,7 @@ import app.skerry.ui.generated.resources.ftail_fkey_edit
 import app.skerry.ui.generated.resources.ftail_fkey_quit
 import app.skerry.ui.generated.resources.ftail_fkey_save
 import app.skerry.ui.generated.resources.ftail_fkey_search
+import app.skerry.ui.generated.resources.sftp_edit_buffer
 import app.skerry.ui.generated.resources.sftp_edit_conflict_body
 import app.skerry.ui.generated.resources.sftp_edit_conflict_q
 import app.skerry.ui.generated.resources.sftp_edit_discard
@@ -317,6 +319,8 @@ private fun EditorBuffer(
         modifier = Modifier
             .fillMaxSize()
             .padding(14.dp)
+            // The header names the file; the buffer under it is an unnamed box without this.
+            .fieldName(stringResource(Res.string.sftp_edit_buffer))
             .focusRequester(focus)
             .onPreviewKeyEvent { event ->
                 // Tab types a tab (this is a file editor, and config files are full of them);
@@ -356,7 +360,8 @@ private fun EditorSearchBar(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Sym("search", size = 15.sp, color = Skerry.colors.cyanBright)
-        Txt(stringResource(Res.string.sftp_edit_find), color = Skerry.colors.faint, size = 11.5.sp)
+        val caption = stringResource(Res.string.sftp_edit_find)
+        Txt(caption, color = Skerry.colors.faint, size = 11.5.sp)
         BasicTextField(
             value = draft.textFieldValue(query),
             onValueChange = { draft.accept(it, query, onQueryChange) },
@@ -365,6 +370,8 @@ private fun EditorSearchBar(
             cursorBrush = SolidColor(Skerry.colors.cyan),
             modifier = Modifier
                 .weight(1f)
+                // The caption beside it is a sibling node, so the field has to adopt it.
+                .fieldName(caption)
                 .focusRequester(focus)
                 .fieldFocus(draft)
                 .onPreviewKeyEvent { event ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/PathJumpField.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/PathJumpField.kt
@@ -26,7 +26,11 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.TextUnit
+import app.skerry.ui.design.fieldName
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.sftp_path_field
 import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
 
 /**
  * Type-to-jump path editor shared by the desktop SFTP panes and the mobile Files breadcrumb.
@@ -60,6 +64,9 @@ fun PathJumpField(
         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri, imeAction = ImeAction.Go),
         keyboardActions = KeyboardActions(onGo = { onCommit(draft.text) }),
         modifier = modifier
+            // Nothing on screen labels this field — it opens over the breadcrumb already holding
+            // the path, so its own name is all a reader has (see fieldName).
+            .fieldName(stringResource(Res.string.sftp_path_field))
             .focusRequester(focus)
             .onFocusChanged { if (it.isFocused) everFocused = true else if (everFocused) onCancel() }
             .onPreviewKeyEvent { event ->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileAiBar.kt
@@ -43,6 +43,7 @@ import app.skerry.ui.ai.TerminalAiController
 import app.skerry.ui.ai.aiBlockedMessage
 import app.skerry.ui.ai.aiFailureMessage
 import app.skerry.ui.ai.shortLabel
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.labelUppercase
 import app.skerry.ui.terminal.TerminalScreenState
 import app.skerry.ui.generated.resources.Res
@@ -188,7 +189,8 @@ internal fun MobileAiBarInput(controller: TerminalAiController, terminal: Termin
                         }
                     }
                     else -> {
-                        if (prompt.isEmpty()) Txt(stringResource(Res.string.term_ai_ask_short), color = Skerry.colors.dim, size = 13.sp)
+                        val placeholder = stringResource(Res.string.term_ai_ask_short)
+                        if (prompt.isEmpty()) Txt(placeholder, color = Skerry.colors.dim, size = 13.sp)
                         BasicTextField(
                             value = prompt,
                             onValueChange = { prompt = it },
@@ -197,7 +199,8 @@ internal fun MobileAiBarInput(controller: TerminalAiController, terminal: Termin
                             cursorBrush = SolidColor(Skerry.colors.cyan),
                             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
                             keyboardActions = KeyboardActions(onSend = { submit() }),
-                            modifier = Modifier.fillMaxWidth(),
+                            // The placeholder is the only label this field draws (see fieldName).
+                            modifier = Modifier.fillMaxWidth().fieldName(placeholder),
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileForm.kt
@@ -111,7 +111,9 @@ internal fun MobileFormInput(
         } else {
             KeyboardActions.Default
         },
-        modifier = modifier.fillMaxWidth().fieldFocus(draft).fieldName(),
+        // A captioned MobileFormField still wins; the fallback covers the sheets and palettes that
+        // draw no caption, where the placeholder is the only label the field ever shows.
+        modifier = modifier.fillMaxWidth().fieldFocus(draft).fieldName(fallback = placeholder),
         decorationBox = { inner ->
             Box(
                 Modifier

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileGroupDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileGroupDialogs.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,8 +35,10 @@ import app.skerry.ui.generated.resources.conn_group_delete
 import app.skerry.ui.generated.resources.conn_group_new_title
 import app.skerry.ui.generated.resources.conn_group_rename_hint
 import app.skerry.ui.generated.resources.conn_group_rename_title
+import app.skerry.ui.generated.resources.shell_group_name_placeholder
 import app.skerry.ui.generated.resources.conn_save
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.ui.design.LocalFieldLabel
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
 
@@ -82,7 +85,10 @@ internal fun MobileGroupCreateDialog(onDismiss: () -> Unit, onCreate: (String) -
     MobileCenteredDialog(onDismiss = onDismiss) {
         Txt(stringResource(Res.string.conn_group_new_title), color = Skerry.colors.text, size = 18.sp, weight = FontWeight.Bold)
         Spacer(Modifier.height(14.dp))
-        MobileFormInput(name, { name = it }, "Production")
+        // "Production" is an example of what to type, not what the field is (see [LocalFieldLabel]).
+        CompositionLocalProvider(LocalFieldLabel provides stringResource(Res.string.shell_group_name_placeholder)) {
+            MobileFormInput(name, { name = it }, "Production")
+        }
         Spacer(Modifier.height(18.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             Box(
@@ -136,7 +142,9 @@ internal fun MobileGroupRenameDialog(
         Txt(stringResource(Res.string.conn_group_rename_hint), color = Skerry.colors.dim, size = 12.5.sp)
         Spacer(Modifier.height(14.dp))
         // Prefilled with the old name: selected on focus, so a tap and a keystroke replace it.
-        MobileFormInput(name, { name = it }, "Production", selectAllOnFocus = name == initialName)
+        CompositionLocalProvider(LocalFieldLabel provides stringResource(Res.string.shell_group_name_placeholder)) {
+            MobileFormInput(name, { name = it }, "Production", selectAllOnFocus = name == initialName)
+        }
         Spacer(Modifier.height(18.dp))
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
             Box(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePasswordSheet.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobilePasswordSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -33,12 +34,14 @@ import app.skerry.ui.connection.connectionSubtitle
 import app.skerry.ui.host.rowLabel
 import app.skerry.ui.secure.SecureScreen
 import app.skerry.ui.vault.VaultPresentation
+import app.skerry.ui.generated.resources.shell_password_host_placeholder
 import app.skerry.ui.generated.resources.shell_use_saved_secret
-import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_password_label
+import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_connect
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.rememberPromptFocus
+import app.skerry.ui.design.LocalFieldLabel
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
@@ -80,15 +83,22 @@ fun MobilePasswordSheet(
             Spacer(Modifier.height(18.dp))
             Txt(stringResource(Res.string.term_password_label), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp)
             Spacer(Modifier.height(6.dp))
-            MobileFormInput(
-                value = password,
-                onValueChange = { password = it },
-                modifier = Modifier.focusRequester(focus),
-                placeholder = "••••••••",
-                masked = true,
-                imeAction = ImeAction.Go,
-                onSubmit = { submit() },
-            )
+            // The caption above is a bare sibling `Txt`, so nothing puts it in scope for the field
+            // (see [LocalFieldLabel]) — and the placeholder that would otherwise stand in for a name
+            // is the masking glyphs, drawn to be seen and never to be spoken. The name is the one
+            // the desktop dialog announces (`PasswordDialog`): the caption is drawn in caps, and
+            // "connection password" also tells this prompt apart from the vault's master password.
+            CompositionLocalProvider(LocalFieldLabel provides stringResource(Res.string.shell_password_host_placeholder)) {
+                MobileFormInput(
+                    value = password,
+                    onValueChange = { password = it },
+                    modifier = Modifier.focusRequester(focus),
+                    placeholder = "••••••••",
+                    masked = true,
+                    imeAction = ImeAction.Go,
+                    onSubmit = { submit() },
+                )
+            }
             if (secrets.isNotEmpty()) {
                 Spacer(Modifier.height(18.dp))
                 Txt(stringResource(Res.string.shell_use_saved_secret), color = Skerry.colors.faint, size = 10.5.sp, weight = FontWeight.SemiBold, letterSpacing = 0.6.sp)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileVncScreen.kt
@@ -1,6 +1,8 @@
 package app.skerry.ui.mobile
 
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.generated.resources.rd_keyboard_input
 import app.skerry.ui.remote.remoteKeyEvent
 import app.skerry.ui.remote.RemoteDesktopPanel
 import app.skerry.ui.remote.rememberClipboardActions
@@ -30,6 +32,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -46,10 +49,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.ui.app.LocalSessions
+import app.skerry.ui.app.LocalUserActivity
 import app.skerry.ui.app.MobileDesignState
 import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
@@ -60,6 +68,8 @@ import app.skerry.ui.generated.resources.vnc_connection_lost
 import app.skerry.ui.generated.resources.vnc_session_closed
 import app.skerry.ui.immersive.ImmersiveScreen
 import app.skerry.ui.immersive.hiddenSystemBarsPadding
+import app.skerry.ui.terminal.ANCHOR
+import app.skerry.ui.terminal.imeDeltaToPty
 import app.skerry.ui.vnc.VncTouchSurface
 import androidx.compose.ui.input.key.Key
 import app.skerry.ui.vnc.remoteDesktopAnnouncement
@@ -230,35 +240,59 @@ private fun MobileVncBar(
 
 /**
  * Hidden 1-pixel text field that holds IME focus and forwards typed characters as RFB key events.
- * Diffing the field value turns insertions into key press+release and deletions into Backspace.
+ *
+ * The same funnel the terminal uses ([imeDeltaToPty]): the field is reset to [ANCHOR] after every
+ * change, so what it holds is never the text typed — on a Windows or VNC login screen that text is
+ * a password, and a field's value is `EditableText` in the semantics tree. Diffing against the
+ * anchor turns insertions into key press+release and deletions into Backspace; the anchor is what
+ * makes the first deletion visible at all. [KeyboardOptions] keep the same characters out of
+ * autocorrect and the IME's personalised dictionary.
+ *
  * The soft keyboard is raised explicitly: focus alone is not enough once the field has been focused
  * before (requestFocus on an already-focused field is a no-op, so the keyboard would never return).
  */
 @Composable
-private fun VncImeField(screen: RemoteDesktopScreenState, onClosed: () -> Unit) {
-    var value by remember { mutableStateOf(TextFieldValue("")) }
+internal fun VncImeField(screen: RemoteDesktopScreenState, onClosed: () -> Unit) {
+    val baseline = remember { TextFieldValue(ANCHOR, selection = TextRange(ANCHOR.length)) }
+    var value by remember { mutableStateOf(baseline) }
     val focus = remember { FocusRequester() }
     val keyboard = LocalSoftwareKeyboardController.current
+    val userActivity = LocalUserActivity.current
     BasicTextField(
         value = value,
         onValueChange = { new ->
-            val old = value.text
-            when {
-                new.text.length > old.length -> new.text.substring(old.length).forEach { c ->
-                    val event = if (c == '\n') remoteKeyEvent(Key.Enter, 0) else remoteKeyEvent(Key.Unknown, c.code)
-                    if (event != null) { screen.onKey(event, true); screen.onKey(event, false) }
+            val delta = imeDeltaToPty(ANCHOR, new.text)
+            // The vault's idle auto-lock sees no key or pointer event for this path — the soft
+            // keyboard is its own window — and typing into a session is the plainest evidence
+            // there is that the user is still here (issue #291).
+            if (delta.isNotEmpty()) userActivity()
+            for (ch in delta) {
+                val event = when (ch.code) {
+                    127, 8 -> remoteKeyEvent(Key.Backspace, 0) // DEL / BS
+                    13, 10 -> remoteKeyEvent(Key.Enter, 0) // CR / LF
+                    else -> remoteKeyEvent(Key.Unknown, ch.code)
                 }
-                new.text.length < old.length -> repeat(old.length - new.text.length) {
-                    val backspace = remoteKeyEvent(Key.Backspace, 0) ?: return@repeat
-                    screen.onKey(backspace, true)
-                    screen.onKey(backspace, false)
-                }
+                if (event != null) { screen.onKey(event, true); screen.onKey(event, false) }
             }
-            // Keep a small buffer so the field doesn't grow unbounded; reset when it gets long.
-            value = if (new.text.length > 64) TextFieldValue("") else new
+            value = baseline
         },
-        modifier = Modifier.size(1.dp).focusRequester(focus),
+        // Nothing is drawn in it, so the name is the only thing a reader that lands here gets.
+        modifier = Modifier.size(1.dp).fieldName(stringResource(Res.string.rd_keyboard_input)).focusRequester(focus),
         cursorBrush = androidx.compose.ui.graphics.SolidColor(Color.Transparent),
+        keyboardOptions = KeyboardOptions(
+            capitalization = KeyboardCapitalization.None,
+            autoCorrectEnabled = false,
+            // Password rather than Ascii: it is the variation an IME reads as "do not learn this",
+            // and Ascii alone leaves suggestions and personalised learning on — what is typed here
+            // is a remote login. Nothing is drawn in the field, so masking costs no visual.
+            //
+            // The terminal's funnel deliberately keeps Ascii: a shell needs IME_FLAG_FORCE_ASCII
+            // (which the password variation drops), and the password type also costs glide typing,
+            // voice input and stylus handwriting on the app's primary Android input surface. Here
+            // none of those are worth a keystroke of a remote login screen.
+            keyboardType = KeyboardType.Password,
+            imeAction = ImeAction.None,
+        ),
     )
     LaunchedEffect(Unit) {
         focus.requestFocus()

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
@@ -40,6 +40,7 @@ import app.skerry.ui.app.LocalRunbookRunner
 import app.skerry.ui.app.LocalRunbooks
 import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.design.fieldName
 import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
@@ -123,7 +124,7 @@ fun RunbookPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
 }
 
 @Composable
-private fun RunbookPalette(manager: RunbookManager, onPick: (RunbookEntry) -> Unit) {
+internal fun RunbookPalette(manager: RunbookManager, onPick: (RunbookEntry) -> Unit) {
     // Registered like the snippet palette: it lives in a focusable Popup and must hand the keyboard
     // back to the terminal when it closes.
     rememberModalPresence()
@@ -149,14 +150,16 @@ private fun RunbookPalette(manager: RunbookManager, onPick: (RunbookEntry) -> Un
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Sym("search", size = 15.sp, color = Skerry.colors.faint)
+            val placeholder = stringResource(Res.string.runbook_palette_placeholder)
             Box(Modifier.weight(1f)) {
                 if (query.isEmpty()) {
-                    Txt(stringResource(Res.string.runbook_palette_placeholder), color = Skerry.colors.faint, size = 12.5.sp, font = mono)
+                    Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, font = mono)
                 }
                 BasicTextField(
                     query, { query = it }, singleLine = true, textStyle = style,
                     cursorBrush = SolidColor(Skerry.colors.cyan),
-                    modifier = Modifier.fillMaxWidth().focusRequester(searchFocus),
+                    // The placeholder is the only label this field draws (see fieldName).
+                    modifier = Modifier.fillMaxWidth().focusRequester(searchFocus).fieldName(placeholder),
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/CommandPalette.kt
@@ -45,6 +45,7 @@ import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.term_palette_empty
@@ -142,15 +143,17 @@ private fun PaletteSearch(value: String, onValueChange: (String) -> Unit, mono: 
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Sym("search", size = 16.sp, color = Skerry.colors.faint)
+        val placeholder = stringResource(Res.string.term_palette_placeholder)
         Box(Modifier.weight(1f)) {
-            if (value.isEmpty()) Txt(stringResource(Res.string.term_palette_placeholder), color = Skerry.colors.faint, size = 13.sp, font = mono)
+            if (value.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 13.sp, font = mono)
             BasicTextField(
                 value = value,
                 onValueChange = onValueChange,
                 singleLine = true,
                 textStyle = style,
                 cursorBrush = SolidColor(Skerry.colors.cyan),
-                modifier = Modifier.fillMaxWidth().focusRequester(focus),
+                // The placeholder is the only label this field draws (see fieldName).
+                modifier = Modifier.fillMaxWidth().focusRequester(focus).fieldName(placeholder),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.LocalSnippets
+import app.skerry.ui.design.fieldName
 import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.IconBtn
@@ -116,9 +117,11 @@ internal fun SnippetPalette(manager: SnippetManager, onPick: (SnippetEntry) -> U
             horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Sym("search", size = 15.sp, color = Skerry.colors.faint)
+            val placeholder = stringResource(Res.string.term_run_snippet_placeholder)
             Box(Modifier.weight(1f)) {
-                if (query.isEmpty()) Txt(stringResource(Res.string.term_run_snippet_placeholder), color = Skerry.colors.faint, size = 12.5.sp, font = mono)
-                BasicTextField(query, { query = it }, singleLine = true, textStyle = style, cursorBrush = SolidColor(Skerry.colors.cyan), modifier = Modifier.fillMaxWidth().focusRequester(searchFocus))
+                if (query.isEmpty()) Txt(placeholder, color = Skerry.colors.faint, size = 12.5.sp, font = mono)
+                // The placeholder is the only label this field draws (see fieldName).
+                BasicTextField(query, { query = it }, singleLine = true, textStyle = style, cursorBrush = SolidColor(Skerry.colors.cyan), modifier = Modifier.fillMaxWidth().focusRequester(searchFocus).fieldName(placeholder))
             }
         }
         Column(Modifier.heightIn(max = 300.dp).verticalScroll(rememberScrollState()).padding(top = 6.dp)) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/TerminalScreen.kt
@@ -98,6 +98,8 @@ import app.skerry.shared.terminal.searchTerminal
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.app.LocalUserActivity
 import app.skerry.ui.design.ClaimKeyboard
+import app.skerry.ui.design.fieldName
+import app.skerry.ui.generated.resources.term_keyboard_input
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -1372,7 +1374,8 @@ fun TerminalScreen(
                   }
                   imeValue = imeBaseline
               },
-              modifier = Modifier.size(1.dp).focusRequester(imeFocusRequester),
+              // Nothing is drawn in it, so the name is the only thing a reader that lands here gets.
+              modifier = Modifier.size(1.dp).fieldName(stringResource(Res.string.term_keyboard_input)).focusRequester(imeFocusRequester),
               textStyle = TextStyle(color = Color.Transparent),
               cursorBrush = SolidColor(Color.Transparent),
               keyboardOptions = KeyboardOptions(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/vault/VaultDialogs.kt
@@ -54,6 +54,7 @@ import app.skerry.shared.text.capNotes
 import app.skerry.shared.text.normalizeNotes
 import app.skerry.shared.vault.SshCertificateInspector
 import app.skerry.shared.vault.SshKeyType
+import app.skerry.ui.design.fieldName
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.vault_add
 import app.skerry.ui.generated.resources.vault_add_password
@@ -121,8 +122,6 @@ import app.skerry.ui.design.rememberFieldDraft
 import app.skerry.ui.theme.Skerry
 import androidx.compose.ui.platform.testTag
 import app.skerry.ui.app.UiTags
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.contentDescription
 
 @Composable
 internal fun GenerateKeyDialog(onDismiss: () -> Unit, onCreate: (name: String, type: SshKeyType) -> Unit) {
@@ -446,7 +445,7 @@ internal fun DialogField(
             value = draft.textFieldValue(value),
             onValueChange = { draft.accept(it, value, onValueChange) },
             modifier = Modifier.fillMaxWidth().fieldFocus(draft)
-                .semantics { contentDescription = label }
+                .fieldName(label)
                 .onFocusChanged { focused = it.isFocused },
             singleLine = singleLine,
             textStyle = style,

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantTestFakes.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/ai/AssistantTestFakes.kt
@@ -109,6 +109,14 @@ internal fun terminalAi(reply: String) = TerminalAiController(
     scope = CoroutineScope(Dispatchers.Unconfined),
 )
 
+/** The panel's controller, over the same one-shot provider — enough for the panel to compose. */
+internal fun sessionAssistant(reply: String = "") = SessionAssistantController(
+    policy = AiPolicy.Balanced,
+    settings = { AiSettings(apiKey = "sk-test") },
+    providerFactory = { OneShotProvider(reply) },
+    scope = CoroutineScope(Dispatchers.Unconfined),
+)
+
 internal fun terminalState() = TerminalScreenState(SilentSession(), CoroutineScope(Dispatchers.Unconfined), nowMillis = eagerPublishClock())
 
 /** Ctrl everywhere but macOS — what the selection manager listens for. */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/SearchFieldNamingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/SearchFieldNamingTest.kt
@@ -1,0 +1,292 @@
+package app.skerry.ui.design
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileContentBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.FileItemType
+import app.skerry.shared.graphics.RemoteFramebuffer
+import app.skerry.shared.host.Host
+import app.skerry.ui.ai.AssistantPanel
+import app.skerry.ui.ai.ModelPickerMenu
+import app.skerry.ui.ai.sessionAssistant
+import app.skerry.ui.ai.terminalAi
+import app.skerry.ui.ai.SilentSession
+import app.skerry.ui.ai.terminalState
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.seededRunbooks
+import app.skerry.ui.desktop.seededSnippets
+import app.skerry.ui.desktop.string
+import app.skerry.ui.files.FileEditController
+import app.skerry.ui.files.FileEditorScreen
+import app.skerry.ui.files.PathJumpField
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.assistant_ask_placeholder
+import app.skerry.ui.generated.resources.ftail_fkey_search
+import app.skerry.ui.generated.resources.rd_keyboard_input
+import app.skerry.ui.generated.resources.runbook_palette_placeholder
+import app.skerry.ui.generated.resources.shell_group_name_placeholder
+import app.skerry.ui.generated.resources.shell_password_host_placeholder
+import app.skerry.ui.generated.resources.sftp_edit_buffer
+import app.skerry.ui.generated.resources.sftp_edit_find
+import app.skerry.ui.generated.resources.sftp_path_field
+import app.skerry.ui.generated.resources.term_ai_ask_short
+import app.skerry.ui.generated.resources.term_keyboard_input
+import app.skerry.ui.generated.resources.term_palette_placeholder
+import app.skerry.ui.generated.resources.term_run_snippet_placeholder
+import app.skerry.ui.mobile.MobileAiBarInput
+import app.skerry.ui.mobile.MobileCommandPaletteSheet
+import app.skerry.ui.mobile.MobileGroupCreateDialog
+import app.skerry.ui.mobile.MobileGroupRenameDialog
+import app.skerry.ui.mobile.MobilePasswordSheet
+import app.skerry.ui.mobile.VncImeField
+import app.skerry.ui.remote.FakeRemoteDesktop
+import app.skerry.ui.remote.RemoteDesktopScreenState
+import app.skerry.ui.runbook.RunbookPalette
+import app.skerry.ui.terminal.CommandPalette
+import app.skerry.ui.terminal.SnippetPalette
+import app.skerry.ui.terminal.TerminalScreen
+import app.skerry.ui.terminal.TerminalScreenState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import org.jetbrains.compose.resources.StringResource
+import kotlin.test.Test
+
+/**
+ * Every input the app draws without a caption above it, as a screen reader meets it (issue #228).
+ *
+ * A search box, an ask bar and the soft keyboard's own funnel share a shape: nothing on screen
+ * labels them but a placeholder, which is a sibling text node with no relation to the field. Left
+ * alone the reader announces "edit box" and stops — the case
+ * [Modifier.fieldName]`(fallback = …)` exists for, and the one every palette in the app was
+ * written before it.
+ *
+ * The assertion is deliberately the *lookup*: found by the name, and the node found takes text.
+ * A name that lands on the placeholder label instead of the field would satisfy the first half and
+ * fail the second.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SearchFieldNamingTest {
+
+    @Test
+    fun `the command palette search is named by its placeholder`() =
+        runForm({ CommandPalette(history = null, currentKey = null, onPick = {}, onDismiss = {}) }) {
+            assertNamedInput(Res.string.term_palette_placeholder)
+        }
+
+    @Test
+    fun `the snippet palette search is named by its placeholder`() =
+        runForm({ SnippetPalette(seededSnippets()) {} }) {
+            assertNamedInput(Res.string.term_run_snippet_placeholder)
+        }
+
+    @Test
+    fun `the runbook palette search is named by its placeholder`() =
+        runForm({ RunbookPalette(seededRunbooks()) {} }) {
+            assertNamedInput(Res.string.runbook_palette_placeholder)
+        }
+
+    @Test
+    fun `the model picker search is named by the placeholder it was given`() =
+        runForm({ modelPicker() }) {
+            onNodeWithContentDescription(MODEL_SEARCH).assert(hasSetTextAction())
+        }
+
+    /**
+     * The desktop settings screen composes this menu inside `FormField("Model")`, and a popup is a
+     * subcomposition — so the combo's caption reaches the menu and would name the search box after
+     * the field it belongs to. Two platforms, one composable, two different names: on the phone the
+     * menu is drawn in the page flow with no caption over it.
+     */
+    @Test
+    fun `the model picker search keeps its own name inside a captioned form field`() =
+        runForm({ FormField(FORM_CAPTION) { modelPicker() } }) {
+            onNodeWithContentDescription(MODEL_SEARCH).assert(hasSetTextAction())
+            onNodeWithContentDescription(FORM_CAPTION).assertDoesNotExist()
+        }
+
+    /**
+     * Parity: the phone draws the same palettes and sheets through `MobileFormInput`, which had a
+     * placeholder in hand and passed no fallback — so every one of them the phone shows without a
+     * caption above it was still an unnamed edit box.
+     */
+    @Test
+    fun `the mobile palette search is named by its placeholder`() =
+        runForm({ MobileCommandPaletteSheet(history = null, currentKey = null, onPick = {}, onDismiss = {}) }) {
+            assertNamedInput(Res.string.term_palette_placeholder)
+        }
+
+    @Test
+    fun `the assistant ask box is named by its placeholder`() =
+        runForm({ AssistantPanel(sessionAssistant(), terminal = null, modelLabel = "opus") }) {
+            assertNamedInput(Res.string.assistant_ask_placeholder)
+        }
+
+    @Test
+    fun `the mobile ask bar is named by its placeholder`() =
+        runForm({ MobileAiBarInput(terminalAi(reply = "uptime"), terminalState()) }) {
+            assertNamedInput(Res.string.term_ai_ask_short)
+        }
+
+    /** No placeholder at all here: the field is prefilled with the path, so it names itself. */
+    @Test
+    fun `the path jump field names itself`() =
+        runForm({
+            PathJumpField(
+                path = "/var/log",
+                mono = FontFamily.Monospace,
+                textSize = 12.sp,
+                onCommit = {},
+                onCancel = {},
+            ) { inner -> inner() }
+        }) {
+            assertNamedInput(Res.string.sftp_path_field)
+        }
+
+    @Test
+    fun `the file editor buffer names itself`() = withEditor { controller ->
+        runForm({ FileEditorScreen(controller, onClose = {}, modifier = Modifier.fillMaxSize()) }) {
+            assertNamedInput(Res.string.sftp_edit_buffer)
+        }
+    }
+
+    /** The find bar's caption is a sibling `Txt`, so the field has to adopt it explicitly. */
+    @Test
+    fun `the file editor find bar is named by the caption beside it`() = withEditor { controller ->
+        runForm({ FileEditorScreen(controller, onClose = {}, modifier = Modifier.fillMaxSize()) }) {
+            onNodeWithText(string(Res.string.ftail_fkey_search), substring = true).performClick()
+            waitForIdle()
+            assertNamedInput(Res.string.sftp_edit_find)
+        }
+    }
+
+    /**
+     * The terminal's soft-keyboard funnel is a 1dp field with nothing drawn in it — the one input
+     * on the phone that a reader can reach and cannot possibly identify from the screen.
+     */
+    @Test
+    fun `the terminal soft-keyboard funnel is named`() {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val state = TerminalScreenState(SilentSession(), scope)
+        // A failing assertion is exactly what this test exists to produce, and the terminal's
+        // outbound writer waits on a channel that is never closed: cancelled in a finally, or a
+        // regression here leaks a coroutine into every test that runs after it.
+        try {
+            runForm({
+                Box(Modifier.fillMaxSize()) { TerminalScreen(state, Modifier.fillMaxSize(), imeInput = true) }
+            }) {
+                assertNamedInput(Res.string.term_keyboard_input)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** Same funnel on the remote-desktop screen, feeding RFB key events instead of a PTY. */
+    @Test
+    fun `the remote desktop soft-keyboard funnel is named`() {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val screen = RemoteDesktopScreenState(FakeRemoteDesktop(framebuffer = RemoteFramebuffer(4, 4)), scope)
+        try {
+            runForm({ VncImeField(screen) {} }) { assertNamedInput(Res.string.rd_keyboard_input) }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /**
+     * A placeholder is only a name when it names the field. `MobilePasswordSheet` draws the masking
+     * dots as its placeholder and its caption as a plain sibling `Txt`, so the fallback alone made
+     * a reader announce the glyphs — on the one field of the app that holds an SSH password.
+     */
+    @Test
+    fun `the connect password field is named by its caption, not by the masking dots`() =
+        runForm({ MobilePasswordSheet(HOST, onDismiss = {}, onConnect = {}) }) {
+            onNodeWithContentDescription(string(Res.string.shell_password_host_placeholder)).assert(hasSetTextAction())
+            onNodeWithContentDescription(MASK_DOTS).assertDoesNotExist()
+        }
+
+    /** Same shape with an example value for a placeholder: "Production" is not what the field is. */
+    @Test
+    fun `the group name field is named by what it holds, not by the example in it`() =
+        runForm({ MobileGroupCreateDialog(onDismiss = {}, onCreate = {}) }) {
+            assertNamedInput(Res.string.shell_group_name_placeholder)
+        }
+
+    /** The rename dialog prefills the old name, so its placeholder never draws — and still named it. */
+    @Test
+    fun `the group rename field is named too`() =
+        runForm({ MobileGroupRenameDialog(initialName = "Production", onDismiss = {}, onSave = {}, onDelete = {}) }) {
+            assertNamedInput(Res.string.shell_group_name_placeholder)
+        }
+
+    @Composable
+    private fun modelPicker() = ModelPickerMenu(
+        models = listOf("claude-opus-5"),
+        selected = "claude-opus-5",
+        favorites = emptySet(),
+        onToggleFavorite = {},
+        onSelect = {},
+        emptyText = "none",
+        searchPlaceholder = MODEL_SEARCH,
+    )
+
+    private fun androidx.compose.ui.test.ComposeUiTest.assertNamedInput(name: StringResource) {
+        onNodeWithContentDescription(string(name)).assert(hasSetTextAction())
+    }
+}
+
+/** A buffer already loaded, so the editor draws the field rather than its loading notice. */
+private fun withEditor(body: (FileEditController) -> Unit) {
+    val item = FileItem("nginx.conf", PATH, FileItemType.File, CONTENT.length.toLong(), 100)
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    try {
+        body(
+            FileEditController(
+                source = InMemoryFile(item),
+                item = item,
+                readOnly = false,
+                scope = scope,
+            ).also { it.open() },
+        )
+    } finally {
+        scope.cancel()
+    }
+}
+
+/** The one file the editor test opens; navigation is never exercised. */
+private class InMemoryFile(private val item: FileItem) : FileContentBrowser, FileBrowser {
+    override val label = "prod-web-01"
+    override suspend fun realpath(path: String) = path
+    override suspend fun list(path: String): List<FileItem> = emptyList()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+    override suspend fun stat(path: String): FileItem = item
+    override suspend fun readFile(path: String, maxBytes: Long): ByteArray = CONTENT.encodeToByteArray()
+    override suspend fun writeFile(path: String, data: ByteArray) = Unit
+}
+
+private const val PATH = "/etc/nginx/nginx.conf"
+private const val CONTENT = "server {\n}\n"
+private const val MODEL_SEARCH = "Search models…"
+
+/** What `MobilePasswordSheet` draws in the empty field — glyphs to be seen, never spoken. */
+private const val MASK_DOTS = "••••••••"
+
+private val HOST = Host("h1", "prod-web-01", "192.168.1.45", 22, "root")
+
+/** Any caption will do — what matters is that one is in scope at all. */
+private const val FORM_CAPTION = "Model"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/RemoteMenuCheckRowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/RemoteMenuCheckRowTest.kt
@@ -1,0 +1,41 @@
+package app.skerry.ui.remote
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.assertIsToggleable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The remote-desktop session menu's tick rows (issue #228).
+ *
+ * Same shape as the broadcast and import rows covered in
+ * [app.skerry.ui.session.BroadcastFormTest] and [app.skerry.ui.mobile.MobileCheckRowTest]: the tick
+ * is a Material Symbol ligature and `Sym` clears its own semantics, so the row is the only node
+ * that can say it is a checkbox and which way it is set. This one is reached from a menu the shell
+ * tests never open, which is how it stayed the uncovered member of the set.
+ */
+@OptIn(ExperimentalTestApi::class)
+class RemoteMenuCheckRowTest {
+
+    @Test
+    fun `a menu check row reads as a checkbox and flips`() {
+        var toggles = 0
+        val checked = mutableStateOf(false)
+        runForm({
+            CheckRow(LABEL, checked.value) { toggles++; checked.value = !checked.value }
+        }) {
+            onNodeWithText(LABEL).assertIsToggleable().assertIsOff().performClick()
+            waitForIdle()
+            onNodeWithText(LABEL).assertIsOn()
+        }
+        assertTrue(toggles == 1, "the row's toggle reached the caller $toggles times, not once")
+    }
+}
+
+private const val LABEL = "View only"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/VncImeFunnelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/remote/VncImeFunnelTest.kt
@@ -1,0 +1,107 @@
+package app.skerry.ui.remote
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import app.skerry.shared.graphics.RemoteFramebuffer
+import app.skerry.ui.app.LocalUserActivity
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.mobile.VncImeField
+import app.skerry.ui.terminal.ANCHOR
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * What the remote desktop's soft-keyboard funnel is allowed to keep, and what it owes the rest of
+ * the app.
+ *
+ * Everything typed here goes to a remote machine, and on a Windows or VNC login screen that is a
+ * password. The field held the last 64 characters of it in its own `TextFieldValue` — which is
+ * `EditableText` in the semantics tree, readable by any accessibility service. The terminal's
+ * funnel has diffed against a constant anchor since it was written
+ * ([app.skerry.ui.terminal.imeDeltaToPty]); this one now does the same, and reports typing to the
+ * idle auto-lock the same way (issue #291's policy: every kind of input defers the lock).
+ */
+@OptIn(ExperimentalTestApi::class)
+class VncImeFunnelTest {
+
+    @Test
+    fun `typing reaches the session without being retained in the field`() = withFunnel { session, _ ->
+        onNode(hasSetTextAction()).performTextInput(TYPED)
+
+        assertEquals(
+            TYPED.toList(),
+            session.keys.filter { it.second }.mapNotNull { it.first.codePoint.takeIf { c -> c != 0 }?.toChar() },
+            "the characters typed did not reach the remote desktop",
+        )
+        assertEquals(
+            ANCHOR,
+            editableText(),
+            "the funnel kept what was typed — on a login screen that is the password",
+        )
+    }
+
+    /**
+     * The deletion the anchor exists for: nothing has been typed since the last reset, so without
+     * it the field is empty, there is nothing for the IME to delete, and the Backspace a user just
+     * pressed at a login prompt never reaches the server.
+     */
+    @Test
+    fun `a backspace on an untouched field still reaches the session`() = withFunnel { session, _ ->
+        onNode(hasSetTextAction()).performTextClearance()
+
+        val backspace = remoteKeyEvent(Key.Backspace, 0)
+        assertTrue(
+            session.keys.any { it.first.keySym == backspace?.keySym && it.second },
+            "clearing the field sent ${session.keys.size} events, none of them a backspace",
+        )
+        assertEquals(ANCHOR, editableText(), "the field did not return to the anchor after a deletion")
+    }
+
+    /**
+     * The soft keyboard is its own window: it produces neither a key event nor a pointer event, so
+     * `Modifier.idleActivity` sees nothing and the vault locks on top of a session being typed into.
+     */
+    @Test
+    fun `typing through the funnel defers the idle auto-lock`() {
+        var reported = false
+        withFunnel(onActivity = { reported = true }) { _, _ ->
+            onNode(hasSetTextAction()).performTextInput("a")
+        }
+        assertTrue(reported, "typing through the soft keyboard never reached the idle timer")
+    }
+
+    private fun ComposeUiTest.editableText(): String? =
+        onNode(hasSetTextAction()).fetchSemanticsNode().config.getOrNull(SemanticsProperties.EditableText)?.text
+
+    private fun withFunnel(
+        onActivity: () -> Unit = {},
+        body: ComposeUiTest.(FakeRemoteDesktop, RemoteDesktopScreenState) -> Unit,
+    ) {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val session = FakeRemoteDesktop(framebuffer = RemoteFramebuffer(4, 4))
+        val screen = RemoteDesktopScreenState(session, scope)
+        try {
+            runForm({
+                CompositionLocalProvider(LocalUserActivity provides onActivity) { VncImeField(screen) {} }
+            }) {
+                waitForIdle()
+                body(session, screen)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+}
+
+private const val TYPED = "hunter2"


### PR DESCRIPTION
Closes #228.

A search box, an ask bar and a soft-keyboard funnel share a shape: nothing on screen labels them but a placeholder, which is a sibling text node with no relation to the field. A reader announced "edit box" and stopped.

## Inputs that now have a name

| Where | Name it announces |
|---|---|
| Command / snippet / runbook palettes, model picker, assistant ask bar and its mobile twin | their placeholder, via `Modifier.fieldName(fallback = …)` |
| Every phone sheet and dialog drawn through `MobileFormInput` | its placeholder — one fallback covers them all |
| Path jump field, file editor buffer, file editor find bar | new strings, en + ru + zh |
| The two 1dp funnels the soft keyboard types into (terminal, remote desktop) | "Terminal input" / "Remote desktop input" |

A caption above a field still outranks the fallback — that precedence is the documented contract of `LocalFieldLabel` and it did not change.

Three fields needed more than a fallback:

- **`ModelPickerMenu`** resets `LocalFieldLabel` around its search row. A popup is a subcomposition, so the `FormField("Model")` caption of the combo it drops out of reached the box inside and named it after the trigger, while the phone — which draws the same menu in the page flow — called it "Search models…". One composable, two platforms, two names.
- **`MobilePasswordSheet`** and **both group dialogs** draw their caption as a bare sibling `Txt`, so the fallback would have named them after what is drawn *in* the field: the masking glyphs `••••••••`, and the example value "Production", untranslated in every locale. They now announce the same names their desktop twins already use (`shell_password_host_placeholder`, `shell_group_name_placeholder`).

The checkbox half of the issue — `toggleable(role = Role.Checkbox)` on the four glyph rows — was already in `main`; this adds the one test that was missing, for the remote-desktop menu's row.

## The remote desktop's funnel changed behaviour

`VncImeField` kept the last 64 characters typed into it in its own `TextFieldValue`. That value is `EditableText` in the semantics tree, readable by any accessibility service, and on a Windows or VNC login screen it is a password. It also carried no `KeyboardOptions`, so those characters went to the IME with autocorrect and personalised learning on.

It now does what the terminal's funnel has always done: diff against a constant anchor (`imeDeltaToPty`) and reset after every change, so the field holds nothing. It asks for a password keyboard, which is the input-type variation an IME reads as "do not learn this". And it reports typing to the vault's idle auto-lock — a soft keyboard is its own window and produces neither a key nor a pointer event, so #291's policy had a hole exactly here: type into a remote desktop without touching the screen and the vault locked on top of the live session.

The terminal's funnel deliberately keeps `KeyboardType.Ascii`: a shell needs `IME_FLAG_FORCE_ASCII`, which the password variation drops, and the password type also costs glide typing, voice input and stylus handwriting on the app's primary Android input surface. The reasoning is in the comment beside the VNC one.

## Tests

`SearchFieldNamingTest` (16 cases) looks each field up *by its accessible name* and asserts the node found takes text — a name that landed on the placeholder label instead of the field would satisfy the first half and fail the second. `VncImeFunnelTest` covers the funnel: characters reach the session, nothing is retained, a backspace on an untouched field still reaches the server, and typing defers the idle lock. All three fail with the funnel reverted.

## Verifying by eye

Desktop, Orca or NVDA on: open the command palette (`Ctrl+K`), the snippet palette and the model picker in Settings → AI, and tab into the search box — each should be announced by its placeholder, and the model picker's should say "Search models…", not "Model".

Android, TalkBack on: connect to a host that asks for a password — the field is "connection password", not eight bullets. Open Connections → new group — "Group name", not "Production". Open a remote desktop, raise the keyboard and swipe to the field — "Remote desktop input".

## Not verified

Android device, live SSH/RDP/VNC server. Everything above was run on the desktop JVM target only; the Android side is compile-verified (`:androidApp:compileDebugKotlin`). The TalkBack phrasing for a password-typed field and the exact behaviour of a third-party IME under `TYPE_TEXT_VARIATION_PASSWORD` both want a pass on a real device.