### PR TITLE
Stop the connect guard and the render tests from flaking (#328, #330)

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sync/SyncCoordinator.kt
@@ -129,8 +129,18 @@ class SyncCoordinator(
      * What the double-submit guard reads — not [SyncStatus.Busy], which the silent keep-connected restore
      * ([restoreSession]) raises just the same: a restore that happened to start first turned the user's own
      * connect into a no-op, with nothing on screen to say the tap did anything (issue #278). Set on the
-     * calling (main) thread before the launch, cleared when the launched operation returns — @Volatile
-     * because that clear runs on [scope] and the guard reads it without the lock.
+     * calling (main) thread before the launch; released by the operation ITSELF, the moment what it was
+     * going to do is decided — in [activateSession], with the session live and the first cycle about to
+     * publish it. What is left of the operation then needs no guard: [opMutex] serializes it and the
+     * next connect simply queues behind it, instead of being dropped in silence (issue #328). The
+     * `finally` around each launch is the backstop for every path that never gets that far (a failure,
+     * a cancellation, the password-replace pause). @Volatile because the release runs on
+     * [scope] and the guard reads it without the lock.
+     *
+     * Deliberately NOT keyed on the status alone: [_status] is written from a dozen places that never
+     * took the guard — a background cycle on the previous session, [disconnect], [pauseForLock] — and any
+     * of them landing in the window between [beginLinking] and the operation's own first status would
+     * hand the guard back for an operation that has not begun.
      */
     @Volatile
     private var linkingInFlight = false
@@ -465,8 +475,8 @@ class SyncCoordinator(
      * the account key (see [doConnect]).
      */
     fun connect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean = false) {
-        // Guard against a double launch: a repeat click while the previous connect/claim is in flight
-        // would spawn a second Ktor client (pool/socket leak) and a status race. Calls come from UI
+        // Guard against a double launch: a repeat click while the previous connect/claim is still
+        // deciding would spawn a second Ktor client (pool/socket leak) and a status race. Calls come from UI
         // handlers on the main thread, so check-then-set without CAS is enough (like panel busy flags).
         if (linkingInFlight) {
             masterPassword.fill(' ')
@@ -488,15 +498,22 @@ class SyncCoordinator(
         masterPassword.fill(' ')
         scope.launch {
             try {
-                opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected) }
+                opMutex.withLock { doConnect(serverUrl, accountId, owned, keepConnected, linking = linking) }
             } finally {
+                // [doConnect] wipes the copy it was handed; this covers the connect that never got that
+                // far — cancelled while queued on [opMutex], with the password resident. A cancel that
+                // lands before the body is entered runs no `finally` at all and is not covered here;
+                // only [close] cancels this scope, and nothing in the app calls it.
+                owned.fill(' ')
                 endLinking(linking)
             }
         }
     }
 
     // Under [opMutex] (see connect): session activation must not race with disconnect.
-    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false) {
+    // [linking]: the operation this connect is, if it is a user-initiated one — [activateSession] releases
+    // its guard once the session is live.
+    private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false, linking: Int? = null) {
         _status.value = SyncStatus.Busy
         val dataKey = vault.exportDataKey()
         if (dataKey == null) {
@@ -680,6 +697,7 @@ class SyncCoordinator(
                 SyncConfig(serverUrl, accountId, deviceId, keepConnected, sealed),
                 resetCursor = adoptedKey || mustReconcile,
                 clearLocalRecords = mustReconcile,
+                linking = linking,
             )
         } catch (e: CancellationException) {
             throw e // don't swallow cancellation — it would break structured concurrency
@@ -716,6 +734,12 @@ class SyncCoordinator(
         config: SyncConfig,
         resetCursor: Boolean,
         clearLocalRecords: Boolean = false,
+        /**
+         * The linking operation this activation belongs to, if it is one ([restoreSession] and
+         * [doChangeAccountPassword] never take the guard and pass `null`). Released below, as soon as the
+         * operation's own result is on screen.
+         */
+        linking: Int? = null,
     ) {
         // Publish and reconcile in ONE [syncMutex] section. Publishing is what makes a session syncable,
         // and the reconcile below is what makes it safe to sync: split into two sections, the mutex is
@@ -773,6 +797,19 @@ class SyncCoordinator(
                 }
             }
             health.setTarget(config.serverUrl)
+            // The operation is decided here: the session is live, the link is saved, the reconcile has
+            // run. Everything left — this first cycle, the subscriptions, the superseded client's socket
+            // pool — is tail work no observer can tell apart from being connected, and a connect issued
+            // on the strength of what it publishes used to hit a guard nothing on screen accounted for
+            // and be dropped in silence (issue #328). Released BEFORE the cycle publishes, not after:
+            // whoever is woken by that status must find the guard already down. A repeat click landing
+            // inside the cycle costs one redundant connect, which [opMutex] serializes; a double click
+            // is long over by the time an activation gets this far.
+            //
+            // Released here rather than off the status itself: [_status] is written by a dozen paths that
+            // never took the guard — a cycle on the session this one replaces, [disconnect], the
+            // auto-lock — and any of them would otherwise hand back a guard that is not theirs.
+            if (linking != null) endLinking(linking)
             // The debt recorded above is retired by the sync cycle itself ([retireDischargedDebt]) — not
             // here, because a first cycle that fails leaves it to a later retry to finish the reconcile.
             runSync()
@@ -991,9 +1028,12 @@ class SyncCoordinator(
         scope.launch {
             try {
                 opMutex.withLock {
-                    doConnect(pending.serverUrl, pending.accountId, pending.password, pending.keepConnected, allowPasswordReplace = true)
+                    doConnect(pending.serverUrl, pending.accountId, pending.password, pending.keepConnected, allowPasswordReplace = true, linking = linking)
                 }
             } finally {
+                // see [connect]: the re-run cancelled while queued never reaches [doConnect]'s wipe, and
+                // the stash it was handed is by then the only reference left to that password.
+                pending.password.fill(' ') // idempotent with [doConnect]'s own wipe on the normal path
                 endLinking(linking)
             }
         }
@@ -1223,15 +1263,17 @@ class SyncCoordinator(
         clearPendingReplace()
         scope.launch {
             try {
-                opMutex.withLock { doClaimPairing(payload, owned, keepConnected) }
+                opMutex.withLock { doClaimPairing(payload, owned, keepConnected, linking = linking) }
             } finally {
+                owned.fill(' ') // see [connect]: the claim cancelled while queued never reaches the wipe
                 endLinking(linking)
             }
         }
     }
 
     // Under [opMutex] (see claimPairing): session activation must not race with disconnect.
-    private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean) {
+    // [linking]: as in [doConnect] — the operation whose guard [activateSession] releases.
+    private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean, linking: Int? = null) {
         _status.value = SyncStatus.Busy
         val parsed = PairingPayload.decode(payload)
         if (parsed == null) {
@@ -1311,6 +1353,7 @@ class SyncCoordinator(
                 result.session,
                 SyncConfig(parsed.serverUrl, result.accountId, deviceId, keepConnected, sealed),
                 resetCursor = true,
+                linking = linking,
             )
         } catch (e: CancellationException) {
             throw e

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/render/SceneFrames.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/render/SceneFrames.kt
@@ -1,0 +1,104 @@
+package app.skerry.ui.render
+
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.graphics.PixelMap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.graphics.toPixelMap
+import kotlin.test.fail
+import org.jetbrains.skia.Image
+
+/**
+ * How long a render test waits for the screen to show what it is waiting for.
+ *
+ * These scenes are driven by hand, one 60 Hz tick at a time, but what they wait for is not on the
+ * frame clock: a recomposition, a font loaded on [kotlinx.coroutines.Dispatchers.Default], the first
+ * bytes of a fake connection. Spending a fixed number of frames on that is a latency assertion
+ * nobody meant to make — on an idle machine five frames are plenty, on a loaded CI runner they are
+ * not, and the assert reads the frame before the one that would have passed (issue #330).
+ *
+ * The budget is therefore not a latency claim: it only has to be large enough that anything slower
+ * is a screen that never repaints rather than a busy machine. Waits that assert a *period* — a
+ * cursor blinking off within its own half-period — pass their own small [timeoutMillis], and that
+ * budget is the assertion.
+ */
+private const val RENDER_WAIT_BUDGET_MS = 10_000L
+
+/** One 60 Hz tick, in nanoseconds — what each frame advances the scene's clock by. */
+private const val FRAME_NANOS = 16_666_667L
+
+/** How long a wait sleeps between attempts: one frame period, so a wait costs frames, not a spin. */
+private const val POLL_MILLIS = 16L
+
+/**
+ * Drives an [ImageComposeScene] frame by frame for the offscreen render tests: publishes pending
+ * snapshot writes, advances the frame clock by one tick and renders.
+ *
+ * The five render tests that wait for a repaint used to carry their own copy of this — ten in all.
+ * Tests that render a scene only to lay it out or to shoot a screenshot still drive their own frames;
+ * they wait for nothing, so they are not the issue #330 class. [pauseMillis] is the wall clock each frame gives back to work
+ * that does not run on the frame clock — async fonts and the fake connection; a scene driven on
+ * [kotlinx.coroutines.Dispatchers.Unconfined] does its work at the emit point and needs none.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+internal class SceneFrames(
+    private val scene: ImageComposeScene,
+    private val pauseMillis: Long = 0,
+) {
+    private var timeNanos = 0L
+
+    /** One frame. */
+    fun next(): PixelMap {
+        val pixels = draw().toComposeImageBitmap().toPixelMap()
+        if (pauseMillis > 0) Thread.sleep(pauseMillis)
+        return pixels
+    }
+
+    /** Drive one frame without reading it back — for a test that renders only to move the composition on. */
+    fun advance() {
+        draw()
+        if (pauseMillis > 0) Thread.sleep(pauseMillis)
+    }
+
+    private fun draw(): Image {
+        Snapshot.sendApplyNotifications()
+        timeNanos += FRAME_NANOS
+        return scene.render(timeNanos)
+    }
+
+    /**
+     * [count] frames, the last one returned. For settling a scene that has nothing to wait *for* —
+     * a fresh layout before the first emit — and for the negative assertions, where "still not on
+     * screen after N frames" is the whole claim and no condition can be waited on.
+     */
+    fun settle(count: Int): PixelMap {
+        var pixels = next()
+        repeat(count - 1) { pixels = next() }
+        return pixels
+    }
+
+    /**
+     * Renders until [condition] holds, and fails naming [what] when [timeoutMillis] passes without
+     * it — so a screen that never followed reads as a sentence about the screen, and never as a
+     * colour assertion that a slow runner could have produced just as well.
+     */
+    fun awaitFrame(
+        what: String,
+        timeoutMillis: Long = RENDER_WAIT_BUDGET_MS,
+        condition: (PixelMap) -> Boolean,
+    ): PixelMap {
+        val deadline = System.nanoTime() + timeoutMillis * 1_000_000
+        var pixels = next()
+        while (!condition(pixels)) {
+            if (System.nanoTime() > deadline) {
+                fail("timed out after ${timeoutMillis}ms waiting for $what")
+            }
+            // [next] already paused a scene that asked for one; sleeping again here would halve the
+            // frame rate the budget is counted in.
+            if (pauseMillis == 0L) Thread.sleep(POLL_MILLIS)
+            pixels = next()
+        }
+        return pixels
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookEditorFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookEditorFormTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -88,7 +89,12 @@ class RunbookEditorFormTest {
         shell.runbooks.save(RunbookDraft(label = "Synced empty procedure"))
 
         onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).performClick()
-        waitForIdle()
+        // The palette fills from the library on the shell's own scope, which waitForIdle does not
+        // wait for: asserting on the frame after the click reads an empty palette on a loaded
+        // runner and a full one on an idle machine (issue #330).
+        waitUntil("the palette to list the runnable runbook", timeoutMillis = 10_000) {
+            onAllNodesWithText("Runnable").fetchSemanticsNodes().isNotEmpty()
+        }
 
         onNodeWithText("Runnable").assertIsDisplayed()
         onNodeWithText("Synced empty procedure").assertDoesNotExist()
@@ -100,7 +106,9 @@ class RunbookEditorFormTest {
         shell.runbooks.save(RunbookDraft(label = "Synced empty procedure"))
 
         onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).performClick()
-        waitForIdle()
+        waitUntil("the palette to say why it offers nothing", timeoutMillis = 10_000) {
+            onAllNodesWithText(string(Res.string.runbook_none_runnable)).fetchSemanticsNodes().isNotEmpty()
+        }
 
         onNodeWithText(string(Res.string.runbook_none_runnable)).assertIsDisplayed()
     }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/ReactivationFixtures.kt
@@ -16,6 +16,7 @@ import app.skerry.shared.vault.RecordType
 import app.skerry.shared.vault.Vault
 import app.skerry.shared.vault.VaultCrypto
 import app.skerry.shared.vault.VaultRecord
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -58,7 +59,19 @@ internal class ReactivatingClient(
     /** What every pull serves. A non-empty page is what moves the cursor off zero. */
     private val serves: List<RemoteRecord> = emptyList(),
     private val servesCursor: Long = 1,
+    /**
+     * Held open until completed, so a test can stand inside the window a superseding connect spends
+     * closing this client — the tail of an activation whose status is already on screen.
+     */
+    private val closeGate: CompletableDeferred<Unit>? = null,
+    /**
+     * Held open until completed, so a test can stand inside a connect that has reached the server: the
+     * operation holds the coordinator's operation lock and its guard, with nothing published yet.
+     */
+    private val loginGate: CompletableDeferred<Unit>? = null,
 ) : SyncClient {
+    /** Completed when [login] is entered — the signal that the connect is at the server. */
+    val loggingIn: CompletableDeferred<Unit> = CompletableDeferred()
     val pushed: MutableList<RemoteRecord> = CopyOnWriteArrayList()
 
     /** What each pull asked for — `0` is the full re-pull a reconcile's cursor reset forces. */
@@ -81,8 +94,11 @@ internal class ReactivatingClient(
 
     override suspend fun register(accountId: String, authKey: ByteArray, wrappedDataKey: ByteArray, device: DeviceInfo): SyncSession =
         throw SyncException(SyncException.Kind.CONFLICT, "account exists")
-    override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession =
-        SyncSession(accountId, accessToken = accessToken, refreshToken = "refresh", reactivated = revoked.getAndSet(false))
+    override suspend fun login(accountId: String, authKey: ByteArray, device: DeviceInfo): SyncSession {
+        loggingIn.complete(Unit)
+        loginGate?.await()
+        return SyncSession(accountId, accessToken = accessToken, refreshToken = "refresh", reactivated = revoked.getAndSet(false))
+    }
     override suspend fun fetchWrappedDataKey(session: SyncSession): ByteArray {
         val n = fetches.getAndIncrement()
         if (throwOnFirstFetch && n == 0) throw SyncException(SyncException.Kind.NETWORK, "unreachable")
@@ -110,6 +126,7 @@ internal class ReactivatingClient(
     // tests drive and re-save the config from under the assertions. Reachability is covered elsewhere.
     override suspend fun ping(): Boolean = false
     override suspend fun close() {
+        closeGate?.await()
         closed.set(true)
     }
     override suspend fun listDevices(session: SyncSession): List<RemoteDevice> = emptyList()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorConnectGuardTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sync/SyncCoordinatorConnectGuardTest.kt
@@ -1,0 +1,135 @@
+package app.skerry.ui.sync
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Issue #328: what the "a connect is already in flight" guard is allowed to swallow.
+ *
+ * The guard drops a second connect so a repeat click cannot spawn a second session, and it used to
+ * stand until the coroutine that ran the connect returned — well past the point where the result is
+ * on screen. Everything after the status is published (the superseded client's socket pool, the
+ * subscriptions, the link write) is invisible to the caller, so a connect issued on the strength of
+ * that status hit a guard nothing on screen accounted for and was dropped in silence: no Busy, no
+ * failure, no session. What is left of the previous connect is serialized by the coordinator's own
+ * operation lock; the new one has only to queue behind it.
+ */
+class SyncCoordinatorConnectGuardTest {
+
+    private val crypto = IonspinVaultCrypto()
+    private val account = "maya"
+    private val password = "vault-A"
+    private val firstUrl = "https://one.test"
+    private val secondUrl = "https://two.test"
+    private val thirdUrl = "https://three.test"
+
+    @Test
+    fun `a connect issued on a published status is not swallowed by the previous connect's tail`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newAccountVault(crypto, password)
+        val wrap = wrapOwnKey(vault, crypto, password, account)
+        // The first client's close is what the second connect ends on — held open, it pins the
+        // coordinator inside that tail for as long as this test needs to aim at it.
+        val closing = CompletableDeferred<Unit>()
+        val first = ReactivatingClient(wrap, reactivated = false, closeGate = closing)
+        val second = ReactivatingClient(wrap, reactivated = false)
+        val third = ReactivatingClient(wrap, reactivated = false)
+        val sut = SyncCoordinator(
+            clientFactory = { url ->
+                when (url) {
+                    firstUrl -> first
+                    secondUrl -> second
+                    else -> third
+                }
+            },
+            crypto = crypto,
+            vault = vault,
+            configStore = InMemorySyncConfigStore(),
+            debtStore = InMemoryReconcileDebtStore(),
+            syncState = InMemorySyncStateStore(),
+        )
+        try {
+            sut.connect(firstUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the first session to come up") { it is SyncStatus.Online }
+
+            // Every connect publishes Busy on the caller's thread before it launches, so this waits
+            // for the SECOND connect's own Online and not for the one already standing.
+            sut.connect(secondUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the second session to come up") { it is SyncStatus.Online }
+            // On the server, not just on screen: a swallowed second connect would publish no Busy at all,
+            // and the wait above would have matched the first connect's Online without noticing.
+            awaitSync("the second server to be connected to") { while (second.pulledSince.isEmpty()) delay(20) }
+
+            // Online is on screen and the second connect is still winding down inside `close`.
+            sut.connect(thirdUrl, account, password.toCharArray())
+            closing.complete(Unit)
+            awaitSync("the third server to be connected to") { while (third.pulledSince.isEmpty()) delay(20) }
+        } finally {
+            closing.complete(Unit)
+            sut.close()
+        }
+    }
+
+    /**
+     * The other half of the same guard: what it must still refuse. The status is written by a dozen paths
+     * that never took the guard — a background cycle on the session that is still live, a disconnect, an
+     * auto-lock — and the release cannot be read off the status alone, or any of them would hand the guard
+     * back for an operation that has not published anything yet. Here the connect is held at the server
+     * while a manual cycle publishes Online for the PREVIOUS session; a connect issued on that status is
+     * still a double submit and is still dropped.
+     */
+    @Test
+    fun `a background cycle on the old session does not release the guard of a connect in flight`() = runBlocking {
+        initializeVaultCrypto()
+        val vault = newAccountVault(crypto, password)
+        val wrap = wrapOwnKey(vault, crypto, password, account)
+        val holding = CompletableDeferred<Unit>()
+        val first = ReactivatingClient(wrap, reactivated = false)
+        val second = ReactivatingClient(wrap, reactivated = false, loginGate = holding)
+        val third = ReactivatingClient(wrap, reactivated = false)
+        val sut = SyncCoordinator(
+            clientFactory = { url ->
+                when (url) {
+                    firstUrl -> first
+                    secondUrl -> second
+                    else -> third
+                }
+            },
+            crypto = crypto,
+            vault = vault,
+            configStore = InMemorySyncConfigStore(),
+            debtStore = InMemoryReconcileDebtStore(),
+            syncState = InMemorySyncStateStore(),
+        )
+        try {
+            sut.connect(firstUrl, account, password.toCharArray())
+            sut.status.awaitStatus("the first session to come up") { it is SyncStatus.Online }
+
+            sut.connect(secondUrl, account, password.toCharArray())
+            awaitSync("the second connect to reach the server") { second.loggingIn.await() }
+
+            // It is holding the operation lock with nothing published; the first session is still live,
+            // and a cycle over it publishes a result that belongs to neither connect.
+            sut.syncNow()
+            sut.status.awaitStatus("the background cycle to publish its own result") { it is SyncStatus.Online }
+
+            // connect() raises Busy on the caller's thread before it launches, so an admitted connect is
+            // visible right here — no waiting, no race with the one still at the server.
+            sut.connect(thirdUrl, account, password.toCharArray())
+            assertTrue(
+                sut.status.value is SyncStatus.Online,
+                "the connect still at the server owns the guard; a cycle that never took it must not hand it " +
+                    "back — status was ${sut.status.value}",
+            )
+        } finally {
+            holding.complete(Unit)
+            sut.close()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/FullAppThemeSwitchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/FullAppThemeSwitchRenderTest.kt
@@ -1,12 +1,9 @@
 package app.skerry.ui.terminal
 
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.toComposeImageBitmap
-import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
 import app.skerry.shared.host.Host
@@ -29,11 +26,11 @@ import app.skerry.ui.connection.toTarget
 import app.skerry.ui.desktop.DesktopDesignApp
 import app.skerry.ui.host.HostManagerController
 import app.skerry.ui.host.hostCatalogOf
+import app.skerry.ui.render.SceneFrames
 import app.skerry.ui.session.SessionsController
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.test.Test
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import kotlin.test.assertFalse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -69,65 +66,48 @@ class FullAppThemeSwitchRenderTest {
                 scene.setContent {
                     SkerryTheme { DesktopDesignApp(state = state, hosts = hosts, sessions = sessions) }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    val img = scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                    Thread.sleep(16) // async fonts/fake connection, as in Screenshot.kt
-                    return img
-                }
+                // The terminal comes up on a fake connection and async fonts, neither of which is on
+                // the frame clock: every wait below is for the screen to say something, never for a
+                // number of frames to go by (issue #330).
+                val frames = SceneFrames(scene, pauseMillis = FRAME_PAUSE_MS)
 
-                // Wait for a live terminal with the Night Sea palette (SGR 44 fill).
-                var pixels = frame()
-                var attempts = 0
-                while (!pixels.hasColor(NIGHT_SEA_ANSI_BLUE) && attempts < 120) {
-                    pixels = frame()
-                    attempts++
+                frames.awaitFrame("a live terminal with SGR 44 fill in the Night Sea palette") {
+                    it.hasColor(NIGHT_SEA_ANSI_BLUE)
                 }
-                assertTrue(
-                    pixels.hasColor(NIGHT_SEA_ANSI_BLUE),
-                    "did not see a live terminal with SGR 44 fill in the Night Sea palette",
-                )
 
                 // Unified theming: switching the APP theme alone must recolor the terminal to the
                 // theme's twin (Blackwater's ANSI blue is unique to its terminal palette — the
                 // green-accent chrome never paints it).
                 state.settings.chooseThemeMode(app.skerry.ui.theme.ThemeMode.BLACKWATER)
-                repeat(5) { pixels = frame() }
-                assertTrue(
-                    pixels.hasColor(BLACKWATER_ANSI_BLUE),
-                    "terminal should follow the app theme to its terminal twin",
-                )
-                if (pixels.hasColor(NIGHT_SEA_ANSI_BLUE)) {
-                    fail("Night Sea blue pixels remain after the app theme switch: the terminal did not follow")
+                // Both halves on ONE frame: "the new colour appeared" and "the old one is gone at some
+                // later point" is a weaker claim than the repaint this test is about.
+                val switched = frames.awaitFrame("the terminal to follow the app theme to its terminal twin") {
+                    it.hasColor(BLACKWATER_ANSI_BLUE)
                 }
+                assertFalse(switched.hasColor(NIGHT_SEA_ANSI_BLUE), "Night Sea pixels survived the app theme switch")
                 state.settings.chooseThemeMode(app.skerry.ui.theme.ThemeMode.DARK)
-                repeat(5) { pixels = frame() }
 
                 // Exact user path: open Settings -> Appearance over the terminal, opt into a
                 // separate terminal theme (unified theming follows the app theme otherwise),
                 // click the theme card, close settings; the terminal stays in composition.
                 state.openSettings()
                 state.showSettingsTab(app.skerry.ui.app.SettingsTab.Appearance)
-                repeat(3) { pixels = frame() }
+                frames.settle(SETTLE_FRAMES)
                 state.settings.toggleCustomTerminalTheme()
                 state.settings.chooseTerminalTheme(TerminalThemes.SolarizedLight)
-                repeat(3) { pixels = frame() }
+                frames.settle(SETTLE_FRAMES)
                 state.closeSettings()
-                repeat(5) { pixels = frame() }
 
-                assertTrue(
-                    pixels.hasColor(SOLARIZED_BG),
-                    "terminal background should recolor to Solarized Light",
-                )
-                assertTrue(
-                    pixels.hasColor(SOLARIZED_ANSI_BLUE),
-                    "SGR 44 fill should recolor to Solarized blue",
-                )
-                if (pixels.hasColor(NIGHT_SEA_ANSI_BLUE)) {
-                    fail("Night Sea blue pixels (ANSI 4) remain: terminal was not repainted after theme switch")
+                frames.awaitFrame("the terminal background to recolor to Solarized Light") {
+                    it.hasColor(SOLARIZED_BG)
                 }
+                val recolored = frames.awaitFrame("the SGR 44 fill to recolor to Solarized blue") {
+                    it.hasColor(SOLARIZED_ANSI_BLUE)
+                }
+                assertFalse(
+                    recolored.hasColor(NIGHT_SEA_ANSI_BLUE),
+                    "Night Sea ANSI 4 pixels survived the terminal theme switch",
+                )
             }
         } finally {
             sessions.disconnectAll()
@@ -178,6 +158,12 @@ class FullAppThemeSwitchRenderTest {
     }
 
     private companion object {
+        /** Wall clock each frame gives back to the fake connection and the async fonts. */
+        const val FRAME_PAUSE_MS = 16L
+
+        /** Frames spent letting the settings panel appear — nothing is asserted about them. */
+        const val SETTLE_FRAMES = 3
+
         val NIGHT_SEA_ANSI_BLUE = 0xFF4A9EDB.toInt()
         val BLACKWATER_ANSI_BLUE = 0xFF1E86CC.toInt()
         val SOLARIZED_BG = 0xFFFDF6E3.toInt()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowFocusTraversalTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/HostRowFocusTraversalTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.InternalComposeUiApi
@@ -19,6 +18,7 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
 import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.render.SceneFrames
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -50,17 +50,12 @@ class HostRowFocusTraversalTest {
                     }
                 }
             }
-            var timeNanos = 0L
-            fun frame() {
-                Snapshot.sendApplyNotifications()
-                timeNanos += 16_666_667L
-                scene.render(timeNanos)
-            }
-            frame()
+            val frames = SceneFrames(scene)
+            frames.advance()
             fun tab() {
                 scene.sendKeyEvent(KeyEvent(Key.Tab, KeyEventType.KeyDown))
                 scene.sendKeyEvent(KeyEvent(Key.Tab, KeyEventType.KeyUp))
-                frame()
+                frames.advance()
             }
 
             tab()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalHighlightRenderTest.kt
@@ -2,7 +2,6 @@ package app.skerry.ui.terminal
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
@@ -11,8 +10,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.toComposeImageBitmap
-import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
@@ -22,6 +19,7 @@ import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.render.SceneFrames
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.math.abs
 import kotlin.test.Test
@@ -69,10 +67,24 @@ class TerminalHighlightRenderTest {
 
     private val theme = TerminalThemes.NightSea
 
+    /** Frames spent on layout before the first emit — nothing is asserted about them. */
+    private val layoutFrames = 3
+
+    /**
+     * Frames a claim about what must NOT be on screen is given. A negative has no condition to wait
+     * for, so the budget is all there is — and these scenes feed and resize synchronously
+     * ([Dispatchers.Unconfined]), which is what makes a budget honest here and not on a scene whose
+     * work runs off the frame clock (issue #330).
+     */
+    private val settleFrames = 6
+
+    /** The cursor's blink half-period: the waits about its phase assert that period by name. */
+    private val blinkBudgetMs = 2_500L
+
     /** Runs [body] against a rendered terminal with the given highlight settings. */
     private fun withScreen(
         highlight: TerminalHighlight,
-        body: (session: FakeSession, frame: () -> PixelMap) -> Unit,
+        body: (session: FakeSession, frames: SceneFrames) -> Unit,
     ) {
         // Unconfined: feed/resize run synchronously at the emit point, making frames deterministic.
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
@@ -91,64 +103,63 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
+                val frames = SceneFrames(scene)
                 // Let layout settle (resize -> sized=true) before emitting.
-                repeat(3) { frame() }
-                body(session, ::frame)
+                frames.settle(layoutFrames)
+                body(session, frames)
             }
         } finally {
             scope.cancel()
         }
     }
 
-    /** Renders a few frames and reports whether [color] ended up on screen. */
-    private fun settle(frame: () -> PixelMap, color: Color): Boolean {
-        var pixels = frame()
-        repeat(4) { pixels = frame() }
-        return pixels.hasColorNear(color.toArgb())
-    }
-
     @Test
     fun typedCommandIsPaintedInTheThemeGreen() {
-        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frames ->
             session.emit("user@host:~$ git status")
-            assertTrue(settle(frame, theme.ansi[2]), "a known command should be drawn in the theme's green")
+            frames.awaitFrame("a known command to be drawn in the theme's green") {
+                it.hasColorNear(theme.ansi[2].toArgb())
+            }
         }
     }
 
     @Test
     fun theSwitchTurnsHighlightingOff() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             session.emit("user@host:~$ git status")
-            assertFalse(settle(frame, theme.ansi[2]), "nothing may be recolored while the switch is off")
+            assertFalse(
+                frames.settle(settleFrames).hasColorNear(theme.ansi[2].toArgb()),
+                "nothing may be recolored while the switch is off",
+            )
         }
     }
 
     @Test
     fun outputLevelsArePaintedOnlyWhenAskedFor() {
-        withScreen(TerminalHighlight(commandLine = false, output = true)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = true)) { session, frames ->
             session.emit("\r\nERROR failed to bind\r\n")
-            assertTrue(settle(frame, theme.ansi[1]), "a log level should be drawn in the theme's red")
+            frames.awaitFrame("a log level to be drawn in the theme's red") {
+                it.hasColorNear(theme.ansi[1].toArgb())
+            }
         }
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             session.emit("\r\nERROR failed to bind\r\n")
-            assertFalse(settle(frame, theme.ansi[1]), "output stays plain while the switch is off")
+            assertFalse(
+                frames.settle(settleFrames).hasColorNear(theme.ansi[1].toArgb()),
+                "output stays plain while the switch is off",
+            )
         }
     }
 
     @Test
     fun theServerWinsTheArgumentAboutColor() {
-        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frames ->
             // The server prints ERROR in its own green; the client's rule would make it red.
             session.emit("\r\n\u001b[32mERROR failed to bind\u001b[0m\r\n")
-            var pixels = frame()
-            repeat(4) { pixels = frame() }
-            assertTrue(pixels.hasColorNear(theme.ansi[2].toArgb()), "the server's green must survive")
+            val pixels = frames.awaitFrame("the server's own green to be drawn") {
+                it.hasColorNear(theme.ansi[2].toArgb())
+            }
+            // The same frame, not a later one: the claim is about what the server's green was drawn with.
             assertFalse(pixels.hasColorNear(theme.ansi[1].toArgb()), "an already-colored cell must not be repainted")
         }
     }
@@ -173,13 +184,8 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
-                repeat(3) { frame() }
+                val frames = SceneFrames(scene)
+                frames.settle(layoutFrames)
 
                 session.emit("user@host:~$ ")
                 state.typeInput("git status")
@@ -188,25 +194,13 @@ class TerminalHighlightRenderTest {
                 // The shell echoes the newline and draws the next prompt; the command is now history.
                 session.emit("\r\nuser@host:~$ ")
 
-                var pixels = frame()
-                repeat(5) { pixels = frame() }
-                assertTrue(
-                    pixels.hasColorNear(theme.ansi[2].toArgb()),
-                    "the executed command must stay green once the cursor moves to the next prompt",
-                )
+                frames.awaitFrame("the executed command to stay green once the cursor moves to the next prompt") {
+                    it.hasColorNear(theme.ansi[2].toArgb())
+                }
             }
         } finally {
             scope.cancel()
         }
-    }
-
-    /** Real-time poll: the blink coroutine delays on the wall clock, not the render clock. */
-    private fun pollFrames(frame: () -> PixelMap, tries: Int = 25, cond: (PixelMap) -> Boolean): Boolean {
-        repeat(tries) {
-            Thread.sleep(100)
-            if (cond(frame())) return true
-        }
-        return false
     }
 
     // NightSea's cursor #2BBDEE happens to equal ansi[6] (cyan) - the cursor-presence probes below
@@ -237,19 +231,16 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun cursorBlinkRepaintsWithoutRecomposingTheScreen() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             session.emit("x")
-            repeat(5) { frame() }
-            // Two-phase poll: a single sample races the wall-clock blink phase on a cold JVM.
-            assertTrue(
-                pollFrames(frame) { it.hasColorNear(theme.cursor.toArgb()) },
-                "the cursor must become visible",
-            )
+            // Two phases: the blink coroutine delays on the wall clock, not on the render clock.
+            frames.awaitFrame("the cursor to become visible", timeoutMillis = blinkBudgetMs) {
+                it.hasColorNear(theme.cursor.toArgb())
+            }
             val compositions = terminalScreenCompositions
-            assertTrue(
-                pollFrames(frame) { !it.hasColorNear(theme.cursor.toArgb()) },
-                "the cursor must blink off within ~2.5s",
-            )
+            frames.awaitFrame("the cursor to blink off", timeoutMillis = blinkBudgetMs) {
+                !it.hasColorNear(theme.cursor.toArgb())
+            }
             assertEquals(
                 compositions, terminalScreenCompositions,
                 "a blink toggle must repaint the overlay, not recompose the screen",
@@ -259,32 +250,37 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun aSteadyCursorNeverBlanks() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             // DECSCUSR 2 = steady block; the effect's early-return must pin the phase on.
             session.emit("${'\u001b'}[2 qx")
-            repeat(5) { frame() }
-            // Longer than two half-periods: a blink regression would blank at least once.
+            frames.awaitFrame("the steady cursor to be drawn", timeoutMillis = blinkBudgetMs) {
+                it.hasColorNear(theme.cursor.toArgb())
+            }
+            // Longer than two half-periods: a blink regression would blank at least once. A period
+            // is exactly what this asserts, so the frames are counted on purpose.
             repeat(13) {
                 Thread.sleep(100)
-                assertTrue(frame().hasColorNear(theme.cursor.toArgb()), "a steady cursor must never blank")
+                assertTrue(frames.next().hasColorNear(theme.cursor.toArgb()), "a steady cursor must never blank")
             }
         }
     }
 
     @Test
     fun aClosedSessionHidesTheCursor() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             session.emit("x")
-            assertTrue(
-                pollFrames(frame) { it.hasColorNear(theme.cursor.toArgb()) },
-                "the cursor must become visible first",
-            )
+            frames.awaitFrame("the cursor to become visible first", timeoutMillis = blinkBudgetMs) {
+                it.hasColorNear(theme.cursor.toArgb())
+            }
             session.die()
-            repeat(3) { frame() }
-            // Gone and stays gone: the overlay is not composed for a dead session.
-            repeat(5) {
+            // One frame for the composition to drop the overlay, then samples across more than one full
+            // blink period (2 x 530 ms). Deliberately NOT preceded by a wait for the cursor to go: such a
+            // wait returns at the start of an OFF phase, and every sample after it would land inside that
+            // same phase — a cursor still blinking over a dead session would go unnoticed.
+            frames.next()
+            repeat(13) {
                 Thread.sleep(100)
-                assertFalse(frame().hasColorNear(theme.cursor.toArgb()), "a dead session must not draw a cursor")
+                assertFalse(frames.next().hasColorNear(theme.cursor.toArgb()), "a dead session must not draw a cursor")
             }
         }
     }
@@ -307,31 +303,23 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
-                repeat(3) { frame() }
+                val frames = SceneFrames(scene)
+                frames.settle(layoutFrames)
                 // Concealed AND dim X at cell 0 (SGR 2;8 - the combination where a naive alpha
                 // override repainted the secret in 60% black); cursor sits at cell 1, clear of
                 // the probed region.
                 session.emit("${'\u001b'}[2;8mX")
-                repeat(5) { frame() }
+                frames.settle(settleFrames)
                 // Select across the row: the wash paints under the glyph pass, and hidden strokes
                 // of any color read through it as non-uniformity.
                 scene.sendPointerEvent(PointerEventType.Press, Offset(16f, 20f))
                 scene.sendPointerEvent(PointerEventType.Move, Offset(120f, 24f))
-                repeat(3) { frame() }
-                val after = frame()
                 // Guard against a vacuous pass: the wash color itself must be present on blank
                 // cells clear of the cursor cell - a frame delta on the probed row would also be
                 // satisfied by a mere cursor blink.
-                assertTrue(
-                    after.regionHasColor(selectionWash, 60..110, cell0InteriorY),
-                    "the drag must visibly paint the selection wash",
-                )
+                val after = frames.awaitFrame("the drag to visibly paint the selection wash") {
+                    it.regionHasColor(selectionWash, 60..110, cell0InteriorY)
+                }
                 assertTrue(
                     after.regionIsUniform(cell0InteriorX, cell0InteriorY, tolerance = 8),
                     "the concealed cell under the wash must be indistinguishable from blank cells",
@@ -344,13 +332,12 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun concealedTextDrawsNoUnderline() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             // SGR 8;4: concealed and underlined. The underline would trace the position and run
             // length of the hidden text - the whole cell, band included, must stay blank.
             session.emit("${'\u001b'}[8;4mX")
-            repeat(5) { frame() }
             assertTrue(
-                frame().regionIsUniform(cell0InteriorX, cell0WithUnderlineY, tolerance = 8),
+                frames.settle(settleFrames).regionIsUniform(cell0InteriorX, cell0WithUnderlineY, tolerance = 8),
                 "a concealed cell must not draw its underline",
             )
         }
@@ -358,28 +345,25 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun concealedUrlDrawsNoLinkUnderline() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             // Visible URL first: pins the probe region to where the link underline actually lands,
             // so a drifted band cannot make the concealed assertion below pass vacuously.
             session.emit("https://example.com\r\n\r\n")
-            repeat(5) { frame() }
-            assertTrue(
-                // Tolerance 90: the ~1.3px line antialiases against the near-black background,
-                // so no pixel reads as pure cyan (the strongest measures ~#1F8BB0, blue off by 62);
-                // 90 still cannot match the background itself (green differs by 175) or the
-                // foreground (red differs by 187).
-                frame().regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90),
-                "a visible bare URL must get the link underline",
-            )
+            // Tolerance 90: the ~1.3px line antialiases against the near-black background, so no
+            // pixel reads as pure cyan (the strongest measures ~#1F8BB0, blue off by 62); 90 still
+            // cannot match the background itself (green differs by 175) or the foreground (red
+            // differs by 187).
+            frames.awaitFrame("a visible bare URL to get the link underline") {
+                it.regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90)
+            }
             // The same URL concealed (SGR 8): LINK_UNDERLINE_STYLE carries its own color and
             // hidden=false, so underlineDrawColor's hidden gate never sees it - the link passes
             // themselves must skip concealed cells, or the underline traces the hidden run.
             session.emit("${'\u001b'}[2J${'\u001b'}[H${'\u001b'}[8mhttps://example.com${'\u001b'}[0m\r\n\r\n")
-            repeat(5) { frame() }
             assertFalse(
                 // The same wide tolerance makes this STRICTER: even a faint antialiased trace
                 // of the underline fails it.
-                frame().regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90),
+                frames.settle(settleFrames).regionHasColor(linkCyan, urlUnderlineX, urlUnderlineY, tolerance = 90),
                 "a concealed URL must not draw the link underline",
             )
         }
@@ -387,24 +371,21 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun concealedHyperlinkDrawsNoLinkUnderline() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             // Visible OSC 8 hyperlink first: pins the probe band for pass 4, a structurally
             // separate loop (keyed on the cell's hyperlink) from the bare-URL pass 5 that
             // concealedUrlDrawsNoLinkUnderline covers.
             session.emit("\u001b]8;;https://example.com\u0007link\u001b]8;;\u0007\r\n\r\n")
-            repeat(5) { frame() }
-            assertTrue(
-                frame().regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90),
-                "a visible OSC 8 hyperlink must get the link underline",
-            )
+            frames.awaitFrame("a visible OSC 8 hyperlink to get the link underline") {
+                it.regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90)
+            }
             // The same hyperlink concealed (SGR 8): the span filter that protects bare URLs never
             // sees OSC 8 cells, so pass 4 needs its own hidden gate - and its own test.
             session.emit(
                 "\u001b[2J\u001b[H\u001b]8;;https://example.com\u0007\u001b[8mlink\u001b[0m\u001b]8;;\u0007\r\n\r\n",
             )
