### PR TITLE
Never discard a confirmed file operation, and give the phone a refresh

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
@@ -95,11 +95,25 @@ class FilePaneController(
      * in [selectTo] stay consistent with [selection] writes in the same transaction.
      */
     private var anchor: String? by mutableStateOf(null)
-    private var busy = false
 
     /**
-     * Serializes the actual work of [op]/[queuedOp]. [busy] alone can only drop a racing operation;
-     * the gate is what lets a queued one wait for the in-flight listing to finish.
+     * Whether a pane operation (listing, navigation, create/delete/rename) is running or waiting its
+     * turn. Snapshot state, so a screen can say so: every operation costs a round trip, and over a
+     * phone link a listing that just sits there is indistinguishable from one that did nothing.
+     */
+    val busy: Boolean get() = pending > 0
+
+    /**
+     * Operations requested and not yet finished — the one owner of [busy]. A flag set by [op] and
+     * cleared by [queuedOp] would let one path clear what the other still owns, and the pane would
+     * report itself idle with a listing in flight.
+     */
+    private var pending: Int by mutableStateOf(0)
+
+    /**
+     * Serializes the actual work of [op]/[queuedOp]: the pane scope is main-confined in production,
+     * but nothing in the contract says so, and the gate is what makes a queued operation wait for
+     * the in-flight listing rather than interleave with it.
      */
     private val gate = Mutex()
 
@@ -176,24 +190,40 @@ class FilePaneController(
         loadedEntries().firstOrNull { it.path == resolved }?.let { setCursor(it) }
     }
 
-    /** Reloads the current directory. */
+    /** Reloads the current directory. Dropped while the pane works — see [op]. */
     fun refresh() = op { reload() }
 
+    /**
+     * Reloads the current directory without being droppable, for the callers whose listing the
+     * source has already changed underneath: a finished transfer, a saved edit. [refresh] is a
+     * keypress and may be dropped; this one may not — nobody is going to press it again, and the
+     * pane would go on showing files a move has already taken away (same failure as issue #327).
+     */
+    fun reloadNow() = queuedOp { reload() }
+
     /** Creates subdirectory [name] in the current directory and moves the cursor to it. */
-    fun mkdir(name: String) = op {
-        val created = childPath(name)
-        browser.mkdir(created)
-        reload()
-        // An active name filter can hide the just-created directory — creating something the user
-        // can't see reads as a silent failure, so drop the filter to reveal it.
-        if (nameFilter.isNotEmpty() && loadedEntries().none { it.path == created }) setNameFilter("")
-        loadedEntries().firstOrNull { it.path == created }?.let { setCursor(it) }
+    fun mkdir(name: String) {
+        val dir = path
+        queuedOp {
+            val created = childPath(dir, name)
+            browser.mkdir(created)
+            reload()
+            if (path != dir) return@queuedOp
+            // An active name filter can hide the just-created directory — creating something the user
+            // can't see reads as a silent failure, so drop the filter to reveal it.
+            if (nameFilter.isNotEmpty() && loadedEntries().none { it.path == created }) setNameFilter("")
+            loadedEntries().firstOrNull { it.path == created }?.let { setCursor(it) }
+        }
     }
 
-    /** Deletes [item] (directories recursively). */
-    fun delete(item: FileItem) = op {
-        browser.delete(item)
-        reload()
+    /**
+     * Deletes [item] (directories recursively) — the single-row path the phone's context menu uses.
+     * Same rule as [deleteAll]: the path is rebuilt from the directory and a validated name, never
+     * from the one the server put in the listing (issue #313).
+     */
+    fun delete(item: FileItem) {
+        val dir = path
+        queuedOp { deleteAll(dir, listOf(item)) }
     }
 
     /**
@@ -208,25 +238,68 @@ class FilePaneController(
      * Deletes all [operands] (F8): selected rows, or the cursored one. Each is removed
      * recursively. One [reload] afterward; no-op if [operands] is empty. Confirmation is the
      * UI's responsibility.
+     *
+     * The targets and the directory are read now, not when the queued body runs: the user confirmed
+     * *these* rows in *that* directory, and the operation may wait behind another one — including a
+     * navigation — while the listing stays live under their finger.
      */
-    fun deleteSelected() = op {
+    fun deleteSelected() {
+        val dir = path
         val targets = operands()
-        if (targets.isEmpty()) return@op
+        if (targets.isEmpty()) return
+        queuedOp { deleteAll(dir, targets) }
+    }
+
+    private suspend fun deleteAll(dir: String, targets: List<FileItem>) {
         targets.forEach { item ->
             // Deletes via a path rebuilt from [path] + a validated name, not server-controlled item.path.
             val name = item.name
             if (isUnsafeListingName(name)) {
                 throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
             }
-            browser.delete(item.copy(path = childPath(name)))
+            val target = childPath(dir, name)
+            browser.delete(item.copy(path = target))
+            // Dropped by the path that was deleted, not by the one the listing reported: the two
+            // agree for an honest source, and where they don't, the row that stays is the honest answer.
+            dropFromListing(target)
         }
         reload()
     }
 
-    /** Renames [item] to [newName] within the current directory. */
-    fun rename(item: FileItem, newName: String) = op {
-        browser.rename(item.path, childPath(newName))
+    /** Renames [item] to [newName] within the current directory, keeping the cursor on the row. */
+    fun rename(item: FileItem, newName: String) {
+        val dir = path
+        queuedOp { renameIn(dir, item, newName) }
+    }
+
+    private suspend fun renameIn(dir: String, item: FileItem, newName: String) {
+        // Same rule as [deleteAll]: the source is rebuilt from [dir] and a validated name, never
+        // from the path the server put in the listing.
+        val name = item.name
+        if (isUnsafeListingName(name)) {
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+        }
+        val renamed = childPath(dir, newName)
+        browser.rename(childPath(dir, name), renamed)
+        val wasCursored = cursor == item.path
+        rewriteListing { entries ->
+            entries.mapNotNull {
+                when (it.path) {
+                    item.path -> it.copy(name = newName, path = renamed)
+                    // A rename that replaced a file leaves two rows on one path until the relist
+                    // lands, and both listings key their rows on it.
+                    renamed -> null
+                    else -> it
+                }
+            }
+        }
+        if (wasCursored) loadedEntries().firstOrNull { it.path == renamed }?.let { setCursor(it) }
         reload()
+        if (path != dir) return
+        // Same rule as [mkdir]: a new name the active filter doesn't match would take the row off
+        // screen, and a row that vanishes after a rename reads as the file being gone.
+        if (nameFilter.isNotEmpty() && loadedEntries().none { it.path == renamed }) setNameFilter("")
+        if (wasCursored) loadedEntries().firstOrNull { it.path == renamed }?.let { setCursor(it) }
     }
 
     /** Selects only [item] (plain click), setting it as the Shift-range anchor. */
@@ -413,6 +486,29 @@ class FilePaneController(
         cursorOnParent = cursor == null && hasParent
     }
 
+    /**
+     * Applies a change the source has already confirmed to the cached listing, without asking for a
+     * new one. The [reload] that follows is the authority; this is what the row does in the
+     * meantime. Every operation costs a round trip and the listing after it costs another — over a
+     * phone link, leaving the deleted row on screen for that second trip reads as "nothing
+     * happened" (issue #327). No-op outside [FilePaneState.Loaded]: there is no listing to correct.
+     *
+     * Rows are matched by path, and the paths built here join with `/`, so the rewrite only bites on
+     * a POSIX/SFTP listing. On the desktop local pane under Windows the keys are backslash-separated
+     * and nothing matches: the row survives until the relist, which for a local directory is a
+     * no-round-trip `list()`.
+     */
+    private fun rewriteListing(transform: (List<FileItem>) -> List<FileItem>) {
+        if (state !is FilePaneState.Loaded) return
+        rawEntries = transform(rawEntries).sortedForPane()
+        state = FilePaneState.Loaded(visible(rawEntries))
+        pruneSelection()
+        clampCursor()
+    }
+
+    /** Drops the row at [path] from the cached listing — see [rewriteListing]. */
+    private fun dropFromListing(path: String) = rewriteListing { entries -> entries.filterNot { it.path == path } }
+
     /** Reloads the current [path] in place (refresh/after mkdir/rename/delete). */
     private suspend fun reload() {
         state = loadState(path)
@@ -505,41 +601,37 @@ class FilePaneController(
     }
 
     /**
-     * Runs a pane operation, serialized via [busy]. Any [FileBrowserException] from the operation
-     * moves the pane to [FilePaneState.Error].
+     * Runs a pane operation, dropping it while the pane is already working. Only for commands the
+     * user can simply issue again — refresh, navigation — where a second request means the same
+     * thing as the first. Anything the user confirmed goes through [queuedOp].
      *
-     * [busy] is a plain (non-`@Volatile`) flag: relies on [scope] being single-threaded/
-     * main-confined. A multi-threaded dispatcher would race on [busy].
+     * The check-and-set on [pending], and [pending] itself, are not atomic: [scope] is required to
+     * be main-confined, as every production caller's is. A multi-threaded scope would lose an
+     * increment or a decrement, and a lost decrement pins the pane at [busy] for good.
      */
     private fun op(block: suspend () -> Unit) {
         if (busy) return
-        busy = true
-        scope.launch {
-            try {
-                gate.withLock { runOp(block) }
-            } finally {
-                busy = false
-            }
-        }
+        launchOp(block)
     }
 
     /**
      * Like [op], but waits its turn instead of being dropped while another operation runs. For
-     * requests arriving from outside the pane ([revealPath]): they race the pane's own first
-     * listing ([start]) and there is nothing on screen to retry from, whereas dropping a keypress
-     * the user can simply press again is exactly what [op] is for.
+     * everything the user already confirmed — a delete, a rename, a new directory — and for requests
+     * arriving from outside the pane ([revealPath]). Issue #327: a confirmed action that is silently
+     * discarded is the worst outcome the pane has, because the dialog closed and the screen looks
+     * exactly as if it had gone through.
      */
-    private fun queuedOp(block: suspend () -> Unit) {
-        scope.launch {
-            gate.withLock {
-                busy = true
-                try {
-                    runOp(block)
-                } finally {
-                    busy = false
-                }
-            }
-        }
+    private fun queuedOp(block: suspend () -> Unit) = launchOp(block)
+
+    /**
+     * Body shared by [op]/[queuedOp]. [pending] is raised before the launch, so a second [op] issued
+     * in the same frame still sees the pane as busy, and lowered on completion rather than in a
+     * `finally` inside the coroutine: a scope already cancelled never runs the body at all, and a
+     * pane stuck at [busy] would refuse every request it is given afterwards.
+     */
+    private fun launchOp(block: suspend () -> Unit) {
+        pending++
+        scope.launch { gate.withLock { runOp(block) } }.invokeOnCompletion { pending-- }
     }
 
     /** Body shared by [op]/[queuedOp]: runs the operation, mapping a failure into [FilePaneState.Error]. */
@@ -552,9 +644,6 @@ class FilePaneController(
             state = FilePaneState.Error(e.failure)
         }
     }
-
-    /** Path of child [name] in the current directory. */
-    private fun childPath(name: String): String = childPath(path, name)
 
     /**
      * Lexical parent of an absolute path for the "up" action. Does not resolve `"$path/.."` via

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -163,7 +163,7 @@ class TransferCoordinator(
         confirmOverwrite(items, remote) { destDir ->
             launchExclusive {
                 runUpload(items, destDir)
-                remote.refresh()
+                remote.reloadNow()
                 local.clearSelection()
             }
         }
@@ -185,7 +185,7 @@ class TransferCoordinator(
         confirmOverwrite(items, local) { destDir ->
             launchExclusive {
                 runDownload(items, destDir, sourceDir)
-                local.refresh()
+                local.reloadNow()
                 remote.clearSelection()
             }
         }
@@ -206,8 +206,8 @@ class TransferCoordinator(
                 launchExclusive {
                     runUpload(items, destDir)
                     val failed = deleteSources(items) { localBrowser.delete(it) }
-                    remote.refresh()
-                    local.refresh()
+                    remote.reloadNow()
+                    local.reloadNow()
                     if (failed == null) local.clearSelection() else transfers.fail(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
@@ -225,8 +225,8 @@ class TransferCoordinator(
                     // Deletes via a path rebuilt from the directory snapshot + a validated name, not
                     // server-controlled item.path.
                     val failed = deleteSources(items) { remoteBrowser.delete(it.copy(path = safeRemoteChild(it.name, remoteDir))) }
-                    local.refresh()
-                    remote.refresh()
+                    local.reloadNow()
+                    remote.reloadNow()
                     if (failed == null) remote.clearSelection() else transfers.fail(failed.name, FileTransferFailure.DeleteSource)
                 }
             }
@@ -305,7 +305,7 @@ class TransferCoordinator(
             sftp.upload(source.stagingPath, target) { transferred, total ->
                 transfers.step(source.name, 1, 1, transferred, total)
             }
-            remote.refresh()
+            remote.reloadNow()
         }
     }
 
@@ -328,7 +328,7 @@ class TransferCoordinator(
             item = item.copy(path = childPath(pane.path, item.name)),
             readOnly = readOnly,
             scope = scope,
-            onSaved = { pane.refresh() },
+            onSaved = { pane.reloadNow() },
         ).also { it.open() }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesChrome.kt
@@ -37,13 +37,16 @@ import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.PathJumpField
 import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_fkey_refresh
 import app.skerry.ui.generated.resources.sftp_connecting
 import app.skerry.ui.generated.resources.sftp_files_title
 import app.skerry.ui.generated.resources.sftp_filter_hint
+import app.skerry.ui.generated.resources.sftp_loading
 import app.skerry.ui.generated.resources.sftp_no_session
 import app.skerry.ui.generated.resources.sftp_no_session_hint
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.fieldFocus
@@ -94,6 +97,10 @@ internal fun MobileFilesBreadcrumbRow(
     // Live mode: the trailing funnel icon toggles the quick-filter row; [filterActive] tints it.
     onToggleFilter: (() -> Unit)? = null,
     filterActive: Boolean = false,
+    // Live mode: asks the pane for the directory again — the phone's F9. [busy] means an operation
+    // is already in flight, and the control says so instead of pretending a tap would do anything.
+    onRefresh: (() -> Unit)? = null,
+    busy: Boolean = false,
 ) {
     var editing by remember(path) { mutableStateOf(false) }
     // Drawn filtered, edited raw: what the field submits has to be the path the pane is actually in
@@ -144,17 +151,33 @@ internal fun MobileFilesBreadcrumbRow(
                 ),
             )
         }
+        if (onRefresh != null && !editing) {
+            // One node across both states, and it keeps its name: a node swapped in place of another
+            // is an insertion a screen reader says nothing about, and it would drop the focus of
+            // whoever just activated it. What changed is the pane's state, not the button's identity,
+            // so the state goes to the live region below and the button only goes inert.
+            IconBtn(
+                if (busy) "sync" else "refresh",
+                onClick = onRefresh,
+                // A finger, not a mouse: the glyph stays 18sp and the hit box is the button. Two
+                // 18dp targets 6dp apart on a phone means the funnel takes the press meant for the
+                // refresh — the same "the button did nothing" this screen is being fixed for.
+                box = 32,
+                tint = Skerry.colors.faint,
+                label = stringResource(Res.string.ftail_fkey_refresh),
+                enabled = !busy,
+            )
+            // A round trip that starts and ends in silence is what makes a phone link read as
+            // "nothing happened" — for a screen reader that is the only signal there is.
+            StatusAnnouncer(if (busy) stringResource(Res.string.sftp_loading) else "")
+        }
         if (onToggleFilter != null && !editing) {
-            Sym(
+            IconBtn(
                 "filter_alt",
-                contentDescription = stringResource(Res.string.sftp_tip_filter_toggle),
-                size = 18.sp,
-                color = if (filterActive) Skerry.colors.cyanBright else Skerry.colors.faint,
-                modifier = Modifier.clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = onToggleFilter,
-                ),
+                onClick = onToggleFilter,
+                box = 32,
+                tint = if (filterActive) Skerry.colors.cyanBright else Skerry.colors.faint,
+                label = stringResource(Res.string.sftp_tip_filter_toggle),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesMockView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesMockView.kt
@@ -46,7 +46,9 @@ internal fun MockMobileFilesView(mono: FontFamily) {
     Box(Modifier.fillMaxSize().background(Skerry.colors.bg)) {
         Column(Modifier.fillMaxSize()) {
             MobileFilesTitle()
-            MobileFilesBreadcrumbRow(label = "prod-web-01", path = "/var/www", mono = mono)
+            // The screenshot path draws what the live screen draws: a preview breadcrumb without
+            // the refresh the live one now carries is store-asset drift.
+            MobileFilesBreadcrumbRow(label = "prod-web-01", path = "/var/www", mono = mono, onRefresh = {})
             Column(Modifier.fillMaxWidth().padding(top = 12.dp, start = 12.dp, end = 12.dp)) {
                 MOCK_REMOTE_FILES.forEach { MockFileRow(it, mono) }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
@@ -43,6 +43,7 @@ import app.skerry.ui.files.fileBrowserFailureText
 import app.skerry.ui.files.fileDisplayName
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_local_label
 import app.skerry.ui.generated.resources.shell_tip_close
 import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_fkey_edit
@@ -66,6 +67,42 @@ import app.skerry.ui.sftp.NameDialog
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.theme.Skerry
+
+/**
+ * Breadcrumb row of the live pane. Everything it shows and everything it does comes from [pane], so
+ * the one live call site wires a pane rather than repeating six arguments — the same seam
+ * [MobileLivePane] is, and testable the same way. [filterOpen] is the screen's own state, since the
+ * quick-filter row it toggles is drawn outside this row.
+ */
+@Composable
+internal fun MobileLiveBreadcrumb(
+    pane: FilePaneController,
+    mono: FontFamily,
+    filterOpen: Boolean,
+    onFilterOpenChange: (Boolean) -> Unit,
+) {
+    MobileFilesBreadcrumbRow(
+        pane.label.ifBlank { stringResource(Res.string.ftail_local_label) },
+        pane.path,
+        mono,
+        onGoToPath = pane::goToPath,
+        // The funnel both opens and closes: closing while filter text is present also clears it, so
+        // the icon is never a visible no-op.
+        onToggleFilter = {
+            if (filterOpen || pane.nameFilter.isNotEmpty()) {
+                pane.setNameFilter("")
+                onFilterOpenChange(false)
+            } else {
+                onFilterOpenChange(true)
+            }
+        },
+        filterActive = filterOpen || pane.nameFilter.isNotEmpty(),
+        // The phone's F9: the desktop panel has a refresh button, this screen had nothing but
+        // leaving the directory and coming back (issue #327).
+        onRefresh = pane::refresh,
+        busy = pane.busy,
+    )
+}
 
 /**
  * Live pane (Remote or Local) over [FilePaneController]: listing + ".." up row + rename/delete
@@ -129,6 +166,7 @@ internal fun MobileLivePane(
             title = stringResource(Res.string.sftp_rename),
             confirmLabel = stringResource(Res.string.sftp_rename),
             initial = entry.name,
+            existing = pane.currentEntryNames(),
             onConfirm = { pane.rename(entry, it); renaming = null },
             onDismiss = { renaming = null },
         )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -32,7 +32,6 @@ import app.skerry.ui.files.TransferCoordinator
 import app.skerry.ui.files.fileDisplayPath
 import app.skerry.ui.files.platformLocalBrowser
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.ftail_local_label
 import app.skerry.ui.generated.resources.ftail_open_failed
 import app.skerry.ui.generated.resources.sftp_connecting
 import app.skerry.ui.generated.resources.sftp_create
@@ -166,22 +165,7 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                     val downloadHere = remember(c) {
                         { item: FileItem -> c.remote.selectOnly(item); c.downloadSelection() }
                     }
-                    MobileFilesBreadcrumbRow(
-                        pane.label.ifBlank { stringResource(Res.string.ftail_local_label) },
-                        pane.path,
-                        mono, onGoToPath = pane::goToPath,
-                        // The funnel both opens and closes: closing while filter text is present
-                        // also clears it, so the icon is never a visible no-op.
-                        onToggleFilter = {
-                            if (filterOpen || pane.nameFilter.isNotEmpty()) {
-                                pane.setNameFilter("")
-                                filterOpen = false
-                            } else {
-                                filterOpen = true
-                            }
-                        },
-                        filterActive = filterOpen || pane.nameFilter.isNotEmpty(),
-                    )
+                    MobileLiveBreadcrumb(pane, mono, filterOpen, onFilterOpenChange = { filterOpen = it })
                     if (filterOpen || pane.nameFilter.isNotEmpty()) {
                         MobileFilterRow(pane, mono, onClose = { filterOpen = false })
                     }
@@ -243,6 +227,7 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                 title = stringResource(Res.string.sftp_new_folder),
                 confirmLabel = stringResource(Res.string.sftp_create),
                 initial = "",
+                existing = pane.currentEntryNames(),
                 onConfirm = { pane.mkdir(it); creatingFolder = false },
                 onDismiss = { creatingFolder = false },
             )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpView.kt
@@ -284,6 +284,7 @@ private fun LiveSftpView(
                 SftpWorkBarActions(
                     localActive = active == ActivePane.Local,
                     enabled = c != null,
+                    busy = c != null && (c.local.busy || c.remote.busy),
                     onRefresh = { fKey(9) },
                     onNewFolder = { fKey(7) },
                     onFilter = { if (active == ActivePane.Local) localFilterTick++ else remoteFilterTick++ },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpWorkBar.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpWorkBar.kt
@@ -22,6 +22,7 @@ import app.skerry.ui.app.LocalSftpPrefs
 import app.skerry.ui.app.SftpPrefs
 import app.skerry.ui.design.AnchoredDropdown
 import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.ToggleRow
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.labelUppercase
@@ -29,6 +30,7 @@ import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_col_modified
 import app.skerry.ui.generated.resources.sftp_col_permissions
 import app.skerry.ui.generated.resources.sftp_columns
+import app.skerry.ui.generated.resources.sftp_loading
 import app.skerry.ui.generated.resources.sftp_new_folder
 import app.skerry.ui.generated.resources.sftp_tip_back
 import app.skerry.ui.generated.resources.sftp_tip_download
@@ -79,8 +81,23 @@ internal fun SftpWorkBarActions(
     onNewFolder: () -> Unit,
     onFilter: () -> Unit,
     onTransfer: () -> Unit,
+    // A pane is already listing/deleting/renaming: the panes drop a second request while one runs,
+    // so the button says what it is doing instead of looking live and doing nothing.
+    busy: Boolean = false,
 ) {
-    IconBtn("refresh", onClick = onRefresh, box = 26, tooltip = stringResource(Res.string.sftp_tip_refresh), enabled = enabled)
+    // One button across both states, and it keeps its name: what changed is the panes' state, which
+    // goes to the live region, not the button's identity. Unlike the phone's single-pane control it
+    // stays live while busy — it refreshes BOTH panes, and the one that is idle still has a listing
+    // to fetch; each pane drops its own redundant request.
+    IconBtn(
+        if (busy) "sync" else "refresh",
+        onClick = onRefresh,
+        box = 26,
+        tint = if (busy) Skerry.colors.cyanBright else Skerry.colors.dim,
+        tooltip = stringResource(Res.string.sftp_tip_refresh),
+        enabled = enabled,
+    )
+    StatusAnnouncer(if (busy) stringResource(Res.string.sftp_loading) else "")
     IconBtn("create_new_folder", onClick = onNewFolder, box = 26, tooltip = stringResource(Res.string.sftp_new_folder), enabled = enabled)
     IconBtn("filter_alt", onClick = onFilter, box = 26, tooltip = stringResource(Res.string.sftp_tip_filter), enabled = enabled)
     ColumnsMenu(LocalSftpPrefs.current)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
@@ -9,6 +9,7 @@ import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.ui.sftp.FakeSftpClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -17,20 +18,27 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 private const val HOME = "/home/skerry"
 
-/** Fake source rooted at HOME, seeded with a mix of directories and files. */
-private fun seededBrowser(): SftpFileBrowser {
-    val fake = FakeSftpClient(startDir = HOME).apply {
-        seedDir("$HOME/zeta")
-        seedDir("$HOME/alpha")
-        seedFile("$HOME/readme.txt", size = 11)
-        seedFile("$HOME/build.log", size = 200)
-    }
-    return SftpFileBrowser(fake, label = "prod-web-01")
+/**
+ * Fake source rooted at HOME, seeded with a mix of directories and files. Handed out as the client
+ * itself for the tests that hold its next listing in flight ([FakeSftpClient.listGate]) or make it
+ * refuse a delete ([FakeSftpClient.removeError]).
+ */
+private fun seededFake(): FakeSftpClient = FakeSftpClient(startDir = HOME).apply {
+    seedDir("$HOME/zeta")
+    seedDir("$HOME/alpha")
+    seedFile("$HOME/readme.txt", size = 11)
+    seedFile("$HOME/build.log", size = 200)
 }
+
+private fun browserOn(fake: FakeSftpClient): SftpFileBrowser = SftpFileBrowser(fake, label = "prod-web-01")
+
+private fun seededBrowser(): SftpFileBrowser = browserOn(seededFake())
 
 /** Same seed plus a nested file under alpha, for testing navigation into a directory. */
 private fun seededBrowserWithNested(): SftpFileBrowser {
@@ -195,6 +203,352 @@ class FilePaneControllerTest {
         advanceUntilIdle()
         val names = c.loaded().entries.map { it.name }
         assertTrue("manual.txt" in names && "readme.txt" !in names)
+    }
+
+    /**
+     * Issue #327. A phone talks to its servers over a link where every round trip costs: the delete
+     * itself is one, the listing that follows is another. Holding the row on screen for the second
+     * one reads as "the delete did nothing" — so the listing drops the row the moment the source
+     * confirms it is gone, and the relist that follows only reconciles what else moved.
+     */
+    @Test
+    fun `delete drops the row when the source confirms, without waiting for the relist`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        val target = c.entry("readme.txt")
+        val relist = CompletableDeferred<Unit>()
+        fake.listGate = relist
+
+        c.delete(target)
+        advanceUntilIdle()
+
+        assertEquals(listOf("alpha", "zeta", "build.log"), c.loaded().entries.map { it.name })
+        assertTrue(c.busy, "the relist is still in flight")
+
+        relist.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("alpha", "zeta", "build.log"), c.loaded().entries.map { it.name })
+        assertFalse(c.busy, "the operation is over")
+    }
+
+    /** Same contract for a batch delete: each row goes as its own removal is confirmed. */
+    @Test
+    fun `deleteSelected drops the rows it deleted before the relist returns`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        c.selectOnly(c.entry("readme.txt"))
+        c.toggle(c.entry("build.log"))
+        val relist = CompletableDeferred<Unit>()
+        fake.listGate = relist
+
+        c.deleteSelected()
+        advanceUntilIdle()
+
+        assertEquals(listOf("alpha", "zeta"), c.loaded().entries.map { it.name })
+        relist.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("alpha", "zeta"), c.loaded().entries.map { it.name })
+    }
+
+    /** A delete the source refuses is not a delete: the row has to survive it. */
+    @Test
+    fun `a delete the source refuses leaves the file where it was`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        fake.removeError = "Permission denied"
+
+        c.delete(c.entry("readme.txt"))
+        advanceUntilIdle()
+        assertIs<FilePaneState.Error>(c.state)
+
+        fake.removeError = null
+        c.refresh()
+        advanceUntilIdle()
+        assertTrue(c.loaded().entries.any { it.name == "readme.txt" }, "nothing was deleted")
+    }
+
+    /** The renamed row carries its new name straight away, sorted into its new place. */
+    @Test
+    fun `rename shows the new name before the relist returns`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        val relist = CompletableDeferred<Unit>()
+        fake.listGate = relist
+
+        c.rename(c.entry("readme.txt"), "manual.txt")
+        advanceUntilIdle()
+
+        assertEquals(listOf("alpha", "zeta", "build.log", "manual.txt"), c.loaded().entries.map { it.name })
+        assertEquals("$HOME/manual.txt", c.loaded().entries.last().path)
+
+        relist.complete(Unit)
+        advanceUntilIdle()
+        assertEquals(listOf("alpha", "zeta", "build.log", "manual.txt"), c.loaded().entries.map { it.name })
+    }
+
+    /**
+     * Issue #313: the pane acts on the *name* it showed, resolved against the directory it was
+     * showing — a listing entry named ".." is a hostile server trying to make the user's confirmed
+     * delete land above the directory they were looking at.
+     */
+    @Test
+    fun `a delete of a row the server named dot-dot never reaches the source`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+
+        c.delete(FileItem("..", "$HOME/..", FileItemType.Directory, size = 0, modifiedEpochSeconds = 0))
+        advanceUntilIdle()
+
+        // IllegalName and nothing else: unguarded, this reaches the source and comes back as the
+        // browser's own prefix refusal, a different failure on a request that should never be sent.
+        assertEquals(FileBrowserFailure.IllegalName, assertIs<FilePaneState.Error>(c.state).failure)
+        c.refresh()
+        advanceUntilIdle()
+        assertEquals(listOf("alpha", "zeta", "build.log", "readme.txt"), c.loaded().entries.map { it.name })
+    }
+
+    /** The path the server attached to the row is not what gets deleted — the name under it is. */
+    @Test
+    fun `a delete follows the row name, not the path the server attached to it`() = runTest {
+        val fake = seededFake().apply { seedFile("/etc/passwd", size = 42) }
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+
+        c.delete(c.entry("readme.txt").copy(path = "/etc/passwd"))
+        advanceUntilIdle()
+
+        assertNotNull(fake.stat("/etc/passwd"), "the path the server pointed at is untouched")
+        assertNull(fake.stat("$HOME/readme.txt"), "the row the user confirmed is gone")
+    }
+
+    /** Same rule on the rename source: a ".." row must not become a handle on the parent directory. */
+    @Test
+    fun `a rename of a row the server named dot-dot never reaches the source`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+
+        c.rename(FileItem("..", "$HOME/..", FileItemType.Directory, size = 0, modifiedEpochSeconds = 0), "loot")
+        advanceUntilIdle()
+
+        assertEquals(FileBrowserFailure.IllegalName, assertIs<FilePaneState.Error>(c.state).failure)
+        // Where the unguarded rename lands: "$HOME/.." resolves to /home, and the source moves the
+        // whole parent under the directory on screen.
+        assertNull(fake.stat("$HOME/loot"), "the parent directory was not moved anywhere")
+    }
+
+    /** Renaming acts on the row's name in the directory on screen, whatever path the listing carried. */
+    @Test
+    fun `a rename follows the row name, not the path the server attached to it`() = runTest {
+        val fake = seededFake().apply { seedFile("/etc/passwd", size = 42) }
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+
+        c.rename(c.entry("readme.txt").copy(path = "/etc/passwd"), "manual.txt")
+        advanceUntilIdle()
+
+        assertNotNull(fake.stat("/etc/passwd"), "the path the server pointed at is untouched")
+        assertNotNull(fake.stat("$HOME/manual.txt"), "the row the user confirmed was renamed in place")
+        assertNull(fake.stat("$HOME/readme.txt"))
+    }
+
+    /**
+     * A quick filter is a view, not a scope: renaming a row out of it must not read as "my file is
+     * gone" — the same rule [mkdir] already follows for a directory created out of view.
+     */
+    @Test
+    fun `a rename out of the active filter clears the filter instead of hiding the row`() = runTest {
+        val c = controllerOn(seededBrowser())
+        c.start()
+        advanceUntilIdle()
+        c.setNameFilter("log")
+        assertEquals(listOf("build.log"), c.loaded().entries.map { it.name })
+
+        c.rename(c.entry("build.log"), "notes.txt")
+        advanceUntilIdle()
+
+        assertEquals("", c.nameFilter)
+        assertTrue(c.loaded().entries.any { it.name == "notes.txt" }, "the renamed row is on screen")
+    }
+
+    /** Renaming the row under the cursor must not throw the cursor back to the top of the listing. */
+    @Test
+    fun `rename keeps the cursor on the row it renamed`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        c.setCursor(c.entry("readme.txt"))
+        val relist = CompletableDeferred<Unit>()
+        fake.listGate = relist
+
+        c.rename(c.entry("readme.txt"), "manual.txt")
+        advanceUntilIdle()
+        assertEquals("$HOME/manual.txt", c.cursoredItem()?.path, "before the relist")
+
+        relist.complete(Unit)
+        advanceUntilIdle()
+        assertEquals("$HOME/manual.txt", c.cursoredItem()?.path, "after the relist")
+    }
+
+    /**
+     * A rename the source resolved by replacing the target: both listings key their rows on the
+     * path, and two rows sharing one is a hard failure on desktop, not a cosmetic one.
+     */
+    @Test
+    fun `a rename onto an existing name leaves one row on that path`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        val relist = CompletableDeferred<Unit>()
+        fake.listGate = relist
+
+        c.rename(c.entry("readme.txt"), "build.log")
+        advanceUntilIdle()
+
+        assertEquals(1, c.loaded().entries.count { it.path == "$HOME/build.log" })
+    }
+
+    /**
+     * The pane drops a request that arrives while it is working, which is right for a keypress the
+     * user can press again and wrong for something they confirmed in a dialog: the dialog closes,
+     * the row stays, and nothing was ever sent. That is issue #327 read literally.
+     */
+    @Test
+    fun `a delete confirmed while the pane is working is not discarded`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        val target = c.entry("readme.txt")
+
+        val listing = CompletableDeferred<Unit>()
+        fake.listGate = listing
+        c.refresh()
+        advanceUntilIdle()
+        assertTrue(c.busy, "the refresh is still in flight")
+
+        c.delete(target)
+        advanceUntilIdle()
+
+        fake.listGate = null
+        listing.complete(Unit)
+        advanceUntilIdle()
+
+        assertFalse(c.loaded().entries.any { it.name == "readme.txt" }, "the confirmed delete has to reach the source")
+        assertFalse(c.busy)
+    }
+
+    /**
+     * A batch delete waits its turn now, and the listing stays live under the user's finger while it
+     * does. The rows it removes have to be the rows they confirmed, not whatever happens to be
+     * selected by the time its turn comes.
+     */
+    @Test
+    fun `deleteSelected removes the rows that were selected when it was confirmed`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        c.selectOnly(c.entry("readme.txt"))
+
+        val listing = CompletableDeferred<Unit>()
+        fake.listGate = listing
+        c.refresh()
+        advanceUntilIdle()
+
+        c.deleteSelected()
+        c.selectOnly(c.entry("build.log"))
+        advanceUntilIdle()
+
+        fake.listGate = null
+        listing.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(listOf("alpha", "zeta", "build.log"), c.loaded().entries.map { it.name })
+    }
+
+    /**
+     * The pane keeps showing the old directory until a navigation's listing lands, so an operation
+     * confirmed in that window belongs to the directory on screen. Resolving it against wherever the
+     * pane ended up would delete or move something the user never saw.
+     */
+    @Test
+    fun `a rename confirmed before a navigation lands stays in the directory it was confirmed in`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        val target = c.entry("readme.txt")
+
+        val listing = CompletableDeferred<Unit>()
+        fake.listGate = listing
+        c.open(c.entry("alpha"))
+        advanceUntilIdle()
+
+        c.rename(target, "manual.txt")
+        advanceUntilIdle()
+
+        fake.listGate = null
+        listing.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("$HOME/alpha", c.path, "the navigation still lands")
+        assertEquals(
+            listOf("alpha", "build.log", "manual.txt", "zeta"),
+            fake.list(HOME).map { it.name }.sorted(),
+        )
+        assertEquals(emptyList(), fake.list("$HOME/alpha").map { it.name })
+    }
+
+    /** The pane says when it is working, so a screen can show it instead of looking stuck. */
+    @Test
+    fun `busy is false at rest and true while an operation runs`() = runTest {
+        val fake = seededFake()
+        val c = controllerOn(browserOn(fake))
+        c.start()
+        advanceUntilIdle()
+        assertFalse(c.busy)
+        val alpha = c.entry("alpha")
+        val gate = CompletableDeferred<Unit>()
+        fake.listGate = gate
+
+        c.open(alpha)
+        advanceUntilIdle()
+        assertTrue(c.busy, "the listing of alpha is still in flight")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertFalse(c.busy)
+    }
+
+    /** A pane whose scope died mid-flight would otherwise stay busy forever and refuse everything after. */
+    @Test
+    fun `busy clears when the pane scope is already gone`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val c = FilePaneController(seededBrowser(), scope)
+        c.start()
+        advanceUntilIdle()
+        scope.cancel()
+
+        c.refresh()
+        advanceUntilIdle()
+
+        assertFalse(c.busy)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -257,6 +257,32 @@ class TransferCoordinatorTest {
         assertTrue(r.local.selection.isEmpty())
     }
 
