### PR TITLE
fix(i18n): replace private domain placeholder with example.com in Chinese strings

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sync.xml
@@ -38,7 +38,7 @@
 
     <!-- 表单字段 -->
     <string name="sync_field_server_url">服务器 URL</string>
-    <string name="sync_placeholder_server_url">https://sync.onepve.com</string>
+    <string name="sync_placeholder_server_url">https://sync.example.com</string>
     <string name="sync_field_account">账户邮箱</string>
     <string name="sync_placeholder_account">your@email.com</string>
     <string name="sync_field_master_password">同步账户主密码</string>


### PR DESCRIPTION
## Summary

While testing the sync setup screen, I noticed that the placeholder URL for the sync server in `values-zh/strings_sync.xml` was still using `https://sync.onepve.com` instead of the generic `https://sync.example.com`.

This PR replaces it with `https://sync.example.com` to align with the English and Russian translations and keep placeholders neutral (๑•̀ㅂ•́)و✧.