-            repeat(5) { frame() }
             assertFalse(
-                frame().regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90),
+                frames.settle(settleFrames).regionHasColor(linkCyan, hyperlinkBandX, urlUnderlineY, tolerance = 90),
                 "a concealed OSC 8 hyperlink must not draw the link underline",
             )
         }
@@ -412,28 +393,22 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun concealedTextStaysHiddenUnderTheBlockCursor() {
-        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = false, output = false)) { session, frames ->
             // SGR 8 conceals X; CUB puts the block cursor onto it. The text pass renders the
             // glyph transparent (TerminalGlyphs.toSpanStyle); the cursor overlay must not repaint
             // it readable in the contrast color.
             session.emit("${'\u001b'}[8mX${'\u001b'}[D")
-            repeat(5) { frame() }
-            var checkedWhileLit = false
-            var attempts = 0
-            while (!checkedWhileLit && attempts++ < 25) {
-                Thread.sleep(100)
-                val px = frame()
-                if (px.regionHasColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY)) {
-                    // A solid block: any glyph stroke inside the interior (antialiased or not)
-                    // breaks the uniform cursor fill and reveals the concealed character.
-                    assertTrue(
-                        px.regionAllNearColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY, tolerance = 40),
-                        "a concealed glyph must not be redrawn readable under the cursor",
-                    )
-                    checkedWhileLit = true
-                }
+            // The sample has to be taken while the block is lit, which is a phase of the wall-clock
+            // blink — so the wait is for that phase, and never for a number of frames to go by.
+            val lit = frames.awaitFrame("the block cursor to be lit over the concealed cell", timeoutMillis = blinkBudgetMs) {
+                it.regionHasColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY)
             }
