### PR TITLE
Name the member whose key a seal was refused for (#326)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_lib.xml
@@ -168,6 +168,8 @@
     <string name="lib_teams_peer_state_first_sight">Записан при первой встрече: так ответил сервер, никто это не подтверждал.</string>
     <string name="lib_teams_peer_state_none">На этом устройстве по этому аккаунту записей ещё нет.</string>
     <string name="lib_teams_peer_state_unreadable">Устройство не может прочитать запись по этому аккаунту.</string>
+    <string name="lib_teams_peer_refused">Ключ отклонён: отпечаток не тот, что записан</string>
+    <string name="lib_teams_peer_state_refused">Этому аккаунту ничего не запечатывается: публикуемый ключ — не тот отпечаток, что за ним записан.</string>
     <string name="lib_teams_accept">Принять</string>
     <string name="lib_teams_decline">Отклонить</string>
     <string name="lib_teams_role_owner">ВЛАДЕЛЕЦ</string>
@@ -274,7 +276,7 @@
     <string name="lib_teams_scope_members_count">с доступом: %1$d</string>
     <string name="lib_teams_err_already_shared">Эта запись уже расшарена в другой области этой команды — сначала уберите её оттуда</string>
     <string name="lib_teams_err_scopes_unsupported">Этот sync-сервер слишком старый для областей доступа — обновите сервер</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">Опубликованный ключ участника не тот, что за ним записан, — под него ничего не запечатано. Сверьте отпечаток по доверенному каналу и подтвердите его в списке участников</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">Опубликованный ключ участника не тот, что за ним записан, — под него ничего не запечатано. В списке участников его строка помечена: сверьте отпечаток по доверенному каналу и подтвердите его там</string>
     <string name="lib_teams_err_unconfirmed_key_ignored">Пришёл ключ команды, подписанный не тем ключом, что записан за этим аккаунтом, — он проигнорирован</string>
     <string name="lib_teams_err_invite_unverified">Приглашение не проверено — откройте команду и сверьте отпечаток пригласившего перед принятием</string>
     <string name="lib_teams_err_pin_not_recorded">Подтверждённый отпечаток не удалось сохранить на этом устройстве — этому ключу ничего не отправлено</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_lib.xml
@@ -162,6 +162,8 @@
     <string name="lib_teams_peer_state_first_sight">来自首次见到的记录：这是服务器的答复，无人确认过。</string>
     <string name="lib_teams_peer_state_none">本设备尚无该账户的任何记录。</string>
     <string name="lib_teams_peer_state_unreadable">本设备无法读取该账户的记录。</string>
+    <string name="lib_teams_peer_refused">密钥被拒绝：与记录的指纹不符</string>
+    <string name="lib_teams_peer_state_refused">未向该账户封装任何密钥：它发布的密钥不是为其记录的指纹。</string>
     <string name="lib_teams_accept">接受</string>
     <string name="lib_teams_decline">拒绝</string>
     <string name="lib_teams_role_owner">拥有者</string>
@@ -268,7 +270,7 @@
     <string name="lib_teams_scope_members_count">%1$d 人可访问</string>
     <string name="lib_teams_err_already_shared">该记录已共享到此团队的另一个范围 — 请先在那里取消共享</string>
     <string name="lib_teams_err_scopes_unsupported">此同步服务器版本过旧，不支持访问范围 — 请更新服务器</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">成员发布的密钥不是为其记录的那把 — 未向其封装任何密钥。请通过可信渠道核对指纹，并在成员列表中确认</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">成员发布的密钥不是为其记录的那把 — 未向其封装任何密钥。成员列表已标记其所在行：请通过可信渠道核对指纹并在该处确认</string>
     <string name="lib_teams_err_unconfirmed_key_ignored">收到的团队密钥所用的签名密钥不是该账户已记录的那把，已被忽略</string>
     <string name="lib_teams_err_invite_unverified">此邀请未经验证 — 请打开团队并核对邀请者的指纹后再接受</string>
     <string name="lib_teams_err_pin_not_recorded">无法在此设备上保存已确认的指纹，未向该密钥发送任何内容</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_lib.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_lib.xml
@@ -165,6 +165,8 @@
     <string name="lib_teams_peer_state_first_sight">On record from a first sight: this is what the server answered, and nobody has confirmed it.</string>
     <string name="lib_teams_peer_state_none">This device has nothing on record for this account yet.</string>
     <string name="lib_teams_peer_state_unreadable">This device can't read what is on record for this account.</string>
+    <string name="lib_teams_peer_refused">Key refused: not the fingerprint on record</string>
+    <string name="lib_teams_peer_state_refused">Nothing is sealed to this account: the key it publishes is not the fingerprint on record for it.</string>
     <string name="lib_teams_accept">Accept</string>
     <string name="lib_teams_decline">Decline</string>
     <string name="lib_teams_role_owner">OWNER</string>
@@ -271,7 +273,7 @@
     <string name="lib_teams_scope_members_count">%1$d with access</string>
     <string name="lib_teams_err_already_shared">This record is already shared into another scope of this team — unshare it there first</string>
     <string name="lib_teams_err_scopes_unsupported">This sync server is too old for access scopes — update the server</string>
-    <string name="lib_teams_err_peer_key_unconfirmed">A member's published key is not the one on record for them — nothing was sealed to it. Check the fingerprint over a trusted channel and confirm it in the member list</string>
+    <string name="lib_teams_err_peer_key_unconfirmed">A member's published key is not the one on record for them — nothing was sealed to it. The member list marks their row: check the fingerprint over a trusted channel and confirm it there</string>
     <string name="lib_teams_err_unconfirmed_key_ignored">A team key arrived signed by a key that is not the one on record for that account, and was ignored</string>
     <string name="lib_teams_err_invite_unverified">This invite was not verified — reopen the team and check the inviter's fingerprint before accepting</string>
     <string name="lib_teams_err_pin_not_recorded">The confirmed fingerprint couldn't be stored on this device — nothing was sent to that key</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTeamsView.kt
@@ -606,7 +606,7 @@ private fun MobileTeamDetail(
     val rows = remember(team, members, grants, canManage, marks) {
         teamMemberRows(
             team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true,
-            marks?.self, marks?.pins.orEmpty(),
+            marks?.self, marks?.pins.orEmpty(), marks?.refused.orEmpty(),
         )
     }
     val now = remember(tick, members) { epochMillis() }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/ConfirmPeerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/ConfirmPeerDialog.kt
@@ -163,7 +163,11 @@ internal fun ConfirmPeerKeyDialog(
         if (state != null) {
             Txt(
                 state,
-                color = if (trust == PeerTrust.CONFIRMED) Skerry.colors.dim else Skerry.colors.amber,
+                color = when (trust) {
+                    PeerTrust.CONFIRMED -> Skerry.colors.dim
+                    PeerTrust.REFUSED -> Skerry.colors.sunset
+                    else -> Skerry.colors.amber
+                },
                 size = 12.sp, lineHeight = 17.sp, modifier = Modifier.padding(top = 10.dp),
             )
         }
@@ -231,7 +235,14 @@ internal fun ConfirmPeerKeyDialogFor(
     // ceremony, and re-reading it after the confirm lands would have the dialog claim the answer it
     // was opened to obtain.
     val trust = produceState<PeerTrust?>(null, accountId) {
-        value = peerTrust(tc.peerPins(listOf(accountId))[accountId] ?: Pin.None, self = false)
+        value = peerTrust(
+            tc.peerPins(listOf(accountId))[accountId] ?: Pin.None,
+            self = false,
+            // Read at the same moment as the pin, and for the same reason: the dialog states what
+            // stood before this ceremony. A refusal is the one fact a confirmed pin cannot carry, and
+            // the row that was pressed is the row wearing it (#326).
+            refused = accountId in tc.refusedPeers.value,
+        )
     }.value
     ConfirmPeerKeyDialog(
         accountId = accountId,

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerRefusals.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerRefusals.kt
@@ -1,0 +1,81 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.team.PeerKeys
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.getAndUpdate
+import kotlinx.coroutines.flow.update
+
+/**
+ * Which colleagues a peer-key lookup has refused to seal to, and what has already been said about
+ * them in the current pass.
+ *
+ * [TeamsFailure] is an enum and carries no account id, so the error told the user to confirm a
+ * fingerprint in the member list without naming whose row — and the pin cannot supply the name
+ * either: a colleague who rotated their Teams identity leaves one that is still confirmed, identical
+ * to every healthy member's (#326). This is what the member list marks a row from.
+ *
+ * A set because one rotation walks every recipient and may refuse several of them; its size is the
+ * member list's, which is the server's to bound.
+ *
+ * A mark is evidence about one account, and only evidence about that same account takes it away —
+ * the lookup that finds the key back on its pin, or the confirm that moves the pin to it. Tying the
+ * marks to the error slot instead would clear every one of them on the next operation of any kind,
+ * so the second colleague a rotation refused would go back to wearing the quiet confirmed mark
+ * while nothing had been done about their key.
+ */
+internal class PeerRefusals {
+
+    private val _accounts = MutableStateFlow<Set<String>>(emptySet())
+
+    /** The accounts whose published key is not the one on record for them. */
+    val accounts: StateFlow<Set<String>> = _accounts
+
+    /**
+     * account+fingerprint pairs already announced, so one refusal on the adopting side is said once
+     * per pass rather than once per scope it appears in. A de-duplicator, not a record of what the
+     * user has seen: it is emptied with the slot the warning lives in, and from there the warning has
+     * to be earnable again — otherwise the next pass over the same unconfirmed key would say nothing.
+     *
+     * A flow rather than a plain set because [forgetAnnounced] runs on whichever thread emptied the
+     * error slot while a sync-driven pass may be adding to it on another.
+     */
+    private val announced = MutableStateFlow<Set<String>>(emptySet())
+
+    /**
+     * Files the verdict a lookup reached about [accountId], and hands it on unchanged. The lookup is
+     * the authority on the account it looked up and on no other: [PeerKeys.Pinned] retires the mark,
+     * [PeerKeys.Unconfirmed] raises it, and an account that has published nothing was never held to
+     * a pin at all.
+     */
+    fun record(accountId: String, keys: PeerKeys): PeerKeys {
+        when (keys) {
+            is PeerKeys.Pinned -> settled(accountId)
+            is PeerKeys.Unconfirmed -> mark(accountId)
+            PeerKeys.Unpublished -> Unit
+        }
+        return keys
+    }
+
+    /** Whether this refusal is the first of its account+fingerprint in the current pass. */
+    fun announcing(keys: PeerKeys.Unconfirmed): Boolean {
+        val pair = "${keys.accountId}:${keys.fingerprint}"
+        return pair !in announced.getAndUpdate { it + pair }
+    }
+
+    fun mark(accountId: String) = _accounts.update { it + accountId }
+
+    /** The account's key is on record again — a lookup found it pinned, or a confirm wrote it. */
+    fun settled(accountId: String) = _accounts.update { it - accountId }
+
+    /** Empties the de-duplicator with the error slot the warnings it guards are written to. */
+    fun forgetAnnounced() {
+        announced.value = emptySet()
+    }
+
+    /** Empties both: another account's vault is another account's colleagues. */
+    fun clear() {
+        _accounts.value = emptySet()
+        announced.value = emptySet()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerTrust.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/PeerTrust.kt
@@ -1,7 +1,10 @@
 package app.skerry.ui.teams
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -16,9 +19,11 @@ import app.skerry.ui.generated.resources.lib_teams_key_pin_unreadable
 import app.skerry.ui.generated.resources.lib_teams_peer_confirm
 import app.skerry.ui.generated.resources.lib_teams_peer_confirmed
 import app.skerry.ui.generated.resources.lib_teams_peer_mark
+import app.skerry.ui.generated.resources.lib_teams_peer_refused
 import app.skerry.ui.generated.resources.lib_teams_peer_state_confirmed
 import app.skerry.ui.generated.resources.lib_teams_peer_state_first_sight
 import app.skerry.ui.generated.resources.lib_teams_peer_state_none
+import app.skerry.ui.generated.resources.lib_teams_peer_state_refused
 import app.skerry.ui.generated.resources.lib_teams_peer_state_unreadable
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
@@ -46,6 +51,14 @@ enum class PeerTrust {
     /** Whatever the server answered on the first seal to this account — nobody has confirmed it. */
     FIRST_SIGHT,
 
+    /**
+     * A seal to this account was just refused: the key they publish is not the fingerprint on record
+     * for them, whatever that record says about itself. Not derivable from the pin — a colleague who
+     * rotated their identity leaves a pin that is still confirmed, so their row drew the same quiet
+     * mark as every healthy one while nothing could be sealed to them (#326).
+     */
+    REFUSED,
+
     /** Nothing on record: this account has never sealed anything to them. */
     NONE,
 
@@ -63,13 +76,22 @@ enum class PeerTrust {
 /**
  * What [pin] says about a member. [self] is whether this is the reader's own row — null when the
  * screen cannot tell, which is not the same answer as "no".
+ *
+ * [refused] outranks what the record claims, and only that: a lookup that just refused this account
+ * has compared the pin against the published key, which is the one thing the pin alone cannot say.
+ *
+ * Two states still come first. Whose row it is — a refusal naming this account would otherwise offer
+ * a ceremony with oneself. And a pin this device cannot read: the lookup refuses that exactly as it
+ * refuses a key that moved, so a refusal is no evidence at all about the colleague's key, and saying
+ * theirs is not the fingerprint on record sends the user to verify a change that never happened.
  */
-fun peerTrust(pin: Pin, self: Boolean?): PeerTrust = when {
+fun peerTrust(pin: Pin, self: Boolean?, refused: Boolean = false): PeerTrust = when {
     self == null -> PeerTrust.UNKNOWN
     self -> PeerTrust.SELF
+    pin == Pin.Unreadable -> PeerTrust.UNREADABLE
+    refused -> PeerTrust.REFUSED
     pin is Pin.Known && pin.origin == PinOrigin.CONFIRMED -> PeerTrust.CONFIRMED
     pin is Pin.Known -> PeerTrust.FIRST_SIGHT
-    pin == Pin.Unreadable -> PeerTrust.UNREADABLE
     else -> PeerTrust.NONE
 }
 
@@ -97,14 +119,19 @@ internal fun pinNoticeText(notice: PinNotice): String? = when (notice) {
 @Composable
 internal fun peerTrustText(trust: PeerTrust): String? = when (trust) {
     PeerTrust.SELF, PeerTrust.UNKNOWN -> null
+    PeerTrust.REFUSED -> stringResource(Res.string.lib_teams_peer_state_refused)
     PeerTrust.CONFIRMED -> stringResource(Res.string.lib_teams_peer_state_confirmed)
     PeerTrust.FIRST_SIGHT -> stringResource(Res.string.lib_teams_peer_state_first_sight)
     PeerTrust.NONE -> stringResource(Res.string.lib_teams_peer_state_none)
     PeerTrust.UNREADABLE -> stringResource(Res.string.lib_teams_peer_state_unreadable)
 }
 
-/** What a member list needs to draw its marks: whose row is whose, and what is pinned for each. */
-internal class MemberPins(val self: String?, val pins: Map<String, Pin>)
+/**
+ * What a member list needs to draw its marks: whose row is whose, what is pinned for each, and which
+ * of them a seal was just refused for — the one thing the pins cannot say, since a refused key and a
+ * healthy one leave the same record behind (#326).
+ */
+internal class MemberPins(val self: String?, val pins: Map<String, Pin>, val refused: Set<String>)
 
 /**
  * [MemberPins] for [accountIds], off the frame — null until the vault has answered, and then no row
@@ -117,14 +144,23 @@ internal class MemberPins(val self: String?, val pins: Map<String, Pin>)
  * One helper for both surfaces — the phone and the desktop must not end up reading this differently.
  */
 @Composable
-internal fun rememberMemberPins(tc: TeamsCoordinator, accountIds: List<String>, tick: Int): MemberPins? =
-    produceState<MemberPins?>(null, accountIds, tick) {
+internal fun rememberMemberPins(tc: TeamsCoordinator, accountIds: List<String>, tick: Int): MemberPins? {
+    // Collected rather than read inside the vault pass: a refusal lands when an operation ends, which
+    // is not when the list is rekeyed, and a mark that waits for the next reread points at nothing
+    // while the error it belongs to is already on screen.
+    val refused by tc.refusedPeers.collectAsState()
+    val read = produceState<Pair<String?, Map<String, Pin>>?>(null, accountIds, tick) {
         // Cleared first: `produceState` keeps the previous value across a key change, and a member
         // the refreshed list added is absent from the old map — its row would wear the amber mark of
         // an unconfirmed key until the vault answers, which is a claim about a key nothing read yet.
         value = null
-        value = MemberPins(tc.selfAccountId(), tc.peerPins(accountIds))
+        value = tc.selfAccountId() to tc.peerPins(accountIds)
     }.value
+    // Remembered, not rebuilt: the screens key their row list on this value and it has no equality of
+    // its own, so a fresh instance per recomposition re-sorts and re-maps every member on each frame
+    // the surrounding screen redraws for anything at all — the busy flag, a sync stamp.
+    return remember(read, refused) { read?.let { (self, pins) -> MemberPins(self, pins, refused) } }
+}
 
 /**
  * The mark a member row wears for its key: a quiet one for a fingerprint a human confirmed, an amber
@@ -138,25 +174,36 @@ internal fun rememberMemberPins(tc: TeamsCoordinator, accountIds: List<String>, 
 @Composable
 internal fun PeerTrustBadge(trust: PeerTrust, onConfirm: () -> Unit, modifier: Modifier = Modifier) {
     if (!trust.confirmable) return
-    val confirmed = trust == PeerTrust.CONFIRMED
     val action = stringResource(Res.string.lib_teams_peer_confirm)
+    val state = when (trust) {
+        PeerTrust.CONFIRMED -> stringResource(Res.string.lib_teams_peer_confirmed)
+        PeerTrust.REFUSED -> stringResource(Res.string.lib_teams_peer_refused)
+        else -> null
+    }
     GlyphButton(
-        icon = if (confirmed) "verified_user" else "gpp_maybe",
+        icon = when (trust) {
+            PeerTrust.CONFIRMED -> "verified_user"
+            // Its own glyph and the danger tone, not the amber one every first sight wears: the error
+            // says to confirm a fingerprint in the member list, and a mark shared with each unrelated
+            // row names nobody (#326).
+            PeerTrust.REFUSED -> "gpp_bad"
+            else -> "gpp_maybe"
+        },
         // The state first when there is one, then what pressing it does: the mark is read as a status
         // and used as a control, and a name carrying only the status describes no purpose (WCAG 4.1.2).
         // Joined by a format string rather than by a literal stop — the punctuation between two
         // sentences belongs to the locale, and zh does not end one with a Latin full stop.
-        label = if (confirmed) {
-            stringResource(Res.string.lib_teams_peer_mark, stringResource(Res.string.lib_teams_peer_confirmed), action)
-        } else {
-            action
-        },
+        label = if (state != null) stringResource(Res.string.lib_teams_peer_mark, state, action) else action,
         onClick = onConfirm,
         modifier = modifier,
         // Small for a row, never below the minimum target size — this is the only way into the
         // ceremony, and the glyph alone is a 14sp mark (WCAG 2.5.8).
         box = 24.dp,
         iconSize = 14.sp,
-        iconColor = if (confirmed) Skerry.colors.cyanBright else Skerry.colors.amber,
+        iconColor = when (trust) {
+            PeerTrust.CONFIRMED -> Skerry.colors.cyanBright
+            PeerTrust.REFUSED -> Skerry.colors.sunset
+            else -> Skerry.colors.amber
+        },
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamScreenContent.kt
@@ -168,7 +168,7 @@ internal fun TeamScreen(
             val rows = remember(team, members, grants, canManage, marks) {
                 teamMemberRows(
                     team, members, grants?.byScope.orEmpty(), canManage, grants?.complete ?: true,
-                    marks?.self, marks?.pins.orEmpty(),
+                    marks?.self, marks?.pins.orEmpty(), marks?.refused.orEmpty(),
                 )
             }
             // Read once per reread rather than per row, so every row of one paint agrees on "now".

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsCoordinator.kt
@@ -224,12 +224,16 @@ class TeamsCoordinator(
         syncSpace = { syncSpace(it) },
     )
 
+    /** Which colleagues a lookup refused, and what has already been said about them (#326). */
+    private val refusals = PeerRefusals()
+
     /**
-     * account+fingerprint pairs already reported by [adoptingKeys], so one refusal is announced once
-     * per pass rather than once per scope it appears in. Cleared with the error slot itself
-     * ([resetError]) — the set is a de-duplicator, not a record of what the user has seen.
+     * The rows whose published key is not the one on record for them — what the member list draws
+     * its refused mark from. A mark stands until the account's own key is looked at again, not until
+     * the next operation empties the error slot: a rotation can refuse several colleagues at once,
+     * and dealing with one of them says nothing about the others (#326).
      */
-    private val reportedUnconfirmed = mutableSetOf<String>()
+    val refusedPeers: StateFlow<Set<String>> get() = refusals.accounts
 
     /**
      * Every seal to another account resolves its keys through here: the fingerprint pinned for that
@@ -237,7 +241,7 @@ class TeamsCoordinator(
      * answer (#319). What to do with a refusal is the caller's — it answers something the user asked
      * for, and each caller knows which of its steps it belongs to.
      */
-    private val sealingKeys: PeerKeyLookup = { s, c, accountId -> peerStore.fetchPinned(s, c, accountId) }
+    private val sealingKeys: PeerKeyLookup = { s, c, accountId -> refusals.record(accountId, peerStore.fetchPinned(s, c, accountId)) }
 
     /**
      * The same check for keys arriving from the other side — a team rekey envelope, a scope grant.
@@ -248,10 +252,8 @@ class TeamsCoordinator(
      * about it, not a dozen.
      */
     private val adoptingKeys: PeerKeyLookup = { s, c, accountId ->
-        peerStore.checkPinned(s, c, accountId).also {
-            if (it is PeerKeys.Unconfirmed && reportedUnconfirmed.add("${it.accountId}:${it.fingerprint}")) {
-                markError(TeamsFailure.UnconfirmedKeyIgnored)
-            }
+        refusals.record(accountId, peerStore.checkPinned(s, c, accountId)).also {
+            if (it is PeerKeys.Unconfirmed && refusals.announcing(it)) markError(TeamsFailure.UnconfirmedKeyIgnored)
         }
     }
 
@@ -305,7 +307,7 @@ class TeamsCoordinator(
      */
     private fun resetError() {
         _lastError.value = null
-        reportedUnconfirmed.clear()
+        refusals.forgetAnnounced()
     }
 
     /**
@@ -559,11 +561,12 @@ class TeamsCoordinator(
      * against. Answers the failure to report, or null when it is on record.
      *
      * One place because all three ceremonies — the invite send, the invite accept, the member list's
-     * own confirm — end in the same write and owe the same two refusals.
+     * own confirm — end in the same write and owe the same two refusals. And it is the one write
+     * that retires a refusal mark: the pin now names the key the server publishes.
      */
     private fun confirmShown(accountId: String, shown: InvitePreview): TeamsFailure? =
         when (peerStore.confirm(accountId, shown.fingerprint, shown.pinned)) {
-            ConfirmOutcome.RECORDED -> null
+            ConfirmOutcome.RECORDED -> null.also { refusals.settled(accountId) }
             ConfirmOutcome.MOVED -> TeamsFailure.PinMovedMeanwhile
             ConfirmOutcome.REFUSED -> TeamsFailure.PinNotRecorded
         }
@@ -985,11 +988,15 @@ class TeamsCoordinator(
             .forEach { syncTeam(it.id) }
     }
 
-    /** Lock team vaults (called when the account vault locks — team keys become inaccessible). */
+    /** Lock team vaults and drop what this account held (called on vault reset — another account). */
     fun lock() {
         teamVaults.lockAll()
         _teams.value = emptyList()
         verifiedInvites.value = emptyMap() // drop cached invite payloads (they hold teamKey material)
+        // The refusal marks go with them: they are read off the flow rather than re-derived from a
+        // vault pass, and the member listing of the next account is a single round trip that lands
+        // before anything would empty them.
+        refusals.clear()
     }
 
     // --- internals ---

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/teams/TeamsScreenModel.kt
@@ -54,6 +54,12 @@ fun teamMemberRows(
     selfAccountId: String? = null,
     /** What is pinned for each member — [app.skerry.shared.team.Pin.None] for anyone absent from it. */
     pins: Map<String, Pin> = emptyMap(),
+    /**
+     * Accounts a seal was just refused for. Not a property of the pin: a colleague who rotated their
+     * identity leaves one that is still confirmed, so their row wore the same quiet mark as every
+     * healthy one while the error told the user to confirm a fingerprint it never named (#326).
+     */
+    refused: Set<String> = emptySet(),
 ): List<TeamMemberRowUi> {
     val scopeNames = team.scopes.associate { it.id to it.name }
     return members
@@ -74,6 +80,7 @@ fun teamMemberRows(
                 trust = peerTrust(
                     pins[member.accountId] ?: Pin.None,
                     self = selfAccountId?.let { it == member.accountId },
+                    refused = member.accountId in refused,
                 ),
             )
         }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/teams/TeamsScreenModelTest.kt
@@ -161,6 +161,91 @@ class TeamsScreenModelTest {
     }
 
     /**
+     * The row the error is talking about. A colleague who rotated their Teams identity leaves a pin
+     * that is still confirmed, so their row drew the same quiet mark as every healthy one while every
+     * seal to them was being refused — the remedy existed but had to be found by opening the ceremony
+     * row by row (#326).
+     */
+    @Test
+    fun `a member whose key was refused is marked, whatever the pin still says about them`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(
+                member(owner, TeamRole.OWNER),
+                member(admin, TeamRole.ADMIN),
+                member(editor, TeamRole.EDITOR),
+            ),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = owner,
+            pins = mapOf(
+                admin to Pin.Known("SHA256:aaa", PinOrigin.CONFIRMED),
+                editor to Pin.Known("SHA256:bbb", PinOrigin.CONFIRMED),
+            ),
+            refused = setOf(admin),
+        )
+
+        fun trustOf(id: String) = rows.single { it.member.accountId == id }.trust
+        assertEquals(PeerTrust.REFUSED, trustOf(admin), "the pin is confirmed and the published key is not it")
+        assertEquals(PeerTrust.CONFIRMED, trustOf(editor), "an unrelated row keeps its own state")
+        assertTrue(PeerTrust.REFUSED.confirmable, "the ceremony is the remedy the error points at")
+    }
+
+    /**
+     * A pin this device cannot read is refused by the same lookup, and for a reason that says nothing
+     * about the colleague's key. Drawing that as "the key they publish is not the one on record"
+     * sends the user to verify a change that never happened — the record on this device is what
+     * cannot be read.
+     */
+    @Test
+    fun `a pin this device cannot read is not reported as a key that moved`() {
+        val rows = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = owner,
+            pins = mapOf(admin to Pin.Unreadable),
+            refused = setOf(admin),
+        )
+
+        assertEquals(PeerTrust.UNREADABLE, rows.single { it.member.accountId == admin }.trust)
+    }
+
+    /**
+     * A rotation walks every recipient and can refuse more than one of them, and the reader's own row
+     * is never one of them: a refusal naming this account would otherwise offer a ceremony with
+     * oneself, and with no session to say whose row is whose no row may claim anything at all.
+     */
+    @Test
+    fun `a refusal never marks the own row, nor any row when the session is unknown`() {
+        val marked = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN), member(editor, TeamRole.EDITOR)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = owner,
+            refused = setOf(owner, admin, editor),
+        )
+        assertEquals(PeerTrust.SELF, marked.single { it.member.accountId == owner }.trust)
+        assertEquals(
+            listOf(admin, editor),
+            marked.filter { it.trust == PeerTrust.REFUSED }.map { it.member.accountId }.sorted(),
+            "a rotation refuses as many recipients as it walks",
+        )
+
+        val sessionless = teamMemberRows(
+            team = team(TeamRole.OWNER),
+            members = listOf(member(owner, TeamRole.OWNER), member(admin, TeamRole.ADMIN)),
+            scopeGrants = emptyMap(),
+            canManage = true,
+            selfAccountId = null,
+            refused = setOf(admin),
+        )
+        assertTrue(sessionless.all { it.trust == PeerTrust.UNKNOWN })
+    }
+
+    /**
      * Without a live session the screen cannot say whose row is whose, and reading that as "not me"
      * put the amber "confirm this member's key" on the reader themselves.
      */

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/MemberPinsMarkTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/MemberPinsMarkTest.kt
@@ -1,0 +1,90 @@
+package app.skerry.ui.teams
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.vault.initializeVaultCrypto
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_teams_peer_refused
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.compose.resources.stringResource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The link the issue is about, end to end: a seal the coordinator refused, and the row the member
+ * list draws a mark on because of it.
+ *
+ * The state tests either side of it — which account the coordinator names, and which state a row
+ * takes from a name — both stay green with the refusal dropped on the way between them
+ * ([rememberMemberPins] is where the vault pass and the refusal flow meet). This is the test that
+ * does not.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MemberPinsMarkTest : TeamsPeerPinFixture() {
+
+    @Test
+    fun `the member the coordinator refused is the row the member list marks`() {
+        val f = runBlocking { initializeVaultCrypto(); newFixture() }
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        listOf(bob, carol).forEach {
+            client.published[it] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        }
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3))
+        val coord = coordinator(f, client)
+        val members = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        runBlocking {
+            coord.createScope(teamId, "Production")
+            coord.grantScope(teamId, "prod", bob) // first sight pins both
+            coord.grantScope(teamId, "prod", carol)
+            // Bob rotates his Teams identity: the pin for him stays confirmed and stops matching.
+            client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+            coord.grantScope(teamId, "prod", bob)
+        }
+
+        var refusedMark = ""
+        var marked: String? = null
+        runForm({
+            refusedMark = stringResource(Res.string.lib_teams_peer_refused)
+            val marks = rememberMemberPins(coord, members.map { it.accountId }, tick = 0)
+            val rows = teamMemberRows(
+                team = teamUi(),
+                members = members,
+                scopeGrants = emptyMap(),
+                canManage = true,
+                selfAccountId = marks?.self,
+                pins = marks?.pins.orEmpty(),
+                refused = marks?.refused.orEmpty(),
+            )
+            marked = rows.singleOrNull { it.trust == PeerTrust.REFUSED }?.member?.accountId
+            TeamMemberTable(rows = rows, now = 0, onChangeRole = {}, onRemove = {}, onConfirmKey = {})
+        }) {
+            waitForIdle()
+            assertEquals(
+                1,
+                onAllNodesWithContentDescription(refusedMark, substring = true).fetchSemanticsNodes().size,
+                "one row wears the mark, and it is drawn from what the coordinator refused",
+            )
+        }
+        assertEquals(bob, marked)
+    }
+
+    private fun teamUi() = TeamUi(
+        id = teamId,
+        name = "Ops",
+        ownerAccountId = self,
+        role = TeamRole.OWNER,
+        status = TeamMemberStatus.ACTIVE,
+        memberCount = 3,
+        hasKey = true,
+    )
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/PeerTrustBadgeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/PeerTrustBadgeTest.kt
@@ -11,6 +11,7 @@ import app.skerry.ui.desktop.runForm
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.lib_teams_peer_confirm
 import app.skerry.ui.generated.resources.lib_teams_peer_confirmed
+import app.skerry.ui.generated.resources.lib_teams_peer_refused
 import app.skerry.ui.mobile.MobileMemberRow
 import org.jetbrains.compose.resources.stringResource
 import kotlin.test.Test
@@ -75,6 +76,40 @@ class PeerTrustBadgeTest {
         assertEquals(ACCOUNT, opened, "a confirmed pin that stopped matching has no other way back")
     }
 
+    /**
+     * The row a refused seal is talking about. Its own mark, not the amber one a first sight wears:
+     * the error says "confirm it in the member list", and on a team of a dozen a mark shared with
+     * every unrelated first sight names nobody (#326).
+     */
+    @Test
+    fun `the refused row wears its own mark and opens the ceremony`() {
+        var opened: String? = null
+        var refusedMark = ""
+        var plainAction = ""
+        runForm({
+            refusedMark = stringResource(Res.string.lib_teams_peer_refused)
+            plainAction = stringResource(Res.string.lib_teams_peer_confirm)
+            TeamMemberTable(
+                rows = listOf(row(PeerTrust.REFUSED, ACCOUNT), row(PeerTrust.FIRST_SIGHT, OTHER)),
+                now = NOW,
+                onChangeRole = {},
+                onRemove = {},
+                onConfirmKey = { opened = it.member.accountId },
+            )
+        }) {
+            waitForIdle()
+            assertEquals(
+                1,
+                onAllNodesWithContentDescription(refusedMark, substring = true).fetchSemanticsNodes().size,
+                "the mark names one row, not every row that is not confirmed",
+            )
+            onNodeWithContentDescription(refusedMark, substring = true).performClick()
+            waitForIdle()
+        }
+        assertEquals(ACCOUNT, opened)
+        assertTrue(refusedMark != plainAction, "a refusal that reads like a first sight names nobody")
+    }
+
     @Test
     fun `the own row and a row whose owner cannot be told wear no mark`() {
         listOf(PeerTrust.SELF, PeerTrust.UNKNOWN).forEach { trust ->
@@ -115,9 +150,9 @@ class PeerTrustBadgeTest {
     }
 }
 
-private fun row(trust: PeerTrust) = TeamMemberRowUi(
+private fun row(trust: PeerTrust, accountId: String = ACCOUNT) = TeamMemberRowUi(
     member = TeamMember(
-        accountId = ACCOUNT,
+        accountId = accountId,
         role = TeamRole.EDITOR,
         status = TeamMemberStatus.ACTIVE,
         createdAt = NOW,
@@ -131,4 +166,5 @@ private fun row(trust: PeerTrust) = TeamMemberRowUi(
 )
 
 private const val ACCOUNT = "bob@example.com"
+private const val OTHER = "carol@example.com"
 private const val NOW = 1_700_000_000_000L

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorPeerPinTest.kt
@@ -1,40 +1,19 @@
 package app.skerry.ui.teams
 
-import app.skerry.shared.sync.InMemorySyncStateStore
-import app.skerry.shared.sync.RecordPage
-import app.skerry.shared.sync.RemoteRecord
-import app.skerry.shared.sync.SyncException
 import app.skerry.shared.sync.SyncSession
 import app.skerry.shared.team.AccountKeys
-import app.skerry.shared.team.TeamActivityEntry
 import app.skerry.shared.team.TeamClient
 import app.skerry.shared.team.Pin
 import app.skerry.shared.team.PinOrigin
-import app.skerry.shared.team.TeamIdentityStore
-import app.skerry.shared.team.TeamInviteCodec
 import app.skerry.shared.team.TeamKeyStore
 import app.skerry.shared.team.TeamMember
 import app.skerry.shared.team.TeamMemberStatus
 import app.skerry.shared.team.TeamPeerStore
 import app.skerry.shared.team.TeamRole
-import app.skerry.shared.team.TeamScopeGrantEntry
-import app.skerry.shared.team.TeamScopeRef
-import app.skerry.shared.team.TeamScopeSummary
-import app.skerry.shared.team.TeamSessionKind
 import app.skerry.shared.team.TeamSummary
-import app.skerry.shared.team.TeamVaults
-import app.skerry.shared.team.accountKeyFingerprint
-import app.skerry.shared.vault.FileVault
-import app.skerry.shared.vault.IonspinVaultCrypto
 import app.skerry.shared.vault.RecordType
-import app.skerry.shared.vault.SharingKeyPair
-import app.skerry.shared.vault.SigningKeyPair
 import app.skerry.shared.vault.initializeVaultCrypto
-import app.skerry.ui.sync.TeamLink
 import kotlinx.coroutines.runBlocking
-import okio.FileSystem
-import okio.Path.Companion.toPath
-import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -49,170 +28,10 @@ import kotlin.test.assertTrue
  * account's own key table is the server's, so it can hand out one key for the check and another for
  * the seal, or simply swap a member's key once and wait for the next grant or rotation.
  *
- * The fake below is that server. What it must not achieve is a team key, a scope key or a rotated
- * key ending up under a key nobody ever read out loud.
+ * [TeamsPeerPinFixture] is that server. What it must not achieve is a team key, a scope key or a
+ * rotated key ending up under a key nobody ever read out loud.
  */
-class TeamsCoordinatorPeerPinTest {
-
-    private val crypto = IonspinVaultCrypto()
-    private val teamId = "team-pin"
-    private val self = "alice@example.com"
-    private val bob = "bob@example.com"
-    private val carol = "carol@example.com"
-    private val dave = "dave@example.com"
-
-    /** An account's published keys, as the server holds them — swappable between two fetches. */
-    private class Published(var keys: AccountKeys)
-
-    private fun keysOf(sharing: SharingKeyPair, signing: SigningKeyPair) =
-        AccountKeys(sharing.publicKey, signing.publicKey)
-
-    private fun fingerprintOf(keys: AccountKeys) = accountKeyFingerprint(keys.sharing, keys.signing)
-
-    /**
-     * Fake team network: a mutable key table, a mutable member list, and every envelope the client
-     * hands over kept for inspection.
-     */
-    private class FakePeerClient(private val self: String, private val teamId: String) : TeamClient {
-        val published = mutableMapOf<String, Published>()
-        var teams: List<TeamSummary> = emptyList()
-        var memberList: List<TeamMember> = emptyList()
-        val accepted = mutableListOf<String>()
-        val removed = mutableListOf<String>()
-        val grants = mutableListOf<Pair<String, ByteArray>>()
-        val invites = mutableListOf<String>()
-        val teamRekeys = mutableListOf<Map<String, ByteArray>>()
-        val scopeEnvelopes = linkedMapOf<String, MutableMap<String, ByteArray>>()
-        val scopeEpochs = mutableMapOf<String, Long>()
-        var teamEpoch = 0L
-        /** How many times each account's key was fetched — the double fetch is the hole (#319 item 1). */
-        val fetches = mutableMapOf<String, Int>()
-
-        /** Run inside the lookup, for whatever the round trip is supposed to give the world time to do. */
-        var duringFetch: (() -> Unit)? = null
-
-        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
-            fetches[accountId] = (fetches[accountId] ?: 0) + 1
-            duringFetch?.invoke()
-            return published[accountId]?.keys
-        }
-
-        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = teams
-        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = memberList
-        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
-        override suspend fun accept(session: SyncSession, teamId: String) { accepted += teamId }
-
-        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {
-            removed += accountId
-            memberList = memberList.filter { it.accountId != accountId }
-            scopeEnvelopes.values.forEach { it.remove(accountId) }
-        }
-
-        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
-            if (teamRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "team rekey failed")
-            teamRekeys += envelopes
-            teamEpoch = newEpoch
-        }
-
-        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> =
-            scopeEnvelopes.map { (scopeId, grants) ->
-                TeamScopeSummary(scopeId, scopeEpochs[scopeId] ?: 0, grants.size, grants[self])
-            }
-
-        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
-            scopeEnvelopes[scopeId] = mutableMapOf(self to envelope)
-            scopeEpochs[scopeId] = 0
-        }
-
-        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) {
-            grants += accountId to envelope
-            scopeEnvelopes[scopeId]?.put(accountId, envelope)
-        }
-
-        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
-            scopeEnvelopes[scopeId]?.keys?.map { TeamScopeGrantEntry(it, 0) } ?: emptyList()
-
-        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) {
-            scopeEnvelopes[scopeId]?.remove(accountId)
-        }
-
-        /** Set to fail every scope rotation the way an exhausted retry does. */
-        var scopeRekeyFails = false
-
-        /** The same for the team key's own rotation. */
-        var teamRekeyFails = false
-
-        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
-            if (scopeRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "scope rekey failed")
-            scopeEpochs[scopeId] = newEpoch
-            val holders = scopeEnvelopes[scopeId] ?: return
-            envelopes.forEach { (account, env) -> if (holders.containsKey(account)) holders[account] = env }
-        }
-
-        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage =
-            RecordPage(emptyList(), since)
-
-        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage =
-            RecordPage(records, 1)
-
-        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
-        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) {
-            invites += accountId
-        }
-        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
-        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
-        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
-        override suspend fun reportSessionEvent(
-            session: SyncSession,
-            teamId: String,
-            recordId: String,
-            kind: TeamSessionKind,
-            durationSec: Long?,
-        ) = error("unused")
-        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
-    }
-
-    private class Fixture(val vault: FileVault, val teamVaults: TeamVaults)
-
-    private fun newFixture(): Fixture {
-        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
-        FileSystem.SYSTEM.delete(vaultFile)
-        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
-        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
-        vault.create("master".toCharArray())
-        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }))
-    }
-
-    private fun coordinator(f: Fixture, client: TeamClient, ids: Iterator<String> = listOf("prod").iterator()) =
-        TeamsCoordinator(
-            live = { TeamLink(SyncSession(self, "access", "refresh"), client, "test-link") },
-            vault = f.vault,
-            crypto = crypto,
-            teamVaults = f.teamVaults,
-            teamState = InMemorySyncStateStore(),
-            newId = { ids.next() },
-        )
-
-    /** An invite from [inviter] to us, sealed to our own sharing key and signed by their identity. */
-    private fun inviteEnvelope(f: Fixture, inviter: String, signing: SigningKeyPair, epoch: Int = 0): ByteArray {
-        val identity = TeamIdentityStore(f.vault, crypto).ensure()
-        return TeamInviteCodec(crypto).seal(
-            recipientPublicKey = identity.sharing.publicKey,
-            inviter = signing,
-            inviterId = inviter,
-            inviteeId = self,
-            teamId = teamId,
-            teamKey = crypto.newDataKey(),
-            teamName = "Ops",
-            epoch = epoch,
-        )
-    }
-
-    private fun invitedTeam(envelope: ByteArray) = TeamSummary(
-        id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
-        status = TeamMemberStatus.INVITED, createdAt = 0, memberCount = 2,
-        envelope = envelope, keyEpoch = 0, keyEnvelope = null,
-    )
+class TeamsCoordinatorPeerPinTest : TeamsPeerPinFixture() {
 
     /**
      * Item 1: the banner verifies the envelope's signature against one fetch and used to fingerprint
@@ -477,23 +296,6 @@ class TeamsCoordinatorPeerPinTest {
         assertTrue(client.removed.contains(dave), "the revocation itself still stands")
         assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
     }
-
-    /** A scope key granted to us by [granter], signed with [signing] and bound to [scopeId]. */
-    private fun scopeEnvelope(f: Fixture, granter: String, signing: SigningKeyPair, scopeId: String, epoch: Int): ByteArray {
-        val identity = TeamIdentityStore(f.vault, crypto).ensure()
-        return TeamInviteCodec(crypto).seal(
-            recipientPublicKey = identity.sharing.publicKey,
-            inviter = signing,
-            inviterId = granter,
-            inviteeId = self,
-            teamId = teamId,
-            teamKey = crypto.newDataKey(),
-            teamName = "Production",
-            epoch = epoch,
-            scopeId = scopeId,
-        )
-    }
-
 
     /**
      * The send half of the ceremony: pressing Send is a human saying the fingerprint on screen is the
@@ -963,25 +765,4 @@ class TeamsCoordinatorPeerPinTest {
         assertEquals(Pin.Unreadable, coord.peerPins(listOf(bob))[bob])
     }
 
-    /**
-     * The id a pin for [accountId] would use, asked of the store rather than assumed from its
-     * namespace: pin an unrelated account, read the id it filed, and swap the account in.
-     */
-    private fun pinIdOf(f: Fixture, accountId: String): String {
-        val probe = "probe@example.com"
-        TeamPeerStore(f.vault).confirm(probe, "probe")
-        val filed = f.vault.records().single { it.type == RecordType.TEAM_PEER && !it.deleted }.id
-        return filed.removeSuffix(probe) + accountId
-    }
-
-    /** The team as the server lists it once we are a member of it. */
-    private fun activeTeam(role: TeamRole, members: Int = 2, keyEpoch: Long = 0, keyEnvelope: ByteArray? = null) = TeamSummary(
-        id = teamId, ownerAccountId = if (role == TeamRole.OWNER) self else bob, role = role,
-        status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = members,
-        envelope = null, keyEpoch = keyEpoch, keyEnvelope = keyEnvelope,
-    )
-
-    private companion object {
-        const val NOW = "2026-08-24T00:00:00Z"
-    }
 }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRefusedPeersTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsCoordinatorRefusedPeersTest.kt
@@ -1,0 +1,250 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.team.TeamKeyStore
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.vault.initializeVaultCrypto
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * Which member a refused seal was about. [TeamsFailure] is an enum and carries no account id, so the
+ * error told the user to confirm a fingerprint in the member list without naming whose row — and the
+ * pin cannot supply the name either: a colleague who rotated their Teams identity leaves one that is
+ * still confirmed, identical to every healthy member's (#326).
+ */
+class TeamsCoordinatorRefusedPeersTest : TeamsPeerPinFixture() {
+
+    /**
+     * The refusal used to carry no account id at all — `TeamsFailure` is an enum — so the screen told
+     * the user to confirm a fingerprint in the member list without naming whose. A rotation walks
+     * every recipient and can refuse more than one, so what comes out is the set of them (#326).
+     */
+    @Test
+    fun `a rotation that steps over recipients names every one of them`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        listOf(bob, carol, dave).forEach {
+            client.published[it] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        }
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(carol, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(dave, TeamRole.VIEWER, TeamMemberStatus.ACTIVE, 0),
+        )
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 4))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight pins each of them
+        coord.grantScope(teamId, "prod", carol)
+        coord.grantScope(teamId, "prod", dave)
+
+        // Bob and dave rotated their Teams identity; carol did not. The pins for the two of them are
+        // still what they were, so nothing about their rows says which is which.
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[dave] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.removeMember(teamId, carol)
+
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+        assertEquals(setOf(bob, dave), coord.refusedPeers.value, "both refused recipients, and nobody else")
+    }
+
+    /** A grant refused for one member names that member and no other. */
+    @Test
+    fun `a refused grant names the member it was refused for`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 2))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+
+        coord.grantScope(teamId, "prod", bob)
+
+        assertEquals(TeamsFailure.PeerKeyUnconfirmed, coord.lastError.value)
+        assertEquals(setOf(bob), coord.refusedPeers.value)
+    }
+
+    /**
+     * The other lookup. A key arriving from the other side is held to the same pin and stepped over
+     * the same way, and the remedy is the same ceremony — so the row it belongs to has to be named
+     * there too, even though the banner over it is the milder one.
+     */
+    @Test
+    fun `a key ignored on the way in names the account it came from`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        val signing = crypto.newSigningKeyPair()
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), signing))
+        client.teams = listOf(invitedTeam(inviteEnvelope(f, bob, signing)))
+        val coord = coordinator(f, client)
+        assertIs<InviteVerdict.Verified>(coord.acceptPreview(teamId))
+        coord.accept(teamId) // the ceremony pins Bob
+
+        // The server rotates Bob's published key to one of its own and offers a scope under it.
+        val attacker = crypto.newSigningKeyPair()
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), attacker))
+        client.teams = listOf(activeTeam(TeamRole.VIEWER))
+        client.scopeEnvelopes["prod"] = mutableMapOf(self to scopeEnvelope(f, bob, attacker, "prod", epoch = 0))
+        coord.refresh()
+
+        assertEquals(TeamsFailure.UnconfirmedKeyIgnored, coord.lastError.value)
+        assertEquals(setOf(bob), coord.refusedPeers.value)
+    }
+
+    /**
+     * The ceremony the mark opens is the one thing that empties the slot the mark lives in. A confirm
+     * that did not record leaves the account exactly where it was — refused — so the row must keep
+     * its mark rather than go quiet under the failure it just raised.
+     */
+    @Test
+    fun `a confirm that did not record leaves the mark where it was`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 2))
+        client.memberList = listOf(
+            TeamMember(self, TeamRole.OWNER, TeamMemberStatus.ACTIVE, 0),
+            TeamMember(bob, TeamRole.EDITOR, TeamMemberStatus.ACTIVE, 0),
+        )
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.grantScope(teamId, "prod", bob) // refused: the key moved
+        val shown = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob)).preview
+        assertEquals(setOf(bob), coord.refusedPeers.value)
+
+        // The key moves once more between the fingerprint being read out loud and Confirm being
+        // pressed: nothing is written, and the pin still does not match what the server publishes.
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.confirmPeer(shown)
+
+        assertEquals(TeamsFailure.RecipientKeyChanged, coord.lastError.value)
+        assertEquals(setOf(bob), coord.refusedPeers.value, "the ceremony failed, so the row is where it was")
+    }
+
+    /** A confirm that did record is the remedy working: the pin moved, and the mark goes with it. */
+    @Test
+    fun `a confirm that recorded clears the mark`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 2))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.grantScope(teamId, "prod", bob) // refused: the key moved
+        val shown = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob)).preview
+
+        coord.confirmPeer(shown)
+
+        assertNull(coord.lastError.value)
+        assertEquals(emptySet(), coord.refusedPeers.value)
+    }
+
+    /**
+     * A mark is evidence about one colleague, so only evidence about that same colleague may take it
+     * away. A rotation refuses several recipients at once; opening the ceremony for one of them — or
+     * doing anything else at all — must not quietly clear the rest, which would leave a member whose
+     * key is still refused wearing the same quiet mark as everyone healthy: #326's own bug, one row
+     * over.
+     */
+    @Test
+    fun `a mark on one colleague outlives an operation about another`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        listOf(bob, dave).forEach {
+            client.published[it] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        }
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 3))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight pins both
+        coord.grantScope(teamId, "prod", dave)
+        listOf(bob, dave).forEach {
+            client.published[it] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        }
+        coord.grantScope(teamId, "prod", bob)
+        coord.grantScope(teamId, "prod", dave)
+        assertEquals(setOf(bob, dave), coord.refusedPeers.value)
+
+        // The manager deals with bob and never touches dave.
+        val shown = assertIs<PeerKeyVerdict.Ready>(coord.peerKey(bob)).preview
+        coord.confirmPeer(shown)
+
+        assertEquals(setOf(dave), coord.refusedPeers.value, "dave's key is still refused, and still says so")
+    }
+
+    /**
+     * The other direction, and the reason a mark needs no expiry: the lookup that raised it is the
+     * one that takes it back. A colleague whose published key is the pinned one again is no longer
+     * refused, whether the pin moved under a confirm or the server stopped substituting.
+     */
+    @Test
+    fun `a lookup that finds the key back on its pin clears the mark`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        val pinned = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.published[bob] = pinned
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 2))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.grantScope(teamId, "prod", bob)
+        assertEquals(setOf(bob), coord.refusedPeers.value)
+
+        client.published[bob] = pinned
+        coord.grantScope(teamId, "prod", bob)
+
+        assertNull(coord.lastError.value)
+        assertEquals(emptySet(), coord.refusedPeers.value)
+    }
+
+    /** Another account's vault is another account's colleagues: a reset takes every mark with it. */
+    @Test
+    fun `a vault reset drops every mark`() = runBlocking {
+        initializeVaultCrypto()
+        val f = newFixture()
+        TeamKeyStore(f.vault).put(teamId, "Ops", TeamRole.OWNER, crypto.newDataKey(), epoch = 0)
+        val client = FakePeerClient(self, teamId)
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        client.teams = listOf(activeTeam(TeamRole.OWNER, members = 2))
+        val coord = coordinator(f, client)
+        coord.createScope(teamId, "Production")
+        coord.grantScope(teamId, "prod", bob) // first sight
+        client.published[bob] = Published(keysOf(crypto.newSharingKeyPair(), crypto.newSigningKeyPair()))
+        coord.grantScope(teamId, "prod", bob)
+        assertEquals(setOf(bob), coord.refusedPeers.value)
+
+        coord.lock()
+
+        assertEquals(emptySet(), coord.refusedPeers.value)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsDialogFormTest.kt
@@ -22,7 +22,9 @@ import app.skerry.ui.generated.resources.lib_teams_invite_check_retry
 import app.skerry.ui.generated.resources.lib_teams_invite_key_changed_ack
 import app.skerry.ui.generated.resources.lib_teams_key_changed_unconfirmed
 import app.skerry.ui.generated.resources.lib_teams_key_pin_unreadable
+import app.skerry.ui.generated.resources.lib_teams_peer_state_confirmed
 import app.skerry.ui.generated.resources.lib_teams_peer_state_first_sight
+import app.skerry.ui.generated.resources.lib_teams_peer_state_refused
 import app.skerry.ui.desktop.runForm
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.shared.team.Pin
@@ -450,6 +452,46 @@ class TeamsDialogFormTest {
             }
         }
         assertTrue(dismissed, "the screen was never told the dialog is gone")
