### PR TITLE
Hold every seal to a peer against a fingerprint a human confirmed

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -147,9 +147,14 @@
     <string name="lib_teams_invite_send">Отправить приглашение</string>
     <string name="lib_teams_your_fingerprint">Ваш отпечаток: %1$s</string>
     <string name="lib_teams_invited_banner">Вас пригласили в эту команду</string>
+    <string name="lib_teams_invite_checking">Проверяем отправителя приглашения…</string>
     <string name="lib_teams_invited_by">Пригласил %1$s</string>
     <string name="lib_teams_invited_fingerprint">Перед принятием сверьте отпечаток пригласившего по доверенному каналу: %1$s</string>
     <string name="lib_teams_invite_unverified">Не удалось проверить отправителя приглашения. Не принимайте, если не доверяете.</string>
+    <string name="lib_teams_invite_check_failed">Приглашение проверить не удалось.</string>
+    <string name="lib_teams_invite_check_retry">Повторить</string>
+    <string name="lib_teams_invite_key_changed_ack">Новый отпечаток подтверждён по доверенному каналу</string>
+    <string name="lib_teams_invite_key_changed">Отличается от ключа, закреплённого за этим аккаунтом. Сверьте новый отпечаток по доверенному каналу.</string>
     <string name="lib_teams_accept">Принять</string>
     <string name="lib_teams_decline">Отклонить</string>
     <string name="lib_teams_role_owner">ВЛАДЕЛЕЦ</string>
@@ -256,6 +261,11 @@
     <string name="lib_teams_scope_members_count">с доступом: %1$d</string>
     <string name="lib_teams_err_already_shared">Эта запись уже расшарена в другой области этой команды — сначала уберите её оттуда</string>
     <string name="lib_teams_err_scopes_unsupported">Этот sync-сервер слишком старый для областей доступа — обновите сервер</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">Опубликованный ключ участника не тот, что был подтверждён, — под него ничего не запечатано. Удалите его из команды и пригласите заново, чтобы подтвердить новый ключ</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">Пришёл ключ команды, подписанный неподтверждённой личностью, — он проигнорирован</string>
+    <string name="lib_teams_err_invite_unverified">Приглашение не проверено — откройте команду и сверьте отпечаток пригласившего перед принятием</string>
+    <string name="lib_teams_err_pin_not_recorded">Подтверждённый отпечаток не удалось сохранить на этом устройстве — этому ключу ничего не отправлено</string>
+    <string name="lib_teams_err_identity_unreadable">Устройство не может прочитать свой командный ключ, приглашение здесь не открыть</string>
     <!-- Экран команды: шапка, таблица участников, карточки (см. TeamsView) -->
     <string name="lib_teams_header_title">Команда</string>
     <!-- %1$s — название команды, %2$d — число участников -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -141,9 +141,14 @@
     <string name="lib_teams_invite_send">发送邀请</string>
     <string name="lib_teams_your_fingerprint">你的指纹：%1$s</string>
     <string name="lib_teams_invited_banner">你被邀请加入此团队</string>
+    <string name="lib_teams_invite_checking">正在核验此邀请的发送者…</string>
     <string name="lib_teams_invited_by">邀请人：%1$s</string>
     <string name="lib_teams_invited_fingerprint">接受前请通过可信渠道确认邀请人的指纹：%1$s</string>
     <string name="lib_teams_invite_unverified">无法验证邀请的发送者。除非信任，否则不要接受。</string>
+    <string name="lib_teams_invite_check_failed">无法检查此邀请。</string>
+    <string name="lib_teams_invite_check_retry">重试</string>
+    <string name="lib_teams_invite_key_changed_ack">已通过可信渠道确认新指纹</string>
+    <string name="lib_teams_invite_key_changed">与该账户已固定的密钥不一致。继续之前请通过可信渠道核对新指纹。</string>
     <string name="lib_teams_accept">接受</string>
     <string name="lib_teams_decline">拒绝</string>
     <string name="lib_teams_role_owner">拥有者</string>
@@ -250,6 +255,11 @@
     <string name="lib_teams_scope_members_count">%1$d 人可访问</string>
     <string name="lib_teams_err_already_shared">该记录已共享到此团队的另一个范围 — 请先在那里取消共享</string>
     <string name="lib_teams_err_scopes_unsupported">此同步服务器版本过旧，不支持访问范围 — 请更新服务器</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">成员发布的密钥不是已确认的那把 — 未向其封装任何密钥。将其移出团队后重新邀请，以确认新密钥</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">收到的团队密钥由未确认的身份签名，已被忽略</string>
+    <string name="lib_teams_err_invite_unverified">此邀请未经验证 — 请打开团队并核对邀请者的指纹后再接受</string>
+    <string name="lib_teams_err_pin_not_recorded">无法在此设备上保存已确认的指纹，未向该密钥发送任何内容</string>
+    <string name="lib_teams_err_identity_unreadable">此设备无法读取自己的团队身份密钥，无法在此打开邀请</string>
     <!-- 团队界面：标题栏、成员表、汇总卡片（见 TeamsView） -->
     <string name="lib_teams_header_title">团队</string>
     <!-- %1$s — 团队名称，%2$d — 成员数 -->

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -144,9 +144,14 @@
     <string name="lib_teams_invite_send">Send invite</string>
     <string name="lib_teams_your_fingerprint">Your fingerprint: %1$s</string>
     <string name="lib_teams_invited_banner">You are invited to this team</string>
+    <string name="lib_teams_invite_checking">Checking who sent this invite…</string>
     <string name="lib_teams_invited_by">Invited by %1$s</string>
     <string name="lib_teams_invited_fingerprint">Before accepting, confirm the inviter's fingerprint over a trusted channel: %1$s</string>
     <string name="lib_teams_invite_unverified">Couldn't verify who sent this invite. Don't accept unless you trust it.</string>
+    <string name="lib_teams_invite_check_failed">The invite couldn't be checked.</string>
+    <string name="lib_teams_invite_check_retry">Retry</string>
+    <string name="lib_teams_invite_key_changed_ack">New fingerprint confirmed over a trusted channel</string>
+    <string name="lib_teams_invite_key_changed">This differs from the key pinned for this account. Confirm the new fingerprint over a trusted channel before continuing.</string>
     <string name="lib_teams_accept">Accept</string>
     <string name="lib_teams_decline">Decline</string>
     <string name="lib_teams_role_owner">OWNER</string>
@@ -253,6 +258,11 @@
     <string name="lib_teams_scope_members_count">%1$d with access</string>
     <string name="lib_teams_err_already_shared">This record is already shared into another scope of this team — unshare it there first</string>
     <string name="lib_teams_err_scopes_unsupported">This sync server is too old for access scopes — update the server</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">A member's published key is not the one confirmed for them — nothing was sealed to it. Remove them from the team and invite again to confirm the new key</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">A team key arrived signed by an identity that is not the confirmed one, and was ignored</string>
+    <string name="lib_teams_err_invite_unverified">This invite was not verified — reopen the team and check the inviter's fingerprint before accepting</string>
+    <string name="lib_teams_err_pin_not_recorded">The confirmed fingerprint couldn't be stored on this device — nothing was sent to that key</string>
+    <string name="lib_teams_err_identity_unreadable">This device can't read its team identity, so the invite can't be opened here</string>
     <!-- Teams screen: header, member table, summary cards (see TeamsView) -->
     <string name="lib_teams_header_title">Team</string>
     <!-- %1$s — team name, %2$d — member count -->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -65,6 +66,7 @@ import app.skerry.ui.design.ConfirmActionDialog
 import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.session.SessionStatus
@@ -108,6 +110,15 @@ import app.skerry.ui.teams.HistoryTarget
 import app.skerry.ui.teams.TeamActivityDialog
 import app.skerry.ui.teams.RolePickerDialog
 import app.skerry.ui.teams.InviteMemberDialogForTeam
+import app.skerry.ui.teams.InviteCheck
+import app.skerry.ui.teams.inviteCheckAnnouncement
+import app.skerry.ui.teams.rememberInviteCheck
+import app.skerry.ui.design.ToggleRow
+import app.skerry.ui.teams.inviteCheckLines
+import app.skerry.ui.teams.rememberInviteAcknowledgement
+import app.skerry.ui.teams.readyToAccept
+import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.teams.InvitePreview
 import app.skerry.ui.teams.SharedRecordUi
 import app.skerry.ui.teams.TeamScopeUi
@@ -503,9 +514,46 @@ private fun MobileTeamDetail(
                 Sym("mail", size = 18.sp, color = Skerry.colors.amber)
                 Txt(stringResource(Res.string.lib_teams_invited_banner), color = Skerry.colors.text, size = 12.5.sp)
             }