-            assertTrue(checkedWhileLit, "the block cursor must have been sampled while lit")
+            // A solid block: any glyph stroke inside the interior (antialiased or not) breaks the
+            // uniform cursor fill and reveals the concealed character.
+            assertTrue(
+                lit.regionAllNearColor(theme.cursor.toArgb(), cell0InteriorX, cell0InteriorY, tolerance = 40),
+                "a concealed glyph must not be redrawn readable under the cursor",
+            )
         }
     }
 
@@ -455,35 +430,28 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
-                repeat(3) { frame() }
+                val frames = SceneFrames(scene)
+                frames.settle(layoutFrames)
+                val scansBefore = linkScanPasses
                 session.emit("see https://example.com")
-                repeat(5) { frame() }
+                frames.awaitFrame("the hoisted link scan to run over the new content") { linkScanPasses > scansBefore }
                 val passes = linkScanPasses
-                assertTrue(passes > 0, "the hoisted link scan must still be wired into composition")
 
                 // A selection drag repaints the canvas on every move; the scan keys on content and
                 // window, not on frames - computed in the draw phase it would rerun per repaint.
                 scene.sendPointerEvent(PointerEventType.Press, Offset(40f, 20f))
                 scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 24f))
-                val afterFirstMove = frame()
                 // Guard against a vacuous pass: the wash color must be present on the blank cell 3
                 // inside the dragged range - a frame delta would also be satisfied by cursor blink.