+    }
+
+    /**
+     * The row the refusal was about opens this dialog, and it has to say so: the pin behind a
+     * colleague who rotated their Teams identity still reads as confirmed, so wording the state off
+     * the pin alone would greet a refused key with "confirmed" (#326).
+     */
+    @Test
+    fun `a refused key is worded as refused, not as the confirmed pin behind it`() {
+        var refusedWording = ""
+        var confirmedWording = ""
+        var ack = ""
+        var confirmed: InvitePreview? = null
+        runForm({
+            refusedWording = stringResource(Res.string.lib_teams_peer_state_refused)
+            confirmedWording = stringResource(Res.string.lib_teams_peer_state_confirmed)
+            ack = stringResource(Res.string.lib_teams_invite_key_changed_ack)
+            ConfirmPeerKeyDialog(
+                accountId = ACCOUNT,
+                check = PeerKeyVerdict.Ready(
+                    InvitePreview(ACCOUNT, PEER_FINGERPRINT, pinned = Pin.Known(MOVED_FROM, PinOrigin.CONFIRMED)),
+                ),
+                trust = PeerTrust.REFUSED,
+                ownFingerprint = OWN_FINGERPRINT,
+                busy = false,
+                onRetry = {},
+                onConfirm = { confirmed = it },
+                onDismiss = {},
+            )
+        }) {
+            waitForIdle()
+            onNodeWithContentDescription(refusedWording, substring = true).assertExists()
+            onNodeWithContentDescription(confirmedWording, substring = true).assertDoesNotExist()
+            onNodeWithTag(UiTags.FORM_SAVE).assertIsNotEnabled() // the refused key still moved (#323)
+            onNodeWithContentDescription(ack).performClick()
+            waitForIdle()
+            onNodeWithTag(UiTags.FORM_SAVE).performClick()
+            waitForIdle()
+        }
+        assertEquals(PEER_FINGERPRINT, confirmed?.fingerprint)
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsPeerPinFixture.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/teams/TeamsPeerPinFixture.kt
@@ -1,0 +1,243 @@
+package app.skerry.ui.teams
+
+import app.skerry.shared.sync.InMemorySyncStateStore
+import app.skerry.shared.sync.RecordPage
+import app.skerry.shared.sync.RemoteRecord
+import app.skerry.shared.sync.SyncException
+import app.skerry.shared.sync.SyncSession
+import app.skerry.shared.team.AccountKeys
+import app.skerry.shared.team.TeamActivityEntry
+import app.skerry.shared.team.TeamClient
+import app.skerry.shared.team.TeamIdentityStore
+import app.skerry.shared.team.TeamInviteCodec
+import app.skerry.shared.team.TeamMember
+import app.skerry.shared.team.TeamMemberStatus
+import app.skerry.shared.team.TeamPeerStore
+import app.skerry.shared.team.TeamRole
+import app.skerry.shared.team.TeamScopeGrantEntry
+import app.skerry.shared.team.TeamScopeRef
+import app.skerry.shared.team.TeamScopeSummary
+import app.skerry.shared.team.TeamSessionKind
+import app.skerry.shared.team.TeamSummary
+import app.skerry.shared.team.TeamVaults
+import app.skerry.shared.team.accountKeyFingerprint
+import app.skerry.shared.vault.FileVault
+import app.skerry.shared.vault.IonspinVaultCrypto
+import app.skerry.shared.vault.RecordType
+import app.skerry.shared.vault.SharingKeyPair
+import app.skerry.shared.vault.SigningKeyPair
+import app.skerry.ui.sync.TeamLink
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import java.nio.file.Files
+
+/**
+ * The sync server the peer-pin tests run against, and the account it runs against it: a mutable key
+ * table the fake is free to swap between two fetches, a real file vault, and a coordinator wired to
+ * both.
+ *
+ * A base class rather than a second copy per test file: what these tests are about is a server that
+ * answers one key for the check and another for the seal, and a fake that drifts between two files
+ * stops being that server for one of them.
+ */
+abstract class TeamsPeerPinFixture {
+
+    protected val crypto = IonspinVaultCrypto()
+    protected val teamId = "team-pin"
+    protected val self = "alice@example.com"
+    protected val bob = "bob@example.com"
+    protected val carol = "carol@example.com"
+    protected val dave = "dave@example.com"
+
+    /** An account's published keys, as the server holds them — swappable between two fetches. */
+    protected class Published(var keys: AccountKeys)
+
+    protected fun keysOf(sharing: SharingKeyPair, signing: SigningKeyPair) =
+        AccountKeys(sharing.publicKey, signing.publicKey)
+
+    protected fun fingerprintOf(keys: AccountKeys) = accountKeyFingerprint(keys.sharing, keys.signing)
+
+    /**
+     * Fake team network: a mutable key table, a mutable member list, and every envelope the client
+     * hands over kept for inspection.
+     */
+    protected class FakePeerClient(private val self: String, private val teamId: String) : TeamClient {
+        val published = mutableMapOf<String, Published>()
+        var teams: List<TeamSummary> = emptyList()
+        var memberList: List<TeamMember> = emptyList()
+        val accepted = mutableListOf<String>()
+        val removed = mutableListOf<String>()
+        val grants = mutableListOf<Pair<String, ByteArray>>()
+        val invites = mutableListOf<String>()
+        val teamRekeys = mutableListOf<Map<String, ByteArray>>()
+        val scopeEnvelopes = linkedMapOf<String, MutableMap<String, ByteArray>>()
+        val scopeEpochs = mutableMapOf<String, Long>()
+        var teamEpoch = 0L
+        /** How many times each account's key was fetched — the double fetch is the hole (#319 item 1). */
+        val fetches = mutableMapOf<String, Int>()
+
+        /** Run inside the lookup, for whatever the round trip is supposed to give the world time to do. */
+        var duringFetch: (() -> Unit)? = null
+
+        override suspend fun fetchPublicKey(session: SyncSession, accountId: String): AccountKeys? {
+            fetches[accountId] = (fetches[accountId] ?: 0) + 1
+            duringFetch?.invoke()
+            return published[accountId]?.keys
+        }
+
+        override suspend fun listTeams(session: SyncSession): List<TeamSummary> = teams
+        override suspend fun members(session: SyncSession, teamId: String): List<TeamMember> = memberList
+        override suspend fun publishKey(session: SyncSession, publicKey: ByteArray, signPublicKey: ByteArray) = Unit
+        override suspend fun accept(session: SyncSession, teamId: String) { accepted += teamId }
+
+        override suspend fun removeMember(session: SyncSession, teamId: String, accountId: String) {
+            removed += accountId
+            memberList = memberList.filter { it.accountId != accountId }
+            scopeEnvelopes.values.forEach { it.remove(accountId) }
+        }
+
+        override suspend fun rekey(session: SyncSession, teamId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            if (teamRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "team rekey failed")
+            teamRekeys += envelopes
+            teamEpoch = newEpoch
+        }
+
+        override suspend fun listScopes(session: SyncSession, teamId: String): List<TeamScopeSummary> =
+            scopeEnvelopes.map { (scopeId, grants) ->
+                TeamScopeSummary(scopeId, scopeEpochs[scopeId] ?: 0, grants.size, grants[self])
+            }
+
+        override suspend fun createScope(session: SyncSession, teamId: String, scopeId: String, envelope: ByteArray) {
+            scopeEnvelopes[scopeId] = mutableMapOf(self to envelope)
+            scopeEpochs[scopeId] = 0
+        }
+
+        override suspend fun grantScope(session: SyncSession, teamId: String, scopeId: String, accountId: String, envelope: ByteArray) {
+            grants += accountId to envelope
+            scopeEnvelopes[scopeId]?.put(accountId, envelope)
+        }
+
+        override suspend fun scopeGrants(session: SyncSession, teamId: String, scopeId: String): List<TeamScopeGrantEntry> =
+            scopeEnvelopes[scopeId]?.keys?.map { TeamScopeGrantEntry(it, 0) } ?: emptyList()
+
+        override suspend fun revokeScope(session: SyncSession, teamId: String, scopeId: String, accountId: String) {
+            scopeEnvelopes[scopeId]?.remove(accountId)
+        }
+
+        /** Set to fail every scope rotation the way an exhausted retry does. */
+        var scopeRekeyFails = false
+
+        /** The same for the team key's own rotation. */
+        var teamRekeyFails = false
+
+        override suspend fun rekeyScope(session: SyncSession, teamId: String, scopeId: String, newEpoch: Long, envelopes: Map<String, ByteArray>) {
+            if (scopeRekeyFails) throw SyncException(SyncException.Kind.NETWORK, "scope rekey failed")
+            scopeEpochs[scopeId] = newEpoch
+            val holders = scopeEnvelopes[scopeId] ?: return
+            envelopes.forEach { (account, env) -> if (holders.containsKey(account)) holders[account] = env }
+        }
+
+        override suspend fun pullTeam(session: SyncSession, ref: TeamScopeRef, since: Long): RecordPage =
+            RecordPage(emptyList(), since)
+
+        override suspend fun pushTeam(session: SyncSession, ref: TeamScopeRef, records: List<RemoteRecord>): RecordPage =
+            RecordPage(records, 1)
+
+        override suspend fun createTeam(session: SyncSession, teamId: String) = error("unused")
+        override suspend fun invite(session: SyncSession, teamId: String, accountId: String, role: TeamRole, envelope: ByteArray) {
+            invites += accountId
+        }
+        override suspend fun changeRole(session: SyncSession, teamId: String, accountId: String, role: TeamRole) = error("unused")
+        override suspend fun deleteScope(session: SyncSession, teamId: String, scopeId: String) = error("unused")
+        override suspend fun teamActivity(session: SyncSession, teamId: String): List<TeamActivityEntry> = error("unused")
+        override suspend fun reportSessionEvent(
+            session: SyncSession,
+            teamId: String,
+            recordId: String,
+            kind: TeamSessionKind,
+            durationSec: Long?,
+        ) = error("unused")
+        override suspend fun deleteTeam(session: SyncSession, teamId: String) = error("unused")
+    }
+
+    protected class Fixture(val vault: FileVault, val teamVaults: TeamVaults)
+
+    protected fun newFixture(): Fixture {
+        val vaultFile = Files.createTempFile("skerry-acct", ".json").toString().toPath()
+        FileSystem.SYSTEM.delete(vaultFile)
+        val teamDir = Files.createTempDirectory("skerry-teamvaults").toString().toPath()
+        val vault = FileVault(vaultFile, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW })
+        vault.create("master".toCharArray())
+        return Fixture(vault, TeamVaults(teamDir, crypto, deviceId = "dev-alice", fileSystem = FileSystem.SYSTEM, now = { NOW }))
+    }
+
+    protected fun coordinator(f: Fixture, client: TeamClient, ids: Iterator<String> = listOf("prod").iterator()) =
+        TeamsCoordinator(
+            live = { TeamLink(SyncSession(self, "access", "refresh"), client, "test-link") },
+            vault = f.vault,
+            crypto = crypto,
+            teamVaults = f.teamVaults,
+            teamState = InMemorySyncStateStore(),
+            newId = { ids.next() },
+        )
+
+    /** An invite from [inviter] to us, sealed to our own sharing key and signed by their identity. */
+    protected fun inviteEnvelope(f: Fixture, inviter: String, signing: SigningKeyPair, epoch: Int = 0): ByteArray {
+        val identity = TeamIdentityStore(f.vault, crypto).ensure()
+        return TeamInviteCodec(crypto).seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = signing,
+            inviterId = inviter,
+            inviteeId = self,
+            teamId = teamId,
+            teamKey = crypto.newDataKey(),
+            teamName = "Ops",
+            epoch = epoch,
+        )
+    }
+
+    protected fun invitedTeam(envelope: ByteArray) = TeamSummary(
+        id = teamId, ownerAccountId = bob, role = TeamRole.VIEWER,
+        status = TeamMemberStatus.INVITED, createdAt = 0, memberCount = 2,
+        envelope = envelope, keyEpoch = 0, keyEnvelope = null,
+    )
+
+    /** A scope key granted to us by [granter], signed with [signing] and bound to [scopeId]. */
+    protected fun scopeEnvelope(f: Fixture, granter: String, signing: SigningKeyPair, scopeId: String, epoch: Int): ByteArray {
+        val identity = TeamIdentityStore(f.vault, crypto).ensure()
+        return TeamInviteCodec(crypto).seal(
+            recipientPublicKey = identity.sharing.publicKey,
+            inviter = signing,
+            inviterId = granter,
+            inviteeId = self,
+            teamId = teamId,
+            teamKey = crypto.newDataKey(),
+            teamName = "Production",
+            epoch = epoch,
+            scopeId = scopeId,
+        )
+    }
+
+
+    /**
+     * The id a pin for [accountId] would use, asked of the store rather than assumed from its
+     * namespace: pin an unrelated account, read the id it filed, and swap the account in.
+     */
+    protected fun pinIdOf(f: Fixture, accountId: String): String {
+        val probe = "probe@example.com"
+        TeamPeerStore(f.vault).confirm(probe, "probe")
+        val filed = f.vault.records().single { it.type == RecordType.TEAM_PEER && !it.deleted }.id
+        return filed.removeSuffix(probe) + accountId
+    }
+
+    /** The team as the server lists it once we are a member of it. */
+    protected fun activeTeam(role: TeamRole, members: Int = 2, keyEpoch: Long = 0, keyEnvelope: ByteArray? = null) = TeamSummary(
+        id = teamId, ownerAccountId = if (role == TeamRole.OWNER) self else bob, role = role,
+        status = TeamMemberStatus.ACTIVE, createdAt = 0, memberCount = members,
+        envelope = null, keyEpoch = keyEpoch, keyEnvelope = keyEnvelope,
+    )
+
+    protected companion object {
+        const val NOW = "2026-08-24T00:00:00Z"
+    }
+}


