### PR TITLE
Queue a transfer picked while another one runs (#317)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
@@ -23,9 +23,10 @@
     <!-- Типизированные ошибки файлового браузера/передачи (сырой текст платформы не показывается) -->
     <string name="ftail_err_local_io">Ошибка локальной файловой системы</string>
     <string name="ftail_err_sftp">Ошибка SFTP</string>
-    <string name="ftail_err_illegal_name">Недопустимое имя в списке файлов</string>
+    <string name="ftail_err_illegal_name">Недопустимое имя файла</string>
     <string name="ftail_err_open_source">Не удалось открыть выбранный файл</string>
     <string name="ftail_err_open_target">Не удалось открыть файл для записи</string>
+    <string name="ftail_err_session_closed">Сессия закрыта до начала передачи</string>
     <string name="ftail_err_too_large">Файл слишком большой, чтобы открыть его</string>
 
     <!-- Ошибки просмотрщика/редактора (F3/F4) -->

--- a/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_sftp.xml
@@ -115,6 +115,11 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">готово</string>
+    <string name="sftp_queue_waiting">ожидание</string>
+    <string name="sftp_queue_backlog">В очереди на канал: %1$d</string>
+    <string name="sftp_queue_cancel">Отменить %1$s</string>
+    <string name="sftp_queue_clear">Убрать %1$s</string>
+    <string name="sftp_queue_state">%1$s: %2$s</string>
     <string name="sftp_path_field">Перейти к пути</string>
     <string name="sftp_edit_buffer">Содержимое файла</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
@@ -23,9 +23,10 @@
     <!-- 文件浏览器/传输的类型化失败原因（原始平台文本不会展示给用户） -->
     <string name="ftail_err_local_io">本地文件系统错误</string>
     <string name="ftail_err_sftp">SFTP 错误</string>
-    <string name="ftail_err_illegal_name">列表中的文件名不安全</string>
+    <string name="ftail_err_illegal_name">文件名不安全</string>
     <string name="ftail_err_open_source">无法打开所选文件</string>
     <string name="ftail_err_open_target">无法打开保存目标</string>
+    <string name="ftail_err_session_closed">会话在传输开始前已关闭</string>
     <string name="ftail_err_too_large">文件太大，无法打开</string>
 
     <!-- 查看器/编辑器（F3/F4）失败原因 -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_sftp.xml
@@ -115,6 +115,11 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">完成</string>
+    <string name="sftp_queue_waiting">等待中</string>
+    <string name="sftp_queue_backlog">等待通道：%1$d</string>
+    <string name="sftp_queue_cancel">取消 %1$s</string>
+    <string name="sftp_queue_clear">清除 %1$s</string>
+    <string name="sftp_queue_state">%1$s：%2$s</string>
     <string name="sftp_path_field">跳转到路径</string>
     <string name="sftp_edit_buffer">文件内容</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
@@ -23,9 +23,10 @@
     <!-- Typed file browser / transfer failures (raw platform text never reaches the user) -->
     <string name="ftail_err_local_io">Local filesystem error</string>
     <string name="ftail_err_sftp">SFTP error</string>
-    <string name="ftail_err_illegal_name">Unsafe name in the listing</string>
+    <string name="ftail_err_illegal_name">Unsafe file name</string>
     <string name="ftail_err_open_source">Failed to open the selected file</string>
     <string name="ftail_err_open_target">Failed to open the save target</string>
+    <string name="ftail_err_session_closed">Session closed before it started</string>
     <string name="ftail_err_too_large">File is too large to open</string>
 
     <!-- Viewer/editor (F3/F4) failures -->

--- a/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_sftp.xml
@@ -117,6 +117,11 @@
     <!-- Transfer queue under the panes -->
     <string name="sftp_queue_progress">%1$d% · %2$s / %3$s</string>
     <string name="sftp_queue_done">done</string>
+    <string name="sftp_queue_waiting">waiting</string>
+    <string name="sftp_queue_backlog">Waiting for the channel: %1$d</string>
+    <string name="sftp_queue_cancel">Cancel %1$s</string>
+    <string name="sftp_queue_clear">Clear %1$s</string>
+    <string name="sftp_queue_state">%1$s: %2$s</string>
     <!-- Accessible names for the two inputs the panes draw without a caption (issue #228) -->
     <string name="sftp_path_field">Jump to path</string>
     <string name="sftp_edit_buffer">File contents</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/connection/ConnectionController.kt
@@ -770,8 +770,13 @@ class ConnectionController(
      * outlives the editor UI, so the channel is closed only once that write is done
      * ([TransferCoordinator.awaitEditorWrites]) — otherwise closing the tab right after Save would
      * leave the remote file truncated (the write is an in-place truncate).
+     *
+     * Transfers still waiting for the channel are released first: their turn will never come, and
+     * each of them may hold a handle the platform gave the user's picker — a document created at a
+     * chosen location, a cached copy of a picked file (issue #317).
      */
     private fun closeSftpQuietly(client: SftpClient, coordinator: TransferCoordinator?) {
+        coordinator?.releaseQueued()
         scope.launch(NonCancellable) {
             runCatching { coordinator?.awaitEditorWrites() }
             runCatching { client.close() }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/DisplayName.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/DisplayName.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.sftp_unprintable_name
 import org.jetbrains.compose.resources.stringResource
 
@@ -26,6 +27,19 @@ internal fun fileDisplayName(raw: String): String {
     // filter is a scan and an allocation the name has not earned twice.
     return remember(raw, unprintable) { untrustedLabel(raw).ifBlank { unprintable } }
 }
+
+/**
+ * A transfer's file name as it is drawn — a queue row, the mobile card, what a screen reader is
+ * told about them.
+ *
+ * The empty string is the app's own sentinel here: an operation that has not named a file yet (it
+ * was refused, or failed before the first one opened). Everything else is the host's text and goes
+ * through [fileDisplayName] — whitespace included, since a name of spaces is a name the far side
+ * chose, not an absent one.
+ */
+@Composable
+internal fun transferDisplayName(raw: String): String =
+    if (raw.isEmpty()) stringResource(Res.string.ftail_file_fallback) else fileDisplayName(raw)
 
 /**
  * A directory path as it is drawn — a breadcrumb, a work-bar subtitle, the destination half of a

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
@@ -12,6 +12,7 @@ import app.skerry.ui.generated.resources.ftail_err_illegal_name
 import app.skerry.ui.generated.resources.ftail_err_local_io
 import app.skerry.ui.generated.resources.ftail_err_open_source
 import app.skerry.ui.generated.resources.ftail_err_open_target
+import app.skerry.ui.generated.resources.ftail_err_session_closed
 import app.skerry.ui.generated.resources.ftail_err_sftp
 import app.skerry.ui.generated.resources.ftail_err_too_large
 import app.skerry.ui.generated.resources.ftail_transfer_error
@@ -50,5 +51,6 @@ fun transferFailureText(failure: FileTransferFailure): String = stringResource(
         FileTransferFailure.IllegalName -> Res.string.ftail_err_illegal_name
         FileTransferFailure.OpenSource -> Res.string.ftail_err_open_source
         FileTransferFailure.OpenTarget -> Res.string.ftail_err_open_target
+        FileTransferFailure.SessionClosed -> Res.string.ftail_err_session_closed
     },
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferCoordinator.kt
@@ -17,71 +17,10 @@ import app.skerry.ui.sync.nowMillis
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
-/**
- * Typed, user-facing reason for a failed transfer; the UI maps it to a localized string. Raw
- * exception text is never shown — a [FileBrowserException] contributes only its
- * [FileBrowserFailure], anything else lands on [Transfer].
- */
-enum class FileTransferFailure {
-    /** The byte transfer itself failed (stream/SFTP/local I/O). */
-    Transfer,
-
-    /** Files reached the destination, but a source could not be removed after a move. */
-    DeleteSource,
-
-    /** A listing entry carried a name unsafe to use as a path component. */
-    IllegalName,
-
-    /** The picked upload source could not be opened. */
-    OpenSource,
-
-    /** The chosen download target could not be opened. */
-    OpenTarget,
-}
-
-/** Maps a browser failure onto the transfer bar's reason; I/O-level causes collapse to [FileTransferFailure.Transfer]. */
-private fun FileBrowserFailure.toTransferFailure(): FileTransferFailure = when (this) {
-    FileBrowserFailure.IllegalName -> FileTransferFailure.IllegalName
-    FileBrowserFailure.OpenSource -> FileTransferFailure.OpenSource
-    FileBrowserFailure.OpenTarget -> FileTransferFailure.OpenTarget
-    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp, FileBrowserFailure.TooLarge ->
-        FileTransferFailure.Transfer
-}
-
-/** Cross-pane batch transfer state, for the bottom transfer bar. */
-sealed interface TransferState {
-    /** No transfer in progress. */
-    data object Idle : TransferState
-
-    /**
-     * Transferring file [name] ([fileIndex] of [fileCount] in the batch), [transferred] of [total]
-     * bytes ([total] = 0 if unknown).
-     */
-    data class Active(
-        val name: String,
-        val direction: TransferDirection,
-        val fileIndex: Int,
-        val fileCount: Int,
-        val transferred: Long,
-        val total: Long,
-    ) : TransferState
-
-    /**
-     * Transfer of [name] failed; [failure] is the typed reason, localized by the UI. [name] is
-     * blank when the failure happened before any file became active — the UI substitutes a
-     * localized placeholder.
-     */
-    data class Failed(val name: String, val failure: FileTransferFailure) : TransferState
-}
-
-/**
- * Overwrite conflict awaiting confirmation. [names] are entries in the destination directory that
- * would be overwritten; [proceed] runs the deferred transfer once the user confirms.
- */
-class OverwriteConflict(val names: List<String>, val proceed: () -> Unit)
+/** Top-level names an operation still on the queue is going to create in directory [dir]. */
+private class PlannedWrite(val dir: String, val names: Set<String>)
 
 /**
  * Coordinates file transfer between the [local] and [remote] panes over a single [SftpClient].
@@ -90,7 +29,8 @@ class OverwriteConflict(val names: List<String>, val proceed: () -> Unit)
  * directory, updates [transfer] for the progress bar, then reloads the destination and clears the
  * source selection. On upload, directories in the selection are skipped; on download, a directory
  * is transferred recursively (tree walked via [sftp], local subdirectories recreated via
- * [localBrowser]). At most one transfer runs at a time (serialized via [busy]).
+ * [localBrowser]). At most one transfer runs at a time; the rest wait their turn in
+ * [TransferRunner], visible on the queue as they wait.
  */
 @Stable
 class TransferCoordinator(
@@ -105,7 +45,13 @@ class TransferCoordinator(
 ) {
     private val transfers = TransferQueue(now)
 
-    /** The transfer queue, oldest first: what is moving now plus the last few finished entries. */
+    /**
+     * Runs the operations, one at a time and in order. Everything the coordinator starts goes
+     * through it, so no requested operation is ever dropped without a row saying what became of it.
+     */
+    private val runner = TransferRunner(scope, transfers)
+
+    /** The transfer queue, oldest first: what is waiting and moving now, plus the last few finished. */
     val queue: List<TransferEntry> get() = transfers.list
 
     /**
@@ -115,29 +61,47 @@ class TransferCoordinator(
     val transfer: TransferState get() = transfers.latest
 
     /**
-     * Whether bytes are moving right now — a transfer, or an editor save ([openEditor]; the same
-     * [editorWrites] lock session teardown waits on). Read by the vault's idle auto-lock, which
-     * defers locking while it is true: a lock closes the session this runs on, and a half-written
-     * file is not what a timeout should leave behind — a save is open-truncate-write, so cutting it
-     * loses the file. [busy] itself stays private: it is the serialization latch, held across the
-     * overwrite prompt too, which is the user being asked something, not work in flight.
+     * Whether this session still owes the user file work — a transfer running or waiting its turn,
+     * or an editor save ([openEditor]; the same [editorWrites] lock session teardown waits on).
+     * Read by the vault's idle auto-lock, which defers locking while it is true: a lock closes the
+     * session this runs on, and a half-written file is not what a timeout should leave behind — a
+     * save is open-truncate-write, so cutting it loses the file. A queued operation counts for the
+     * same reason: locking would close the channel its turn never came on. A question put to the
+     * user — an open "Overwrite?" dialog — does not: nothing has been requested yet.
      */
-    val writeInFlight: Boolean get() = transfer is TransferState.Active || editorWrites.isLocked
+    val writeInFlight: Boolean get() = transfers.hasWork || editorWrites.isLocked
 
     /**
      * Overwrite conflict awaiting confirmation: the destination directory already has entries
      * named [OverwriteConflict.names]. While non-null, the UI shows an "Overwrite?" dialog;
-     * [resolveOverwrite] either runs the deferred transfer or cancels it.
+     * [resolveOverwrite] either runs the deferred transfer or cancels it. Head of [conflicts].
      */
     var overwrite: OverwriteConflict? by mutableStateOf(null)
         private set
 
     /**
-     * Serializes transfers: the check-and-set on [busy] isn't atomic, but is safe since
-     * `uploadSelection`/`downloadSelection` are called from UI handlers on the main thread, same
-     * as [FilePaneController].
+     * Conflicts still to be answered, in the order they were raised. Normally at most one — the
+     * dialog is modal — but the native file picker draws over it, so a second picked upload can
+     * reach the coordinator while the first is still being asked about. Replacing the pending
+     * conflict would drop the staged copy the first one holds, which is the defect this queue
+     * exists to avoid, so they are answered one after another instead.
      */
-    private var busy = false
+    private val conflicts = ArrayDeque<OverwriteConflict>()
+
+    /**
+     * Top-level names an operation that has not finished yet will write, and where. The overwrite
+     * check reads the destination pane's *listing*, which only catches up when the pane reloads —
+     * after an operation ends. While transfers were serialized by a latch there was never a second
+     * operation to be stale about; a queue makes it stale by construction, and the two would
+     * silently overwrite each other. Worst case is a move: the second one's source is deleted after
+     * the transfer, so the file it overwrote exists nowhere. Entries are added when an operation is
+     * submitted and dropped when it leaves, however it leaves.
+     */
+    private val plannedWrites = mutableListOf<PlannedWrite>()
+
+    /** Names an operation still on the queue will write into [dir]. */
+    private fun planned(dir: String): Set<String> =
+        plannedWrites.filter { it.dir == dir }.flatMapTo(mutableSetOf()) { it.names }
 
     /**
      * Held for the duration of an editor's write ([openEditor]). The session's teardown waits on it
@@ -155,13 +119,14 @@ class TransferCoordinator(
     /**
      * Uploads the local pane's selection into the remote pane's current directory. Files are
      * uploaded as-is; directories recursively (subtree recreated on the host), symmetric with
-     * download. Symlinks/other are skipped. Progress/error go to [transfer]; serialized via [busy].
+     * download. Symlinks/other are skipped. Progress/error go to [transfer]; runs when the channel
+     * is free, waits on the queue until then.
      */
     fun uploadSelection() {
         val items = local.selectedItems()
         if (items.isEmpty()) return
         confirmOverwrite(items, remote) { destDir ->
-            launchExclusive {
+            submit(TransferDirection.Upload, items.first().name, destDir, items.map { it.name }) {
                 runUpload(items, destDir)
                 remote.reloadNow()
                 local.clearSelection()
@@ -174,16 +139,18 @@ class TransferCoordinator(
      * downloaded as-is; directories recursively: a tree-walk plan is built first
      * ([buildDownloadPlan]), local subdirectories are recreated ([ensureDir]), then files are
      * downloaded in order with a shared progress counter. Symlinks/other are skipped (never
-     * followed). Progress/error go to [transfer]; serialized via [busy].
+     * followed). Progress/error go to [transfer]; runs when the channel is free, waits on the queue
+     * until then.
      */
     fun downloadSelection() {
         val items = remote.selectedItems()
         if (items.isEmpty()) return
-        // Snapshot of the source directory at request time: while the Overwrite dialog is open,
-        // pane navigation must not move the download sources to a different directory.
+        // Snapshot of the source directory at request time: while the Overwrite dialog is open or
+        // the operation waits its turn, pane navigation must not move the download sources to a
+        // different directory.
         val sourceDir = remote.path
         confirmOverwrite(items, local) { destDir ->
-            launchExclusive {
+            submit(TransferDirection.Download, items.first().name, destDir, items.map { it.name }) {
                 runDownload(items, destDir, sourceDir)
                 local.reloadNow()
                 remote.clearSelection()
@@ -203,7 +170,7 @@ class TransferCoordinator(
             val items = local.selectedItems()
             if (items.isEmpty()) return
             confirmOverwrite(items, remote) { destDir ->
-                launchExclusive {
+                submit(TransferDirection.Upload, items.first().name, destDir, items.map { it.name }) {
                     runUpload(items, destDir)
                     val failed = deleteSources(items) { localBrowser.delete(it) }
                     remote.reloadNow()
@@ -220,7 +187,7 @@ class TransferCoordinator(
             // deletion path rebuild.
             val remoteDir = remote.path
             confirmOverwrite(items, local) { destDir ->
-                launchExclusive {
+                submit(TransferDirection.Download, items.first().name, destDir, items.map { it.name }) {
                     runDownload(items, destDir, remoteDir)
                     // Deletes via a path rebuilt from the directory snapshot + a validated name, not
                     // server-controlled item.path.
@@ -255,51 +222,91 @@ class TransferCoordinator(
      * document; desktop: chosen path). SFTP writes bytes to `target.stagingPath`; on success,
      * `target.finalize()` copies staging to the Uri; on error/cancel, `target.discard()`. Unlike
      * [downloadSelection], the target isn't tied to the local pane — this is the mobile Files
-     * screen's download-out-of-sandbox path. Progress/error go to [transfer]; serialized via the
-     * same [busy] (through [launchExclusive]). Directories are ignored (no recursive transfer here).
+     * screen's download-out-of-sandbox path. Progress/error go to [transfer]; it takes its turn on
+     * the queue like every other operation. Directories are ignored (no recursive transfer here).
+     *
+     * The target is discarded on every path that doesn't move it — a failed transfer, a failed
+     * `finalize()`, a cancelled session, an operation dropped before its turn came. On Android that
+     * is not housekeeping: the picker has already created the document at the location the user
+     * chose, so leaving it is leaving them an empty file where they asked for their data.
      * `discard()` is wrapped in [runCatching] so a cleanup failure doesn't mask the original error.
      */
     fun downloadToTarget(item: FileItem, target: DownloadTarget) {
         if (item.type != FileItemType.File) return
-        launchExclusive {
-            try {
-                transfers.begin(TransferDirection.Download)
-                transfers.step(target.displayName, 1, 1, 0, item.size)
-                sftp.download(item.path, target.stagingPath) { transferred, total ->
-                    transfers.step(target.displayName, 1, 1, transferred, total)
-                }
-                target.finalize()
-            } catch (e: Exception) { // Includes CancellationException — staging is cleaned up either way.
-                runCatching { target.discard() }
-                throw e
+        var moved = false
+        submit(
+            direction = TransferDirection.Download,
+            name = target.displayName,
+            // The target is a path the platform picker owns, not a directory this app writes into,
+            // so there is nothing for another queued operation to clash with.
+            destDir = "",
+            writes = emptyList(),
+            onFinally = { if (!moved) runCatching { target.discard() } },
+        ) {
+            transfers.step(target.displayName, 1, 1, 0, item.size)
+            sftp.download(item.path, target.stagingPath) { transferred, total ->
+                transfers.step(target.displayName, 1, 1, transferred, total)
             }
+            target.finalize()
+            moved = true
         }
     }
 
     /**
      * Fallback upload: uploads an arbitrary local [source] (from a native picker) into the remote
      * pane's current directory, for when the local pane has nothing selected. Remote name is
-     * `source.name`. Progress/error go to [transfer]; `source.cleanup()` runs on completion
-     * (success or error) and the remote pane reloads. Serialized via the same [busy] as
-     * selection-based transfers.
+     * `source.name`. Progress/error go to [transfer]; it takes its turn on the queue like every
+     * other operation, and the remote pane reloads afterwards.
+     *
+     * `source.cleanup()` runs on every path the source leaves by — a finished or failed transfer, a
+     * refused overwrite, an operation dropped before its turn came. The picker has already copied
+     * the whole file into the app's cache by the time this is called (the Uri grant is short-lived),
+     * so a path that forgets to release it leaks a full copy of whatever the user picked.
      */
     fun uploadSource(source: UploadSource) {
-        if (busy) return
-        // Snapshot of the destination directory at request time: pane navigation while the
-        // Overwrite dialog is open must not redirect the upload to a different directory (TOCTOU).
+        // The name is whatever the picker's provider reported — on Android an
+        // OpenableColumns.DISPLAY_NAME from an app we do not control — and it becomes a path
+        // component on the host, under the user's own credentials. A name that would climb out of
+        // the destination directory never gets that far, and never reaches the conflict check
+        // either: no listing entry can match it, so nothing would have been asked.
+        if (isUnsafeListingName(source.name)) {
+            refuse(source, FileTransferFailure.IllegalName)
+            return
+        }
+        // Snapshot of the destination directory at request time: pane navigation while the Overwrite
+        // dialog is open, or while the upload waits its turn, must not redirect it (TOCTOU).
         val destDir = remote.path
-        if (source.name in remote.currentEntryNames()) {
-            overwrite = OverwriteConflict(listOf(source.name)) { runUploadSource(source, destDir) }
+        if (source.name in remote.currentEntryNames() + planned(destDir)) {
+            ask(
+                OverwriteConflict(
+                    names = listOf(source.name),
+                    proceed = { runUploadSource(source, destDir) },
+                    cancel = { runner.release { source.cleanup() } },
+                ),
+            )
             return
         }
         runUploadSource(source, destDir)
     }
 
+    /**
+     * Turns a picked source away with a row that says why, and releases its staged copy. The row is
+     * the point: this is the one path where the app refuses something the user already answered a
+     * picker for, and #317 is what happens when such a refusal is silent.
+     */
+    private fun refuse(source: UploadSource, failure: FileTransferFailure) {
+        transfers.abandon(transfers.enqueue(TransferDirection.Upload, source.name), failure)
+        runner.release { source.cleanup() }
+    }
+
     private fun runUploadSource(source: UploadSource, destDir: String) {
-        launchExclusive(onFinally = { runCatching { source.cleanup() } }) {
-            // Opened first, like every other operation: whatever the block does afterwards, the
-            // entry exists to carry the outcome.
-            transfers.begin(TransferDirection.Upload)
+        submit(
+            direction = TransferDirection.Upload,
+            name = source.name,
+            destDir = destDir,
+            writes = listOf(source.name),
+            onFinally = { runCatching { source.cleanup() } },
+        ) {
             val target = childPath(destDir, source.name)
             transfers.step(source.name, 1, 1, 0, 0)
             sftp.upload(source.stagingPath, target) { transferred, total ->
@@ -332,82 +339,99 @@ class TransferCoordinator(
         ).also { it.open() }
     }
 
-    /** Drops one finished queue entry ([id]); a transfer still running is left alone. */
+    /**
+     * Drops one queue entry ([id]); a transfer still running is left alone. An entry still waiting
+     * for its turn is cancelled by dropping it, and whatever it was holding — a picked upload's
+     * staged copy, a "Save to…" document — is released with it.
+     */
     fun dismissTransfer(id: Long) {
+        runner.cancelWaiting(id)
         transfers.dismiss(id)
     }
 
-    /** Drops every finished entry at once, leaving only what is still running. */
-    fun dismissCompleted() {
-        transfers.dismissCompleted()
+    /**
+     * Releases every operation the session still owes an answer or a turn to: the channel is
+     * closing, so neither will come. Their rows are closed as failed rather than dropped — the user
+     * asked for them — and their handles go back to the platform. Called by the session teardown
+     * before the SFTP channel is closed.
+     *
+     * The unanswered questions go first and matter most: a picked upload stopped at the "Overwrite?"
+     * dialog has no queue row yet, and its staged copy is a byte-for-byte copy of whatever the user
+     * picked sitting in the app's cache. Nothing else ever comes back for it.
+     */
+    fun releaseQueued() {
+        while (conflicts.isNotEmpty()) conflicts.removeFirst().cancel()
+        overwrite = null
+        runner.releaseWaiting()
     }
 
     /**
      * Checks top-level name conflicts between [items] and destination [dest] before starting a
      * transfer. No overlap: proceeds immediately. Overlap: raises the [overwrite] dialog, deferring
      * [proceed] until confirmed ([resolveOverwrite]). Only the top level is checked (nested-tree
-     * merges aren't handled here). Silently no-ops if a transfer is already running ([busy]).
+     * merges aren't handled here).
      *
      * [proceed] receives a snapshot of the destination directory taken here (when the dialog is
      * shown): the destination pane can be navigated while the dialog is open, so reading
      * `dest.path` at confirmation time would redirect the write elsewhere (TOCTOU) while the
      * conflict check still applied to the old directory.
+     *
+     * What an operation already on the queue is going to write counts as existing ([planned]): the
+     * pane's listing does not know about it yet, and without that the two would overwrite each
+     * other with nothing asked.
      */
     private fun confirmOverwrite(items: List<FileItem>, dest: FilePaneController, proceed: (destDir: String) -> Unit) {
-        if (busy) return
         val destDir = dest.path
-        val existing = dest.currentEntryNames()
+        val existing = dest.currentEntryNames() + planned(destDir)
         val clash = items.map { it.name }.filter { it in existing }
-        if (clash.isEmpty()) proceed(destDir) else overwrite = OverwriteConflict(clash) { proceed(destDir) }
+        if (clash.isEmpty()) proceed(destDir) else ask(OverwriteConflict(clash, proceed = { proceed(destDir) }))
     }
 
-    /** User's answer to the overwrite dialog: true runs the deferred transfer, else cancels it. */
-    fun resolveOverwrite(overwrite: Boolean) {
-        val pending = this.overwrite ?: return
-        this.overwrite = null
-        if (overwrite) pending.proceed()
+    /** Puts a conflict to the user, behind any that are already waiting for an answer. */
+    private fun ask(conflict: OverwriteConflict) {
+        conflicts += conflict
+        if (overwrite == null) overwrite = conflict
     }
 
     /**
-     * Runs a transfer, serialized via [busy]: while one is active, new calls are ignored. Any
-     * error moves the bar to [TransferState.Failed] (name taken from the current active step);
-     * [CancellationException] propagates. [onFinally] is a completion hook (success/error/cancel)
-     * for the caller's resource cleanup (staging files, etc.); runs before [busy] is cleared —
-     * swallowing its own failures is the caller's responsibility (wrap in [runCatching]).
+     * User's answer to the overwrite dialog: true runs the deferred transfer, false releases what
+     * it would have consumed. The next unanswered conflict, if any, takes the dialog's place.
      */
-    private fun launchExclusive(onFinally: suspend () -> Unit = {}, block: suspend () -> Unit) {
-        if (busy) return
-        busy = true
-        scope.launch {
-            try {
-                block()
-                // A block can finish normally having already closed its own entry as failed
-                // (a move whose transfer went through but whose source delete didn't) — that
-                // verdict wins, so the entry is only marked done while it is still open.
-                if (transfers.hasOpenEntry) transfers.end(TransferStatus.Done)
-            } catch (e: CancellationException) {
-                // A cancelled operation is over too: leaving the entry Active would show a
-                // progress bar that never moves again.
-                transfers.end(TransferStatus.Failed(FileTransferFailure.Transfer))
-                throw e
-            } catch (e: Exception) {
-                val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
-                transfers.end(TransferStatus.Failed(failure))
-            } finally {
-                onFinally()
-                busy = false
-            }
-        }
+    fun resolveOverwrite(overwrite: Boolean) {
+        val pending = conflicts.removeFirstOrNull() ?: return
+        this.overwrite = conflicts.firstOrNull()
+        if (overwrite) pending.proceed() else pending.cancel()
+    }
+
+    /**
+     * Hands an operation to [runner]: it opens the queue entry ([direction] and [name] label it
+     * until the transfer names the file it is on), runs [block] when the channel is free, and
+     * closes the entry however it ends. [destDir] and [writes] are the top-level names it will
+     * create, claimed for as long as it is on the queue so the next operation's overwrite check can
+     * see them ([planned]). [onFinally] releases whatever the operation was holding and runs
+     * exactly once, whether or not [block] ever got to run — swallowing its own failures is the
+     * caller's responsibility (wrap in [runCatching]).
+     */
+    private fun submit(
+        direction: TransferDirection,
+        name: String,
+        destDir: String,
+        writes: List<String>,
+        onFinally: suspend () -> Unit = {},
+        block: suspend () -> Unit,
+    ) {
+        val plan = PlannedWrite(destDir, writes.toSet())
+        plannedWrites += plan
+        runner.submit(direction, name, onFinally = { plannedWrites.remove(plan); onFinally() }, block = block)
     }
 
     /**
      * Uploads [items] (files as-is, directories recursively via [buildUploadPlan]) into remote
      * [remoteDir], recreating the subtree on the host ([ensureDir]); ends in
-     * [TransferState.Idle]. No serialization/post-actions — called inside an already-armed
-     * [launchExclusive] block.
+     * [TransferState.Idle]. No serialization/post-actions — called inside a block [runner] has
+     * already opened the queue entry for.
      */
     private suspend fun runUpload(items: List<FileItem>, remoteDir: String) {
-        transfers.begin(TransferDirection.Upload)
         val plan = buildUploadPlan(localBrowser, items, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(remoteBrowser, it) }
@@ -423,11 +447,10 @@ class TransferCoordinator(
     /**
      * Downloads [items] (files as-is, directories recursively via [buildDownloadPlan]) from remote
      * [remoteDir] into local [localDir], recreating the subtree ([ensureDir]); ends in
-     * [TransferState.Idle]. No serialization/post-actions — called inside an already-armed
-     * [launchExclusive] block.
+     * [TransferState.Idle]. No serialization/post-actions — called inside a block [runner] has
+     * already opened the queue entry for.
      */
     private suspend fun runDownload(items: List<FileItem>, localDir: String, remoteDir: String) {
-        transfers.begin(TransferDirection.Download)
         val plan = buildDownloadPlan(sftp, items, localDir, remoteDir)
         // Directories are created in pre-order: parent always before children.
         plan.dirs.forEach { ensureDir(localBrowser, it) }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferQueue.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferQueue.kt
@@ -5,12 +5,18 @@ import androidx.compose.runtime.mutableStateListOf
 import app.skerry.ui.sftp.TransferDirection
 import app.skerry.ui.sync.nowMillis
 
-/** Where a queue entry stands: still moving bytes, finished, or stopped by a failure. */
+/** Where a queue entry stands: waiting its turn, moving bytes, finished, or stopped by a failure. */
 sealed interface TransferStatus {
+    /** Requested while the channel was busy; starts when the operation ahead of it ends. */
+    data object Waiting : TransferStatus
     data object Active : TransferStatus
     data object Done : TransferStatus
     data class Failed(val failure: FileTransferFailure) : TransferStatus
 }
+
+/** Whether the operation is over — its row is history, and the user's to clear. */
+val TransferStatus.isFinished: Boolean
+    get() = this == TransferStatus.Done || this is TransferStatus.Failed
 
 /**
  * One line of the transfer queue: a single operation (F5/F6, a picked upload, a download to a
@@ -39,14 +45,15 @@ data class TransferEntry(
 const val MAX_COMPLETED_TRANSFERS = 3
 
 /**
- * What the transfer strip lists: the running operation plus the last few finished ones. One entry
- * per operation, opened by the operation itself (it knows the direction) and closed once, by
- * whoever runs it — [TransferCoordinator.launchExclusive] does that for every exit path, so no
- * operation can leave an entry open.
+ * What the transfer strip lists: what is waiting, what is running, and the last few finished ones.
+ * One entry per operation, opened when the operation is requested ([enqueue]) and closed once, by
+ * whoever runs it — [TransferRunner] does that for every exit path, so no operation can leave an
+ * entry open.
  *
- * Transfers are serialized by the coordinator, so at most one entry is [TransferStatus.Active] and
- * it is always the newest; every lookup here relies on that. [now] is the wall clock behind the
- * entries' elapsed time (hence the speed), injected so tests can pin it.
+ * [TransferRunner] runs operations one at a time, so at most one entry is [TransferStatus.Active];
+ * every lookup here relies on that. Waiting entries sit *after* it — they were requested later —
+ * which is why the running one is looked up rather than read off the end. [now] is the wall clock
+ * behind the entries' elapsed time (hence the speed), injected so tests can pin it.
  */
 @Stable
 class TransferQueue(private val now: () -> Long = ::nowMillis) {
@@ -64,17 +71,22 @@ class TransferQueue(private val now: () -> Long = ::nowMillis) {
      */
     val latest: TransferState
         get() {
-            val last = entries.lastOrNull() ?: return TransferState.Idle
-            return when (val status = last.status) {
-                TransferStatus.Active ->
-                    TransferState.Active(last.name, last.direction, last.fileIndex, last.fileCount, last.transferred, last.total)
-                TransferStatus.Done -> TransferState.Idle
-                is TransferStatus.Failed -> TransferState.Failed(last.name, status.failure)
+            entries.lastOrNull { it.status == TransferStatus.Active }?.let {
+                return TransferState.Active(it.name, it.direction, it.fileIndex, it.fileCount, it.transferred, it.total)
             }
+            // Nothing is moving: what is left to report is how the last operation ended. That can
+            // be one that never ran — an entry abandoned by [abandon] outlives the transfer it was
+            // queued behind, and its verdict is the newer one.
+            val last = entries.lastOrNull { it.status.isFinished } ?: return TransferState.Idle
+            val failed = last.status as? TransferStatus.Failed ?: return TransferState.Idle
+            return TransferState.Failed(last.id, last.name, failed.failure)
         }
 
-    /** Whether the newest entry is still running — the caller's cue that it is theirs to close. */
-    val hasOpenEntry: Boolean get() = entries.lastOrNull()?.status == TransferStatus.Active
+    /** Whether an entry is still running — the caller's cue that it is theirs to close. */
+    val hasOpenEntry: Boolean get() = entries.any { it.status == TransferStatus.Active }
+
+    /** Whether any operation is running or still waiting for its turn on the channel. */
+    val hasWork: Boolean get() = entries.any { !it.status.isFinished }
 
     private var nextEntryId = 1L
 
@@ -82,22 +94,50 @@ class TransferQueue(private val now: () -> Long = ::nowMillis) {
     private var startedAt = 0L
     private var bytesDone = 0L
 
-    /** Opens the entry of an operation about to start. */
-    fun begin(direction: TransferDirection) {
-        startedAt = now()
-        bytesDone = 0
+    /**
+     * Opens the entry of a requested operation and returns its id. The entry starts [Waiting]:
+     * every operation goes through the queue, whether or not it has to wait there. [name] is what
+     * the operation is about — the picked file, or the first of a selection — so a waiting row is
+     * not a blank line; [step] replaces it with the file actually moving once the transfer starts.
+     */
+    fun enqueue(direction: TransferDirection, name: String): Long {
+        val id = nextEntryId++
         entries += TransferEntry(
-            id = nextEntryId++,
+            id = id,
             direction = direction,
-            name = "",
+            name = name,
             fileIndex = 0,
             fileCount = 0,
             transferred = 0,
             total = 0,
             bytesDone = 0,
             elapsedMillis = 0,
-            status = TransferStatus.Active,
+            status = TransferStatus.Waiting,
         )
+        return id
+    }
+
+    /**
+     * Starts the entry [id]: from here its bytes and its elapsed time count, so a spell in the
+     * queue never shows up as a slow transfer.
+     */
+    fun activate(id: Long) {
+        startedAt = now()
+        bytesDone = 0
+        val index = entries.indexOfFirst { it.id == id }
+        if (index >= 0) entries[index] = entries[index].copy(status = TransferStatus.Active)
+    }
+
+    /**
+     * Closes a waiting entry as failed, for [failure] — the channel went away before its turn came,
+     * or the operation was refused before it could take one. Dropping the row instead would be the
+     * silent no-op the queue exists to avoid.
+     */
+    fun abandon(id: Long, failure: FileTransferFailure) {
+        val index = entries.indexOfFirst { it.id == id && it.status == TransferStatus.Waiting }
+        if (index < 0) return
+        entries[index] = entries[index].copy(status = TransferStatus.Failed(failure))
+        trim()
     }
 
     /** Progress of the file the running operation is on ([index] of [count] in the operation). */
@@ -133,20 +173,22 @@ class TransferQueue(private val now: () -> Long = ::nowMillis) {
     /** Closes the running entry (if one is still open) and trims the finished ones. */
     fun end(status: TransferStatus, name: String? = null) {
         updateActive { it.copy(status = status, name = name ?: it.name, elapsedMillis = now() - startedAt) }
-        // Oldest finished entries go first; the running one is never touched.
-        while (entries.count { it.status != TransferStatus.Active } > MAX_COMPLETED_TRANSFERS) {
-            entries.removeAt(entries.indexOfFirst { it.status != TransferStatus.Active })
+        trim()
+    }
+
+    /** Oldest finished entries go first; what is running or still waiting is never touched. */
+    private fun trim() {
+        while (entries.count { it.status.isFinished } > MAX_COMPLETED_TRANSFERS) {
+            entries.removeAt(entries.indexOfFirst { it.status.isFinished })
         }
     }
 
-    /** Drops one finished entry ([id]); a transfer still running is left alone. */
+    /**
+     * Drops entry [id]; a transfer still running is left alone. A waiting one goes — that is how
+     * the user cancels it, and [TransferRunner.cancelWaiting] releases what it was holding.
+     */
     fun dismiss(id: Long) {
         entries.removeAll { it.id == id && it.status != TransferStatus.Active }
-    }
-
-    /** Drops every finished entry at once, leaving only what is still running. */
-    fun dismissCompleted() {
-        entries.removeAll { it.status != TransferStatus.Active }
     }
 
     private fun updateActive(edit: (TransferEntry) -> TransferEntry) {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferRunner.kt
@@ -1,0 +1,132 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.ui.sftp.TransferDirection
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
+
+/** One operation the channel has no room for yet: its queue entry, its work, its cleanup. */
+private class PendingTransfer(
+    val id: Long,
+    val onFinally: suspend () -> Unit,
+    val block: suspend () -> Unit,
+)
+
+/**
+ * Runs transfer operations one at a time over the session's single SFTP channel, in the order they
+ * were requested: one submitted while another is running waits its turn and starts when the channel
+ * frees up.
+ *
+ * Waiting rather than dropping is the whole point (issue #317). Both mobile entry points hand over a
+ * handle the user has already committed to — the SAF document "Save to…" created at the location
+ * they chose, the full copy of a picked upload sitting in the app's cache — so an operation dropped
+ * on the floor leaves an empty file where the user asked for their data, and a copy nothing ever
+ * deletes.
+ *
+ * Every operation gets its [TransferQueue] entry when it is submitted, so a waiting one is visible
+ * and can be taken back ([cancelWaiting]). [onFinally] runs exactly once per operation — after the
+ * block on every exit path, or on its own if the operation never gets to run — and under
+ * [NonCancellable], because releasing the picker's handle is what it is for and a dying scope is
+ * when that matters most.
+ *
+ * Not thread-safe by design: operations are submitted from UI handlers and the coordinator's scope
+ * is confined to the same thread, like [FilePaneController].
+ */
+internal class TransferRunner(private val scope: CoroutineScope, private val queue: TransferQueue) {
+
+    private val pending = ArrayDeque<PendingTransfer>()
+    private var running = false
+
+    /**
+     * Submits an operation. [direction] and [name] fill in its queue row before it starts — [name]
+     * is what the operation is about, replaced by the file actually moving once it does.
+     */
+    fun submit(
+        direction: TransferDirection,
+        name: String,
+        onFinally: suspend () -> Unit = {},
+        block: suspend () -> Unit,
+    ) {
+        val id = queue.enqueue(direction, name)
+        pending += PendingTransfer(id, onFinally, block)
+        if (!running) startNext()
+    }
+
+    /**
+     * Takes the waiting operation with entry [id] back off the queue and releases its handle. No-op
+     * if [id] is not waiting — already running (not the user's to cancel), or already finished.
+     * Leaves the row to the caller: this is the user dropping it, and dropping means it goes.
+     */
+    fun cancelWaiting(id: Long) {
+        val op = pending.firstOrNull { it.id == id } ?: return
+        pending.remove(op)
+        release(op.onFinally)
+    }
+
+    /**
+     * Releases every operation still waiting — the channel is going away, so their turn will never
+     * come. The rows are closed as failed rather than dropped: the user asked for them.
+     */
+    fun releaseWaiting() {
+        while (pending.isNotEmpty()) {
+            val op = pending.removeFirst()
+            queue.abandon(op.id, FileTransferFailure.SessionClosed)
+            release(op.onFinally)
+        }
+    }
+
+    /** Releases a handle no transfer will ever consume (a refused overwrite, say). */
+    fun release(handle: suspend () -> Unit) {
+        scope.launch(NonCancellable) { runCatching { handle() } }
+    }
+
+    /**
+     * Starts the next operation, or goes idle when there is none. Any error closes its entry as
+     * [TransferStatus.Failed] (named after the step it stopped on); [CancellationException]
+     * propagates. A scope that has already died runs nothing: what is left is released instead, or
+     * the handles would sit in a queue that never advances again.
+     *
+     * [CoroutineStart.ATOMIC] closes the gap between that check and the dispatch: a scope cancelled
+     * in between would otherwise skip the body altogether, and with it the `finally` that releases
+     * the operation's handle — the leak this class exists to prevent, one dispatch later.
+     */
+    private fun startNext() {
+        if (!scope.isActive) {
+            releaseWaiting()
+            running = false
+            return
+        }
+        val op = pending.removeFirstOrNull()
+        if (op == null) {
+            running = false
+            return
+        }
+        running = true
+        queue.activate(op.id)
+        scope.launch(start = CoroutineStart.ATOMIC) {
+            try {
+                op.block()
+                // A block can finish normally having already closed its own entry as failed
+                // (a move whose transfer went through but whose source delete didn't) — that
+                // verdict wins, so the entry is only marked done while it is still open.
+                if (queue.hasOpenEntry) queue.end(TransferStatus.Done)
+            } catch (e: CancellationException) {
+                // A cancelled operation is over too: leaving the entry Active would show a
+                // progress bar that never moves again.
+                queue.end(TransferStatus.Failed(FileTransferFailure.Transfer))
+                throw e
+            } catch (e: Exception) {
+                val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
+                queue.end(TransferStatus.Failed(failure))
+            } finally {
+                withContext(NonCancellable) { runCatching { op.onFinally() } }
+                startNext()
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferState.kt
@@ -1,0 +1,78 @@
+package app.skerry.ui.files
+
+import app.skerry.shared.files.FileBrowserException
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.ui.sftp.TransferDirection
+
+/**
+ * Typed, user-facing reason for a failed transfer; the UI maps it to a localized string. Raw
+ * exception text is never shown — a [FileBrowserException] contributes only its
+ * [FileBrowserFailure], anything else lands on [Transfer].
+ */
+enum class FileTransferFailure {
+    /** The byte transfer itself failed (stream/SFTP/local I/O). */
+    Transfer,
+
+    /** Files reached the destination, but a source could not be removed after a move. */
+    DeleteSource,
+
+    /** A listing entry carried a name unsafe to use as a path component. */
+    IllegalName,
+
+    /** The picked upload source could not be opened. */
+    OpenSource,
+
+    /** The chosen download target could not be opened. */
+    OpenTarget,
+
+    /** The session closed while the operation was still waiting its turn on the channel. */
+    SessionClosed,
+}
+
+/** Maps a browser failure onto the transfer bar's reason; I/O-level causes collapse to [FileTransferFailure.Transfer]. */
+internal fun FileBrowserFailure.toTransferFailure(): FileTransferFailure = when (this) {
+    FileBrowserFailure.IllegalName -> FileTransferFailure.IllegalName
+    FileBrowserFailure.OpenSource -> FileTransferFailure.OpenSource
+    FileBrowserFailure.OpenTarget -> FileTransferFailure.OpenTarget
+    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp, FileBrowserFailure.TooLarge ->
+        FileTransferFailure.Transfer
+}
+
+/** Cross-pane batch transfer state, for the bottom transfer bar. */
+sealed interface TransferState {
+    /** No transfer in progress. */
+    data object Idle : TransferState
+
+    /**
+     * Transferring file [name] ([fileIndex] of [fileCount] in the batch), [transferred] of [total]
+     * bytes ([total] = 0 if unknown).
+     */
+    data class Active(
+        val name: String,
+        val direction: TransferDirection,
+        val fileIndex: Int,
+        val fileCount: Int,
+        val transferred: Long,
+        val total: Long,
+    ) : TransferState
+
+    /**
+     * Transfer of [name] failed; [failure] is the typed reason, localized by the UI. [name] is
+     * empty when the failure happened before any file became active — the UI substitutes a
+     * localized placeholder. [id] is the queue entry it came from, so a single-line view can clear
+     * that row rather than every finished one.
+     */
+    data class Failed(val id: Long, val name: String, val failure: FileTransferFailure) : TransferState
+}
+
+/**
+ * Overwrite conflict awaiting confirmation. [names] are entries in the destination directory that
+ * would be overwritten; [proceed] runs the deferred transfer once the user confirms, [cancel] runs
+ * instead when the user refuses — "no" is an answer too, and whatever [proceed] would have consumed
+ * (a picked upload's staged copy) is nobody else's to release.
+ */
+class OverwriteConflict(
+    val names: List<String>,
+    val proceed: () -> Unit,
+    val cancel: () -> Unit = {},
+)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -35,17 +36,19 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.files.FilePaneController
 import app.skerry.ui.files.FilePaneState
+import app.skerry.ui.files.TransferEntry
 import app.skerry.ui.files.TransferState
+import app.skerry.ui.files.TransferStatus
 import app.skerry.ui.files.fileBrowserFailureText
 import app.skerry.ui.files.fileDisplayName
+import app.skerry.ui.files.transferDisplayName
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.ftail_local_label
-import app.skerry.ui.generated.resources.shell_tip_close
-import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_fkey_edit
 import app.skerry.ui.generated.resources.ftail_fkey_view
 import app.skerry.ui.generated.resources.sftp_delete
@@ -53,9 +56,13 @@ import app.skerry.ui.generated.resources.sftp_download_to_device
 import app.skerry.ui.generated.resources.sftp_error
 import app.skerry.ui.generated.resources.sftp_loading
 import app.skerry.ui.generated.resources.sftp_meta_joined
+import app.skerry.ui.generated.resources.sftp_queue_cancel
+import app.skerry.ui.generated.resources.sftp_queue_clear
+import app.skerry.ui.generated.resources.sftp_queue_waiting
 import app.skerry.ui.generated.resources.sftp_rename
 import app.skerry.ui.generated.resources.sftp_transfer_error
 import app.skerry.ui.sftp.TransferDirection
+import app.skerry.ui.sftp.transferQueueAnnouncement
 import app.skerry.ui.sftp.fileDateText
 import app.skerry.ui.sftp.permissionsText
 import app.skerry.ui.sftp.sizeText
@@ -268,20 +275,27 @@ private fun MobileFileUpRow(mono: FontFamily, onClick: () -> Unit) {
     }
 }
 
-/**
- * The file a transfer card names. Blank is not "unprintable": a transfer that failed before it
- * reported a file has no name yet, and says so with the neutral stand-in.
- */
-@Composable
-private fun transferName(raw: String): String =
-    if (raw.isBlank()) stringResource(Res.string.ftail_file_fallback) else fileDisplayName(raw)
 
 /**
  * Mobile layout's transfer card (below the list): direction icon + name + percent + bar.
  * Active shows live progress; Failed shows the error with a close button; Idle renders nothing.
+ *
+ * The card follows what is actually moving, and below it comes one row per operation still waiting
+ * for the channel — each cancellable, like the desktop queue strip. This screen has no strip to
+ * list them on, and a picked upload or "Save to…" that lands while a transfer is running has to
+ * show *something*: the picker committed the user's file before the app ever saw it (issue #317).
+ *
+ * [onDrop] takes one row off the queue by its id — clearing a failed card, cancelling a waiting
+ * operation and releasing what it held. One callback because it is one action: the row goes.
  */
 @Composable
-internal fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDismiss: () -> Unit) {
+internal fun MobileTransferCard(
+    transfer: TransferState,
+    queue: List<TransferEntry>,
+    mono: FontFamily,
+    onDrop: (Long) -> Unit,
+) {
+    StatusAnnouncer(transferQueueAnnouncement(queue))
     when (transfer) {
         TransferState.Idle -> Unit
 
@@ -303,7 +317,7 @@ internal fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDis
                     horizontalArrangement = Arrangement.spacedBy(9.dp),
                 ) {
                     Sym(if (up) "upload" else "download", size = 17.sp, color = Skerry.colors.cyan)
-                    Txt(transferName(transfer.name), color = Skerry.colors.textBright, size = 12.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+                    Txt(transferDisplayName(transfer.name), color = Skerry.colors.textBright, size = 12.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
                     Txt("$percent%", color = Skerry.colors.dim, size = 11.sp)
                 }
                 Spacer(Modifier.height(8.dp))
@@ -329,13 +343,66 @@ internal fun MobileTransferCard(transfer: TransferState, mono: FontFamily, onDis
                 Txt(
                     stringResource(
                         Res.string.sftp_transfer_error,
-                        transferName(transfer.name),
+                        transferDisplayName(transfer.name),
                         transferFailureText(transfer.failure),
                     ),
                     color = Skerry.colors.sunset, size = 11.5.sp, maxLines = 6, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
-                IconBtn("close", label = stringResource(Res.string.shell_tip_close), onClick = onDismiss, box = 26, icon = 16.sp)
+                IconBtn(
+                    "close",
+                    label = stringResource(Res.string.sftp_queue_clear, transferDisplayName(transfer.name)),
+                    // The row the card is showing, not every finished one: the label names one file.
+                    onClick = { onDrop(transfer.id) },
+                    box = 26,
+                    icon = 16.sp,
+                )
             }
         }
+    }
+    val waiting = queue.filter { it.status == TransferStatus.Waiting }
+    if (waiting.isEmpty()) return
+    Column(
+        // No top padding: the card above ends with its own, and with no card there is nothing to
+        // separate from either. Bounded and scrollable, because the screen below it does not
+        // scroll: a long backlog would push its own tail — and the FAB — off the display.
+        Modifier
+            .padding(start = 22.dp, end = 22.dp, bottom = 14.dp)
+            .fillMaxWidth()
+            .heightIn(max = WAITING_ROWS_MAX_HEIGHT)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        waiting.forEach { entry -> key(entry.id) { MobileWaitingRow(entry, mono, onDrop) } }
+    }
+}
+
+/** About three waiting rows: enough to see the backlog, little enough to leave the list its screen. */
+private val WAITING_ROWS_MAX_HEIGHT = 132.dp
+
+/**
+ * One operation still queued behind the running transfer: dimmed, named, and cancellable. Taking it
+ * back is what releases the handle the picker already committed — the SAF document at the chosen
+ * location, or the staged copy of the picked upload.
+ */
+@Composable
+private fun MobileWaitingRow(entry: TransferEntry, mono: FontFamily, onCancel: (Long) -> Unit) {
+    val up = entry.direction == TransferDirection.Upload
+    val name = transferDisplayName(entry.name)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Skerry.colors.surface2)
+            .border(1.dp, Skerry.colors.overlayStrong, RoundedCornerShape(12.dp))
+            .padding(start = 14.dp, end = 6.dp, top = 8.dp, bottom = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(9.dp),
+    ) {
+        Sym(if (up) "upload" else "download", size = 17.sp, color = Skerry.colors.dim)
+        Txt(name, color = Skerry.colors.dim, size = 12.5.sp, font = mono, maxLines = 1, overflow = TextOverflow.Ellipsis, modifier = Modifier.weight(1f))
+        Txt(stringResource(Res.string.sftp_queue_waiting), color = Skerry.colors.dim, size = 11.sp)
+        // Named after its row: several operations wait at once, and identical controls cannot be
+        // told apart by a screen reader navigating controls rather than reading in order.
+        IconBtn("close", label = stringResource(Res.string.sftp_queue_cancel, name), onClick = { onCancel(entry.id) }, box = 26, icon = 16.sp)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesView.kt
@@ -183,7 +183,7 @@ private fun LiveMobileFilesView(controller: ConnectionController, subtitle: Stri
                         onOpenEditor = openEditor,
                         modifier = Modifier.weight(1f),
                     )
-                    MobileTransferCard(c.transfer, mono, onDismiss = c::dismissCompleted)
+                    MobileTransferCard(c.transfer, c.queue, mono, onDrop = c::dismissTransfer)
                     Spacer(Modifier.height(88.dp)) // room for the floating FAB (push screen has no tab bar)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/TransferQueueStrip.kt
@@ -1,11 +1,14 @@
 package app.skerry.ui.sftp
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -21,39 +24,59 @@ import androidx.compose.ui.unit.sp
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.MeterBar
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.files.TransferEntry
 import app.skerry.ui.files.TransferStatus
-import app.skerry.ui.files.fileDisplayName
+import app.skerry.ui.files.isFinished
+import app.skerry.ui.files.transferDisplayName
 import app.skerry.ui.files.transferFailureText
 import app.skerry.ui.forward.humanRate
 import app.skerry.ui.generated.resources.Res
-import app.skerry.ui.generated.resources.shell_tip_close
-import app.skerry.ui.generated.resources.ftail_file_fallback
 import app.skerry.ui.generated.resources.ftail_transfer_counter
 import app.skerry.ui.generated.resources.sftp_meta_joined
+import app.skerry.ui.generated.resources.sftp_queue_backlog
+import app.skerry.ui.generated.resources.sftp_queue_cancel
+import app.skerry.ui.generated.resources.sftp_queue_clear
 import app.skerry.ui.generated.resources.sftp_queue_done
 import app.skerry.ui.generated.resources.sftp_queue_progress
+import app.skerry.ui.generated.resources.sftp_queue_state
+import app.skerry.ui.generated.resources.sftp_queue_waiting
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
 
 /**
- * Transfer queue under the panes: one row per operation — what is moving now, and the last few
- * that finished, so the outcome of a transfer is still readable after it ends. Empty queue, no
- * strip. [onDismiss] drops a finished row by its id.
+ * Transfer queue under the panes: one row per operation — what is waiting for the channel, what is
+ * moving now, and the last few that finished, so the outcome of a transfer is still readable after
+ * it ends. Empty queue, no strip. [onDismiss] drops a row by its id: a finished one is cleared, a
+ * waiting one is cancelled.
  */
 @Composable
 internal fun TransferQueueStrip(queue: List<TransferEntry>, mono: FontFamily, onDismiss: (Long) -> Unit) {
+    // Above the early return, so the region survives the strip appearing and disappearing.
+    StatusAnnouncer(transferQueueAnnouncement(queue))
     if (queue.isEmpty()) return
     HLine()
     Column(
-        Modifier.fillMaxWidth().background(Skerry.colors.surface).padding(horizontal = 12.dp, vertical = 6.dp),
+        // Bounded and scrollable: the queue is as long as the user makes it (holding F5 keeps
+        // submitting), and the strip is measured before the weighted panes above it — an unbounded
+        // one would squeeze them and push the cancel buttons, the only way to hand a queued handle
+        // back, off the window.
+        Modifier
+            .fillMaxWidth()
+            .background(Skerry.colors.surface)
+            .heightIn(max = QUEUE_MAX_HEIGHT)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         queue.forEach { entry -> key(entry.id) { TransferQueueRow(entry, mono, onDismiss) } }
     }
 }
+
+/** About five rows: the whole finished history plus a running transfer and some of its backlog. */
+private val QUEUE_MAX_HEIGHT = 116.dp
 
 /** Name column of a queue row — wide enough for a release archive, fixed so the bars line up. */
 private val QUEUE_NAME_WIDTH = 180.dp
@@ -66,6 +89,7 @@ private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: 
     val done = entry.status == TransferStatus.Done
     val failed = entry.status as? TransferStatus.Failed
     val active = entry.status == TransferStatus.Active
+    val waiting = entry.status == TransferStatus.Waiting
     Row(
         Modifier.fillMaxWidth().padding(vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -78,11 +102,13 @@ private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: 
             color = when {
                 failed != null -> Skerry.colors.sunset
                 done -> Skerry.colors.moss
+                // Dimmed until it is this row's turn: the strip is read at a glance, and only one
+                // row can be moving bytes.
+                waiting -> Skerry.colors.dim
                 else -> Skerry.colors.teal
             },
         )
-        // Blank is not "unprintable": a transfer that failed before it named a file has no name yet.
-        val name = if (entry.name.isBlank()) stringResource(Res.string.ftail_file_fallback) else fileDisplayName(entry.name)
+        val name = transferDisplayName(entry.name)
         val title = if (entry.fileCount > 1) {
             stringResource(Res.string.ftail_transfer_counter, name, entry.fileIndex, entry.fileCount)
         } else {
@@ -123,16 +149,29 @@ private fun TransferQueueRow(entry: TransferEntry, mono: FontFamily, onDismiss: 
             // the dismiss button out of the row either.
             modifier = Modifier.widthIn(max = QUEUE_TAIL_MAX_WIDTH),
         )
-        // A finished row is the user's to clear; a running one has nothing to dismiss yet.
-        if (active) Box(Modifier.size(22.dp)) else IconBtn("close", label = stringResource(Res.string.shell_tip_close), onClick = { onDismiss(entry.id) }, box = 22, icon = 14.sp)
+        // A finished row is the user's to clear and a waiting one theirs to cancel; a running one
+        // has nothing to dismiss yet. The two say different things out loud: cancelling drops work
+        // the user asked for, clearing drops a line of history.
+        if (active) {
+            Box(Modifier.size(22.dp))
+        } else {
+            // Named after the row it belongs to: the queue routinely holds several rows of the same
+            // status, and a list of identical "Cancel" controls is not navigable without sight.
+            val label = stringResource(if (waiting) Res.string.sftp_queue_cancel else Res.string.sftp_queue_clear, name)
+            IconBtn("close", label = label, onClick = { onDismiss(entry.id) }, box = 22, icon = 14.sp)
+        }
     }
 }
 
-/** Right-hand text of a queue row: the failure, "done", or percent · bytes · speed while running. */
+/**
+ * Right-hand text of a queue row: the failure, "done", "waiting", or percent · bytes · speed while
+ * running.
+ */
 @Composable
 private fun transferTailText(entry: TransferEntry): String {
     (entry.status as? TransferStatus.Failed)?.let { return transferFailureText(it.failure) }
     if (entry.status == TransferStatus.Done) return stringResource(Res.string.sftp_queue_done)
+    if (entry.status == TransferStatus.Waiting) return stringResource(Res.string.sftp_queue_waiting)
     // Throughput goes through the app's one rate formatter (the tunnel table, the host monitor and
     // the mobile terminal header all read it), so the same speed never gets two spellings.
     val speedText = transferSpeed(entry.bytesDone, entry.elapsedMillis)?.let { humanRate(it) }
@@ -146,3 +185,31 @@ private fun transferTailText(entry: TransferEntry): String {
     }
     return if (speedText != null) stringResource(Res.string.sftp_meta_joined, progress, speedText) else progress
 }
+
+/**
+ * What the queue is doing, for a screen reader: how the last operation ended, and how much is still
+ * waiting for the channel. Both are otherwise silent — a picked upload that has to queue draws a row
+ * and says nothing, and an operation abandoned when the session closed only stops being mentioned.
+ *
+ * It is the state, not its telemetry: progress and speed are deliberately left out, or every
+ * callback would talk over the user.
+ */
+@Composable
+internal fun transferQueueAnnouncement(queue: List<TransferEntry>): String {
+    val last = queue.lastOrNull { it.status.isFinished }
+    // Success is announced too, not only failure: on the desktop a finished row stays on the strip,
+    // so a transfer that went through is a visible outcome, and one that is only visible is the gap
+    // a live region exists to close.
+    val outcome = last?.let { stringResource(Res.string.sftp_queue_state, transferDisplayName(it.name), outcomeText(it.status)) }
+    val count = queue.count { it.status == TransferStatus.Waiting }
+    val backlog = if (count > 0) stringResource(Res.string.sftp_queue_backlog, count) else ""
+    // Both clauses, always: an operation that failed while others were still queued would otherwise
+    // never be spoken at all. The cost is that advancing the queue restates the last outcome — and
+    // every one of those restatements does follow a real change of state.
+    return listOfNotNull(outcome, backlog).filter { it.isNotEmpty() }.joinToString(". ")
+}
+
+/** How a finished entry ended, in one word or one sentence. */
+@Composable
+private fun outcomeText(status: TransferStatus): String =
+    (status as? TransferStatus.Failed)?.let { transferFailureText(it.failure) } ?: stringResource(Res.string.sftp_queue_done)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -4,6 +4,7 @@ package app.skerry.ui.connection
 
 import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntry
 import app.skerry.shared.mosh.MoshSetupException
@@ -22,6 +23,10 @@ import app.skerry.shared.ssh.SshAuthenticationException
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshHostKeyRejectedException
 import app.skerry.shared.ssh.SshTarget
+import app.skerry.ui.files.FakeUploadSource
+import app.skerry.ui.files.entry
+import app.skerry.ui.files.localFake
+import app.skerry.ui.files.remoteFake
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -526,6 +531,38 @@ class ConnectionControllerTest {
         scope.cancel()
     }
 
+    @Test
+    fun `disconnecting releases a transfer that was still waiting for the channel`() = runTest {
+        // The session teardown is the last thing that can hand a picked file back to the platform:
+        // whatever is still queued when the channel closes never gets a turn (issue #317).
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val connection = FakeSshConnection(FakeShellChannel(), sftp = remote)
+        val (controller, scope) = controllerWith(FakeSshTransport(connection))
+        controller.connect(testTarget, SshAuth.Password("pw"))
+        advanceUntilIdle()
+
+        val coordinator = controller.openTransferCoordinator(SftpFileBrowser(localFake(), "This Mac"), "prod-web-01")
+        advanceUntilIdle()
+        coordinator.local.toggle(coordinator.local.entry("a.txt"))
+        coordinator.uploadSelection()
+        advanceUntilIdle() // held inside the first transfer
+
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+        coordinator.uploadSource(source)
+        advanceUntilIdle()
+        assertEquals(0, source.cleanups)
+
+        controller.disconnect()
+        advanceUntilIdle()
+
+        assertEquals(1, source.cleanups, "the staged copy must not outlive the session that dropped it")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        scope.cancel()
+    }
 }
 
 /** SFTP client stub: only object identity and the closed flag matter. */

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferBacklogTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferBacklogTest.kt
@@ -1,0 +1,315 @@
+package app.skerry.ui.files
+
+import app.skerry.ui.sftp.TransferDirection
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * What happens to an operation the channel has no room for yet (issue #317). Both mobile entry
+ * points hand the coordinator a handle the user has already committed to — the SAF document
+ * "Save to…" created at the chosen location, the full copy of a picked upload sitting in the app's
+ * cache — so an operation dropped on the floor leaves an empty file where the user asked for their
+ * data, and a copy nothing ever deletes. It waits its turn instead.
+ */
+class TransferBacklogTest {
+
+    @Test
+    fun `a download to a picked target requested while a transfer runs waits its turn`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle() // held inside the first transfer
+
+        val target = FakeDownloadTarget("r.txt", "/staging/r.txt")
+        r.coordinator.downloadToTarget(r.remote.entry("r.txt"), target)
+        advanceUntilIdle()
+
+        assertFalse(target.finalized, "the channel is busy — nothing should have been written yet")
+        assertFalse(target.discarded, "a waiting target is not a failed one")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertTrue(target.finalized, "the picked target must be written once the channel frees up")
+        assertFalse(target.discarded, "a document that was written is not one to remove")
+        assertEquals("$RHOME/r.txt" to "/staging/r.txt", r.remoteFake.lastDownload)
+    }
+
+    @Test
+    fun `a picked upload requested while a transfer runs waits its turn`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle() // held inside the first transfer
+
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        assertEquals(0, source.cleanups, "the staged copy is still the transfer's to read")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("/tmp/picked.txt" to "$RHOME/picked.txt", r.remoteFake.lastUpload)
+        assertEquals(1, source.cleanups)
+    }
+
+    @Test
+    fun `refusing the overwrite of a picked upload releases its staged copy`() = runTest {
+        val remote = remoteFake().apply { seedFile("$RHOME/picked.txt", size = 4) }
+        val r = rig(remote = remote)
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+
+        r.coordinator.uploadSource(source)
+        assertNotNull(r.coordinator.overwrite, "expected an Overwrite dialog")
+
+        r.coordinator.resolveOverwrite(false)
+        advanceUntilIdle()
+
+        assertNull(r.remoteFake.lastUpload, "the user said no")
+        assertEquals(1, source.cleanups, "a refused upload still has a staged copy to release")
+    }
+
+    @Test
+    fun `a waiting operation is a row of its own, behind the running one`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        r.coordinator.uploadSource(FakeUploadSource("picked.txt", "/tmp/picked.txt"))
+        advanceUntilIdle()
+
+        assertEquals(TransferStatus.Active, r.coordinator.queue.first().status)
+        val waiting = r.coordinator.queue.last()
+        assertEquals(TransferStatus.Waiting, waiting.status)
+        assertEquals("picked.txt", waiting.name)
+        val active = assertIs<TransferState.Active>(r.coordinator.transfer)
+        assertEquals("a.txt", active.name, "the single-line view follows what is actually moving")
+        assertTrue(r.coordinator.writeInFlight, "work the session still owes is work in flight")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `dismissing a waiting operation releases the handle it was holding`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val target = FakeDownloadTarget("r.txt", "/staging/r.txt")
+        r.coordinator.downloadToTarget(r.remote.entry("r.txt"), target)
+        advanceUntilIdle()
+
+        r.coordinator.dismissTransfer(r.coordinator.queue.last().id)
+        advanceUntilIdle()
+
+        assertTrue(target.discarded, "the document the picker created is the coordinator's to remove")
+        assertEquals(1, r.coordinator.queue.size, "the cancelled row goes with it")
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+        assertNull(r.remoteFake.lastDownload, "a cancelled download must not run later")
+    }
+
+    @Test
+    fun `queued operations are released when the session closes the channel`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        r.coordinator.releaseQueued()
+        advanceUntilIdle()
+
+        assertEquals(1, source.cleanups, "the staged copy outlives nothing")
+        val abandoned = r.coordinator.queue.last()
+        val status = assertIs<TransferStatus.Failed>(abandoned.status, "the row says the upload never happened")
+        assertEquals(FileTransferFailure.SessionClosed, status.failure)
+        assertEquals("picked.txt", abandoned.name)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a second overwrite question waits for the first to be answered`() = runTest {
+        // The native picker draws over the dialog, so a second picked upload can arrive while the
+        // first is still being asked about. Replacing the pending conflict would strand its copy.
+        val remote = remoteFake().apply {
+            seedFile("$RHOME/one.txt", size = 4)
+            seedFile("$RHOME/two.txt", size = 4)
+        }
+        val r = rig(remote = remote)
+        val first = FakeUploadSource("one.txt", "/tmp/one.txt")
+        val second = FakeUploadSource("two.txt", "/tmp/two.txt")
+
+        r.coordinator.uploadSource(first)
+        r.coordinator.uploadSource(second)
+
+        assertEquals(listOf("one.txt"), r.coordinator.overwrite?.names)
+
+        r.coordinator.resolveOverwrite(false)
+        assertEquals(listOf("two.txt"), r.coordinator.overwrite?.names, "the second question takes its place")
+
+        r.coordinator.resolveOverwrite(true)
+        advanceUntilIdle()
+
+        assertEquals(1, first.cleanups)
+        assertEquals(1, second.cleanups)
+        assertEquals("/tmp/two.txt" to "$RHOME/two.txt", r.remoteFake.lastUpload)
+    }
+
+    @Test
+    fun `operations run in the order they were asked for`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val second = FakeUploadSource("second.txt", "/tmp/second.txt")
+        val third = FakeUploadSource("third.txt", "/tmp/third.txt")
+        r.coordinator.uploadSource(second)
+        r.coordinator.uploadSource(third)
+        advanceUntilIdle()
+
+        assertEquals(listOf("a.txt", "second.txt", "third.txt"), r.coordinator.queue.map { it.name })
+
+        // The user takes the middle one back; the one behind it keeps its place.
+        r.coordinator.dismissTransfer(r.coordinator.queue[1].id)
+        advanceUntilIdle()
+        assertEquals(1, second.cleanups)
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals("/tmp/third.txt" to "$RHOME/third.txt", r.remoteFake.lastUpload)
+        assertEquals(1, third.cleanups)
+    }
+
+    @Test
+    fun `a waiting operation is released when the scope that would have run it dies`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        // Not releaseQueued(): the scope simply dies, which is what a cancelled session does to the
+        // transfer that was running. Whatever was behind it must still be handed back.
+        r.scope.cancel()
+        advanceUntilIdle()
+
+        assertEquals(1, source.cleanups, "the staged copy is the app's to release, cancelled or not")
+        // Handing the copy back is not enough on its own: a dead scope still dispatches the next
+        // operation, and the fake records the upload before it ever suspends. So the queued work
+        // must not have been started at all.
+        assertEquals("$LHOME/a.txt" to "$RHOME/a.txt", r.remoteFake.lastUpload, "nothing may go out on a dead channel")
+        val abandoned = r.coordinator.queue.last()
+        val status = assertIs<TransferStatus.Failed>(abandoned.status)
+        assertEquals(FileTransferFailure.SessionClosed, status.failure)
+        assertEquals("picked.txt", abandoned.name)
+    }
+
+    @Test
+    fun `an unanswered overwrite question releases its source when the session closes`() = runTest {
+        val remote = remoteFake().apply { seedFile("$RHOME/picked.txt", size = 4) }
+        val r = rig(remote = remote)
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
+
+        r.coordinator.uploadSource(source)
+        assertNotNull(r.coordinator.overwrite)
+
+        r.coordinator.releaseQueued()
+        advanceUntilIdle()
+
+        assertNull(r.coordinator.overwrite, "the question goes with the channel it was about")
+        assertEquals(1, source.cleanups, "an upload nobody will ever answer for still holds a copy")
+    }
+
+    @Test
+    fun `what a queued operation is going to write counts as already there`() = runTest {
+        val remote = remoteFake().apply { uploadSize = 10 }
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
+        val r = rig(remote = remote)
+        r.local.toggle(r.local.entry("a.txt"))
+        r.coordinator.uploadSelection()
+        advanceUntilIdle()
+
+        // Queued, not yet written: the remote listing knows nothing about it.
+        r.coordinator.uploadSource(FakeUploadSource("picked.txt", "/tmp/picked.txt"))
+        advanceUntilIdle()
+        assertNull(r.coordinator.overwrite)
+
+        r.coordinator.uploadSource(FakeUploadSource("picked.txt", "/tmp/other.txt"))
+
+        assertEquals(
+            listOf("picked.txt"),
+            r.coordinator.overwrite?.names,
+            "two queued uploads of the same name would overwrite each other with nothing asked",
+        )
+
+        r.coordinator.resolveOverwrite(false)
+        gate.complete(Unit)
+        advanceUntilIdle()
+    }
+
+    @Test
+    fun `a picked upload the provider named unsafely is refused out loud`() = runTest {
+        val r = rig()
+        // Android hands over an OpenableColumns.DISPLAY_NAME from an app we do not control, and it
+        // becomes a path component on the host.
+        val source = FakeUploadSource("../escaped.txt", "/tmp/escaped.txt")
+
+        r.coordinator.uploadSource(source)
+        advanceUntilIdle()
+
+        assertNull(r.remoteFake.lastUpload, "nothing may be written outside the destination")
+        val row = r.coordinator.queue.single()
+        assertEquals(TransferDirection.Upload, row.direction)
+        val status = assertIs<TransferStatus.Failed>(row.status, "a refusal the user cannot see is the bug")
+        assertEquals(FileTransferFailure.IllegalName, status.failure)
+        assertEquals(1, source.cleanups)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -3,10 +3,8 @@ package app.skerry.ui.files
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.files.SftpFileBrowser
-import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.FakeSftpClient
 import app.skerry.ui.sftp.TransferDirection
-import app.skerry.ui.sftp.UploadSource
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -136,21 +134,6 @@ class TransferCoordinatorTest {
         assertTrue(r.remoteFake.downloads.none { it.first.endsWith("evil.txt") })
     }
 
-    /** Test target for "Save to..." downloads: records the staging path and finalize/discard. */
-    private class FakeDownloadTarget(
-        override val displayName: String,
-        override val stagingPath: String,
-        private val finalizeError: String? = null,
-    ) : DownloadTarget {
-        var finalized = false
-        var discarded = false
-        override suspend fun finalize() {
-            finalizeError?.let { throw RuntimeException(it) }
-            finalized = true
-        }
-        override suspend fun discard() { discarded = true }
-    }
-
     @Test
     fun `downloadToTarget streams a remote file into the picked target and finalizes it`() = runTest {
         val r = rig()
@@ -160,7 +143,10 @@ class TransferCoordinatorTest {
         advanceUntilIdle()
 
         assertEquals("$RHOME/r.txt" to "/staging/r.txt", r.remoteFake.lastDownload)
-        assertTrue(target.finalized)
+        assertEquals(1, target.finalizes)
+        // The document the picker created is now the user's file: removing it afterwards would
+        // hand them an empty one at the location they chose, which is issue #317 inverted.
+        assertEquals(0, target.discards)
         assertEquals(TransferState.Idle, r.coordinator.transfer)
     }
 
@@ -173,7 +159,7 @@ class TransferCoordinatorTest {
         advanceUntilIdle()
 
         assertIs<TransferState.Failed>(r.coordinator.transfer)
-        assertTrue(target.discarded)
+        assertEquals(1, target.discards, "exactly one release, whichever way the operation ended")
     }
 
     @Test
@@ -216,12 +202,7 @@ class TransferCoordinatorTest {
     @Test
     fun `uploadSource uploads a picked file into the remote directory and refreshes it`() = runTest {
         val r = rig()
-        val source = object : UploadSource {
-            override val name = "picked.txt"
-            override val stagingPath = "/tmp/picked.txt"
-            var cleaned = false
-            override suspend fun cleanup() { cleaned = true }
-        }
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
 
         r.coordinator.uploadSource(source)
         advanceUntilIdle()
@@ -229,7 +210,7 @@ class TransferCoordinatorTest {
         val remoteNames = (r.remote.state as FilePaneState.Loaded).entries.map { it.name }
         assertTrue("picked.txt" in remoteNames)
         assertEquals(TransferState.Idle, r.coordinator.transfer)
-        assertTrue(source.cleaned)
+        assertEquals(1, source.cleanups)
     }
 
     @Test
@@ -661,21 +642,29 @@ class TransferCoordinatorTest {
     }
 
     @Test
-    fun `a second transfer requested while one runs does not open a second entry`() = runTest {
+    fun `a second transfer requested while one runs waits on the queue and then goes through`() = runTest {
         val remote = remoteFake().apply { uploadSize = 10 }
-        remote.transferGate = CompletableDeferred()
+        val gate = CompletableDeferred<Unit>()
+        remote.transferGate = gate
         val r = rig(remote = remote)
         r.local.toggle(r.local.entry("a.txt"))
         r.coordinator.uploadSelection()
         advanceUntilIdle()
 
+        r.local.clearSelection()
         r.local.toggle(r.local.entry("b.txt"))
         r.coordinator.uploadSelection()
         advanceUntilIdle()
 
-        assertEquals(1, r.coordinator.queue.size)
-        remote.transferGate!!.complete(Unit)
+        assertEquals(2, r.coordinator.queue.size)
+        assertEquals(TransferStatus.Waiting, r.coordinator.queue.last().status)
+        assertEquals("b.txt", r.coordinator.queue.last().name, "a waiting row says what it is for")
+
+        gate.complete(Unit)
         advanceUntilIdle()
+
+        assertTrue(r.coordinator.queue.all { it.status == TransferStatus.Done })
+        assertEquals("$LHOME/b.txt" to "$RHOME/b.txt", r.remoteFake.lastUpload)
     }
 
     @Test
@@ -695,11 +684,7 @@ class TransferCoordinatorTest {
     @Test
     fun `a picked upload and a download to a target each get their own queue entry`() = runTest {
         val r = rig()
-        val source = object : UploadSource {
-            override val name = "picked.txt"
-            override val stagingPath = "/tmp/picked.txt"
-            override suspend fun cleanup() = Unit
-        }
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
 
         r.coordinator.uploadSource(source)
         advanceUntilIdle()
@@ -709,12 +694,7 @@ class TransferCoordinatorTest {
         assertEquals(TransferDirection.Upload, uploaded.direction)
         assertEquals(TransferStatus.Done, uploaded.status)
 
-        val target = object : DownloadTarget {
-            override val displayName = "r.txt"
-            override val stagingPath = "/tmp/r.txt"
-            override suspend fun finalize() = Unit
-            override suspend fun discard() = Unit
-        }
+        val target = FakeDownloadTarget("r.txt", "/tmp/r.txt")
         r.coordinator.downloadToTarget(r.remote.entry("r.txt"), target)
         advanceUntilIdle()
 
@@ -726,57 +706,12 @@ class TransferCoordinatorTest {
     }
 
     @Test
-    fun `dismissing the finished entries clears them all at once`() = runTest {
-        val r = rig()
-        r.local.toggle(r.local.entry("a.txt"))
-        r.coordinator.uploadSelection()
-        advanceUntilIdle()
-        r.local.toggle(r.local.entry("b.txt"))
-        r.coordinator.uploadSelection()
-        advanceUntilIdle()
-        assertEquals(2, r.coordinator.queue.size)
-
-        r.coordinator.dismissCompleted()
-
-        assertTrue(r.coordinator.queue.isEmpty())
-    }
-
-    @Test
-    fun `dismissing the finished entries leaves a running one alone`() = runTest {
-        val remote = remoteFake().apply { uploadSize = 10 }
-        val r = rig(remote = remote)
-        // One transfer all the way through, then a second held open: the bulk dismiss has to tell
-        // them apart, not simply clear or spare the whole list.
-        r.local.toggle(r.local.entry("a.txt"))
-        r.coordinator.uploadSelection()
-        advanceUntilIdle()
-        remote.transferGate = CompletableDeferred()
-        r.local.toggle(r.local.entry("b.txt"))
-        r.coordinator.uploadSelection()
-        advanceUntilIdle()
-        assertEquals(2, r.coordinator.queue.size)
-
-        r.coordinator.dismissCompleted()
-
-        val left = r.coordinator.queue.single()
-        assertEquals(TransferStatus.Active, left.status)
-        assertEquals("b.txt", left.name)
-        remote.transferGate!!.complete(Unit)
-        advanceUntilIdle()
-    }
-
-    @Test
     fun `a picked upload that fails still lands on the queue`() = runTest {
         // The fallback upload path (native picker, nothing selected in the local pane) had only
         // success coverage: its failure has to reach the queue like any other.
         val remote = remoteFake().apply { uploadError = "disk full" }
         val r = rig(remote = remote)
-        val source = object : UploadSource {
-            override val name = "picked.txt"
-            override val stagingPath = "/tmp/picked.txt"
-            var cleaned = false
-            override suspend fun cleanup() { cleaned = true }
-        }
+        val source = FakeUploadSource("picked.txt", "/tmp/picked.txt")
 
         r.coordinator.uploadSource(source)
         advanceUntilIdle()
@@ -785,7 +720,7 @@ class TransferCoordinatorTest {
         assertEquals(FileTransferFailure.Transfer, status.failure)
         // The staged copy the picker made is the coordinator's to delete on the way out — a failed
         // upload leaves it behind otherwise, and nothing else ever comes back for it.
-        assertTrue(source.cleaned)
+        assertEquals(1, source.cleanups)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferQueueTest.kt
@@ -17,12 +17,17 @@ class TransferQueueTest {
     private var clock = 1_000L
     private fun queue() = TransferQueue { clock }
 
+    /** Opens an entry and starts it right away — the shape of an operation that never had to wait. */
+    private fun TransferQueue.start(direction: TransferDirection, name: String = "") {
+        activate(enqueue(direction, name))
+    }
+
     @Test
     fun `an opened entry is the running one until it is closed`() {
         val queue = queue()
         assertFalse(queue.hasOpenEntry)
 
-        queue.begin(TransferDirection.Upload)
+        queue.start(TransferDirection.Upload)
         assertTrue(queue.hasOpenEntry)
 
         queue.end(TransferStatus.Done)
@@ -32,7 +37,7 @@ class TransferQueueTest {
     @Test
     fun `progress lands on the running entry, bytes and time accumulate over the operation`() {
         val queue = queue()
-        queue.begin(TransferDirection.Upload)
+        queue.start(TransferDirection.Upload)
         queue.step("a.txt", index = 1, count = 2, transferred = 4, total = 10)
         queue.fileFinished(10)
         clock = 3_000L
@@ -51,11 +56,11 @@ class TransferQueueTest {
     @Test
     fun `the single-line state follows the newest entry, not the newest failure`() {
         val queue = queue()
-        queue.begin(TransferDirection.Upload)
+        queue.start(TransferDirection.Upload)
         queue.fail("a.txt", FileTransferFailure.Transfer)
         assertIs<TransferState.Failed>(queue.latest)
 
-        queue.begin(TransferDirection.Upload)
+        queue.start(TransferDirection.Upload)
         queue.step("b.txt", 1, 1, 0, 10)
         val active = assertIs<TransferState.Active>(queue.latest)
         assertEquals("b.txt", active.name)
@@ -74,7 +79,7 @@ class TransferQueueTest {
         // The coordinator's blocks may close their own entry as failed and then return normally;
         // the generic "done" that follows must not overwrite the failure.
         val queue = queue()
-        queue.begin(TransferDirection.Download)
+        queue.start(TransferDirection.Download)
         queue.fail("r.txt", FileTransferFailure.DeleteSource)
 
         queue.end(TransferStatus.Done)
@@ -87,7 +92,7 @@ class TransferQueueTest {
     fun `entries keep distinct ids in the order they were opened`() {
         val queue = queue()
         repeat(3) {
-            queue.begin(TransferDirection.Upload)
+            queue.start(TransferDirection.Upload)
             queue.end(TransferStatus.Done)
         }
         val ids = queue.list.map { it.id }
@@ -100,7 +105,7 @@ class TransferQueueTest {
         val queue = queue()
         val ids = mutableListOf<Long>()
         repeat(MAX_COMPLETED_TRANSFERS + 2) {
-            queue.begin(TransferDirection.Upload)
+            queue.start(TransferDirection.Upload)
             queue.end(TransferStatus.Done)
             ids += queue.list.last().id
         }
@@ -108,25 +113,9 @@ class TransferQueueTest {
     }
 
     @Test
-    fun `dismissing separates the finished entries from the one still running`() {
-        val queue = queue()
-        queue.begin(TransferDirection.Upload)
-        queue.end(TransferStatus.Done)
-        queue.begin(TransferDirection.Download)
-        queue.step("r.txt", 1, 1, 0, 30)
-        val runningId = queue.list.last().id
-
-        queue.dismissCompleted()
-
-        val left = queue.list.single()
-        assertEquals(runningId, left.id)
-        assertEquals(TransferStatus.Active, left.status)
-    }
-
-    @Test
     fun `dismissing by id refuses to drop a running entry`() {
         val queue = queue()
-        queue.begin(TransferDirection.Upload)
+        queue.start(TransferDirection.Upload)
         val id = queue.list.single().id
 
         queue.dismiss(id)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRig.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRig.kt
@@ -1,7 +1,9 @@
 package app.skerry.ui.files
 
 import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.ui.sftp.DownloadTarget
 import app.skerry.ui.sftp.FakeSftpClient
+import app.skerry.ui.sftp.UploadSource
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -36,6 +38,8 @@ internal class Rig(
     val localFake: FakeSftpClient,
     val remoteFake: FakeSftpClient,
     val coordinator: TransferCoordinator,
+    /** The scope the coordinator runs its transfers on — cancelled to play the session dying. */
+    val scope: CoroutineScope,
 )
 
 internal fun TestScope.rig(
@@ -48,9 +52,49 @@ internal fun TestScope.rig(
     val localCtl = FilePaneController(localBrowser, scope())
     val remoteCtl = FilePaneController(remoteBrowser, scope())
     localCtl.start(); remoteCtl.start(); advanceUntilIdle()
-    val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, scope(), now)
-    return Rig(localCtl, remoteCtl, local, remote, coordinator)
+    val transferScope = scope()
+    val coordinator = TransferCoordinator(remote, localCtl, localBrowser, remoteCtl, remoteBrowser, transferScope, now)
+    return Rig(localCtl, remoteCtl, local, remote, coordinator, transferScope)
 }
 
 internal fun FilePaneController.entry(name: String) =
     (state as FilePaneState.Loaded).entries.first { it.name == name }
+
+/**
+ * Test target for "Save to..." downloads. Both outcomes are counted rather than flagged: the
+ * contract is that exactly one of them happens exactly once, and a document that is written *and*
+ * then removed is as much a defect as one that is never written at all.
+ */
+internal class FakeDownloadTarget(
+    override val displayName: String,
+    override val stagingPath: String,
+    private val finalizeError: String? = null,
+) : DownloadTarget {
+    var finalizes = 0
+        private set
+    var discards = 0
+        private set
+    val finalized: Boolean get() = finalizes > 0
+    val discarded: Boolean get() = discards > 0
+    override suspend fun finalize() {
+        // error(), not a bare throw: detekt reads a `throw` inside a method named finalize as the
+        // Java finalizer hazard, and this one is the DownloadTarget contract's finalize.
+        finalizeError?.let { error(it) }
+        finalizes++
+    }
+    override suspend fun discard() { discards++ }
+}
+
+/**
+ * Test source for picked uploads. [cleanups] counts the calls rather than flagging them: the
+ * contract is "exactly once", and a second release of a handle the platform already freed is as
+ * much a defect as never releasing it.
+ */
+internal class FakeUploadSource(
+    override val name: String,
+    override val stagingPath: String,
+) : UploadSource {
+    var cleanups = 0
+        private set
+    override suspend fun cleanup() { cleanups++ }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileTransferQueueTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileTransferQueueTest.kt
@@ -1,0 +1,85 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.files.FileTransferFailure
+import app.skerry.ui.files.TransferEntry
+import app.skerry.ui.files.TransferState
+import app.skerry.ui.files.TransferStatus
+import app.skerry.ui.sftp.TransferDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The phone's half of issue #317. The picker on Android has already created the document, or copied
+ * the picked file into the app's cache, before the app gets a say — so an operation that has to wait
+ * for the channel must be as visible and as cancellable here as it is in the desktop queue strip.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileTransferQueueTest {
+
+    private fun entry(id: Long, direction: TransferDirection, name: String, status: TransferStatus) =
+        TransferEntry(id, direction, name, 1, 1, 0, 0, 0, 0, status)
+
+    @Test
+    fun `an operation waiting behind the running one is a row of its own, and cancellable`() {
+        val cancelled = mutableListOf<Long>()
+        runForm({
+            MobileTransferCard(
+                transfer = TransferState.Active("r.log", TransferDirection.Download, 1, 1, 4, 10),
+                queue = listOf(
+                    entry(1, TransferDirection.Download, "r.log", TransferStatus.Active),
+                    entry(2, TransferDirection.Upload, "video.mp4", TransferStatus.Waiting),
+                ),
+                mono = FontFamily.Monospace,
+                onDrop = { cancelled += it },
+            )
+        }) {
+            onNodeWithText("r.log").assertIsDisplayed()
+            onNodeWithText("video.mp4").assertIsDisplayed()
+            onNodeWithContentDescription("Cancel video.mp4").assertIsDisplayed().performClick()
+            waitForIdle()
+        }
+        assertEquals(listOf(2L), cancelled)
+    }
+
+    @Test
+    fun `the card says out loud what is still waiting`() {
+        runForm({
+            MobileTransferCard(
+                transfer = TransferState.Idle,
+                queue = listOf(entry(1, TransferDirection.Upload, "picked.txt", TransferStatus.Waiting)),
+                mono = FontFamily.Monospace,
+                onDrop = {},
+            )
+        }) {
+            onNodeWithContentDescription("Waiting for the channel: 1").assertExists()
+        }
+    }
+
+    @Test
+    fun `clearing a failed card drops that row, not every finished one`() {
+        val dropped = mutableListOf<Long>()
+        runForm({
+            MobileTransferCard(
+                transfer = TransferState.Failed(7, "picked.txt", FileTransferFailure.SessionClosed),
+                queue = listOf(
+                    entry(6, TransferDirection.Upload, "earlier.txt", TransferStatus.Done),
+                    entry(7, TransferDirection.Upload, "picked.txt", TransferStatus.Failed(FileTransferFailure.SessionClosed)),
+                ),
+                mono = FontFamily.Monospace,
+                onDrop = { dropped += it },
+            )
+        }) {
+            // The label names one file, so the button must act on that one row.
+            onNodeWithContentDescription("Clear picked.txt").assertIsDisplayed().performClick()
+            waitForIdle()
+        }
+        assertEquals(listOf(7L), dropped)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/TransferQueueRowTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/TransferQueueRowTest.kt
@@ -1,0 +1,114 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.files.FileTransferFailure
+import app.skerry.ui.files.TransferEntry
+import app.skerry.ui.files.TransferStatus
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The queue strip's rows, from a screen reader's side (issue #317): an operation that had to wait
+ * for the channel has to be visible, cancellable, and heard — the picker already committed the
+ * user's file by the time the app queued it, so a silent row is a file nobody ever gets back.
+ */
+@OptIn(ExperimentalTestApi::class)
+class TransferQueueRowTest {
+
+    private fun entry(id: Long, direction: TransferDirection, name: String, status: TransferStatus) =
+        TransferEntry(id, direction, name, 1, 1, 0, 0, 0, 0, status)
+
+    @Test
+    fun `waiting work is cancelled, finished work is cleared, and a running transfer is neither`() {
+        val dropped = mutableListOf<Long>()
+        runForm({
+            TransferQueueStrip(
+                listOf(
+                    entry(1, TransferDirection.Download, "r.log", TransferStatus.Active),
+                    entry(2, TransferDirection.Upload, "video.mp4", TransferStatus.Waiting),
+                    entry(3, TransferDirection.Upload, "a.txt", TransferStatus.Done),
+                ),
+                FontFamily.Monospace,
+                onDismiss = { dropped += it },
+            )
+        }) {
+            // Named after the row: a queue of identical "Cancel" controls cannot be navigated.
+            onNodeWithContentDescription("Clear a.txt").assertIsDisplayed()
+            onNodeWithContentDescription("Cancel video.mp4").assertIsDisplayed().performClick()
+            waitForIdle()
+        }
+        // Only the waiting row was pressed, and the running one offered nothing to press.
+        assertEquals(listOf(2L), dropped)
+    }
+
+    @Test
+    fun `the strip says out loud what is waiting and how the last operation ended`() {
+        runForm({
+            TransferQueueStrip(
+                listOf(
+                    entry(1, TransferDirection.Upload, "a.txt", TransferStatus.Failed(FileTransferFailure.SessionClosed)),
+                    entry(2, TransferDirection.Upload, "picked.txt", TransferStatus.Waiting),
+                ),
+                FontFamily.Monospace,
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithContentDescription(
+                "a.txt: Session closed before it started. Waiting for the channel: 1",
+            ).assertExists()
+        }
+    }
+
+    @Test
+    fun `an empty queue keeps the live region and says nothing`() {
+        // The region has to outlive the strip it describes: a node that appears together with its
+        // message is an insertion, and Compose emits no live-region event for one.
+        runForm({ TransferQueueStrip(emptyList(), FontFamily.Monospace, onDismiss = {}) }) {
+            onNodeWithContentDescription("").assertExists()
+        }
+    }
+
+    @Test
+    fun `a transfer that went through is announced too, not only one that failed`() {
+        // The desktop keeps a finished row on the strip, so success is a visible outcome — and one
+        // that is only visible is what a live region is for.
+        runForm({
+            TransferQueueStrip(
+                listOf(entry(1, TransferDirection.Download, "r.log", TransferStatus.Done)),
+                FontFamily.Monospace,
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithContentDescription("r.log: done").assertExists()
+        }
+    }
+
+    @Test
+    fun `a hostile remote name is flattened in the row, its button and what is spoken`() {
+        // The name is the far side's text: a bidi override in it makes one queue row read as
+        // another file, and a screen reader speak it.
+        runForm({
+            TransferQueueStrip(
+                listOf(entry(1, TransferDirection.Download, SPOOFED, TransferStatus.Waiting)),
+                FontFamily.Monospace,
+                onDismiss = {},
+            )
+        }) {
+            onNodeWithText(SPOOFED).assertDoesNotExist()
+            onNodeWithText(FLATTENED).assertIsDisplayed()
+            onNodeWithContentDescription("Cancel $SPOOFED").assertDoesNotExist()
+            onNodeWithContentDescription("Cancel $FLATTENED").assertExists()
+        }
+    }
+}
+
+/** Written as an escape, never as the character itself. */
+private const val SPOOFED = "report\u202Egpj.exe"
+
+private const val FLATTENED = "reportgpj.exe"

--- a/gradle/detekt-baseline-composeApp.xml
+++ b/gradle/detekt-baseline-composeApp.xml
@@ -52,7 +52,6 @@
     <ID>EmptyFunctionBlock:ScreenshotSeeds.kt$&lt;no name provided&gt;${}</ID>
     <ID>EmptyFunctionBlock:SecureScreen.desktop.kt${}</ID>
     <ID>ExceptionRaisedInUnexpectedLocation:FilePicker.android.kt$SafDownloadTarget$override suspend fun finalize(): Unit</ID>
-    <ID>ExceptionRaisedInUnexpectedLocation:TransferCoordinatorTest.kt$TransferCoordinatorTest.FakeDownloadTarget$override suspend fun finalize()</ID>
     <ID>LargeClass:FilePaneControllerTest.kt$FilePaneControllerTest</ID>
     <ID>LargeClass:SessionsControllerTest.kt$SessionsControllerTest</ID>
     <ID>LargeClass:SyncCoordinator.kt$SyncCoordinator</ID>
@@ -111,7 +110,6 @@
     <ID>TooGenericExceptionThrown:HostMetricsControllerTest.kt$HostMetricsControllerTest$throw RuntimeException("boom")</ID>
     <ID>TooGenericExceptionThrown:HostMetricsMonitorControllerTest.kt$HostMetricsMonitorControllerTest$throw RuntimeException("channel dropped")</ID>
     <ID>TooGenericExceptionThrown:PingControllerTest.kt$PingControllerTest$throw RuntimeException("boom")</ID>
-    <ID>TooGenericExceptionThrown:TransferCoordinatorTest.kt$TransferCoordinatorTest.FakeDownloadTarget$throw RuntimeException(it)</ID>
     <ID>UnusedParameter:MobileSnippetsView.kt$mono: FontFamily</ID>
     <ID>UnusedPrivateProperty:ScreenshotFakes.kt$FakeConnection$val tick = polls++</ID>
     <ID>UseCheckOrError:RemoteDesktopScreenStateTest.kt$RemoteDesktopScreenStateTest.&lt;no name provided&gt;$throw IllegalStateException("Socket closed")</ID>


### PR DESCRIPTION
Fixes #317.

A "Save to…" download or a picked upload requested while another transfer was running was dropped
on the floor: no error, no row, nothing. On Android the Storage Access Framework had already created
the document, so the user was left with an empty file exactly where they asked for their data, and a
dropped upload left a full copy of the picked file in `cacheDir/sftp/` that nothing ever deleted.

Such an operation now waits its turn.

## What changed

**A queue with a real backlog.** `TransferRunner` runs operations one at a time over the session's
single SFTP channel, in the order they were asked for. Every operation gets its queue entry when it
is submitted, so one that has to wait is a row of its own — dimmed, named, and marked *waiting* —
next to the one that is moving bytes.

**Nothing leaves without releasing what it holds.** Each operation carries a cleanup that runs
exactly once, on every exit path: after the block, or on its own if the block never ran, and under
`NonCancellable`, because handing the platform back its handle is precisely what a dying scope must
not skip. That covers a finished transfer, a failed one, a cancelled one, a refused overwrite, and
one still queued when the session closes.

**Waiting work is the user's to take back.** The close button on a waiting row cancels the
operation and releases its handle — the SAF document is removed, the staged copy deleted. Desktop
gets this in the queue strip, Android in the transfer card, with the same per-row control.

**Closing the session settles the queue.** `ConnectionController` releases every operation still
waiting for the channel, and every upload still stopped at an unanswered "Overwrite?" dialog, before
the SFTP channel is closed. Their rows close as failed rather than vanishing — the user asked for
them.

Three defects found alongside the reported one, fixed here:

- answering **No** to "Overwrite?" for a picked upload never deleted its staged copy;
- a native picker draws over the Compose dialog, so a second overwrite question replaced the first
  and stranded its handle — the questions are a queue now;
- what a queued operation is going to write did not count as existing, so two queued uploads of the
  same name would overwrite each other with nothing asked.

A picked upload whose provider reports an unsafe name (`OpenableColumns.DISPLAY_NAME` comes from an
app we do not control and becomes a path component on the host) is refused with a row that says why,
instead of reaching the remote path builder.

## Accessibility

Both the desktop strip and the mobile card carry a polite live region: what is waiting for the
channel, and how the last operation ended. Progress and speed stay out of it deliberately — a
message driven by transfer callbacks would talk over the user. The per-row buttons are labelled for
what they do: *Cancel this transfer* on a waiting row, *Clear this row* on a finished one.

New strings in en, ru and zh.

## How to check it by eye

1. Connect to a host, open Files, start a large download (F5).
2. While it runs, use **Save to…** on another remote file and pick a location.
3. The second operation appears in the queue as *waiting*, and starts on its own when the first
   ends — the file at the chosen location gets its contents.
4. Press × on the waiting row instead: the row goes and the file at the chosen location is removed,
   not left empty.
5. Repeat with a picked upload, and with the session disconnected while one is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