-                assertTrue(
-                    afterFirstMove.regionHasColor(selectionWash, 39..44, cell0InteriorY),
-                    "the drag must visibly paint the selection wash",
-                )
+                frames.awaitFrame("the drag to visibly paint the selection wash") {
+                    it.regionHasColor(selectionWash, 39..44, cell0InteriorY)
+                }
                 repeat(5) { step ->
                     scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 24f))
-                    frame()
+                    frames.next()
                 }
                 scene.sendPointerEvent(PointerEventType.Release, Offset(180f, 24f))
-                frame()
+                frames.next()
                 assertEquals(passes, linkScanPasses, "selection repaints must not rescan links")
             }
         } finally {
@@ -509,39 +477,33 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
-                repeat(3) { frame() }
+                val frames = SceneFrames(scene)
+                frames.settle(layoutFrames)
+                val runsBefore = glyphRunSegmentations
                 session.emit("hello world")
-                repeat(5) { frame() }
+                frames.awaitFrame("the draw pass to segment the new row into runs") {
+                    glyphRunSegmentations > runsBefore
+                }
                 val segmentations = glyphRunSegmentations
-                assertTrue(segmentations > 0, "the draw pass must still segment rows into runs")
 
                 // A selection drag repaints the canvas per move; rows and highlights are unchanged,
                 // so every repaint must reuse the cached runs instead of re-segmenting the window.
                 scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 20f))
                 scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 24f))
