### PR TITLE
Seal the team invite to the key whose fingerprint was verified

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -229,6 +229,7 @@
     <string name="lib_teams_err_not_connected">Синхронизация не подключена</string>
     <string name="lib_teams_err_vault_locked">Хранилище заблокировано</string>
     <string name="lib_teams_err_no_recipient_key">Аккаунт ещё не опубликовал ключ шеринга — попросите приглашаемого один раз открыть вкладку Teams</string>
+    <string name="lib_teams_err_recipient_key_changed">Ключ аккаунта изменился после сверки отпечатка — ничего не отправлено, пригласите заново и сверьте новый</string>
     <string name="lib_teams_err_already_invited">Этот аккаунт уже участник или уже приглашён</string>
     <string name="lib_teams_err_no_such_account">Такого аккаунта нет на sync-сервере</string>
     <string name="lib_teams_err_key_missing">Ключ команды недоступен на этом устройстве</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -223,6 +223,7 @@
     <string name="lib_teams_err_not_connected">同步未连接</string>
     <string name="lib_teams_err_vault_locked">保险库已锁定</string>
     <string name="lib_teams_err_no_recipient_key">此账户尚未发布共享密钥，请让被邀请者打开一次“团队”</string>
+    <string name="lib_teams_err_recipient_key_changed">核对指纹后此账户的密钥已更改 — 未发送任何内容，请重新邀请并核对新指纹</string>
     <string name="lib_teams_err_already_invited">此账户已是成员或有待处理的邀请</string>
     <string name="lib_teams_err_no_such_account">同步服务器上没有此账户</string>
     <string name="lib_teams_err_key_missing">团队密钥在此设备上不可用</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -226,6 +226,7 @@
     <string name="lib_teams_err_not_connected">Sync is not connected</string>
     <string name="lib_teams_err_vault_locked">Vault is locked</string>
     <string name="lib_teams_err_no_recipient_key">This account hasn't published a sharing key yet — ask the invitee to open Teams once</string>
+    <string name="lib_teams_err_recipient_key_changed">The account's key changed after you verified the fingerprint — nothing was sent, invite again and check the new one</string>
     <string name="lib_teams_err_already_invited">This account is already a member or has a pending invite</string>
     <string name="lib_teams_err_no_such_account">No such account on the sync server</string>
     <string name="lib_teams_err_key_missing">Team key is unavailable on this device</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -106,8 +106,8 @@ import app.skerry.ui.generated.resources.shell_create
 import app.skerry.ui.generated.resources.shell_route_team
 import app.skerry.ui.teams.HistoryTarget
 import app.skerry.ui.teams.TeamActivityDialog
-import app.skerry.ui.teams.InviteMemberDialog
 import app.skerry.ui.teams.RolePickerDialog
+import app.skerry.ui.teams.InviteMemberDialogForTeam
 import app.skerry.ui.teams.InvitePreview
 import app.skerry.ui.teams.SharedRecordUi
 import app.skerry.ui.teams.TeamScopeUi
@@ -118,7 +118,7 @@ import app.skerry.ui.teams.ScopeAccessDialog
 import app.skerry.ui.teams.NewScopeButton
 import app.skerry.ui.teams.ScopeSection
 import app.skerry.ui.teams.TeamsCoordinator
-import app.skerry.ui.teams.teamsFailureText
+import app.skerry.ui.teams.TeamsErrorLine
 import app.skerry.ui.teams.SyncPill
 import app.skerry.ui.teams.SharePicker
 import app.skerry.ui.teams.runbookSummary
@@ -229,7 +229,8 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     LaunchedEffect(Unit) { tc.refresh(); tc.syncAll(); tick++ }
 
     var showCreate by remember { mutableStateOf(false) }
-    var showInvite by remember { mutableStateOf(false) }
+    // The team the invite dialog was opened for, not a Boolean (desktop parity).
+    var inviteTeamId by remember { mutableStateOf<String?>(null) }
     var invitePreview by remember { mutableStateOf<InvitePreview?>(null) }
     var sharePicker by remember { mutableStateOf<RecordType?>(null) }
     var confirm by remember { mutableStateOf<MobileTeamsConfirm?>(null) }
