### PR TITLE
Take the Android version code from gradle.properties and cut 0.4.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,8 +298,8 @@ jobs:
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
 
       - name: Assemble release APK
-        # versionCode must be a monotonic integer; the tag's semver can't map to one, so use
-        # the run number (grows every run). A dispatch input still overrides it if provided.
+        # versionCode comes from gradle.properties as it stands there (see the note in that file);
+        # a workflow_dispatch input overrides it.
         # Signing passwords are scoped to this step only; version values go through env (not
         # interpolated into the shell) to close the expression-injection surface.
         env:
@@ -307,11 +307,11 @@ jobs:
           SKERRY_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           SKERRY_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
           VERSION_NAME: ${{ needs.version.outputs.name }}
-          VERSION_CODE: ${{ needs.version.outputs.code || github.run_number }}
+          VERSION_CODE: ${{ needs.version.outputs.code }}
         run: >
           ./gradlew :androidApp:assembleRelease --stacktrace
           ${VERSION_NAME:+"-Pskerry.versionName=$VERSION_NAME"}
-          "-Pskerry.versionCode=$VERSION_CODE"
+          ${VERSION_CODE:+"-Pskerry.versionCode=$VERSION_CODE"}
 
       - name: Rename APK to match the other artifacts
         # AGP emits androidApp-release.apk. Rename it to the Skerry-<version> scheme the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,9 @@ Wire the keep-alive setting end to end with dead-link detection
 - **ProGuard/minification is disabled on purpose** for the desktop release — it broke the
   crypto stack (JNA/libsodium, okio, BouncyCastle's signed jar). See the comment in
   `composeApp/build.gradle.kts` before trying to re-enable it.
-- **Releases**: pushing a `v*` tag runs the release workflow, which builds
+- **Releases**: bump both `skerry.versionName` and `skerry.versionCode` in `gradle.properties`
+  first — the workflow takes the Android version code from that file and nothing downstream can
+  recover from a code that did not grow. Then pushing a `v*` tag runs the release workflow, which builds
   `.deb`/`.rpm`/`.AppImage` (x64 + arm64), `.msi` (x64), `.dmg` (arm64 + x64, unsigned),
   a signed `.apk`, and `SHA256SUMS.txt`, and publishes them as a **draft** GitHub Release
   — a maintainer reviews and publishes it manually.

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -31,8 +31,14 @@ android {
         applicationId = "app.skerry"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        // Version from the single source (gradle.properties); the release workflow overrides it.
-        versionCode = (providers.gradleProperty("skerry.versionCode").orNull ?: "1").toInt()
+        // Version from the single source (gradle.properties). A workflow_dispatch input can
+        // override either value, and a `v*` tag push takes versionName from the tag.
+        // The code has no fallback on purpose. It used to default to 1, which no release could
+        // reach while the workflow always passed `-Pskerry.versionCode` (it stamped the CI run
+        // number). It no longer does, so a lost property line would quietly publish an APK that
+        // every installed build outranks — failing configuration is the cheaper end of that.
+        versionCode = providers.gradleProperty("skerry.versionCode").orNull?.trim()?.toIntOrNull()
+            ?: error("skerry.versionCode is missing or not a whole number — see gradle.properties")
         versionName = providers.gradleProperty("skerry.versionName").orNull ?: "0.1.0"
         // Local AI (Llamatik/llama.cpp): the AAR carries natives for four ABIs (~52 MB unpacked).
         // The project's real Android devices are arm64; the other ABIs are dead weight in the APK.

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,13 @@ android.nonTransitiveRClass=true
 android.useAndroidX=true
 
 # Skerry release version — single source of truth for desktop packaging and Android.
-# The release workflow overrides them: -Pskerry.versionName=… -Pskerry.versionCode=…
-skerry.versionName=0.4.0
-skerry.versionCode=14
+# The two halves are not read the same way: versionCode is taken from this file, while versionName
+# is taken from the tag on a `v*` push and from this file everywhere else. A workflow_dispatch
+# input can override either.
+# versionCode must grow with every release that reaches a store or a GitHub asset — Android refuses
+# an update whose code is not higher, and Google Play / RuStore reject the upload outright. It was
+# seeded at 116 because the APKs published up to 0.4.0 carried the CI run number instead of this
+# value, and the last one shipped as 115. The `version-bump` check blocks a versionName bump that
+# leaves the code behind.
+skerry.versionName=0.4.1
+skerry.versionCode=116

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.0"
+version = "0.4.1"
 
 // Second launcher in the same distribution: `bin/skerry-admin` (the administration CLI) ships next
 // to `bin/server`, so the Docker image gets it for free — the Dockerfile copies the whole install

--- a/sync-wire/build.gradle.kts
+++ b/sync-wire/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "app.skerry"
-version = "0.4.0"
+version = "0.4.1"
 
 kotlin {
     jvmToolchain(21)

--- a/tools/harness/checks.py
+++ b/tools/harness/checks.py
@@ -9,7 +9,9 @@ Rules apply to **lines this branch adds**, not to the whole repository — legac
 debt. The i18n parity rule is the exception: it is a property of the resource set as a whole, and
 the set is clean today, so any drift belongs to the change that caused it.
 
-Escape hatch: `harness-allow: <rule>` anywhere on the offending line.
+Escape hatch: `harness-allow: <rule>` anywhere on the offending line — except `version-bump`,
+whose file has no *end-of-line* comment syntax, so a trailing marker would land inside the version
+string. Its hatch is a line of its own, spelled exactly `# harness-allow: version-bump`.
 """
 
 from __future__ import annotations
@@ -118,6 +120,10 @@ SECRET_PATHS = ("/vault/", "/guard/", "/team/", "/share/", "/sync/")
 SHORTCUT_FILE = "composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopShortcuts.kt"
 KEYBOARD_SETTINGS = "composeApp/src/commonMain/kotlin/app/skerry/ui/settings/KeyboardSection.kt"
 FILE_SIZE_LIMIT = 500
+VERSION_FILE = "gradle.properties"
+VERSION_RULE = "version-bump"
+VERSION_NAME = re.compile(r"^\s*skerry\.versionName\s*=\s*(\S+)\s*$")
+VERSION_CODE = re.compile(r"^\s*skerry\.versionCode\s*=\s*(\d+)\s*$")
 
 
 def _line_rules(added: list[tuple[str, int, str]]) -> list[Finding]:
@@ -331,6 +337,112 @@ def _shortcut_rule(added: list[tuple[str, int, str]]) -> list[Finding]:
     return []
 
 
+def _version_bump(added: list[tuple[str, int, str]], cwd: str | None, base: str) -> list[Finding]:
+    """A release bump must move both halves of the version, and move the code upwards.
+
+    The release workflow used to stamp the APK with `github.run_number`, monotonic for free. It now
+    reads `skerry.versionCode` as it is written here, so forgetting the bump no longer fails
+    anywhere in this repository — it fails at the store upload, days later, on an artifact that is
+    already tagged and published.
+
+    The hatch is a comment line in the file, not the offending line: a `.properties` value runs to
+    the end of its line, so a trailing `harness-allow` would end up inside the version string.
+    """
+    mine = [(line, text) for path, line, text in added if path == VERSION_FILE]
+    # A line that is nothing but the marker, not merely a line containing it: the file's own comment
+    # block documents this rule, and a reworded paragraph re-adds every line of it — on the release
+    # bump, which is the one commit the rule exists for.
+    if any(text.strip() == f"# harness-allow: {VERSION_RULE}" for _, text in mine):
+        return []
+    named = coded = None
+    for line, text in mine:
+        if VERSION_NAME.match(text):
+            named = line
+        match = VERSION_CODE.match(text)
+        if match:
+            coded = (line, int(match.group(1)))
+    if named is None:
+        return []
+    if coded is None:
+        # git emits changed lines only, so a code left exactly where it was is absent from the diff
+        # — "not written" and "not moved" are the same mistake and get the same sentence.
+        return [Finding(VERSION_RULE, BLOCK, VERSION_FILE, named,
+                        "skerry.versionName moved without skerry.versionCode — Android refuses an "
+                        "update whose code did not grow, and the stores reject the upload.")]
+    line, code = coded
+    previous, problem = _previous_version_code(cwd, base)
+    if problem:
+        return [Finding(VERSION_RULE, BLOCK, VERSION_FILE, line, problem)]
+    if previous is not None and code <= previous:
+        return [Finding(VERSION_RULE, BLOCK, VERSION_FILE, line,
+                        f"skerry.versionCode {code} is not above {previous} — an Android version "
+                        "code only ever grows.")]
+    return []
+
+
+def _baseline_refs(cwd: str | None, base: str) -> list[tuple[str, str]]:
+    """Every commit whose version code this branch has to clear, as (name, commit).
+
+    Not the branch point alone: two branches forked from the same commit can reach for the same
+    number, and the second one has to be told. Not one ref either — a local `main` that has not been
+    pulled since the last release answers with a code that is already spent, and a baseline that can
+    only be *too low* turns "no comparison" into a confident wrong one.
+
+    A name is kept once `rev-parse --verify` peels it to a commit — `git show :gradle.properties` is
+    not a failure but the syntax for reading the *index*, which hands back the very value being
+    committed — and only if that commit shares history with HEAD. This repository has had its
+    history rewritten once; an abandoned ref left behind by that can carry a high code belonging to
+    no lineage we are on, and taking the maximum would make it block every branch forever.
+
+    Dedup is on the commit, not the name: in the ordinary case all three candidates are the same
+    commit, and a finding that names it twice reads as two baselines failing instead of one.
+    """
+    found: list[tuple[str, str]] = []
+    for ref in ("origin/main", "main", base or state.merge_base(cwd=cwd)):
+        if not ref:
+            continue
+        code, out = state.git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"], cwd)
+        commit = out.strip()
+        if code != 0 or any(commit == known for _, known in found):
+            continue
+        if state.git(["merge-base", commit, "HEAD"], cwd)[0] == 0:
+            found.append((ref, commit))
+    return found
+
+
+def _previous_version_code(cwd: str | None, base: str) -> tuple[int | None, str | None]:
+    """(the code to beat, why it could not be read).
+
+    The highest code across every baseline, so a stale ref can lower the bar for nobody.
+
+    A file that does not exist there is the one silence kept: that is what the first commit of a
+    fresh clone looks like, and it is not a version that went backwards. Everything else is
+    reported — a monotonicity rule that quietly stops comparing is worse than one that says it
+    could not.
+    """
+    refs = _baseline_refs(cwd, base)
+    if not refs:
+        return None, ("neither main nor the branch point resolves, so the previous "
+                      "skerry.versionCode could not be read — it was not compared.")
+    codes, seen = [], []
+    for ref, commit in refs:
+        code, text = state.git(["show", f"{commit}:{VERSION_FILE}"], cwd)
+        if code != 0:
+            continue
+        seen.append(ref)
+        for line in text.split("\n"):
+            match = VERSION_CODE.match(line)
+            if match:
+                codes.append(int(match.group(1)))
+                break
+    if codes:
+        return max(codes), None
+    if seen:
+        return None, (f"{VERSION_FILE} at {', '.join(seen)} carries no skerry.versionCode — the "
+                      "value this branch has to beat could not be read, so it was not compared.")
+    return None, None
+
+
 def _tests_present(added: list[tuple[str, int, str]], task: dict) -> list[Finding]:
     if task["kind"] not in ("bug", "feature"):
         return []
@@ -368,6 +480,7 @@ def run(cwd: str | None = None, task: dict | None = None, base: str = "") -> lis
     findings = _line_rules(added)
     findings += _cancellation_rule(added, cwd)
     findings += _shortcut_rule(added)
+    findings += _version_bump(added, cwd, base)
     findings += _tests_present(added, task)
     findings += _file_size(cwd, added)
     findings += _i18n_parity(cwd)

--- a/tools/harness/selftest.py
+++ b/tools/harness/selftest.py
@@ -729,6 +729,154 @@ class TestChecks(SandboxCase):
         self.box.write(checks.KEYBOARD_SETTINGS, "val row = KeyboardBinding(label, \"F1\")\n")
         self.assertEqual(self._findings("shortcut-settings"), [])
 
+    def test_a_version_name_without_a_code_is_blocked(self):
+        self.box.write("gradle.properties", "skerry.versionName=0.4.1\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, checks.BLOCK)
+
+    def test_a_version_name_with_a_code_is_fine(self):
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=116\n")
+        self.assertEqual(self._findings("version-bump"), [])
+
+    def test_a_version_code_alone_is_fine(self):
+        # Seeding the code without touching the name is the safe direction — the rule is about a
+        # release that moves the name and leaves the code behind, not the reverse.
+        self.box.write("gradle.properties", "skerry.versionCode=116\n")
+        self.assertEqual(self._findings("version-bump"), [])
+
+    def test_a_version_code_that_does_not_grow_is_blocked(self):
+        self._seed_version("0.4.0", 200)
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=116\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, checks.BLOCK)
+        # The message proves which branch fired: a code equal to the base is absent from the diff
+        # entirely, so counting findings cannot tell the comparison from the missing-code rule.
+        self.assertIn("is not above 200", found[0].message)
+
+    def test_a_version_code_that_grows_is_fine(self):
+        self._seed_version("0.4.0", 116)
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=117\n")
+        self.assertEqual(self._findings("version-bump"), [])
+
+    def test_a_code_a_sibling_branch_already_took_is_blocked(self):
+        # main moved to 117 after this branch forked, so 117 is still an addition against the fork
+        # point — only a comparison against main's tip can see that it is already spent.
+        self._seed_version("0.4.1", 117, merge_back=False)
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=117\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, checks.BLOCK)
+        self.assertIn("is not above 117", found[0].message)
+
+    def test_a_baseline_without_a_code_is_reported_not_ignored(self):
+        # The file exists but carries no code line: a real previous value may have been there and
+        # the rule stopped comparing, so it says so instead of passing in silence.
+        self._seed_version("0.4.0", None)
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=116\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        # BLOCK, not WARN: a warning is print-only here — `checks.main` sets its exit code from the
+        # blocking findings alone, so "could not compare" would commit exactly like "compared fine".
+        self.assertEqual(found[0].severity, checks.BLOCK)
+
+    def test_an_allow_comment_silences_the_version_rule(self):
+        self._seed_version("0.4.0", 200)
+        self.box.write("gradle.properties",
+                       "# harness-allow: version-bump\n"
+                       "skerry.versionName=0.4.1\nskerry.versionCode=116\n")
+        self.assertEqual(self._findings("version-bump"), [])
+
+    def test_prose_about_the_hatch_does_not_invoke_it(self):
+        # The file's own comment block documents this rule; a reworded paragraph must not disarm it.
+        self._seed_version("0.4.0", 200)
+        self.box.write("gradle.properties",
+                       "# the version-bump check takes a harness-allow: version-bump line\n"
+                       "skerry.versionName=0.4.1\nskerry.versionCode=116\n")
+        self.assertEqual(len(self._findings("version-bump")), 1)
+
+    def test_a_stale_baseline_cannot_lower_the_bar(self):
+        # main regressed below the branch point — a rewritten history, or a ref never pulled. The
+        # highest code any baseline knows is the one to beat, so the lower ref buys nothing.
+        self._seed_version("0.4.0", 200)
+        run_git(self.box.path, "checkout", "-q", "main")
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.0\nskerry.versionCode=100\n")
+        self.box.commit("main regresses")
+        run_git(self.box.path, "checkout", "-q", "refactor/checks")
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=150\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        self.assertIn("is not above 200", found[0].message)
+
+    def test_a_tree_with_no_baseline_at_all_is_reported(self):
+        # Outside a repository both git calls fail, exactly as they do on an unborn HEAD — where the
+        # old code read `git show :gradle.properties`, which is the *index*, and compared the value
+        # being committed with itself.
+        previous, problem = checks._previous_version_code(tempfile.gettempdir(), "")
+        self.assertIsNone(previous)
+        self.assertTrue(problem)
+
+    def test_an_unrelated_ref_cannot_raise_the_bar(self):
+        # A leftover origin/main from before a history rewrite: it resolves, and it carries a high
+        # code that belongs to a lineage this branch is not on. Taking the maximum unfiltered would
+        # let it block every legitimate bump until the number climbed past an abandoned one.
+        self._seed_version("0.4.0", 116)
+        run_git(self.box.path, "checkout", "-q", "--orphan", "abandoned")
+        self.box.write("gradle.properties",
+                       "skerry.versionName=9.0.0\nskerry.versionCode=9000\n")
+        self.box.commit("abandoned lineage")
+        head = run_git(self.box.path, "rev-parse", "HEAD").strip()
+        run_git(self.box.path, "checkout", "-q", "refactor/checks")
+        run_git(self.box.path, "update-ref", "refs/remotes/origin/main", head)
+        # The ref has to actually exist, or the test passes on a baseline that was never consulted.
+        self.assertEqual(
+            run_git(self.box.path, "rev-parse", "--verify", "--quiet", "origin/main^{commit}").strip(),
+            head)
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=117\n")
+        self.assertEqual(self._findings("version-bump"), [])
+
+    def test_a_baseline_whose_code_line_does_not_parse_is_blocked(self):
+        # The regex is the only reader of that line. A reformat at the baseline — a trailing
+        # comment, a quoted value — is not "no previous code", it is a comparison that cannot be
+        # made, and this rule is not allowed to fall silent on one.
+        run_git(self.box.path, "checkout", "-q", "main")
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.0\nskerry.versionCode=116 # bumped for 0.4.0\n")
+        self.box.commit("seed an unreadable code")
+        run_git(self.box.path, "checkout", "-q", "refactor/checks")
+        run_git(self.box.path, "merge", "-q", "main")
+        self.box.write("gradle.properties",
+                       "skerry.versionName=0.4.1\nskerry.versionCode=117\n")
+        found = self._findings("version-bump")
+        self.assertEqual(len(found), 1)
+        self.assertEqual(found[0].severity, checks.BLOCK)
+        # Named once, not once per candidate ref: without dedup on the commit the same tree renders
+        # as "at main, <sha>" and reads as two independent baselines failing.
+        self.assertIn("gradle.properties at main carries no skerry.versionCode", found[0].message)
+
+    def _seed_version(self, name: str, code: int | None, merge_back: bool = True) -> None:
+        """Put a version on main, and by default on this branch's point as well.
+
+        `merge_back=False` leaves main ahead: that is the sibling-branch case, where the code is
+        already spent on main but still reads as an addition against the fork point.
+        """
+        body = f"skerry.versionName={name}\n" + (f"skerry.versionCode={code}\n" if code else "")
+        run_git(self.box.path, "checkout", "-q", "main")
+        self.box.write("gradle.properties", body)
+        self.box.commit(f"seed {name}")
+        run_git(self.box.path, "checkout", "-q", "refactor/checks")
+        if merge_back:
+            run_git(self.box.path, "merge", "-q", "main")
+
     def test_a_feature_without_tests_is_blocked(self):
         self.box.write("shared/src/commonMain/kotlin/A.kt", "val a = 1\n")
         task = {"kind": "feature", "areas": ["shared"], "paths": [], "code_paths": []}


### PR DESCRIPTION
## What this changes

The release workflow stamped the release APK with `github.run_number`. `skerry.versionCode` in `gradle.properties` was therefore decorative and had drifted to `14`, while the APK published for 0.4.0 shipped as `115`. Nothing in the repository could see the gap, and nothing downstream recovers from a version code that did not grow — Android refuses an update whose code is not higher, and Google Play and RuStore reject the upload outright.

`gradle.properties` is now the single source of the Android version code.

- The workflow passes `-Pskerry.versionCode` only when a `workflow_dispatch` input supplies one. On a `v*` tag push the flag is omitted and the file's value is used. `versionName` is unchanged: it still comes from the tag on a tag push.
- `androidApp/build.gradle.kts` fails at configuration when the property is missing or is not a whole number. It used to fall back to `1` — unreachable while the workflow always passed the flag, and a silent downgrade the moment it stopped.
- The code is seeded at `116`, above the last published run number.

## The new check

`version-bump` joins the deterministic rules in `tools/harness/checks.py`. It blocks:

- a `skerry.versionName` that moves without `skerry.versionCode`;
- a code that does not clear the highest value carried by any baseline sharing this history (`origin/main`, `main`, and the branch point) — so two branches forked from the same commit cannot both claim the same number, and a `main` that has not been pulled cannot lower the bar.

Baselines are deduplicated by resolved commit and filtered to those that share history with `HEAD`: an abandoned ref left behind by a history rewrite would otherwise carry a high code belonging to no lineage this branch is on and block every bump after it. The escape hatch is a comment line of its own in `gradle.properties`, spelled exactly `# harness-allow: version-bump`, because a `.properties` value runs to the end of its line.

The harness selftest covers the rule with 13 cases; every branch of it was mutation-checked, and each mutation kills exactly one test.

## Release 0.4.1

`skerry.versionName`, `server/build.gradle.kts` and `sync-wire/build.gradle.kts` all move to 0.4.1. The wire contract and the team routes changed after the `v0.4.0` tag, so the server is released alongside the clients.

## Verifying

```bash
./gradlew :androidApp:assembleRelease
aapt2 dump badging androidApp/build/outputs/apk/release/androidApp-release.apk | head -1
# versionCode='116' versionName='0.4.1'

python3 tools/harness/selftest.py     # 178 tests
tools/harness/gate.py checks
```

To see the check fire, edit `skerry.versionName` in `gradle.properties` without touching the code line and run `tools/harness/gate.py checks`.

## Not verified

The release workflow itself has not been run — the version path is exercised only by the local Gradle build and the selftest. No Android device, no live sync server.