### PR TITLE
Teams: a pin now says who vouched for it

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -154,7 +154,20 @@
     <string name="lib_teams_invite_check_failed">Приглашение проверить не удалось.</string>
     <string name="lib_teams_invite_check_retry">Повторить</string>
     <string name="lib_teams_invite_key_changed_ack">Новый отпечаток подтверждён по доверенному каналу</string>
-    <string name="lib_teams_invite_key_changed">Отличается от ключа, закреплённого за этим аккаунтом. Сверьте новый отпечаток по доверенному каналу.</string>
+    <string name="lib_teams_invite_key_changed">Отличается от отпечатка, подтверждённого для этого аккаунта. Сверьте новый по доверенному каналу.</string>
+    <string name="lib_teams_key_changed_unconfirmed">Отличается от ключа, который это устройство увидело первым; ни один из них никто не подтверждал. Сверьте отпечаток по доверенному каналу.</string>
+    <string name="lib_teams_key_pin_unreadable">Устройство не может прочитать запись по этому аккаунту. Сверьте отпечаток по доверенному каналу.</string>
+    <string name="lib_teams_peer_confirmed">Отпечаток подтверждён по доверенному каналу</string>
+    <string name="lib_teams_peer_confirm">Подтвердить ключ участника</string>
+    <string name="lib_teams_peer_mark">%1$s. %2$s</string>
+    <string name="lib_teams_peer_confirm_action">Подтвердить</string>
+    <string name="lib_teams_peer_verify">Сверьте отпечаток с участником по доверенному каналу. Все последующие ключи, запечатанные этому аккаунту, проверяются по нему.</string>
+    <string name="lib_teams_peer_checking">Запрашиваем ключ участника…</string>
+    <string name="lib_teams_peer_check_failed">Ключ участника прочитать не удалось.</string>
+    <string name="lib_teams_peer_state_confirmed">Отпечаток для этого аккаунта уже подтверждён по доверенному каналу.</string>
+    <string name="lib_teams_peer_state_first_sight">Записан при первой встрече: так ответил сервер, никто это не подтверждал.</string>
+    <string name="lib_teams_peer_state_none">На этом устройстве по этому аккаунту записей ещё нет.</string>
+    <string name="lib_teams_peer_state_unreadable">Устройство не может прочитать запись по этому аккаунту.</string>
     <string name="lib_teams_accept">Принять</string>
     <string name="lib_teams_decline">Отклонить</string>
     <string name="lib_teams_role_owner">ВЛАДЕЛЕЦ</string>
@@ -261,10 +274,11 @@
     <string name="lib_teams_scope_members_count">с доступом: %1$d</string>
     <string name="lib_teams_err_already_shared">Эта запись уже расшарена в другой области этой команды — сначала уберите её оттуда</string>
     <string name="lib_teams_err_scopes_unsupported">Этот sync-сервер слишком старый для областей доступа — обновите сервер</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">Опубликованный ключ участника не тот, что был подтверждён, — под него ничего не запечатано. Удалите его из команды и пригласите заново, чтобы подтвердить новый ключ</string>
-    <string name="lib_teams_err_unconfirmed_key_ignored">Пришёл ключ команды, подписанный неподтверждённой личностью, — он проигнорирован</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">Опубликованный ключ участника не тот, что за ним записан, — под него ничего не запечатано. Сверьте отпечаток по доверенному каналу и подтвердите его в списке участников</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">Пришёл ключ команды, подписанный не тем ключом, что записан за этим аккаунтом, — он проигнорирован</string>
     <string name="lib_teams_err_invite_unverified">Приглашение не проверено — откройте команду и сверьте отпечаток пригласившего перед принятием</string>
     <string name="lib_teams_err_pin_not_recorded">Подтверждённый отпечаток не удалось сохранить на этом устройстве — этому ключу ничего не отправлено</string>
+    <string name="lib_teams_err_pin_moved">Пока отпечаток был на экране, запись об этом аккаунте изменилась — ничего не подтверждено. Сверьте заново</string>
     <string name="lib_teams_err_identity_unreadable">Устройство не может прочитать свой командный ключ, приглашение здесь не открыть</string>
     <!-- Экран команды: шапка, таблица участников, карточки (см. TeamsView) -->
     <string name="lib_teams_header_title">Команда</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -148,7 +148,20 @@
     <string name="lib_teams_invite_check_failed">无法检查此邀请。</string>
     <string name="lib_teams_invite_check_retry">重试</string>
     <string name="lib_teams_invite_key_changed_ack">已通过可信渠道确认新指纹</string>
-    <string name="lib_teams_invite_key_changed">与该账户已固定的密钥不一致。继续之前请通过可信渠道核对新指纹。</string>
+    <string name="lib_teams_invite_key_changed">与该账户已确认的指纹不一致。继续之前请通过可信渠道核对新指纹。</string>
+    <string name="lib_teams_key_changed_unconfirmed">与本设备最初看到的密钥不一致，且两者都无人确认。继续之前请通过可信渠道核对该指纹。</string>
+    <string name="lib_teams_key_pin_unreadable">本设备无法读取该账户的记录。继续之前请通过可信渠道核对该指纹。</string>
+    <string name="lib_teams_peer_confirmed">指纹已通过可信渠道确认</string>
+    <string name="lib_teams_peer_confirm">确认该成员的密钥</string>
+    <string name="lib_teams_peer_mark">%1$s。%2$s</string>
+    <string name="lib_teams_peer_confirm_action">确认</string>
+    <string name="lib_teams_peer_verify">请通过可信渠道与该成员核对此指纹。此后封装给该账户的每把密钥都以它为准。</string>
+    <string name="lib_teams_peer_checking">正在获取成员的密钥…</string>
+    <string name="lib_teams_peer_check_failed">无法读取该成员的密钥。</string>
+    <string name="lib_teams_peer_state_confirmed">该账户的指纹此前已通过可信渠道确认。</string>
+    <string name="lib_teams_peer_state_first_sight">来自首次见到的记录：这是服务器的答复，无人确认过。</string>
+    <string name="lib_teams_peer_state_none">本设备尚无该账户的任何记录。</string>
+    <string name="lib_teams_peer_state_unreadable">本设备无法读取该账户的记录。</string>
     <string name="lib_teams_accept">接受</string>
     <string name="lib_teams_decline">拒绝</string>
     <string name="lib_teams_role_owner">拥有者</string>
@@ -255,10 +268,11 @@
     <string name="lib_teams_scope_members_count">%1$d 人可访问</string>
     <string name="lib_teams_err_already_shared">该记录已共享到此团队的另一个范围 — 请先在那里取消共享</string>
     <string name="lib_teams_err_scopes_unsupported">此同步服务器版本过旧，不支持访问范围 — 请更新服务器</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">成员发布的密钥不是已确认的那把 — 未向其封装任何密钥。将其移出团队后重新邀请，以确认新密钥</string>
-    <string name="lib_teams_err_unconfirmed_key_ignored">收到的团队密钥由未确认的身份签名，已被忽略</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">成员发布的密钥不是为其记录的那把 — 未向其封装任何密钥。请通过可信渠道核对指纹，并在成员列表中确认</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">收到的团队密钥所用的签名密钥不是该账户已记录的那把，已被忽略</string>
     <string name="lib_teams_err_invite_unverified">此邀请未经验证 — 请打开团队并核对邀请者的指纹后再接受</string>
     <string name="lib_teams_err_pin_not_recorded">无法在此设备上保存已确认的指纹，未向该密钥发送任何内容</string>
+    <string name="lib_teams_err_pin_moved">指纹显示期间该账户的记录已发生变化 — 未确认任何内容。请重新核对</string>
     <string name="lib_teams_err_identity_unreadable">此设备无法读取自己的团队身份密钥，无法在此打开邀请</string>
     <!-- 团队界面：标题栏、成员表、汇总卡片（见 TeamsView） -->
     <string name="lib_teams_header_title">团队</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -151,7 +151,20 @@
     <string name="lib_teams_invite_check_failed">The invite couldn't be checked.</string>
     <string name="lib_teams_invite_check_retry">Retry</string>
     <string name="lib_teams_invite_key_changed_ack">New fingerprint confirmed over a trusted channel</string>
-    <string name="lib_teams_invite_key_changed">This differs from the key pinned for this account. Confirm the new fingerprint over a trusted channel before continuing.</string>
+    <string name="lib_teams_invite_key_changed">This differs from the fingerprint confirmed for this account. Confirm the new one over a trusted channel before continuing.</string>
+    <string name="lib_teams_key_changed_unconfirmed">This differs from the key this device saw first — nobody confirmed either of them. Confirm this fingerprint over a trusted channel before continuing.</string>
+    <string name="lib_teams_key_pin_unreadable">This device can't read what is on record for this account. Confirm this fingerprint over a trusted channel before continuing.</string>
+    <string name="lib_teams_peer_confirmed">Fingerprint confirmed over a trusted channel</string>
+    <string name="lib_teams_peer_confirm">Confirm this member's key</string>
+    <string name="lib_teams_peer_mark">%1$s. %2$s</string>
+    <string name="lib_teams_peer_confirm_action">Confirm</string>
+    <string name="lib_teams_peer_verify">Read this fingerprint back to the member over a trusted channel. Every key sealed to this account afterwards is held to it.</string>
+    <string name="lib_teams_peer_checking">Fetching the member's key…</string>
+    <string name="lib_teams_peer_check_failed">The member's key couldn't be read.</string>
+    <string name="lib_teams_peer_state_confirmed">A fingerprint for this account was already confirmed over a trusted channel.</string>
+    <string name="lib_teams_peer_state_first_sight">On record from a first sight: this is what the server answered, and nobody has confirmed it.</string>
+    <string name="lib_teams_peer_state_none">This device has nothing on record for this account yet.</string>
+    <string name="lib_teams_peer_state_unreadable">This device can't read what is on record for this account.</string>
     <string name="lib_teams_accept">Accept</string>
     <string name="lib_teams_decline">Decline</string>
     <string name="lib_teams_role_owner">OWNER</string>
@@ -258,10 +271,11 @@
     <string name="lib_teams_scope_members_count">%1$d with access</string>
     <string name="lib_teams_err_already_shared">This record is already shared into another scope of this team — unshare it there first</string>
     <string name="lib_teams_err_scopes_unsupported">This sync server is too old for access scopes — update the server</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">A member's published key is not the one confirmed for them — nothing was sealed to it. Remove them from the team and invite again to confirm the new key</string>
-    <string name="lib_teams_err_unconfirmed_key_ignored">A team key arrived signed by an identity that is not the confirmed one, and was ignored</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">A member's published key is not the one on record for them — nothing was sealed to it. Check the fingerprint over a trusted channel and confirm it in the member list</string>
+    <string name="lib_teams_err_unconfirmed_key_ignored">A team key arrived signed by a key that is not the one on record for that account, and was ignored</string>
     <string name="lib_teams_err_invite_unverified">This invite was not verified — reopen the team and check the inviter's fingerprint before accepting</string>
     <string name="lib_teams_err_pin_not_recorded">The confirmed fingerprint couldn't be stored on this device — nothing was sent to that key</string>
+    <string name="lib_teams_err_pin_moved">What is on record for this account changed while its fingerprint was on screen — nothing was confirmed. Check it again</string>
     <string name="lib_teams_err_identity_unreadable">This device can't read its team identity, so the invite can't be opened here</string>
     <!-- Teams screen: header, member table, summary cards (see TeamsView) -->
     <string name="lib_teams_header_title">Team</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamRows.kt
@@ -31,6 +31,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_nothing_shared
 import app.skerry.ui.generated.resources.lib_teams_status_invited
 import app.skerry.ui.teams.HistoryTarget
+import app.skerry.ui.teams.PeerTrustBadge
 import app.skerry.ui.teams.RoleBadge
 import app.skerry.ui.teams.SharedRecordUi
 import app.skerry.ui.teams.TeamMemberRowUi
