### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
 # The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.3.4
-skerry.versionCode=13
+skerry.versionName=0.4.0
+skerry.versionCode=14

--- a/server/README.md
+++ b/server/README.md
@@ -24,8 +24,8 @@ unavailable to the server.
 
 Multi-arch images (amd64 + arm64) are published to Docker Hub as
 [`secherkasov/skerry-sync`](https://hub.docker.com/r/secherkasov/skerry-sync) — tags:
-exact `<version>`, `<major.minor>`, `latest`. The server is released on its own cadence,
-independently of the Skerry client versions.
+exact `<version>`, `<major.minor>`, `latest`. The server is released separately from the clients — its own
+`server-v*` tag and its own workflow. Its version numbers have matched the client release so far.
 
 ```bash
 docker run -d --name skerry-sync \

--- a/server/README.ru.md
+++ b/server/README.ru.md
@@ -24,8 +24,8 @@ Vaultwarden). Сервер хранит **только шифротекст** �
 
 Мультиархитектурные образы (amd64 + arm64) публикуются на Docker Hub как
 [`secherkasov/skerry-sync`](https://hub.docker.com/r/secherkasov/skerry-sync) — теги:
-точная `<версия>`, `<major.minor>`, `latest`. Сервер релизится в своём собственном темпе,
-независимо от версий клиентов Skerry.
+точная `<версия>`, `<major.minor>`, `latest`. Сервер релизится отдельно от клиентов — своим тегом
+`server-v*` и своим workflow. Номера версий до сих пор совпадали с клиентским релизом.
 
 ```bash
 docker run -d --name skerry-sync \

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.4"
+version = "0.4.0"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.3.4"
+version = "0.4.0"
 
 kotlin {
     jvmToolchain(21)


### PR DESCRIPTION
Release 0.4.0 for the clients and the sync server.

- `gradle.properties` — `skerry.versionName` 0.3.4 → 0.4.0, `skerry.versionCode` 13 → 14
- `server/build.gradle.kts`, `sync-wire/build.gradle.kts` — `version` 0.3.4 → 0.4.0

Minor rather than patch: since 0.3.4 the library gained folders for snippets, runbooks and keychain
secrets, snippets gained notes, a trust prompt now stands in front of an SSH host key and an RDP
certificate, the idle auto-lock counts every kind of user input, and an RDP session is drawn at the
display's real DPI. New fields are defaulted, so records written before 0.4.0 read back unchanged.

`server/` and `sync-wire/` carry no code changes since 0.3.4 — the wire contract is unmoved and a
0.4.0 client talks to a 0.3.4 server. The server is rebuilt under the new number so the two stay in
step, as every prior release did.

`server/README` no longer claims the server is versioned independently of the clients: the release
mechanism is separate (its own `server-v*` tag and workflow), but the numbers have matched since
0.1.2.