### PR DESCRIPTION
Closes #326.

## What it does

A seal to a colleague whose published key is not the pinned one is refused with `lib_teams_err_peer_key_unconfirmed`, which asks the user to confirm a fingerprint in the member list — without naming whose row. The pin could not supply the name either: a colleague who rotated their Teams identity leaves a pin that is still `Known(oldFingerprint, CONFIRMED)`, so their row drew the same quiet confirmed mark as every healthy member, while the amber first-sight marks sat on unrelated rows.

`TeamsFailure` is an enum and carries no account id, so the id now comes out of the lookup. Both peer-key lookups (`sealingKeys` via `fetchPinned`, `adoptingKeys` via `checkPinned`) already see `PeerKeys.Unconfirmed(accountId, fingerprint)`; they file it in a new `PeerRefusals`, and the member list draws a third row state from that set.

- **New row state `PeerTrust.REFUSED`** — a red `gpp_bad` mark on `Skerry.colors.sunset` with its own wording, distinct from the amber first-sight mark and the quiet confirmed one. Desktop and phone draw it from the same `teamMemberRows`.
- **The confirm dialog the mark opens says "refused"** rather than repeating what the stale pin behind it still claims.
- **`peerTrust` now ranks an unreadable pin above a refusal** — `TeamPeerStore.resolve` answers `Unconfirmed` both for a fingerprint mismatch and for a pin it cannot read, and the two do not have the same remedy.
- **New strings in en/ru/zh**: `lib_teams_peer_refused`, `lib_teams_peer_state_refused`; `lib_teams_err_peer_key_unconfirmed` reworded to say the member list marks the row.