-                val afterFirstMove = frame()
-                assertTrue(
-                    afterFirstMove.regionHasColor(selectionWash, 16..20, cell0InteriorY),
-                    "the drag must visibly paint the selection wash",
-                )
+                frames.awaitFrame("the drag to visibly paint the selection wash") {
+                    it.regionHasColor(selectionWash, 16..20, cell0InteriorY)
+                }
                 repeat(5) { step ->
                     scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 24f))
-                    frame()
+                    frames.next()
                 }
                 scene.sendPointerEvent(PointerEventType.Release, Offset(180f, 24f))
-                frame()
+                frames.next()
                 assertEquals(segmentations, glyphRunSegmentations, "selection repaints must not re-segment rows")
 
                 // New content really does re-segment.
                 session.emit("!")
-                repeat(5) { frame() }
-                assertTrue(glyphRunSegmentations > segmentations, "new content must re-segment its rows")
+                frames.awaitFrame("new content to re-segment its rows") { glyphRunSegmentations > segmentations }
             }
         } finally {
             scope.cancel()
@@ -566,36 +528,30 @@ class TerminalHighlightRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
-                repeat(3) { frame() }
+                val frames = SceneFrames(scene)
+                frames.settle(layoutFrames)
                 // Two content-equal rows carry two DISTINCT RowHighlight instances - a
                 // content-keyed cache aliases them into one entry and the identity check misses
                 // alternately, re-segmenting both rows on every repaint. Retry-loop logs are
                 // exactly this shape. An idle frame does not re-execute the draw lambda, so the
                 // repaints are forced with a selection drag (wash-guarded against a no-op).
+                val runsBefore = glyphRunSegmentations
                 session.emit("ERROR connection lost\r\nERROR connection lost\r\n")
-                repeat(5) { frame() }
+                frames.awaitFrame("the duplicate rows to be segmented") { glyphRunSegmentations > runsBefore }
                 val segmentations = glyphRunSegmentations
                 scene.sendPointerEvent(PointerEventType.Press, Offset(20f, 60f))
                 scene.sendPointerEvent(PointerEventType.Move, Offset(60f, 64f))
-                val afterFirstMove = frame()
                 // Probe columns 3..5 of the dragged row: the cursor block sits on column 0 and
                 // would read as cursor color, not wash.
-                assertTrue(
-                    afterFirstMove.regionHasColor(selectionWash, 40..56, 54..64),
-                    "the drag must visibly paint the selection wash",
-                )
+                frames.awaitFrame("the drag to visibly paint the selection wash") {
+                    it.regionHasColor(selectionWash, 40..56, 54..64)
+                }
                 repeat(4) { step ->
                     scene.sendPointerEvent(PointerEventType.Move, Offset(80f + step * 20f, 64f))
-                    frame()
+                    frames.next()
                 }
                 scene.sendPointerEvent(PointerEventType.Release, Offset(160f, 64f))
-                frame()
+                frames.next()
                 assertEquals(
                     segmentations, glyphRunSegmentations,
                     "repaints of duplicate highlighted rows must not re-segment",
@@ -608,58 +564,59 @@ class TerminalHighlightRenderTest {
 
     @Test
     fun aHighlightChangeResegmentsItsRows() {
-        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = true, output = false)) { session, frames ->
+            val runsBefore = glyphRunSegmentations
             session.emit("$ ls -la")
-            repeat(5) { frame() }
+            frames.awaitFrame("the live line to be segmented") { glyphRunSegmentations > runsBefore }
             val segmentations = glyphRunSegmentations
             // A cursor move through the live line rebuilds that row's RowHighlight instance; the
             // run cache must treat it as a miss - runs bake the highlight kinds in.
             session.emit("\u001b[D")
-            repeat(5) { frame() }
-            assertTrue(
-                glyphRunSegmentations > segmentations,
-                "a rebuilt highlight must re-segment its row",
-            )
+            frames.awaitFrame("a rebuilt highlight to re-segment its row") {
+                glyphRunSegmentations > segmentations
+            }
         }
     }
 
     @Test
     fun rewritingTheLineUnderAStationaryCursorRecomputesTheOverlay() {
-        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frames ->
             // Both lines are 8 cells, so after the rewrite the cursor lands on the same (row, col)
             // and the background map is empty both times (no output markers, nothing executed) -
             // the exact shape where keying the overlay on the background map alone kept stale
             // spans painted over the new text.
+            val overlaysBefore = liveOverlayPasses
             session.emit("$ ls -la")
-            repeat(5) { frame() }
+            frames.awaitFrame("the live overlay to run over the typed line") { liveOverlayPasses > overlaysBefore }
             val passes = liveOverlayPasses
 
             session.emit("\r$ git st")
-            repeat(5) { frame() }
-            assertTrue(
-                liveOverlayPasses > passes,
-                "an in-place rewrite under a stationary cursor must recompute the live overlay",
-            )
+            frames.awaitFrame(
+                "an in-place rewrite under a stationary cursor to recompute the live overlay",
+            ) { liveOverlayPasses > passes }
         }
     }
 
     @Test
     fun cursorMovesDoNotRescanTheBackgroundPass() {
-        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frame ->
+        withScreen(TerminalHighlight(commandLine = true, output = true)) { session, frames ->
+            val scansBefore = backgroundHighlightPasses
             session.emit("\r\nERROR failed to bind\r\nuser@host:~$ echo hi")
-            repeat(4) { frame() }
+            frames.awaitFrame("the background pass to scan the emitted window") {
+                backgroundHighlightPasses > scansBefore
+            }
             val passes = backgroundHighlightPasses
 
             // Pure cursor motion over the live line: the whole-window output/executed scan must
-            // stay cached - only the small live-command overlay may recompute.
+            // stay cached - only the small live-command overlay may recompute. Nothing may happen,
+            // so this one is a budget: frames in which the count must not move.
             session.emit("\u001b[D")
-            repeat(4) { frame() }
+            frames.settle(settleFrames)
             assertEquals(passes, backgroundHighlightPasses, "a cursor move must not rescan the window")
 
             // Real content invalidates the background pass.
             session.emit("x")
-            repeat(4) { frame() }
-            assertTrue(backgroundHighlightPasses > passes, "new content must rescan")
+            frames.awaitFrame("new content to rescan the window") { backgroundHighlightPasses > passes }
         }
     }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalSearchRenderTest.kt
