### PR TITLE
Add Simplified Chinese READMEs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,8 @@ Wire the keep-alive setting end to end with dead-link detection
 1. Branch from `main`.
 2. Make sure `./gradlew test allTests` passes — CI runs it on every PR, under `xvfb-run`.
 3. Keep desktop ⇆ Android parity for anything user-facing.
-4. When touching `README.md`, mirror the change in `README.ru.md` (and vice versa) — the
-   two must stay structurally identical.
+4. When touching `README.md`, mirror the change in `README.ru.md` and `README.zh.md` (and vice
+   versa) — the three must stay structurally identical.
 
 ## Packaging notes
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/img/banner.png" alt="Skerry — the SSH client, the way it should be. Terminal · SFTP · tunnels · VNC/RDP · encrypted vault · no accounts, no cloud. Linux · Windows · macOS · Android" width="820">
 
-**English** · [Русский](README.ru.md)
+**English** · [Русский](README.ru.md) · [简体中文](README.zh.md)
 
 [![CI](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml/badge.svg)](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)

--- a/README.ru.md
+++ b/README.ru.md
@@ -2,7 +2,7 @@
 
 <img src="docs/img/banner.png" alt="Skerry — SSH-клиент, каким он должен быть. Терминал · SFTP · туннели · VNC/RDP · шифрованное хранилище · без аккаунтов и облака. Linux · Windows · macOS · Android" width="820">
 