@@ -249,7 +250,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     // Column's trailing children they'd get whatever height the scroll body left (≈0) and collapse.
     Box(Modifier.fillMaxSize()) {
     Column(Modifier.fillMaxWidth().verticalScroll(rememberScrollState()).padding(horizontal = 18.dp)) {
-        error?.let { Txt(teamsFailureText(it), color = Skerry.colors.sunset, size = 11.5.sp, modifier = Modifier.padding(vertical = 6.dp)) }
+        TeamsErrorLine(error, size = 11.5.sp, modifier = Modifier.padding(vertical = 6.dp))
         Row(
             Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(vertical = 8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -272,7 +273,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                 tick = tick,
                 busy = busy,
                 lastSyncedAt = syncStamps[selected.id],
-                onInvite = { showInvite = true; invitePreview = null },
+                onInvite = { inviteTeamId = selected.id; invitePreview = null },
                 onShare = { sharePicker = it },
                 onConfirm = { confirm = it },
                 onAccept = { scope.launch { tc.accept(selected.id); tick++ } },
@@ -326,17 +327,17 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
             onCreate = { name -> showCreate = false; scope.launch { tc.createTeam(name); tick++ } },
         )
     }
-    val inviteTeam = selected
-    if (showInvite && inviteTeam != null) {
-        InviteMemberDialog(
+    inviteTeamId?.let { teamId ->
+        InviteMemberDialogForTeam(
+            teams = teams,
+            teamId = teamId,
             preview = invitePreview,
             ownFingerprint = tc.ownFingerprint(),
             busy = busy,
-            assignableRoles = inviteTeam.role.assignableRoles(),
             onLookup = { accountId -> scope.launch { invitePreview = tc.previewInvite(accountId) } },
             onEdited = { invitePreview = null },
-            onSend = { accountId, role -> showInvite = false; scope.launch { tc.invite(inviteTeam.id, accountId, role); tick++ } },
-            onDismiss = { showInvite = false },
+            onSend = { id, verified, role -> inviteTeamId = null; scope.launch { tc.invite(id, verified, role); tick++ } },
+            onDismiss = { inviteTeamId = null },
         )
     }
     val historyTeam = selected

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -46,7 +46,7 @@ import app.skerry.shared.snippet.VaultSnippetStore
 
 /** Typed cause of a Teams operation failure (text in the UI layer, syncFailureText style). */
 enum class TeamsFailure {
-    NotConnected, VaultLocked, NoRecipientKey, AlreadyInvited, NoSuchAccount,
+    NotConnected, VaultLocked, NoRecipientKey, RecipientKeyChanged, AlreadyInvited, NoSuchAccount,
     KeyMissing, Network, Protocol, Forbidden, VaultUnreadable,
     TooManyRequests, ServerError, AlreadyShared, ScopesUnsupported,
 }
@@ -81,7 +81,11 @@ data class TeamUi(
     val scopes: List<TeamScopeUi> = emptyList(),
 )
 
-/** Invite confirmation data: the invitee's key fingerprint is verified over voice/chat. */
+/**
+ * Invite confirmation data: the invitee's key fingerprint is verified over voice/chat. Passing it
+ * back to [TeamsCoordinator.invite] is what binds the send to the key that was read out loud — the
+ * type exists so an invite cannot be sent without one.
+ */
 data class InvitePreview(val accountId: String, val fingerprint: String)
 
 /**
@@ -322,15 +326,30 @@ class TeamsCoordinator(
         }
     }
 
-    /** Invite step 2: seal+sign teamKey+name to the invitee's key and create an invite membership with role [role]. */
-    suspend fun invite(teamId: String, accountId: String, role: TeamRole) {
+    /**
+     * Invite step 2: seal+sign teamKey+name to the key [verified] was taken from and create an
+     * invite membership with role [role].
+     *
+     * The key is fetched again here (the preview is a UI state that may be minutes old), so it is
+     * re-fingerprinted and compared against the one the user confirmed out of band. The server owns
+     * the key table: answering the lookup with the invitee's real key and the send with one of its
+     * own would otherwise seal the team key to the server, with the user having verified a
+     * fingerprint that was never used (#316). A mismatch stops the send with
+     * [TeamsFailure.RecipientKeyChanged] — which is also the right answer for the honest case, an
+     * invitee who rotated their identity between the two steps.
+     */
+    suspend fun invite(teamId: String, verified: InvitePreview, role: TeamRole) {
         val (s, c) = live() ?: return markError(TeamsFailure.NotConnected)
         val entry = keyStore.get(teamId) ?: return markError(TeamsFailure.KeyMissing)
         val teamKey = entry.dataKey() ?: return markError(TeamsFailure.KeyMissing)
+        val accountId = verified.accountId
         op {
             val identity = identityStore.ensure()
             val recipient = c.fetchPublicKey(s, accountId)
                 ?: return@op markError(TeamsFailure.NoRecipientKey)
+            if (accountKeyFingerprint(recipient.sharing, recipient.signing) != verified.fingerprint) {
+                return@op markError(TeamsFailure.RecipientKeyChanged)
+            }
             // Sign the envelope with our identity and bind it to (teamId, inviter=self, invitee, epoch):
             // a malicious server can neither forge the invite nor retarget it to another team/invitee.
             val envelope = inviteCodec.seal(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
@@ -160,9 +160,54 @@ fun CreateTeamDialog(onDismiss: () -> Unit, onCreate: (String) -> Unit) {
 }
 
 /**
+ * [InviteMemberDialog] for the team that [teamId] names, resolved from [teams] on every recomposition.
+ *
+ * The team is addressed by an id captured when the dialog opened, never by whichever team the screen
+ * has selected now: the selection follows the server's team list, which is refreshed on a sync signal
+ * while the dialog is up. Reading it at Send time would let a reorder — or the deletion of the team
+ * the user was looking at — send the invite to a team whose key nobody meant to share (#316 verifies
+ * the recipient; this is the same rule for the other end of the seal).
+ *
+ * A team that left the list takes its dialog with it, [onDismiss] included: without that the screen
+ * would still hold the vanished id, and a team removed and re-invited under the same id (they are
+ * client-generated) would pop the dialog open again on the next refresh.
+ */
+@Composable
+internal fun InviteMemberDialogForTeam(
+    teams: List<TeamUi>,
+    teamId: String,
+    preview: InvitePreview?,
+    ownFingerprint: String?,
+    busy: Boolean,
+    onLookup: (String) -> Unit,
+    onEdited: () -> Unit,
+    onSend: (String, InvitePreview, TeamRole) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val team = teams.firstOrNull { it.id == teamId }
+    if (team == null) {
+        LaunchedEffect(teamId) { onDismiss() }
+        return
+    }
+    InviteMemberDialog(
+        preview = preview,
+        ownFingerprint = ownFingerprint,
+        busy = busy,
+        assignableRoles = team.role.assignableRoles(),
+        onLookup = onLookup,
+        onEdited = onEdited,
+        onSend = { verified, role -> onSend(team.id, verified, role) },
+        onDismiss = onDismiss,
+    )
+}
+
+/**
  * Two-step invite: enter accountId → [onLookup] fetches the published key; once [preview] arrives,
  * show the fingerprint for verification over a trusted channel and only then allow sending. Changing
  * the entered id clears the preview via [onEdited] (can't send to an unverified key).
+ *
+ * [onSend] carries the preview itself, not the typed id: the send is bound to the fingerprint that
+ * was verified, and the coordinator re-checks the key against it before sealing (#316).
  */
 @Composable
 fun InviteMemberDialog(
@@ -172,7 +217,7 @@ fun InviteMemberDialog(
     assignableRoles: List<TeamRole>,
     onLookup: (String) -> Unit,
     onEdited: () -> Unit,
-    onSend: (String, TeamRole) -> Unit,
+    onSend: (InvitePreview, TeamRole) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var accountId by remember { mutableStateOf("") }
@@ -181,17 +226,20 @@ fun InviteMemberDialog(
     val focus = remember { FocusRequester() }
     LaunchedEffect(Unit) { focus.requestFocus() }
     val mono = LocalFonts.current.mono
-    val ready = preview != null && preview.accountId == accountId.trim()
+    // The preview only counts while the typed id still matches it — editing the field must not leave
+    // a stale verification standing behind the Send button.
+    val verified = preview?.takeIf { it.accountId == accountId.trim() }
+    val ready = verified != null
     fun submit() {
         val id = accountId.trim()
         if (id.isEmpty() || busy) return
-        if (ready) onSend(id, role) else onLookup(id)
+        if (verified != null) onSend(verified, role) else onLookup(id)
     }
     TeamsDialogCard(onDismiss, label = stringResource(Res.string.lib_teams_invite_title)) {
         Txt(stringResource(Res.string.lib_teams_invite_title), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
         Txt(stringResource(Res.string.lib_teams_invite_subtitle), color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp, modifier = Modifier.padding(top = 4.dp, bottom = 16.dp))
         TeamsTextField(accountId, { accountId = it; onEdited() }, stringResource(Res.string.lib_teams_invite_account_placeholder), ::submit, focus)
-        if (preview != null && ready) {
+        if (verified != null) {
             Column(
                 Modifier
                     .fillMaxWidth()
@@ -202,7 +250,7 @@ fun InviteMemberDialog(
                     .padding(12.dp),
             ) {
                 Txt(stringResource(Res.string.lib_teams_invite_fingerprint).uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
-                Txt(preview.fingerprint, color = Skerry.colors.cyanBright, size = 14.sp, font = mono, modifier = Modifier.padding(top = 4.dp))
+                Txt(verified.fingerprint, color = Skerry.colors.cyanBright, size = 14.sp, font = mono, modifier = Modifier.padding(top = 4.dp))
                 Txt(stringResource(Res.string.lib_teams_invite_verify), color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
                 if (ownFingerprint != null) {
                     Txt(stringResource(Res.string.lib_teams_your_fingerprint, ownFingerprint), color = Skerry.colors.faint, size = 11.sp, font = mono, modifier = Modifier.padding(top = 8.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.runbook.VaultRunbookStore
@@ -57,6 +58,7 @@ import app.skerry.ui.design.SIDEBAR_WIDTH
 import app.skerry.ui.design.SectionHeader
 import app.skerry.ui.design.SidebarSectionTitle
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.VLine
 import app.skerry.ui.design.untrustedLabel
@@ -77,6 +79,7 @@ import app.skerry.ui.generated.resources.lib_teams_err_no_recipient_key
 import app.skerry.ui.generated.resources.lib_teams_err_no_such_account
 import app.skerry.ui.generated.resources.lib_teams_err_not_connected
 import app.skerry.ui.generated.resources.lib_teams_err_protocol
+import app.skerry.ui.generated.resources.lib_teams_err_recipient_key_changed
 import app.skerry.ui.generated.resources.lib_teams_err_scopes_unsupported
 import app.skerry.ui.generated.resources.lib_teams_err_server_error
 import app.skerry.ui.generated.resources.lib_teams_err_too_many_requests
@@ -146,7 +149,8 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     LaunchedEffect(Unit) { tc.refresh(); tc.syncAll(); tick++ }
 
     var showCreate by remember { mutableStateOf(false) }
-    var showInvite by remember { mutableStateOf(false) }
+    // The team the invite dialog was opened for, not a Boolean: see InviteMemberDialogForTeam.
+    var inviteTeamId by remember { mutableStateOf<String?>(null) }
     var invitePreview by remember { mutableStateOf<InvitePreview?>(null) }
     var sharePicker by remember { mutableStateOf<RecordType?>(null) }
     var confirm by remember { mutableStateOf<TeamsConfirm?>(null) }
@@ -177,7 +181,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                 LiveTeamRow(team, active = team.id == selected?.id) { selectedId = team.id }
             }
             Spacer(Modifier.weight(1f))
-            error?.let { Txt(teamsFailureText(it), color = Skerry.colors.sunset, size = 11.sp, modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) }
+            TeamsErrorLine(error, size = 11.sp, modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp))
             PrimaryButton(stringResource(Res.string.lib_teams_create), onClick = { showCreate = true }, icon = "group_add", modifier = Modifier.fillMaxWidth())
         }
         VLine(Skerry.colors.line)
@@ -191,7 +195,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                     scopeId = scopeId,
                     tick = tick,
                     busy = busy,
-                    onInvite = { showInvite = true; invitePreview = null },
+                    onInvite = { inviteTeamId = selected.id; invitePreview = null },
                     onConfirm = { confirm = it },
                     onAccept = { scope.launch2 { tc.accept(selected.id); afterOp() } },
                     onDecline = { scope.launch2 { tc.decline(selected.id); afterOp() } },
@@ -213,17 +217,17 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
             onCreate = { name -> showCreate = false; scope.launch2 { tc.createTeam(name); afterOp() } },
         )
     }
-    val inviteTeam = selected
-    if (showInvite && inviteTeam != null) {
-        InviteMemberDialog(
+    inviteTeamId?.let { teamId ->
+        InviteMemberDialogForTeam(
+            teams = teams,
+            teamId = teamId,
             preview = invitePreview,
             ownFingerprint = tc.ownFingerprint(),
             busy = busy,
-            assignableRoles = inviteTeam.role.assignableRoles(),
             onLookup = { accountId -> scope.launch2 { invitePreview = tc.previewInvite(accountId) } },
             onEdited = { invitePreview = null },
-            onSend = { accountId, role -> showInvite = false; scope.launch2 { tc.invite(inviteTeam.id, accountId, role); afterOp() } },
-            onDismiss = { showInvite = false },
+            onSend = { id, verified, role -> inviteTeamId = null; scope.launch2 { tc.invite(id, verified, role); afterOp() } },
+            onDismiss = { inviteTeamId = null },
         )
     }
     val shareTeam = selected
@@ -367,12 +371,30 @@ private fun LiveTeamRow(team: TeamUi, active: Boolean, onClick: () -> Unit) {
 /** A record to show the history of: its id, plus the name to put in the dialog's title. */
 internal data class HistoryTarget(val recordId: String, val label: String)
 
+/**
+ * The Teams error line, spoken as well as drawn.
+ *
+ * A Teams failure lands after the dialog that asked for it is gone — invite, share and the
+ * destructive confirmations all close on the click — so this line is the only report of it, and a
+ * plain Txt appearing in a sidebar tells a screen reader nothing (WCAG 4.1.3). The announcer stays
+ * composed while there is no error, so the message that arrives is a change to a node that was
+ * already there rather than an insertion; same shape as SyncFormError (#244).
+ */
+@Composable
+internal fun TeamsErrorLine(failure: TeamsFailure?, size: TextUnit, modifier: Modifier = Modifier) {
+    val text = failure?.let { teamsFailureText(it) } ?: ""
+    StatusAnnouncer(text)
+    if (failure == null) return
+    Txt(text, color = Skerry.colors.sunset, size = size, modifier = modifier)
+}
+
 /** Text for a typed Teams error (analogous to syncFailureText). */
 @Composable
 internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
     TeamsFailure.NotConnected -> stringResource(Res.string.lib_teams_err_not_connected)
     TeamsFailure.VaultLocked -> stringResource(Res.string.lib_teams_err_vault_locked)
     TeamsFailure.NoRecipientKey -> stringResource(Res.string.lib_teams_err_no_recipient_key)
+    TeamsFailure.RecipientKeyChanged -> stringResource(Res.string.lib_teams_err_recipient_key_changed)
     TeamsFailure.AlreadyInvited -> stringResource(Res.string.lib_teams_err_already_invited)
     TeamsFailure.NoSuchAccount -> stringResource(Res.string.lib_teams_err_no_such_account)
     TeamsFailure.KeyMissing -> stringResource(Res.string.lib_teams_err_key_missing)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteBindingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteBindingTest.kt
@@ -1,0 +1,190 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
+import app.skerry.shared.team.TeamSessionKind
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.SharingKeyPair
+import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.ui.sync.TeamLink
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * The invite ceremony's whole point is that the fingerprint the user reads out loud belongs to the
+ * key the team key is sealed to (#316). The sync server owns the key table, so it can answer the
+ * lookup with the invitee's real key and the send with one of its own: the fake below does exactly
+ * that, and the send must stop rather than seal to a key nobody verified.
+ */
+class TeamsCoordinatorInviteBindingTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val teamId = "team-inv-bind"
+    private val self = "alice@example.com"
+    private val bob = "bob@example.com"
+
+    /** Fake team network whose published key for [bob] can be swapped between two fetches. */
+    private class FakeInviteClient(private val bob: String, var bobKeys: AccountKeys) : TeamClient {
+        val invites = mutableListOf<Triple<String, TeamRole, ByteArray>>()
+        var keyFetches = 0
+
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
+            keyFetches += 1
+            return if (accountId == bob) bobKeys else null
+        }
+
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) {
+            invites += Triple(accountId, role, envelope)
+        }
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = emptyList()
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = emptyList()
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage =
+            RecordPage(emptyList(), since)
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage =
+            RecordPage(emptyList(), 0)
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = emptyList()
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> = emptyList()
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+    }
+
+    private class Fixture(val vault: FileVault, val teamVaults: TeamVaults)
+
+    private fun newFixture(): Fixture {
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile) // FileVault creates it
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }))
+    }
+
+    private fun coordinator(f: Fixture, client: TeamClient) = TeamsCoordinator(
+        live = { TeamLink(SyncSession(self, "access", "refresh"), client, "test-link") },
+        vault = f.vault,
+        crypto = crypto,
+        teamVaults = f.teamVaults,
+        teamState = InMemorySyncStateStore(),
+        newId = { "unused" },
+    )
+
+    private fun keysOf(sharing: SharingKeyPair) = AccountKeys(sharing.publicKey, crypto.newSigningKeyPair().publicKey)
+
+    @Test
+    fun `a key that changed between the lookup and the send stops the invite`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+
+        val real = crypto.newSharingKeyPair()
+        val client = FakeInviteClient(bob, keysOf(real))
+        val coord = coordinator(f, client)
+
+        val preview = assertNotNull(coord.previewInvite(bob), "lookup must return a fingerprint")
+        // The server swaps its answer between the two steps: the fingerprint the user just read out
+        // loud is no longer the key the second fetch returns.
+        client.bobKeys = keysOf(crypto.newSharingKeyPair())
+        coord.invite(teamId, preview, TeamRole.VIEWER)
+
+        assertEquals(emptyList(), client.invites, "the team key must not be sealed to an unverified key")
+        assertEquals(TeamsFailure.RecipientKeyChanged, coord.lastError.value)
+    }
+
+    /**
+     * The fingerprint hashes the sharing key AND the signing key, so a server that leaves the key the
+     * envelope is sealed to alone and swaps only the identity the invitee signs with must be refused
+     * too — otherwise the invitee's later envelopes verify against a key nobody read out loud.
+     */
+    @Test
+    fun `a signing key swapped under the same sharing key is a mismatch too`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+
+        val real = crypto.newSharingKeyPair()
+        val client = FakeInviteClient(bob, keysOf(real))
+        val coord = coordinator(f, client)
+
+        val preview = assertNotNull(coord.previewInvite(bob))
+        client.bobKeys = AccountKeys(real.publicKey, crypto.newSigningKeyPair().publicKey)
+        coord.invite(teamId, preview, TeamRole.VIEWER)
+
+        assertEquals(emptyList(), client.invites)
+        assertEquals(TeamsFailure.RecipientKeyChanged, coord.lastError.value)
+    }
+
+    @Test
+    fun `an unchanged key seals the invite to the key whose fingerprint was verified`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+
+        val real = crypto.newSharingKeyPair()
+        val client = FakeInviteClient(bob, keysOf(real))
+        val coord = coordinator(f, client)
+
+        val preview = assertNotNull(coord.previewInvite(bob))
+        coord.invite(teamId, preview, TeamRole.VIEWER)
+
+        assertNull(coord.lastError.value)
+        assertEquals(1, client.invites.size)
+        // The send fetches the key again rather than trusting the preview: the check is on fresh
+        // material, so a key that moved between the two steps cannot slip through unnoticed.
+        assertEquals(2, client.keyFetches)
+        val (accountId, role, envelope) = client.invites.single()
+        assertEquals(bob, accountId)
+        assertEquals(TeamRole.VIEWER, role)
+        // Opening under the very key pair whose fingerprint the preview showed IS the property: the
+        // envelope was sealed to the verified key, not to whatever the second lookup returned.
+        val opened = assertNotNull(TeamInviteCodec(crypto).open(real, envelope), "sealed to the verified key")
+        assertEquals(teamId, opened.teamId)
+        assertEquals(bob, opened.inviteeAccountId)
+        assertEquals(self, opened.inviterAccountId)
+        assertEquals("Ops", opened.teamName)
+    }
+
+    private companion object {
+        const val NOW = "2026-08-23T00:00:00Z"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
@@ -1,12 +1,17 @@
 package app.skerry.ui.teams
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
+import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.desktop.runForm
@@ -51,7 +56,7 @@ class TeamsDialogFormTest {
     @Test
     fun `an invite is looked up before it can be sent`() {
         var lookedUp: String? = null
-        var sent: Pair<String, TeamRole>? = null
+        var sent: Pair<InvitePreview, TeamRole>? = null
         runForm({
             InviteMemberDialog(
                 preview = null,
@@ -60,7 +65,7 @@ class TeamsDialogFormTest {
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
                 onLookup = { lookedUp = it },
                 onEdited = {},
-                onSend = { id, role -> sent = id to role },
+                onSend = { verified, role -> sent = verified to role },
                 onDismiss = {},
             )
         }) {
@@ -75,7 +80,7 @@ class TeamsDialogFormTest {
     /** With the looked-up key on screen the same button sends, and sends the role that is selected. */
     @Test
     fun `an invite is sent once its key is on screen`() {
-        var sent: Pair<String, TeamRole>? = null
+        var sent: Pair<InvitePreview, TeamRole>? = null
         runForm({
             InviteMemberDialog(
                 preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
@@ -84,7 +89,7 @@ class TeamsDialogFormTest {
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
                 onLookup = {},
                 onEdited = {},
-                onSend = { id, role -> sent = id to role },
+                onSend = { verified, role -> sent = verified to role },
                 onDismiss = {},
             )
         }) {
@@ -92,7 +97,8 @@ class TeamsDialogFormTest {
             onNodeWithTag(UiTags.FORM_SAVE).performClick()
             waitForIdle()
         }
-        assertEquals(ACCOUNT, sent?.first)
+        assertEquals(ACCOUNT, sent?.first?.accountId)
+        assertEquals(PEER_FINGERPRINT, sent?.first?.fingerprint, "the send must carry the verified fingerprint")
         assertEquals(TeamRole.VIEWER, sent?.second, "the invite should default to the least privilege")
     }
 
@@ -103,7 +109,7 @@ class TeamsDialogFormTest {
     @Test
     fun `changing the account after a lookup does not send to the old key`() {
         var edited = false
-        var sent: Pair<String, TeamRole>? = null
+        var sent: Pair<InvitePreview, TeamRole>? = null
         runForm({
             InviteMemberDialog(
                 preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
@@ -112,7 +118,7 @@ class TeamsDialogFormTest {
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
                 onLookup = {},
                 onEdited = { edited = true },
-                onSend = { id, role -> sent = id to role },
+                onSend = { verified, role -> sent = verified to role },
                 onDismiss = {},
             )
         }) {
@@ -123,9 +129,81 @@ class TeamsDialogFormTest {
         assertTrue(edited, "the dialog did not report the id being edited")
         assertNull(sent, "the invite went to the account whose key was on screen, not the typed one")
     }
+
+    /**
+     * The team list is the server's answer and is refreshed under an open dialog: it reorders on a
+     * membership signal, and the team the screen shows as selected moves with it. The invite must
+     * still go to the team the dialog was opened for, or the server picks whose key gets shared.
+     */
+    @Test
+    fun `the invite goes to the team the dialog was opened for, not the first one in the list`() {
+        var teams by mutableStateOf(listOf(team(TEAM_ID), team(OTHER_TEAM_ID)))
+        var sentTo: String? = null
+        runForm({
+            InviteMemberDialogForTeam(
+                teams = teams,
+                teamId = TEAM_ID,
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onLookup = {},
+                onEdited = {},
+                onSend = { id, _, _ -> sentTo = id },
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithTag(UiTags.FORM_FIELD).performTextReplacement(ACCOUNT)
+            // The server answers a refresh while the user is still reading the fingerprint out loud.
+            teams = listOf(team(OTHER_TEAM_ID), team(TEAM_ID))
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).performClick()
+            waitForIdle()
+        }
+        assertEquals(TEAM_ID, sentTo)
+    }
+
+    /**
+     * A team that disappeared from the list takes its dialog with it — and the screen has to be told,
+     * or it keeps the vanished id and reopens the dialog the moment a team is re-invited under it.
+     */
+    @Test
+    fun `a team gone from the list closes its invite dialog and clears the screen's state`() {
+        var dismissed = false
+        runForm({
+            InviteMemberDialogForTeam(
+                teams = listOf(team(OTHER_TEAM_ID)),
+                teamId = TEAM_ID,
+                preview = null,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onLookup = {},
+                onEdited = {},
+                onSend = { _, _, _ -> },
+                onDismiss = { dismissed = true },
+            )
+        }) {
+            waitForIdle()
+            onAllNodesWithTag(UiTags.FORM_SAVE).fetchSemanticsNodes().let {
+                assertTrue(it.isEmpty(), "the dialog stayed up for a team that is gone")
+            }
+        }
+        assertTrue(dismissed, "the screen was never told the dialog is gone")
+    }
 }
 
+private fun team(id: String) = TeamUi(
+    id = id,
+    name = id,
+    ownerAccountId = ACCOUNT,
+    role = TeamRole.OWNER,
+    status = TeamMemberStatus.ACTIVE,
+    memberCount = 1,
+    hasKey = true,
+)
+
 private const val TEAM = "platform"
+private const val TEAM_ID = "team-opened-for"
+private const val OTHER_TEAM_ID = "team-that-jumped-first"
 private const val ACCOUNT = "alice@example.com"
 private const val OTHER_ACCOUNT = "mallory@example.com"
 private const val OWN_FINGERPRINT = "SHA256:ownownownownownownownownownownownownownownow"

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsErrorAnnouncementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsErrorAnnouncementTest.kt
@@ -1,0 +1,54 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.sp
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * A Teams failure arrives after the dialog that caused it is gone — invite closes on the click, and
+ * the refusal #316 introduced lands a round-trip later. The sidebar line is the only report of it,
+ * so it has to be spoken as well as drawn (WCAG 4.1.3), by a node that was already there when the
+ * message changed.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TeamsErrorAnnouncementTest {
+
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    @Test
+    fun `a failure that lands after the dialog closed is announced`() {
+        var failure by mutableStateOf<TeamsFailure?>(null)
+        runForm({ TeamsErrorLine(failure, size = 11.sp) }) {
+            onNode(polite).assertContentDescriptionEquals("")
+            failure = TeamsFailure.RecipientKeyChanged
+            waitForIdle()
+            // The same node, a new description: a status change, not a node appearing.
+            val spoken = onNode(polite).fetchSemanticsNode()
+                .config[SemanticsProperties.ContentDescription].first()
+            assertTrue(spoken.isNotBlank(), "the refusal is drawn but never spoken")
+            onNodeWithText(spoken).assertExists()
+        }
+    }
+
+    /** Every failure has something to say: an unspoken one reads as the operation having done nothing. */
+    @Test
+    fun `every teams failure announces something`() {
+        val spoken = mutableMapOf<TeamsFailure, String>()
+        runForm({ TeamsFailure.entries.forEach { spoken[it] = teamsFailureText(it) } }) { waitForIdle() }
+        for (failure in TeamsFailure.entries) {
+            assertTrue(spoken[failure].orEmpty().isNotBlank(), "$failure announces nothing")
+        }
+        val heard = spoken.values.toList()
+        assertTrue(heard.size == heard.toSet().size, "two failures say the same sentence: $heard")
+    }
+}


### PR DESCRIPTION
Closes #316.

Inviting someone to a team is a two-step ceremony: look the account up, read the fingerprint of its
published key, confirm that fingerprint over a channel the server does not control, and only then
send. The fingerprint was not bound to the key the invite was sealed to — `previewInvite` fetched the
key, derived the fingerprint and dropped the key, and `invite` fetched the key again, from the same
server, and sealed the team key to whatever the second answer was. Nothing compared the two.

The sync server owns `/account/keys/{accountId}`, so answering the lookup with the invitee's real key
and the send with a key of its own got the team key sealed to the server, with the user having
verified a fingerprint that was never used.

## What changed

- `TeamsCoordinator.invite` takes the `InvitePreview` from step 1 instead of a bare account id. It
  still re-fetches the key (the preview is UI state and may be minutes old) but re-derives the
  fingerprint and compares it with the one that was confirmed, refusing the send on a mismatch. The
  fingerprint covers the sharing key and the signing key, so a swap of either half is caught.
- A new `TeamsFailure.RecipientKeyChanged` says so, in en/ru/zh. It is also the right answer for the
  honest case — an invitee who rotated their identity between the two steps.
- `InviteMemberDialog` hands `onSend` the preview rather than the typed id, so an invite cannot be
  sent without a verification the coordinator can check.

Two neighbours of the same rule came out of the review and are fixed here:

- The invite dialog took its team from the screen's current selection, which follows the server's
  team list and is refreshed while the dialog is open — a reorder could send the invite to a team
  nobody meant to share. It is now addressed by the team id captured when it opened, and closes
  itself, screen state included, if that team leaves the list.
- A Teams failure lands after the dialog that asked for it is gone, and the line that reports it was
  a plain text row: for a screen reader the refusal was silent (WCAG 4.1.3). It now goes through
  `StatusAnnouncer`, the same primitive the sync form uses.

## Not in scope

`TeamSpaces.grantScope` and the re-seal loop after a rotation also seal to a freshly fetched key, and
the invitee's half has a window of its own: `acceptPreview` fingerprints a second fetch of the
inviter's key rather than the one `openVerifiedInvite` checked the signature against. Closing those
needs a verified fingerprint persisted per account — a design change rather than an extra check — so
they are tracked in #319, which #316 anticipated under "Related, not the same".

## Verifying by hand

Teams → a team you own → Invite. Type an account id, press Next, and the fingerprint appears; press
Send and the invite goes out as before. Editing the id after the lookup still turns Send back into
Next. Seeing the refusal itself needs a server that changes its answer between the two calls, which
is what the new test does.