@@ -2,15 +2,12 @@ package app.skerry.ui.terminal
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.toComposeImageBitmap
-import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
@@ -19,6 +16,7 @@ import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
 import app.skerry.ui.design.DesignFonts
 import app.skerry.ui.design.LocalFonts
+import app.skerry.ui.render.SceneFrames
 import app.skerry.ui.theme.SkerryTheme
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -45,6 +43,9 @@ import kotlinx.coroutines.flow.asStateFlow
  */
 @OptIn(ExperimentalComposeUiApi::class)
 class TerminalSearchRenderTest {
+
+    /** Frames spent letting layout settle before the first emit — nothing is asserted about them. */
+    private val layoutFrames = 3
 
     /** Fake PTY session: output only, input/resize are no-ops. */
     private class FakeSession : TerminalSession {
@@ -81,44 +82,38 @@ class TerminalSearchRenderTest {
                         }
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
+                val frames = SceneFrames(scene)
 
                 // Let layout settle (resize -> sized=true) before emitting, so the rows stay on screen.
-                repeat(3) { frame() }
+                frames.settle(layoutFrames)
                 // Blank lines first: the panel is pinned to the pane's top-right corner and would
                 // otherwise cover the very rows whose highlight this test looks for.
                 session.emit("\r\n\r\n\r\n\r\nalpha one\r\nalpha two")
 
                 val match = theme.searchMatch.over(theme.background)
                 val current = theme.searchCurrentMatch.over(theme.background)
-                var pixels = frame()
-                repeat(3) { pixels = frame() }
-                assertFalse(pixels.hasColorNear(match), "nothing is highlighted before a search runs")
+                // A fixed budget, and here that IS the claim: nothing may ever paint the wash, so
+                // there is no condition to wait for — only frames in which it must not appear.
+                assertFalse(
+                    frames.settle(layoutFrames).hasColorNear(match),
+                    "nothing is highlighted before a search runs",
+                )
 
                 state.search.open()
                 state.search.updateQuery("alpha")
                 assertTrue(state.search.matches.size == 2, "expected both rows to match, got ${state.search.matches}")
 
-                pixels = frame()
-                var attempts = 0
-                while (!(pixels.hasColorNear(match) && pixels.hasColorNear(current)) && attempts < 30) {
-                    pixels = frame()
-                    attempts++
-                }
-                assertTrue(pixels.hasColorNear(match), "an unselected hit should carry the match wash")
-                assertTrue(pixels.hasColorNear(current), "the selected hit should carry the stronger wash")
+                // Both washes on ONE frame: they come out of the same draw pass, and "each appeared at
+                // some point" would pass on a frame that never showed them together.
+                val hits = frames.awaitFrame("an unselected hit to carry the match wash") { it.hasColorNear(match) }
+                assertTrue(hits.hasColorNear(current), "the selected hit must carry the stronger wash on that frame")
 
                 // Closing the panel drops the highlight with it.
                 state.search.close()
-                pixels = frame()
-                repeat(2) { pixels = frame() }
-                assertFalse(pixels.hasColorNear(match), "highlight should disappear once search is closed")
-                assertFalse(pixels.hasColorNear(current), "selected-hit highlight should disappear too")
+                val closed = frames.awaitFrame("the match wash to disappear once search is closed") {
+                    !it.hasColorNear(match)
+                }
+                assertFalse(closed.hasColorNear(current), "the selected-hit wash must be gone on that frame too")
             }
         } finally {
             scope.cancel()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalThemeSwitchRenderTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalThemeSwitchRenderTest.kt
@@ -3,22 +3,19 @@ package app.skerry.ui.terminal
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.snapshots.Snapshot
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.ImageComposeScene
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.PixelMap
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.graphics.toComposeImageBitmap
-import androidx.compose.ui.graphics.toPixelMap
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.use
 import app.skerry.shared.ssh.PtySize
 import app.skerry.shared.terminal.TerminalSession
 import app.skerry.shared.terminal.TerminalState
+import app.skerry.ui.render.SceneFrames
 import kotlin.test.Test
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import kotlin.test.assertFalse
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -70,47 +67,41 @@ class TerminalThemeSwitchRenderTest {
                         TerminalScreen(state, Modifier.fillMaxSize())
                     }
                 }
