### PR TITLE
Team device count, and "New scope" in the screen header

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -282,7 +282,7 @@
     <string name="lib_teams_card_storage">Хранит</string>
     <string name="lib_teams_card_storage_value">только шифртекст</string>
     <string name="lib_teams_card_version">Версия</string>
-    <string name="lib_teams_card_devices">Устройства</string>
+    <string name="lib_teams_card_devices">Устройства команды</string>
     <string name="lib_teams_card_devices_value">привязано: %1$d</string>
     <string name="lib_teams_card_shared">Общее в команде</string>
     <string name="lib_teams_card_hosts">Хосты</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -276,7 +276,7 @@
     <string name="lib_teams_card_storage">存储</string>
     <string name="lib_teams_card_storage_value">仅密文</string>
     <string name="lib_teams_card_version">版本</string>
-    <string name="lib_teams_card_devices">设备</string>
+    <string name="lib_teams_card_devices">团队设备</string>
     <string name="lib_teams_card_devices_value">已配对 %1$d 台</string>
     <string name="lib_teams_card_shared">团队共享</string>
     <string name="lib_teams_card_hosts">主机</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -279,7 +279,7 @@
     <string name="lib_teams_card_storage">Storage</string>
     <string name="lib_teams_card_storage_value">ciphertext only</string>
     <string name="lib_teams_card_version">Version</string>
-    <string name="lib_teams_card_devices">Devices</string>
+    <string name="lib_teams_card_devices">Team devices</string>
     <string name="lib_teams_card_devices_value">%1$d paired</string>
     <string name="lib_teams_card_shared">Shared with the team</string>
     <string name="lib_teams_card_hosts">Hosts</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -114,6 +115,7 @@ import app.skerry.ui.teams.TeamUi
 import app.skerry.ui.teams.CreateScopeDialog
 import app.skerry.ui.teams.ScopeAccess
 import app.skerry.ui.teams.ScopeAccessDialog
+import app.skerry.ui.teams.NewScopeButton
 import app.skerry.ui.teams.ScopeSection
 import app.skerry.ui.teams.TeamsCoordinator
 import app.skerry.ui.teams.teamsFailureText
@@ -409,6 +411,38 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     }
 }
 