@@ -116,6 +117,8 @@ internal fun MobileMemberRow(
     now: Long,
     onChangeRole: () -> Unit,
     onRemove: () -> Unit,
+    /** Opens the fingerprint ceremony for a member whose key nobody has confirmed (#323). */
+    onConfirmKey: () -> Unit,
 ) {
     val mono = LocalFonts.current.mono
     val m = row.member
@@ -128,7 +131,15 @@ internal fun MobileMemberRow(
     ) {
         InitialsAvatar(m.accountId, size = 28.dp)
         Column(Modifier.weight(1f)) {
-            Txt(untrustedLabel(m.accountId), color = Skerry.colors.text, size = 12.5.sp, font = mono, weight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Txt(
+                    untrustedLabel(m.accountId), color = Skerry.colors.text, size = 12.5.sp, font = mono,
+                    weight = FontWeight.Medium, maxLines = 1, overflow = TextOverflow.Ellipsis,
+                    // Shrinks rather than pushes the mark off the card, exactly as the desktop row does.
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                PeerTrustBadge(row.trust, onConfirm = onConfirmKey)
+            }
             // Same rule as the desktop table: an access list we failed to read is "?", never an
             // empty chip row — the phone is where granting and revoking actually happens.
             // A space name is a peer's too, and here it shares a line with "last seen".

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -119,6 +119,8 @@ import app.skerry.ui.teams.rememberInviteAcknowledgement
 import app.skerry.ui.teams.readyToAccept
 import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
+import app.skerry.ui.teams.ConfirmPeerKeyDialogFor
+import app.skerry.ui.teams.rememberMemberPins
 import app.skerry.ui.teams.InvitePreview
 import app.skerry.ui.teams.SharedRecordUi
 import app.skerry.ui.teams.TeamScopeUi
@@ -249,6 +251,8 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
     // One record's history instead of the team's whole feed (desktop parity).
     var historyRecord by remember { mutableStateOf<HistoryTarget?>(null) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
+    // The member whose key the confirm ceremony is open for — the account id, not the row (desktop parity).
+    var confirmKeyFor by remember { mutableStateOf<String?>(null) }
     // Selected share space of the current team ("" = team-wide), like the desktop screen.
     var selectedScope by remember { mutableStateOf("") }
     var showCreateScope by remember { mutableStateOf(false) }
@@ -297,6 +301,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
                 onShowHistory = { showHistory = true },
                 onShowRecordHistory = { historyRecord = it },
                 onChangeRole = { member -> rolePicker = member },
+                onConfirmKey = { accountId -> confirmKeyFor = accountId },
                 onSelectScope = { selectedScope = it },
                 onNewScope = { showCreateScope = true },
                 onScopeAccess = { scopeAccess = it },
@@ -338,6 +343,15 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
             onCreate = { name -> showCreate = false; scope.launch { tc.createTeam(name); tick++ } },
         )
     }
+    confirmKeyFor?.let { accountId ->
+        ConfirmPeerKeyDialogFor(
+            tc = tc,
+            accountId = accountId,
+            busy = busy,
+            onConfirm = { verified -> confirmKeyFor = null; scope.launch { tc.confirmPeer(verified); tick++ } },
+            onDismiss = { confirmKeyFor = null },
+        )
+    }
     inviteTeamId?.let { teamId ->
         InviteMemberDialogForTeam(
             teams = teams,
@@ -345,7 +359,7 @@ private fun MobileTeamsBody(tc: TeamsCoordinator) {
             preview = invitePreview,
             ownFingerprint = tc.ownFingerprint(),
             busy = busy,
-            onLookup = { accountId -> scope.launch { invitePreview = tc.previewInvite(accountId) } },
+            onLookup = { accountId -> scope.launch { invitePreview = tc.previewPeerKey(accountId) } },
             onEdited = { invitePreview = null },
             onSend = { id, verified, role -> inviteTeamId = null; scope.launch { tc.invite(id, verified, role); tick++ } },
             onDismiss = { inviteTeamId = null },
@@ -473,6 +487,7 @@ private fun MobileTeamDetail(
     onShowHistory: () -> Unit,
     onShowRecordHistory: (HistoryTarget) -> Unit,
     onChangeRole: (TeamMember) -> Unit,
+    onConfirmKey: (String) -> Unit,
     onSelectScope: (String) -> Unit,
     onNewScope: () -> Unit,
     onScopeAccess: (TeamScopeUi) -> Unit,
@@ -586,8 +601,13 @@ private fun MobileTeamDetail(
     MobileTeamsSectionLabel(stringResource(Res.string.share_live_sessions))
     SharedSessionsList(team.id, LocalSharedSessions.current, onJoin = rememberJoinSharedSession(), modifier = Modifier.padding(bottom = 14.dp))
     MobileTeamsSectionLabel(stringResource(Res.string.lib_teams_members))
-    val rows = remember(team, members, grants, canManage) {
-        teamMemberRows(team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true)
+    // One vault pass for the whole list, keyed to the same reread as the list itself (desktop parity).
+    val marks = rememberMemberPins(tc, members.map { it.accountId }, tick)
+    val rows = remember(team, members, grants, canManage, marks) {
+        teamMemberRows(
+            team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true,
+            marks?.self, marks?.pins.orEmpty(),
+        )
     }
     val now = remember(tick, members) { epochMillis() }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -597,6 +617,7 @@ private fun MobileTeamDetail(
                 now = now,
                 onChangeRole = { onChangeRole(row.member) },
                 onRemove = { onConfirm(MobileTeamsConfirm.Remove(team.id, row.member.accountId)) },
+                onConfirmKey = { onConfirmKey(row.member.accountId) },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/ConfirmPeerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/ConfirmPeerDialog.kt
@@ -1,0 +1,246 @@
+package app.skerry.ui.teams
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.pinNotice
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.design.CancelButton
+import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.design.PrimaryButton
+import app.skerry.ui.design.StatusAnnouncer
+import app.skerry.ui.design.ToggleRow
+import app.skerry.ui.design.Txt
+import app.skerry.ui.design.untrustedLabel
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
+import app.skerry.ui.generated.resources.lib_teams_invite_fingerprint
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
+import app.skerry.ui.generated.resources.lib_teams_peer_check_failed
+import app.skerry.ui.generated.resources.lib_teams_peer_checking
+import app.skerry.ui.generated.resources.lib_teams_peer_confirm
+import app.skerry.ui.generated.resources.lib_teams_peer_confirm_action
+import app.skerry.ui.generated.resources.lib_teams_peer_verify
+import app.skerry.ui.generated.resources.lib_teams_your_fingerprint
+import app.skerry.ui.generated.resources.shell_cancel
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+/**
+ * The fingerprint block both ceremonies draw: the key, the instruction to read it back over a
+ * channel the server does not own, whatever the record has to say against it, and this account's own
+ * fingerprint so the other side can check back.
+ *
+ * One composable because the two ceremonies are the same ceremony — the invite dialog's second step
+ * and the member list's confirmation (#323). A second copy is a copy that drifts, and the thing it
+ * would drift on is which of these lines a key that moved is allowed to skip.
+ */
+@Composable
+internal fun FingerprintCeremony(
+    fingerprint: String,
+    /** What the user is asked to do with the fingerprint — the one line that differs between the two. */
+    instruction: String,
+    /** What the record says against this fingerprint; null when it agrees or there is none. */
+    notice: String?,
+    acknowledged: Boolean,
+    onAcknowledge: () -> Unit,
+    ownFingerprint: String?,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(7.dp))
+            .background(Skerry.colors.cyan.copy(alpha = 0.06f))
+            .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp))
+            .padding(12.dp),
+    ) {
+        Txt(
+            stringResource(Res.string.lib_teams_invite_fingerprint).uppercase(),
+            color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp,
+        )
+        Txt(fingerprint, color = Skerry.colors.cyanBright, size = 14.sp, font = LocalFonts.current.mono, modifier = Modifier.padding(top = 4.dp))
+        Txt(instruction, color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
+        // A record that disagrees costs a second, deliberate gesture: confirming replaces it, and an
+        // honest rotation and a server trying its luck reach this screen looking identical. One
+        // click could not carry the difference — the person on the trusted channel can (#319).
+        if (notice != null) {
+            Txt(notice, color = Skerry.colors.amber, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
+            ToggleRow(
+                label = stringResource(Res.string.lib_teams_invite_key_changed_ack),
+                on = acknowledged,
+                onToggle = onAcknowledge,
+                labelSize = 11.5.sp,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+        if (ownFingerprint != null) {
+            Txt(
+                stringResource(Res.string.lib_teams_your_fingerprint, ownFingerprint),
+                color = Skerry.colors.faint, size = 11.sp, font = LocalFonts.current.mono,
+                modifier = Modifier.padding(top = 8.dp),
+            )
+        }
+    }
+}
+
+/**
+ * Fetches the published key of [accountId] for the confirm dialog and keeps the answer. Re-keyed on
+ * [attempt] so Retry re-runs it; the value is cleared first because `produceState` keeps the previous
+ * one across a key change, and a retry that redraws the same failure looks like a button that does
+ * nothing.
+ */
+@Composable
+internal fun rememberPeerKeyCheck(tc: TeamsCoordinator, accountId: String, attempt: Int): PeerKeyVerdict? =
+    produceState<PeerKeyVerdict?>(null, accountId, attempt) {
+        value = null
+        value = tc.peerKey(accountId)
+    }.value
+
+/**
+ * Confirm a colleague's Teams key from the member list — the ceremony that was only reachable by
+ * inviting someone (#323).
+ *
+ * A scope grant and a key rotation seal to whatever the server first answered with and show no
+ * fingerprint at all, so the record could only ever say "this is what we saw". This is where a human
+ * reads one out loud and the record starts saying "confirmed" — the word the screens use.
+ *
+ * [check] null means the lookup has not answered yet. Nothing is confirmable until it has, and a
+ * failure is stated here rather than in the screen's error line: the dialog is over that line, and
+ * two live regions saying one thing is what the invite banner was fixed for (WCAG 4.1.3).
+ */
+@Composable
+internal fun ConfirmPeerKeyDialog(
+    accountId: String,
+    check: PeerKeyVerdict?,
+    /** What the record held when the dialog opened, stated before the fingerprint is read out loud. */
+    trust: PeerTrust,
+    ownFingerprint: String?,
+    busy: Boolean,
+    onRetry: () -> Unit,
+    onConfirm: (InvitePreview) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val ready = (check as? PeerKeyVerdict.Ready)?.preview
+    // Keyed on the fingerprint, not on the dialog: the tick belongs to the key it was given for, and
+    // a retry answering with a different one asks the question again.
+    var acknowledged by remember(ready?.fingerprint) { mutableStateOf(false) }
+    val notice = ready?.let { pinNoticeText(pinNotice(it.pinned, it.fingerprint)) }
+    val blocked = busy || ready == null || (notice != null && !acknowledged)
+    val title = stringResource(Res.string.lib_teams_peer_confirm)
+    val failed = (check as? PeerKeyVerdict.Failed)?.let {
+        stringResource(Res.string.lib_teams_peer_check_failed) + " " + teamsFailureText(it.reason)
+    }
+    val state = peerTrustText(trust)
+    TeamsDialogCard(onDismiss, label = title) {
+        Txt(title, color = Skerry.colors.text, size = 16.sp, weight = FontWeight.SemiBold, letterSpacing = (-0.2).sp)
+        Txt(
+            untrustedLabel(accountId),
+            color = Skerry.colors.dim, size = 12.5.sp, font = LocalFonts.current.mono,
+            modifier = Modifier.padding(top = 4.dp),
+        )
+        if (state != null) {
+            Txt(
+                state,
+                color = if (trust == PeerTrust.CONFIRMED) Skerry.colors.dim else Skerry.colors.amber,
+                size = 12.sp, lineHeight = 17.sp, modifier = Modifier.padding(top = 10.dp),
+            )
+        }
+        // Composed above the block it describes, not inside it: the fingerprint arrives after the
+        // dialog is already up, and a node inserted together with its text announces nothing. The
+        // state line is carried here for the same reason and no other — it is the one fact the
+        // decision turns on, and it lands from a vault read that starts when the dialog mounts.
+        StatusAnnouncer(
+            listOfNotNull(
+                state,
+                when {
+                    failed != null -> failed
+                    ready == null -> stringResource(Res.string.lib_teams_peer_checking)
+                    else -> stringResource(Res.string.lib_teams_invite_fingerprint) + " " + ready.fingerprint +
+                        (notice?.let { " $it" } ?: "")
+                },
+            ).joinToString(" "),
+        )
+        when {
+            failed != null -> Txt(failed, color = Skerry.colors.amber, size = 12.sp, lineHeight = 17.sp, modifier = Modifier.padding(top = 12.dp))
+            ready == null -> Txt(stringResource(Res.string.lib_teams_peer_checking), color = Skerry.colors.dim, size = 12.sp, modifier = Modifier.padding(top = 12.dp))
+            else -> FingerprintCeremony(
+                fingerprint = ready.fingerprint,
+                instruction = stringResource(Res.string.lib_teams_peer_verify),
+                notice = notice,
+                acknowledged = acknowledged,
+                onAcknowledge = { acknowledged = !acknowledged },
+                ownFingerprint = ownFingerprint,
+                modifier = Modifier.padding(top = 12.dp),
+            )
+        }
+        Row(
+            Modifier.fillMaxWidth().padding(top = 18.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.End),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (check is PeerKeyVerdict.Failed) {
+                GhostButton(stringResource(Res.string.lib_teams_invite_check_retry), onClick = onRetry, fg = Skerry.colors.amber)
+            }
+            CancelButton(stringResource(Res.string.shell_cancel), onClick = onDismiss, modifier = Modifier.testTag(UiTags.FORM_CANCEL))
+            PrimaryButton(
+                stringResource(Res.string.lib_teams_peer_confirm_action),
+                onClick = { ready?.let(onConfirm) },
+                enabled = !blocked,
+                modifier = Modifier.testTag(UiTags.FORM_SAVE),
+            )
+        }
+    }
+}
+
+/**
+ * [ConfirmPeerKeyDialog] wired to its own lookup and its own Retry — the shape both screens mount,
+ * so the phone and the desktop cannot end up asking the question differently.
+ */
+@Composable
+internal fun ConfirmPeerKeyDialogFor(
+    tc: TeamsCoordinator,
+    accountId: String,
+    busy: Boolean,
+    onConfirm: (InvitePreview) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var attempt by remember(accountId) { mutableIntStateOf(0) }
+    // Read once, when the dialog opens: it is a statement about what the record held *before* this
+    // ceremony, and re-reading it after the confirm lands would have the dialog claim the answer it
+    // was opened to obtain.
+    val trust = produceState<PeerTrust?>(null, accountId) {
+        value = peerTrust(tc.peerPins(listOf(accountId))[accountId] ?: Pin.None, self = false)
+    }.value
+    ConfirmPeerKeyDialog(
+        accountId = accountId,
+        check = rememberPeerKeyCheck(tc, accountId, attempt),
+        trust = trust ?: PeerTrust.UNKNOWN,
+        ownFingerprint = tc.ownFingerprint(),
+        busy = busy,
+        onRetry = { attempt += 1 },
+        onConfirm = onConfirm,
+        onDismiss = onDismiss,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/InviteCheck.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/InviteCheck.kt
@@ -10,10 +10,11 @@ import androidx.compose.ui.graphics.Color
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_invite_check_failed
 import app.skerry.ui.generated.resources.lib_teams_invite_checking
-import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
 import app.skerry.ui.generated.resources.lib_teams_invite_unverified
 import app.skerry.ui.generated.resources.lib_teams_invited_by
 import app.skerry.ui.generated.resources.lib_teams_invited_fingerprint
+import app.skerry.shared.team.PinNotice
+import app.skerry.shared.team.pinNotice
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
@@ -49,19 +50,27 @@ internal sealed interface InviteCheck {
 internal class InviteAcknowledgement(val moved: String?, val acknowledged: Boolean, val toggle: () -> Unit)
 
 /**
- * Holds that acknowledgement for one banner. Remembered as the fingerprint that was acknowledged
- * rather than as a flag: the check is re-run by every reread of the screen and visits [Pending] on
- * the way there, so a flag keyed on the state would be cleared by an action on some other team and
- * ask the user to tick it again. A different fingerprint is a different question, and matches nothing.
+ * Holds that acknowledgement for one banner. Remembered as the question that was answered — the
+ * fingerprint and what the record said against it — rather than as a flag: the check is re-run by
+ * every reread of the screen and visits [Pending] on the way there, so a flag keyed on the state
+ * would be cleared by an action on some other team and ask the user to tick it again.
+ *
+ * The notice is half of that pair because these records arrive from this account's own devices
+ * whenever the server delivers them, and the question can get harder under a standing tick: a
+ * "nobody confirmed either of them" the user answered must not stand in for "this differs from the
+ * fingerprint confirmed for this account" once the confirmation lands (#323).
  *
  * One holder for both surfaces — a second copy of this is a copy no test on the other surface reads.
  */
 @Composable
 internal fun rememberInviteAcknowledgement(check: InviteCheck): InviteAcknowledgement {
-    var acknowledgedFor by remember { mutableStateOf<String?>(null) }
-    val moved = (check as? InviteCheck.Verified)?.preview?.takeIf { it.keyChanged }?.fingerprint
-    val acknowledged = moved != null && acknowledgedFor == moved
-    return InviteAcknowledgement(moved, acknowledged) { acknowledgedFor = if (acknowledged) null else moved }
+    var answered by remember { mutableStateOf<Pair<String, PinNotice>?>(null) }
+    val preview = (check as? InviteCheck.Verified)?.preview
+    val asked = preview
+        ?.let { it.fingerprint to pinNotice(it.pinned, it.fingerprint) }
+        ?.takeIf { (_, notice) -> notice != PinNotice.NOTHING }
+    val acknowledged = asked != null && answered == asked
+    return InviteAcknowledgement(asked?.first, acknowledged) { answered = if (acknowledged) null else asked }
 }
 
 /**
@@ -110,7 +119,8 @@ internal fun inviteCheckAnnouncement(check: InviteCheck): String = when (check) 
         val preview = check.preview
         val identity = stringResource(Res.string.lib_teams_invited_by, untrustedLabel(preview.accountId)) + " " +
             stringResource(Res.string.lib_teams_invited_fingerprint, preview.fingerprint)
-        if (preview.keyChanged) identity + " " + stringResource(Res.string.lib_teams_invite_key_changed) else identity
+        val notice = pinNoticeText(pinNotice(preview.pinned, preview.fingerprint))
+        if (notice != null) "$identity $notice" else identity
     }
 }
 
@@ -131,7 +141,9 @@ internal fun inviteCheckLines(check: InviteCheck): List<InviteCheckLine> = when 
         val preview = check.preview
         add(InviteCheckLine(stringResource(Res.string.lib_teams_invited_by, untrustedLabel(preview.accountId)), Skerry.colors.dim))
         add(InviteCheckLine(stringResource(Res.string.lib_teams_invited_fingerprint, preview.fingerprint), Skerry.colors.cyanBright, mono = true))
-        if (preview.keyChanged) add(InviteCheckLine(stringResource(Res.string.lib_teams_invite_key_changed), Skerry.colors.amber))
+        // Worded by how the record it disagrees with got there: a fingerprint a human confirmed and
+        // one the server was simply first to answer with are not the same claim (#323).
+        pinNoticeText(pinNotice(preview.pinned, preview.fingerprint))?.let { add(InviteCheckLine(it, Skerry.colors.amber)) }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerTrust.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerTrust.kt
@@ -1,0 +1,162 @@
+package app.skerry.ui.teams
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinNotice
+import app.skerry.shared.team.PinOrigin
+import app.skerry.ui.design.GlyphButton
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_key_changed_unconfirmed
+import app.skerry.ui.generated.resources.lib_teams_key_pin_unreadable
+import app.skerry.ui.generated.resources.lib_teams_peer_confirm
+import app.skerry.ui.generated.resources.lib_teams_peer_confirmed
+import app.skerry.ui.generated.resources.lib_teams_peer_mark
+import app.skerry.ui.generated.resources.lib_teams_peer_state_confirmed
+import app.skerry.ui.generated.resources.lib_teams_peer_state_first_sight
+import app.skerry.ui.generated.resources.lib_teams_peer_state_none
+import app.skerry.ui.generated.resources.lib_teams_peer_state_unreadable
+import app.skerry.ui.theme.Skerry
+import org.jetbrains.compose.resources.stringResource
+
+// What this account holds for a colleague's Teams key, in the two shapes the screens ask about it
+// (#323). Both are decided here, away from the composables, because the whole point is that one word
+// — "confirmed" — may only ever describe a fingerprint a human read out loud; a `when` copied into
+// two views is a `when` that drifts.
+
+/**
+ * What is on record for one member, as the member list draws it.
+ *
+ * [CONFIRMED] and the rest are not degrees of the same thing: a first sight is whatever the server
+ * answered the first time something was sealed to the account, held to from then on but vouched for
+ * by nobody. Until #322 the record could not tell the two apart, so an invite ceremony and a server's
+ * first answer produced the same state and the screens called both of them confirmed.
+ */
+enum class PeerTrust {
+    /** This account. There is no ceremony with oneself, and the member list offers none. */
+    SELF,
+
+    /** A fingerprint a human read out loud: the invite ceremony, or the member list's own confirm. */
+    CONFIRMED,
+
+    /** Whatever the server answered on the first seal to this account — nobody has confirmed it. */
+    FIRST_SIGHT,
+
+    /** Nothing on record: this account has never sealed anything to them. */
+    NONE,
+
+    /** A record exists and this device cannot read it — a locked vault, or a payload that stopped opening. */
+    UNREADABLE,
+
+    /**
+     * Whose row this is cannot be told: there is no live session, so [TeamsCoordinator.selfAccountId]
+     * answers nothing. The row makes no claim and offers no ceremony — treating "unknown" as "not me"
+     * is what put the amber mark on the reader's own row.
+     */
+    UNKNOWN,
+}
+
+/**
+ * What [pin] says about a member. [self] is whether this is the reader's own row — null when the
+ * screen cannot tell, which is not the same answer as "no".
+ */
+fun peerTrust(pin: Pin, self: Boolean?): PeerTrust = when {
+    self == null -> PeerTrust.UNKNOWN
+    self -> PeerTrust.SELF
+    pin is Pin.Known && pin.origin == PinOrigin.CONFIRMED -> PeerTrust.CONFIRMED
+    pin is Pin.Known -> PeerTrust.FIRST_SIGHT
+    pin == Pin.Unreadable -> PeerTrust.UNREADABLE
+    else -> PeerTrust.NONE
+}
+
+/**
+ * Whether the member list offers the ceremony for this member — every row but one's own and one whose
+ * owner cannot be told.
+ *
+ * A confirmed pin is offered too, and that is the point: a colleague who rotates their identity leaves
+ * a confirmed pin that no longer matches their published key, every seal to them is refused from then
+ * on, and the ceremony is the only way back. Withholding it there left the error's own instruction —
+ * "confirm it in the member list" — pointing at nothing (#323).
+ */
+val PeerTrust.confirmable: Boolean get() = this != PeerTrust.SELF && this != PeerTrust.UNKNOWN
+
+/** The warning a notice draws next to the fingerprint, or null when there is nothing to warn about. */
+@Composable
+internal fun pinNoticeText(notice: PinNotice): String? = when (notice) {
+    PinNotice.NOTHING -> null
+    PinNotice.MOVED_FROM_CONFIRMED -> stringResource(Res.string.lib_teams_invite_key_changed)
+    PinNotice.MOVED_FROM_FIRST_SIGHT -> stringResource(Res.string.lib_teams_key_changed_unconfirmed)
+    PinNotice.UNREADABLE -> stringResource(Res.string.lib_teams_key_pin_unreadable)
+}
+
+/** What the confirm dialog states about the account before the user reads the fingerprint out loud. */
+@Composable
+internal fun peerTrustText(trust: PeerTrust): String? = when (trust) {
+    PeerTrust.SELF, PeerTrust.UNKNOWN -> null
+    PeerTrust.CONFIRMED -> stringResource(Res.string.lib_teams_peer_state_confirmed)
+    PeerTrust.FIRST_SIGHT -> stringResource(Res.string.lib_teams_peer_state_first_sight)
+    PeerTrust.NONE -> stringResource(Res.string.lib_teams_peer_state_none)
+    PeerTrust.UNREADABLE -> stringResource(Res.string.lib_teams_peer_state_unreadable)
+}
+
+/** What a member list needs to draw its marks: whose row is whose, and what is pinned for each. */
+internal class MemberPins(val self: String?, val pins: Map<String, Pin>)
+
+/**
+ * [MemberPins] for [accountIds], off the frame — null until the vault has answered, and then no row
+ * claims anything about a key.
+ *
+ * Not a `remember` block: the read takes the account vault's single lock, which every write holds
+ * across a whole-file re-serialize and rewrite, and a member with no readable pin costs a record-list
+ * scan on top. Done in composition it blocks the frame for the length of a sync merge's commit.
+ *
+ * One helper for both surfaces — the phone and the desktop must not end up reading this differently.
+ */
+@Composable
+internal fun rememberMemberPins(tc: TeamsCoordinator, accountIds: List<String>, tick: Int): MemberPins? =
+    produceState<MemberPins?>(null, accountIds, tick) {
+        // Cleared first: `produceState` keeps the previous value across a key change, and a member
+        // the refreshed list added is absent from the old map — its row would wear the amber mark of
+        // an unconfirmed key until the vault answers, which is a claim about a key nothing read yet.
+        value = null
+        value = MemberPins(tc.selfAccountId(), tc.peerPins(accountIds))
+    }.value
+
+/**
+ * The mark a member row wears for its key: a quiet one for a fingerprint a human confirmed, an amber
+ * shield for everything else — a first sight, an account nothing was ever sealed to, a record this
+ * device cannot read. Both open the ceremony; the own row and a row whose owner cannot be told wear
+ * neither.
+ *
+ * The mark is the whole point of the row change: without it "confirmed" was a word two different
+ * states shared, and there was no way to promote one of them short of re-inviting the person (#323).
+ */
+@Composable
+internal fun PeerTrustBadge(trust: PeerTrust, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
+    if (!trust.confirmable) return
+    val confirmed = trust == PeerTrust.CONFIRMED
+    val action = stringResource(Res.string.lib_teams_peer_confirm)
+    GlyphButton(
+        icon = if (confirmed) "verified_user" else "gpp_maybe",
+        // The state first when there is one, then what pressing it does: the mark is read as a status
+        // and used as a control, and a name carrying only the status describes no purpose (WCAG 4.1.2).
+        // Joined by a format string rather than by a literal stop — the punctuation between two
+        // sentences belongs to the locale, and zh does not end one with a Latin full stop.
+        label = if (confirmed) {
+            stringResource(Res.string.lib_teams_peer_mark, stringResource(Res.string.lib_teams_peer_confirmed), action)
+        } else {
+            action
+        },
+        onClick = onConfirm,
+        modifier = modifier,
+        // Small for a row, never below the minimum target size — this is the only way into the
+        // ceremony, and the glyph alone is a 14sp mark (WCAG 2.5.8).
+        box = 24.dp,
+        iconSize = 14.sp,
+        iconColor = if (confirmed) Skerry.colors.cyanBright else Skerry.colors.amber,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamMemberTable.kt
@@ -62,6 +62,8 @@ internal fun TeamMemberTable(
     scopesLoading: Boolean = false,
     onChangeRole: (TeamMemberRowUi) -> Unit,
     onRemove: (TeamMemberRowUi) -> Unit,
+    /** Opens the fingerprint ceremony for a member whose key nobody has confirmed (#323). */
+    onConfirmKey: (TeamMemberRowUi) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier.fillMaxWidth()) {
@@ -74,14 +76,26 @@ internal fun TeamMemberTable(
         }
         HLine()
         rows.forEach { row ->
-            MemberRow(row, now, scopesLoading, onChangeRole = { onChangeRole(row) }, onRemove = { onRemove(row) })
+            MemberRow(
+                row, now, scopesLoading,
+                onChangeRole = { onChangeRole(row) },
+                onRemove = { onRemove(row) },
+                onConfirmKey = { onConfirmKey(row) },
+            )
             HLine()
         }
     }
 }
 
 @Composable
-private fun MemberRow(row: TeamMemberRowUi, now: Long, scopesLoading: Boolean, onChangeRole: () -> Unit, onRemove: () -> Unit) {
+private fun MemberRow(
+    row: TeamMemberRowUi,
+    now: Long,
+    scopesLoading: Boolean,
+    onChangeRole: () -> Unit,
+    onRemove: () -> Unit,
+    onConfirmKey: () -> Unit,
+) {
     val mono = LocalFonts.current.mono
     val member = row.member
     val invited = member.status == TeamMemberStatus.INVITED
@@ -101,7 +115,11 @@ private fun MemberRow(row: TeamMemberRowUi, now: Long, scopesLoading: Boolean, o
                 weight = FontWeight.Medium,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+                // Shrinks rather than pushes the mark off the row: a long account id must not be the
+                // reason a key nobody confirmed has nothing on screen to say so.
+                modifier = Modifier.weight(1f, fill = false),
             )
+            PeerTrustBadge(row.trust, onConfirm = onConfirmKey)
         }
         Box(Modifier.width(ROLE_WIDTH)) {
             if (invited) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -109,6 +109,7 @@ internal fun TeamScreen(
     onSync: () -> Unit,
     onShowHistory: () -> Unit,
     onChangeRole: (TeamMember) -> Unit,
+    onConfirmKey: (String) -> Unit,
     onSelectScope: (String) -> Unit,
     onNewScope: () -> Unit,
     onScopeAccess: (TeamScopeUi) -> Unit,
@@ -161,8 +162,14 @@ internal fun TeamScreen(
                 )
             }
             ScopeStrip(team, scopeId, canManage, onSelectScope, onScopeAccess, onDeleteScope = { onConfirm(TeamsConfirm.DeleteScope(team.id, it.id)) })
-            val rows = remember(team, members, grants, canManage) {
-                teamMemberRows(team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true)
+            // One vault pass for the whole list, keyed to the same reread as the list itself: the
+            // marks and the rows must not disagree about who has been confirmed (#323).
+            val marks = rememberMemberPins(tc, members.map { it.accountId }, tick)
+            val rows = remember(team, members, grants, canManage, marks) {
+                teamMemberRows(
+                    team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true,
+                    marks?.self, marks?.pins.orEmpty(),
+                )
             }
             // Read once per reread rather than per row, so every row of one paint agrees on "now".
             val now = remember(tick, members) { epochMillis() }
@@ -172,6 +179,7 @@ internal fun TeamScreen(
                 scopesLoading = canManage && grants == null,
                 onChangeRole = { onChangeRole(it.member) },
                 onRemove = { onConfirm(TeamsConfirm.Remove(team.id, it.member.accountId)) },
+                onConfirmKey = { onConfirmKey(it.member.accountId) },
             )
             TeamSummaryCards(
                 cards = teamCards(tc, team, scopeId, tick, feed, members),

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -9,8 +9,11 @@ import app.skerry.shared.sync.SyncStateStore
 import app.skerry.shared.sync.SyncException
 import app.skerry.shared.team.AccountIdentity
 import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.ConfirmOutcome
 import app.skerry.shared.team.PeerKeys
 import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinNotice
+import app.skerry.shared.team.pinNotice
 import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.TeamIdentityStore
@@ -80,6 +83,15 @@ enum class TeamsFailure {
     PinNotRecorded,
 
     /**
+     * The record for the account moved while its fingerprint was on screen, so the confirmation was
+     * not written (#323). Its own value rather than [PinNotRecorded]: nothing is wrong with this
+     * device, the question simply has to be asked again against what is on record now — a pin that
+     * moved costs an acknowledgement, and a gate decided against a record that has since changed is
+     * no gate.
+     */
+    PinMovedMeanwhile,
+
+    /**
      * This device cannot read the Teams identity an invite is sealed to — the record is gone (a
      * reactivation reconcile drops it and the re-pull has not landed) or no longer decrypts. A
      * separate value because the alternative is telling the user their colleague sent something
@@ -127,12 +139,33 @@ data class InvitePreview(
     val accountId: String,
     val fingerprint: String,
     /**
-     * The account already had a different fingerprint pinned. Confirming this one replaces it, so
-     * the screen has to say so — an identity that moved is either an honest rotation or the server
-     * trying its luck, and only the person on the other end of the trusted channel can tell.
+     * What this account already held for [accountId] when the fingerprint was read. Carried whole
+     * rather than as a flag: whether the record on the other side of the comparison was confirmed by
+     * a human or merely seen first decides what a screen may call it (#323).
+     *
+     * Required, not defaulted: the write this preview is passed to holds itself to this value, and
+     * [Pin.None] is a positive claim that the ceremony saw an empty record. Defaulting to it would
+     * let a caller that never read a pin pass the very gate that read exists for.
      */
-    val keyChanged: Boolean = false,
-)
+    val pinned: Pin,
+) {
+    /**
+     * The record does not simply agree with [fingerprint], so confirming replaces it and costs a
+     * second, deliberate gesture. An identity that moved is either an honest rotation or the server
+     * trying its luck, and only the person on the other end of the trusted channel can tell; a pin
+     * this device cannot read asks the same question, having nothing to compare against.
+     */
+    val keyChanged: Boolean get() = pinNotice(pinned, fingerprint) != PinNotice.NOTHING
+}
+
+/** What a peer-key lookup answered: the fingerprint to confirm, or why it could not be fetched. */
+sealed interface PeerKeyVerdict {
+    /** The account's published key, fingerprinted, under whatever this device already holds for it. */
+    data class Ready(val preview: InvitePreview) : PeerKeyVerdict
+
+    /** The key could not be read — offline, no published key, a server that errored. Worth retrying. */
+    data class Failed(val reason: TeamsFailure) : PeerKeyVerdict
+}
 
 /** What [TeamsCoordinator.acceptPreview] could establish about an invite. */
 sealed interface InviteVerdict {
@@ -408,22 +441,39 @@ class TeamsCoordinator(
         }
     }
 
-    /** Invite step 1: the invitee's key + fingerprint for verification over a trusted channel. */
-    suspend fun previewInvite(accountId: String): InvitePreview? {
-        val (s, c) = live() ?: run { markError(TeamsFailure.NotConnected); return null }
+    /**
+     * The account's published key and what this device holds for it — the lookup behind both
+     * ceremonies that show a fingerprint to a human: the invite dialog's first step, and the member
+     * list's own confirmation of a colleague this account never invited (#323).
+     *
+     * The reason a lookup failed is the answer rather than a write to [lastError], because the
+     * confirm dialog is a modal with a line of its own to say it on: routing it through the error
+     * slot as well would make a screen reader say the same failure twice, on two live regions, the
+     * way the invite banner used to (WCAG 4.1.3).
+     */
+    suspend fun peerKey(accountId: String): PeerKeyVerdict {
+        val (s, c) = live() ?: return PeerKeyVerdict.Failed(TeamsFailure.NotConnected)
         return try {
             val keys = c.fetchPublicKey(s, accountId)
-            if (keys == null) {
-                markError(TeamsFailure.NoRecipientKey)
-                null
-            } else {
-                val fingerprint = accountKeyFingerprint(keys.sharing, keys.signing)
-                InvitePreview(accountId, fingerprint, keyChanged = pinMoved(accountId, fingerprint))
-            }
+                ?: return PeerKeyVerdict.Failed(TeamsFailure.NoRecipientKey)
+            val fingerprint = accountKeyFingerprint(keys.sharing, keys.signing)
+            val pinned = peerStore.pins(listOf(accountId))[accountId] ?: Pin.None
+            PeerKeyVerdict.Ready(InvitePreview(accountId, fingerprint, pinned))
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            markError(e.toFailure())
+            PeerKeyVerdict.Failed(e.toFailure())
+        }
+    }
+
+    /**
+     * [peerKey] for the invite dialog, which has no line of its own and reports through [lastError]
+     * like the rest of its steps.
+     */
+    suspend fun previewPeerKey(accountId: String): InvitePreview? = when (val verdict = peerKey(accountId)) {
+        is PeerKeyVerdict.Ready -> verdict.preview
+        is PeerKeyVerdict.Failed -> {
+            markError(verdict.reason)
             null
         }
     }
@@ -471,11 +521,59 @@ class TeamsCoordinator(
             // the server names, and another record may already hold it — must stop the seal rather
             // than surface once the team key has left.
             if (!vault.isUnlocked) return@op markError(TeamsFailure.VaultLocked)
-            if (!peerStore.confirm(accountId, verified.fingerprint)) return@op markError(TeamsFailure.PinNotRecorded)
+            confirmShown(accountId, verified)?.let { return@op markError(it) }
             c.invite(s, teamId, accountId, role, envelope)
             refreshUnlocked(s, c)
         }
     }
+
+    /**
+     * Record [verified] as a fingerprint a human read out loud — the same ceremony the invite ends
+     * with, for a colleague this account never invited (#323).
+     *
+     * Without it the only way to confirm an account was to invite it: a scope grant and a rotation
+     * pin whatever the server answered on the first sight and show no fingerprint at all, so the
+     * record could never say more than "this is what we saw first". Promoting one is what lets the
+     * screens use the word "confirmed" about anything.
+     *
+     * The key is fetched again and re-fingerprinted here, exactly as [invite] does and for the same
+     * reason: the preview is a UI state that may be minutes old, and the key table is the server's —
+     * answering the lookup with the colleague's real key and this call with one of its own would
+     * write a confirmation for a key nobody read (#316).
+     */
+    suspend fun confirmPeer(verified: InvitePreview) {
+        val (s, c) = live() ?: return markError(TeamsFailure.NotConnected)
+        if (!vault.isUnlocked) return markError(TeamsFailure.VaultLocked)
+        op {
+            val keys = c.fetchPublicKey(s, verified.accountId) ?: return@op markError(TeamsFailure.NoRecipientKey)
+            if (accountKeyFingerprint(keys.sharing, keys.signing) != verified.fingerprint) {
+                return@op markError(TeamsFailure.RecipientKeyChanged)
+            }
+            if (!vault.isUnlocked) return@op markError(TeamsFailure.VaultLocked)
+            confirmShown(verified.accountId, verified)?.let { markError(it) }
+        }
+    }
+
+    /**
+     * Record the fingerprint [shown] carries as confirmed, held to the pin the ceremony was drawn
+     * against. Answers the failure to report, or null when it is on record.
+     *
+     * One place because all three ceremonies — the invite send, the invite accept, the member list's
+     * own confirm — end in the same write and owe the same two refusals.
+     */
+    private fun confirmShown(accountId: String, shown: InvitePreview): TeamsFailure? =
+        when (peerStore.confirm(accountId, shown.fingerprint, shown.pinned)) {
+            ConfirmOutcome.RECORDED -> null
+            ConfirmOutcome.MOVED -> TeamsFailure.PinMovedMeanwhile
+            ConfirmOutcome.REFUSED -> TeamsFailure.PinNotRecorded
+        }
+
+    /**
+     * What this account holds for each of [accountIds] — how the member table tells a fingerprint a
+     * human confirmed from one the server was simply first to answer with (#323). One vault pass, so
+     * every row of a paint agrees.
+     */
+    suspend fun peerPins(accountIds: Collection<String>): Map<String, Pin> = peerStore.pins(accountIds)
 
     /** Change a member's role (owner/admin; the server enforces anti-escalation). */
     suspend fun changeRole(teamId: String, accountId: String, role: TeamRole) {
@@ -599,9 +697,7 @@ class TeamsCoordinator(
             // The keys the signature was checked against, not a second fetch of the same account: the
             // server owns the key table, and answering the check with a key it forged the invite
             // under and the fingerprint with the real colleague's key is the whole attack (#319).
-            val inviter = verified.payload.inviterAccountId
-            val fingerprint = accountKeyFingerprint(verified.inviterKeys.sharing, verified.inviterKeys.signing)
-            InviteVerdict.Verified(InvitePreview(inviter, fingerprint, keyChanged = pinMoved(inviter, fingerprint)))
+            InviteVerdict.Verified(verified.preview())
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -626,11 +722,7 @@ class TeamsCoordinator(
             // for this account): a membership whose later envelopes nothing guards is the state this
             // whole change exists to prevent.
             if (!vault.isUnlocked) return@op markError(TeamsFailure.VaultLocked)
-            val pinned = peerStore.confirm(
-                invite.inviterAccountId,
-                accountKeyFingerprint(verified.inviterKeys.sharing, verified.inviterKeys.signing),
-            )
-            if (!pinned) return@op markError(TeamsFailure.PinNotRecorded)
+            confirmShown(invite.inviterAccountId, verified.preview())?.let { return@op markError(it) }
             // Placeholder role: the server returns the actual role at refreshUnlocked (listTeams).
             keyStore.put(teamId, invite.teamName, TeamRole.VIEWER, invite.teamKey, invite.epoch)
             c.accept(s, teamId)
@@ -1059,8 +1151,23 @@ class TeamsCoordinator(
         )
     }
 
-    /** A pending invite whose signature was checked, with the very keys it was checked against. */
-    internal class VerifiedInvite(val payload: TeamInvitePayload, val inviterKeys: AccountKeys)
+    /**
+     * A pending invite whose signature was checked, with the very keys it was checked against and
+     * what was pinned for the inviter when the banner drew its fingerprint. [pinned] is read here
+     * rather than at accept time: it is what decided whether the banner demanded an acknowledgement,
+     * and the write that follows is held to it.
+     */
+    internal class VerifiedInvite(
+        val payload: TeamInvitePayload,
+        val inviterKeys: AccountKeys,
+        val pinned: Pin,
+    ) {
+        fun preview() = InvitePreview(
+            payload.inviterAccountId,
+            accountKeyFingerprint(inviterKeys.sharing, inviterKeys.signing),
+            pinned,
+        )
+    }
 
     /**
      * Open the invite envelope for [teamId] and verify the inviter's signature and binding. Returns
@@ -1075,7 +1182,10 @@ class TeamsCoordinator(
         if (payload.teamId != teamId || payload.inviteeAccountId != s.accountId) return null
         val inviterKeys = c.fetchPublicKey(s, payload.inviterAccountId) ?: return null
         if (!inviteCodec.verify(payload, inviterKeys.signing)) return null
-        return VerifiedInvite(payload, inviterKeys).also { verified ->
+        // The pin is read here so the banner's fingerprint and the acknowledgement it may demand are
+        // decided against one state, and the accept that follows is held to that same state.
+        val pinned = peerStore.pins(listOf(payload.inviterAccountId))[payload.inviterAccountId] ?: Pin.None
+        return VerifiedInvite(payload, inviterKeys, pinned).also { verified ->
             verifiedInvites.update { it + (teamId to verified) }
         }
     }
@@ -1108,19 +1218,6 @@ class TeamsCoordinator(
                 _busy.value = false
             }
         }
-    }
-
-    /**
-     * Whether [fingerprint] differs from what is pinned for [accountId] — false when nothing is
-     * pinned yet. Only the two ceremonies that show a fingerprint to a human ask this; everything
-     * else refuses a moved key outright (see [fetchPinned]).
-     */
-    private fun pinMoved(accountId: String, fingerprint: String): Boolean = when (val pin = peerStore.pin(accountId)) {
-        Pin.None -> false
-        // Nothing to compare against, and sending replaces the record: the user is the only one who
-        // can say whether this fingerprint is the colleague's, so they are asked rather than told.
-        Pin.Unreadable -> true
-        is Pin.Known -> pin.fingerprint != fingerprint
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsDialogs.kt
@@ -39,9 +39,9 @@ import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.ModalScrim
 import app.skerry.ui.design.PrimaryButton
 import app.skerry.ui.design.StatusAnnouncer
-import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.consumeClicks
+import app.skerry.shared.team.pinNotice
 import app.skerry.shared.team.TeamRole
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_invite_role
@@ -49,15 +49,12 @@ import app.skerry.ui.generated.resources.lib_teams_create_subtitle
 import app.skerry.ui.generated.resources.lib_teams_create_title
 import app.skerry.ui.generated.resources.lib_teams_invite_account_placeholder
 import app.skerry.ui.generated.resources.lib_teams_invite_fingerprint
-import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
-import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.generated.resources.lib_teams_invite_next
 import app.skerry.ui.generated.resources.lib_teams_invite_send
 import app.skerry.ui.generated.resources.lib_teams_invite_subtitle
 import app.skerry.ui.generated.resources.lib_teams_invite_title
 import app.skerry.ui.generated.resources.lib_teams_invite_verify
 import app.skerry.ui.generated.resources.lib_teams_name_placeholder
-import app.skerry.ui.generated.resources.lib_teams_your_fingerprint
 import app.skerry.ui.generated.resources.shell_cancel
 import app.skerry.ui.generated.resources.shell_create
 import org.jetbrains.compose.resources.stringResource
@@ -229,18 +226,24 @@ fun InviteMemberDialog(
     var role by remember { mutableStateOf(assignableRoles.lastOrNull() ?: TeamRole.VIEWER) }
     val focus = remember { FocusRequester() }
     LaunchedEffect(Unit) { focus.requestFocus() }
-    val mono = LocalFonts.current.mono
     // The preview only counts while the typed id still matches it — editing the field must not leave
     // a stale verification standing behind the Send button.
     val verified = preview?.takeIf { it.accountId == accountId.trim() }
     val ready = verified != null
-    // Keyed on the fingerprint, not on the dialog: the tick belongs to the key it was given for, and
-    // a lookup answering with a different one asks the question again.
-    var acknowledged by remember(verified?.fingerprint) { mutableStateOf(false) }
-    // A key that moved costs a second, deliberate gesture. Sending replaces the pin, so an honest
-    // rotation and a server trying its luck reach this dialog looking identical — the difference is
-    // in what the person on the trusted channel says, and one click could not carry it (#319).
-    val blockedByKeyChange = verified != null && verified.keyChanged && !acknowledged
+    // What the peer record says against this fingerprint, worded by how the record got there: a key
+    // a human confirmed and a key the server was simply first to answer with are not the same claim,
+    // and the dialog used to describe both as "confirmed" (#323).
+    val notice = verified?.let { pinNoticeText(pinNotice(it.pinned, it.fingerprint)) }
+    // Keyed on the fingerprint and on what is said against it, not on the dialog: the tick belongs to
+    // the question it answered. A lookup answering with a different key asks it again — and so does
+    // one that answers the same key while the record behind it escalates from "nobody confirmed
+    // either of these" to "this differs from the fingerprint confirmed for this account".
+    var acknowledged by remember(verified?.fingerprint, notice) { mutableStateOf(false) }
+    // A record that disagrees costs a second, deliberate gesture. Sending replaces the pin, so an
+    // honest rotation and a server trying its luck reach this dialog looking identical — the
+    // difference is in what the person on the trusted channel says, and one click could not carry
+    // it (#319).
+    val blockedByKeyChange = notice != null && !acknowledged
     fun submit() {
         val id = accountId.trim()
         if (id.isEmpty() || busy || blockedByKeyChange) return
@@ -253,44 +256,23 @@ fun InviteMemberDialog(
         // The lookup's answer arrives while the field has focus and Send silently becomes live; the
         // fingerprint block below is an insertion nothing announces on its own (WCAG 4.1.3).
         StatusAnnouncer(
-            when {
-                verified == null -> ""
-                verified.keyChanged ->
-                    stringResource(Res.string.lib_teams_invite_fingerprint) + " " + verified.fingerprint + " " +
-                        stringResource(Res.string.lib_teams_invite_key_changed)
-                else -> stringResource(Res.string.lib_teams_invite_fingerprint) + " " + verified.fingerprint
+            if (verified == null) {
+                ""
+            } else {
+                stringResource(Res.string.lib_teams_invite_fingerprint) + " " + verified.fingerprint +
+                    (notice?.let { " $it" } ?: "")
             },
         )
         if (verified != null) {
-            Column(
-                Modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp)
-                    .clip(RoundedCornerShape(7.dp))
-                    .background(Skerry.colors.cyan.copy(alpha = 0.06f))
-                    .border(1.dp, Skerry.colors.cyan14, RoundedCornerShape(7.dp))
-                    .padding(12.dp),
-            ) {
-                Txt(stringResource(Res.string.lib_teams_invite_fingerprint).uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp)
-                Txt(verified.fingerprint, color = Skerry.colors.cyanBright, size = 14.sp, font = mono, modifier = Modifier.padding(top = 4.dp))
-                Txt(stringResource(Res.string.lib_teams_invite_verify), color = Skerry.colors.dim, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
-                // An account whose fingerprint moved is either an honest identity rotation or the
-                // server trying its luck. Sending replaces the pin, so the difference has to be on
-                // screen — the person on the trusted channel is the only one who can tell (#319).
-                if (verified.keyChanged) {
-                    Txt(stringResource(Res.string.lib_teams_invite_key_changed), color = Skerry.colors.amber, size = 11.5.sp, lineHeight = 16.sp, modifier = Modifier.padding(top = 8.dp))
-                    ToggleRow(
-                        label = stringResource(Res.string.lib_teams_invite_key_changed_ack),
-                        on = acknowledged,
-                        onToggle = { acknowledged = !acknowledged },
-                        labelSize = 11.5.sp,
-                        modifier = Modifier.padding(top = 8.dp),
-                    )
-                }
-                if (ownFingerprint != null) {
-                    Txt(stringResource(Res.string.lib_teams_your_fingerprint, ownFingerprint), color = Skerry.colors.faint, size = 11.sp, font = mono, modifier = Modifier.padding(top = 8.dp))
-                }
-            }
+            FingerprintCeremony(
+                fingerprint = verified.fingerprint,
+                instruction = stringResource(Res.string.lib_teams_invite_verify),
+                notice = notice,
+                acknowledged = acknowledged,
+                onAcknowledge = { acknowledged = !acknowledged },
+                ownFingerprint = ownFingerprint,
+                modifier = Modifier.padding(top = 12.dp),
+            )
         }
         if (assignableRoles.isNotEmpty()) {
             Txt(stringResource(Res.string.lib_teams_invite_role).uppercase(), color = Skerry.colors.faint, size = 10.sp, weight = FontWeight.SemiBold, letterSpacing = 0.5.sp, modifier = Modifier.padding(top = 16.dp, bottom = 8.dp))

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsMock.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsMock.kt
@@ -110,6 +110,7 @@ internal fun TeamsMockView() {
                         now = now,
                         onChangeRole = {},
                         onRemove = {},
+                        onConfirmKey = {},
                     )
                     TeamSummaryCards(
                         cards = TeamCards(

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.teams
 
+import app.skerry.shared.team.Pin
 import app.skerry.shared.team.TeamActivityDay
 import app.skerry.shared.team.TeamActivityKind
 import app.skerry.shared.team.TeamMember
@@ -23,6 +24,11 @@ data class TeamMemberRowUi(
     val scopesKnown: Boolean,
     /** The viewer may change this member's role or remove them (mirrors the server ACL). */
     val manageable: Boolean,
+    /**
+     * What this device holds for the member's Teams key — and in particular whether a human ever
+     * confirmed it, or the server was simply the first to answer with it (#323).
+     */
+    val trust: PeerTrust = PeerTrust.NONE,
 )
 
 /**
@@ -40,6 +46,14 @@ fun teamMemberRows(
     scopeGrants: Map<String, Set<String>>,
     canManage: Boolean,
     grantsComplete: Boolean = true,
+    /**
+     * This account, so its own row is not offered a ceremony with itself. Null means the screen
+     * cannot tell — there is no live session — and then no row wears a mark at all: reading unknown
+     * as "not me" put the amber "confirm this member's key" on the reader themselves.
+     */
+    selfAccountId: String? = null,
+    /** What is pinned for each member — [app.skerry.shared.team.Pin.None] for anyone absent from it. */
+    pins: Map<String, Pin> = emptyMap(),
 ): List<TeamMemberRowUi> {
     val scopeNames = team.scopes.associate { it.id to it.name }
     return members
@@ -57,6 +71,10 @@ fun teamMemberRows(
                 manageable = canManage &&
                     member.accountId != team.ownerAccountId &&
                     canModifyMember(team.role, member.role),
+                trust = peerTrust(
+                    pins[member.accountId] ?: Pin.None,
+                    self = selfAccountId?.let { it == member.accountId },
+                ),
             )
         }
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsView.kt
@@ -81,6 +81,7 @@ import app.skerry.ui.generated.resources.lib_teams_err_no_recipient_key
 import app.skerry.ui.generated.resources.lib_teams_err_no_such_account
 import app.skerry.ui.generated.resources.lib_teams_err_not_connected
 import app.skerry.ui.generated.resources.lib_teams_err_peer_key_unconfirmed
+import app.skerry.ui.generated.resources.lib_teams_err_pin_moved
 import app.skerry.ui.generated.resources.lib_teams_err_pin_not_recorded
 import app.skerry.ui.generated.resources.lib_teams_err_protocol
 import app.skerry.ui.generated.resources.lib_teams_err_recipient_key_changed
@@ -162,6 +163,9 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
     // Set to look at one record's history instead of the team's whole feed ("who touched this host").
     var historyRecord by remember { mutableStateOf<HistoryTarget?>(null) }
     var rolePicker by remember { mutableStateOf<TeamMember?>(null) }
+    // The member whose key the confirm ceremony is open for — the account id, not the row: the member
+    // list is refreshed on every sync signal while the dialog is up.
+    var confirmKeyFor by remember { mutableStateOf<String?>(null) }
     // Selected share space of the current team ("" = team-wide). Kept per team so switching teams
     // doesn't land on a scope id that belongs to another one.
     var selectedScope by remember { mutableStateOf("") }
@@ -206,6 +210,7 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
                     onSync = { scope.launch2 { tc.refresh(); tc.syncTeam(selected.id); afterOp() } },
                     onShowHistory = { showHistory = true },
                     onChangeRole = { member -> rolePicker = member },
+                    onConfirmKey = { accountId -> confirmKeyFor = accountId },
                     onSelectScope = { selectedScope = it },
                     onNewScope = { showCreateScope = true },
                     onScopeAccess = { scopeAccess = it },
@@ -228,10 +233,19 @@ private fun TeamsLiveView(tc: TeamsCoordinator) {
             preview = invitePreview,
             ownFingerprint = tc.ownFingerprint(),
             busy = busy,
-            onLookup = { accountId -> scope.launch2 { invitePreview = tc.previewInvite(accountId) } },
+            onLookup = { accountId -> scope.launch2 { invitePreview = tc.previewPeerKey(accountId) } },
             onEdited = { invitePreview = null },
             onSend = { id, verified, role -> inviteTeamId = null; scope.launch2 { tc.invite(id, verified, role); afterOp() } },
             onDismiss = { inviteTeamId = null },
+        )
+    }
+    confirmKeyFor?.let { accountId ->
+        ConfirmPeerKeyDialogFor(
+            tc = tc,
+            accountId = accountId,
+            busy = busy,
+            onConfirm = { verified -> confirmKeyFor = null; scope.launch2 { tc.confirmPeer(verified); afterOp() } },
+            onDismiss = { confirmKeyFor = null },
         )
     }
     val shareTeam = selected
@@ -414,6 +428,7 @@ internal fun teamsFailureText(f: TeamsFailure): String = when (f) {
     TeamsFailure.UnconfirmedKeyIgnored -> stringResource(Res.string.lib_teams_err_unconfirmed_key_ignored)
     TeamsFailure.InviteUnverified -> stringResource(Res.string.lib_teams_err_invite_unverified)
     TeamsFailure.PinNotRecorded -> stringResource(Res.string.lib_teams_err_pin_not_recorded)
+    TeamsFailure.PinMovedMeanwhile -> stringResource(Res.string.lib_teams_err_pin_moved)
     TeamsFailure.IdentityUnreadable -> stringResource(Res.string.lib_teams_err_identity_unreadable)
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
@@ -1,5 +1,7 @@
 package app.skerry.ui.teams
 
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinOrigin
 import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
@@ -124,6 +126,81 @@ class TeamsScreenModelTest {
 
         assertTrue(rows.none { it.scopesKnown })
         assertTrue(teamMemberRows(team(TeamRole.OWNER), listOf(member(owner, TeamRole.OWNER)), emptyMap(), canManage = true).all { it.scopesKnown })
+    }
+
+    /**
+     * The mark a row wears for its key. "Confirmed" may only describe a fingerprint a human read out
+     * loud, so a first sight, a record this device cannot read and an account nothing was ever sealed
+     * to are three states the row must not draw as one (#323).
+     */
+    @Test
+    fun `each row states how its member's key got on record`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(
+                member(owner, TeamRole.OWNER),
+                member(admin, TeamRole.ADMIN),
+                member(editor, TeamRole.EDITOR),
+                member(invitee, TeamRole.VIEWER),
+            ),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = owner,
+            pins = mapOf(
+                admin to Pin.Known("SHA256:aaa", PinOrigin.CONFIRMED),
+                editor to Pin.Known("SHA256:bbb", PinOrigin.FIRST_SIGHT),
+                invitee to Pin.Unreadable,
+            ),
+        )
+
+        fun trustOf(id: String) = rows.single { it.member.accountId == id }.trust
+        assertEquals(PeerTrust.SELF, trustOf(owner), "there is no ceremony with oneself")
+        assertEquals(PeerTrust.CONFIRMED, trustOf(admin))
+        assertEquals(PeerTrust.FIRST_SIGHT, trustOf(editor))
+        assertEquals(PeerTrust.UNREADABLE, trustOf(invitee))
+    }
+
+    /**
+     * Without a live session the screen cannot say whose row is whose, and reading that as "not me"
+     * put the amber "confirm this member's key" on the reader themselves.
+     */
+    @Test
+    fun `with no session to say whose row is whose, no row claims anything`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = null,
+            pins = mapOf(admin to Pin.Known("SHA256:aaa", PinOrigin.CONFIRMED)),
+        )
+
+        assertTrue(rows.all { it.trust == PeerTrust.UNKNOWN })
+        assertTrue(rows.none { it.trust.confirmable })
+    }
+
+    /**
+     * Every member but oneself is offered the ceremony — a confirmed one included. A colleague who
+     * rotates their identity leaves a pin that no longer matches their published key, and the mark is
+     * the only way back to a seal that is not refused.
+     */
+    @Test
+    fun `every member but oneself is offered the ceremony`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = owner,
+            // Nothing pinned for the other member: the state every team that predates the store is in.
+            pins = emptyMap(),
+        )
+
+        assertEquals(PeerTrust.NONE, rows.single { it.member.accountId == admin }.trust)
+        assertTrue(rows.single { it.member.accountId == admin }.trust.confirmable)
+        assertTrue(PeerTrust.CONFIRMED.confirmable, "a rotated identity has no other way back")
+        assertFalse(PeerTrust.SELF.confirmable)
+        assertFalse(PeerTrust.UNKNOWN.confirmable)
     }
 
     @Test

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/InviteBannerGateTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/InviteBannerGateTest.kt
@@ -14,7 +14,10 @@ import app.skerry.ui.generated.resources.lib_teams_invite_check_failed
 import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
+import app.skerry.ui.generated.resources.lib_teams_key_changed_unconfirmed
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinOrigin
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -79,7 +82,7 @@ class InviteBannerGateTest {
         runForm({
             accept = stringResource(Res.string.lib_teams_accept)
             InviteBanner(
-                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT)),
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, Pin.None)),
                 busy = false,
                 onAccept = {},
                 onDecline = {},
@@ -97,13 +100,39 @@ class InviteBannerGateTest {
         runForm({
             warning = stringResource(Res.string.lib_teams_invite_key_changed)
             InviteBanner(
-                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)),
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, pinned = confirmedPin(OTHER_FINGERPRINT))),
                 busy = false,
                 onAccept = {},
                 onDecline = {},
             )
         }) {
             onNodeWithText(warning).assertExists()
+        }
+    }
+
+    /**
+     * And is called out by how the record it disagrees with got there. The banner builds its own
+     * lines rather than sharing the invite dialog's block, so the two wordings can drift apart here
+     * without any other test noticing (#323).
+     */
+    @Test
+    fun `a fingerprint that moved from a first sight is worded as one nobody confirmed`() {
+        var unconfirmed = ""
+        var confirmed = ""
+        runForm({
+            unconfirmed = stringResource(Res.string.lib_teams_key_changed_unconfirmed)
+            confirmed = stringResource(Res.string.lib_teams_invite_key_changed)
+            InviteBanner(
+                InviteCheck.Verified(
+                    InvitePreview(INVITER, FINGERPRINT, pinned = Pin.Known(OTHER_FINGERPRINT, PinOrigin.FIRST_SIGHT)),
+                ),
+                busy = false,
+                onAccept = {},
+                onDecline = {},
+            )
+        }) {
+            onNodeWithText(unconfirmed).assertExists()
+            onNodeWithText(confirmed).assertDoesNotExist()
         }
     }
 
@@ -121,7 +150,7 @@ class InviteBannerGateTest {
             accept = stringResource(Res.string.lib_teams_accept)
             ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
             InviteBanner(
-                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)),
+                InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, pinned = confirmedPin(OTHER_FINGERPRINT))),
                 busy = false,
                 onAccept = {},
                 onDecline = {},
@@ -168,7 +197,7 @@ class InviteBannerGateTest {
     fun `an acknowledgement survives a re-check that answers the same fingerprint`() {
         var accept = ""
         var ack = ""
-        val verified = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true))
+        val verified = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, pinned = confirmedPin(OTHER_FINGERPRINT)))
         val check = mutableStateOf<InviteCheck>(verified)
         runForm({
             accept = stringResource(Res.string.lib_teams_accept)
@@ -181,10 +210,41 @@ class InviteBannerGateTest {
 
             runOnIdle { check.value = InviteCheck.Pending }
             waitForIdle()
-            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)) }
+            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, pinned = confirmedPin(OTHER_FINGERPRINT))) }
             waitForIdle()
 
             onNodeWithText(accept).assertIsEnabled()
+        }
+    }
+
+    /**
+     * And neither does it answer a harder question about the same fingerprint. The check re-runs on
+     * every reread, and the record it measures against arrives from this account's own devices
+     * whenever the server chooses to deliver it: a tick given for "nobody confirmed either of them"
+     * must not stand in for "this differs from the fingerprint confirmed for this account" (#323).
+     */
+    @Test
+    fun `an acknowledgement given against a first sight does not answer for a confirmed pin`() {
+        var accept = ""
+        var ack = ""
+        val check = mutableStateOf<InviteCheck>(
+            InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, Pin.Known(OTHER_FINGERPRINT, PinOrigin.FIRST_SIGHT))),
+        )
+        runForm({
+            accept = stringResource(Res.string.lib_teams_accept)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            InviteBanner(check.value, busy = false, onAccept = {}, onDecline = {})
+        }) {
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithText(accept).assertIsEnabled()
+
+            runOnIdle {
+                check.value = InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, confirmedPin(OTHER_FINGERPRINT)))
+            }
+            waitForIdle()
+
+            onNodeWithText(accept).assertIsNotEnabled()
         }
     }
 
@@ -193,7 +253,7 @@ class InviteBannerGateTest {
     fun `an acknowledgement does not carry over to another fingerprint`() {
         var accept = ""
         var ack = ""
-        val check = mutableStateOf<InviteCheck>(InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, keyChanged = true)))
+        val check = mutableStateOf<InviteCheck>(InviteCheck.Verified(InvitePreview(INVITER, FINGERPRINT, pinned = confirmedPin(OTHER_FINGERPRINT))))
         runForm({
             accept = stringResource(Res.string.lib_teams_accept)
             ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
@@ -202,7 +262,7 @@ class InviteBannerGateTest {
             onNodeWithContentDescription(ack).performClick()
             waitForIdle()
 
-            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, OTHER_FINGERPRINT, keyChanged = true)) }
+            runOnIdle { check.value = InviteCheck.Verified(InvitePreview(INVITER, OTHER_FINGERPRINT, pinned = confirmedPin(FINGERPRINT))) }
             waitForIdle()
 
             onNodeWithText(accept).assertIsNotEnabled()
@@ -211,6 +271,9 @@ class InviteBannerGateTest {
 
     private companion object {
         const val INVITER = "bob@example.com"
+        /** A fingerprint a human confirmed for the account, so a different one on screen has moved. */
+        fun confirmedPin(fingerprint: String) = Pin.Known(fingerprint, PinOrigin.CONFIRMED)
+
         const val OTHER_FINGERPRINT = "SKY-9999 8888 7777 6666"
         const val FINGERPRINT = "SKY-1111 2222 3333 4444"
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/PeerTrustBadgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/PeerTrustBadgeTest.kt
@@ -1,0 +1,134 @@
+package app.skerry.ui.teams
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_peer_confirm
+import app.skerry.ui.generated.resources.lib_teams_peer_confirmed
+import app.skerry.ui.mobile.MobileMemberRow
+import org.jetbrains.compose.resources.stringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The mark a member row wears for its key, and the ceremony it opens.
+ *
+ * It is the only way into that ceremony from the member list — the error a refused seal raises says
+ * "confirm it in the member list", and nothing else on the screen calls `onConfirmKey`. So which
+ * rows offer it, and that pressing it names the right account, is the behaviour worth pinning: with
+ * the affordance deleted the state tests all still passed (#323).
+ */
+@OptIn(ExperimentalTestApi::class)
+class PeerTrustBadgeTest {
+
+    @Test
+    fun `a key nobody confirmed wears a mark that opens the ceremony for that member`() {
+        var opened: String? = null
+        var action = ""
+        runForm({
+            action = stringResource(Res.string.lib_teams_peer_confirm)
+            TeamMemberTable(
+                rows = listOf(row(PeerTrust.FIRST_SIGHT)),
+                now = NOW,
+                onChangeRole = {},
+                onRemove = {},
+                onConfirmKey = { opened = it.member.accountId },
+            )
+        }) {
+            waitForIdle()
+            onNodeWithContentDescription(action, substring = true).performClick()
+            waitForIdle()
+        }
+        assertEquals(ACCOUNT, opened)
+    }
+
+    /**
+     * A colleague who rotates their identity leaves a confirmed pin that no longer matches their
+     * published key: every seal to them is refused from then on, and this mark is the way back. It
+     * used to be the one state that drew an inert glyph.
+     */
+    @Test
+    fun `a confirmed key still opens the ceremony`() {
+        var opened: String? = null
+        var confirmed = ""
+        runForm({
+            confirmed = stringResource(Res.string.lib_teams_peer_confirmed)
+            TeamMemberTable(
+                rows = listOf(row(PeerTrust.CONFIRMED)),
+                now = NOW,
+                onChangeRole = {},
+                onRemove = {},
+                onConfirmKey = { opened = it.member.accountId },
+            )
+        }) {
+            waitForIdle()
+            onNodeWithContentDescription(confirmed, substring = true).performClick()
+            waitForIdle()
+        }
+        assertEquals(ACCOUNT, opened, "a confirmed pin that stopped matching has no other way back")
+    }
+
+    @Test
+    fun `the own row and a row whose owner cannot be told wear no mark`() {
+        listOf(PeerTrust.SELF, PeerTrust.UNKNOWN).forEach { trust ->
+            var action = ""
+            runForm({
+                action = stringResource(Res.string.lib_teams_peer_confirm)
+                TeamMemberTable(
+                    rows = listOf(row(trust)),
+                    now = NOW,
+                    onChangeRole = {},
+                    onRemove = {},
+                    onConfirmKey = {},
+                )
+            }) {
+                waitForIdle()
+                assertTrue(
+                    onAllNodesWithContentDescription(action, substring = true).fetchSemanticsNodes().isEmpty(),
+                    "$trust must not be offered a ceremony",
+                )
+            }
+        }
+    }
+
+    /** The phone draws the same mark and opens the same ceremony. */
+    @Test
+    fun `the phone row opens the ceremony too`() {
+        var opened = false
+        var action = ""
+        runForm({
+            action = stringResource(Res.string.lib_teams_peer_confirm)
+            MobileMemberRow(row(PeerTrust.NONE), now = NOW, onChangeRole = {}, onRemove = {}, onConfirmKey = { opened = true })
+        }) {
+            waitForIdle()
+            onNodeWithContentDescription(action, substring = true).performClick()
+            waitForIdle()
+        }
+        assertTrue(opened)
+    }
+}
+
+private fun row(trust: PeerTrust) = TeamMemberRowUi(
+    member = TeamMember(
+        accountId = ACCOUNT,
+        role = TeamRole.EDITOR,
+        status = TeamMemberStatus.ACTIVE,
+        createdAt = NOW,
+        lastSeenAt = NOW,
+    ),
+    isOwner = false,
+    scopes = emptyList(),
+    scopesKnown = true,
+    manageable = true,
+    trust = trust,
+)
+
+private const val ACCOUNT = "bob@example.com"
+private const val NOW = 1_700_000_000_000L

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamMemberNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamMemberNameTest.kt
@@ -29,6 +29,7 @@ class TeamMemberNameTest {
             now = NOW,
             onChangeRole = {},
             onRemove = {},
+            onConfirmKey = {},
         )
     }) {
         onNodeWithText(FLATTENED).assertIsDisplayed()
@@ -38,7 +39,7 @@ class TeamMemberNameTest {
     /** The phone draws the same row, and the removal it opens is irreversible. */
     @Test
     fun `the phone member row draws the account id flattened`() = runForm({
-        MobileMemberRow(row(), now = NOW, onChangeRole = {}, onRemove = {})
+        MobileMemberRow(row(), now = NOW, onChangeRole = {}, onRemove = {}, onConfirmKey = {})
     }) {
         onNodeWithText(FLATTENED).assertIsDisplayed()
         onNodeWithText(SPOOFED).assertDoesNotExist()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteBindingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorInviteBindingTest.kt
@@ -121,7 +121,7 @@ class TeamsCoordinatorInviteBindingTest {
         val client = FakeInviteClient(bob, keysOf(real))
         val coord = coordinator(f, client)
 
-        val preview = assertNotNull(coord.previewInvite(bob), "lookup must return a fingerprint")
+        val preview = assertNotNull(coord.previewPeerKey(bob), "lookup must return a fingerprint")
         // The server swaps its answer between the two steps: the fingerprint the user just read out
         // loud is no longer the key the second fetch returns.
         client.bobKeys = keysOf(crypto.newSharingKeyPair())
@@ -146,7 +146,7 @@ class TeamsCoordinatorInviteBindingTest {
         val client = FakeInviteClient(bob, keysOf(real))
         val coord = coordinator(f, client)
 
-        val preview = assertNotNull(coord.previewInvite(bob))
+        val preview = assertNotNull(coord.previewPeerKey(bob))
         client.bobKeys = AccountKeys(real.publicKey, crypto.newSigningKeyPair().publicKey)
         coord.invite(teamId, preview, TeamRole.VIEWER)
 
@@ -164,7 +164,7 @@ class TeamsCoordinatorInviteBindingTest {
         val client = FakeInviteClient(bob, keysOf(real))
         val coord = coordinator(f, client)
 
-        val preview = assertNotNull(coord.previewInvite(bob))
+        val preview = assertNotNull(coord.previewPeerKey(bob))
         coord.invite(teamId, preview, TeamRole.VIEWER)
 
         assertNull(coord.lastError.value)

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.team.AccountKeys
 import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinOrigin
 import app.skerry.shared.team.TeamIdentityStore
 import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamKeyStore
@@ -87,8 +88,12 @@ class TeamsCoordinatorPeerPinTest {
         /** How many times each account's key was fetched — the double fetch is the hole (#319 item 1). */
         val fetches = mutableMapOf<String, Int>()
 
+        /** Run inside the lookup, for whatever the round trip is supposed to give the world time to do. */
+        var duringFetch: (() -> Unit)? = null
+
         override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
             fetches[accountId] = (fetches[accountId] ?: 0) + 1
+            duringFetch?.invoke()
             return published[accountId]?.keys
         }
 
@@ -515,7 +520,7 @@ class TeamsCoordinatorPeerPinTest {
         )
         val coord = coordinator(f, client)
 
-        val first = assertNotNull(coord.previewInvite(bob))
+        val first = assertNotNull(coord.previewPeerKey(bob))
         assertFalse(first.keyChanged, "nothing was ever pinned for this account, so nothing moved")
         coord.invite(teamId, first, TeamRole.VIEWER)
         assertEquals(listOf(bob), client.invites)
@@ -523,7 +528,7 @@ class TeamsCoordinatorPeerPinTest {
         // The server publishes another key for the same colleague after the ceremony.
         client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
 
-        val second = assertNotNull(coord.previewInvite(bob))
+        val second = assertNotNull(coord.previewPeerKey(bob))
         assertTrue(second.keyChanged, "the fingerprint differs from the pinned one and the user must be told")
         // …and until a human confirms the new one, nothing is sealed to it.
         coord.createScope(teamId, "Production")
@@ -753,7 +758,7 @@ class TeamsCoordinatorPeerPinTest {
         val client = FakePeerClient(self, teamId)
         client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
         val coord = coordinator(f, client)
-        val preview = assertNotNull(coord.previewInvite(bob))
+        val preview = assertNotNull(coord.previewPeerKey(bob))
         TeamKeyStore(f.vault).put(pinIdOf(f, bob), "Squat", TeamRole.VIEWER, crypto.newDataKey(), epoch = 0)
 
         coord.invite(teamId, preview, TeamRole.VIEWER)
@@ -780,6 +785,182 @@ class TeamsCoordinatorPeerPinTest {
         assertEquals(emptyList(), client.accepted)
         assertNull(TeamKeyStore(f.vault).get(teamId), "no key is adopted without a pin to hold it to")
         assertEquals(TeamsFailure.PinNotRecorded, coord.lastError.value)
+    }
+
+    /**
+     * A scope grant pins whatever the server answered, and until #323 that pin was indistinguishable
+     * from one a human read out loud. Confirming from the member list is what promotes it: the same
+     * fingerprint, a different claim about who vouched for it.
+     */
+    @Test
+    fun `confirming from the member list promotes a first sight pin without moving it`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob)
+
+        val first = assertIs<Pin.Known>(coord.peerPins(listOf(bob))[bob])
+        assertEquals(PinOrigin.FIRST_SIGHT, first.origin, "nobody read this fingerprint out loud")
+
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+        coord.confirmPeer(ready.preview)
+
+        val after = assertIs<Pin.Known>(coord.peerPins(listOf(bob))[bob])
+        assertEquals(PinOrigin.CONFIRMED, after.origin)
+        assertEquals(first.fingerprint, after.fingerprint, "confirming records who vouched, it does not move the key")
+        assertNull(coord.lastError.value)
+    }
+
+    /**
+     * The confirm re-fetches the key for the same reason the invite does (#316): the fingerprint on
+     * screen is what the user read out loud, and the server owns the key table. Answering the confirm
+     * with a different key must not have the record claim a human confirmed it.
+     */
+    @Test
+    fun `a confirm the server answers with another key leaves the pin as it was`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob)
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+
+        // The server swaps the key between the fingerprint being read out loud and the confirm.
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.confirmPeer(ready.preview)
+
+        assertEquals(TeamsFailure.RecipientKeyChanged, coord.lastError.value)
+        val after = assertIs<Pin.Known>(coord.peerPins(listOf(bob))[bob])
+        assertEquals(PinOrigin.FIRST_SIGHT, after.origin, "the ceremony did not reach the key that is now published")
+        assertEquals(ready.preview.fingerprint, after.fingerprint)
+    }
+
+    /** A vault that locked between the fingerprint being read out loud and the press writes nothing. */
+    @Test
+    fun `a confirm against a vault that locked meanwhile records nothing`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        val coord = coordinator(f, client)
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+
+        f.vault.lock()
+        coord.confirmPeer(ready.preview)
+
+        assertEquals(TeamsFailure.VaultLocked, coord.lastError.value)
+        f.vault.unlock("master".toCharArray())
+        assertEquals(Pin.None, TeamPeerStore(f.vault).pin(bob), "nothing was written")
+    }
+
+    /**
+     * And so does one that locks during the round trip the press starts. The confirm re-fetches the
+     * key before writing (#316), which is a suspension long enough for an idle timer to fire — the
+     * check the press passed on its way in says nothing about the state the write lands in.
+     */
+    @Test
+    fun `a confirm against a vault that locks during the lookup records nothing`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        val coord = coordinator(f, client)
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+
+        client.duringFetch = { f.vault.lock() } // the idle timer fires while the key is in flight
+        coord.confirmPeer(ready.preview)
+
+        assertEquals(TeamsFailure.VaultLocked, coord.lastError.value)
+        f.vault.unlock("master".toCharArray())
+        assertEquals(Pin.None, TeamPeerStore(f.vault).pin(bob), "nothing was written")
+    }
+
+    /**
+     * The acknowledgement a moved pin costs is decided from the record the ceremony was drawn against.
+     * These records sync between this account's own devices, so the server chooses when one lands: it
+     * must not be able to slip one in behind a dialog that has already asked its question (#323).
+     */
+    @Test
+    fun `a confirm is refused when the record moved while the fingerprint was on screen`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val client = FakePeerClient(self, teamId)
+        val keys = keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair())
+        client.published[bob] = Published(keys)
+        val coord = coordinator(f, client)
+        // The dialog opens against an empty record and demands no acknowledgement…
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+        assertEquals(Pin.None, ready.preview.pinned)
+
+        // …and a pin for another key lands from the account's own sync before the press.
+        TeamPeerStore(f.vault).confirm(bob, "an-older-fingerprint")
+        coord.confirmPeer(ready.preview)
+
+        assertEquals(TeamsFailure.PinMovedMeanwhile, coord.lastError.value)
+        assertEquals(
+            Pin.Known("an-older-fingerprint", PinOrigin.CONFIRMED),
+            TeamPeerStore(f.vault).pin(bob),
+            "the record the ceremony never saw stands",
+        )
+    }
+
+    /**
+     * The same gate on the invitee's side, where the press adopts a team key. The banner decides its
+     * acknowledgement from the pin it read when it drew the fingerprint, so a record landing behind
+     * it must not turn an unanswered question into an answered one (#323).
+     */
+    @Test
+    fun `an accept is refused when the record moved while the fingerprint was on the banner`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId)) // drawn against an empty record
+
+        // A pin for another key arrives from this account's own sync before Accept is pressed.
+        TeamPeerStore(f.vault).confirm(bob, "an-older-fingerprint")
+        coord.accept(teamId)
+
+        assertEquals(TeamsFailure.PinMovedMeanwhile, coord.lastError.value)
+        assertEquals(emptyList(), client.accepted)
+        assertNull(TeamKeyStore(f.vault).get(teamId), "no key is adopted against a record nobody was shown")
+    }
+
+    /** A confirm whose record cannot be written says so, rather than reading as a confirmation. */
+    @Test
+    fun `a confirm whose pin cannot be written is reported`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        val coord = coordinator(f, client)
+        val ready = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob))
+        TeamKeyStore(f.vault).put(pinIdOf(f, bob), "Squat", TeamRole.VIEWER, crypto.newDataKey(), epoch = 0)
+
+        coord.confirmPeer(ready.preview)
+
+        assertEquals(TeamsFailure.PinNotRecorded, coord.lastError.value)
+        assertEquals(Pin.Unreadable, coord.peerPins(listOf(bob))[bob])
     }
 
     /**

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
@@ -18,9 +18,15 @@ import app.skerry.shared.team.TeamRole
 import app.skerry.ui.app.UiTags
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed
+import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
+import app.skerry.ui.generated.resources.lib_teams_key_changed_unconfirmed
+import app.skerry.ui.generated.resources.lib_teams_key_pin_unreadable
+import app.skerry.ui.generated.resources.lib_teams_peer_state_first_sight
 import app.skerry.ui.desktop.runForm
 import org.jetbrains.compose.resources.stringResource
+import app.skerry.shared.team.Pin
+import app.skerry.shared.team.PinOrigin
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -89,7 +95,7 @@ class TeamsDialogFormTest {
         var sent: Pair<InvitePreview, TeamRole>? = null
         runForm({
             InviteMemberDialog(
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.None),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
@@ -119,7 +125,7 @@ class TeamsDialogFormTest {
         runForm({
             warning = stringResource(Res.string.lib_teams_invite_key_changed)
             InviteMemberDialog(
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, keyChanged = true),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.Known(MOVED_FROM, PinOrigin.CONFIRMED)),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
@@ -147,7 +153,7 @@ class TeamsDialogFormTest {
         runForm({
             ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
             InviteMemberDialog(
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, keyChanged = true),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.Known(MOVED_FROM, PinOrigin.CONFIRMED)),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
@@ -175,7 +181,7 @@ class TeamsDialogFormTest {
         runForm({
             warning = stringResource(Res.string.lib_teams_invite_key_changed)
             InviteMemberDialog(
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.None),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
@@ -192,6 +198,173 @@ class TeamsDialogFormTest {
     }
 
     /**
+     * The member list's own ceremony (#323). A first sight is what the server answered when something
+     * was first sealed to the account: nothing about it has to be acknowledged, it simply has never
+     * been vouched for, and confirming is exactly that — the fingerprint on screen, read out loud.
+     */
+    @Test
+    fun `a first sight key is confirmed with the fingerprint that is on screen`() {
+        var confirmed: InvitePreview? = null
+        runForm({
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = PeerKeyVerdict.Ready(
+                    InvitePreview(ACCOUNT, PEER_FINGERPRINT, pinned = Pin.Known(PEER_FINGERPRINT, PinOrigin.FIRST_SIGHT)),
+                ),
+                trust = PeerTrust.FIRST_SIGHT,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = {},
+                onConfirm = { confirmed = it },
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsEnabled().performClick()
+            waitForIdle()
+        }
+        assertEquals(PEER_FINGERPRINT, confirmed?.fingerprint)
+    }
+
+    /**
+     * A key that moved costs the same second gesture here as it does on the invite — and says so in
+     * its own words: neither the record nor the key on screen was ever confirmed by anyone, which is
+     * not the sentence a moved *confirmed* pin gets.
+     */
+    @Test
+    fun `a key that moved from a first sight is worded as such and still costs the acknowledgement`() {
+        var warning = ""
+        var confirmedWording = ""
+        var ack = ""
+        var confirmed: InvitePreview? = null
+        runForm({
+            warning = stringResource(Res.string.lib_teams_key_changed_unconfirmed)
+            confirmedWording = stringResource(Res.string.lib_teams_invite_key_changed)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = PeerKeyVerdict.Ready(
+                    InvitePreview(ACCOUNT, PEER_FINGERPRINT, pinned = Pin.Known(MOVED_FROM, PinOrigin.FIRST_SIGHT)),
+                ),
+                trust = PeerTrust.FIRST_SIGHT,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = {},
+                onConfirm = { confirmed = it },
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            onNodeWithText(warning).assertExists()
+            onNodeWithText(confirmedWording).assertDoesNotExist()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).performClick()
+            waitForIdle()
+        }
+        assertEquals(PEER_FINGERPRINT, confirmed?.fingerprint, "the confirm carries the fingerprint that was acknowledged")
+    }
+
+    /**
+     * A record this device cannot read has nothing to compare the fingerprint against, so it asks the
+     * same second question a moved pin does — the fail-closed branch `pinNotice` exists for.
+     */
+    @Test
+    fun `a pin this device cannot read still costs the acknowledgement`() {
+        var warning = ""
+        var ack = ""
+        var confirmed: InvitePreview? = null
+        runForm({
+            warning = stringResource(Res.string.lib_teams_key_pin_unreadable)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = PeerKeyVerdict.Ready(InvitePreview(ACCOUNT, PEER_FINGERPRINT, pinned = Pin.Unreadable)),
+                trust = PeerTrust.UNREADABLE,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = {},
+                onConfirm = { confirmed = it },
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            onNodeWithText(warning).assertExists()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).performClick()
+            waitForIdle()
+        }
+        assertEquals(PEER_FINGERPRINT, confirmed?.fingerprint)
+    }
+
+    /**
+     * The one fact the decision turns on has to be spoken. What the record already held arrives from
+     * a vault read that starts when the dialog mounts, so its line is inserted after a screen reader
+     * has read the dialog — and a node inserted with its text announces nothing. It goes into the
+     * live region with the fingerprint, or the user confirming a key is never told whether they are
+     * replacing something a human vouched for (WCAG 4.1.3).
+     */
+    @Test
+    fun `the dialog announces what the record held, not only the fingerprint`() {
+        var state by mutableStateOf(PeerTrust.UNKNOWN)
+        var wording = ""
+        runForm({
+            wording = stringResource(Res.string.lib_teams_peer_state_first_sight)
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = PeerKeyVerdict.Ready(
+                    InvitePreview(ACCOUNT, PEER_FINGERPRINT, pinned = Pin.Known(PEER_FINGERPRINT, PinOrigin.FIRST_SIGHT)),
+                ),
+                trust = state,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = {},
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            state = PeerTrust.FIRST_SIGHT
+            waitForIdle()
+            onNodeWithContentDescription(wording, substring = true).assertExists()
+            onNodeWithContentDescription(PEER_FINGERPRINT, substring = true).assertExists()
+        }
+    }
+
+    /** Nothing is confirmable before the key is on screen, and a lookup that failed offers a retry. */
+    @Test
+    fun `a key still being fetched confirms nothing, and a failed one retries`() {
+        var retried = 0
+        var check by mutableStateOf<PeerKeyVerdict?>(null)
+        var retry = ""
+        runForm({
+            retry = stringResource(Res.string.lib_teams_invite_check_retry)
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = check,
+                trust = PeerTrust.NONE,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = { retried += 1 },
+                onConfirm = {},
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+            check = PeerKeyVerdict.Failed(TeamsFailure.NotConnected)
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled()
+            onNodeWithText(retry).performClick()
+            waitForIdle()
+        }
+        assertEquals(1, retried)
+    }
+
+    /**
      * Editing the id after a lookup makes the fingerprint on screen the wrong one. The dialog says so
      * through [onEdited], and the press must go back to being a lookup rather than a send.
      */
@@ -201,7 +374,7 @@ class TeamsDialogFormTest {
         var sent: Pair<InvitePreview, TeamRole>? = null
         runForm({
             InviteMemberDialog(
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.None),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 assignableRoles = listOf(TeamRole.ADMIN, TeamRole.VIEWER),
@@ -232,7 +405,7 @@ class TeamsDialogFormTest {
             InviteMemberDialogForTeam(
                 teams = teams,
                 teamId = TEAM_ID,
-                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT),
+                preview = InvitePreview(accountId = ACCOUNT, fingerprint = PEER_FINGERPRINT, pinned = Pin.None),
                 ownFingerprint = OWN_FINGERPRINT,
                 busy = false,
                 onLookup = {},
@@ -297,3 +470,6 @@ private const val ACCOUNT = "alice@example.com"
 private const val OTHER_ACCOUNT = "mallory@example.com"
 private const val OWN_FINGERPRINT = "SHA256:ownownownownownownownownownownownownownownow"
 private const val PEER_FINGERPRINT = "SHA256:peerpeerpeerpeerpeerpeerpeerpeerpeerpeerpeer"
+
+/** What the account was confirmed under before — so the fingerprint on screen has moved. */
+private const val MOVED_FROM = "SHA256:oldoldoldoldoldoldoldoldoldoldoldoldoldoldold"

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/PinNotice.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/PinNotice.kt
@@ -1,0 +1,33 @@
+package app.skerry.shared.team
+
+/**
+ * What the record says against a fingerprint that is on screen waiting to be confirmed. [NOTHING] is
+ * the quiet case — the record agrees, or there is none — and the other three each cost a second,
+ * deliberate gesture before the ceremony may proceed.
+ *
+ * Beside the record rather than in the screens that word it: it is the question the user is asked,
+ * and [TeamPeerStore.confirm] refuses a write whose question has changed since. A copy of this rule
+ * on the UI side is a copy the store could not hold the write to.
+ */
+enum class PinNotice {
+    /** The record agrees with the fingerprint, or nothing was ever recorded to disagree with it. */
+    NOTHING,
+
+    /** It differs from one a human confirmed: an honest rotation, or the server trying its luck. */
+    MOVED_FROM_CONFIRMED,
+
+    /** It differs from a first sight — nobody has confirmed either key, and neither is worth more. */
+    MOVED_FROM_FIRST_SIGHT,
+
+    /** A record exists and this device cannot read it, so there is nothing to compare against. */
+    UNREADABLE,
+}
+
+/** How [pinned] measures against a [fingerprint] about to be confirmed. */
+fun pinNotice(pinned: Pin, fingerprint: String): PinNotice = when {
+    pinned is Pin.Known && pinned.fingerprint == fingerprint -> PinNotice.NOTHING
+    pinned is Pin.Known && pinned.origin == PinOrigin.CONFIRMED -> PinNotice.MOVED_FROM_CONFIRMED
+    pinned is Pin.Known -> PinNotice.MOVED_FROM_FIRST_SIGHT
+    pinned == Pin.Unreadable -> PinNotice.UNREADABLE
+    else -> PinNotice.NOTHING
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamPeerStore.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/team/TeamPeerStore.kt
@@ -3,6 +3,7 @@ package app.skerry.shared.team
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
+import app.skerry.shared.vault.VaultRecord
 import app.skerry.shared.vault.VaultRecordCodec
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -20,7 +21,30 @@ import kotlinx.serialization.Serializable
  * what makes one verification durable — it is the fingerprint every later fetch is held to.
  */
 @Serializable
-data class TeamPeerEntry(val fingerprint: String)
+data class TeamPeerEntry(
+    val fingerprint: String,
+    /**
+     * How the fingerprint got here. Defaulted rather than required, and defaulted to the weaker of
+     * the two: records written before this field existed carry no claim at all, and reading them as
+     * a confirmation would put the word on a fingerprint nobody read out loud — the defect this
+     * field exists to fix (#323). Such a pin still guards every seal; it is only asked to be
+     * confirmed from the member list before a screen calls it confirmed.
+     */
+    val origin: PinOrigin = PinOrigin.FIRST_SIGHT,
+)
+
+/**
+ * How a pinned fingerprint was established. The distinction is the whole point of the record: a key
+ * the server answered with is held to from then on, but nobody vouched for it, and only a human on a
+ * channel the server does not own can turn it into a confirmation (#323).
+ */
+enum class PinOrigin {
+    /** A human read the fingerprint out loud: the invite ceremony, or the member list's own confirm. */
+    CONFIRMED,
+
+    /** Whatever the server answered the first time something was sealed to the account. */
+    FIRST_SIGHT,
+}
 
 /** What this account holds for a peer: nothing, something it cannot read, or a fingerprint. */
 sealed interface Pin {
@@ -35,8 +59,25 @@ sealed interface Pin {
      */
     data object Unreadable : Pin
 
-    /** The fingerprint pinned for the account. */
-    class Known(val fingerprint: String) : Pin
+    /**
+     * The fingerprint pinned for the account, and what the record claims about it.
+     *
+     * A data class because a pin is compared: the ceremony carries the one it was shown into the
+     * write that replaces it, and screens hold it inside their own state.
+     */
+    data class Known(val fingerprint: String, val origin: PinOrigin) : Pin
+}
+
+/** What a [TeamPeerStore.confirm] did, or why it did nothing. */
+enum class ConfirmOutcome {
+    /** The fingerprint is on record, confirmed. */
+    RECORDED,
+
+    /** The record moved between the ceremony and the write, so what was shown is not what was replaced. */
+    MOVED,
+
+    /** The id is not this store's to write: a record of another type holds it. */
+    REFUSED,
 }
 
 /** Store of [RecordType.TEAM_PEER] records. Synced between the account's own devices like team keys. */
@@ -56,24 +97,54 @@ class TeamPeerStore(
     /** What is pinned for [accountId]. */
     fun pin(accountId: String): Pin = vault.transaction {
         if (!vault.isUnlocked) return@transaction Pin.Unreadable
-        val id = recordId(accountId)
-        // One transaction for both reads: a compact landing between them would drop the record
-        // `codec.get` just failed on, and the fallback would read the fail-open answer.
-        codec.get(id)?.let { return@transaction Pin.Known(it.fingerprint) }
-        // codec.get answers null for "absent", "tombstoned", "present but does not decrypt" and
-        // "present as another type" alike. Both of the last two mean a pin this device cannot read:
-        // a blob that stopped opening (an adopted account key), or a record the server named after
-        // this id and got there first. Reading either as "nothing pinned" would pin whatever the
-        // server publishes next — so any live record at the id fails the read closed.
-        // [None] is answered exactly when a first-sight pin could be written here, and a tombstone
-        // holds an id's type until compaction — so a deleted TEAM the server named after this pin
-        // leaves the slot unwritable just as a live one does. Reading that as "nothing was ever
-        // pinned" would pin on first sight, silently drop the write, and call the next fetch first
-        // sight again: every later seal follows whatever the server publishes, forever and without
-        // a word (#319 reopened for that account). Unwritable reads as unreadable, which fails closed.
-        val at = recordAt(id)
-        if (at == null || (at.deleted && at.type == RecordType.TEAM_PEER)) Pin.None else Pin.Unreadable
+        // One transaction for the lookup and the read it decides: a compact landing between them
+        // would drop the record the payload read is about to ask for.
+        pinAt(recordAt(recordId(accountId)))
     }
+
+    /**
+     * What [record] — whatever sits at a pin's id, of any type, tombstoned or not — says is pinned
+     * for that account.
+     *
+     * A payload that does not decrypt, and a record of another type the server named after this id
+     * and got there first, both mean a pin this device cannot read. Reading either as "nothing
+     * pinned" would pin whatever the server publishes next — so any live record at the id fails the
+     * read closed. [Pin.None] is answered exactly when a first-sight pin could be written here, and
+     * a tombstone holds an id's type until compaction: a deleted TEAM the server named after this
+     * pin leaves the slot unwritable just as a live one does. Reading that as "nothing was ever
+     * pinned" would pin on first sight, silently drop the write, and call the next fetch first sight
+     * again — every later seal following whatever the server publishes, forever and without a word
+     * (#319 reopened for that account). Unwritable reads as unreadable, which fails closed.
+     */
+    private fun pinAt(record: VaultRecord?): Pin {
+        if (record != null && record.type == RecordType.TEAM_PEER && !record.deleted) {
+            codec.decode(vault.openPayload(record.id))
+                ?.let { return Pin.Known(it.fingerprint, it.origin) }
+        }
+        return if (record == null || (record.deleted && record.type == RecordType.TEAM_PEER)) Pin.None else Pin.Unreadable
+    }
+
+    /**
+     * What is pinned for each of [accountIds] — the member list's read, in one transaction so every
+     * row of one paint answers against the same vault state.
+     *
+     * Suspending, and on [vaultDispatcher] for the same reason the write path is: the transaction
+     * takes the account vault's single lock, which every write holds across a whole-file re-serialize
+     * and rewrite. Read from a composition it would block the frame for the length of a sync merge's
+     * commit.
+     */
+    suspend fun pins(accountIds: Collection<String>): Map<String, Pin> =
+        withContext(vaultDispatcher) {
+            vault.transaction {
+                if (!vault.isUnlocked) return@transaction accountIds.associateWith { Pin.Unreadable }
+                // One pass over the record list for the whole table. [pin] scans it per account — and
+                // twice for one with no pin, which is the common case — while the member list is the
+                // server's to size and this runs inside the account vault's single lock.
+                val wanted = accountIds.mapTo(mutableSetOf()) { recordId(it) }
+                val found = vault.records().filter { it.id in wanted }.associateBy { it.id }
+                accountIds.associateWith { pinAt(found[recordId(it)]) }
+            }
+        }
 
     /**
      * The record at [id], of this type or another, tombstoned or not. Tombstones count for the write
@@ -83,24 +154,38 @@ class TeamPeerStore(
     private fun recordAt(id: String) = vault.records().firstOrNull { it.id == id }
 
     /**
-     * Pin a fingerprint a human just confirmed out of band (the invite send, the invite accept).
-     * Replaces whatever was pinned: an honest identity rotation is re-confirmed by the same ceremony
-     * that pinned the first key, and the user is shown that it moved before they get here.
+     * Pin a fingerprint a human just confirmed out of band (the invite send, the invite accept, the
+     * member list's own ceremony). Replaces whatever was pinned: an honest identity rotation is
+     * re-confirmed by the same ceremony that pinned the first key, and the user is shown that it
+     * moved before they get here.
      *
-     * Answers `false` when the id is not this store's to write — a record of another type is sitting
-     * on it. The ceremony the caller was about to record has to stop there.
+     * [shown] is what the ceremony was drawn against — pass it and the write is refused if the record
+     * moved since. What a moved pin costs is a second, deliberate acknowledgement, and that gate is
+     * decided from a pin read when the screen opened: the records sync between this account's own
+     * devices, and the server chooses when one arrives. Delivering it after the dialog said "nothing
+     * is on record" would otherwise replace a confirmed pin with no gate at all. Null means the
+     * caller has no ceremony to hold the write to.
      */
-    fun confirm(accountId: String, fingerprint: String): Boolean {
+    fun confirm(accountId: String, fingerprint: String, shown: Pin? = null): ConfirmOutcome {
         check(vault.isUnlocked) { "pinning a peer needs an unlocked vault" }
         return vault.transaction {
             val id = recordId(accountId)
-            // False rather than a throw when another record already holds the id: [Vault.put] refuses
+            // Refused rather than thrown when another record already holds the id: [Vault.put] refuses
             // to re-type a record, and the caller has to stop the ceremony it was about to record —
-            // sealing a key whose confirmation cannot be written is worse than not sealing it.
+            // sealing a key whose confirmation cannot be written is worse than not sealing it. Checked
+            // before [shown], because an id this store cannot write is the more specific answer.
             val squat = recordAt(id)
-            if (squat != null && squat.type != RecordType.TEAM_PEER) return@transaction false
-            codec.put(id, TeamPeerEntry(fingerprint))
-            true
+            if (squat != null && squat.type != RecordType.TEAM_PEER) return@transaction ConfirmOutcome.REFUSED
+            // Measured on what the ceremony's gate was decided from — [pinNotice] against the
+            // fingerprint about to be written — rather than on the record as a whole. A first sight
+            // of that very fingerprint landing mid-ceremony contradicts nothing the user was told,
+            // and refusing there would throw away a phone call; a record that became a *confirmed*
+            // one asks a harder question than the one they answered, and does refuse.
+            if (shown != null && pinNotice(pin(accountId), fingerprint) != pinNotice(shown, fingerprint)) {
+                return@transaction ConfirmOutcome.MOVED
+            }
+            codec.put(id, TeamPeerEntry(fingerprint, PinOrigin.CONFIRMED))
+            ConfirmOutcome.RECORDED
         }
     }
 
@@ -117,7 +202,7 @@ class TeamPeerStore(
             // store's record still holds — a write the vault would refuse anyway.
             val at = recordAt(id)
             if (at == null || (at.deleted && at.type == RecordType.TEAM_PEER)) {
-                codec.put(id, TeamPeerEntry(fingerprint))
+                codec.put(id, TeamPeerEntry(fingerprint, PinOrigin.FIRST_SIGHT))
             }
         }
     }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamPeerStoreTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/team/TeamPeerStoreTest.kt
@@ -24,6 +24,7 @@ class TeamPeerStoreTest {
 
     private val session = SyncSession("alice@example.com", "access", "refresh")
     private val bob = "bob@example.com"
+    private val carol = "carol@example.com"
 
     /** A client whose key table answers with whatever it was last set to — i.e. the sync server. */
     private class FakeKeys(var keys: AccountKeys?) : TeamClient {
@@ -240,7 +241,7 @@ class TeamPeerStoreTest {
 
         assertEquals(Pin.Unreadable, store.pin(bob))
         assertIs<PeerKeys.Unconfirmed>(store.fetchPinned(session, FakeKeys(keys(1)), bob))
-        assertFalse(store.confirm(bob, "aaaa-bbbb"), "an id another record holds is not this store's")
+        assertEquals(ConfirmOutcome.REFUSED, store.confirm(bob, "aaaa-bbbb"), "an id another record holds is not this store's")
         // Neither adopted nor destroyed: the squat is the server's doing, and this client leaves it
         // exactly where it is while refusing to read a pin out of it.
         val squat = vault.records().single { it.id == squatId }
@@ -266,7 +267,7 @@ class TeamPeerStoreTest {
         vault.remove(squatId)
 
         assertEquals(Pin.Unreadable, store.pin(bob), "a pin that cannot be written cannot be trusted")
-        assertFalse(store.confirm(bob, "aaaa-bbbb"))
+        assertEquals(ConfirmOutcome.REFUSED, store.confirm(bob, "aaaa-bbbb"))
         // Refused, not thrown: whatever ceremony asked for the pin reports it and stops, rather than
         // unwinding on an exception from the vault.
         store.rememberFirstSight(bob, "aaaa-bbbb")
@@ -287,10 +288,158 @@ class TeamPeerStoreTest {
         vault.unreadable += vault.records().single { it.type == RecordType.TEAM_PEER }.id
 
         assertEquals(Pin.Unreadable, store.pin(bob))
-        assertTrue(store.confirm(bob, "cccc-dddd"))
+        assertEquals(ConfirmOutcome.RECORDED, store.confirm(bob, "cccc-dddd"))
 
         vault.unreadable.clear()
         assertEquals("cccc-dddd", pinned(store, bob))
+    }
+
+    /**
+     * The two ways a fingerprint reaches the record are not the same claim, and the record used to
+     * hold neither: an invite ceremony and whatever the server answered on a first grant both left
+     * the same [Pin.Known], so the screens could only say "pinned" and called it "confirmed" (#323).
+     */
+    @Test
+    fun `a pin says whether a human confirmed it or the server was simply first`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+        assertEquals(PinOrigin.FIRST_SIGHT, origin(store, bob))
+
+        store.confirm(carol, "cccc-dddd")
+        assertEquals(PinOrigin.CONFIRMED, origin(store, carol))
+    }
+
+    /**
+     * Confirming a key this device had only ever seen is the promotion the member list exists for:
+     * the fingerprint does not move, but what the record claims about it does.
+     */
+    @Test
+    fun `confirming a first sight pin promotes it without moving the fingerprint`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+
+        assertEquals(ConfirmOutcome.RECORDED, store.confirm(bob, "aaaa-bbbb"))
+
+        assertEquals("aaaa-bbbb", pinned(store, bob))
+        assertEquals(PinOrigin.CONFIRMED, origin(store, bob))
+    }
+
+    /**
+     * Records written before the provenance existed carry no claim at all. Reading them as confirmed
+     * would put the word on a fingerprint nobody ever read out loud — which is the whole defect — so
+     * an absent provenance is a first sight, and the member list asks for the ceremony.
+     */
+    @Test
+    fun `a pin written before provenance was recorded reads as a first sight`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        vault.put(pinIdOf(bob), RecordType.TEAM_PEER, """{"fingerprint":"aaaa-bbbb"}""".encodeToByteArray())
+
+        assertEquals("aaaa-bbbb", pinned(store, bob))
+        assertEquals(PinOrigin.FIRST_SIGHT, origin(store, bob))
+    }
+
+    /** One vault pass for a whole member list, and every row of it reading the same vault state. */
+    @Test
+    fun `pins answers for a whole list, absent accounts included`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.confirm(bob, "aaaa-bbbb")
+
+        val pins = store.pins(listOf(bob, carol))
+
+        assertEquals("aaaa-bbbb", (pins[bob] as? Pin.Known)?.fingerprint)
+        assertEquals(Pin.None, pins[carol], "an account nothing was ever sealed to has no pin")
+    }
+
+    /**
+     * What a moved pin costs is a second, deliberate acknowledgement, and that gate is decided from a
+     * pin read when the ceremony opened. These records sync between this account's own devices and
+     * the server chooses when one arrives: delivered after the screen said "nothing is on record", it
+     * would replace a confirmed pin having asked nothing (#323).
+     */
+    @Test
+    fun `a confirmation is refused when the record moved since the ceremony saw it`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val shown = store.pin(bob) // nothing on record: the dialog demands no acknowledgement
+
+        store.rememberFirstSight(bob, "aaaa-bbbb") // …and the record lands while it is on screen
+
+        assertEquals(ConfirmOutcome.MOVED, store.confirm(bob, "cccc-dddd", shown))
+        assertEquals("aaaa-bbbb", pinned(store, bob), "the record the ceremony never saw stands")
+        assertEquals(PinOrigin.FIRST_SIGHT, origin(store, bob))
+    }
+
+    @Test
+    fun `a confirmation against the record the ceremony saw is written`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+        val shown = store.pin(bob)
+
+        assertEquals(ConfirmOutcome.RECORDED, store.confirm(bob, "cccc-dddd", shown))
+        assertEquals("cccc-dddd", pinned(store, bob))
+        assertEquals(PinOrigin.CONFIRMED, origin(store, bob))
+    }
+
+    /** An id this store cannot write is the more specific answer, and outranks the moved check. */
+    @Test
+    fun `a squatted id is refused rather than reported as moved`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val shown = store.pin(bob)
+        vault.put(pinIdOf(bob), RecordType.TEAM, "team key".encodeToByteArray())
+
+        assertEquals(ConfirmOutcome.REFUSED, store.confirm(bob, "cccc-dddd", shown))
+    }
+
+    /**
+     * The refusal is measured on what the ceremony's question was decided from, not on the record
+     * as a whole. A first sight landing on the very fingerprint the user just read out loud
+     * contradicts nothing they were told — refusing there would throw away a phone call because a
+     * rotation happened to seal to the same key while it was being made (#323).
+     */
+    @Test
+    fun `a first sight of the fingerprint on screen does not refuse the confirmation`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        val shown = store.pin(bob) // nothing on record: the ceremony demands no acknowledgement
+
+        store.rememberFirstSight(bob, "aaaa-bbbb") // …and a seal to the same key lands behind it
+
+        assertEquals(ConfirmOutcome.RECORDED, store.confirm(bob, "aaaa-bbbb", shown))
+        assertEquals(PinOrigin.CONFIRMED, origin(store, bob))
+    }
+
+    /**
+     * And still refuses when the provenance alone moved: "nobody confirmed either of them" is a
+     * weaker claim than "this differs from the fingerprint confirmed for this account", and the
+     * acknowledgement was given against the weaker one.
+     */
+    @Test
+    fun `a confirmation is refused when the record it disagrees with became a confirmed one`() = runTest {
+        initializeVaultCrypto()
+        val vault = FakeVault()
+        val store = TeamPeerStore(vault)
+        store.rememberFirstSight(bob, "aaaa-bbbb")
+        val shown = store.pin(bob) // the ceremony warns about a first sight
+
+        store.confirm(bob, "aaaa-bbbb") // another of this account's devices confirms it meanwhile
+
+        assertEquals(ConfirmOutcome.MOVED, store.confirm(bob, "cccc-dddd", shown))
+        assertEquals("aaaa-bbbb", pinned(store, bob), "the stronger record the ceremony never saw stands")
     }
 
     /** The pin's record id, asked of the store rather than assumed from its namespace. */
@@ -303,4 +452,8 @@ class TeamPeerStoreTest {
     /** The pin's own fingerprint, or null when nothing readable is pinned. */
     private fun pinned(store: TeamPeerStore, accountId: String) =
         (store.pin(accountId) as? Pin.Known)?.fingerprint
+
+    /** What the pin claims about its fingerprint, or null when nothing readable is pinned. */
+    private fun origin(store: TeamPeerStore, accountId: String) =
+        (store.pin(accountId) as? Pin.Known)?.origin
 }


### PR DESCRIPTION
## Teams: a pin now says who vouched for it

A peer pin used to record a fingerprint and nothing else, so the invite ceremony — a human reading
the fingerprint out loud over a channel the server does not own — and a first sight, whatever the
server answered when a scope grant or a key rotation first sealed to the account, produced the same
record. The screens called both of them "confirmed", which taught the reader to move a pin onto an
attacker's key.

### What changed

- `TeamPeerEntry` carries a `PinOrigin` (`CONFIRMED` / `FIRST_SIGHT`) and `Pin.Known` carries it on.
  Records written before the field existed read as `FIRST_SIGHT` — the weaker claim.
- The invite banner and the invite dialog word their warning by how the record they disagree with got
  there. A pin nobody confirmed no longer produces the sentence "differs from the fingerprint
  confirmed for this account".
- Every member row wears a mark for its key: quiet for a confirmed fingerprint, amber for a first
  sight, an unreadable record, or an account nothing was ever sealed to. Pressing it opens the same
  fingerprint ceremony the invite ends with, so a first-sight pin can be promoted without re-inviting
  the person. A confirmed pin opens it too: a colleague who rotates their identity leaves a pin that
  no longer matches their published key, every seal to them is refused from then on, and this is the
  way back.
- The confirmation is held to the record the ceremony was drawn against. These records sync between
  the account's own devices and the server chooses when one arrives; delivered after the dialog said
  "nothing is on record" it would replace a confirmed pin having asked nothing.
- `lib_teams_err_peer_key_unconfirmed` now points at the member list instead of telling a manager to
  remove the member and invite them again.
- `PinNotice` — what the record says against a fingerprint on screen — moved next to the record it
  is about, so the store refuses a confirmation whose question changed while it was being asked, on
  the same rule the banner and the dialog word. A record that merely became confirmed for the very
  fingerprint being written no longer costs the ceremony.
- The acknowledgement on the invite banner is remembered as the question it answered, not as the
  fingerprint alone: a tick given for "nobody confirmed either of them" no longer stands in for
  "this differs from the fingerprint confirmed for this account" when the confirmation lands behind
  the banner.
- The confirm dialog announces what the record held together with the fingerprint — the state line
  arrives from a vault read after the dialog is already up, and a node inserted with its text
  announces nothing (WCAG 4.1.3).
- A whole member list is one pass over the vault's record list instead of one scan per member.

### Decisions

- **A seal to a never-confirmed account is not refused.** A team that predates the pin record has no
  pins at all; refusing there would leave it unable to rotate its key away from a removed member.
  What the change does instead is record the provenance, say it on screen, and offer the promotion.
- **The refusal error stays provenance-neutral.** One rotation aggregates many recipients into a
  single error slot, and they need not share a provenance. Provenance is stated per member, in the
  member list and in the confirm dialog.
- Telling an honest identity rotation from a substitution still needs continuity, which a fingerprint
  alone cannot express. Out of scope here, as the issue says.

Closes #323.

### Verify

Team screen → the member list. Every member but yourself carries a mark next to their account id.
Press an amber one: the dialog fetches the account's published key, shows its fingerprint and what is
on record for it, and Confirm is closed until the fingerprint is read back over a channel the server
does not own — and until the acknowledgement is ticked, if the record disagrees. After confirming,
the mark turns quiet.

### Not verified

Android device, live sync server. Everything here was exercised on the desktop JVM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