-                var timeNanos = 0L
-                fun frame(): PixelMap {
-                    Snapshot.sendApplyNotifications()
-                    timeNanos += 16_666_667L
-                    return scene.render(timeNanos).toComposeImageBitmap().toPixelMap()
-                }
+                val frames = SceneFrames(scene)
 
                 // First frames: layout -> LaunchedEffect(resize) -> sized=true. Emit output only after
                 // the grid settles: shrinking from 80x24 to the actual grid pushes top rows into
                 // scrollback under autoscroll, so the test rows must stay on screen.
-                repeat(3) { frame() }
+                frames.settle(LAYOUT_FRAMES)
                 // Line 1: SGR 44, background fill (drawRect). Line 2: SGR 32 + 3x U+2588 FULL BLOCK,
                 // solid glyphs (drawText). Exactly three blocks: the TextMeasurer cache holds 8
                 // entries, and all keys must fit in it (as with a few short user runs), or LRU eviction
                 // would mask a stale-color bug.
                 session.emit("\u001b[44m          \u001b[0m\r\n\u001b[32m███\u001b[0m")
 
-                // Wait for both old-palette render paths to draw (frames for effects/snapshot publish).
-                var pixels = frame()
-                var attempts = 0
-                while ((!pixels.hasColor(NIGHT_SEA_ANSI_BLUE) || !pixels.hasColor(NIGHT_SEA_ANSI_GREEN)) && attempts < 30) {
-                    pixels = frame()
-                    attempts++
-                }
-                assertTrue(pixels.hasColor(NIGHT_SEA_ANSI_BLUE), "did not see SGR 44 fill in the Night Sea palette")
-                assertTrue(pixels.hasColor(NIGHT_SEA_ANSI_GREEN), "did not see SGR 32 glyphs in the Night Sea palette")
+                // Both old-palette render paths have to have drawn before the switch means anything.
+                frames.awaitFrame("the SGR 44 fill in the Night Sea palette") { it.hasColor(NIGHT_SEA_ANSI_BLUE) }
+                frames.awaitFrame("the SGR 32 glyphs in the Night Sea palette") { it.hasColor(NIGHT_SEA_ANSI_GREEN) }
 
                 // Switch theme at runtime, as clicking the Appearance card does.
                 theme.value = TerminalThemes.SolarizedLight