## Lifetime of a mark

A rotation walks every recipient and can refuse several at once, so what is carried is a set, bounded by the member list. A mark is evidence about one account, and only evidence about that same account retires it: the lookup that finds the key back on its pin, or the confirm that moves the pin to it. A vault reset drops them all.

Tying the set to the error slot instead — clearing it with `resetError()` — would wipe every mark on the next operation of any kind, so the second colleague a rotation refused would go back to wearing the quiet confirmed mark with nothing done about their key: #326's own bug, one row over.

## Tests

- `TeamsCoordinatorRefusedPeersTest` — a rotation names every recipient it stepped over; a refused grant names its member; a refusal on the adopting side names the account it came from; a confirm that did not record leaves the mark; a confirm that recorded clears it; a mark on one colleague outlives an operation about another; a lookup that finds the key back on its pin clears the mark; a vault reset drops every mark.
- `MemberPinsMarkTest` — end to end: a live coordinator driven through a real refusal, then `rememberMemberPins` + `teamMemberRows` + `TeamMemberTable`, asserting exactly one row carries the refused description and that it is the refused member.
- `TeamsScreenModelTest`, `PeerTrustBadgeTest`, `TeamsDialogFormTest` — the row state's precedence, the badge, and the dialog's refused wording.
- `TeamsPeerPinFixture` extracted so the peer-pin fake server is shared by two test classes.