+    /**
+     * Issue #327's bug class on the transfer path: F9 on the destination pane while the move runs
+     * leaves that pane working when the move finishes. A relist dropped there is one nobody will
+     * ask for again, and the pane goes on showing files the move has already taken away.
+     */
+    @Test
+    fun `a move relists the panes even with a listing already in flight`() = runTest {
+        val r = rig()
+        val held = CompletableDeferred<Unit>()
+        r.remoteFake.listGate = held
+        r.remote.refresh() // the user's F9, answered from the tree as it is now
+        advanceUntilIdle()
+
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.moveSelection(fromLocal = true)
+        advanceUntilIdle()
+
+        r.remoteFake.listGate = null
+        held.complete(Unit) // the stale listing lands, without the moved file in it
+        advanceUntilIdle()
+
+        val remoteNames = (r.remote.state as FilePaneState.Loaded).entries.map { it.name }
+        assertTrue("a.txt" in remoteNames, "expected the moved file on remote, have: $remoteNames")
+        assertTrue("a.txt" !in (r.local.state as FilePaneState.Loaded).entries.map { it.name })
+    }
+
     @Test
     fun `moveSelection from local moves a directory recursively then deletes it`() = runTest {
         val r = rig()

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -45,9 +45,12 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
     var listGate: CompletableDeferred<Unit>? = null
 
     override suspend fun list(path: String): List<SftpEntry> {
-        listGate?.await()
         val dir = children[realpathSync(path)] ?: throw SftpException("No directory $path")
-        return dir.values.toList()
+        // Answered from the tree as it was when the request arrived, like a real round trip: a
+        // listing held in flight must be able to land stale.
+        val answer = dir.values.toList()
+        listGate?.await()
+        return answer
     }
 
     override suspend fun stat(path: String): SftpEntry? {

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileFilesRefreshTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileFilesRefreshTest.kt
@@ -1,0 +1,175 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertHeightIsAtLeast
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertWidthIsAtLeast
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.files.FilePaneController
+import app.skerry.ui.sftp.FakeSftpClient
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #327: on the phone a file the user deleted stayed on screen, and there was nothing to
+ * press to ask for the listing again — the desktop panel has F9 and a refresh button, the phone
+ * had neither, so the only way out was to leave the directory and come back.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileFilesRefreshTest {
+
+    /** The whole context-menu path, the one the report describes: long-press → Delete → confirm. */
+    @Test
+    fun `deleting a file from the context menu drops its row`() {
+        val fake = FakeSftpClient(startDir = "/srv").apply {
+            seedDir("/srv")
+            seedFile("/srv/alpha.txt")
+            seedFile("/srv/beta.txt")
+        }
+        // Unconfined: the source answers in place, so the listing is settled by waitForIdle and the
+        // test never waits on wall-clock time — the one call it holds is held explicitly.
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val pane = FilePaneController(SftpFileBrowser(fake, label = "stub"), scope)
+        pane.start()
+        try {
+            runForm({
+                MobileLivePane(
+                    pane = pane,
+                    mono = FontFamily.Monospace,
+                    onTransfer = {},
+                    onDownloadHere = null,
+                    onOpenEditor = { _, _ -> },
+                    modifier = Modifier,
+                )
+            }) {
+                onNodeWithText("alpha.txt").performTouchInput { longClick() }
+                waitForIdle()
+                onNodeWithText("Delete").performClick()
+                waitForIdle()
+                onNodeWithText("Delete file?").assertExists()
+
+                // Hold the relist that follows the delete: the row has to go when the source
+                // confirms it is gone, not a round trip later. Waiting for the relist is exactly
+                // what the report read as "the delete did nothing".
+                val relist = CompletableDeferred<Unit>()
+                fake.listGate = relist
+                onNodeWithText("Delete").performClick()
+                waitForIdle()
+
+                onNodeWithText("alpha.txt").assertDoesNotExist()
+                onNodeWithText("beta.txt").assertExists()
+
+                fake.listGate = null
+                relist.complete(Unit)
+                waitForIdle()
+                onNodeWithText("alpha.txt").assertDoesNotExist()
+                onNodeWithText("beta.txt").assertExists()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    /** The breadcrumb row carries the refresh the phone was missing. */
+    @Test
+    fun `the breadcrumb row offers a refresh`() {
+        var refreshed = 0
+        runForm({
+            MobileFilesBreadcrumbRow(
+                label = "prod-web-01",
+                path = "/srv",
+                mono = FontFamily.Monospace,
+                onGoToPath = {},
+                onRefresh = { refreshed++ },
+                busy = false,
+            )
+        }) {
+            onNodeWithContentDescription("Refresh")
+                .assertIsDisplayed()
+                // A finger, not a mouse: the glyph is 18sp and the funnel sits 6dp away, so the
+                // press has to land on a button-sized box rather than on the glyph itself.
+                .assertWidthIsAtLeast(32.dp)
+                .assertHeightIsAtLeast(32.dp)
+                .performClick()
+            waitForIdle()
+        }
+        assertEquals(1, refreshed)
+    }
+
+    /**
+     * While the pane is working the row announces it and the control does not fire: a second
+     * request would be dropped by the pane's own serialization, and a button that looks live but
+     * does nothing is exactly what the report read as a broken refresh.
+     */
+    @Test
+    fun `while the pane works the row announces it and the refresh stays inert`() {
+        var refreshed = 0
+        runForm({
+            MobileFilesBreadcrumbRow(
+                label = "prod-web-01",
+                path = "/srv",
+                mono = FontFamily.Monospace,
+                onGoToPath = {},
+                onRefresh = { refreshed++ },
+                busy = true,
+            )
+        }) {
+            onNodeWithContentDescription("Loading…").assertExists()
+            onNodeWithContentDescription("Refresh").assertIsDisplayed().assertIsNotEnabled().performClick()
+            waitForIdle()
+        }
+        assertEquals(0, refreshed)
+    }
+
+    /**
+     * The wiring itself, at the seam the one live call site uses: the button has to reach the
+     * pane's own refresh, and the state it reports has to be the pane's own. Asserting the two
+     * literals at the breadcrumb row proves neither.
+     */
+    @Test
+    fun `the live breadcrumb asks its own pane for the listing and reports its state`() {
+        val fake = FakeSftpClient(startDir = "/srv").apply {
+            seedDir("/srv")
+            seedFile("/srv/alpha.txt")
+        }
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val pane = FilePaneController(SftpFileBrowser(fake, label = "prod-web-01"), scope)
+        pane.start()
+        try {
+            runForm({
+                MobileLiveBreadcrumb(pane, FontFamily.Monospace, filterOpen = false, onFilterOpenChange = {})
+            }) {
+                onNodeWithContentDescription("Loading…").assertDoesNotExist()
+
+                // Held before the press, so the listing the press asks for is still in flight when
+                // the row is next drawn.
+                val relist = CompletableDeferred<Unit>()
+                fake.listGate = relist
+                onNodeWithContentDescription("Refresh").performClick()
+                waitForIdle()
+                onNodeWithContentDescription("Loading…").assertExists()
+
+                fake.listGate = null
+                relist.complete(Unit)
+                waitForIdle()
+                onNodeWithContentDescription("Loading…").assertDoesNotExist()
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpWorkBarBusyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpWorkBarBusyTest.kt
@@ -1,0 +1,69 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import app.skerry.ui.desktop.runForm
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The panel's refresh button (issue #327, desktop half): it has to say when a pane is listing —
+ * keeping its own name, and putting the state in the live region a screen reader hears — without
+ * refusing the press, because it drives both panes and the other one may be idle.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SftpWorkBarBusyTest {
+
+    @Test
+    fun `an idle panel offers the refresh and fires it`() {
+        var refreshed = 0
+        runForm({
+            // The bar lays its actions out in a row; stacked in the root they would overlap and a
+            // click would land on whichever was drawn last.
+            Row {
+                SftpWorkBarActions(
+                    localActive = true,
+                    enabled = true,
+                    onRefresh = { refreshed++ },
+                    onNewFolder = {},
+                    onFilter = {},
+                    onTransfer = {},
+                    busy = false,
+                )
+            }
+        }) {
+            onNodeWithContentDescription("Refresh both panes (F9)").assertIsDisplayed().performClick()
+            waitForIdle()
+        }
+        assertEquals(1, refreshed)
+    }
+
+    @Test
+    fun `a working panel announces the listing and still refreshes`() {
+        var refreshed = 0
+        runForm({
+            // The bar lays its actions out in a row; stacked in the root they would overlap and a
+            // click would land on whichever was drawn last.
+            Row {
+                SftpWorkBarActions(
+                    localActive = true,
+                    enabled = true,
+                    onRefresh = { refreshed++ },
+                    onNewFolder = {},
+                    onFilter = {},
+                    onTransfer = {},
+                    busy = true,
+                )
+            }
+        }) {
+            onNodeWithContentDescription("Loading…").assertExists()
+            onNodeWithContentDescription("Refresh both panes (F9)").assertIsDisplayed().performClick()
+            waitForIdle()
+        }
+        // One pane listing must not veto the other pane's refresh — each drops its own request.
+        assertEquals(1, refreshed)
+    }
+}


### PR DESCRIPTION
Fixes #327. Closes #313.

## What the pane does now

**A confirmed operation is never discarded.** The file pane dropped any request that
arrived while it was still working. That is the right answer for a keypress the user can
simply press again — refresh, navigation — and the wrong one for something confirmed in a
dialog: the dialog closed, the row stayed, and nothing had been sent. Delete, rename and
"new directory" now wait their turn instead.

**A confirmed delete or rename shows immediately.** It used to take a second round trip —
the operation itself, then the listing that followed — before the screen moved. Over a
phone link that reads as "the operation did nothing". The listing now drops or rewrites
the row the moment the source confirms it, and the relist that follows only reconciles
what else moved. A rename keeps the cursor on the row it renamed, and drops a row it
replaced rather than leaving two on one path.

**The phone has a refresh.** The desktop panel has F9 and a work-bar button; the Files
screen on Android had neither, so leaving the directory and coming back was the only way
to ask for the listing again. The breadcrumb row now carries one, drawn as a button with a
finger-sized hit box — as does the quick-filter funnel beside it, which used to be an
18dp glyph 6dp away from its neighbour.

**Both refresh controls report the pane's state.** While an operation is in flight the
control switches to the sync glyph in the accent tint and the state goes to a polite live
region, so a screen reader hears the round trip start; the control keeps its own accessible
name across the change. On the phone, where the button drives the one pane on screen, it
also goes inert rather than looking live and silently doing nothing. On the desktop it
stays live on purpose — one button drives both panes, and a listing in flight on the left
must not veto a refresh of the right.

**A confirmed operation keeps what it was confirmed against.** Waiting instead of being
dropped means the pane can move underneath it, so the target rows *and* the directory are
read when the user confirms. A navigation that lands in between can no longer redirect a
delete or move a renamed file into a directory the user never saw.

**The phone's delete and its name dialogs match the desktop's (#313).** The single-row
delete now validates the name and rebuilds the path instead of trusting the one the server
put in the listing, and the rename and new-directory dialogs refuse a name already in the
directory.

**A relist nobody will ask for again is not droppable.** The listing that follows a finished
transfer or a saved edit used to be dropped if the pane happened to be working — press F9 on
the destination pane during a slow F6 Move and the pane kept showing files the move had
already taken away. Those relists now wait their turn like a confirmed operation. A rename
that takes the row out of an active quick filter also clears the filter, the rule "new
directory" already followed: a row that vanishes reads as the file being gone.

**`busy` is one value with one owner.** It is derived from a counter raised before the
launch and lowered on completion, so a queued operation can no longer clear the flag an
in-flight one set, and a pane whose scope is gone does not stay busy forever.

## How to see it

Desktop, `./gradlew :composeApp:run`: open an SFTP session, delete a file (F8) or rename
one (F2) — the row goes as soon as the server answers, not a listing later. Press F9 or
the refresh button and watch it turn cyan while the listing is in flight.

Android, `./gradlew :androidApp:installDebug`: open a host → Files, long-press a file →
Delete → confirm; the row goes immediately. The refresh sits in the breadcrumb row, left
of the filter funnel. Delete one file and confirm a second one straight away — the second
one is no longer swallowed.

## Not verified

- Nothing was run on a live Android device or against a live SFTP server; the Android side
  is covered by the shared controller tests and `:androidApp:compileDebugKotlin`.
- TalkBack was not exercised on a device — the live region and the stable control name are
  asserted through the Compose semantics tree only.
- The "lost refresh" as originally reported could not be reproduced from the code: the
  controller always relisted after a delete. What is fixed here are the two paths that
  produce exactly that experience — a confirmed operation silently dropped, and a
  round-trip wait with no way to ask again.