-                pixels = frame()
-                pixels = frame() // second frame in case of deferred invalidation
 
-                assertTrue(pixels.hasColor(SOLARIZED_BG), "terminal background should recolor to Solarized Light")
-                assertTrue(pixels.hasColor(SOLARIZED_ANSI_BLUE), "SGR 44 fill should recolor to Solarized blue")
-                if (pixels.hasColor(NIGHT_SEA_ANSI_BLUE)) {
-                    fail("SGR 44 fill stayed Night Sea blue: background layer not repainted after theme switch")
+                frames.awaitFrame("the terminal background to recolor to Solarized Light") { it.hasColor(SOLARIZED_BG) }
+                frames.awaitFrame("the SGR 44 fill to recolor to Solarized blue") { it.hasColor(SOLARIZED_ANSI_BLUE) }
+                // The last of the three positives is also where both negatives are read: the repaint this
+                // test is about is one frame carrying the new palette and nothing of the old, not two
+                // conditions that may hold frames apart.
+                val recolored = frames.awaitFrame("the SGR 32 glyphs to recolor to Solarized green") {
+                    it.hasColor(SOLARIZED_ANSI_GREEN)
                 }
-                if (pixels.hasColor(NIGHT_SEA_ANSI_GREEN)) {
-                    fail("SGR 32 glyphs stayed Night Sea green: drawText painted with stale TextMeasurer cache color")
-                }
-                assertTrue(pixels.hasColor(SOLARIZED_ANSI_GREEN), "SGR 32 glyphs should recolor to Solarized green")
+                assertFalse(
+                    recolored.hasColor(NIGHT_SEA_ANSI_BLUE),
+                    "the SGR 44 fill is still Night Sea blue: the background layer did not repaint",
+                )
+                assertFalse(
+                    recolored.hasColor(NIGHT_SEA_ANSI_GREEN),
+                    "the SGR 32 glyphs are still Night Sea green: drawText painted from a stale TextMeasurer cache",
+                )
             }
         } finally {
             scope.cancel()
@@ -128,6 +119,9 @@ class TerminalThemeSwitchRenderTest {
     }
 
     private companion object {
+        /** Frames spent letting layout settle before the first emit — nothing is asserted about them. */
+        const val LAYOUT_FRAMES = 3
+
         val NIGHT_SEA_ANSI_BLUE = 0xFF4A9EDB.toInt()
         val NIGHT_SEA_ANSI_GREEN = 0xFF5DCE9E.toInt()
         val SOLARIZED_BG = 0xFFFDF6E3.toInt()

--- a/gradle/detekt-baseline-composeApp.xml
+++ b/gradle/detekt-baseline-composeApp.xml
@@ -31,8 +31,8 @@
     <ID>CyclomaticComplexMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) fun main()</ID>
     <ID>CyclomaticComplexMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) private fun renderMobile(out: String, viewName: String, overlay: String, live: Boolean)</ID>
     <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
-    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
-    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean, linking: Int? = null)</ID>
+    <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false, linking: Int? = null)</ID>
     <ID>CyclomaticComplexMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun runSyncLocked(c: SyncClient, s: SyncSession)</ID>
     <ID>CyclomaticComplexMethod:SyncFailureText.kt$internal fun syncFailureResource(reason: SyncFailureReason): StringResource</ID>
     <ID>CyclomaticComplexMethod:TeamActivityFeedView.kt$private fun rowIcon(kind: TeamActivityKind): String</ID>
@@ -61,8 +61,8 @@
     <ID>LongMethod:Screenshot.kt$@OptIn(ExperimentalComposeUiApi::class) fun main()</ID>
     <ID>LongMethod:SessionShareController.kt$SessionShareController$fun share(teamId: String, teamName: String, paneId: String, label: String, source: ShareSource, readOnlyOnly: Boolean)</ID>
     <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
-    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
-    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean, linking: Int? = null)</ID>
+    <ID>LongMethod:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false, linking: Int? = null)</ID>
     <ID>LongMethod:TerminalThemeTest.kt$TerminalThemeTest$@Test fun every_theme_matches_its_golden_palette()</ID>
     <ID>LongMethod:VncTouchSurface.kt$private suspend fun androidx.compose.ui.input.pointer.PointerInputScope.vncTouchGestures( screen: RemoteDesktopScreenState, pad: VncTrackpad, canvasSize: () -&gt; IntSize, )</ID>
     <ID>LongMethod:main.kt$fun main(args: Array&lt;String&gt;)</ID>
@@ -88,8 +88,8 @@
     <ID>NestedBlockDepth:AndroidSecretFileReader.kt$AndroidSecretFileReader$override fun read(ref: String): SecretFileResult</ID>
     <ID>NestedBlockDepth:HostMenuWidthTest.kt$HostMenuWidthTest$@Test fun `the row menu never renders narrower than its floor`()</ID>
     <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doChangeAccountPassword(cfg: SyncConfig, current: CharArray, next: CharArray): AccountPasswordChange</ID>
-    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean)</ID>
-    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false)</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doClaimPairing(payload: String, localPassword: CharArray, keepConnected: Boolean, linking: Int? = null)</ID>
+    <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun doConnect(serverUrl: String, accountId: String, masterPassword: CharArray, keepConnected: Boolean, allowPasswordReplace: Boolean = false, linking: Int? = null)</ID>
     <ID>NestedBlockDepth:SyncCoordinator.kt$SyncCoordinator$private suspend fun runSyncLocked(c: SyncClient, s: SyncSession)</ID>
     <ID>NestedBlockDepth:TerminalGlyphs.kt$internal fun DrawScope.drawCellUnderline(style: TermStyle, left: Float, top: Float, width: Float, chh: Float, palette: Palette, effects: UnderlineEffects, theme: TerminalTheme)</ID>
     <ID>SpreadOperator:KeyboardInteractiveDialog.kt$(*Array(challenge.prompts.size) { "" })</ID>


### PR DESCRIPTION
Closes #328. Closes #330.

## The connect that was dropped in silence

A connect issued while the previous one was winding down did nothing at all: no Busy, no failure, no
session, and the previous server still on screen.

The double-submit guard stood until the launched coroutine returned, which is long past the point
where the operation's result reaches the user. By then the session is live, the link is saved and the
first sync cycle has published Online; what is left — the subscriptions, the superseded client's
socket pool — is invisible to the caller. A connect made on the strength of that status met a guard
nothing on screen accounted for.

The guard is now released by the operation itself. The token taken by `beginLinking()` is carried
through `doConnect`/`doClaimPairing` into `activateSession` and dropped there, with the session live
and the first cycle about to publish it — before that publication, so a caller woken by the status
finds the guard already down. What is left of the operation needs no guard: `opMutex` serializes it
and the next connect queues behind it.

Releasing it off the status instead would have been wrong: `_status` is written from a dozen paths
that never took the guard — a background cycle on the session being replaced, `disconnect`, the
auto-lock — and any of them would hand back a guard that is not theirs. Two tests pin both halves:
one proves a connect issued on a published status is honoured, the other that a background cycle on
the old session does not release the guard of a connect still at the server.

The per-launch `finally` stays as the backstop for the paths that never get that far, and now also
wipes the password copy that an operation cancelled while queued would otherwise leave in memory.

## The render tests that waited on frame counts

`FullAppThemeSwitchRenderTest` failed on CI and passed everywhere else. It, and nine other places,
waited by rendering a fixed number of frames — five frames, thirty attempts — and then asserted. That
is a statement about how fast the machine is, not about what the screen shows: on an idle laptop five
frames are plenty, on a loaded runner the assert reads the frame before the one that would have
passed.

`SceneFrames` replaces those ten hand-rolled copies. `awaitFrame` drives frames until the screen says
what the test is waiting for, and fails with what it was waiting for if the budget runs out. Fixed
budgets remain only where the claim is a negative and there is nothing to wait for — those keep a
short, documented frame count, because the count is the assertion. Where a test asserts both that the
new colour appeared and that the old one is gone, both are now read from the same frame.

## Verifying

Run `./gradlew :composeApp:desktopTest --rerun` — the whole desktop suite, including the two new sync
tests and the six reworked render tests. Both new tests were checked negatively: with the release
removed the first fails, and with the release keyed on the status the second fails while the first
passes.

For the connect fix by hand: connect to a sync server, wait for Online, and immediately connect to a
second one. Before this change the second tap was swallowed while the first connect closed its
client; now it takes.