+/**
+ * The phone's team actions. Its own composable for the same reason as the desktop header's: the
+ * screen around it needs a live coordinator, and both the New-scope button's placement and this
+ * row's wrapping have to be assertable without one.
+ */
+@Composable
+internal fun MobileTeamActions(
+    lastSyncedAt: Long?,
+    busy: Boolean,
+    canManage: Boolean,
+    canAudit: Boolean,
+    onSync: () -> Unit,
+    onShowHistory: () -> Unit,
+    onNewScope: () -> Unit,
+    onInvite: () -> Unit,
+) {
+    // A manager sees four actions here and a Row would measure the last of them — Invite — into
+    // whatever is left of a phone's width. It wraps instead; nothing is pushed off the screen.
+    FlowRow(
+        Modifier.fillMaxWidth().padding(top = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        itemVerticalAlignment = Alignment.CenterVertically,
+    ) {
+        // How stale the screen is, and the way to fix that — the same pill the desktop header carries.
+        SyncPill(lastSyncedAt, onSync)
+        if (canAudit) GhostButton(stringResource(Res.string.lib_teams_history), onClick = onShowHistory, icon = "history")
+        if (canManage) NewScopeButton(onClick = onNewScope, enabled = !busy)
+        if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
+    }
+}
+
 @Composable
 private fun MobileTeamDetail(
     tc: TeamsCoordinator,
@@ -479,12 +513,16 @@ private fun MobileTeamDetail(
         Txt(stringResource(Res.string.lib_teams_no_key), color = Skerry.colors.amber, size = 12.sp, modifier = Modifier.padding(top = 10.dp))
     }
 
-    Row(Modifier.padding(top = 12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-        // How stale the screen is, and the way to fix that — the same pill the desktop header carries.
-        SyncPill(lastSyncedAt, onSync)
-        if (canAudit) GhostButton(stringResource(Res.string.lib_teams_history), onClick = onShowHistory, icon = "history")
-        if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
-    }
+    MobileTeamActions(
+        lastSyncedAt = lastSyncedAt,
+        busy = busy,
+        canManage = canManage,
+        canAudit = canAudit,
+        onSync = onSync,
+        onShowHistory = onShowHistory,
+        onNewScope = onNewScope,
+        onInvite = onInvite,
+    )
 
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_scopes))
     ScopeSection(
@@ -492,7 +530,6 @@ private fun MobileTeamDetail(
         selected = scopeId,
         canManage = canManage,
         onSelect = onSelectScope,
-        onNew = onNewScope,
         onAccess = onScopeAccess,
         onDelete = { onConfirm(MobileTeamsConfirm.DeleteScope(team.id, it.id)) },
     )
@@ -553,7 +590,7 @@ private fun MobileTeamDetail(
     // The same three summary cards as the desktop screen, stacked; the lists they lead to on the
     // desktop are already on this screen, so the counts here are plain facts.
     TeamSummaryCardsStacked(
-        cards = teamCards(tc, team, scopeId, tick, teamFeed(tc, team, tick, canAudit)),
+        cards = teamCards(tc, team, scopeId, tick, teamFeed(tc, team, tick, canAudit), members),
         modifier = Modifier.padding(top = 24.dp),
     )
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScopesUi.kt
@@ -60,14 +60,15 @@ import org.jetbrains.compose.resources.stringResource
  * always first — records without a scope stay visible to everyone, as they were before scopes
  * existed. A scope whose key never reached us is shown greyed out: a manager may see it listed and
  * delete it, but its records are ciphertext to them.
+ *
+ * Chips only. Creating a scope is a team action and lives in the screen's header beside Invite —
+ * a button in this row is a different shape from everything around it.
  */
 @Composable
 private fun ScopeChipRow(
     scopes: List<TeamScopeUi>,
     selected: String,
-    canManage: Boolean,
     onSelect: (String) -> Unit,
-    onNew: () -> Unit,
 ) {
     FlowRow(
         Modifier.fillMaxWidth(),
@@ -78,10 +79,13 @@ private fun ScopeChipRow(
         scopes.forEach { scope ->
             ScopeChip(untrustedLabel(scope.name), active = selected == scope.id, muted = !scope.hasKey) { onSelect(scope.id) }
         }
-        if (canManage) {
-            GhostButton(stringResource(Res.string.lib_teams_scope_new), onClick = onNew, icon = "add")
-        }
     }
+}
+
+/** "New scope" as the screen headers carry it — one button, the same on desktop and on the phone. */
+@Composable
+internal fun NewScopeButton(onClick: () -> Unit, enabled: Boolean = true) {
+    GhostButton(stringResource(Res.string.lib_teams_scope_new), onClick = onClick, icon = "add", enabled = enabled)
 }
 
 /**
@@ -95,16 +99,21 @@ internal fun ScopeSection(
     selected: String,
     canManage: Boolean,
     onSelect: (String) -> Unit,
-    onNew: () -> Unit,
     onAccess: (TeamScopeUi) -> Unit,
     onDelete: (TeamScopeUi) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
-        ScopeChipRow(scopes = scopes, selected = selected, canManage = canManage, onSelect = onSelect, onNew = onNew)
+        ScopeChipRow(scopes = scopes, selected = selected, onSelect = onSelect)
         val active = scopes.firstOrNull { it.id == selected } ?: return@Column
         if (canManage) {
-            Row(Modifier.padding(top = 10.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            // Wraps rather than a Row: on a phone at a large text scale "Delete scope" is the button
+            // that would land off the edge, and the column around it only scrolls vertically.
+            FlowRow(
+                Modifier.fillMaxWidth().padding(top = 10.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
                 GhostButton(stringResource(Res.string.lib_teams_scope_access), onClick = { onAccess(active) }, icon = "key")
                 GhostButton(
                     stringResource(Res.string.lib_teams_scope_delete),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -132,6 +132,7 @@ internal fun TeamScreen(
         invited = invited,
         onSync = onSync,
         onInvite = onInvite,
+        onNewScope = onNewScope,
         onLeave = { onConfirm(TeamsConfirm.Leave(team.id)) },
         onDelete = { onConfirm(TeamsConfirm.Delete(team.id)) },
     )
@@ -148,7 +149,7 @@ internal fun TeamScreen(
                     modifier = Modifier.padding(horizontal = 22.dp, vertical = 12.dp),
                 )
             }
-            ScopeStrip(team, scopeId, canManage, onSelectScope, onNewScope, onScopeAccess, onDeleteScope = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) })
+            ScopeStrip(team, scopeId, canManage, onSelectScope, onScopeAccess, onDeleteScope = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) })
             val rows = remember(team, members, grants, canManage) {
                 teamMemberRows(team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true)
             }
@@ -162,7 +163,7 @@ internal fun TeamScreen(
                 onRemove = { onConfirm(TeamsConfirm.Remove(team.id, it.member.accountId)) },
             )
             TeamSummaryCards(
-                cards = teamCards(tc, team, scopeId, tick, feed),
+                cards = teamCards(tc, team, scopeId, tick, feed, members),
                 onOpen = onOpenShared,
                 modifier = Modifier.padding(horizontal = 22.dp, vertical = 16.dp),
             )
@@ -182,6 +183,7 @@ private fun TeamHeader(
     invited: Boolean,
     onSync: () -> Unit,
     onInvite: () -> Unit,
+    onNewScope: () -> Unit,
     onLeave: () -> Unit,
     onDelete: () -> Unit,
 ) {
@@ -189,11 +191,44 @@ private fun TeamHeader(
         title = stringResource(Res.string.lib_teams_header_title),
         subtitle = stringResource(Res.string.lib_teams_header_subtitle, untrustedLabel(team.name), team.memberCount),
         actions = {
-            if (!invited) SyncPill(lastSyncedAt, onSync)
-            if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
-            if (!invited) TeamOverflowMenu(owner = owner, onLeave = onLeave, onDelete = onDelete)
+            TeamHeaderActions(
+                lastSyncedAt = lastSyncedAt,
+                busy = busy,
+                owner = owner,
+                canManage = canManage,
+                invited = invited,
+                onSync = onSync,
+                onNewScope = onNewScope,
+                onInvite = onInvite,
+                onLeave = onLeave,
+                onDelete = onDelete,
+            )
         },
     )
+}
+
+/**
+ * The header's action set. Its own composable rather than a lambda in [TeamHeader] because the
+ * screen around it needs a live coordinator to draw at all: creating a share space is reachable
+ * from here and from nowhere else, and that has to be assertable without one.
+ */
+@Composable
+internal fun TeamHeaderActions(
+    lastSyncedAt: Long?,
+    busy: Boolean,
+    owner: Boolean,
+    canManage: Boolean,
+    invited: Boolean,
+    onSync: () -> Unit,
+    onNewScope: () -> Unit,
+    onInvite: () -> Unit,
+    onLeave: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    if (!invited) SyncPill(lastSyncedAt, onSync)
+    if (canManage) NewScopeButton(onClick = onNewScope, enabled = !busy)
+    if (canManage) PrimaryButton(stringResource(Res.string.lib_teams_invite), onClick = onInvite, icon = "person_add", enabled = !busy)
+    if (!invited) TeamOverflowMenu(owner = owner, onLeave = onLeave, onDelete = onDelete)
 }
 
 /** "synced 12 s ago" — and the way to sync now, since the two are the same question. */
@@ -268,7 +303,6 @@ private fun ScopeStrip(
     scopeId: String,
     canManage: Boolean,
     onSelect: (String) -> Unit,
-    onNew: () -> Unit,
     onAccess: (TeamScopeUi) -> Unit,
     onDeleteScope: (TeamScopeUi) -> Unit,
 ) {
@@ -283,7 +317,6 @@ private fun ScopeStrip(
             selected = scopeId,
             canManage = canManage,
             onSelect = onSelect,
-            onNew = onNew,
             onAccess = onAccess,
             onDelete = onDeleteScope,
         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSummaryCards.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSummaryCards.kt
@@ -48,6 +48,7 @@ internal data class TeamCards(
     val lastRekeyAt: Long?,
     val endpoint: String?,
     val serverVersion: String?,
+    /** Devices of the team's own active members — see [teamDeviceCount], null when unknowable. */
     val devices: Int?,
     val hosts: Int,
     val snippets: Int,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenData.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenData.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import app.skerry.shared.sync.AccountSummary
 import app.skerry.shared.team.TeamActivityDay
 import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.buildTeamActivityFeed
 import app.skerry.shared.vault.RecordType
 import app.skerry.ui.app.LocalSharedSessions
@@ -80,7 +81,14 @@ private data class ServerFacts(val endpoint: String?, val summary: AccountSummar
 
 /** Counts and server facts behind the three summary cards. */
 @Composable
-internal fun teamCards(tc: TeamsCoordinator, team: TeamUi, scopeId: String, tick: Int, feed: List<TeamActivityDay>): TeamCards {
+internal fun teamCards(
+    tc: TeamsCoordinator,
+    team: TeamUi,
+    scopeId: String,
+    tick: Int,
+    feed: List<TeamActivityDay>,
+    members: List<TeamMember>,
+): TeamCards {
     val sync = LocalSync.current
     val shares = LocalSharedSessions.current
     val counts = remember(team.id, scopeId, tick) {
@@ -102,7 +110,7 @@ internal fun teamCards(tc: TeamsCoordinator, team: TeamUi, scopeId: String, tick
         lastRekeyAt = lastRekeyAt(feed),
         endpoint = server?.endpoint,
         serverVersion = server?.summary?.serverVersion,
-        devices = server?.summary?.devices,
+        devices = remember(members) { teamDeviceCount(members) },
         hosts = counts[RecordType.HOST] ?: 0,
         snippets = counts[RecordType.SNIPPET] ?: 0,
         runbooks = counts[RecordType.RUNBOOK] ?: 0,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
@@ -61,6 +61,21 @@ fun teamMemberRows(
         }
 }
 
+/**
+ * How many devices this team is reachable on: the paired devices of its active members. An invitee
+ * has not adopted the team key yet, so their devices are not the team's.
+ *
+ * Null when the answer isn't knowable rather than a total that is silently short — a server that
+ * doesn't report the per-member count, and an empty member list. Empty means the list hasn't landed
+ * (first frame, no session, a failed call): a team the screen can draw always has at least its
+ * owner, so "no active members" is never a fact about the team.
+ */
+fun teamDeviceCount(members: List<TeamMember>): Int? {
+    val active = members.filter { it.status == TeamMemberStatus.ACTIVE }
+    if (active.isEmpty() || active.any { it.devices == null }) return null
+    return active.sumOf { it.devices ?: 0 }
+}
+
 /** Sort rank of a role, highest privilege first. */
 private val TeamRole.rank: Int
     get() = when (this) {

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
@@ -28,7 +28,8 @@ class TeamsScreenModelTest {
         role: TeamRole,
         status: TeamMemberStatus = TeamMemberStatus.ACTIVE,
         lastSeenAt: Long? = null,
-    ) = TeamMember(id, role, status, createdAt = 0, lastSeenAt = lastSeenAt)
+        devices: Int? = null,
+    ) = TeamMember(id, role, status, createdAt = 0, lastSeenAt = lastSeenAt, devices = devices)
 
     private fun team(role: TeamRole) = TeamUi(
         id = "team-1",
@@ -43,6 +44,38 @@ class TeamsScreenModelTest {
             TeamScopeUi(id = "s-db", name = "db", memberCount = 1, hasKey = true),
         ),
     )
+
+    @Test
+    fun `the device count is the team's own, and an invite has not brought its devices in yet`() {
+        val count = teamDeviceCount(
+            listOf(
+                member(owner, TeamRole.OWNER, devices = 2),
+                member(admin, TeamRole.ADMIN, devices = 3),
+                member(invitee, TeamRole.VIEWER, TeamMemberStatus.INVITED, devices = 4),
+            ),
+        )
+        assertEquals(5, count)
+    }
+
+    @Test
+    fun `a server that does not report device counts leaves the number unknown, not zero`() {
+        assertNull(teamDeviceCount(listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN))))
+        // One member unreported makes the sum an undercount — say nothing rather than a wrong total.
+        assertNull(teamDeviceCount(listOf(member(owner, TeamRole.OWNER, devices = 2), member(admin, TeamRole.ADMIN))))
+    }
+
+    @Test
+    fun `a member list that has not landed is unknown, not a team with no devices`() {
+        // Offline, a failed members call and the first frame all arrive as an empty list. A team the
+        // screen can draw has at least its owner, so this is never a fact about the team.
+        assertNull(teamDeviceCount(emptyList()))
+        assertNull(teamDeviceCount(listOf(member(invitee, TeamRole.VIEWER, TeamMemberStatus.INVITED, devices = 3))))
+    }
+
+    @Test
+    fun `a member whose every device was revoked counts as zero, which is a fact`() {
+        assertEquals(2, teamDeviceCount(listOf(member(owner, TeamRole.OWNER, devices = 2), member(admin, TeamRole.ADMIN, devices = 0))))
+    }
 
     @Test
     fun `the table lists active members by rank and keeps invitees last`() {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeChromeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeChromeTest.kt
@@ -1,0 +1,141 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.mobile.MobileTeamActions
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_invite
+import app.skerry.ui.generated.resources.lib_teams_scope_access
+import app.skerry.ui.generated.resources.lib_teams_scope_delete
+import app.skerry.ui.generated.resources.lib_teams_scope_new
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.getString
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Where the scope chrome puts its actions. Creating a scope is a team action and belongs in the
+ * screen header beside Invite; the chip row draws chips and nothing else. A manager is the only
+ * viewer who could see the button, so that is the case worth pinning — this ran green before the
+ * move with the button in the wrong place, because nothing tested it with `canManage = true`.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TeamScopeChromeTest {
+
+    private val newScope = runBlocking { getString(Res.string.lib_teams_scope_new) }
+    private val access = runBlocking { getString(Res.string.lib_teams_scope_access) }
+    private val invite = runBlocking { getString(Res.string.lib_teams_invite) }
+    private val deleteScope = runBlocking { getString(Res.string.lib_teams_scope_delete) }
+
+    @Test
+    fun `a manager's chip row offers no create button — that lives in the header`() = runForm({
+        ScopeSection(
+            scopes = listOf(TeamScopeUi(id = "s1", name = "prod", memberCount = 2, hasKey = true)),
+            selected = "s1",
+            canManage = true,
+            onSelect = {},
+            onAccess = {},
+            onDelete = {},
+        )
+    }) {
+        // The manager actions on the selected scope are still there — this is the chip row's own
+        // chrome, and its absence would mean the test proved nothing.
+        onNodeWithText(access).assertIsDisplayed()
+        onNodeWithText(newScope).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the header is where a manager creates a share space`() = runForm({
+        Row {
+            TeamHeaderActions(
+                lastSyncedAt = null,
+                busy = false,
+                owner = true,
+                canManage = true,
+                invited = false,
+                onSync = {},
+                onNewScope = {},
+                onInvite = {},
+                onLeave = {},
+                onDelete = {},
+            )
+        }
+    }) {
+        onNodeWithText(newScope).assertIsDisplayed()
+    }
+
+    @Test
+    fun `a member who cannot manage the team is not offered a share space`() = runForm({
+        Row {
+            TeamHeaderActions(
+                lastSyncedAt = null,
+                busy = false,
+                owner = false,
+                canManage = false,
+                invited = false,
+                onSync = {},
+                onNewScope = {},
+                onInvite = {},
+                onLeave = {},
+                onDelete = {},
+            )
+        }
+    }) {
+        onNodeWithText(newScope).assertDoesNotExist()
+    }
+
+    /**
+     * The phone's action row at a phone's width. Four actions in a plain Row measure the last one —
+     * Invite, the screen's primary — into whatever is left, and it lands off the edge; the row wraps
+     * instead. Asserted at 300 dp because that is narrower than the four laid out side by side.
+     */
+    @Test
+    fun `the phone's actions wrap instead of pushing Invite off the edge`() = runForm({
+        Box(Modifier.width(300.dp)) {
+            MobileTeamActions(
+                lastSyncedAt = null,
+                busy = false,
+                canManage = true,
+                canAudit = true,
+                onSync = {},
+                onShowHistory = {},
+                onNewScope = {},
+                onInvite = {},
+            )
+        }
+    }) {
+        onNodeWithText(invite).assertIsDisplayed()
+        onNodeWithText(newScope).assertIsDisplayed()
+    }
+
+    /**
+     * The scope manager's own actions at a phone's width. Side by side they need ~210 dp, so at 160
+     * a plain Row squeezes "Delete scope" into what is left of the line and the label is cut; the
+     * row wraps instead. Asserted on the geometry rather than on visibility because a squeezed
+     * button still has bounds — only its position says whether the wrap happened.
+     */
+    @Test
+    fun `the scope actions wrap instead of cutting Delete short`() = runForm({
+        Box(Modifier.width(160.dp)) {
+            ScopeSection(
+                scopes = listOf(TeamScopeUi(id = "s1", name = "prod", memberCount = 2, hasKey = true)),
+                selected = "s1",
+                canManage = true,
+                onSelect = {},
+                onAccess = {},
+                onDelete = {},
+            )
+        }
+    }) {
+        val first = onNodeWithText(access).fetchSemanticsNode().boundsInRoot
+        val second = onNodeWithText(deleteScope).fetchSemanticsNode().boundsInRoot
+        assertTrue(second.top >= first.bottom, "Delete scope sits beside Access instead of below it")
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamScopeNameTest.kt
@@ -26,7 +26,6 @@ class TeamScopeNameTest {
             selected = "s1",
             canManage = false,
             onSelect = {},
-            onNew = {},
             onAccess = {},
             onDelete = {},
         )

--- a/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
+++ b/server/src/main/kotlin/app/skerry/server/db/TeamRepository.kt
@@ -84,16 +84,29 @@ class TeamRepository(private val db: Database) {
     }
 
     /**
-     * Newest device activity of each of [accountIds] (epoch millis), for the members list. One query
-     * for the whole team rather than a lookup per member, and accounts with no device row are simply
-     * absent from the map — the endpoint reports them as never seen.
+     * What the members list says about an account's devices: when any of them was last active
+     * ([lastSeenAt], epoch millis) and how many are still paired ([active]). Revoked devices count
+     * as neither gone nor present for freshness — they held the key once — but they are not
+     * devices the team reaches any more, so [active] leaves them out.
      */
-    suspend fun lastSeenByAccount(accountIds: Collection<String>): Map<String, Long> = dbTransaction(db) {
+    data class MemberDevices(val lastSeenAt: Long, val active: Int)
+
+    /**
+     * Device facts for each of [accountIds], for the members list. One query for the whole team
+     * rather than a lookup per member, and accounts with no device row are simply absent from the
+     * map — the endpoint reports them as never seen and holding nothing.
+     */
+    suspend fun devicesByAccount(accountIds: Collection<String>): Map<String, MemberDevices> = dbTransaction(db) {
         if (accountIds.isEmpty()) return@dbTransaction emptyMap()
         Devices.selectAll()
             .where { Devices.accountId inList accountIds.toSet() }
             .groupingBy { it[Devices.accountId] }
-            .fold(0L) { newest, row -> maxOf(newest, row[Devices.lastSeenAt]) }
+            .fold(MemberDevices(0L, 0)) { acc, row ->
+                MemberDevices(
+                    lastSeenAt = maxOf(acc.lastSeenAt, row[Devices.lastSeenAt]),
+                    active = acc.active + if (row[Devices.revoked]) 0 else 1,
+                )
+            }
     }
 
     suspend fun membership(teamId: String, accountId: String): TeamMemberRow? = dbTransaction(db) {

--- a/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/TeamRoutes.kt
@@ -138,9 +138,20 @@ fun Route.teamRoutes(services: Services) {
         val teamId = call.requiredPathId("id") ?: return@get
         call.requireActiveMember(services, teamId, principal.accountId) ?: return@get
         val rows = services.teams.members(teamId)
-        val lastSeen = services.teams.lastSeenByAccount(rows.map { it.accountId })
+        val devices = services.teams.devicesByAccount(rows.map { it.accountId })
         val members = rows.map {
-            TeamMemberDto(it.accountId, it.role, it.status, it.createdAt, lastSeen[it.accountId])
+            val d = devices[it.accountId]
+            TeamMemberDto(
+                accountId = it.accountId,
+                role = it.role,
+                status = it.status,
+                createdAt = it.createdAt,
+                lastSeenAt = d?.lastSeenAt,
+                // Only for a member who actually joined: an invite is addressed by e-mail and costs
+                // the inviter nothing, so reporting a stranger's device count would make the members
+                // list a probe. The screen sums active members anyway.
+                devices = if (it.status == TeamMemberStatus.ACTIVE) d?.active ?: 0 else null,
+            )
         }
         call.respond(TeamMembersResponse(members))
     }

--- a/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
+++ b/server/src/test/kotlin/app/skerry/server/routes/TeamRoutesTest.kt
@@ -250,6 +250,51 @@ class TeamRoutesTest {
     }
 
     @Test
+    fun `members report how many devices each account has paired, revoked ones excluded`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val aliceTokens = client.registerAccount(alice, password)
+        val bobTokens = client.registerAccount(bob, password, deviceId = "dev-bob")
+        client.createTeam(aliceTokens.accessToken)
+        client.invite(aliceTokens.accessToken, bob, byteArrayOf(1))
+        client.post("/teams/$teamId/accept") { bearerAuth(bobTokens.accessToken) }
+
+        client.srpLogin(bob, password, deviceId = "dev-bob-2", deviceName = "Phone")
+        val thirdLogin = System.currentTimeMillis()
+        client.srpLogin(bob, password, deviceId = "dev-bob-3", deviceName = "Tablet")
+        // A revoked device holds no team key any more, so it is not one of the team's devices.
+        client.delete("/devices/dev-bob-3") { bearerAuth(bobTokens.accessToken) }
+
+        val members: TeamMembersResponse = client.get("/teams/$teamId/members") { bearerAuth(aliceTokens.accessToken) }.body()
+        val bobRow = members.members.single { it.accountId == bob }
+        assertEquals(1, members.members.single { it.accountId == alice }.devices)
+        assertEquals(2, bobRow.devices)
+        // The revoked device was bob's most recent activity, and it still counts for freshness:
+        // revoking says the key is gone, not that the sign-in never happened.
+        val bobSeen = bobRow.lastSeenAt
+        assertNotNull(bobSeen)
+        assertTrue(bobSeen >= thirdLogin, "the revoked device's activity must still count: $bobSeen < $thirdLogin")
+    }
+
+    @Test
+    fun `an account that has not accepted the invite has no device count in the members list`() = testApplication {
+        val services = testServices()
+        application { configureServer(services) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val aliceTokens = client.registerAccount(alice, password)
+        client.registerAccount(bob, password, deviceId = "dev-bob")
+        client.createTeam(aliceTokens.accessToken)
+        client.invite(aliceTokens.accessToken, bob, byteArrayOf(1))
+
+        val members: TeamMembersResponse = client.get("/teams/$teamId/members") { bearerAuth(aliceTokens.accessToken) }.body()
+        assertNull(members.members.single { it.accountId == bob }.devices)
+        assertEquals(1, members.members.single { it.accountId == alice }.devices)
+    }
+
+    @Test
     fun `ACL non-members get 404 members cannot invite owner cannot be removed`() = testApplication {
         val services = testServices()
         application { configureServer(services) }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamClient.kt
@@ -100,6 +100,12 @@ class TeamMember(
      * that doesn't report it — the member table then shows nothing rather than inventing a time.
      */
     val lastSeenAt: Long? = null,
+    /**
+     * How many devices this member still has paired, as the server counts them — null on a server
+     * that doesn't report it. The team's own device total is the sum over its active members, so a
+     * single null makes that total unknown rather than an undercount.
+     */
+    val devices: Int? = null,
 )
 
 /** An account's published Teams identity keys (both public halves; see [TeamClient.fetchPublicKey]). */

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sync/KtorSyncClient.kt
@@ -369,7 +369,7 @@ class KtorSyncClient(
             bearerAuth(session.accessToken)
         }.bodyChecked()
         return resp.members.map {
-            TeamMember(it.accountId, TeamRole.fromWire(it.role), TeamMemberStatus.fromWire(it.status), it.createdAt, it.lastSeenAt)
+            TeamMember(it.accountId, TeamRole.fromWire(it.role), TeamMemberStatus.fromWire(it.status), it.createdAt, it.lastSeenAt, it.devices)
         }
     }
 

--- a/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
+++ b/sync-wire/src/main/kotlin/app/skerry/sync/wire/TeamWireDto.kt
@@ -69,6 +69,13 @@ data class TeamMemberDto(
      * still around.
      */
     val lastSeenAt: Long? = null,
+    /**
+     * How many devices the member still has paired — revoked ones excluded. Null for a member who
+     * has not accepted the invite (their devices are not the team's, and are nobody's business
+     * here) and on a server that predates the field, which is why the team's device total is a
+     * question the client answers with "unknown" rather than an undercount.
+     */
+    val devices: Int? = null,
 )
 
 @Serializable


### PR DESCRIPTION
The **Devices** row on a team's Server card now counts the paired devices of that team's active members, and **New scope** sits in the screen header beside Invite instead of in the scope chip row.

## Device count

`GET /teams/{id}/members` reports a per-member `devices` count:

| Case | Reported |
|---|---|
| Active member | number of devices still paired |
| Revoked device | not counted (it still feeds `lastSeenAt` — it held the key once) |
| Invited member | `null` — an invite is addressed by e-mail and costs the inviter nothing, so a device count there would make the members list a probe |

The client sums the active members. The card shows `—` when the answer is not knowable — a server that predates the field, a member whose count is missing, or a member list that has not loaded — rather than a total that is silently short. The label reads **Team devices** in all three locales.

## New scope

The button moves out of the scope chip row into the header action set, on desktop (`TeamHeaderActions`) and on the phone (`MobileTeamActions`). It is shown only to a member who may manage the team, and is disabled while the screen is busy. The chip row now draws chips and the selected scope's own actions, nothing else.

Both action rows are `FlowRow`: at a phone's width four header actions in a plain row measured Invite off the edge, and at a large text scale the scope row did the same to Delete scope.

## Also in this PR

- `TeamMemberDto.devices` (wire, defaulted to `null`) and `TeamMember.devices`.
- `TeamRepository.devicesByAccount` replaces `lastSeenByAccount` — one query answers both freshness and count.
- `teamDeviceCount(members)` in `TeamsScreenModel`, covered by unit tests; `TeamScopeChromeTest` pins the button's placement and both wrapping rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