-[English](README.md) · **Русский**
+[English](README.md) · **Русский** · [简体中文](README.zh.md)
 
 [![CI](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml/badge.svg)](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml)
 [![Релиз](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,0 +1,282 @@
+<div align="center">
+
+<img src="docs/img/banner.png" alt="Skerry — SSH 客户端本该有的样子。终端 · SFTP · 隧道 · VNC/RDP · 加密保险库 · 无账号，无云端。Linux · Windows · macOS · Android" width="820">
+
+[English](README.md) · [Русский](README.ru.md) · **简体中文**
+
+[![CI](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml/badge.svg)](https://github.com/SeCherkasov/SkerrySSH/actions/workflows/ci.yml)
+[![发布](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)
+[![客户端: GPL-3.0](https://img.shields.io/badge/clients-GPL--3.0-blue)](LICENSE)
+[![服务端: AGPL-3.0](https://img.shields.io/badge/server-AGPL--3.0-blue)](server/LICENSE)
+
+</div>
+
+---
+
+开源 SSH 客户端，单一内核（Kotlin Multiplatform），覆盖所有平台：
+**Linux · Windows · macOS · Android**。
+
+- **本地优先** — 无需账号和外部服务即可完整使用；同步是可选的，且由你自己托管。
+- **零知识** — 保险库由 Argon2id + XChaCha20-Poly1305 封存；主密码和加密密钥从不离开设备。
+- **AI 受策略约束** — 模型输出被当作不可信输入：执行命令需要明确确认；本地推理（llama.cpp）
+  杜绝一切外发流量。
+
+---
+
+## 与同类产品对比
+
+| | Skerry | Termius | PuTTY | Tabby |
+|---|---|---|---|---|
+| **许可证** | GPL-3.0 / AGPL-3.0 | 专有 | MIT | MIT |
+| **平台** | Linux · Windows · macOS · Android | Linux · Windows · macOS · Android · iOS | Windows · Unix | Linux · Windows · macOS |
+| **价格** | 免费 | 每月 $10 起 | 免费 | 免费 |
+| **无需账号** | ✅ | ⚠️ 仅本地 | ✅ | ✅ |
+| **加密保险库** | ✅ | ✅ | ❌ | ⚠️ 需手动开启 |
+| **同步** | ✅ 自托管 | ✅ 厂商云 | ❌ | ✅ 自托管 |
+| **团队共享** | ✅ | ⚠️ 付费 | ❌ | ❌ |
+| **SFTP** | ✅ 双栏 | ✅ | ⚠️ 仅命令行 | ✅ |
+| **Mosh** | ✅ | ✅ | ❌ | ❌ |
+| **VNC / RDP** | ✅ | ❌ | ❌ | ❌ |
+| **实时会话共享** | ✅ | ⚠️ 付费 | ❌ | ❌ |
+| **AI 助手** | ✅ 本地或自带密钥 | ⚠️ 仅云端 | ❌ | ❌ |
+
+*竞品数据取自各项目官网，2026-07-23。如有出入，请提交 PR 更正或开一个
+[issue](../../issues/new)。*
+
+---
+
+## 状态
+
+**Linux**、**Windows**、**macOS** 和 **Android** 处于活跃开发中。
+
+**iOS/iPadOS** 已推迟，原因是缺少用于构建和调试的硬件 — 项目中没有 iOS 目标。
+
+---
+
+## 安装
+
+安装包见 **[最新发布](../../releases/latest)**：
+
+| 平台 | 架构 | 文件 |
+|---|---|---|
+| Linux | x86_64 | `.deb`、`.rpm`、`.AppImage` |
+| Linux | arm64 | `.deb`、`.rpm`、`.AppImage` |
+| Windows | x64 | `.msi`、`.zip` |
+| macOS | Apple Silicon | `.dmg` |
+| macOS | Intel | `.dmg` |
+| Android | arm64-v8a | `.apk` |
+
+- **签名。** 构建产物未签名：项目没有 Apple 开发者账号。Gatekeeper 会拦截 macOS 构建的首次
+  启动 — 右键点击应用 → 打开，或在 系统设置 → 隐私与安全性 中放行。Windows 的 `.msi` 同样
+  未签名，SmartScreen 会在首次运行时告警。
+- **macOS 包版本。** “显示简介”里显示的是 `1.x.y` 而不是 `0.x`：打包要求主版本号 ≥ 1。
+  真实版本在“关于”界面上。
+- **校验和。** `sha256sum -c --ignore-missing SHA256SUMS.txt`
+
+从源码构建见[下文](#从源码构建)。
+
+---
+
+## 截图
+
+![带主机管理器、会话标签页和实时指标面板的终端](docs/screenshots/terminal.webp)
+
+<details>
+<summary>更多截图</summary>
+
+![四个分屏窗格，输入同步](docs/screenshots/panes.webp)
+
+![双栏 SFTP 文件管理器](docs/screenshots/sftp.webp)
+
+![端口转发管理器](docs/screenshots/tunnels.webp)
+
+![保险库：密钥、密码、证书](docs/screenshots/vault.webp)
+
+![主机监控：CPU、内存、磁盘、服务、容器](docs/screenshots/monitor.webp)
+
+![运行手册：带变量的多步骤流程](docs/screenshots/runbooks.webp)
+
+![带变量和快捷键的片段](docs/screenshots/snippets.webp)
+
+![按主机配置策略的 AI 助手](docs/screenshots/ai.webp)
+
+![团队：成员、角色、访问范围、共享保险库](docs/screenshots/teams.webp)
+
+| 主机列表 | 终端 |
+|---|---|
+| ![带分组和标签的主机列表](docs/screenshots/mobile-hosts.webp) | ![移动端终端](docs/screenshots/mobile-terminal.webp) |
+
+</details>
+
+---
+
+## 功能
+
+- **协议** — SSH、Mosh、Telnet、串口（桌面端和 Android USB-OTG），以及完全不需要连接的
+  本地 shell 标签页。
+- **SSH** — 跳板机（ProxyJump）、来自保险库或磁盘的证书、CA 签发的主机密钥证书、
+  keyboard-interactive 双因素认证、自动重连、从 `~/.ssh/config` 导入主机。
+- **SFTP** — 双栏文件管理器：文件查看器和编辑器、可排序的列、名称过滤、传输队列。
+- **端口转发** — 本地、远程、动态/SOCKS；保险库解锁后自动建立转发；一键转发在主机上
+  发现的端口。
+- **容器** — 直接从主机 exec 进入 Docker 容器或 Kubernetes Pod。
+- **远程桌面** — 为本项目编写的 VNC 和 RDP 客户端栈：截图、Ctrl+Alt+Del、剪贴板交换、
+  会话中途改设置。有解码器时 RDP 支持 H.264：Android 始终可用，桌面端需要 PATH 上有
+  `ffmpeg`。
+- **终端** — 自研网格模拟，每个标签页最多四个平铺窗格并同步输入、回滚缓冲区搜索、语法高亮、
+  基于历史的命令面板、向多个会话广播输入、把输出里的文件路径在 SFTP 中打开、
+  会话录制（asciinema v2）并可在应用内回放。
+- **主机监控** — 独立界面：带历史曲线的 CPU、内存和网络，以水位显示的磁盘和交换分区，
+  进程排行，systemd 单元，挂载点，容器，以及在设备上触发的阈值告警。
+- **会话共享** — 通过端到端加密通道把终端串流给同事，只读或交出键盘。
+- **生产环境守卫** — 对带 `prod` 标签主机上的每条命令做风险评分，危险命令需要确认。
+- **运行手册** — 在实时会话中逐步执行一套流程：每一步是一条命令或一次 SFTP 传输，
+  可暂停等待确认，退出码非零则停止。运行日志记录每一步的状态、耗时和输出。
+- **片段** — 命令库，带前缀补全，`${{…}}` 变量（日期/时间、uuid、随机数、剪贴板、
+  保险库密文、交互输入的参数）在运行时展开，并先给出确认预览。
+- **AI** — 按主机设定策略，桌面端在会话旁提供助手面板，移动端按键呼出输入表单，
+  可用自己的 OpenAI 密钥或本地模型。参见 [AI 与隐私](#ai-与隐私)。
+- **保险库** — Argon2id + XChaCha20-Poly1305 保护密钥、密码、身份和证书，Android 支持
+  生物识别解锁；密文卡片显示算法、指纹、有效期、依赖方和最近一次使用；30 天回收站，
+  可在任何已同步设备上恢复。
+- **同步** — 可选、自托管、零知识：通过 WebSocket 实时推送，扫码配对设备，
+  浏览器端账号区域由单独的密码保护 — 只有元数据和设备吊销，别无其他。
+  参见 [同步服务器](#同步服务器)。
+- **团队** — 端到端加密地共享主机、片段和运行手册，按成员设定访问范围，
+  活动流记录谁改了哪台主机、谁开了哪个会话。
+- **界面** — 深色和浅色主题，终端跟随应用主题，“系统”模式跟随操作系统，
+  界面语言支持英语、俄语和简体中文。
+
+---
+
+## AI 与隐私
+
+助手的行为边界：
+
+- **请求内容** — 请求文本和一段固定的系统提示。终端输出、主机列表和保险库记录都不会发送。
+- **云端模式** — 只用你自己的 OpenAI 密钥：流量从应用直达你设置的端点，中间没有任何服务器。
+- **主机策略** — 决定请求发往何处：
+  - **严格**（新主机的默认值）— 只用本地模型。
+  - **均衡** — 走云端，但从提示中剥离明显的密文：私钥、令牌、`password=…`。
+    该机制基于模式匹配，不提供任何保证。
+  - **宽松** — 不做脱敏直接走云端，适用于不敏感的系统。
+  - **关闭** — 在该主机上隐藏助手。
+- **快速对话** — 始终开启脱敏，本地模型也不例外。
+- **本地模型** — 通过设备上的 llama.cpp 运行 GGUF（Qwen3、Phi-4 Mini），没有外发流量。
+- **命令执行** — 模型输出不可信：执行需要明确确认，危险命令需要再确认一次。
+
+---
+
+## 技术栈
+
+- **语言与界面** — Kotlin 2.4、Compose Multiplatform 1.9
+- **构建** — Gradle 9.6、Android Gradle Plugin 9.1、JDK 21（所有模块均为 `jvmToolchain(21)`）
+- **Android** — minSdk 26（Android 8.0）、compileSdk 37、targetSdk 36
+- **SSH 与加密** — sshj、BouncyCastle、libsodium（ionspin KMP）：Argon2id +
+  XChaCha20-Poly1305
+- **终端** — 自研网格模拟，桌面端本地 shell 使用 pty4j
+- **远程桌面** — 为本项目编写的 VNC（RFB）和 RDP 栈，不依赖第三方客户端
+- **串口** — jSerialComm（桌面端）、usb-serial-for-android（Android）
+- **AI** — 本地模型用 llamatik（llama.cpp 绑定），云端用 Ktor 客户端
+- **同步** — Ktor（客户端和服务端）、Exposed、SQLite/PostgreSQL、HikariCP、Nimbus SRP-6a
+- **质量** — JUnit 5、Kover 覆盖率、detekt 静态分析
+
+确切版本见 [`gradle/libs.versions.toml`](gradle/libs.versions.toml)。
+
+---
+
+## 仓库结构
+
+```
+shared/       # KMP 内核: ssh/, sftp/, vault/, sync/, team/, share/, terminal/, ai/ (+ai/local),
+              # telnet/, serial/, mosh/, rdp/, vnc/, graphics/, audio/, tunnel/, container/,
+              # snippet/, runbook/, host/, tag/, files/, guard/, update/
+composeApp/   # 界面 (Compose Multiplatform): commonMain + androidMain + desktopMain
+androidApp/   # Android 应用 (MainActivity, manifest), applicationId app.skerry
+server/       # 自托管同步服务器 (Ktor, AGPL-3.0)
+sync-wire/    # 客户端与服务端共用的传输协议契约
+docs/         # 文档与设计素材
+```
+
+---
+
+## 从源码构建
+
+开发流程、提交规范和打包说明见 **[CONTRIBUTING.md](CONTRIBUTING.md)**。
+
+需要 **JDK 21**（必要时 `foojay-resolver` 会自动获取）和 Android SDK — 每一次客户端构建都会
+配置 `:androidApp`，因此即便只构建桌面端，也要设置 `ANDROID_HOME` 或在 `local.properties`
+中设置 `sdk.dir`。
+
+安装包按构建机器的操作系统和 CPU 架构生成：arm64 的 `.dmg` 只能在 macOS/ARM 上产出。
+
+```bash
+./gradlew :composeApp:run                                # 运行
+./gradlew :composeApp:packageDistributionForCurrentOS    # .deb / .rpm / .msi / .dmg
+./gradlew :composeApp:packageAppImage                    # 便携版 Linux .AppImage
+./gradlew :composeApp:packagePortableZip                 # 便携版 .zip
+```
+
+Android：
+
+```bash
+ANDROID_HOME=$HOME/Android/Sdk ./gradlew :androidApp:installDebug
+```
+
+测试（JUnit 5）和静态分析：
+
+```bash
+./gradlew test allTests    # 只跑 `test` 会跳过多平台模块
+./gradlew detektAll        # 既有问题记录在 gradle/detekt-baseline-*.xml
+```
+
+---
+
+## 同步服务器
+
+服务器只用于同步设备，而且始终是你自己的服务器：不存在厂商云。
+
+设计上零知识：留在服务器上的是密文（包装后的 `dataKey`、加密的保险库记录）和同步元数据。
+认证使用 SRP-6a，密码从不传输，服务器无法解密你存放的任何内容。
+
+快速开始 — 使用 [Docker Hub](https://hub.docker.com/r/secherkasov/skerry-sync) 上的
+多架构预构建镜像，SQLite 存放在具名卷中，无需配置：
+
+```bash
+docker run -d --name skerry-sync -p 8080:8080 \
+  -e SKERRY_JWT_SECRET="$(openssl rand -base64 48)" \
+  -e SKERRY_ADMIN_TOKEN="$(openssl rand -hex 16)" \
+  -v skerry-data:/data \
+  secherkasov/skerry-sync:latest
+```
+
+服务器监听 `http://localhost:8080`，并自带一个离线的内置 Web 前端：`/` 是公开页面，
+`/account` 是账号中心，`/console` 是运维控制台。从源码构建 — 在仓库根目录执行
+`docker compose up -d --build`；PostgreSQL 由 [docker-compose.yml](docker-compose.yml)
+中的 `db` 服务和 postgres 相关变量启用。仅构建服务端时不需要 Android SDK：
+`./gradlew :server:run -PserverOnly`。
+
+配置、API 端点、TLS 终结（Caddy/nginx）、备份和隐私模型见
+**[server/README.md](server/README.md)**（[中文](server/README.zh.md)）。
+
+---
+
+## 安全
+
+私密漏洞报告、受支持的版本、威胁模型和审计状态见 **[SECURITY.md](SECURITY.md)**。
+
+---
+
+## 参与开发
+
+欢迎提交 issue 和 pull request。环境搭建、模块结构、项目的开发方式以及 PR 需要满足的条件见
+**[CONTRIBUTING.md](CONTRIBUTING.md)**。
+
+---
+
+## 许可证
+
+- 客户端（`shared/`、`composeApp/`、`androidApp/`）— [GPL-3.0](LICENSE)
+- 同步服务器（`server/`）— [AGPL-3.0](server/LICENSE)：以服务形式托管的分支必须把改动
+  回馈给本项目。
+- 内置字体 — OFL-1.1 和 Apache-2.0，文本和版本见 [licenses/](licenses/README.md)

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Skerry Sync Server
 
-**English** · [Русский](README.ru.md)
+**English** · [Русский](README.ru.md) · [简体中文](README.zh.md)
 
 Self-hosted, zero-knowledge E2E sync for [Skerry](../README.md) (Vaultwarden model). The
 server stores **ciphertext only** — the wrapped `dataKey` and encrypted vault records — plus

--- a/server/README.ru.md
+++ b/server/README.ru.md
@@ -1,6 +1,6 @@
 # Skerry Sync Server
 
-[English](README.md) · **Русский**
+[English](README.md) · **Русский** · [简体中文](README.zh.md)
 
 Self-hosted, zero-knowledge E2E-синхронизация для [Skerry](../README.ru.md) (модель
 Vaultwarden). Сервер хранит **только шифротекст** — обёрнутый `dataKey` и зашифрованные

--- a/server/README.zh.md
+++ b/server/README.zh.md
@@ -1,0 +1,360 @@
+# Skerry 同步服务器
+
+[English](README.md) · [Русский](README.ru.md) · **简体中文**
+
+为 [Skerry](../README.zh.md) 提供自托管、零知识的端到端同步（Vaultwarden 模型）。服务器
+**只存储密文** — 被包装的 `dataKey` 和加密后的保险库记录 — 外加同步元数据。主密码、
+`masterKey` 和 `dataKey` 从不离开设备，服务器无从获取。
+
+> 许可证：**AGPL-3.0**（见 `LICENSE`）。Skerry 客户端是 GPL-3.0。
+
+## 内容概览
+
+- **技术栈**：Kotlin + Ktor（Netty）、Exposed、HikariCP。认证：SRP-6a（Nimbus）+ JWT。
+- **存储**：默认 SQLite（单个文件，零配置）；改 `SKERRY_DB_URL` 即可切到 PostgreSQL。
+- **服务器上不做加解密**，这是设计使然：服务器无法解密用户数据。注册时上传 SRP
+  salt/verifier 和被包装的 `dataKey`；登录是一次 SRP-6a 交换，密码本身从不传输。
+
+## 快速开始
+
+### Docker（预构建镜像，推荐）
+
+多架构镜像（amd64 + arm64）发布在 Docker Hub 上，仓库为
+[`secherkasov/skerry-sync`](https://hub.docker.com/r/secherkasov/skerry-sync) — 标签有：
+精确的 `<version>`、`<major.minor>`、`latest`。服务器与客户端分开发布 — 有自己的
+`server-v*` 标签和自己的工作流。目前为止它的版本号与客户端发布保持一致。
+
+```bash
+docker run -d --name skerry-sync \
+  -p 8080:8080 \
+  -e SKERRY_JWT_SECRET="$(openssl rand -base64 48)" \
+  -e SKERRY_ADMIN_TOKEN="$(openssl rand -hex 16)" \
+  -v skerry-data:/data \
+  secherkasov/skerry-sync:latest
+```
+
+重建容器时要保持 `SKERRY_JWT_SECRET` 不变（把它放进 env 文件）— 改动它会让所有已签发的
+令牌失效。
+
+### Docker Compose（从源码构建）
+
+```bash
+# 在仓库根目录执行
+export SKERRY_JWT_SECRET="$(openssl rand -base64 48)"
+export SKERRY_ADMIN_TOKEN="$(openssl rand -hex 16)"
+docker compose up -d --build
+```
+
+两种方式都会让服务器起在 `http://localhost:8080`。数据放在 `skerry-data` 卷里（SQLite）。
+要换成 PostgreSQL，取消 `docker-compose.yml` 中 `db` 服务和 postgres 变量的注释。
+
+容器以非特权用户运行，提供 `/healthz` 健康检查，镜像使用 `-PserverOnly` 构建 — 不需要
+Android SDK。管理 CLI 随镜像一同提供：`docker exec skerry-sync skerry-admin --help`。
+
+### 本地运行（Gradle）
+
+```bash
+SKERRY_JWT_SECRET=dev-secret SKERRY_ADMIN_TOKEN=admin ./gradlew :server:run -PserverOnly
+```
+
+## 配置
+
+一切都通过环境变量配置（单一 `.env` 模型）；带注释的模板见
+[`.env.example`](.env.example)。所有取值对本地运行都有合理的默认值 — 生产环境唯一
+*必须*设置的是稳定的 `SKERRY_JWT_SECRET`。
+
+| 变量 | 默认值 | 用途 |
+|---|---|---|
+| `SKERRY_HOST` | `0.0.0.0` | 绑定的网络接口。在反向代理之后设为 `127.0.0.1`。 |
+| `SKERRY_PORT` | `8080` | 监听端口。 |
+| `SKERRY_DB_URL` | `jdbc:sqlite:skerry-sync.db` | JDBC URL；`jdbc:postgresql://…` 会把驱动切到 PostgreSQL。 |
+| `SKERRY_DB_USER` / `SKERRY_DB_PASSWORD` | *(空)* | 数据库凭据（PostgreSQL）。 |
+| `SKERRY_JWT_SECRET` | `dev-insecure-change-me` | JWT 签名密钥。**除非设置 `SKERRY_DEV=1`，否则服务器拒绝以默认值启动。** 轮换它会让所有已签发的令牌失效。 |
+| `SKERRY_JWT_ISSUER` | `skerry-sync` | JWT 的 `iss` 声明。 |
+| `SKERRY_ADMIN_TOKEN` | *(空)* | 运维控制台令牌（`/console`、`/admin/*`）。为空 ⇒ 管理数据端点关闭。 |
+| `SKERRY_ACCESS_TTL` | `900`（15 分钟） | access 令牌有效期，单位秒。 |
+| `SKERRY_REFRESH_TTL` | `2592000`（30 天） | refresh 令牌有效期，单位秒。 |
+| `SKERRY_PAIRING_TTL` | `300`（5 分钟） | 一次性扫码配对会话的有效期。 |
+| `SKERRY_TOMBSTONE_DAYS` | `90` | 删除墓碑在被物理清理前保留多久。 |
+| `SKERRY_CORS_HOSTS` | *(空)* | 逗号分隔的允许 CORS 来源。为空则禁用 CORS（原生客户端不受其约束）。 |
+| `SKERRY_MAX_BODY_BYTES` | `4194304`（4 MiB） | 请求体上限（防 OOM/滥用）；更大的请求会得到 `413`。 |
+| `SKERRY_DEV` | *(未设置)* | `1` 解锁默认 JWT 密钥，仅用于本地开发。 |
+| `SKERRY_METRICS` | `off` | Prometheus `/metrics`：`off`（404）、`token`（bearer）、`open`（无凭据）。 |
+| `SKERRY_METRICS_TOKEN` | *(空)* | `SKERRY_METRICS=token` 时使用的 bearer 令牌。模式为 `token` 而此项为空时启动失败。 |
+| `SKERRY_METRICS_INVENTORY_SECONDS` | `60` | 存量指标的刷新间隔（最小 15，`0` 表示禁用）。 |
+
+## 同步是怎么工作的
+
+1. **注册** — 客户端在本地派生密钥（Argon2id → `masterKey` → `authKey`/`dataKey`），
+   上传 SRP salt/verifier 以及用主密钥包装过的 `dataKey`。上传的任何内容都不足以解密
+   任何东西。
+2. **登录** — SRP-6a 的 challenge/verify；服务器只得知客户端知道密码，而永远得不到密码
+   本身。成功后签发短期的 access + refresh JWT。
+3. **推送/拉取** — 客户端 `PUT` 一批加密记录；冲突按后写者胜出解决（先看记录 `version`，
+   再用 `deviceId` 决胜）。拉取是按单调游标（`?since=`）取增量。
+4. **实时更新** — `/sync` WebSocket 推送“有变更”的信号，只携带新游标，绝不携带内容；
+   客户端随后自行拉取增量。
+5. **删除** — 以墓碑形式传播，超过 `SKERRY_TOMBSTONE_DAYS` 后被物理清除。
+6. **新设备** — 要么登录后从 `/vault/keys` 取回被包装的 `dataKey`，要么使用快速扫码配对
+   （`/pairing/*`，一次性会话，TTL 很短）。
+
+所有密文块（`blob`、`wrappedDataKey`、`encryptedDataKey`）都以 base64 传输。
+
+## API
+
+### 健康检查与认证
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/healthz` | 存活探针（公开；容器健康检查使用）。从不触碰数据库。 |
+| `GET` | `/readyz` | 就绪探针：`200` + `{"status":"ready","db":"up"}`；数据库探测连续失败三次时返回 `503`。 |
+| `GET` | `/metrics` | Prometheus 指标输出。默认关闭 — 见 `SKERRY_METRICS`。 |
+| `POST` | `/auth/register` | 注册：SRP salt/verifier + 被包装的 dataKey → 令牌。 |
+| `POST` | `/auth/srp/challenge` → `/auth/srp/verify` | SRP-6a 登录，不传输密码。 |
+| `POST` | `/auth/refresh` | access/refresh 令牌轮换。 |
+| `POST` | `/auth/change-password` | 更换密码：用当前密码做 SRP 证明，提交新的 verifier 和重新包装的 dataKey。 |
+| `GET` | `/auth/web-password`（JWT） | 账号是否设置了 Web 密码 — 应用中“Web 访问”卡片读取的就是它。 |
+| `POST` | `/auth/web-password`（JWT） | 从应用设置、轮换或清除 **Web** 密码。清除同时会吊销已打开的浏览器会话。 |
+| `POST` | `/auth/web-login` | 用 Web 密码换取标准令牌对。有速率限制；该会话注册为 `platform = "web"` 的设备。 |
+
+### 保险库与设备（JWT 认证）
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/vault/keys` | 供新设备取用的被包装 `dataKey`。 |
+| `GET` | `/vault/records?since={cursor}` | 加密记录的增量。 |
+| `GET` | `/vault/envelopes` | 记录元数据和一小段密文预览 — 只有尺寸，绝不含 blob（账号区域的“存储”一节）。 |
+| `GET` | `/account/summary` | 调用者自己的汇总：设备、记录、墓碑、密文大小、最后同步时间。 |
+| `GET` | `/account/activity` | 调用者自己的审计记录（不含团队范围内的条目）。 |
+| `PUT` | `/vault/records` | 批量 upsert，采用 LWW（先 version，再 deviceId）。 |
+| `WS` | `/sync` | “有变更”推送（只有游标，没有内容）。 |
+| `GET` / `DELETE` | `/devices`、`/devices/{id}` | 设备列表与吊销。 |
+| `POST` | `/pairing/start`（需认证）→ `/pairing/claim` | 本地快速扫码配对。 |
+
+### 团队（JWT 认证）
+
+端到端加密的共享：团队记录对服务器而言就是密文，成员资格通过针对成员公钥的密封信封
+邀请来授予。
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `PUT` | `/account/key` | 发布账号公钥。 |
+| `GET` | `/account/keys/{accountId}` | 取某个成员的公钥（用于封装信封）。 |
+| `POST` / `GET` / `DELETE` | `/teams`、`/teams/{id}` | 创建、列出、删除团队。 |
+| `GET` / `POST` | `/teams/{id}/members` | 成员列表；邀请（密封信封）。 |
+| `PUT` | `/teams/{id}/members/{accountId}/role` | 修改角色（owner/member）。 |
+| `DELETE` | `/teams/{id}/members/{accountId}` | 移除成员／吊销访问权。 |
+| `POST` | `/teams/{id}/accept` | 接受邀请。 |
+| `GET` / `PUT` | `/teams/{id}/records` | 拉取/推送加密的共享记录。 |
+| `GET` | `/teams/{id}/activity` | 团队活动流。 |
+
+### 管理接口（受 `SKERRY_ADMIN_TOKEN` 保护，请求头 `X-Admin-Token`）
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/admin/health` | 存活探针（公开）。 |
+| `GET` | `/admin/stats` | 汇总：账号、设备、记录、blob 大小。 |
+| `GET` | `/admin/devices` | 全部设备，含平台、游标、最后同步时间。 |
+| `GET` | `/admin/activity` | 审计日志（最近 2000 条事件）。 |
+| `GET` | `/admin/accounts`、`/admin/accounts/{id}/records` | 账号列表，以及按账号列出的记录元数据。 |
+| `DELETE` | `/admin/devices/{id}?accountId=` | 从控制台吊销一台设备。 |
+| `DELETE` | `/admin/accounts/{id}/tombstones` | 提前清除某账号的墓碑。 |
+| `DELETE` | `/admin/accounts/{id}` | 删除账号及其全部数据。 |
+
+### 删除账号
+
+`DELETE /admin/accounts/{id}` 在一个事务里删掉该账号拥有的一切：记录、设备、配对会话、
+它发布的 Teams 公钥、它的成员资格和范围授权 — 不会留下任何指向已不存在 id 的行
+（SQLite 不强制外键，PostgreSQL 则会在还有残留时直接拒绝删除）。该账号**拥有**的团队会
+转交给资历最深的活跃成员，由其成为新 owner；若没有活跃成员，团队连同其全部记录、范围和
+授权一并删除。审计记录会写明每个受影响的团队及其新 owner，该团队自己的活动流里会落一条
+`team.owner_replaced`，其余每位成员都会收到与任何成员变更相同的实时信号。之后剩余成员应
+轮换团队密钥 — 被删除的账号知道它，而只有客户端才能轮换。
+
+这之后没有任何机制阻止同一个人重新注册同一个 id：id 是确定性的，本地保险库还在他们的
+设备上，因此一次新的注册会把它重新上传。若这一点很重要，请把实例关闭注册
+（`SKERRY_REGISTRATION=closed`）。
+
+## Web 前端
+
+一份静态产物，三个入口，由 Ktor 自己提供服务：
+
+| URL | 面向谁 | 凭据 | 显示什么 |
+|---|---|---|---|
+| `/` | 任何人 | 无 | 实例是否在服务、版本是多少、是否开放注册，以及粘贴到客户端里的 URL。 |
+| `/account` | 账号所有者 | 账号 id + **Web 密码**（在应用中设置） | 设备、团队、实时会话、已存记录的信封、账号自己的日志、安全相关的交接。 |
+| `/console` | 运维人员 | `SKERRY_ADMIN_TOKEN` | 实例总量、账号（设备和记录信封在行内展开）、可观测性、审计日志。 |
+
+Web 密码是一个独立凭据，与任何保险库密钥无关：索取它的页面由它所保护的同一台服务器提供，
+因此主密码绝不会经由这条路径传输。用它登录的浏览器只能读取服务器本就以明文持有的元数据，
+无法解密任何记录 — `dataKey` 不在这条流程里。它拿到的令牌在服务端就被限定为只读，
+不含 `/vault/keys` 和 `/vault/records`，另外允许吊销设备。丢了这个密码的代价是从应用里
+重置一次；丢了主密码则依然是设计上不可恢复的。
+
+密码在应用中设置：**设置 → 同步 → Web 访问**，需在一台已连接的设备上操作。同一张卡片可以
+轮换和撤销它 — 撤销的同时也会让当时打开的浏览器会话退出登录。长度为 8–256 个字符。
+卡片背后的端点是 `POST /auth/web-password`（`{"password": null}` 表示清除），脚本也可以
+这样调用。
+
+账号的令牌对存放在 `sessionStorage` 里，随标签页关闭而消失；管理令牌只保存在内存中，
+页面刷新后会再次索取。每一个破坏性操作（吊销、清除、删除）在执行前都会说明它确切的
+影响范围。
+
+团队成员资格和密钥**不能**在浏览器里管理：邀请或密钥轮换要用团队密钥密封一个信封，而
+任何浏览器会话都没有团队密钥。团队相关面板是只读的。
+
+界面语言：英语、俄语、中文（先看 URL 里的 `?lang=`，再看已保存的偏好，最后看浏览器）。
+零知识在整个过程中都成立 — 列表只显示 id、类型、大小和时间戳，密文预览就以密文的样子呈现。
+
+> 字体（Space Grotesk、JetBrains Mono）已内置进服务器
+> （`resources/web/assets/fonts/*.woff2`），图标是内联 SVG，CSP 为 `default-src 'self'`。
+> 页面完全可离线工作，不请求任何外部 CDN。中文回落到系统 CJK 字体栈 — 内置字体只含
+> latin + latin-ext。
+
+> ⚠️ 元数据包含 `accountId`（一个邮箱地址），并且会保留在审计日志中（最近 2000 条事件）。
+> 对于单人自托管，运维者*就是*数据主体 — 这可以接受。管理令牌以明文放在 `X-Admin-Token`
+> 请求头里：前面要放一个 TLS 终结器（见下文），否则该令牌在网络上是可见的。
+
+## 管理 CLI
+
+`skerry-admin` 与服务器打包在同一个镜像里（`/app/bin/skerry-admin`），驱动的是与运维控制台
+相同的 `/admin` 端点 — 每个操作只有一套实现和一道授权关卡。它需要 `SKERRY_ADMIN_TOKEN`
+和一个可达的服务器；它从不直接访问数据库。
+
+```bash
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin stats
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices list --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin devices revoke devA --account alice@example.com
+docker exec -e SKERRY_ADMIN_TOKEN=… skerry-sync skerry-admin accounts delete alice@example.com --yes
+```
+
+| 命令 | 用途 |
+|---|---|
+| `health` | 存活状态和版本（无需令牌）。 |
+| `stats` | 实例总量：账号、活跃设备、记录、存储。 |
+| `accounts list` / `accounts records <id>` | 带汇总的账号列表；按账号列出的记录元数据。 |
+| `accounts purge-tombstones <id>` | 丢弃所有设备都已同步越过的删除标记。 |
+| `accounts delete <id> --yes` | 删除账号及其全部数据（不可逆，因此需要这个标志）。 |
+| `devices list [--account id]` | 活跃设备，最近出现的排在前面。 |
+| `devices revoke <id> --account <id>` | 吊销一台设备（它之后仍可重新认证）。 |
+| `activity` | 最近的审计日志事件。 |
+| `metrics` | 原始 Prometheus 指标输出（使用 `SKERRY_METRICS_TOKEN`）。 |
+
+全局选项：`--url`（默认取 `SKERRY_ADMIN_URL`，否则 `http://127.0.0.1:$SKERRY_PORT`）、
+`--token` / `--token-file`（命令行标志在 `ps` 里可见 — 优先用环境变量或密钥文件）、
+`--limit`、`--json`（原样打印服务器返回的 JSON，便于交给 `jq`）、`--help`。
+
+退出码是给脚本用的：`0` 成功，`1` 出错，`2` 用法错误，`3` 未授权，`4` 未找到，
+`5` 服务器不可达。用 `--url https://sync.example.com` 可以对远程实例执行；URL 必须指向
+服务器根路径（不支持反向代理的路径前缀）。
+
+## 指标与监控
+
+`/metrics` 提供 Prometheus 指标输出 — 默认关闭，因为在一台零知识服务器上，元数据*就是*
+攻击面。用令牌来启用它：
+
+```bash
+-e SKERRY_METRICS=token -e SKERRY_METRICS_TOKEN="$(openssl rand -hex 24)"
+```
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: skerry-sync
+    static_configs: [{ targets: ["sync.example.com:8080"] }]
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/skerry-metrics-token
+```
+
+除了标准的 `jvm_*`、`process_*` 和 `hikaricp_*` 系列之外，你还能拿到：
+
+| 指标系列 | 能回答什么 |
+|---|---|
+| `skerry_http_server_requests_seconds` | 按 `method`、`route`（**模板**，绝不含 id）、`status` 划分的延迟和请求量。 |
+| `skerry_http_rejected_requests_total`、`skerry_http_unhandled_exceptions_total` | 在路由之前就被拒绝的请求（411/413）；服务端故障。 |
+| `skerry_auth_attempts_total{kind,outcome}`、`skerry_auth_tokens_issued_total` | 登录/注册/刷新的结果 — 暴力破解的信号。 |
+| `skerry_admin_auth_failures_total`、`skerry_metrics_auth_failures_total` | 静态令牌错误，也就是有人在试探控制台或抓取端点。 |
+| `skerry_auth_jwt_rejected_total{reason}`、`skerry_team_authz_denied_total{reason}` | 被拒绝的设备令牌；被拒绝的团队/范围访问。 |
+| `skerry_sync_records_received_total` / `_pulled_total` / `skerry_sync_push_bytes_total` | 按范围（`account`、`team`）划分的同步量。 |
+| `skerry_sync_ws_sessions`、`…_opened_total`、`…_closed_total{reason}`、`…_session_duration_seconds` | 实时推送套接字：开着几条、因何关闭、持续多久。 |
+| `skerry_accounts`、`skerry_devices{state}`、`skerry_records{state}`、`skerry_storage_bytes{scope}`、`skerry_db_file_bytes`、`skerry_teams`、`skerry_pairing_sessions{state}` | 存量数据，在后台刷新（见 `SKERRY_METRICS_INVENTORY_SECONDS`）。 |
+| `skerry_inventory_last_success_time_seconds`、`skerry_inventory_errors_total` | 上面那些存量数据是否还新鲜。 |
+| `skerry_db_up`、`skerry_db_probe_duration_seconds` | `/readyz` 背后的就绪探测。 |
+| `skerry_build_info{version}`、`skerry_server_start_time_seconds` | 正在运行的版本；用于发现重启。 |
+
+**任何标签都不会携带 accountId、deviceId、recordId、teamId、scopeId 或 IP 地址。** 这些都是
+客户端自选的值：作为标签，它们会让用户把指标注册表撑到进程崩溃，而且会公开正是这套设计
+刻意不让服务器接触到的元数据。按账号的数字放在管理令牌之后，见 `/admin/accounts`。
+
+一套可以起步的告警：
+
+```promql
+skerry_db_up == 0                                                    # 数据库不可达
+time() - skerry_inventory_last_success_time_seconds > 300            # 存量指标已经过期
+changes(skerry_server_start_time_seconds[15m]) > 2                   # 重启循环
+rate(skerry_admin_auth_failures_total[10m]) > 0                      # 有人在猜管理令牌
+sum(rate(skerry_auth_attempts_total{outcome="denied"}[10m])) > 0.2   # 登录暴力破解
+hikaricp_connections_pending > 0                                     # 争抢那一条 SQLite 连接
+predict_linear(skerry_db_file_bytes[6h], 7*24*3600) > 20e9           # 本周之内容量就会被撑满
+skerry_records{state="tombstone"} / skerry_records{state="live"} > 0.5  # 墓碑清理没有在跑
+```
+
+## 生产环境安全
+
+- 设置一个稳定的 `SKERRY_JWT_SECRET`（否则一次重启就会让所有令牌失效），以及一个非空的
+  `SKERRY_ADMIN_TOKEN`。
+- 备份 = 那个 SQLite 文件（`/data`）或者 PostgreSQL 转储；数据是加密的，但这是你唯一的
+  恢复点。
+- 服务器本身监听明文 HTTP — TLS 由反向代理终结（见下文）。载荷本来就是端到端加密的
+  （零知识），SRP 走明文也是安全的，但**管理令牌和元数据（包括 `accountId` = 邮箱地址）
+  是明文传输的** — 没有 TLS 时它们在网络上可见。对于公网可达的主机，TLS 是必需的。
+
+### TLS 终结
+
+把客户端指向 `https://…` — `/sync` WebSocket 会自动切到 `wss://`（同一主机）。
+
+**Caddy**（自动 Let's Encrypt，最省事的方案）：
+
+```caddy
+sync.example.com {
+    reverse_proxy localhost:8080
+}
+```
+
+**nginx**（自备证书或用 Certbot；`/sync` 的 WebSocket 升级必须转发过去）：
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name sync.example.com;
+    ssl_certificate     /etc/letsencrypt/live/sync.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sync.example.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # WebSocket /sync（实时拉取）：缺了这两个头，实时通知就会失效。
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 1h; # /sync 是长连接，不要因超时把它切断
+    }
+}
+```
+
+把服务器绑定到回环地址（`SKERRY_HOST=127.0.0.1`），这样 8080 端口就无法绕过代理被访问。
+
+> **在可信局域网内不启用 TLS 自托管**是一个可以接受的、有意为之的选择：流量是端到端加密的，
+> 元数据也留在局域网内。Android 客户端允许明文连接（`network_security_config.xml`）。
+> 一旦这台主机能从外部访问 — 就加上 TLS。
+
+## 测试
+
+```bash
+./gradlew :server:test
+```
+
+它们覆盖 LWW 冲突、SRP 往返、JWT、团队角色/ACL，以及完整的 HTTP 流程
+（注册 → 登录 → 推送/拉取 → 设备 → 配对 → 管理）。


### PR DESCRIPTION
Simplified Chinese translations of the two READMEs, so the documentation covers the same three languages the app's UI does.

- `README.zh.md` — full translation of `README.md`.
- `server/README.zh.md` — full translation of `server/README.md`.
- Language switcher line updated in all six README files.
- `CONTRIBUTING.md`: the "mirror README changes" rule now names all three languages.

Terminology comes from the application's own Chinese locale (`composeApp/src/commonMain/composeResources/values-zh`) rather than being translated freehand: 保险库 (vault), 片段 (snippets), 运行手册 (runbooks), 隧道 (tunnel), 端口转发 (port forwarding), 共享会话 (session sharing).

Structure is identical to the English originals — same headings, tables, code blocks and block quotes. Every `SKERRY_*` variable, every `skerry_*` metric and every API endpoint in `server/README.zh.md` matches the English file exactly; the in-document anchors (`#从源码构建`, `#ai-与隐私`, `#同步服务器`) were verified against the anchors GitHub actually generates.