### PR TITLE
Link the wiki from the top of every README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 [![Release](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)
 [![Clients: GPL-3.0](https://img.shields.io/badge/clients-GPL--3.0-blue)](LICENSE)
 [![Server: AGPL-3.0](https://img.shields.io/badge/server-AGPL--3.0-blue)](server/LICENSE)
+[![Wiki](https://img.shields.io/badge/wiki-user%20guide%20%26%20development-brightgreen)](https://github.com/SeCherkasov/SkerrySSH/wiki)
+
+📖 **[Wiki](https://github.com/SeCherkasov/SkerrySSH/wiki)** — user guide and development documentation (EN · RU)
 
 </div>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -8,6 +8,9 @@
 [![Релиз](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)
 [![Клиенты: GPL-3.0](https://img.shields.io/badge/clients-GPL--3.0-blue)](LICENSE)
 [![Сервер: AGPL-3.0](https://img.shields.io/badge/server-AGPL--3.0-blue)](server/LICENSE)
+[![Вики](https://img.shields.io/badge/wiki-%D1%80%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE%20%D0%B8%20%D1%80%D0%B0%D0%B7%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%BA%D0%B0-brightgreen)](https://github.com/SeCherkasov/SkerrySSH/wiki/Home-ru)
+
+📖 **[Вики](https://github.com/SeCherkasov/SkerrySSH/wiki/Home-ru)** — руководство пользователя и документация по разработке (RU · EN)
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,6 +8,9 @@
 [![发布](https://img.shields.io/github/v/release/SeCherkasov/SkerrySSH)](../../releases/latest)
 [![客户端: GPL-3.0](https://img.shields.io/badge/clients-GPL--3.0-blue)](LICENSE)
 [![服务端: AGPL-3.0](https://img.shields.io/badge/server-AGPL--3.0-blue)](server/LICENSE)
+[![Wiki](https://img.shields.io/badge/wiki-user%20guide%20%26%20development-brightgreen)](https://github.com/SeCherkasov/SkerrySSH/wiki)
+
+📖 **[Wiki](https://github.com/SeCherkasov/SkerrySSH/wiki)** — 用户指南与开发文档（English · Русский）
 
 </div>
 


### PR DESCRIPTION
The GitHub wiki now holds the user guide and the development documentation, in English and Russian. Every README points at it from the header — a badge in the badge row and a line under it, before the first paragraph — so the documentation is visible without scrolling.

`README.ru.md` links to the Russian table of contents (`Home-ru`); `README.md` and `README.zh.md` link to the English one, and the Chinese line says which languages the wiki is written in.

Docs only — no code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)