+            // The same ceremony as on the desktop, drawn from the same state: who sent it, the
+            // fingerprint to confirm over a trusted channel, and Accept only once both are on screen
+            // (#319). The phone showed two buttons and nothing to check them against.
+            // Both counters only ever go up, so their sum changes whichever moves — the screen's
+            // reread, or Retry below.
+            var retries by remember(team.id) { mutableIntStateOf(0) }
+            val check = rememberInviteCheck(tc, team.id, tick + retries)
+            val ack = rememberInviteAcknowledgement(check)
+            // Composed above the lines it describes, not among them: only a node that survives the
+            // state change and carries the text itself announces anything (see StatusAnnouncer).
+            StatusAnnouncer(inviteCheckAnnouncement(check))
+            inviteCheckLines(check).forEach { line ->
+                Txt(
+                    line.text,
+                    color = line.color,
+                    size = 12.sp,
+                    lineHeight = 17.sp,
+                    font = if (line.mono) LocalFonts.current.mono else null,
+                    modifier = Modifier.padding(top = 10.dp),
+                )
+            }
+            if (ack.moved != null) {
+                ToggleRow(
+                    label = stringResource(Res.string.lib_teams_invite_key_changed_ack),
+                    on = ack.acknowledged,
+                    onToggle = ack.toggle,
+                    labelSize = 12.sp,
+                    modifier = Modifier.padding(top = 10.dp),
+                )
+            }
             Row(Modifier.padding(top = 12.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                PrimaryButton(stringResource(Res.string.lib_teams_accept), onClick = onAccept, enabled = !busy)
+                PrimaryButton(
+                    stringResource(Res.string.lib_teams_accept),
+                    onClick = onAccept,
+                    enabled = readyToAccept(check, busy, ack.acknowledged),
+                )
                 GhostButton(stringResource(Res.string.lib_teams_decline), onClick = onDecline, fg = Skerry.colors.dim)
+                if (check is InviteCheck.Failed) {
+                    GhostButton(stringResource(Res.string.lib_teams_invite_check_retry), onClick = { retries += 1 }, fg = Skerry.colors.amber)
+                }
             }
         }
         return

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -900,7 +900,9 @@ class SyncCoordinator(
      * pushed once the pull flips the filter on — resurrecting the purged record. Clearing by the maximal
      * (everything-on) filter covers any server settings; only never-synced, device-local types (terminal
      * history) are kept — plus, record by record, the device-local ones the push filter already refuses
-     * ([DeviceLocalRecords]): nothing on the server would restore those.
+     * ([DeviceLocalRecords]): nothing on the server would restore those. The one sync-capable type held
+     * back is [RecordType.TEAM_PEER]: a re-pull restores a pin only if the server wants it restored, and
+     * a device without its pins seals the next rotation to whatever key the server answers with (#319).
      *
      * Throws whatever the clear throws — a vault locked at this moment ([Vault.clearRecords] needs an
      * unlocked one) leaves the debt standing over an un-cleared vault, which is what [reconcileOwed] reads.
@@ -926,7 +928,13 @@ class SyncCoordinator(
         val syncCapable = SyncSettings(syncHosts = true, syncSnippets = true)
         // Device-local records are spared one at a time, not by type: they were never pushed, so the
         // re-pull cannot bring them back and clearing them would simply destroy them (issue #174).
-        vault.clearRecords(RecordType.entries.filter { syncCapable.shouldSync(it) }.toSet(), deviceLocal::survivesClear)
+        // Verified peer fingerprints are spared by type, and for the opposite reason: the re-pull WOULD
+        // bring them back, but only as the server chooses to hand them back. `reactivated` is the
+        // server's own flag, so a server that raises it and then answers the pull without the pins has
+        // walked this device back to trusting whatever key it publishes next (#319). A stale pin costs a
+        // re-confirmation; a missing one costs the confirmation itself.
+        val dropped = RecordType.entries.filter { syncCapable.shouldSync(it) && it != RecordType.TEAM_PEER }
+        vault.clearRecords(dropped.toSet(), deviceLocal::survivesClear)
         syncState.setCursor(link.cursorKey, 0) // reactivation always full-pulls to rebuild from the server
         armedFor = link // only now, and named — see [retireDischargedDebt]
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/InviteCheck.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/InviteCheck.kt
@@ -1,0 +1,147 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_invite_check_failed
+import app.skerry.ui.generated.resources.lib_teams_invite_checking
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_invite_unverified
+import app.skerry.ui.generated.resources.lib_teams_invited_by
+import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * State of the invite banner's verification: an invite is opened, its signature checked and its
+ * inviter's fingerprint derived before Accept means anything.
+ *
+ * States, not a nullable preview: "still checking" and "could not be verified" both used to read as
+ * null while the Accept button stayed live, so pressing it in either state adopted a team key with
+ * no ceremony at all (#319). [Pending] is the screen's own; the other three are
+ * [InviteVerdict] as the coordinator answered it.
+ */
+internal sealed interface InviteCheck {
+    /** The round trip to the server hasn't come back yet — Accept is not offered. */
+    data object Pending : InviteCheck
+
+    /** No envelope, or one that doesn't verify: forged, tampered with, or not addressed to us. */
+    data object Unverified : InviteCheck
+
+    /** The check could not be made — [reason] says why. Retried on the next pass. */
+    data class Failed(val reason: TeamsFailure) : InviteCheck
+
+    /** Opened and verified: [preview] is the inviter and the fingerprint to confirm out of band. */
+    data class Verified(val preview: InvitePreview) : InviteCheck
+}
+
+/**
+ * The second, deliberate confirmation a moved key costs before Accept opens: [moved] is the
+ * fingerprint that has to be acknowledged (null when the key did not move), [acknowledged] whether
+ * it was, and [toggle] the control that ticks it.
+ */
+internal class InviteAcknowledgement(val moved: String?, val acknowledged: Boolean, val toggle: () -> Unit)
+
+/**
+ * Holds that acknowledgement for one banner. Remembered as the fingerprint that was acknowledged
+ * rather than as a flag: the check is re-run by every reread of the screen and visits [Pending] on
+ * the way there, so a flag keyed on the state would be cleared by an action on some other team and
+ * ask the user to tick it again. A different fingerprint is a different question, and matches nothing.
+ *
+ * One holder for both surfaces — a second copy of this is a copy no test on the other surface reads.
+ */
+@Composable
+internal fun rememberInviteAcknowledgement(check: InviteCheck): InviteAcknowledgement {
+    var acknowledgedFor by remember { mutableStateOf<String?>(null) }
+    val moved = (check as? InviteCheck.Verified)?.preview?.takeIf { it.keyChanged }?.fingerprint
+    val acknowledged = moved != null && acknowledgedFor == moved
+    return InviteAcknowledgement(moved, acknowledged) { acknowledgedFor = if (acknowledged) null else moved }
+}
+
+/**
+ * Runs the check for [teamId] and keeps its result for the banner to draw. Re-keyed on [attempt], so
+ * a check that could not be made is retried by the same reread that refreshes the rest of the screen
+ * — a banner stuck on "could not be checked" until the app restarts would be a worse lie than the
+ * accusation it replaced.
+ */
+@Composable
+internal fun rememberInviteCheck(tc: TeamsCoordinator, teamId: String, attempt: Int = 0): InviteCheck =
+    produceState<InviteCheck>(InviteCheck.Pending, teamId, attempt) {
+        // produceState keeps the previous value across a key change, so without this a re-check
+        // leaves the old verdict on screen: pressing Retry offline looked exactly like not pressing
+        // it — same sentence, same announcement, no sign anything ran.
+        value = InviteCheck.Pending
+        value = when (val verdict = tc.acceptPreview(teamId)) {
+            is InviteVerdict.Verified -> InviteCheck.Verified(verdict.preview)
+            InviteVerdict.Unverified -> InviteCheck.Unverified
+            is InviteVerdict.Failed -> InviteCheck.Failed(verdict.reason)
+        }
+    }.value
+
+/**
+ * Why the check could not be made, in one line: the fact, then the cause. The cause is the same
+ * sentence [TeamsErrorLine] would have shown — said once, by the banner that asked for the check,
+ * instead of twice by two live regions.
+ */
+@Composable
+internal fun inviteCheckFailedText(reason: TeamsFailure): String =
+    stringResource(Res.string.lib_teams_invite_check_failed) + " " + teamsFailureText(reason)
+
+/**
+ * What a screen reader is told when the check resolves — the same words the banner draws, in one
+ * string for [app.skerry.ui.design.StatusAnnouncer].
+ *
+ * The banner swaps which line it composes per state, and a line that appears is an insertion rather
+ * than a change: without this, the one screen that asks the user to trust a key announces neither
+ * that the check finished nor that the fingerprint differs from the pinned one (WCAG 4.1.3).
+ */
+@Composable
+internal fun inviteCheckAnnouncement(check: InviteCheck): String = when (check) {
+    InviteCheck.Pending -> stringResource(Res.string.lib_teams_invite_checking)
+    InviteCheck.Unverified -> stringResource(Res.string.lib_teams_invite_unverified)
+    is InviteCheck.Failed -> inviteCheckFailedText(check.reason)
+    is InviteCheck.Verified -> {
+        val preview = check.preview
+        val identity = stringResource(Res.string.lib_teams_invited_by, untrustedLabel(preview.accountId)) + " " +
+            stringResource(Res.string.lib_teams_invited_fingerprint, preview.fingerprint)
+        if (preview.keyChanged) identity + " " + stringResource(Res.string.lib_teams_invite_key_changed) else identity
+    }
+}
+
+/** One line of the banner's body: what it says, the tone it says it in, and whether it is a key. */
+internal class InviteCheckLine(val text: String, val color: Color, val mono: Boolean = false)
+
+/**
+ * The banner's body for a state — shared because there are two banners. Desktop and mobile draw the
+ * same sentences at their own type scale, and a hand-copied `when` had them disagreeing about which
+ * state says what; the sizes stay at the call site, the words and the tone do not.
+ */
+@Composable
+internal fun inviteCheckLines(check: InviteCheck): List<InviteCheckLine> = when (check) {
+    InviteCheck.Pending -> listOf(InviteCheckLine(stringResource(Res.string.lib_teams_invite_checking), Skerry.colors.dim))
+    InviteCheck.Unverified -> listOf(InviteCheckLine(stringResource(Res.string.lib_teams_invite_unverified), Skerry.colors.sunset))
+    is InviteCheck.Failed -> listOf(InviteCheckLine(inviteCheckFailedText(check.reason), Skerry.colors.amber))
+    is InviteCheck.Verified -> buildList {
+        val preview = check.preview
+        add(InviteCheckLine(stringResource(Res.string.lib_teams_invited_by, untrustedLabel(preview.accountId)), Skerry.colors.dim))
+        add(InviteCheckLine(stringResource(Res.string.lib_teams_invited_fingerprint, preview.fingerprint), Skerry.colors.cyanBright, mono = true))
+        if (preview.keyChanged) add(InviteCheckLine(stringResource(Res.string.lib_teams_invite_key_changed), Skerry.colors.amber))
+    }
+}
+
+/**
+ * Whether Accept may be pressed — the same rule on both banners, which is the point of it being here.
+ *
+ * A key that moved needs [acknowledged] on top of a verified envelope: accepting then replaces the
+ * pinned fingerprint, so an honest rotation and a server trying its luck look identical on screen
+ * and only the person on the trusted channel can tell them apart. Costing the same single click as
+ * an unchanged key made the warning decoration (#319).
+ */
+internal fun readyToAccept(check: InviteCheck, busy: Boolean, acknowledged: Boolean): Boolean =
+    !busy && check is InviteCheck.Verified && (!check.preview.keyChanged || acknowledged)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
@@ -48,7 +49,9 @@ import app.skerry.ui.design.GhostButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.SectionHeader
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
+import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.boundedVisibleText
 import app.skerry.ui.design.untrustedLabel
@@ -59,10 +62,9 @@ import app.skerry.ui.generated.resources.lib_teams_delete
 import app.skerry.ui.generated.resources.lib_teams_header_subtitle
 import app.skerry.ui.generated.resources.lib_teams_header_title
 import app.skerry.ui.generated.resources.lib_teams_invite
-import app.skerry.ui.generated.resources.lib_teams_invite_unverified
+import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.generated.resources.lib_teams_invited_banner
-import app.skerry.ui.generated.resources.lib_teams_invited_by
-import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
 import app.skerry.ui.generated.resources.lib_teams_leave
 import app.skerry.ui.generated.resources.lib_teams_no_key
 import app.skerry.ui.generated.resources.lib_teams_scopes
@@ -139,7 +141,16 @@ internal fun TeamScreen(
     Row(Modifier.fillMaxSize()) {
         Column(Modifier.weight(1f).fillMaxHeight().verticalScroll(rememberScrollState())) {
             if (invited) {
-                InviteBanner(tc, team, busy, onAccept = onAccept, onDecline = onDecline)
+                // Both counters only ever go up, so their sum changes whichever moves: a screen-wide
+                // reread and the banner's own Retry each start a fresh check.
+                var retries by remember(team.id) { mutableIntStateOf(0) }
+                InviteBanner(
+                    rememberInviteCheck(tc, team.id, tick + retries),
+                    busy,
+                    onAccept = onAccept,
+                    onDecline = onDecline,
+                    onRetry = { retries += 1 },
+                )
                 return@Column
             }
             if (!team.hasKey) {
@@ -323,13 +334,30 @@ private fun ScopeStrip(
     }
 }
 
-/** The invite this account hasn't answered yet: who sent it, their fingerprint, accept or decline. */
+/**
+ * The invite this account hasn't answered yet: who sent it, their fingerprint, accept or decline.
+ *
+ * Accept is offered only once the invite is opened, verified and its fingerprint drawn: it is that
+ * fingerprint the user confirms out of band, and accepting without it is the ceremony skipped
+ * entirely (#319). The coordinator refuses such an accept as well. [check] is passed in rather than
+ * started here so both the state and the gating can be rendered on their own.
+ *
+ * [onRetry] runs the check again: a screen showing an invite offers no sync of its own, so without
+ * it a check that could not be made stayed on screen until the app restarted.
+ */
 @Composable
-private fun InviteBanner(tc: TeamsCoordinator, team: TeamUi, busy: Boolean, onAccept: () -> Unit, onDecline: () -> Unit) {
+internal fun InviteBanner(
+    check: InviteCheck,
+    busy: Boolean,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onRetry: () -> Unit = {},
+) {
     val mono = LocalFonts.current.mono
-    // Verify the inviter's identity (signature + fingerprint) before offering Accept. Null = the
-    // invite couldn't be authenticated (forged/tampered) — warn and don't reveal a fingerprint.
-    val acceptPreview by produceState<InvitePreview?>(null, team.id) { value = tc.acceptPreview(team.id) }
+    val ack = rememberInviteAcknowledgement(check)
+    // Above the states it describes, never inside the `when`: a live region only announces a node
+    // that survives the change and carries the text itself (see StatusAnnouncer).
+    StatusAnnouncer(inviteCheckAnnouncement(check))
     Column(
         Modifier
             .fillMaxWidth()
@@ -344,15 +372,31 @@ private fun InviteBanner(tc: TeamsCoordinator, team: TeamUi, busy: Boolean, onAc
             Sym("mail", size = 18.sp, color = Skerry.colors.amber)
             Txt(stringResource(Res.string.lib_teams_invited_banner), color = Skerry.colors.text, size = 12.5.sp, modifier = Modifier.weight(1f))
             GhostButton(stringResource(Res.string.lib_teams_decline), onClick = onDecline, fg = Skerry.colors.dim)
-            PrimaryButton(stringResource(Res.string.lib_teams_accept), onClick = onAccept, enabled = !busy)
+            PrimaryButton(
+                stringResource(Res.string.lib_teams_accept),
+                onClick = onAccept,
+                enabled = readyToAccept(check, busy, ack.acknowledged),
+            )
         }
-        acceptPreview.let { p ->
-            if (p == null) {
-                Txt(stringResource(Res.string.lib_teams_invite_unverified), color = Skerry.colors.sunset, size = 11.5.sp)
-            } else {
-                Txt(stringResource(Res.string.lib_teams_invited_by, untrustedLabel(p.accountId)), color = Skerry.colors.dim, size = 11.5.sp)
-                Txt(stringResource(Res.string.lib_teams_invited_fingerprint, p.fingerprint), color = Skerry.colors.cyanBright, size = 11.5.sp, font = mono)
-            }
+        inviteCheckLines(check).forEach { line ->
+            Txt(
+                line.text,
+                color = line.color,
+                size = 11.5.sp,
+                lineHeight = 16.sp,
+                font = if (line.mono) mono else null,
+            )
+        }
+        if (check is InviteCheck.Failed) {
+            GhostButton(stringResource(Res.string.lib_teams_invite_check_retry), onClick = onRetry, fg = Skerry.colors.amber)
+        }
+        if (ack.moved != null) {
+            ToggleRow(
+                label = stringResource(Res.string.lib_teams_invite_key_changed_ack),
+                on = ack.acknowledged,
+                onToggle = ack.toggle,
+                labelSize = 11.5.sp,
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSpaces.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamSpaces.kt
@@ -3,14 +3,36 @@ package app.skerry.ui.teams
 import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.team.AccountIdentity
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.PeerKeys
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamKeyStore
 import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
+
+/**
+ * How an account's published keys are resolved: through the fingerprint pinned for that account (see
+ * [app.skerry.shared.team.fetchPinned]), so a key the server moved after the user verified it is
+ * refused instead of trusted (#319). Refusals are reported by the lookup itself, since only the
+ * coordinator knows whether the caller is a user's own action or a background adoption. The pin
+ * store stays with the coordinator that owns the vault — this is the one thing spaces need from it.
+ */
+internal typealias PeerKeyLookup = suspend (SyncSession, TeamClient, String) -> PeerKeys
+
+/**
+ * What sealing to another account takes: our own identity to sign with, and the lookup that resolves
+ * theirs under the pin. The two travel together everywhere a space key is handed over — an identity
+ * without the lookup is the hole #319 closed.
+ */
+internal class SealingIdentity(val own: AccountIdentity, val peerKeys: PeerKeyLookup)
+
+/** An account a space key is being sealed to, with the keys it was resolved under. */
+internal class TeamRecipient(val accountId: String, val keys: AccountKeys)
 
 /** A scope as the UI sees it: the server's metadata plus whether its key actually reached us. */
 data class TeamScopeUi(
@@ -98,30 +120,10 @@ internal class TeamSpaces(
      * also see scopes they hold no key for — they can delete such a scope but not hand it out, since
      * sealing an envelope needs the key itself.
      */
-    suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, identity: AccountIdentity?): List<TeamScopeUi> {
+    suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, sealing: SealingIdentity?): List<TeamScopeUi> {
         val remote = c.listScopes(s, teamId)
-        val adopted = mutableListOf<TeamScopeRef>()
-        for (scope in remote) {
-            val ref = TeamScopeRef(teamId, scope.scopeId)
-            val envelope = scope.envelope ?: continue
-            if (identity == null) continue
-            val payload = inviteCodec.open(identity.sharing, envelope) ?: continue
-            if (payload.teamId != teamId || payload.scopeId != scope.scopeId) continue
-            if (payload.inviteeAccountId != s.accountId) continue
-            val local = keyStore.scope(teamId, scope.scopeId)
-            if (local != null && payload.epoch <= local.epoch) continue
-            val granterKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: continue
-            // The scope id is part of the signed binding: an envelope filed under another scope by
-            // the server doesn't verify here (see TeamInviteCodec).
-            if (!inviteCodec.verify(payload, granterKeys.signing, scopeId = scope.scopeId)) continue
-            if (local == null) {
-                keyStore.putScope(teamId, scope.scopeId, payload.teamName, payload.teamKey, payload.epoch)
-            } else {
-                keyStore.rekeyScope(teamId, scope.scopeId, payload.teamKey, payload.epoch)
-            }
-            teamVaults.reset(ref) // the file (if any) is under the previous key — rebuild on pull
-            adopted += ref
-        }
+        val adopted = remote.filter { adoptScopeKey(s, c, teamId, it, sealing) }
+            .map { TeamScopeRef(teamId, it.scopeId) }
         // Scopes we no longer appear in: the key is useless and the local copy has no right to exist.
         val liveIds = remote.map { it.scopeId }.toSet()
         keyStore.scopes(teamId).keys.filter { it !in liveIds }.forEach { gone ->
@@ -141,6 +143,48 @@ internal class TeamSpaces(
     }
 
     /**
+     * Adopts one scope's sealed key when the envelope is ours, newer than what we hold, and signed by
+     * an identity that still matches its pin. Returns whether the local key moved, so the caller can
+     * re-pull that space.
+     *
+     * The granter's key comes from the server like every other, so it goes through the same pin as a
+     * team rekey envelope: a signature is worth exactly what the key it is checked against is (#319).
+     * The granter is named inside an envelope anyone can seal, so the lookup handed in here is the
+     * one that pins nothing — a first sight on this path would be the server's key, written down as
+     * confirmed.
+     */
+    private suspend fun adoptScopeKey(
+        s: SyncSession,
+        c: TeamClient,
+        teamId: String,
+        scope: TeamScopeSummary,
+        sealing: SealingIdentity?,
+    ): Boolean {
+        if (sealing == null) return false
+        val envelope = scope.envelope ?: return false
+        val payload = inviteCodec.open(sealing.own.sharing, envelope) ?: return false
+        if (payload.teamId != teamId || payload.scopeId != scope.scopeId) return false
+        if (payload.inviteeAccountId != s.accountId) return false
+        val local = keyStore.scope(teamId, scope.scopeId)
+        if (local != null && payload.epoch <= local.epoch) return false
+        val granterKeys = when (val fetched = sealing.peerKeys(s, c, payload.inviterAccountId)) {
+            is PeerKeys.Pinned -> fetched.keys
+            PeerKeys.Unpublished -> return false
+            is PeerKeys.Unconfirmed -> return false // reported by the lookup
+        }
+        // The scope id is part of the signed binding: an envelope filed under another scope by the
+        // server doesn't verify here (see TeamInviteCodec).
+        if (!inviteCodec.verify(payload, granterKeys.signing, scopeId = scope.scopeId)) return false
+        if (local == null) {
+            keyStore.putScope(teamId, scope.scopeId, payload.teamName, payload.teamKey, payload.epoch)
+        } else {
+            keyStore.rekeyScope(teamId, scope.scopeId, payload.teamKey, payload.epoch)
+        }
+        teamVaults.reset(TeamScopeRef(teamId, scope.scopeId)) // the file is under the previous key
+        return true
+    }
+
+    /**
      * Creates a scope with a fresh key, sealed to ourselves: that envelope is what the server hands
      * back to our other devices (and to this one if the local record ever loses the key).
      *
@@ -155,15 +199,21 @@ internal class TeamSpaces(
         keyStore.putScope(teamId, scopeId, name, scopeKey, epoch = 0)
     }
 
-    /** Grants a member the scope: its current key, sealed and signed to them. */
-    suspend fun grantScope(s: SyncSession, c: TeamClient, teamId: String, scopeId: String, accountId: String, identity: AccountIdentity) {
-        val entry = keyStore.scope(teamId, scopeId) ?: return markError(TeamsFailure.KeyMissing)
+    /**
+     * Grants a member the scope: its current key, sealed and signed to them.
+     *
+     * There is no fingerprint on screen here and nothing for the user to contradict, so the key is
+     * taken through the pin rather than trusted as the server answers it (#319). A member whose key
+     * honestly moved has to be re-invited — that ceremony is where a human confirms the new one.
+     */
+    suspend fun grantScope(s: SyncSession, c: TeamClient, ref: TeamScopeRef, recipient: TeamRecipient, identity: AccountIdentity) {
+        val entry = keyStore.scope(ref.teamId, ref.scopeId) ?: return markError(TeamsFailure.KeyMissing)
         val scopeKey = entry.dataKey() ?: return markError(TeamsFailure.KeyMissing)
-        val recipient = c.fetchPublicKey(s, accountId) ?: return markError(TeamsFailure.NoRecipientKey)
         val envelope = seal(
-            recipient.sharing, identity, s.accountId, accountId, teamId, scopeId, scopeKey, entry.name, entry.epoch,
+            recipient.keys.sharing, identity, s.accountId, recipient.accountId,
+            ref.teamId, ref.scopeId, scopeKey, entry.name, entry.epoch,
         )
-        c.grantScope(s, teamId, scopeId, accountId, envelope)
+        c.grantScope(s, ref.teamId, ref.scopeId, recipient.accountId, envelope)
     }
 
     /** Deletes a scope on the server and forgets it locally (key and vault file). */
@@ -192,27 +242,18 @@ internal class TeamSpaces(
      *
      * The team key and a scope key rotate through this one implementation; [target] is what differs.
      */
-    suspend fun rotate(s: SyncSession, c: TeamClient, target: RotationTarget) {
+    suspend fun rotate(s: SyncSession, c: TeamClient, target: RotationTarget): TeamsFailure? {
         val ref = target.ref
-        val currentKey = key(ref) ?: return markError(TeamsFailure.KeyMissing)
-        val spaceName = name(ref)
-        val vault = openUnder(ref, currentKey) ?: return markError(TeamsFailure.KeyMissing)
-        val identity = target.identity
+        val currentKey = key(ref) ?: return TeamsFailure.KeyMissing
+        val vault = openUnder(ref, currentKey) ?: return TeamsFailure.KeyMissing
         var attempt = 0
         while (true) {
-            val serverEpoch = target.serverEpoch(s, c) ?: return markError(TeamsFailure.KeyMissing)
+            val serverEpoch = target.serverEpoch(s, c) ?: return TeamsFailure.KeyMissing
             val newEpoch = (serverEpoch + 1).toInt()
             val newKey = crypto.newDataKey()
-            val envelopes = mutableMapOf<String, ByteArray>()
-            for (accountId in target.recipients(s, c)) {
-                if (accountId == s.accountId) continue // we adopt the key locally, no self-envelope
-                val keys = c.fetchPublicKey(s, accountId) ?: continue // unpublished key: can't re-seal
-                envelopes[accountId] = seal(
-                    keys.sharing, identity, s.accountId, accountId, ref.teamId, ref.scopeId, newKey, spaceName, newEpoch,
-                )
-            }
+            val resealed = resealTo(s, c, target, newKey, newEpoch)
             try {
-                target.commit(s, c, newEpoch.toLong(), envelopes)
+                target.commit(s, c, newEpoch.toLong(), resealed.envelopes)
             } catch (e: SyncException) {
                 newKey.zeroize() // rotation didn't commit — don't leave the unused key dangling
                 // A stale-epoch conflict means someone rotated meanwhile: refetch the epoch and retry.
@@ -226,9 +267,46 @@ internal class TeamSpaces(
             storeKey(ref, newKey, newEpoch)
             vault.rekeyRecords(newKey)
             syncSpace(ref)
-            return
+            return if (resealed.skippedUnconfirmed) TeamsFailure.PeerKeyUnconfirmed else null
         }
     }
+
+    /**
+     * The new key sealed to every remaining recipient of the space, each under the fingerprint pinned
+     * for their account.
+     *
+     * A recipient whose published key is not the pinned one gets **no envelope**: they lose access
+     * until a human confirms the new fingerprint, which is the point (#319). The rotation still goes
+     * through — it exists to take the key away from the member that was just removed, and refusing it
+     * wholesale would leave that member holding it — so the skip is carried out to the caller instead.
+     */
+    private suspend fun resealTo(
+        s: SyncSession,
+        c: TeamClient,
+        target: RotationTarget,
+        newKey: DataKey,
+        newEpoch: Int,
+    ): Resealed {
+        val spaceName = name(target.ref)
+        val envelopes = mutableMapOf<String, ByteArray>()
+        var skipped = false
+        for (accountId in target.recipients(s, c)) {
+            if (accountId == s.accountId) continue // we adopt the key locally, no self-envelope
+            val keys = when (val fetched = target.sealing.peerKeys(s, c, accountId)) {
+                is PeerKeys.Pinned -> fetched.keys
+                PeerKeys.Unpublished -> continue // unpublished key: can't re-seal
+                is PeerKeys.Unconfirmed -> { skipped = true; continue }
+            }
+            envelopes[accountId] = seal(
+                keys.sharing, target.sealing.own, s.accountId, accountId,
+                target.ref.teamId, target.ref.scopeId, newKey, spaceName, newEpoch,
+            )
+        }
+        return Resealed(envelopes, skipped)
+    }
+
+    /** What [resealTo] produced: the envelopes to commit, and whether a recipient was left out. */
+    private class Resealed(val envelopes: Map<String, ByteArray>, val skippedUnconfirmed: Boolean)
 
     /** Open the space's vault under a known key (no stale-file handling — the key is the current one). */
     private fun openUnder(ref: TeamScopeRef, key: DataKey): Vault? {
@@ -270,7 +348,8 @@ internal class TeamSpaces(
  */
 internal class RotationTarget(
     val ref: TeamScopeRef,
-    val identity: AccountIdentity,
+    /** Who signs the new envelopes, and how each recipient's keys are resolved (under their pin). */
+    val sealing: SealingIdentity,
     val serverEpoch: suspend (SyncSession, TeamClient) -> Long?,
     val recipients: suspend (SyncSession, TeamClient) -> List<String>,
     val commit: suspend (SyncSession, TeamClient, Long, Map<String, ByteArray>) -> Unit,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -8,22 +8,29 @@ import app.skerry.shared.sync.KeyedStateStore
 import app.skerry.shared.sync.SyncStateStore
 import app.skerry.shared.sync.SyncException
 import app.skerry.shared.team.AccountIdentity
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.PeerKeys
+import app.skerry.shared.team.Pin
 import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamIdentityStore
 import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamInvitePayload
 import app.skerry.shared.team.TeamKeyStore
-import app.skerry.shared.team.TeamIdentityStore
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamPeerStore
 import app.skerry.shared.team.TeamRole
 import app.skerry.shared.team.TeamScopeRef
-import app.skerry.shared.vault.DataKey
 import app.skerry.shared.team.TeamScopedSyncClient
 import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamSummary
 import app.skerry.shared.team.TeamVaults
 import app.skerry.shared.team.accountKeyFingerprint
+import app.skerry.shared.team.checkPinned
+import app.skerry.shared.team.fetchPinned
+import app.skerry.shared.team.stripShareFields
+import app.skerry.shared.vault.DataKey
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
@@ -38,7 +45,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import app.skerry.shared.team.stripShareFields
 import app.skerry.shared.terminal.epochMillis
 import app.skerry.shared.host.VaultHostStore
 import app.skerry.shared.runbook.VaultRunbookStore
@@ -49,6 +55,37 @@ enum class TeamsFailure {
     NotConnected, VaultLocked, NoRecipientKey, RecipientKeyChanged, AlreadyInvited, NoSuchAccount,
     KeyMissing, Network, Protocol, Forbidden, VaultUnreadable,
     TooManyRequests, ServerError, AlreadyShared, ScopesUnsupported,
+
+    /**
+     * A peer's published key is not the fingerprint pinned for them — nothing was sealed to it
+     * (#319). Either the key moved, or the pin itself can no longer be read on this device.
+     */
+    PeerKeyUnconfirmed,
+
+    /**
+     * A team or scope key arrived signed by an identity that is not the pinned one, and was ignored
+     * (#319). Said once per pass over the keys, however many of them one pass steps over — and again
+     * on the next pass, because the condition stands until the key is confirmed or withdrawn.
+     */
+    UnconfirmedKeyIgnored,
+
+    /** Accept was reached without the inviter's fingerprint having been shown and confirmed (#319). */
+    InviteUnverified,
+
+    /**
+     * The fingerprint the user just confirmed could not be recorded on this device, so nothing was
+     * sealed to the key it belongs to (#319). Its own value rather than [PeerKeyUnconfirmed]: that
+     * one tells a manager to re-invite the member, which is not something an invitee can do.
+     */
+    PinNotRecorded,
+
+    /**
+     * This device cannot read the Teams identity an invite is sealed to — the record is gone (a
+     * reactivation reconcile drops it and the re-pull has not landed) or no longer decrypts. A
+     * separate value because the alternative is telling the user their colleague sent something
+     * forged when nothing is wrong with the invite (#319).
+     */
+    IdentityUnreadable,
 }
 
 /**
@@ -86,7 +123,32 @@ data class TeamUi(
  * back to [TeamsCoordinator.invite] is what binds the send to the key that was read out loud — the
  * type exists so an invite cannot be sent without one.
  */
-data class InvitePreview(val accountId: String, val fingerprint: String)
+data class InvitePreview(
+    val accountId: String,
+    val fingerprint: String,
+    /**
+     * The account already had a different fingerprint pinned. Confirming this one replaces it, so
+     * the screen has to say so — an identity that moved is either an honest rotation or the server
+     * trying its luck, and only the person on the other end of the trusted channel can tell.
+     */
+    val keyChanged: Boolean = false,
+)
+
+/** What [TeamsCoordinator.acceptPreview] could establish about an invite. */
+sealed interface InviteVerdict {
+    /** Opened and verified: [preview] is the inviter and the fingerprint to confirm out of band. */
+    data class Verified(val preview: InvitePreview) : InviteVerdict
+
+    /** No envelope, or one that does not verify — forged, tampered with, or not addressed to us. */
+    data object Unverified : InviteVerdict
+
+    /**
+     * The check could not be made — [reason] says why (offline, locked vault, server error). Worth
+     * retrying, and carried on the verdict rather than written to [TeamsCoordinator.lastError]: the
+     * banner is the one voice for this, and the error line is a second live region on the same screen.
+     */
+    data class Failed(val reason: TeamsFailure) : InviteVerdict
+}
 
 /**
  * Teams coordinator: ties [TeamClient] (network), the account vault (team keys and identity), per-team
@@ -116,6 +178,7 @@ class TeamsCoordinator(
 
     private val keyStore = TeamKeyStore(vault)
     private val identityStore = TeamIdentityStore(vault, crypto)
+    private val peerStore = TeamPeerStore(vault)
     private val inviteCodec = TeamInviteCodec(crypto)
 
     private val spaces = TeamSpaces(
@@ -127,6 +190,37 @@ class TeamsCoordinator(
         markError = { markError(it) },
         syncSpace = { syncSpace(it) },
     )
+
+    /**
+     * account+fingerprint pairs already reported by [adoptingKeys], so one refusal is announced once
+     * per pass rather than once per scope it appears in. Cleared with the error slot itself
+     * ([resetError]) — the set is a de-duplicator, not a record of what the user has seen.
+     */
+    private val reportedUnconfirmed = mutableSetOf<String>()
+
+    /**
+     * Every seal to another account resolves its keys through here: the fingerprint pinned for that
+     * account, refusing a key that is not the confirmed one instead of trusting the server's latest
+     * answer (#319). What to do with a refusal is the caller's — it answers something the user asked
+     * for, and each caller knows which of its steps it belongs to.
+     */
+    private val sealingKeys: PeerKeyLookup = { s, c, accountId -> peerStore.fetchPinned(s, c, accountId) }
+
+    /**
+     * The same check for keys arriving from the other side — a team rekey envelope, a scope grant.
+     * Two differences, both because the account id here is one the server chose rather than one a
+     * user typed: nothing is pinned on first sight (a pin written from here would let the server fix
+     * its own key as the account's confirmed one), and each account+fingerprint is reported once per
+     * pass — a team with a dozen scopes granted to the same refused account has one thing to say
+     * about it, not a dozen.
+     */
+    private val adoptingKeys: PeerKeyLookup = { s, c, accountId ->
+        peerStore.checkPinned(s, c, accountId).also {
+            if (it is PeerKeys.Unconfirmed && reportedUnconfirmed.add("${it.accountId}:${it.fingerprint}")) {
+                markError(TeamsFailure.UnconfirmedKeyIgnored)
+            }
+        }
+    }
 
     private val opMutex = Mutex()
     private val syncMutex = Mutex()
@@ -170,8 +264,15 @@ class TeamsCoordinator(
     private val _lastError = MutableStateFlow<TeamsFailure?>(null)
     val lastError: StateFlow<TeamsFailure?> = _lastError
 
-    fun clearError() {
+    /**
+     * Empties the error slot — and with it the memory of what was already reported into it. The dedup
+     * in [adoptingKeys] exists only so one refusal doesn't re-fire for every scope of one pass; the
+     * slot is emptied at the start of every operation, and from there the warning has to be earnable
+     * again, or the next pass over the same unconfirmed key would say nothing.
+     */
+    private fun resetError() {
         _lastError.value = null
+        reportedUnconfirmed.clear()
     }
 
     /**
@@ -316,7 +417,8 @@ class TeamsCoordinator(
                 markError(TeamsFailure.NoRecipientKey)
                 null
             } else {
-                InvitePreview(accountId, accountKeyFingerprint(keys.sharing, keys.signing))
+                val fingerprint = accountKeyFingerprint(keys.sharing, keys.signing)
+                InvitePreview(accountId, fingerprint, keyChanged = pinMoved(accountId, fingerprint))
             }
         } catch (e: CancellationException) {
             throw e
@@ -362,6 +464,14 @@ class TeamsCoordinator(
                 teamName = entry.name,
                 epoch = entry.epoch,
             )
+            // The fingerprint was read out loud and the envelope is sealed to the key it belongs to:
+            // pin it, so every later seal to this colleague (a scope grant, a rotation) is held to
+            // the same key instead of trusting the server's next answer (#319).
+            // Written before the send, not after it: a pin this device cannot write — the id is one
+            // the server names, and another record may already hold it — must stop the seal rather
+            // than surface once the team key has left.
+            if (!vault.isUnlocked) return@op markError(TeamsFailure.VaultLocked)
+            if (!peerStore.confirm(accountId, verified.fingerprint)) return@op markError(TeamsFailure.PinNotRecorded)
             c.invite(s, teamId, accountId, role, envelope)
             refreshUnlocked(s, c)
         }
@@ -463,22 +573,39 @@ class TeamsCoordinator(
 
     /**
      * Invite step (invitee side): open+verify the envelope and return the **verified inviter's**
-     * account + fingerprint for out-of-band confirmation before accepting. null if the envelope is
-     * missing/forged (signature invalid, wrong team, or not addressed to us).
+     * account + fingerprint for out-of-band confirmation before accepting.
+     *
+     * The three answers are kept apart. [InviteVerdict.Unverified] is a statement about the envelope
+     * — missing, forged, wrong team, not addressed to us — and it is permanent until a new one is
+     * sent. [InviteVerdict.Failed] means the check did not happen: no connection, a locked vault, a
+     * server that errored. Collapsing the second into the first tells the user their colleague sent
+     * something forged because their Wi-Fi dropped; both refuse Accept, but only one is worth
+     * retrying.
+     *
+     * The verdict IS the report — nothing here writes [lastError]. The banner that asked for it draws
+     * the answer and announces it, and [TeamsErrorLine] is a second live region on the same screen:
+     * routing the same event through both makes a screen reader say two unrelated sentences about one
+     * thing, on the ordinary offline path (WCAG 4.1.3).
      */
-    suspend fun acceptPreview(teamId: String): InvitePreview? {
-        val (s, c) = live() ?: run { markError(TeamsFailure.NotConnected); return null }
-        if (!vault.isUnlocked) { markError(TeamsFailure.VaultLocked); return null }
+    suspend fun acceptPreview(teamId: String): InviteVerdict {
+        val (s, c) = live() ?: return InviteVerdict.Failed(TeamsFailure.NotConnected)
+        if (!vault.isUnlocked) return InviteVerdict.Failed(TeamsFailure.VaultLocked)
+        // Before the envelope, because the envelope cannot be opened without it: an identity this
+        // device cannot read is a local condition, and folding it into the verdict below would
+        // accuse the inviter of forging what they sent correctly.
+        if (identityStore.load() == null) return InviteVerdict.Failed(TeamsFailure.IdentityUnreadable)
         return try {
-            val verified = openVerifiedInvite(s, c, teamId) ?: run { markError(TeamsFailure.KeyMissing); return null }
-            val inviterKeys = c.fetchPublicKey(s, verified.payload.inviterAccountId)
-                ?: run { markError(TeamsFailure.NoRecipientKey); return null }
-            InvitePreview(verified.payload.inviterAccountId, accountKeyFingerprint(inviterKeys.sharing, inviterKeys.signing))
+            val verified = openVerifiedInvite(s, c, teamId) ?: return InviteVerdict.Unverified
+            // The keys the signature was checked against, not a second fetch of the same account: the
+            // server owns the key table, and answering the check with a key it forged the invite
+            // under and the fingerprint with the real colleague's key is the whole attack (#319).
+            val inviter = verified.payload.inviterAccountId
+            val fingerprint = accountKeyFingerprint(verified.inviterKeys.sharing, verified.inviterKeys.signing)
+            InviteVerdict.Verified(InvitePreview(inviter, fingerprint, keyChanged = pinMoved(inviter, fingerprint)))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            markError(e.toFailure())
-            null
+            InviteVerdict.Failed(e.toFailure())
         }
     }
 
@@ -487,12 +614,23 @@ class TeamsCoordinator(
         val (s, c) = live() ?: return markError(TeamsFailure.NotConnected)
         if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
         op {
-            // Reuse the invite acceptPreview already opened+verified (no second listTeams/fetchPublicKey),
-            // falling back to a fresh open if the banner didn't run. Either way the signature was checked:
-            // a server-fabricated invite to a fake team is rejected even if the user skipped the fingerprint.
-            val verified = cachedInvite(teamId) ?: openVerifiedInvite(s, c, teamId)
-                ?: return@op markError(TeamsFailure.Forbidden)
+            // Only the invite the banner opened, verified and *showed*. Accepting without it used to
+            // fall back to a fresh open whose only check is a signature against a server-supplied key,
+            // which is no ceremony at all — and the button was live while the banner still resolved
+            // and after it came back unverifiable (#319).
+            val verified = cachedInvite(teamId) ?: return@op markError(TeamsFailure.InviteUnverified)
             val invite = verified.payload
+            // The fingerprint on the banner was confirmed over a trusted channel: pin the inviter, so
+            // the rotation envelopes they send later are held to the same identity. First, and the
+            // join is abandoned if it cannot be written (another record holds the id the server chose
+            // for this account): a membership whose later envelopes nothing guards is the state this
+            // whole change exists to prevent.
+            if (!vault.isUnlocked) return@op markError(TeamsFailure.VaultLocked)
+            val pinned = peerStore.confirm(
+                invite.inviterAccountId,
+                accountKeyFingerprint(verified.inviterKeys.sharing, verified.inviterKeys.signing),
+            )
+            if (!pinned) return@op markError(TeamsFailure.PinNotRecorded)
             // Placeholder role: the server returns the actual role at refreshUnlocked (listTeams).
             keyStore.put(teamId, invite.teamName, TeamRole.VIEWER, invite.teamKey, invite.epoch)
             c.accept(s, teamId)
@@ -518,6 +656,8 @@ class TeamsCoordinator(
             // walked away with.
             val heldScopes = if (accountId == sess.accountId) emptyList() else scopesHeldBy(sess, c, teamId, accountId)
             c.removeMember(sess, teamId, accountId)
+            var teamRotation: TeamsFailure? = null
+            var scopeRotation: TeamsFailure? = null
             if (accountId == sess.accountId) {
                 // Voluntary leave/decline: we can't rotate (we're gone). A remaining manager rotates.
                 forgetTeamLocally(teamId)
@@ -530,31 +670,38 @@ class TeamsCoordinator(
                 // must not skip them. Unguarded it unwound past the loop, so one 5xx on the rekey
                 // left the removed member holding every scope key they had — the exact hole the
                 // rotation exists to close — with nothing to retry it.
-                var teamRotation: Exception? = null
+                // A rotation also fails without throwing: a recipient whose key is not the confirmed
+                // one is skipped while the rest of it commits. That verdict comes back as a return
+                // value rather than through `lastError` — the slot is written by suspend functions
+                // that hold no lock (the member and grant listings a screen keeps refreshing), so
+                // reading it back here would report whichever of them landed last.
                 try {
-                    rotateTeamKey(sess, c, teamId)
+                    teamRotation = rotateTeamKey(sess, c, teamId)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
-                    teamRotation = e
+                    teamRotation = e.toFailure()
                 }
                 // Each scope rotates independently: one failing must not leave the rest un-rotated,
                 // since every skipped scope is a key the removed member still holds.
                 heldScopes.forEach { scopeId ->
-                    try {
+                    val failure = try {
                         rotateScopeKey(sess, c, TeamScopeRef(teamId, scopeId))
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
-                        markError(e.toFailure())
+                        e.toFailure()
                     }
+                    scopeRotation = moreSerious(scopeRotation, failure)
                 }
-                // Reported last on purpose: `lastError` holds one value, and the team key is the
-                // more serious of the two — a scope failure landing after it would otherwise hide
-                // "the removed member still holds the team key" behind "one scope did not rotate".
-                teamRotation?.let { markError(it.toFailure()) }
             }
             refreshUnlocked(sess, c)
+            // Reported after the reread, not before it: refreshUnlocked writes `lastError` of its own
+            // (an unconfirmed key it steps over), so a verdict published first would be replaced by
+            // the milder one. And folded rather than written twice: the team key is usually the more
+            // serious of the two, but not when its own verdict is a rotation that committed while
+            // skipping a recipient — a scope that did not rotate at all outranks that.
+            moreSerious(teamRotation, scopeRotation)?.let { markError(it) }
         }
     }
 
@@ -596,7 +743,14 @@ class TeamsCoordinator(
         if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
         if (scopesUnsupported) return markError(TeamsFailure.ScopesUnsupported)
         op {
-            spaces.grantScope(s, c, teamId, scopeId, accountId, identityStore.ensure())
+            val recipient = when (val fetched = sealingKeys(s, c, accountId)) {
+                is PeerKeys.Pinned -> TeamRecipient(accountId, fetched.keys)
+                PeerKeys.Unpublished -> return@op markError(TeamsFailure.NoRecipientKey)
+                // Nothing on this screen shows a fingerprint, so there is nothing for the user to
+                // contradict: a member whose key moved is re-invited, and that ceremony confirms it.
+                is PeerKeys.Unconfirmed -> return@op markError(TeamsFailure.PeerKeyUnconfirmed)
+            }
+            spaces.grantScope(s, c, TeamScopeRef(teamId, scopeId), recipient, identityStore.ensure())
             refreshUnlocked(s, c)
         }
     }
@@ -610,12 +764,15 @@ class TeamsCoordinator(
         if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
         op {
             c.revokeScope(s, teamId, scopeId, accountId)
+            var rotation: TeamsFailure? = null
             if (accountId == s.accountId) {
                 spaces.forgetScope(teamId, scopeId) // gave up our own access: the local copy must go
             } else {
-                rotateScopeKey(s, c, TeamScopeRef(teamId, scopeId))
+                rotation = rotateScopeKey(s, c, TeamScopeRef(teamId, scopeId))
             }
             refreshUnlocked(s, c)
+            // After the reread, for the reason spelled out in removeMember: it reports on its own.
+            rotation?.let { markError(it) }
         }
     }
 
@@ -806,7 +963,8 @@ class TeamsCoordinator(
      */
     private suspend fun refreshScopes(s: SyncSession, c: TeamClient, teamId: String, identity: AccountIdentity?): List<TeamScopeUi> =
         try {
-            spaces.refreshScopes(s, c, teamId, identity).also { scopesUnsupported = false }
+            spaces.refreshScopes(s, c, teamId, identity?.let { SealingIdentity(it, adoptingKeys) })
+                .also { scopesUnsupported = false }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -854,7 +1012,14 @@ class TeamsCoordinator(
             val payload = inviteCodec.open(identity.sharing, envelope) ?: continue
             if (payload.teamId != summary.id || payload.inviteeAccountId != s.accountId) continue
             if (payload.epoch <= local.epoch) continue
-            val rotatorKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: continue
+            // Held to the pin: the envelope is signed with whatever key the server publishes for the
+            // rotator, so an account whose fingerprint was verified once cannot be impersonated by a
+            // key the server swapped in afterwards (#319).
+            val rotatorKeys = when (val fetched = adoptingKeys(s, c, payload.inviterAccountId)) {
+                is PeerKeys.Pinned -> fetched.keys
+                PeerKeys.Unpublished -> continue
+                is PeerKeys.Unconfirmed -> continue // reported by the lookup
+            }
             if (!inviteCodec.verify(payload, rotatorKeys.signing)) continue
             keyStore.rekey(summary.id, payload.teamKey, payload.epoch)
             teamVaults.reset(TeamScopeRef(summary.id)) // old-key file is unreadable under the new key
@@ -865,13 +1030,13 @@ class TeamsCoordinator(
     }
 
     /** Rotate the team key (member removal). See [TeamSpaces.rotate] for the fail-closed contract. */
-    private suspend fun rotateTeamKey(s: SyncSession, c: TeamClient, teamId: String) {
+    private suspend fun rotateTeamKey(s: SyncSession, c: TeamClient, teamId: String): TeamsFailure? {
         val identity = identityStore.ensure()
-        spaces.rotate(
+        return spaces.rotate(
             s, c,
             RotationTarget(
                 ref = TeamScopeRef(teamId),
-                identity = identity,
+                sealing = SealingIdentity(identity, sealingKeys),
                 serverEpoch = { sess, cl -> cl.listTeams(sess).firstOrNull { it.id == teamId }?.keyEpoch },
                 recipients = { sess, cl -> cl.members(sess, teamId).map { it.accountId } },
                 commit = { sess, cl, epoch, envelopes -> cl.rekey(sess, teamId, epoch, envelopes) },
@@ -880,13 +1045,13 @@ class TeamsCoordinator(
     }
 
     /** Rotate one scope's key (grant revoked, or its holder removed from the team). */
-    private suspend fun rotateScopeKey(s: SyncSession, c: TeamClient, ref: TeamScopeRef) {
+    private suspend fun rotateScopeKey(s: SyncSession, c: TeamClient, ref: TeamScopeRef): TeamsFailure? {
         val identity = identityStore.ensure()
-        spaces.rotate(
+        return spaces.rotate(
             s, c,
             RotationTarget(
                 ref = ref,
-                identity = identity,
+                sealing = SealingIdentity(identity, sealingKeys),
                 serverEpoch = { sess, cl -> cl.listScopes(sess, ref.teamId).firstOrNull { it.scopeId == ref.scopeId }?.keyEpoch },
                 recipients = { sess, cl -> cl.scopeGrants(sess, ref.teamId, ref.scopeId).map { it.accountId } },
                 commit = { sess, cl, epoch, envelopes -> cl.rekeyScope(sess, ref.teamId, ref.scopeId, epoch, envelopes) },
@@ -894,7 +1059,8 @@ class TeamsCoordinator(
         )
     }
 
-    internal class VerifiedInvite(val payload: TeamInvitePayload)
+    /** A pending invite whose signature was checked, with the very keys it was checked against. */
+    internal class VerifiedInvite(val payload: TeamInvitePayload, val inviterKeys: AccountKeys)
 
     /**
      * Open the invite envelope for [teamId] and verify the inviter's signature and binding. Returns
@@ -909,7 +1075,7 @@ class TeamsCoordinator(
         if (payload.teamId != teamId || payload.inviteeAccountId != s.accountId) return null
         val inviterKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: return null
         if (!inviteCodec.verify(payload, inviterKeys.signing)) return null
-        return VerifiedInvite(payload).also { verified ->
+        return VerifiedInvite(payload, inviterKeys).also { verified ->
             verifiedInvites.update { it + (teamId to verified) }
         }
     }
@@ -932,7 +1098,7 @@ class TeamsCoordinator(
         opMutex.withLock {
             _busy.value = true
             try {
-                _lastError.value = null
+                resetError()
                 block()
             } catch (e: CancellationException) {
                 throw e
@@ -942,6 +1108,31 @@ class TeamsCoordinator(
                 _busy.value = false
             }
         }
+    }
+
+    /**
+     * Whether [fingerprint] differs from what is pinned for [accountId] — false when nothing is
+     * pinned yet. Only the two ceremonies that show a fingerprint to a human ask this; everything
+     * else refuses a moved key outright (see [fetchPinned]).
+     */
+    private fun pinMoved(accountId: String, fingerprint: String): Boolean = when (val pin = peerStore.pin(accountId)) {
+        Pin.None -> false
+        // Nothing to compare against, and sending replaces the record: the user is the only one who
+        // can say whether this fingerprint is the colleague's, so they are asked rather than told.
+        Pin.Unreadable -> true
+        is Pin.Known -> pin.fingerprint != fingerprint
+    }
+
+    /**
+     * The more serious of two rotation verdicts, for the single error slot. A rotation that did not
+     * commit outranks one that committed while leaving a recipient out: the first is the removed
+     * member possibly still holding a live key, the second is one colleague to re-confirm.
+     */
+    private fun moreSerious(current: TeamsFailure?, next: TeamsFailure?): TeamsFailure? = when {
+        current == null -> next
+        next == null -> current
+        current == TeamsFailure.PeerKeyUnconfirmed -> next
+        else -> current
     }
 
     private fun markError(reason: TeamsFailure) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
@@ -38,6 +38,8 @@ import app.skerry.ui.design.CancelButton
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
 import app.skerry.shared.team.TeamRole
@@ -47,6 +49,8 @@ import app.skerry.ui.generated.resources.lib_teams_create_subtitle
 import app.skerry.ui.generated.resources.lib_teams_create_title
 import app.skerry.ui.generated.resources.lib_teams_invite_account_placeholder
 import app.skerry.ui.generated.resources.lib_teams_invite_fingerprint
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.generated.resources.lib_teams_invite_next
 import app.skerry.ui.generated.resources.lib_teams_invite_send
 import app.skerry.ui.generated.resources.lib_teams_invite_subtitle
@@ -230,15 +234,33 @@ fun InviteMemberDialog(
     // a stale verification standing behind the Send button.
     val verified = preview?.takeIf { it.accountId == accountId.trim() }
     val ready = verified != null
+    // Keyed on the fingerprint, not on the dialog: the tick belongs to the key it was given for, and
+    // a lookup answering with a different one asks the question again.
+    var acknowledged by remember(verified?.fingerprint) { mutableStateOf(false) }
+    // A key that moved costs a second, deliberate gesture. Sending replaces the pin, so an honest
+    // rotation and a server trying its luck reach this dialog looking identical — the difference is
+    // in what the person on the trusted channel says, and one click could not carry it (#319).
+    val blockedByKeyChange = verified != null && verified.keyChanged && !acknowledged
     fun submit() {
         val id = accountId.trim()
-        if (id.isEmpty() || busy) return
+        if (id.isEmpty() || busy || blockedByKeyChange) return
         if (verified != null) onSend(verified, role) else onLookup(id)
     }
     TeamsDialogCard(onDismiss, label = stringResource(Res.string.lib_teams_invite_title)) {
         Txt(stringResource(Res.string.lib_teams_invite_title), color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
         Txt(stringResource(Res.string.lib_teams_invite_subtitle), color = Skerry.colors.dim, size = 12.5.sp, lineHeight = 18.sp, modifier = Modifier.padding(top = 4.dp, bottom = 16.dp))
         TeamsTextField(accountId, { accountId = it; onEdited() }, stringResource(Res.string.lib_teams_invite_account_placeholder), ::submit, focus)
+        // The lookup's answer arrives while the field has focus and Send silently becomes live; the
+        // fingerprint block below is an insertion nothing announces on its own (WCAG 4.1.3).
+        StatusAnnouncer(
+            when {
+                verified == null -> ""
+                verified.keyChanged ->
+                    stringResource(Res.string.lib_teams_invite_fingerprint) + " " + verified.fingerprint + " " +
+                        stringResource(Res.string.lib_teams_invite_key_changed)
+                else -> stringResource(Res.string.lib_teams_invite_fingerprint) + " " + verified.fingerprint
+            },
+        )
         if (verified != null) {
             Column(
                 Modifier
@@ -252,6 +274,19 @@ fun InviteMemberDialog(
                 Txt(stringResource(Res.string.lib_teams_invite_fingerprint).uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
                 Txt(verified.fingerprint, color = Skerry.colors.cyanBright, size = 14.sp, font = mono, modifier = Modifier.padding(top = 4.dp))
                 Txt(stringResource(Res.string.lib_teams_invite_verify), color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
+                // An account whose fingerprint moved is either an honest identity rotation or the
+                // server trying its luck. Sending replaces the pin, so the difference has to be on
+                // screen — the person on the trusted channel is the only one who can tell (#319).
+                if (verified.keyChanged) {
+                    Txt(stringResource(Res.string.lib_teams_invite_key_changed), color = Skerry.colors.amber, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
+                    ToggleRow(
+                        label = stringResource(Res.string.lib_teams_invite_key_changed_ack),
+                        on = acknowledged,
+                        onToggle = { acknowledged = !acknowledged },
+                        labelSize = 11.5.sp,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
                 if (ownFingerprint != null) {
                     Txt(stringResource(Res.string.lib_teams_your_fingerprint, ownFingerprint), color = Skerry.colors.faint, size = 11.sp, font = mono, modifier = Modifier.padding(top = 8.dp))
                 }
@@ -270,7 +305,7 @@ fun InviteMemberDialog(
             PrimaryButton(
                 if (ready) stringResource(Res.string.lib_teams_invite_send) else stringResource(Res.string.lib_teams_invite_next),
                 onClick = ::submit,
-                enabled = accountId.trim().isNotEmpty() && !busy,
+                enabled = accountId.trim().isNotEmpty() && !busy && !blockedByKeyChange,
                 modifier = Modifier.testTag(UiTags.FORM_SAVE),
             )
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -73,22 +73,26 @@ import app.skerry.ui.generated.resources.lib_teams_empty_title
 import app.skerry.ui.generated.resources.lib_teams_err_already_invited
 import app.skerry.ui.generated.resources.lib_teams_err_already_shared
 import app.skerry.ui.generated.resources.lib_teams_err_forbidden
+import app.skerry.ui.generated.resources.lib_teams_err_invite_unverified
+import app.skerry.ui.generated.resources.lib_teams_err_identity_unreadable
 import app.skerry.ui.generated.resources.lib_teams_err_key_missing
 import app.skerry.ui.generated.resources.lib_teams_err_network
 import app.skerry.ui.generated.resources.lib_teams_err_no_recipient_key
 import app.skerry.ui.generated.resources.lib_teams_err_no_such_account
 import app.skerry.ui.generated.resources.lib_teams_err_not_connected
+import app.skerry.ui.generated.resources.lib_teams_err_peer_key_unconfirmed
+import app.skerry.ui.generated.resources.lib_teams_err_pin_not_recorded
 import app.skerry.ui.generated.resources.lib_teams_err_protocol
 import app.skerry.ui.generated.resources.lib_teams_err_recipient_key_changed
 import app.skerry.ui.generated.resources.lib_teams_err_scopes_unsupported
 import app.skerry.ui.generated.resources.lib_teams_err_server_error
 import app.skerry.ui.generated.resources.lib_teams_err_too_many_requests
+import app.skerry.ui.generated.resources.lib_teams_err_unconfirmed_key_ignored
 import app.skerry.ui.generated.resources.lib_teams_err_vault_locked
 import app.skerry.ui.generated.resources.lib_teams_err_vault_unreadable
-import app.skerry.ui.generated.resources.lib_teams_header_title
 import app.skerry.ui.generated.resources.lib_teams_header_subtitle
+import app.skerry.ui.generated.resources.lib_teams_header_title
 import app.skerry.ui.generated.resources.lib_teams_invite
-import app.skerry.ui.generated.resources.lib_teams_invite_unverified
 import app.skerry.ui.generated.resources.lib_teams_invited_banner
 import app.skerry.ui.generated.resources.lib_teams_invited_by
 import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
@@ -101,13 +105,13 @@ import app.skerry.ui.generated.resources.lib_teams_remove_member_title
 import app.skerry.ui.generated.resources.lib_teams_scope_delete
 import app.skerry.ui.generated.resources.lib_teams_scope_delete_message
 import app.skerry.ui.generated.resources.lib_teams_scopes
+import app.skerry.ui.generated.resources.lib_teams_share_empty
 import app.skerry.ui.generated.resources.lib_teams_share_host
 import app.skerry.ui.generated.resources.lib_teams_share_host_title
 import app.skerry.ui.generated.resources.lib_teams_share_runbook
 import app.skerry.ui.generated.resources.lib_teams_share_runbook_title
 import app.skerry.ui.generated.resources.lib_teams_share_snippet
 import app.skerry.ui.generated.resources.lib_teams_share_snippet_title
-import app.skerry.ui.generated.resources.lib_teams_share_empty
 import app.skerry.ui.generated.resources.lib_teams_shared_hosts_count
 import app.skerry.ui.generated.resources.lib_teams_shared_runbooks_count
 import app.skerry.ui.generated.resources.lib_teams_shared_snippets_count
@@ -406,6 +410,11 @@ internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
     TeamsFailure.ServerError -> stringResource(Res.string.lib_teams_err_server_error)
     TeamsFailure.AlreadyShared -> stringResource(Res.string.lib_teams_err_already_shared)
     TeamsFailure.ScopesUnsupported -> stringResource(Res.string.lib_teams_err_scopes_unsupported)
+    TeamsFailure.PeerKeyUnconfirmed -> stringResource(Res.string.lib_teams_err_peer_key_unconfirmed)
+    TeamsFailure.UnconfirmedKeyIgnored -> stringResource(Res.string.lib_teams_err_unconfirmed_key_ignored)
+    TeamsFailure.InviteUnverified -> stringResource(Res.string.lib_teams_err_invite_unverified)
+    TeamsFailure.PinNotRecorded -> stringResource(Res.string.lib_teams_err_pin_not_recorded)
+    TeamsFailure.IdentityUnreadable -> stringResource(Res.string.lib_teams_err_identity_unreadable)
 }
 
 /** launch from click handlers: a param-less suspend block, shorter than a lambda with CoroutineScope. */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorReactivationTest.kt
@@ -3,6 +3,8 @@ package app.skerry.ui.sync
 import app.skerry.shared.sync.InMemorySyncStateStore
 import app.skerry.shared.sync.SyncSettings
 import app.skerry.shared.sync.SyncSettingsStore
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.TeamPeerStore
 import app.skerry.shared.vault.Credential
 import app.skerry.shared.vault.CredentialSecret
 import app.skerry.shared.vault.CredentialStore
@@ -662,6 +664,37 @@ class SyncCoordinatorReactivationTest {
                 "an activation that doesn't reconcile must not sync a vault that still owes one",
             )
             assertFalse(client.pushed.any { it.id == "r1" }, "the purged record must not reach the server")
+        } finally {
+            sut.close()
+        }
+    }
+
+    /**
+     * Issue #319: `reactivated` is the server's own flag, and the re-pull that follows it returns
+     * whatever the server chooses to return. A verified peer fingerprint dropped here and not handed
+     * back is a device walked back to trusting the next key the server publishes — so the pins are the
+     * one sync-capable type the clear leaves alone.
+     */
+    @Test
+    fun `a reactivated device keeps the peer fingerprints a human verified`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = freshVault()
+        TeamPeerStore(vault).confirm("bob@example.com", "aaaa-bbbb-cccc")
+        vault.put("team-1", RecordType.TEAM, "team key".encodeToByteArray())
+
+        val client = ReactivatingClient(ownWrap(vault), reactivated = true)
+        val sut = SyncCoordinator(clientFactory = { client }, crypto = crypto, vault = vault)
+        try {
+            sut.connect(serverUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the connect to settle") { it is SyncStatus.Online || it is SyncStatus.Failed }
+            assertTrue(sut.status.value is SyncStatus.Online, "reactivation connect should come Online")
+            assertEquals(
+                "aaaa-bbbb-cccc",
+                (TeamPeerStore(vault).pin("bob@example.com") as? Pin.Known)?.fingerprint,
+                "the reconcile must not hand the pin back to the server to re-issue",
+            )
+            // The team key itself is cleared as before: losing it costs a re-pull, not a verification.
+            assertFalse(vault.records().any { it.id == "team-1" })
         } finally {
             sut.close()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/InviteBannerGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/InviteBannerGateTest.kt
@@ -1,0 +1,217 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_accept
+import app.skerry.ui.generated.resources.lib_teams_invite_check_failed
+import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
+import org.jetbrains.compose.resources.stringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The invite banner is where the invitee's half of the ceremony happens: the inviter's fingerprint is
+ * confirmed over a trusted channel, and only then is the team key adopted. Accept used to be live
+ * while the check was still running and while it had failed outright, so the ceremony could be
+ * skipped by pressing the button early (#319). The coordinator refuses such an accept too — this is
+ * the half the user can see.
+ */
+@OptIn(ExperimentalTestApi::class)
+class InviteBannerGateTest {
+
+    @Test
+    fun `accept is closed while the invite is still being checked`() {
+        var accept = ""
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            InviteBanner(InviteCheck.Pending, busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithText(accept).assertIsNotEnabled()
+        }
+    }
+
+    @Test
+    fun `accept is closed for an invite that does not verify`() {
+        var accept = ""
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            InviteBanner(InviteCheck.Unverified, busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithText(accept).assertIsNotEnabled()
+        }
+    }
+
+    /**
+     * The same closed button, a different sentence: a check that could not run says so, instead of
+     * telling the user their colleague sent something forged.
+     */
+    @Test
+    fun `a check that could not run says so, names the cause, and still closes accept`() {
+        var accept = ""
+        var failed = ""
+        var cause = ""
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            failed = stringResource(Res.string.lib_teams_invite_check_failed)
+            cause = teamsFailureText(TeamsFailure.NotConnected)
+            InviteBanner(InviteCheck.Failed(TeamsFailure.NotConnected), busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithText(accept).assertIsNotEnabled()
+            // Both halves in one line: this banner is the only thing that says it, so it has to say
+            // what could not be done and why.
+            onNodeWithText(failed, substring = true).assertExists()
+            onNodeWithText(cause, substring = true).assertExists()
+        }
+    }
+
+    @Test
+    fun `a verified invite opens accept and shows the fingerprint to confirm`() {
+        var accept = ""
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            InviteBanner(
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT)),
+                busy = false,
+                onAccept = {},
+                onDecline = {},
+            )
+        }) {
+            onNodeWithText(accept).assertIsEnabled()
+            onNodeWithText(FINGERPRINT, substring = true).assertExists()
+        }
+    }
+
+    /** An inviter whose key differs from the pinned one is still acceptable — after a warning. */
+    @Test
+    fun `a fingerprint that moved is called out on the banner`() {
+        var warning = ""
+        runForm({
+            warning = stringResource(Res.string.lib_teams_invite_key_changed)
+            InviteBanner(
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)),
+                busy = false,
+                onAccept = {},
+                onDecline = {},
+            )
+        }) {
+            onNodeWithText(warning).assertExists()
+        }
+    }
+
+    /**
+     * A key that moved is the one case where Accept is a decision rather than a formality: it
+     * replaces the pinned fingerprint. Costing the same single click as an unchanged key made the
+     * warning decoration — the acknowledgement is the gesture that carries what the trusted channel
+     * said.
+     */
+    @Test
+    fun `an inviter whose key moved is acknowledged before accept opens`() {
+        var accept = ""
+        var ack = ""
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            InviteBanner(
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)),
+                busy = false,
+                onAccept = {},
+                onDecline = {},
+            )
+        }) {
+            onNodeWithText(accept).assertIsNotEnabled()
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithText(accept).assertIsEnabled()
+        }
+    }
+
+    /**
+     * The screen behind an unanswered invite offers no sync of its own, so a check that could not be
+     * made had nothing to re-run it: the banner carries its own retry.
+     */
+    @Test
+    fun `a check that could not run can be run again`() {
+        var retry = ""
+        var attempts = 0
+        runForm({
+            retry = stringResource(Res.string.lib_teams_invite_check_retry)
+            InviteBanner(
+                InviteCheck.Failed(TeamsFailure.NotConnected),
+                busy = false,
+                onAccept = {},
+                onDecline = {},
+                onRetry = { attempts += 1 },
+            )
+        }) {
+            onNodeWithText(retry).performClick()
+            waitForIdle()
+        }
+        assertEquals(1, attempts)
+    }
+
+    /**
+     * And keeps it across a re-check. The check re-runs on every reread of the Teams screen — an
+     * action on any other team bumps the same counter — and visits Pending on the way there. A tick
+     * remembered per state was cleared by that trip and asked again for a fingerprint that had not
+     * moved since the user confirmed it over the phone.
+     */
+    @Test
+    fun `an acknowledgement survives a re-check that answers the same fingerprint`() {
+        var accept = ""
+        var ack = ""
+        val verified = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true))
+        val check = mutableStateOf<InviteCheck>(verified)
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            InviteBanner(check.value, busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithText(accept).assertIsEnabled()
+
+            runOnIdle { check.value = InviteCheck.Pending }
+            waitForIdle()
+            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)) }
+            waitForIdle()
+
+            onNodeWithText(accept).assertIsEnabled()
+        }
+    }
+
+    /** A fingerprint that moved again is a new question, and the old tick answers none of it. */
+    @Test
+    fun `an acknowledgement does not carry over to another fingerprint`() {
+        var accept = ""
+        var ack = ""
+        val check = mutableStateOf<InviteCheck>(InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)))
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            InviteBanner(check.value, busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+
+            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, OTHER_FINGERPRINT, keyChanged = true)) }
+            waitForIdle()
+
+            onNodeWithText(accept).assertIsNotEnabled()
+        }
+    }
+
+    private companion object {
+        const val INVITER = "bob@example.com"
+        const val OTHER_FINGERPRINT = "SKY-9999 8888 7777 6666"
+        const val FINGERPRINT = "SKY-1111 2222 3333 4444"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteCacheTest.kt
@@ -27,6 +27,7 @@ import okio.FileSystem
 import okio.Path.Companion.toPath
 import java.nio.file.Files
 import kotlin.test.Test
+import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
@@ -120,7 +121,7 @@ class TeamsCoordinatorInviteCacheTest {
             newId = { "unused" },
         )
 
-        assertNotNull(coord.acceptPreview(teamId)) // banner shown: the verified invite is now cached
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId)) // banner shown: the verified invite is now cached
         client.teams = emptyList() // invite revoked / team deleted server-side
         coord.refresh()
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
@@ -1,0 +1,806 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.TeamIdentityStore
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamPeerStore
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
+import app.skerry.shared.team.TeamSessionKind
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.team.accountKeyFingerprint
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SharingKeyPair
+import app.skerry.shared.vault.SigningKeyPair
+import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.ui.sync.TeamLink
+import kotlinx.coroutines.runBlocking
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Every seal after the invite used to go to whatever key the server answered with (#319): the
+ * account's own key table is the server's, so it can hand out one key for the check and another for
+ * the seal, or simply swap a member's key once and wait for the next grant or rotation.
+ *
+ * The fake below is that server. What it must not achieve is a team key, a scope key or a rotated
+ * key ending up under a key nobody ever read out loud.
+ */
+class TeamsCoordinatorPeerPinTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val teamId = "team-pin"
+    private val self = "alice@example.com"
+    private val bob = "bob@example.com"
+    private val carol = "carol@example.com"
+    private val dave = "dave@example.com"
+
+    /** An account's published keys, as the server holds them — swappable between two fetches. */
+    private class Published(var keys: AccountKeys)
+
+    private fun keysOf(sharing: SharingKeyPair, signing: SigningKeyPair) =
+        AccountKeys(sharing.publicKey, signing.publicKey)
+
+    private fun fingerprintOf(keys: AccountKeys) = accountKeyFingerprint(keys.sharing, keys.signing)
+
+    /**
+     * Fake team network: a mutable key table, a mutable member list, and every envelope the client
+     * hands over kept for inspection.
+     */
+    private class FakePeerClient(private val self: String, private val teamId: String) : TeamClient {
+        val published = mutableMapOf<String, Published>()
+        var teams: List<TeamSummary> = emptyList()
+        var memberList: List<TeamMember> = emptyList()
+        val accepted = mutableListOf<String>()
+        val removed = mutableListOf<String>()
+        val grants = mutableListOf<Pair<String, ByteArray>>()
+        val invites = mutableListOf<String>()
+        val teamRekeys = mutableListOf<Map<String, ByteArray>>()
+        val scopeEnvelopes = linkedMapOf<String, MutableMap<String, ByteArray>>()
+        val scopeEpochs = mutableMapOf<String, Long>()
+        var teamEpoch = 0L
+        /** How many times each account's key was fetched — the double fetch is the hole (#319 item 1). */
+        val fetches = mutableMapOf<String, Int>()
+
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
+            fetches[accountId] = (fetches[accountId] ?: 0) + 1
+            return published[accountId]?.keys
+        }
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = teams
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = memberList
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun accept(session: SyncSession, teamId: String) { accepted += teamId }
+
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {
+            removed += accountId
+            memberList = memberList.filter { it.accountId != accountId }
+            scopeEnvelopes.values.forEach { it.remove(accountId) }
+        }
+
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            if (teamRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "team rekey failed")
+            teamRekeys += envelopes
+            teamEpoch = newEpoch
+        }
+
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> =
+            scopeEnvelopes.map { (scopeId, grants) ->
+                TeamScopeSummary(scopeId, scopeEpochs[scopeId] ?: 0, grants.size, grants[self])
+            }
+
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
+            scopeEnvelopes[scopeId] = mutableMapOf(self to envelope)
+            scopeEpochs[scopeId] = 0
+        }
+
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) {
+            grants += accountId to envelope
+            scopeEnvelopes[scopeId]?.put(accountId, envelope)
+        }
+
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
+            scopeEnvelopes[scopeId]?.keys?.map { TeamScopeGrantEntry(it, 0) } ?: emptyList()
+
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) {
+            scopeEnvelopes[scopeId]?.remove(accountId)
+        }
+
+        /** Set to fail every scope rotation the way an exhausted retry does. */
+        var scopeRekeyFails = false
+
+        /** The same for the team key's own rotation. */
+        var teamRekeyFails = false
+
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            if (scopeRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "scope rekey failed")
+            scopeEpochs[scopeId] = newEpoch
+            val holders = scopeEnvelopes[scopeId] ?: return
+            envelopes.forEach { (account, env) -> if (holders.containsKey(account)) holders[account] = env }
+        }
+
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage =
+            RecordPage(emptyList(), since)
+
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage =
+            RecordPage(records, 1)
+
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) {
+            invites += accountId
+        }
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+    }
+
+    private class Fixture(val vault: FileVault, val teamVaults: TeamVaults)
+
+    private fun newFixture(): Fixture {
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile)
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }))
+    }
+
+    private fun coordinator(f: Fixture, client: TeamClient, ids: Iterator<String> = listOf("prod").iterator()) =
+        TeamsCoordinator(
+            live = { TeamLink(SyncSession(self, "access", "refresh"), client, "test-link") },
+            vault = f.vault,
+            crypto = crypto,
+            teamVaults = f.teamVaults,
+            teamState = InMemorySyncStateStore(),
+            newId = { ids.next() },
+        )
+
+    /** An invite from [inviter] to us, sealed to our own sharing key and signed by their identity. */
+    private fun inviteEnvelope(f: Fixture, inviter: String, signing: SigningKeyPair, epoch: Int = 0): ByteArray {
+        val identity = TeamIdentityStore(f.vault, crypto).ensure()
+        return TeamInviteCodec(crypto).seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = signing,
+            inviterId = inviter,
+            inviteeId = self,
+            teamId = teamId,
+            teamKey = crypto.newDataKey(),
+            teamName = "Ops",
+            epoch = epoch,
+        )
+    }
+
+    private fun invitedTeam(envelope: ByteArray) = TeamSummary(
+        id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
+        status = TeamMemberStatus.INVITED, createdAt = 0, memberCount = 2,
+        envelope = envelope, keyEpoch = 0, keyEnvelope = null,
+    )
+
+    /**
+     * Item 1: the banner verifies the envelope's signature against one fetch and used to fingerprint
+     * a second one. A server answering the first with a key it forged the invite under and the second
+     * with the real colleague's key gets its own team confirmed over the phone.
+     */
+    @Test
+    fun `the fingerprint on the invite banner belongs to the key the signature was checked against`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val forged = crypto.newSigningKeyPair()
+        val forgedKeys = keysOf(crypto.newSharingKeyPair(), forged)
+        val realKeys = keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair())
+        val backing = FakePeerClient(self, teamId)
+        backing.teams = listOf(invitedTeam(inviteEnvelope(f, bob, forged)))
+        // The key table is the server's: the fetch the signature is checked against answers with the
+        // key it forged the invite under, any later one with the real colleague's key.
+        var fetches = 0
+        val client = object : TeamClient by backing {
+            override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
+                fetches += 1
+                return if (accountId != bob) null else if (fetches == 1) forgedKeys else realKeys
+            }
+        }
+        val coord = coordinator(f, client)
+
+        val preview = assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId), "the envelope verifies").preview
+
+        assertEquals(
+            fingerprintOf(forgedKeys),
+            preview.fingerprint,
+            "the fingerprint must come from the key the signature was verified against, not a second fetch",
+        )
+        assertEquals(1, fetches, "one fetch, one key: a second answer is a window the server owns")
+    }
+
+    /** Item 2: Accept before the banner resolved adopted a team key with no ceremony at all. */
+    @Test
+    fun `accept refuses an invite whose inviter was never shown`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+
+        coord.accept(teamId) // the Accept button pressed while the banner is still resolving
+
+        assertNull(TeamKeyStore(f.vault).get(teamId), "no team key may be adopted without the ceremony")
+        assertEquals(emptyList(), client.accepted)
+        assertEquals(TeamsFailure.InviteUnverified, coord.lastError.value)
+    }
+
+    /** The same accept, after the banner did resolve, still works — and pins the inviter. */
+    @Test
+    fun `accept after the banner adopts the key and pins the inviter`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+
+        val shown = assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId)).preview
+        coord.accept(teamId)
+
+        assertNotNull(TeamKeyStore(f.vault).get(teamId))
+        assertEquals(listOf(teamId), client.accepted)
+        // The pin is the point of the ceremony: what was read out loud is what every later envelope
+        // from Bob is held to. Adopting the key without writing it leaves the next rotation open.
+        assertEquals(
+            shown.fingerprint,
+            (TeamPeerStore(f.vault).pin(bob) as? Pin.Known)?.fingerprint,
+            "accepting must pin the fingerprint the banner showed",
+        )
+        assertFalse(shown.keyChanged, "nothing was pinned before, so nothing moved")
+    }
+
+    /**
+     * An invite from an account already pinned under another fingerprint is an identity that moved:
+     * an honest rotation, or the server trying its luck. Accepting replaces the pin, so the banner
+     * has to say so before the user reads the new one out loud.
+     */
+    @Test
+    fun `an invite from an account pinned under another key is shown as changed`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        TeamPeerStore(f.vault).confirm(bob, "an-older-fingerprint")
+        val coord = coordinator(f, client)
+
+        val preview = assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId)).preview
+
+        assertTrue(preview.keyChanged, "the pinned fingerprint is not this one")
+        assertEquals(
+            "an-older-fingerprint",
+            (TeamPeerStore(f.vault).pin(bob) as? Pin.Known)?.fingerprint,
+            "showing the banner must not move the pin — only accepting it does",
+        )
+        coord.accept(teamId)
+        assertEquals(preview.fingerprint, (TeamPeerStore(f.vault).pin(bob) as? Pin.Known)?.fingerprint)
+    }
+
+    /**
+     * A check that could not be made is not a check that failed. The banner refuses Accept either
+     * way, but only one of the two is the user's colleague sending something forged — the other is
+     * their own vault being locked, and it is retried rather than accused.
+     */
+    @Test
+    fun `a check that could not be made is not an unverified invite`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+
+        f.vault.lock()
+        assertEquals(InviteVerdict.Failed(TeamsFailure.VaultLocked), coord.acceptPreview(teamId))
+        // The verdict is the whole report: the banner draws and announces it, and writing the shared
+        // error slot as well would have two live regions on one screen speak about one event.
+        assertNull(coord.lastError.value)
+
+        f.vault.unlock("master".toCharArray())
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId), "the same invite verifies once the check can run")
+
+        // An envelope that is genuinely not ours is the other answer, and it is permanent.
+        client.teams = listOf(invitedTeam(ByteArray(96) { 0x7 }))
+        assertEquals(InviteVerdict.Unverified, coord.acceptPreview(teamId))
+    }
+
+    /**
+     * The other local condition that used to read as a forgery: the identity the envelope is sealed
+     * to is gone from this device (a reactivation reconcile drops the record, the re-pull has not
+     * landed) or no longer decrypts. Nothing is wrong with the invite, and the banner must not say
+     * the inviter sent something forged.
+     */
+    @Test
+    fun `an identity this device cannot read is not a forged invite`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+
+        f.vault.remove(f.vault.records().single { it.type == RecordType.TEAM_IDENTITY }.id)
+
+        assertEquals(InviteVerdict.Failed(TeamsFailure.IdentityUnreadable), coord.acceptPreview(teamId))
+        assertNull(coord.lastError.value)
+    }
+
+    /**
+     * Item 4, receiving end: a rotation envelope arrives signed by whatever key the server publishes
+     * for the rotator. Once that account is pinned, a key that moved cannot pass as theirs.
+     */
+    @Test
+    fun `a rotation envelope signed under a moved key is not adopted`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        coord.accept(teamId)
+        val adopted = assertNotNull(TeamKeyStore(f.vault).get(teamId))
+
+        // The server rotates on Bob's behalf under a key of its own and republishes it as his.
+        val attacker = crypto.newSigningKeyPair()
+        val attackerSharing = crypto.newSharingKeyPair()
+        client.published[bob] = Published(keysOf(attackerSharing, attacker))
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 2,
+                envelope = null, keyEpoch = 1, keyEnvelope = inviteEnvelope(f, bob, attacker, epoch = 1),
+            ),
+        )
+        coord.refresh()
+
+        val after = assertNotNull(TeamKeyStore(f.vault).get(teamId))
+        assertEquals(adopted.teamKey, after.teamKey, "a key signed under a fingerprint nobody verified must be ignored")
+        assertEquals(0, after.epoch)
+    }
+
+    /** Item 3: a scope grant sealed to whatever the server answers, with nothing on screen to contradict it. */
+    @Test
+    fun `a scope grant to a key that moved since it was pinned is refused`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = self, role = TeamRole.OWNER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 2,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight: the key is pinned
+        assertEquals(1, client.grants.size)
+
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.grantScope(teamId, "prod", bob)
+
+        assertEquals(1, client.grants.size, "the scope key must not be sealed to a key that moved")
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+    }
+
+    /**
+     * Item 4, sending end: every removal re-seals the new team key to freshly fetched keys, so a
+     * server that failed at invite time only had to wait for the next removal.
+     */
+    @Test
+    fun `a rotation does not re-seal the new team key to a member whose key moved`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[carol] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[dave] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(dave, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = self, role = TeamRole.OWNER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 4,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+        val coord = coordinator(f, client)
+
+        coord.removeMember(teamId, carol) // first rotation: pins the keys it seals to
+        assertTrue(client.teamRekeys.last().containsKey(bob))
+
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.removeMember(teamId, dave)
+
+        val resealed = client.teamRekeys.last()
+        assertFalse(resealed.containsKey(bob), "the rotated key must not be handed to a key nobody verified")
+        assertTrue(client.removed.contains(dave), "the revocation itself still stands")
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+    }
+
+    /** A scope key granted to us by [granter], signed with [signing] and bound to [scopeId]. */
+    private fun scopeEnvelope(f: Fixture, granter: String, signing: SigningKeyPair, scopeId: String, epoch: Int): ByteArray {
+        val identity = TeamIdentityStore(f.vault, crypto).ensure()
+        return TeamInviteCodec(crypto).seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = signing,
+            inviterId = granter,
+            inviteeId = self,
+            teamId = teamId,
+            teamKey = crypto.newDataKey(),
+            teamName = "Production",
+            epoch = epoch,
+            scopeId = scopeId,
+        )
+    }
+
+
+    /**
+     * The send half of the ceremony: pressing Send is a human saying the fingerprint on screen is the
+     * colleague's. Nothing recorded that, so the next fetch for the same account started from zero —
+     * and the banner could not tell the user their colleague's key had moved since.
+     */
+    @Test
+    fun `the invite pins the key it sealed to, and a later lookup says it moved`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = self, role = TeamRole.OWNER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 2,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+        val coord = coordinator(f, client)
+
+        val first = assertNotNull(coord.previewInvite(bob))
+        assertFalse(first.keyChanged, "nothing was ever pinned for this account, so nothing moved")
+        coord.invite(teamId, first, TeamRole.VIEWER)
+        assertEquals(listOf(bob), client.invites)
+
+        // The server publishes another key for the same colleague after the ceremony.
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+
+        val second = assertNotNull(coord.previewInvite(bob))
+        assertTrue(second.keyChanged, "the fingerprint differs from the pinned one and the user must be told")
+        // …and until a human confirms the new one, nothing is sealed to it.
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob)
+        assertEquals(emptyList(), client.grants, "the scope key must not be sealed to a key nobody confirmed")
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+    }
+
+    /**
+     * Item 3, receiving end: a scope grant arrives signed by whatever key the server publishes for the
+     * granter. Once that account is pinned, a signature checked against a key that is not the pinned
+     * one buys nothing — the scope key it carries is the server's to read.
+     */
+    @Test
+    fun `a scope grant signed under an unconfirmed key is not adopted`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        coord.accept(teamId) // the ceremony pins Bob
+
+        // The server rotates Bob's published key to one of its own and offers a scope under it.
+        val attacker = crypto.newSigningKeyPair()
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), attacker))
+        client.teams = listOf(
+            TeamSummary(
+                id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
+                status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = 2,
+                envelope = null, keyEpoch = 0, keyEnvelope = null,
+            ),
+        )
+        client.scopeEnvelopes["prod"] = mutableMapOf(self to scopeEnvelope(f, bob, attacker, "prod", epoch = 0))
+        coord.refresh()
+
+        assertNull(TeamKeyStore(f.vault).scope(teamId, "prod"), "a scope key signed by an unconfirmed identity must be ignored")
+        assertEquals(TeamsFailure.UnconfirmedKeyIgnored, coord.lastError.value)
+    }
+
+    /**
+     * The warning is deliberately re-earnable: an unconfirmed key is a standing condition, not an
+     * event, and a pass over it starts by clearing the slot. Remembered for the lifetime of the
+     * coordinator it would be said once and never again, while the scope key stays unadopted.
+     */
+    @Test
+    fun `a second pass over the same unconfirmed key reports it again`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        coord.accept(teamId) // the ceremony pins Bob
+
+        val attacker = crypto.newSigningKeyPair()
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), attacker))
+        client.teams = listOf(activeTeam(TeamRole.VIEWER))
+        client.scopeEnvelopes["prod"] = mutableMapOf(self to scopeEnvelope(f, bob, attacker, "prod", epoch = 0))
+
+        coord.refresh()
+        assertEquals(TeamsFailure.UnconfirmedKeyIgnored, coord.lastError.value)
+        coord.refresh()
+        assertEquals(TeamsFailure.UnconfirmedKeyIgnored, coord.lastError.value, "the condition still holds, so it is still said")
+    }
+
+    /**
+     * `lastError` holds a single value and the reread that ends a removal writes it too. Published
+     * before that reread, the rotation verdict was replaced by whatever the reread found — "the
+     * removed member still holds the team key" hidden behind the milder "a key nobody confirmed was
+     * ignored", which is the one thing on this screen the user cannot afford to miss.
+     */
+    @Test
+    fun `the rotation verdict outlives the reread that follows it`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        coord.accept(teamId) // pins Bob
+
+        // Bob's published key moves, and the reread has something of its own to complain about: a
+        // scope grant signed under that key, which it steps over with UnconfirmedKeyIgnored.
+        val attacker = crypto.newSigningKeyPair()
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), attacker))
+        client.teams = listOf(activeTeam(TeamRole.VIEWER))
+        client.scopeEnvelopes["prod"] = mutableMapOf(self to scopeEnvelope(f, bob, attacker, "prod", epoch = 0))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+
+        coord.removeMember(teamId, carol)
+
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value, "the rotation verdict is the one that stands")
+    }
+
+    /**
+     * The other rotation trigger: a revoked grant. The scope still rotates for the holders that
+     * stand, the one whose key moved is stepped over rather than re-sealed to, and the skip is said
+     * out loud — a revocation reported as clean while a member's key was never rotated is the
+     * failure this whole path exists to prevent.
+     */
+    @Test
+    fun `revoking a grant rotates the scope past a holder whose key moved`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[carol] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight: both keys are pinned here
+        coord.grantScope(teamId, "prod", carol)
+        val sealedToBob = assertNotNull(client.scopeEnvelopes["prod"]?.get(bob))
+
+        // Bob's key moves, and the reread that ends the revocation has something of its own to
+        // report: a rotated team key signed under that moved key, which it steps over with the
+        // milder UnconfirmedKeyIgnored. The scope verdict is the one the user must be left with.
+        val moved = crypto.newSigningKeyPair()
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), moved))
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3, keyEpoch = 1, keyEnvelope = inviteEnvelope(f, bob, moved, epoch = 1)))
+        coord.revokeScope(teamId, "prod", carol)
+
+        val holders = assertNotNull(client.scopeEnvelopes["prod"])
+        assertFalse(holders.containsKey(carol), "the revocation itself still stands")
+        assertContentEquals(sealedToBob, holders[bob], "the new scope key must not be sealed to a key nobody verified")
+        assertEquals(1L, client.scopeEpochs["prod"], "the scope rotated for the holders that remain")
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+    }
+
+    /**
+     * Both rotations can fail in one removal, and `lastError` holds one of them. The team key is the
+     * more serious of the two — except when its own verdict is the mild one: a rotation that
+     * committed while stepping over a recipient. A scope that never rotated at all is a key the
+     * removed member kept, and it must not be replaced by "one colleague to re-confirm".
+     */
+    @Test
+    fun `a scope that never rotated outranks a team rotation that only skipped someone`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[carol] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight pins both of them
+        coord.grantScope(teamId, "prod", carol) // carol holds the scope key she must lose
+
+        // Bob's key moves: the team rotation commits and steps over him. The scope rotation cannot
+        // commit at all, so carol keeps that key.
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.scopeRekeyFails = true
+        coord.removeMember(teamId, carol)
+
+        assertTrue(client.removed.contains(carol), "the revocation itself still stands")
+        assertEquals(TeamsFailure.Network, coord.lastError.value, "the scope nobody rotated is the one to report")
+    }
+
+    /**
+     * The other direction of the same rule, and the one the removal hangs on: the team key itself
+     * never rotated, so the member who was just removed still holds it. A scope that rotated while
+     * stepping over one recipient is the milder verdict and must not take the slot.
+     */
+    @Test
+    fun `a team key that never rotated outranks a scope that only skipped someone`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[carol] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight pins both of them
+        coord.grantScope(teamId, "prod", carol)
+
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.teamRekeyFails = true
+        coord.removeMember(teamId, carol)
+
+        assertTrue(client.removed.contains(carol), "the revocation itself still stands")
+        assertEquals(1L, client.scopeEpochs["prod"], "the scope rotated, stepping over the moved key")
+        assertEquals(TeamsFailure.Network, coord.lastError.value, "the key the removed member kept is the one to report")
+    }
+
+    /**
+     * A pin the vault refuses to write is the ceremony failing, not a detail: the fingerprint was
+     * read out loud and nothing would record it. The invite goes nowhere.
+     *
+     * The id can be occupied because a team id is the server's to choose, and a vault record is found
+     * by id alone — file a "team" at the pin's id and the confirmation has nowhere to live.
+     */
+    @Test
+    fun `an invite whose pin cannot be written is not sent`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        val coord = coordinator(f, client)
+        val preview = assertNotNull(coord.previewInvite(bob))
+        TeamKeyStore(f.vault).put(pinIdOf(f, bob), "Squat", TeamRole.VIEWER, crypto.newDataKey(), epoch = 0)
+
+        coord.invite(teamId, preview, TeamRole.VIEWER)
+
+        assertEquals(emptyList(), client.invites, "the team key must not be sealed to a key nothing records")
+        assertEquals(TeamsFailure.PinNotRecorded, coord.lastError.value)
+    }
+
+    /** The same refusal on the invitee's side: no membership whose later envelopes nothing guards. */
+    @Test
+    fun `an accept whose pin cannot be written joins nothing`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        TeamKeyStore(f.vault).put(pinIdOf(f, bob), "Squat", TeamRole.VIEWER, crypto.newDataKey(), epoch = 0)
+
+        coord.accept(teamId)
+
+        assertEquals(emptyList(), client.accepted)
+        assertNull(TeamKeyStore(f.vault).get(teamId), "no key is adopted without a pin to hold it to")
+        assertEquals(TeamsFailure.PinNotRecorded, coord.lastError.value)
+    }
+
+    /**
+     * The id a pin for [accountId] would use, asked of the store rather than assumed from its
+     * namespace: pin an unrelated account, read the id it filed, and swap the account in.
+     */
+    private fun pinIdOf(f: Fixture, accountId: String): String {
+        val probe = "probe@example.com"
+        TeamPeerStore(f.vault).confirm(probe, "probe")
+        val filed = f.vault.records().single { it.type == RecordType.TEAM_PEER && !it.deleted }.id
+        return filed.removeSuffix(probe) + accountId
+    }
+
+    /** The team as the server lists it once we are a member of it. */
+    private fun activeTeam(role: TeamRole, members: Int = 2, keyEpoch: Long = 0, keyEnvelope: ByteArray? = null) = TeamSummary(
+        id = teamId, ownerAccountId = if (role == TeamRole.OWNER) self else bob, role = role,
+        status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = members,
+        envelope = null, keyEpoch = keyEpoch, keyEnvelope = keyEnvelope,
+    )
+
+    private companion object {
+        const val NOW = "2026-08-24T00:00:00Z"
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
@@ -7,14 +7,20 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.performTextReplacement
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamRole
 import app.skerry.ui.app.UiTags
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.desktop.runForm
+import org.jetbrains.compose.resources.stringResource
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -100,6 +106,89 @@ class TeamsDialogFormTest {
         assertEquals(ACCOUNT, sent?.first?.accountId)
         assertEquals(PEER_FINGERPRINT, sent?.first?.fingerprint, "the send must carry the verified fingerprint")
         assertEquals(TeamRole.VIEWER, sent?.second, "the invite should default to the least privilege")
+    }
+
+    /**
+     * A fingerprint that differs from the one pinned for the account is either an honest identity
+     * rotation or the server substituting a key of its own. Sending replaces the pin, so the dialog
+     * has to say which fingerprint the user is about to promote to verified (#319).
+     */
+    @Test
+    fun `an account whose key moved says so before the invite is sent`() {
+        var warning = ""
+        runForm({
+            warning = stringResource(Res.string.lib_teams_invite_key_changed)
+            InviteMemberDialog(
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, keyChanged = true),
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
+                onLookup = {},
+                onEdited = {},
+                onSend = { _, _ -> },
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithTag(UiTags.FORM_FIELD).performTextReplacement(ACCOUNT)
+            waitForIdle()
+            onNodeWithText(warning).assertExists()
+        }
+    }
+
+    /**
+     * And says it at the price of a second, deliberate gesture: sending promotes the new fingerprint
+     * to the pinned one, so an honest rotation and a server trying its luck reach this dialog looking
+     * the same. One click could not carry the difference the trusted channel establishes.
+     */
+    @Test
+    fun `an account whose key moved cannot be invited on one click`() {
+        var ack = ""
+        var sent: InvitePreview? = null
+        runForm({
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            InviteMemberDialog(
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, keyChanged = true),
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
+                onLookup = {},
+                onEdited = {},
+                onSend = { verified, _ -> sent = verified },
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithTag(UiTags.FORM_FIELD).performTextReplacement(ACCOUNT)
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).performClick()
+            waitForIdle()
+        }
+        assertEquals(PEER_FINGERPRINT, sent?.fingerprint, "the send carries the fingerprint that was acknowledged")
+    }
+
+    /** The usual case — a key nobody has pinned a different value for — must not cry wolf. */
+    @Test
+    fun `a first invite to an account carries no key-changed warning`() {
+        var warning = ""
+        runForm({
+            warning = stringResource(Res.string.lib_teams_invite_key_changed)
+            InviteMemberDialog(
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
+                onLookup = {},
+                onEdited = {},
+                onSend = { _, _ -> },
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithTag(UiTags.FORM_FIELD).performTextReplacement(ACCOUNT)
+            waitForIdle()
+            onNodeWithText(warning).assertDoesNotExist()
+        }
     }
 
     /**

--- a/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
+++ b/server/src/main/kotlin/app/skerry/server/routes/VaultRoutes.kt
@@ -25,7 +25,7 @@ import io.ktor.server.routing.put
 /** Allowed values for the plaintext `type` field (mirrors core `RecordType`). */
 private val ALLOWED_TYPES = setOf(
     "HOST", "GROUP", "IDENTITY", "CREDENTIAL", "KNOWN_HOST", "SNIPPET", "TUNNEL", "SETTINGS",
-    "TEAM", "TEAM_IDENTITY", "TRASH", "RUNBOOK", "RUNBOOK_RUN", "TRUSTED_CA",
+    "TEAM", "TEAM_IDENTITY", "TEAM_PEER", "TRASH", "RUNBOOK", "RUNBOOK_RUN", "TRUSTED_CA",
 )
 
 /** Ciphertext storage: dataKey wrapping, delta reads, and batch push with LWW. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncEngine.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.cancellation.CancellationException
  * supported server release accepts it.
  */
 private val TYPES_NEWER_THAN_SOME_SERVERS =
-    setOf(RecordType.TRASH, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.TRUSTED_CA)
+    setOf(RecordType.TRASH, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN, RecordType.TRUSTED_CA, RecordType.TEAM_PEER)
 
 /**
  * How a server that predates one of [TYPES_NEWER_THAN_SOME_SERVERS] answers a push carrying it:

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncSettings.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sync/SyncSettings.kt
@@ -37,8 +37,10 @@ data class SyncSettings(
     fun shouldSync(type: RecordType, id: String = ""): Boolean = when (type) {
         RecordType.SETTINGS -> true
         // Team keys and the identity pair carry access to Teams: always synced between a user's
-        // devices, otherwise a team wouldn't open on a second device.
-        RecordType.TEAM, RecordType.TEAM_IDENTITY -> true
+        // devices, otherwise a team wouldn't open on a second device. A verified peer fingerprint
+        // travels with them — a colleague verified on the desktop must be pinned on the phone too,
+        // or the device that happens to run the next rotation seals to an unchecked key (#319).
+        RecordType.TEAM, RecordType.TEAM_IDENTITY, RecordType.TEAM_PEER -> true
         // A runbook is a checklist of the same commands, saved and shared for the same reasons, so
         // it follows the snippets toggle instead of adding a switch nobody would set differently.
         RecordType.SNIPPET, RecordType.RUNBOOK, RecordType.RUNBOOK_RUN -> syncSnippets

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamPeerStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamPeerStore.kt
@@ -1,0 +1,208 @@
+package app.skerry.shared.team
+
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecordCodec
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+
+/**
+ * The fingerprint of another account's Teams keys as this account holds it — one
+ * [RecordType.TEAM_PEER] record per peer.
+ *
+ * The invite ceremony verifies a fingerprint over a channel the server does not own, but that
+ * verification used to end with the send: every later seal to the same colleague (a scope grant, a
+ * key rotation after a member removal) fetched the key again and sealed to whatever came back. A
+ * server that failed at invite time only had to wait for the next removal (#319). This record is
+ * what makes one verification durable — it is the fingerprint every later fetch is held to.
+ */
+@Serializable
+data class TeamPeerEntry(val fingerprint: String)
+
+/** What this account holds for a peer: nothing, something it cannot read, or a fingerprint. */
+sealed interface Pin {
+    /** Nothing was ever pinned for the account. */
+    data object None : Pin
+
+    /**
+     * A pin exists and this device cannot read it: the vault is locked, or the payload no longer
+     * decrypts (what [Vault.adoptDataKey] leaves behind on a device that joins an existing sync
+     * account). Distinct from [None] on purpose — an unreadable pin must fail closed, and must never
+     * be overwritten with whatever the server answers next.
+     */
+    data object Unreadable : Pin
+
+    /** The fingerprint pinned for the account. */
+    class Known(val fingerprint: String) : Pin
+}
+
+/** Store of [RecordType.TEAM_PEER] records. Synced between the account's own devices like team keys. */
+class TeamPeerStore(
+    private val vault: Vault,
+    /**
+     * Where [fetchPinned] and [checkPinned] do their vault work. Every seal to another account goes
+     * through them, and a rotation walks every recipient: on a team that predates this record each
+     * one is a first-sight write, and a vault write re-serializes and re-writes the whole file. The
+     * coordinator's operations run on the caller's thread, which is the UI one.
+     */
+    internal val vaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
+
+    private val codec = VaultRecordCodec(vault, RecordType.TEAM_PEER, TeamPeerEntry.serializer())
+
+    /** What is pinned for [accountId]. */
+    fun pin(accountId: String): Pin = vault.transaction {
+        if (!vault.isUnlocked) return@transaction Pin.Unreadable
+        val id = recordId(accountId)
+        // One transaction for both reads: a compact landing between them would drop the record
+        // `codec.get` just failed on, and the fallback would read the fail-open answer.
+        codec.get(id)?.let { return@transaction Pin.Known(it.fingerprint) }
+        // codec.get answers null for "absent", "tombstoned", "present but does not decrypt" and
+        // "present as another type" alike. Both of the last two mean a pin this device cannot read:
+        // a blob that stopped opening (an adopted account key), or a record the server named after
+        // this id and got there first. Reading either as "nothing pinned" would pin whatever the
+        // server publishes next — so any live record at the id fails the read closed.
+        // [None] is answered exactly when a first-sight pin could be written here, and a tombstone
+        // holds an id's type until compaction — so a deleted TEAM the server named after this pin
+        // leaves the slot unwritable just as a live one does. Reading that as "nothing was ever
+        // pinned" would pin on first sight, silently drop the write, and call the next fetch first
+        // sight again: every later seal follows whatever the server publishes, forever and without
+        // a word (#319 reopened for that account). Unwritable reads as unreadable, which fails closed.
+        val at = recordAt(id)
+        if (at == null || (at.deleted && at.type == RecordType.TEAM_PEER)) Pin.None else Pin.Unreadable
+    }
+
+    /**
+     * The record at [id], of this type or another, tombstoned or not. Tombstones count for the write
+     * guards below because [Vault.put] counts them: an id keeps its type until the record is
+     * physically gone, so a deleted TEAM at a pin's id refuses the write just as a live one does.
+     */
+    private fun recordAt(id: String) = vault.records().firstOrNull { it.id == id }
+
+    /**
+     * Pin a fingerprint a human just confirmed out of band (the invite send, the invite accept).
+     * Replaces whatever was pinned: an honest identity rotation is re-confirmed by the same ceremony
+     * that pinned the first key, and the user is shown that it moved before they get here.
+     *
+     * Answers `false` when the id is not this store's to write — a record of another type is sitting
+     * on it. The ceremony the caller was about to record has to stop there.
+     */
+    fun confirm(accountId: String, fingerprint: String): Boolean {
+        check(vault.isUnlocked) { "pinning a peer needs an unlocked vault" }
+        return vault.transaction {
+            val id = recordId(accountId)
+            // False rather than a throw when another record already holds the id: [Vault.put] refuses
+            // to re-type a record, and the caller has to stop the ceremony it was about to record —
+            // sealing a key whose confirmation cannot be written is worse than not sealing it.
+            val squat = recordAt(id)
+            if (squat != null && squat.type != RecordType.TEAM_PEER) return@transaction false
+            codec.put(id, TeamPeerEntry(fingerprint))
+            true
+        }
+    }
+
+    /**
+     * Pin a key on first sight — nothing has ever been verified for this account, so there is nothing
+     * to contradict. An existing pin is kept, readable or not: only a human may move one, and doing
+     * it here would undo the guarantee on the very fetch it exists to guard.
+     */
+    fun rememberFirstSight(accountId: String, fingerprint: String) {
+        check(vault.isUnlocked) { "pinning a peer needs an unlocked vault" }
+        vault.transaction {
+            val id = recordId(accountId)
+            // Nothing is written over a live pin (only a human moves one) or over an id another
+            // store's record still holds — a write the vault would refuse anyway.
+            val at = recordAt(id)
+            if (at == null || (at.deleted && at.type == RecordType.TEAM_PEER)) {
+                codec.put(id, TeamPeerEntry(fingerprint))
+            }
+        }
+    }
+
+    /**
+     * The pin for [accountId] measured against [fingerprint], recording it on first sight when
+     * [pinOnFirstSight]. One transaction for the read and the write it decides: a merge landing
+     * between them would decide the write against a pin that no longer exists.
+     */
+    internal fun match(accountId: String, fingerprint: String, pinOnFirstSight: Boolean): Pin =
+        vault.transaction {
+            val pin = pin(accountId)
+            if (pin == Pin.None && pinOnFirstSight) rememberFirstSight(accountId, fingerprint)
+            pin
+        }
+
+    /**
+     * The record id for a peer's pin. Namespaced, and that is load-bearing: the account id comes from
+     * the server (a member list, a grant list, the inviter named inside a sealed envelope anyone can
+     * seal), while a vault record is located by id alone and replaced wholesale — an un-namespaced id
+     * would let the server name a credential's or an identity's record and have this client destroy it.
+     */
+    private fun recordId(accountId: String) = "$ID_PREFIX$accountId"
+
+    private companion object {
+        const val ID_PREFIX = "peer:"
+    }
+}
+
+/** What [fetchPinned] found: the account's keys, no published key at all, or a key nobody confirmed. */
+sealed interface PeerKeys {
+    /** The published keys, matching what is pinned for the account (or newly pinned on first sight). */
+    class Pinned(val keys: AccountKeys) : PeerKeys
+
+    /** The account has no Teams keys on this server — it has never opened Teams. */
+    data object Unpublished : PeerKeys
+
+    /**
+     * The published keys are not the ones pinned for the account: they hash to another fingerprint,
+     * or the pin itself cannot be read. Either way nothing may be sealed to them.
+     */
+    class Unconfirmed(val accountId: String, val fingerprint: String) : PeerKeys
+}
+
+/**
+ * The account's published keys under the pin that guards them: the one call every seal to another
+ * account goes through. A key that is not the pinned one is refused rather than sealed to, which is
+ * what stops the sync server — the owner of the key table — from substituting its own key on any
+ * fetch after the one the user verified (#319).
+ *
+ * With nothing pinned yet the key is pinned on first sight: a team that predates this record has no
+ * pins, and refusing there would take the keys away from every existing member. First sight is no
+ * weaker than what the fetch did before; what it adds is that the second sight is checked.
+ */
+suspend fun TeamPeerStore.fetchPinned(session: SyncSession, client: TeamClient, accountId: String): PeerKeys =
+    resolve(session, client, accountId, pinOnFirstSight = true)
+
+/**
+ * Like [fetchPinned], but never writes a pin — for the receiving end (a rekey envelope, a scope
+ * grant), where the account id is one the server chose and nothing on screen was confirmed. A pin
+ * written from there would let the server fix a key of its own as the account's "verified" one, and
+ * the real colleague would be the one refused from that point on.
+ *
+ * Which is the deliberate limit of this side: an account somebody already confirmed is held to that
+ * fingerprint, and one nobody ever confirmed is accepted on first sight without being pinned.
+ * Refusing there instead would mean refusing every colleague this account has never invited — a team
+ * that predates the pin record could not rotate a key at all. Closing that gap needs a rule the
+ * fingerprint alone cannot express (a seal refused to any unconfirmed account, plus continuity
+ * across an honest rekey), which is its own change.
+ */
+suspend fun TeamPeerStore.checkPinned(session: SyncSession, client: TeamClient, accountId: String): PeerKeys =
+    resolve(session, client, accountId, pinOnFirstSight = false)
+
+private suspend fun TeamPeerStore.resolve(
+    session: SyncSession,
+    client: TeamClient,
+    accountId: String,
+    pinOnFirstSight: Boolean,
+): PeerKeys {
+    val keys = client.fetchPublicKey(session, accountId) ?: return PeerKeys.Unpublished
+    val fingerprint = accountKeyFingerprint(keys.sharing, keys.signing)
+    val pin = withContext(vaultDispatcher) { match(accountId, fingerprint, pinOnFirstSight) }
+    return when (pin) {
+        is Pin.Known -> if (pin.fingerprint == fingerprint) PeerKeys.Pinned(keys) else PeerKeys.Unconfirmed(accountId, fingerprint)
+        Pin.Unreadable -> PeerKeys.Unconfirmed(accountId, fingerprint)
+        Pin.None -> PeerKeys.Pinned(keys)
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/FileVault.kt
@@ -273,11 +273,11 @@ class FileVault(
         for (r in remote) {
             val index = working.indexOfFirst { it.id == r.id }
             val local = if (index >= 0) working[index] else null
-            // LWW: higher version wins; on a tie, the lexicographically larger deviceId wins.
-            val wins = local == null ||
-                r.version > local.version ||
-                (r.version == local.version && r.deviceId > local.deviceId)
-            if (!wins) continue
+            if (retypes(local, r)) {
+                rejected += r
+                continue
+            }
+            if (!outranks(local, r)) continue
             // Trial-decrypt before storing: the AAD binds the metadata the record claims, so a
             // compromised server can't roll a record back by replaying an old genuine ciphertext
             // with a bumped version, forge a tombstone from a live blob, or replace a readable
@@ -295,6 +295,27 @@ class FileVault(
         }
         MergeResult(applied, rejected)
     }
+
+    /**
+     * Whether [remote] would change the type of the record already holding its id. An id belongs to
+     * one type for as long as a record holds it (see [store]) — through the sync path as well: a
+     * server that hands back a record carrying another store's id and a type of its own choosing
+     * would otherwise re-type it here, which is the very substitution the local rule refuses (#319).
+     * Such a record joins `rejected`, where a forged one goes, and the local record survives.
+     *
+     * A tombstone does not hold the id here, though [store] treats it as holding one: the remote
+     * record authenticates under this account's key, so it was written by one of our own devices
+     * under the same rule, and refusing it would strand it for good — the cursor moves past a
+     * rejection and only the server's compaction list would ever free the id.
+     */
+    private fun retypes(local: VaultRecord?, remote: VaultRecord) =
+        local != null && !local.deleted && local.type != remote.type
+
+    /** LWW: higher version wins; on a tie, the lexicographically larger deviceId wins. */
+    private fun outranks(local: VaultRecord?, remote: VaultRecord) =
+        local == null ||
+            remote.version > local.version ||
+            (remote.version == local.version && remote.deviceId > local.deviceId)
 
     override fun openPayload(id: String): ByteArray? = synchronized(lock) {
         val key = requireUnlocked()
@@ -322,6 +343,12 @@ class FileVault(
         val key = requireUnlocked()
         val currentMeta = session()
         val index = records.indexOfFirst { it.id == id }
+        // A record is located by id ALONE, and not every id is this device's to choose: a team id, a
+        // peer's account id and a scope id all arrive from the sync server. Re-typing a record in place
+        // would let a server that names a team after another store's record have this client overwrite
+        // it — a verified peer fingerprint replaced by a team key, and the next rotation sealed to
+        // whatever key the server publishes (#319). An id belongs to one type for its whole life.
+        require(index < 0 || records[index].type == type) { "record id already holds a ${records[index].type}" }
         val version = maxOf(if (index >= 0) records[index].version + 1 else 1L, minVersion)
         val at = now()
         val blob = crypto.seal(key, payload, recordAad(id, type, version, deviceId, deleted = false, updatedAt = at))

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecord.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecord.kt
@@ -33,6 +33,12 @@ enum class RecordType {
     TEAM_IDENTITY,
 
     /**
+     * Fingerprint of another account's published Teams keys, as this account verified it — the pin
+     * every later seal to that account is held to (see [app.skerry.shared.team.TeamPeerStore]).
+     */
+    TEAM_PEER,
+
+    /**
      * Snapshot of a deleted record kept for the trash window (see [app.skerry.shared.vault.TrashStore]).
      * A separate type, not a fatter tombstone: tombstones stay empty, and clients that don't know
      * this type keep the record verbatim without ever showing it.

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecordCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vault/VaultRecordCodec.kt
@@ -51,13 +51,21 @@ internal class VaultRecordCodec<T>(
 
     /**
      * Soft-delete a record (tombstone) — delegates to [Vault.remove]. With a [trash] configured the
-     * value is snapshotted first, in the same transaction: a merge landing between the snapshot and
-     * the tombstone would otherwise let the trash hold a payload the deletion never applied to.
+     * value is snapshotted first, in the same transaction as the removal and the ownership check
+     * below: a merge landing in between would otherwise let the trash hold a payload the deletion
+     * never applied to, or move the id under another store between the check and the tombstone.
+     *
+     * A record of another type under the same id is left alone: [Vault.remove] takes no type, and
+     * several stores file ids the sync server chose, so deleting by id alone would let a "team" the
+     * server named after a verified peer fingerprint tombstone that fingerprint (#319). Only this
+     * store's own records are this store's to delete.
      */
     fun remove(id: String) {
-        val bin = trash ?: return vault.remove(id)
         vault.transaction {
-            get(id)?.let { bin.capture(id, type, label(it)) }
+            // Inside the transaction with the removal it guards: a merge landing between the two
+            // would let this tombstone a record the guard was there to spare.
+            if (vault.records().any { it.id == id && it.type != type }) return@transaction
+            trash?.let { bin -> get(id)?.let { bin.capture(id, type, label(it)) } }
             vault.remove(id)
         }
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/sync/SyncSettingsTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/sync/SyncSettingsTest.kt
@@ -31,7 +31,9 @@ class SyncSettingsTest {
         val s = SyncSettings(syncHosts = false, syncSnippets = false)
         // TEAM/TEAM_IDENTITY hold team keys and the identity pair; without them another device
         // can't open team vaults at all, so selective sync never gates them (like SETTINGS).
-        val alwaysOn = setOf(RecordType.SETTINGS, RecordType.TEAM, RecordType.TEAM_IDENTITY)
+        // TEAM_PEER is the verified fingerprint each seal is held to — a device without it seals to
+        // whatever the server answers, so it is not gateable either (#319).
+        val alwaysOn = setOf(RecordType.SETTINGS, RecordType.TEAM, RecordType.TEAM_IDENTITY, RecordType.TEAM_PEER)
         RecordType.entries.filter { it !in alwaysOn }
             .forEach { assertFalse(s.shouldSync(it), "$it must be gated when both off") }
         alwaysOn.forEach { assertTrue(s.shouldSync(it), "$it must always sync") }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamPeerStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamPeerStoreTest.kt
@@ -1,0 +1,306 @@
+package app.skerry.shared.team
+
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.vault.DataKey
+import app.skerry.shared.vault.FakeVault
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The pin behind every seal to another account (#319). What it must get right is who may move a
+ * fingerprint: a human who confirmed the new one out of band, and nobody else — least of all the
+ * server whose answer is being checked.
+ */
+class TeamPeerStoreTest {
+
+    private val session = SyncSession("alice@example.com", "access", "refresh")
+    private val bob = "bob@example.com"
+
+    /** A client whose key table answers with whatever it was last set to — i.e. the sync server. */
+    private class FakeKeys(var keys: AccountKeys?) : TeamClient {
+        var fetches = 0
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
+            fetches += 1
+            return keys
+        }
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = emptyList()
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = emptyList()
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) = error("unused")
+        override suspend fun accept(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) = error("unused")
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage = RecordPage(emptyList(), since)
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage = RecordPage(emptyList(), 0)
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> = emptyList()
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> = emptyList()
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) = error("unused")
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) = error("unused")
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) = error("unused")
+    }
+
+    private fun keys(seed: Byte) = AccountKeys(ByteArray(32) { seed }, ByteArray(32) { (seed + 1).toByte() })
+
+    @Test
+    fun `a first sight pins what the server answered`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val client = FakeKeys(keys(1))
+
+        val result = store.fetchPinned(session, client, bob)
+
+        assertIs<PeerKeys.Pinned>(result)
+        assertEquals(accountKeyFingerprint(keys(1).sharing, keys(1).signing), pinned(store, bob))
+    }
+
+    @Test
+    fun `a key that moved after the pin is refused, and the pin stands`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val client = FakeKeys(keys(1))
+        store.fetchPinned(session, client, bob)
+
+        client.keys = keys(9) // the server publishes a different key for the same account
+        assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, client, bob))
+        // Refusing is only half of it: a refusal that overwrote the pin would let the second attempt
+        // through, which is the same as not having one.
+        assertEquals(accountKeyFingerprint(keys(1).sharing, keys(1).signing), pinned(store, bob))
+    }
+
+    @Test
+    fun `an account with no published key is not a moved one`() = runTest {
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+
+        assertEquals(PeerKeys.Unpublished, store.fetchPinned(session, FakeKeys(null), bob))
+        assertEquals(Pin.None, store.pin(bob), "nothing was answered, so nothing may be pinned")
+    }
+
+    @Test
+    fun `only a confirmed fingerprint moves the pin`() = runTest {
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+        store.rememberFirstSight(bob, "cccc-dddd") // a later fetch must not quietly replace it
+
+        assertEquals("aaaa-bbbb", pinned(store, bob))
+
+        store.confirm(bob, "cccc-dddd") // the invite ceremony: a human read the new one out loud
+
+        assertEquals("cccc-dddd", pinned(store, bob))
+        assertTrue(vault.records().any { it.type == RecordType.TEAM_PEER && !it.deleted })
+    }
+
+    /**
+     * A locked vault cannot answer what was pinned, and "cannot read" must not degrade to "nothing
+     * pinned" — that would seal to whatever the server answered on the next fetch.
+     */
+    @Test
+    fun `a locked vault refuses rather than reading as unpinned`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.confirm(bob, "aaaa-bbbb")
+
+        vault.locked = true
+
+        assertEquals(Pin.Unreadable, store.pin(bob))
+        assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, FakeKeys(keys(1)), bob))
+        assertFailsWith<IllegalStateException> { store.rememberFirstSight(bob, "cccc-dddd") }
+        assertFailsWith<IllegalStateException> { store.confirm(bob, "cccc-dddd") }
+    }
+
+    /**
+     * A record whose payload no longer decrypts is what [app.skerry.shared.vault.Vault.adoptDataKey]
+     * leaves behind on a device that joins an existing sync account. Read as "never pinned" it would
+     * be overwritten with the server's current answer — a verified fingerprint silently replaced.
+     */
+    @Test
+    fun `a pin that cannot be decrypted is not an absent one`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.confirm(bob, "aaaa-bbbb")
+        vault.unreadable += vault.records().single { it.type == RecordType.TEAM_PEER }.id
+
+        assertEquals(Pin.Unreadable, store.pin(bob))
+        assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, FakeKeys(keys(1)), bob))
+        // …and the unreadable record is left alone rather than replaced by what the server answered.
+        assertEquals(1, vault.records().count { it.type == RecordType.TEAM_PEER && !it.deleted })
+        assertEquals(1L, vault.records().single { it.type == RecordType.TEAM_PEER }.version)
+    }
+
+    /**
+     * The account id is the server's to choose (a member list, a grant list, the inviter named inside
+     * an envelope anyone can seal) and a vault record is located by id alone and replaced wholesale.
+     * An un-namespaced pin would let the server name a credential's record and have this client
+     * destroy it — the write lands before any signature is checked.
+     */
+    @Test
+    fun `a pin cannot be filed under another record's id`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        vault.put("cred-1", RecordType.CREDENTIAL, "secret".encodeToByteArray())
+
+        TeamPeerStore(vault).confirm("cred-1", "aaaa-bbbb")
+
+        val credential = vault.records().single { it.id == "cred-1" }
+        assertEquals(RecordType.CREDENTIAL, credential.type)
+        assertEquals("secret", vault.openPayload("cred-1")?.decodeToString())
+    }
+
+    /**
+     * The receiving paths ([checkPinned]) run on account ids the SERVER named — a member list, a
+     * grant list, the inviter inside an envelope anyone can seal. An unpinned account there is still
+     * accepted (a colleague who never invited us has never been confirmed, and refusing every one of
+     * them would leave a team unable to rotate), but the sighting must write NOTHING: a pin created
+     * from this side is the server fixing its own key as the account's verified one, and every later
+     * check would then pass against it.
+     */
+    @Test
+    fun `a receiving path never writes a pin`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val client = FakeKeys(keys(1))
+
+        assertIs<PeerKeys.Pinned>(store.checkPinned(session, client, bob))
+
+        assertEquals(Pin.None, store.pin(bob), "an unconfirmed sighting is not a confirmation")
+        assertTrue(vault.records().none { it.type == RecordType.TEAM_PEER })
+        // Which is what makes the next answer refusable: once a human pins the real key, the server
+        // swapping it is caught — where a pin written above would have made the swap the pinned one.
+        store.confirm(bob, accountKeyFingerprint(keys(1).sharing, keys(1).signing))
+        client.keys = keys(9)
+        assertIs<PeerKeys.Unconfirmed>(store.checkPinned(session, client, bob))
+    }
+
+    /**
+     * The namespace keeps a pin out of another store's way; this is the other direction — a team the
+     * server named after a pin's own record id. A vault record is found by id alone, so without a
+     * type check the "team" would carry the pin off with it: overwritten by [TeamKeyStore.put], or
+     * tombstoned by [TeamKeyStore.remove] when the user leaves a team they never joined.
+     */
+    @Test
+    fun `a team the server named after a pin cannot overwrite or delete it`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.confirm(bob, "aaaa-bbbb")
+        val pinId = vault.records().single { it.type == RecordType.TEAM_PEER }.id
+        val teams = TeamKeyStore(vault)
+
+        assertFailsWith<IllegalArgumentException> {
+            teams.put(pinId, "Ops", TeamRole.OWNER, DataKey(ByteArray(32) { 7 }))
+        }
+        teams.remove(pinId)
+
+        assertEquals("aaaa-bbbb", pinned(store, bob))
+        assertTrue(vault.records().single { it.id == pinId }.let { it.type == RecordType.TEAM_PEER && !it.deleted })
+    }
+
+    /**
+     * The mirror of the test above: here the server gets there FIRST, so the pin's id already holds a
+     * record of another type. Read through the type filter that slot says "never pinned", and the
+     * next fetch would pin whatever the server publishes — with the write then refused by the vault,
+     * taking the ceremony down with a generic error. Any live record at the id means the pin cannot
+     * be read, so the path fails closed instead.
+     */
+    @Test
+    fun `a record squatting the pin id reads as unreadable, not as absent`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val squatId = pinIdOf(bob)
+        vault.put(squatId, RecordType.TEAM, "team key".encodeToByteArray())
+
+        assertEquals(Pin.Unreadable, store.pin(bob))
+        assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, FakeKeys(keys(1)), bob))
+        assertFalse(store.confirm(bob, "aaaa-bbbb"), "an id another record holds is not this store's")
+        // Neither adopted nor destroyed: the squat is the server's doing, and this client leaves it
+        // exactly where it is while refusing to read a pin out of it.
+        val squat = vault.records().single { it.id == squatId }
+        assertEquals(RecordType.TEAM, squat.type)
+        assertEquals(1L, squat.version)
+    }
+
+    /**
+     * And the same id once the squat is deleted. A tombstone still holds the id as far as
+     * [app.skerry.shared.vault.Vault.put] is concerned, so no pin can ever be written for this
+     * account again — and an account whose pin cannot be written must not read as "nothing was ever
+     * pinned". That answer pins on first sight, the write silently no-ops, and every later fetch is
+     * first sight again: the seal follows whatever the server publishes, forever and without a word.
+     * The slot is unreadable, which fails closed.
+     */
+    @Test
+    fun `a tombstoned squat is unreadable, not absent`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val squatId = pinIdOf(bob)
+        vault.put(squatId, RecordType.TEAM, "team key".encodeToByteArray())
+        vault.remove(squatId)
+
+        assertEquals(Pin.Unreadable, store.pin(bob), "a pin that cannot be written cannot be trusted")
+        assertFalse(store.confirm(bob, "aaaa-bbbb"))
+        // Refused, not thrown: whatever ceremony asked for the pin reports it and stops, rather than
+        // unwinding on an exception from the vault.
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+        assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, FakeKeys(keys(1)), bob))
+        assertEquals(RecordType.TEAM, vault.records().single { it.id == squatId }.type)
+    }
+
+    /**
+     * An own pin that no longer decrypts is a different case from the squat above: nothing else is
+     * using the id, so the human who just confirmed a fingerprint out of band may write it.
+     */
+    @Test
+    fun `a confirmation replaces a pin this device can no longer read`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.confirm(bob, "aaaa-bbbb")
+        vault.unreadable += vault.records().single { it.type == RecordType.TEAM_PEER }.id
+
+        assertEquals(Pin.Unreadable, store.pin(bob))
+        assertTrue(store.confirm(bob, "cccc-dddd"))
+
+        vault.unreadable.clear()
+        assertEquals("cccc-dddd", pinned(store, bob))
+    }
+
+    /** The pin's record id, asked of the store rather than assumed from its namespace. */
+    private fun pinIdOf(accountId: String): String {
+        val probe = FakeVault()
+        TeamPeerStore(probe).confirm(accountId, "probe")
+        return probe.records().single().id
+    }
+
+    /** The pin's own fingerprint, or null when nothing readable is pinned. */
+    private fun pinned(store: TeamPeerStore, accountId: String) =
+        (store.pin(accountId) as? Pin.Known)?.fingerprint
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FakeVaultSupport.kt
@@ -70,6 +70,10 @@ internal class FakeVault : Vault {
 
     override fun putAtLeast(id: String, type: RecordType, payload: ByteArray, minVersion: Long) {
         lastPutInTransaction = transactionDepth > 0
+        // [FileVault.store] refuses this, so the fake has to as well: an id belongs to one type for
+        // its whole life, or a store handed a server-chosen id overwrites another store's record.
+        val existing = entries[id]?.record
+        require(existing == null || existing.type == type) { "record id already holds a ${existing?.type}" }
         val version = maxOf((entries[id]?.record?.version ?: 0L) + 1, minVersion)
         entries[id] = Entry(
             VaultRecord(id, type, version, "2026-06-12T00:00:00Z", "test-device", deleted = false, blob = SEALED),

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vault/FileVaultTest.kt
@@ -996,6 +996,84 @@ class FileVaultTest {
         assertNull(v.openRecordPayload(record.copy(deleted = true)))
     }
 
+    /**
+     * A record is located by id alone, and not every id is this device's to choose — a team id, a
+     * peer's account id and a scope id all come from the sync server. Re-typing a record in place
+     * would let a store handed one of those ids overwrite another store's record (#319).
+     */
+    @Test
+    fun `a put may not change an existing record's type`() = vaultTest {
+        val v = vault()
+        v.create("m".toCharArray())
+        v.put("x1", RecordType.TEAM_PEER, "fingerprint".encodeToByteArray())
+
+        assertFailsWith<IllegalArgumentException> { v.put("x1", RecordType.TEAM, "team key".encodeToByteArray()) }
+        assertFailsWith<IllegalArgumentException> {
+            v.putAtLeast("x1", RecordType.TEAM, "team key".encodeToByteArray(), minVersion = 9L)
+        }
+
+        val record = v.records().single()
+        assertEquals(RecordType.TEAM_PEER, record.type)
+        assertEquals(1L, record.version)
+        assertContentEquals("fingerprint".encodeToByteArray(), v.openPayload("x1"))
+        // The type is fixed for the record, not for the id: the same id may be reused once the record
+        // it named is physically gone (compact drops the tombstone; a reconcile clear drops the record).
+        v.remove("x1")
+        v.compact(listOf("x1"))
+        v.put("x1", RecordType.TEAM, "team key".encodeToByteArray())
+        assertEquals(RecordType.TEAM, v.records().single().type)
+    }
+
+    /**
+     * The same rule through the sync path. The record below is authentic — sealed under the shared
+     * account key, honest AAD — and it wins LWW on the deviceId tie-break; its type is the only thing
+     * standing between a verified peer fingerprint and a team key landing on top of it (#319).
+     */
+    @Test
+    fun `mergeRemote may not change an existing record's type`() = vaultTest {
+        val a = vault().apply {
+            create("master".toCharArray())
+            put("peer:bob", RecordType.TEAM_PEER, "fingerprint".encodeToByteArray())
+        }
+        val b = FileVault("/vault-b.json".toPath(), crypto, deviceId = "device-2", fileSystem = fs, now = { TS })
+        b.createWithDataKey(a.exportDataKey()!!)
+        b.put("peer:bob", RecordType.TEAM, "team key".encodeToByteArray())
+
+        val result = a.mergeRemote(listOf(b.records().single()))
+
+        assertEquals(listOf("peer:bob"), result.rejected.map { it.id })
+        assertTrue(result.applied.isEmpty())
+        val kept = a.records().single()
+        assertEquals(RecordType.TEAM_PEER, kept.type)
+        assertContentEquals("fingerprint".encodeToByteArray(), a.openPayload("peer:bob"))
+    }
+
+    /**
+     * A tombstone is where the two rules part. [store] keeps the id reserved until the record is
+     * physically gone, but a remote record authenticates under this account's key — it was written by
+     * one of our own devices under that same rule — and a rejection is never re-delivered, so
+     * refusing it would strand it until the server chose to compact the id.
+     */
+    @Test
+    fun `mergeRemote takes an id whose local record is a tombstone`() = vaultTest {
+        val a = vault().apply {
+            create("master".toCharArray())
+            put("peer:bob", RecordType.TEAM, "team key".encodeToByteArray())
+            remove("peer:bob")
+        }
+        val b = FileVault("/vault-b.json".toPath(), crypto, deviceId = "device-2", fileSystem = fs, now = { TS })
+        b.createWithDataKey(a.exportDataKey()!!)
+        // Written three times so the pin outranks the tombstone (put + remove left it at version 2);
+        // every version is sealed by the device itself, so all of them authenticate.
+        repeat(3) { b.put("peer:bob", RecordType.TEAM_PEER, "fingerprint".encodeToByteArray()) }
+
+        val result = a.mergeRemote(listOf(b.records().single()))
+
+        assertEquals(listOf("peer:bob"), result.applied.map { it.id })
+        assertEquals(RecordType.TEAM_PEER, a.records().single().type)
+        assertContentEquals("fingerprint".encodeToByteArray(), a.openPayload("peer:bob"))
+    }
+
     @Test
     fun `clearRecords spares the records the keep predicate names`() = vaultTest {
         val v = vault()


### PR DESCRIPTION

The invite ceremony verifies a fingerprint over a channel the sync server does not own, but that
verdict was never recorded: every later seal to the same colleague — a scope grant, a rotation after
a removal, an adopted rekey envelope — fetched `/account/keys/{id}` again and trusted the answer.
The server owns that table, so a substitution that failed at invite time only had to wait for the
next removal.

**Peer pins.** A new account-vault record (`TEAM_PEER`, one per peer, synced between the account's
own devices) holds the fingerprint of a peer's Teams keys. Every resolution of another account's
keys goes through it: the fingerprint is recomputed from what the server answered and compared with
the pin. A key that is not the pinned one is refused with `TeamsFailure.PeerKeyUnconfirmed`, and the
pin is left where it is — a refusal that moved the pin would let the second attempt through.

A pin is written when a human confirms one: sending an invite, or accepting one after the inviter's
fingerprint was on screen — and written *before* the seal it records, so a confirmation this device
cannot store stops the send instead of surfacing once the team key has left. Where the user is
acting but nothing was ever pinned, the key is pinned on first sight — a team that predates the
record has no pins, and refusing there would take the keys away from every existing member. Keys arriving from the other side never write a pin: the account id
there is the server's to choose, and a pin written from that path would fix a key of the server's
own as the account's confirmed one.

An unreadable pin — a locked vault, or a payload that no longer decrypts after an adopted account
key — is not an absent one: it refuses instead of degrading to first sight. So is an *unwritable*
one: a record another store put on the pin's id, live or tombstoned, leaves a slot no confirmation
can ever be written to, and "nothing was ever pinned" there would mean first sight on every fetch,
forever. Pin records are filed under a namespaced id, because a vault record is located by id alone
and the account id in question comes from the server.

**A fingerprint that moved.** Accepting or sending replaces the pin, and an honest identity rotation
and a server trying its luck reach the screen looking identical — only the person on the trusted
channel can tell them apart. So a key that differs from the pinned one costs a second, deliberate
acknowledgement before Accept or Send opens, on the banner (desktop and mobile) and in the invite
dialog. Without it the warning cost the same single click as no warning at all.

**The invitee's side.** The banner's fingerprint now comes from the keys the invite's signature was
checked against rather than a second lookup of the same account — answering the check with the key
the invite was forged under and the display with the colleague's real key was the whole attack.
`accept` refuses an invite whose inviter was never shown (`TeamsFailure.InviteUnverified`), Accept
stays closed while the check is pending or failed, and desktop and mobile both show the inviter, the
fingerprint, and a warning when it differs from the pin. Each state is announced to a screen reader.

**Rotation.** A recipient whose key is not the pinned one is skipped rather than aborting the
rotation: the removed member still loses the key, and the skip is reported.

**Keeping a pin.** Two paths could take one away without anyone deciding to. A vault record is
located by id alone, so `Vault.put` and `Vault.mergeRemote` now refuse to change an existing
record's type, and a store deletes only records of its own type — a "team" the server names after a
pin can no longer overwrite or tombstone it, locally or through the sync path. A record already
sitting on a pin's id is the same substitution from the other direction: the pin reads as unreadable
rather than absent, so the ceremony stops instead of pinning whatever the server publishes next. And a reactivation reconcile, which drops every sync-capable record and rebuilds
from the server, now spares `TEAM_PEER`: `reactivated` is the server's own flag, and a device that
came back without its pins seals the next rotation to whatever key the server publishes.

**Invite check states.** `acceptPreview` answers with a verdict rather than a nullable preview:
"does not verify" is a statement about the envelope, "could not be checked" is an offline device, a
locked vault, or a Teams identity this device cannot read. Both close Accept; the second names its
cause and carries its own Retry, since a screen showing an unanswered invite offers no sync of its
own. The identity case is its own failure rather than a forged envelope: the invite is fine, the
device is not, and the inviter should not be accused of it.

**What this does not close.** A pin does not record *how* it was established, so a key pinned on
first sight reads as "confirmed" in the warning a later, honest key change trips. Two rotations
failing in one removal report the more serious of the two, not both. And an account nobody has ever
confirmed is still trusted on first sight, on both sides: the sending paths pin what the server
answers, and the receiving paths accept it without pinning. Refusing there means refusing every
colleague this account has never invited — a team that predates this record could not rotate a key
at all — and telling an honest rekey from a substitution needs continuity the fingerprint alone
cannot carry. Each belongs to a change of its own.

Closes #319.