### PR TITLE
Refuse a toolbar action with nothing to act on

### DIFF
--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/app/UiTags.kt
@@ -44,6 +44,13 @@ object UiTags {
      */
     const val SESSION_TABS: String = "nav.sessionTabs"
 
+    /**
+     * The work bar's overflow button, holding the actions too wide for the row. Tagged because
+     * "More actions" is also the name of every host row's menu button, and the two are told apart
+     * by where they are, which a name cannot say.
+     */
+    const val TOOLBAR_OVERFLOW: String = "nav.toolbarOverflow"
+
     // --- mobile: what navigates ---
 
     /** Item of the bottom tab bar. */

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/DesignPrimitives.kt
@@ -3,6 +3,7 @@ package app.skerry.ui.design
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -281,8 +282,9 @@ fun Dot(color: Color, size: Int = 6, modifier: Modifier = Modifier) {
 /**
  * Titlebar/toolbar icon button: rounded [box]dp square. Material Symbols icon sized [icon], tinted
  * [tint]; [hoverTint] recolors the icon on hover (e.g. the window close cross turning white over
- * its red hover background), `null` keeps [tint]. [enabled] false dims the glyph and swallows the
- * click, for rows where the action exists but has nothing to act on.
+ * its red hover background), `null` keeps [tint]. [enabled] false dims the glyph, refuses the click
+ * and marks the node disabled, for rows where the action exists but has nothing to act on — the
+ * tooltip still answers on hover, which is the whole point of refusing rather than no-oping.
  *
  * [tooltip] is both what the hover shows and what the button is called: the glyph is decoration and
  * carries no name of its own, so a button given no tooltip has no accessible name either.
@@ -309,11 +311,16 @@ fun IconBtn(
     // Custom light hover background (dark theme): clickable's default indication gives a dark
     // ripple that's barely visible on a dark background, so we highlight with a light overlay instead.
     val interaction = remember { MutableInteractionSource() }
-    val hovered by interaction.collectIsHoveredAsState()
+    // Hover is tracked on a source of its own because `clickable` stops emitting it the moment it is
+    // disabled, and the tooltip is the only name this button has: a disabled icon would otherwise be
+    // an unlabelled grey glyph that says neither what it is nor why it is off.
+    val hover = remember { MutableInteractionSource() }
+    val hovered by hover.collectIsHoveredAsState()
     Box(
         modifier
             .size(box.dp)
             .clip(RoundedCornerShape(6.dp))
+            .hoverable(hover)
             .background(if (hovered && enabled) hoverBg else Color.Transparent)
             // Same rule as [Chip]: the press takes the keyboard, and whatever the button opens
             // (a menu, a dialog, a panel) may claim nothing back.

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/MenuPanel.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/MenuPanel.kt
@@ -74,22 +74,28 @@ fun MenuItem(label: String, color: Color = Skerry.colors.text, onClick: () -> Un
     }
 }
 
-/** A [MenuPanel] row that carries the glyph its action has in the toolbar it collapsed out of. */
+/**
+ * A [MenuPanel] row that carries the glyph its action has in the toolbar it collapsed out of.
+ *
+ * [enabled] is the same answer the toolbar button gives: the row and the button are two renderings
+ * of one action, and a row that fires a request the button would have refused is a press that costs
+ * the user the menu and yields nothing.
+ */
 @Composable
-fun MenuActionRow(icon: String, label: String, onClick: () -> Unit) {
+fun MenuActionRow(icon: String, label: String, enabled: Boolean = true, onClick: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()
             .widthIn(min = MENU_MIN_WIDTH)
             .clip(RoundedCornerShape(5.dp))
-            .handsKeyboardBack()
-            .clickable(onClick = onClick)
+            .handsKeyboardBack(enabled)
+            .clickable(enabled = enabled, onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 7.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Sym(icon, size = 15.sp, color = Skerry.colors.cyanBright)
-        Txt(label, color = Skerry.colors.dim, size = 12.sp)
+        Sym(icon, size = 15.sp, color = if (enabled) Skerry.colors.cyanBright else Skerry.colors.faint)
+        Txt(label, color = if (enabled) Skerry.colors.dim else Skerry.colors.faint, size = 12.sp)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/design/PanelGate.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/design/PanelGate.kt
@@ -1,0 +1,20 @@
+package app.skerry.ui.design
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+
+/**
+ * Ties a panel's own open flag to the condition that feeds it: when [available] goes false, [close]
+ * runs.
+ *
+ * The flag and the condition are two different things, and the gap between them is invisible until
+ * it bites. A palette opened over a session that then drops is hidden by the render guard beside
+ * it — but the flag is still set, so the moment the pane reconnects the panel springs back over the
+ * shell the user just got their caret in, unasked. Every popup and sheet that can outlive its
+ * session needs this, on the desktop toolbar and on the phone's session screen alike, which is why
+ * it is written once here rather than a fourth time at the next call site.
+ */
+@Composable
+fun CloseWhenUnavailable(available: Boolean, close: () -> Unit) {
+    LaunchedEffect(available) { if (!available) close() }
+}

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/desktop/DesktopSessionActions.kt
@@ -89,6 +89,11 @@ internal fun runDesktopShortcut(
         // Opens the form of the section on screen: pressed over the desktops list it creates a
         // remote desktop, over the hosts list a shell.
         DesktopShortcut.NewConnection -> state.openModal(state.section)
+        // A tab that is full, a remote desktop or a recording has nowhere to put another pane, and
+        // the chord is still consumed: unlike the refusals below it fires over a live terminal, and
+        // falling through would send Ctrl+Shift+D on to the shell as EOT and end the session. The
+        // snippet binding it could otherwise have reached is marked reserved in the editor, which
+        // warns rather than refuses — so a fall-through here is not certain to reach nothing.
         DesktopShortcut.AddPane -> if (sessions != null) sessions.addPane() else state.toggleSplit()
         DesktopShortcut.SyncPanes -> if (sessions != null) sessions.toggleSyncInput() else Unit
         // Handled by the pane grid itself ([paneGridDirection]), which sees the key only while the
@@ -102,8 +107,11 @@ internal fun runDesktopShortcut(
         }
         // Search over the buffer of the pane the user is looking at (the focused one on a split).
         // With no terminal on screen there is nothing to search: fall through instead of no-oping,
-        // so the chord can still reach a snippet binding.
+        // so the chord can still reach a snippet binding — except over a remote desktop, where a
+        // fall-through reaches no binding either (that needs a connected terminal too) and is typed
+        // into the guest instead.
         DesktopShortcut.FindInTerminal -> {
+            if (sessions?.activeDesktop != null) return true
             val session = sessions?.active ?: return false
             val terminal = paneTerminal(session.focusedPane.controller.uiState) ?: return false
             // The panel lives inside the terminal view, so bring that view up first — pressed over
@@ -114,15 +122,38 @@ internal fun runDesktopShortcut(
         }
         DesktopShortcut.Lock -> onLock()
         DesktopShortcut.Broadcast -> state.openBroadcast()
-        // These three live in toolbar buttons that own their state; the shortcut nudges them.
-        DesktopShortcut.SnippetPalette -> state.requestSnippetPalette()
-        DesktopShortcut.ToggleRecording -> state.requestRecordingToggle()
+        // These three live in toolbar buttons that own their state; the shortcut nudges them, and
+        // asks for nothing where there is no connected pane to nudge for — the button would refuse,
+        // and a request nobody acts on is a chord spent for nothing. Not airtight: with the tab
+        // switched to Files, Monitor or a runbook the pane is still connected but the terminal
+        // toolbar is out of composition, so the request is emitted into a replay-0 flow and
+        // dropped. Closing that needs the request to become a flag the button reads when it does
+        // compose, which is a change of its own — and playback is not exempt from it but the worst
+        // case of it: its button needs no session, yet it lives in the same toolbar, so ⌘⇧P is
+        // dropped over a remote desktop and over an open recording too.
+        DesktopShortcut.SnippetPalette -> {
+            if (!consumesSessionChord(sessions)) return false
+            if (actsOnSessionChord(sessions)) state.requestSnippetPalette()
+        }
+        DesktopShortcut.ToggleRecording -> {
+            if (!consumesSessionChord(sessions)) return false
+            if (actsOnSessionChord(sessions)) state.requestRecordingToggle()
+        }
         DesktopShortcut.PlayRecording -> state.requestCastOpen()
         // Only over a live terminal: the palette inserts into it, so with nothing to insert into the
-        // key falls through (to the snippet hotkey) instead of opening a dead-end overlay.
+        // key falls through (to the snippet hotkey) instead of opening a dead-end overlay — and over
+        // a remote desktop, where it cannot fall through, it opens nothing at all.
         DesktopShortcut.CommandPalette -> {
-            if (sessions?.activeSession?.controller?.uiState !is ConnectionUiState.Connected) return false
-            state.openCommandPalette()
+            if (!consumesSessionChord(sessions)) return false
+            if (actsOnSessionChord(sessions)) {
+                // The picked command lands on the pane's command line, so bring that view up first
+                // — the same reason find and the assistant do it. Pressed over the file panel the
+                // command would otherwise be typed where nobody is looking and found on the way
+                // back.
+                state.clearOverlay()
+                sessions?.setActiveView(SessionView.Terminal)
+                state.openCommandPalette()
+            }
         }
         DesktopShortcut.OpenAssistant -> {
             // The panel lives beside the terminal, so bring that view up first — pressed over SFTP
@@ -135,6 +166,24 @@ internal fun runDesktopShortcut(
     }
     return true
 }
+
+/**
+ * Whether a chord that nudges a session button has something to act on — a connected pane, which is
+ * the same terminal its button reads before drawing itself enabled.
+ */
+private fun actsOnSessionChord(sessions: SessionsController?): Boolean =
+    sessions?.activeSession?.controller?.uiState is ConnectionUiState.Connected
+
+/**
+ * Whether the chord is consumed even where [actsOnSessionChord] says there is nothing to do. Two
+ * cases: a remote-desktop tab, where the framebuffer holds the keyboard, so a chord let through is
+ * not lost but typed into the guest; and the preview shell (no session manager at all), which draws
+ * a terminal of its own for the same reason. Swallowing the key is the whole job there — the caller
+ * still asks [actsOnSessionChord] before doing anything, because a panel that can reach no terminal
+ * is a worse answer than a key that does nothing.
+ */
+private fun consumesSessionChord(sessions: SessionsController?): Boolean =
+    sessions == null || sessions.activeDesktop != null || actsOnSessionChord(sessions)
 
 /**
  * The terminal of a pane's connection state, or `null` if it has none. A dropped session keeps its

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileTerminalView.kt
@@ -63,6 +63,7 @@ import app.skerry.ui.generated.resources.term_ai_dismiss
 import app.skerry.ui.generated.resources.term_disconnect
 import org.jetbrains.compose.resources.stringResource
 import app.skerry.ui.app.AiPolicy
+import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.NoticeDialog
 import app.skerry.ui.app.LocalAi
 import app.skerry.ui.app.LocalHosts
@@ -169,6 +170,14 @@ fun MobileTerminalScreen(state: MobileDesignState) {
     val snippets = LocalSnippets.current
     val activeTerminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal
     val canRunSnippet = snippets != null && activeTerminal != null
+    // Same rule as the desktop toolbar's popups: the pane id survives a drop (the controller
+    // reconnects in place), so a sheet left open would be hidden by its own render guard and then
+    // be back over the terminal the moment auto-reconnect lands.
+    CloseWhenUnavailable(activeTerminal != null) {
+        paletteOpen = false
+        monitorOpen = false
+        historyOpen = false
+    }
 
     // Full-bleed only on request (More → Appearance → Interface); off, the phone keeps its bars
     // and the shell keeps this screen inside the safe area (see MobileChrome.fullBleed).

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/runbook/RunbookPalette.kt
@@ -42,6 +42,7 @@ import app.skerry.ui.app.LocalSessions
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.design.fieldName
 import kotlinx.coroutines.flow.SharedFlow
+import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.Sym
@@ -58,6 +59,8 @@ import app.skerry.ui.generated.resources.runbook_toolbar_tip
 import app.skerry.ui.generated.resources.runbook_untitled
 import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionView
+import app.skerry.ui.terminal.ToolbarAction
+import app.skerry.ui.terminal.toolbarActionEnabled
 import app.skerry.ui.design.untrustedLabel
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.stringResource
@@ -79,11 +82,23 @@ fun RunbookPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
     var open by remember(active) { mutableStateOf(false) }
     // Same signal channel the snippet palette uses: the shortcut and the overflow menu reach the
     // palette without this button having to be on screen (it may be parked out of a narrow toolbar).
-    LaunchedEffect(requests, terminal) { requests?.collect { if (terminal != null) open = true } }
+    // The same condition the button carries, not half of it: a request that arrives mid-run would
+    // otherwise set the flag for a popup the render guard then drops without a word.
+    LaunchedEffect(requests, terminal) {
+        requests?.collect { if (terminal != null && runner?.let { !it.active && it.pending == null } == true) open = true }
+    }
     if (manager == null || runner == null) return
     // While this tab is part of a run, the icon is the way back to the run screen rather than a
     // palette: a second runbook can't start anyway, and the run is what the icon now stands for.
     val inRun = active?.id?.let(runner::runIn)
+    // Nothing to run into without a connected session, and one run at a time: the button is
+    // disabled rather than offering a list that can't start anything. Disabled, not merely dimmed —
+    // a guard inside the handler would still take the press and the focus with nothing to show.
+    val enabled = toolbarActionEnabled(ToolbarAction.Runbook, active)
+    // Ahead of the early return below on purpose: that return takes this out of the composition for
+    // the whole length of a run started from the Runbooks section, which is exactly when the flag
+    // has to be cleared — otherwise the palette is back the moment the run ends.
+    CloseWhenUnavailable(enabled && inRun == null) { open = false }
     if (inRun != null) {
         val sessions = LocalSessions.current
         IconBtn(
@@ -94,29 +109,32 @@ fun RunbookPaletteButton(active: Session?, requests: SharedFlow<Unit>? = null) {
         )
         return
     }
-    // Nothing to run into without a connected session, and one run at a time: the button dims and
-    // doesn't open rather than offering a list that can't start anything.
-    val enabled = terminal != null && !runner.active && runner.pending == null
     Box {
         IconBtn(
             "checklist",
-            onClick = { if (enabled) open = !open },
-            tint = if (enabled) Skerry.colors.dim else Skerry.colors.faint,
+            onClick = { open = !open },
+            enabled = enabled,
             tooltip = stringResource(Res.string.runbook_toolbar_tip),
         )
         if (open && enabled) {
-            Popup(
-                alignment = Alignment.TopEnd,
-                onDismissRequest = { open = false },
-                properties = PopupProperties(focusable = true),
-            ) {
-                RunbookPalette(manager) { entry ->
-                    runner.requestStart(
-                        entry.runbook,
-                        runbookTarget(active.id, terminal, active.controller),
-                        recording = terminal.recording,
-                    )
-                    open = false
+            // The pane and its terminal spelled out again rather than leaned on through `enabled`:
+            // the palette hands both to the runner, and the compiler cannot see through a predicate.
+            val pane = active
+            val live = terminal
+            if (pane != null && live != null) {
+                Popup(
+                    alignment = Alignment.TopEnd,
+                    onDismissRequest = { open = false },
+                    properties = PopupProperties(focusable = true),
+                ) {
+                    RunbookPalette(manager) { entry ->
+                        runner.requestStart(
+                            entry.runbook,
+                            runbookTarget(pane.id, live, pane.controller),
+                            recording = live.recording,
+                        )
+                        open = false
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/session/SessionsController.kt
@@ -191,6 +191,13 @@ class Tab(val id: String, first: Session) {
     val isPlayer: Boolean get() = panes.first().isPlayer
 
     /**
+     * Whether another pane can join this tab. The one place the answer lives: the toolbar's add-pane
+     * button reads it to decide whether to offer itself at all, and [SessionsController.addPane]
+     * enforces it — two copies of the rule is how a button ends up looking live over a refusal.
+     */
+    val acceptsPane: Boolean get() = !isVnc && !isPlayer && !layout.isFull
+
+    /**
      * A blank tab with nothing connected: one pane, no host picked yet. Created by the "+" button;
      * the first connection fills it in place ([SessionsController.connect]).
      */
@@ -502,7 +509,7 @@ class SessionsController(
      */
     fun addPane(id: String? = activeId, slot: PaneSlot? = null): String? {
         val tab = tab(id) ?: return null
-        if (tab.isVnc || tab.isPlayer || tab.layout.isFull) return null
+        if (!tab.acceptsPane) return null
         val pane = Session(newId(), hostId = null, title = "", subtitle = "", controllerFactory())
         pane.controller.bindSessionId(pane.id)
         tab.setPanes(tab.panes + pane)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/share/ShareSessionButton.kt
@@ -31,6 +31,7 @@ import app.skerry.ui.app.LocalSharedSessions
 import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.design.ChipButton
 import app.skerry.ui.design.GhostButton
+import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.InitialsAvatar
 import app.skerry.ui.design.Toggle
@@ -99,7 +100,9 @@ fun ShareSessionButton(
     LaunchedEffect(live, terminal?.cols, terminal?.rows) {
         if (live) controller?.announceGeometry()
     }
-    LaunchedEffect(requests, terminal) { requests?.collect { if (live || terminal != null) open = true } }
+    // `live` is a key too, not just a captured value: a stream stopped without the terminal changing
+    // would otherwise leave this collector opening the panel on a share that is already over.
+    LaunchedEffect(requests, terminal, live) { requests?.collect { if (live || terminal != null) open = true } }
     // A pane that is watching someone else's session gets the viewer's panel behind the same button:
     // its only control is asking the host for permission to type. Relaying a colleague's stream on
     // to a third team is never offered — the pane's own flag decides that, not the viewer registry,
@@ -112,18 +115,19 @@ fun ShareSessionButton(
     if (session?.controller?.isWatched == true) return
     if (controller == null) return
     Box {
+        // Nothing to share without a live session, but a stream already running keeps the control
+        // that stops it. Disabled rather than dimmed-and-live: the guard used to sit in the handler,
+        // where the press was taken and dropped.
+        val canShare = live || terminal != null
+        CloseWhenUnavailable(canShare) { open = false }
         IconBtn(
             name = if (live) "cast_connected" else "cast",
-            tint = when {
-                live -> Skerry.colors.cyanBright
-                terminal != null -> Skerry.colors.dim
-                // Nothing to share without a live session — dimmed, and the panel doesn't open.
-                else -> Skerry.colors.faint
-            },
-            onClick = { if (live || terminal != null) open = !open },
+            tint = if (live) Skerry.colors.cyanBright else Skerry.colors.dim,
+            onClick = { open = !open },
+            enabled = canShare,
             tooltip = stringResource(if (live) Res.string.share_session_stop else Res.string.share_session),
         )
-        if (open) {
+        if (open && canShare) {
             Popup(
                 alignment = Alignment.TopEnd,
                 onDismissRequest = { open = false },

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/PlayRecordingButton.kt
@@ -14,7 +14,6 @@ import app.skerry.ui.generated.resources.shell_tip_play
 import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
-import app.skerry.ui.theme.Skerry
 
 /**
  * Toolbar button that opens a `.cast` file and hands the result to [onOpened] (which shows the
@@ -42,10 +41,13 @@ fun PlayRecordingButton(requests: SharedFlow<Unit>? = null, onOpened: (CastOpenR
     val currentOpen by rememberUpdatedState(open)
     // Hotkey channel (⌘P / Ctrl+Shift+P) — same action as the click.
     LaunchedEffect(requests) { requests?.collect { currentOpen() } }
+    // Disabled rather than merely tinted while a picker is up: the same rule the rest of the
+    // toolbar follows, and it draws the faint tint by itself. The guard inside [open] stays — the
+    // hotkey reaches this button whether or not it is clickable.
     IconBtn(
         "play_circle",
-        tint = if (opening) Skerry.colors.faint else Skerry.colors.dim,
         onClick = { open() },
         tooltip = stringResource(Res.string.shell_tip_play),
+        enabled = !opening,
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/RecordButton.kt
@@ -83,6 +83,9 @@ fun RecordSessionButton(
         name = if (recording) "stop_circle" else "radio_button_checked",
         tint = if (recording) Skerry.colors.sunset else Skerry.colors.dim,
         onClick = toggle,
+        // Nothing to record on a pane that is not connected: the toggle used to run and return on
+        // its own first line, so the press took the focus and left no trace.
+        enabled = toolbarActionEnabled(ToolbarAction.Record, session),
         tooltip = stringResource(if (recording) Res.string.shell_tip_record_stop else Res.string.shell_tip_record),
     )
 }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SessionActions.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
@@ -20,7 +21,10 @@ import androidx.compose.ui.window.PopupProperties
 import app.skerry.ui.app.DesktopDesignState
 import app.skerry.ui.app.DesktopView
 import app.skerry.ui.app.LocalSessionShare
+import app.skerry.ui.app.LocalRunbookRunner
+import app.skerry.ui.app.UiTags
 import app.skerry.ui.app.LocalSessions
+import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.app.LocalTeams
 import app.skerry.ui.design.rememberModalPresence
 import app.skerry.ui.design.IconBtn
@@ -42,8 +46,10 @@ import app.skerry.ui.generated.resources.shell_tip_snippets
 import app.skerry.ui.generated.resources.shell_tip_sync_panes
 import app.skerry.ui.generated.resources.term_player_title
 import app.skerry.ui.runbook.RunbookPaletteButton
+import app.skerry.ui.session.Session
 import app.skerry.ui.session.SessionView
 import app.skerry.ui.share.ShareSessionButton
+import app.skerry.ui.share.ShareUiState
 import app.skerry.ui.share.shareableTeams
 import app.skerry.ui.theme.Skerry
 import org.jetbrains.compose.resources.StringResource
@@ -72,6 +78,48 @@ internal enum class ToolbarAction(val group: ToolbarGroup, val needsSession: Boo
     Snippets(ToolbarGroup.Session, needsSession = true),
     Monitor(ToolbarGroup.Workspace, needsSession = true),
     Files(ToolbarGroup.Workspace, needsSession = true),
+}
+
+/**
+ * Whether [action] can act on the pane in focus, for both of the places one action is drawn: the
+ * button in the row and, once the row is too narrow to hold it, the row of the overflow menu. One
+ * answer for both — a menu row that fires a request the parked button then drops is the same dead
+ * press the buttons themselves stopped making.
+ *
+ * The rule itself is a plain function over booleans, and this reads the composition for them: the
+ * buttons' own request collectors run inside a `LaunchedEffect` and cannot call a composable, and a
+ * rule that only exists inside one is a rule no test can enumerate.
+ */
+@Composable
+internal fun toolbarActionEnabled(action: ToolbarAction, active: Session?): Boolean {
+    val runner = LocalRunbookRunner.current
+    return toolbarActionEnabled(
+        action,
+        hasTerminal = (active?.controller?.uiState as? ConnectionUiState.Connected)?.terminal != null,
+        runnerIdle = runner != null && !runner.active && runner.pending == null,
+        shareLive = LocalSessionShare.current?.state is ShareUiState.Live,
+    )
+}
+
+/**
+ * The rule behind [toolbarActionEnabled], over the three facts the composition supplies:
+ * [hasTerminal] — the pane in focus is connected, [runnerIdle] — no runbook is mid-run, and
+ * [shareLive] — a stream is on the air right now.
+ */
+internal fun toolbarActionEnabled(
+    action: ToolbarAction,
+    hasTerminal: Boolean,
+    runnerIdle: Boolean,
+    shareLive: Boolean,
+): Boolean = when (action) {
+    // Nothing to send into without a connected session.
+    ToolbarAction.Snippets, ToolbarAction.Record -> hasTerminal
+    // Same, plus one run at a time.
+    ToolbarAction.Runbook -> hasTerminal && runnerIdle
+    // Nothing to share without a connected session — but a stream already running keeps the control
+    // that stops it, and on a narrow toolbar the menu row is the only copy of that control left.
+    ToolbarAction.Share -> hasTerminal || shareLive
+    ToolbarAction.Files, ToolbarAction.Monitor, ToolbarAction.Play -> true
 }
 
 /**
@@ -226,12 +274,16 @@ internal fun RowScope.SessionActions(
     // Add pane: live mode puts another independent session on the active tab's grid (up to
     // MAX_PANES); mock/preview toggles the demo split. Dimmed and inert once the tab is full — the
     // same treatment the info button gets when there is nothing for it to open.
-    val canAddPane = tab?.layout?.isFull != true && tab?.isPlayer != true
+    // The tab's own answer, not a second copy of it: `addPane` refuses a full tab, a remote desktop
+    // and a recording, and the copy this replaces had lost one of the three. A remote-desktop tab
+    // does not reach this line today (`activeTerminal` filters it out, so the button is not drawn),
+    // which is exactly why a second copy of the rule could lose that arm unnoticed.
+    val canAddPane = tab?.acceptsPane != false
     if (hasSession) {
         IconBtn(
             "splitscreen_right",
-            onClick = { if (sessions == null) state.toggleSplit() else if (canAddPane) sessions.addPane() },
-            tint = if (canAddPane) Skerry.colors.dim else Skerry.colors.faint,
+            onClick = { if (sessions == null) state.toggleSplit() else sessions.addPane() },
+            enabled = canAddPane,
             tooltip = stringResource(Res.string.shell_tip_add_pane),
         )
     }
@@ -286,7 +338,14 @@ internal fun RowScope.SessionActions(
         )
     }
     if (hidden.isNotEmpty()) {
-        OverflowActionsButton(hidden, state, tabKey = tab?.id, onOpenSftp = openSftp, onOpenMonitor = openMonitor)
+        OverflowActionsButton(
+            hidden,
+            state,
+            tabKey = tab?.id,
+            enabled = { toolbarActionEnabled(it, active) },
+            onOpenSftp = openSftp,
+            onOpenMonitor = openMonitor,
+        )
     }
     // Power: closes the active session (live path) with a confirmation prompt (destructive, no
     // auto-reconnect); no-op stub in mock mode. With no session open there is nothing to close.
@@ -386,12 +445,18 @@ internal fun OverflowActionsButton(
     hidden: Set<ToolbarAction>,
     state: DesktopDesignState,
     tabKey: Any?,
+    enabled: @Composable (ToolbarAction) -> Boolean,
     onOpenSftp: () -> Unit,
     onOpenMonitor: () -> Unit,
 ) {
     var open by remember(tabKey) { mutableStateOf(false) }
     Box {
-        IconBtn("more_horiz", onClick = { open = !open }, tooltip = stringResource(Res.string.shell_tip_more_actions))
+        IconBtn(
+            "more_horiz",
+            modifier = Modifier.testTag(UiTags.TOOLBAR_OVERFLOW),
+            onClick = { open = !open },
+            tooltip = stringResource(Res.string.shell_tip_more_actions),
+        )
         if (open) {
             Popup(alignment = Alignment.TopEnd, onDismissRequest = { open = false }, properties = PopupProperties(focusable = true)) {
                 // Same as [PaneMenu]: a focusable popup holds the keyboard, so it counts as a modal.
@@ -408,7 +473,7 @@ internal fun OverflowActionsButton(
                             ToolbarAction.Play -> state::requestCastOpen
                             ToolbarAction.Share -> state::requestSharePanel
                         }
-                        MenuActionRow(icon = action.icon, label = stringResource(action.label)) {
+                        MenuActionRow(icon = action.icon, label = stringResource(action.label), enabled = enabled(action)) {
                             open = false
                             run()
                         }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/terminal/SnippetPalette.kt
@@ -40,6 +40,7 @@ import app.skerry.ui.app.LocalSnippets
 import app.skerry.ui.design.fieldName
 import kotlinx.coroutines.flow.SharedFlow
 import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.design.CloseWhenUnavailable
 import app.skerry.ui.design.IconBtn
 import app.skerry.ui.design.LocalFonts
 import app.skerry.ui.design.NOTE_PEEK_LINES
@@ -82,9 +83,12 @@ internal fun SnippetPaletteButton(active: Session?, requests: SharedFlow<Unit>? 
     // be a dead-end popup, so the key falls through to whatever else wants it.
     LaunchedEffect(requests, terminal) { requests?.collect { if (terminal != null) open = true } }
     if (manager == null) return
+    val enabled = toolbarActionEnabled(ToolbarAction.Snippets, active)
+    CloseWhenUnavailable(enabled) { open = false }
     Box {
-        // Nowhere to run without a connected session — the button is dimmed and doesn't open.
-        IconBtn("bolt", onClick = { if (terminal != null) open = !open }, tint = if (terminal != null) Skerry.colors.dim else Skerry.colors.faint, tooltip = stringResource(Res.string.shell_tip_snippets))
+        // Nowhere to run without a connected session: disabled rather than dimmed-but-live, so the
+        // press is refused instead of landing on a handler that drops it.
+        IconBtn("bolt", onClick = { open = !open }, enabled = enabled, tooltip = stringResource(Res.string.shell_tip_snippets))
         if (open && terminal != null) {
             Popup(
                 alignment = Alignment.TopEnd,

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionTestFixtures.kt
@@ -7,6 +7,7 @@ package app.skerry.ui.connection
 // kept around.
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import app.skerry.shared.graphics.RemoteFramebuffer
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.ExecResult
@@ -19,7 +20,14 @@ import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshTransport
+import app.skerry.shared.vnc.VncAuth
+import app.skerry.shared.vnc.VncPointerEvent
+import app.skerry.shared.vnc.VncQuality
+import app.skerry.shared.vnc.VncSession
+import app.skerry.shared.vnc.VncTransport
+import app.skerry.shared.vnc.VncUpdate
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -142,4 +150,33 @@ internal class FakeShellChannel : ShellChannel {
         emissions.close()
     }
 
+}
+
+/** VNC transport that returns a fresh fake session on each connect; list is used to verify closes. */
+internal class FakeVncTransport : VncTransport {
+    val sessions = mutableListOf<FakeVncSession>()
+    override suspend fun connect(target: SshTarget, auth: VncAuth): VncSession =
+        FakeVncSession().also { sessions += it }
+}
+
+internal class FakeVncSession : VncSession {
+    var closed = false
+        private set
+
+    override val serverName = "desk"
+    override val framebuffer = RemoteFramebuffer(1, 1)
+
+    // Never emits: keeps the read loop parked (like a quiet server) until the scope is cancelled.
+    override val updates: Flow<VncUpdate> = flow { awaitCancellation() }
+
+    override suspend fun sendPointer(event: VncPointerEvent) {}
+    override suspend fun sendKey(keySym: Long, down: Boolean) {}
+    override suspend fun sendClientCutText(text: String) {}
+    override suspend fun requestUpdate(incremental: Boolean) {}
+    override suspend fun setQuality(quality: VncQuality) {}
+    override suspend fun setDesktopSize(width: Int, height: Int) {}
+    override suspend fun setLocalCursor(enabled: Boolean) {}
+    override suspend fun close() {
+        closed = true
+    }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/desktop/DesktopShortcutsTest.kt
@@ -1,13 +1,36 @@
 package app.skerry.ui.desktop
 
 import androidx.compose.ui.input.key.Key
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.ui.app.DesktopDesignState
+import app.skerry.ui.connection.ConnectionController
+import app.skerry.ui.connection.FakeShellChannel
+import app.skerry.ui.connection.FakeSshConnection
+import app.skerry.ui.connection.FakeSshTransport
+import app.skerry.ui.connection.testTarget
+import app.skerry.shared.vnc.VncAuth
+import app.skerry.shared.vnc.VncRemoteDesktop
+import app.skerry.ui.remote.RemoteDesktopController
+import app.skerry.ui.connection.FakeVncTransport
+import app.skerry.ui.session.MAX_PANES
 import app.skerry.ui.session.PaneDirection
+import app.skerry.ui.session.SessionView
+import app.skerry.ui.session.SessionsController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class DesktopShortcutsTest {
 
     private fun match(ctrl: Boolean = false, shift: Boolean = false, alt: Boolean = false, meta: Boolean = false, key: Key) =
@@ -190,5 +213,150 @@ class DesktopShortcutsTest {
             assertFalse(survivesModal(other), "$other must not act on the session under a modal")
         }
         assertFalse(survivesModal(null), "an unmatched chord runs nothing")
+    }
+
+    /**
+     * The add-pane chord is the one refusal in this file that fires over a live terminal, so it
+     * stays consumed: Ctrl+Shift+D let through is EOT on the wire, and the shell it reaches exits.
+     */
+    @Test
+    fun `Add pane is consumed even once the tab cannot take another`() = runTest {
+        val (sessions, scope) = sessions()
+        sessions.open(hostId = "h", title = "h", subtitle = "u@h:22", target = testTarget, auth = auth)
+        advanceUntilIdle()
+        val state = DesktopDesignState()
+        repeat(MAX_PANES - 1) {
+            assertTrue(runDesktopShortcut(DesktopShortcut.AddPane, state, sessions) {}, "pane ${it + 2} of $MAX_PANES")
+        }
+        assertTrue(
+            runDesktopShortcut(DesktopShortcut.AddPane, state, sessions) {},
+            "a full tab has nowhere to put a pane, but the chord must not reach the shell as EOT",
+        )
+        scope.cancel()
+    }
+
+    /**
+     * The chords that nudge a toolbar button are worth no more than the button: with nothing
+     * connected the button refuses, so the chord has to fall through rather than be spent on a
+     * request nobody acts on. Playback is the exception — it opens a file, not a session.
+     */
+    @Test
+    fun `the session chords fall through with nothing connected`() = runTest {
+        val (sessions, scope) = sessions()
+        val state = DesktopDesignState()
+        for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
+            assertFalse(runDesktopShortcut(chord, state, sessions) {}, "$chord must fall through with no session")
+        }
+        assertTrue(runDesktopShortcut(DesktopShortcut.PlayRecording, state, sessions) {}, "playback needs no session")
+
+        sessions.open(hostId = "h", title = "h", subtitle = "u@h:22", target = testTarget, auth = auth)
+        advanceUntilIdle()
+        // The half that keeps the gate honest: consuming the chord and doing nothing would satisfy
+        // the refusals above and the two "consumed and nothing more" tests both.
+        val asked = recordRequests(state)
+        for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
+            assertTrue(runDesktopShortcut(chord, state, sessions) {}, "$chord acts on a connected session")
+        }
+        advanceUntilIdle()
+        assertEquals(listOf("snippets", "record"), asked, "both buttons are nudged")
+        assertTrue(state.commandPaletteOpen, "the palette has a terminal to insert into")
+        scope.cancel()
+    }
+
+    /**
+     * The palette fills the command line of the pane behind it, so it brings that view forward
+     * first — pressed over the file panel it would otherwise write into a terminal nobody is
+     * looking at, and the command would be found half-typed on the next switch back. Find and the
+     * assistant chord already do this; the palette was the one that did not.
+     */
+    @Test
+    fun `the command palette brings the terminal view forward`() = runTest {
+        val (sessions, scope) = sessions()
+        sessions.open(hostId = "h", title = "h", subtitle = "u@h:22", target = testTarget, auth = auth)
+        advanceUntilIdle()
+        sessions.setActiveView(SessionView.Sftp)
+        val state = DesktopDesignState()
+        assertTrue(runDesktopShortcut(DesktopShortcut.CommandPalette, state, sessions) {})
+        assertEquals(SessionView.Terminal, sessions.active?.view, "the palette writes into the terminal")
+        assertTrue(state.commandPaletteOpen)
+        scope.cancel()
+    }
+
+    /**
+     * Mock mode — no session manager at all, which is how the offscreen screenshot pipeline runs
+     * the app. Nothing is connected there, so nothing is nudged; the chord is consumed all the
+     * same, because that shell draws a terminal too and a fall-through would type Ctrl+Shift+S into
+     * it as XOFF.
+     */
+    @Test
+    fun `the session chords are consumed with no session manager`() = runTest {
+        val state = DesktopDesignState()
+        val asked = recordRequests(state)
+        for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
+            assertTrue(runDesktopShortcut(chord, state, sessions = null) {}, "$chord in mock mode")
+        }
+        advanceUntilIdle()
+        assertFalse(state.commandPaletteOpen, "there is no pane for the palette to insert into")
+        assertEquals(emptyList(), asked, "no button to nudge, so nothing is asked for")
+    }
+
+    /**
+     * A remote desktop has no terminal for the chord to act on — and the framebuffer under it holds
+     * the keyboard, so letting the chord through does not lose it, it types it into the guest.
+     *
+     * Consumed and nothing more: swallowing the key is the whole job here. Opening a panel that
+     * cannot reach a terminal would trade a keystroke in the guest for an overlay whose every row
+     * is a no-op, which is the worse half of both.
+     */
+    @Test
+    fun `the session chords are consumed over a remote desktop`() = runTest {
+        val (sessions, scope) = sessions(vnc = FakeVncTransport())
+        sessions.openVnc(hostId = "h", title = "h", subtitle = "h:5900", target = testTarget, auth = VncAuth.None)
+        advanceUntilIdle()
+        val state = DesktopDesignState()
+        val asked = recordRequests(state)
+        for (chord in listOf(DesktopShortcut.SnippetPalette, DesktopShortcut.ToggleRecording, DesktopShortcut.CommandPalette)) {
+            assertTrue(runDesktopShortcut(chord, state, sessions) {}, "$chord must not reach the guest")
+        }
+        advanceUntilIdle()
+        assertFalse(state.commandPaletteOpen, "the command palette has no terminal to insert into here")
+        assertEquals(emptyList(), asked, "no toolbar button is composed over a desktop tab")
+        assertTrue(
+            runDesktopShortcut(DesktopShortcut.FindInTerminal, state, sessions) {},
+            "find must not reach the guest either",
+        )
+        scope.cancel()
+    }
+
+    private val auth = SshAuth.Password("pw")
+
+    /**
+     * Both button-nudging request flows, in the order they fire. `replay = 0`, so the collectors
+     * have to be live before the chord runs — hence the unconfined dispatcher.
+     */
+    private fun TestScope.recordRequests(state: DesktopDesignState): List<String> {
+        val asked = mutableListOf<String>()
+        val live = UnconfinedTestDispatcher(testScheduler)
+        backgroundScope.launch(live) { state.snippetPaletteRequests.collect { asked += "snippets" } }
+        backgroundScope.launch(live) { state.recordingToggleRequests.collect { asked += "record" } }
+        return asked
+    }
+
+    private fun TestScope.sessions(vnc: FakeVncTransport? = null): Pair<SessionsController, CoroutineScope> {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        var n = 0
+        val controller = SessionsController(
+            newId = { "s${n++}" },
+            controllerFactory = {
+                ConnectionController(
+                    transport = FakeSshTransport(FakeSshConnection(FakeShellChannel())),
+                    scope = scope,
+                    newSessionScope = { CoroutineScope(UnconfinedTestDispatcher(testScheduler)) },
+                )
+            },
+            vncControllerFactory = vnc?.let { { RemoteDesktopController(scope) } },
+            openVncSession = vnc?.let { t -> { target, auth -> VncRemoteDesktop(t.connect(target, auth)) } },
+        )
+        return controller to scope
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/session/SessionsControllerTest.kt
@@ -1,10 +1,7 @@
 package app.skerry.ui.session
 
 import app.skerry.shared.vnc.VncRemoteDesktop
-import app.skerry.shared.vnc.VncQuality
-import app.skerry.shared.vnc.VncUpdate
 import app.skerry.ui.remote.RemoteDesktopController
-import app.skerry.shared.graphics.RemoteFramebuffer
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.ssh.DynamicForwardSpec
 import app.skerry.shared.ssh.ExecResult
@@ -20,13 +17,11 @@ import app.skerry.shared.ssh.SshTransport
 import app.skerry.shared.terminal.Asciicast
 import app.skerry.shared.terminal.CastEvent
 import app.skerry.shared.vnc.VncAuth
-import app.skerry.shared.vnc.VncPointerEvent
 import app.skerry.shared.graphics.RemoteDesktopQuality
-import app.skerry.shared.vnc.VncSession
-import app.skerry.shared.vnc.VncTransport
 import app.skerry.shared.graphics.RemoteDesktopUpdate
 import app.skerry.shared.guard.ProductionGuardPolicy
 import app.skerry.ui.connection.ConnectionController
+import app.skerry.ui.connection.FakeVncTransport
 import app.skerry.ui.connection.ConnectionUiState
 import app.skerry.ui.session.SessionStatus
 import app.skerry.ui.session.asSessionStatus
@@ -42,7 +37,6 @@ import app.skerry.ui.host.HostSection
 import app.skerry.ui.host.prodGuardDialogOpen
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -278,6 +272,28 @@ class SessionsControllerTest {
         sessions.openVnc(hostId = "host-a")
 
         assertNull(sessions.addPane())
+        scope.cancel()
+    }
+
+    /**
+     * The one place the rule lives, asserted arm by arm: [SessionsController.addPane] enforces it
+     * and the toolbar's add-pane button reads it to decide whether to offer itself at all. The
+     * button used to carry a copy of the rule that had lost the remote-desktop arm.
+     */
+    @Test
+    fun `acceptsPane names every tab with nowhere to put one`() = runTest {
+        val (sessions, scope) = sessionsWithVnc(FakeVncTransport())
+        sessions.open(hostId = "host-a")
+        val shell = sessions.active!!
+        assertTrue(shell.acceptsPane, "a shell tab with room")
+        repeat(MAX_PANES - 1) { assertNotNull(sessions.addPane()) }
+        assertFalse(shell.acceptsPane, "a full grid")
+
+        sessions.openVnc(hostId = "host-b")
+        assertFalse(sessions.active!!.acceptsPane, "a remote desktop")
+
+        sessions.openPlayer("recording", Asciicast(80, 24, "cast", emptyList()))
+        assertFalse(sessions.active!!.acceptsPane, "a recording")
         scope.cancel()
     }
 
@@ -1181,35 +1197,6 @@ class SessionsControllerTest {
         assertEquals("web-1", effectiveTabTitle(liveTitle = null, fallback = "web-1"))
         assertEquals("web-1", effectiveTabTitle(liveTitle = "", fallback = "web-1"))
         assertEquals("web-1", effectiveTabTitle(liveTitle = "   ", fallback = "web-1"))
-    }
-}
-
-/** VNC transport that returns a fresh fake session on each connect; list is used to verify closes. */
-private class FakeVncTransport : VncTransport {
-    val sessions = mutableListOf<FakeVncSession>()
-    override suspend fun connect(target: SshTarget, auth: VncAuth): VncSession =
-        FakeVncSession().also { sessions += it }
-}
-
-private class FakeVncSession : VncSession {
-    var closed = false
-        private set
-
-    override val serverName = "desk"
-    override val framebuffer = RemoteFramebuffer(1, 1)
-
-    // Never emits: keeps the read loop parked (like a quiet server) until the scope is cancelled.
-    override val updates: Flow<VncUpdate> = flow { awaitCancellation() }
-
-    override suspend fun sendPointer(event: VncPointerEvent) {}
-    override suspend fun sendKey(keySym: Long, down: Boolean) {}
-    override suspend fun sendClientCutText(text: String) {}
-    override suspend fun requestUpdate(incremental: Boolean) {}
-    override suspend fun setQuality(quality: VncQuality) {}
-    override suspend fun setDesktopSize(width: Int, height: Int) {}
-    override suspend fun setLocalCursor(enabled: Boolean) {}
-    override suspend fun close() {
-        closed = true
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarActionEnabledTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/terminal/ToolbarActionEnabledTest.kt
@@ -1,0 +1,55 @@
+package app.skerry.ui.terminal
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The rule one action is drawn by, in both of its renderings: the button in the work bar and the
+ * row of the overflow menu. Enumerated here rather than through the UI because a disagreement
+ * between the two is a dead press — a lit row that fires a request the parked button drops — and
+ * the arms that only show up on a narrow window are the ones a render test never reaches.
+ */
+class ToolbarActionEnabledTest {
+
+    private fun enabled(action: ToolbarAction, terminal: Boolean, idle: Boolean = true, share: Boolean = false) =
+        toolbarActionEnabled(action, hasTerminal = terminal, runnerIdle = idle, shareLive = share)
+
+    @Test
+    fun `what needs a session to send into is off without one`() {
+        for (action in listOf(ToolbarAction.Snippets, ToolbarAction.Record, ToolbarAction.Runbook)) {
+            assertFalse(enabled(action, terminal = false), "$action with no terminal")
+            assertTrue(enabled(action, terminal = true), "$action with a terminal")
+        }
+    }
+
+    /** One run at a time: the palette can start nothing while a runbook is on this session. */
+    @Test
+    fun `the runbook palette is off mid-run and on either side of it`() {
+        assertFalse(enabled(ToolbarAction.Runbook, terminal = true, idle = false))
+        assertTrue(enabled(ToolbarAction.Runbook, terminal = true, idle = true))
+        // Only the runbook is: a run does not take the snippets or the recording away.
+        assertTrue(enabled(ToolbarAction.Snippets, terminal = true, idle = false))
+        assertTrue(enabled(ToolbarAction.Record, terminal = true, idle = false))
+    }
+
+    /**
+     * Share is the one action that outlives its terminal. A stream on the air when the pane drops
+     * still has to be stoppable, and on a toolbar narrow enough to park the button the menu row is
+     * the only control left — greyed out, the stream keeps running to the team with no way to end it.
+     */
+    @Test
+    fun `share stays on for a stream that outlived its pane`() {
+        assertTrue(enabled(ToolbarAction.Share, terminal = false, share = true))
+        assertTrue(enabled(ToolbarAction.Share, terminal = true, share = false))
+        assertFalse(enabled(ToolbarAction.Share, terminal = false, share = false))
+    }
+
+    /** Not everything on the bar acts on a session: these three stand on their own. */
+    @Test
+    fun `what does not act on a session is always on`() {
+        for (action in listOf(ToolbarAction.Files, ToolbarAction.Monitor, ToolbarAction.Play)) {
+            assertTrue(enabled(action, terminal = false), "$action with nothing connected")
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/MenuChromeTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/design/MenuChromeTest.kt
@@ -146,6 +146,7 @@ class MenuChromeTest {
                             hidden = setOf(ToolbarAction.Files, ToolbarAction.Snippets),
                             state = DesktopDesignState(),
                             tabKey = null,
+                            enabled = { true },
                             onOpenSftp = {},
                             onOpenMonitor = {},
                         )

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/desktop/ShellHarness.kt
@@ -23,20 +23,26 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.ComposeTimeoutException
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isSelectable
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.runDesktopComposeUiTest
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import app.skerry.ui.AppDependencies
@@ -145,10 +151,17 @@ internal fun seededRunbooks(): RunbookManager {
     return RunbookManager(store) { "run-${seq++}" }
 }
 
+/** The window every shell test gets unless it asks for another — `runComposeUiTest`'s own default. */
+internal const val DEFAULT_SHELL_WIDTH = 1024
+
 /** Desktop shell over the seeded catalog. [withSessions] opens two demo tabs over a fake transport. */
 @OptIn(ExperimentalTestApi::class)
 internal fun runDesktopShell(
     withSessions: Boolean = true,
+    // Width of the test window. The toolbar collapses its actions into an overflow menu once they
+    // no longer fit beside the work bar's title, and that menu is a second rendering of the same
+    // actions — reachable in a test only by making the window too small for the row.
+    windowWidth: Int = DEFAULT_SHELL_WIDTH,
     // Custom window chrome, for the tests that drive the titlebar's window gestures. null (the
     // default) renders the decorated-window titlebar, like the offscreen previews.
     windowChrome: WindowChrome? = null,
@@ -156,7 +169,7 @@ internal fun runDesktopShell(
     // test scene's own [WindowInfo] is hardcoded focused, so there is no other way to drive it.
     windowInfo: WindowInfo? = null,
     body: ComposeUiTest.(DesktopShell) -> Unit,
-) = runComposeUiTest {
+) = runDesktopComposeUiTest(width = windowWidth) {
     val keyGenerator = BouncyCastleSshKeyGenerator()
     val credentials = seededVault(keyGenerator)
     val hosts = seededHosts(boundCredentialId = credentials.credentials.firstOrNull()?.id)
@@ -267,6 +280,8 @@ internal class MobileShell(
     val tunnels: TunnelManager,
     val runbooks: RunbookManager,
     val ai: AiAssistantController,
+    /** Null unless the run asked for sessions — the sheets that outlive one are tested through it. */
+    val sessions: SessionsController? = null,
 )
 
 /**
@@ -332,7 +347,7 @@ internal fun runMobileShell(
                 s is ConnectionUiState.Connected
             }
         }
-        body(MobileShell(hosts, state, snippets, tunnels, mobileRunbooks, ai))
+        body(MobileShell(hosts, state, snippets, tunnels, mobileRunbooks, ai, sessions))
     } finally {
         runner.close()
         sessions?.disconnectAll()
@@ -447,6 +462,57 @@ internal fun string(resource: StringResource, vararg args: Any): String = runBlo
  * are already carrying other Gradle workers — a timeout there fails a correct build.
  */
 internal const val CROSS_THREAD_TIMEOUT_MS = 5_000L
+
+/**
+ * Clicks the icon button named [name] once it is enabled.
+ *
+ * The session-scoped toolbar actions are disabled until the composition has caught up with the
+ * connection, and the seeded session connects on a background thread: the model says Connected
+ * before the frame that redraws the toolbar has run. A press on a disabled button is refused with
+ * nothing to show for it, so a test that clicks the instant the harness hands it the shell loses
+ * the click and fails ten seconds later on whatever the click was supposed to open, with nothing in
+ * the message pointing back here. Waiting on the button's own state rather than on a frame count is
+ * what makes that impossible rather than unlikely.
+ *
+ * Enabled, not [androidx.compose.ui.test.hasClickAction]: Compose keeps the `OnClick` action on a
+ * disabled clickable and marks it `Disabled` beside it, so matching on the action would go through
+ * on the very frame this waits out.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun ComposeUiTest.clickIconWhenEnabled(name: String, shell: DesktopShell? = null) {
+    // `!isSelectable()` because the nav rail's own entries carry the same names as some of the
+    // toolbar's buttons ("Snippets" is both), and only the rail's are selectable navigation targets.
+    val button = hasContentDescription(name) and isEnabled() and !isSelectable()
+    try {
+        waitUntil("\"$name\" to become clickable", timeoutMillis = 10_000) {
+            onAllNodes(button).fetchSemanticsNodes().isNotEmpty()
+        }
+    } catch (timeout: ComposeTimeoutException) {
+        // "Condition still not satisfied after 10000ms" names neither the button nor the reason it
+        // stayed disabled, and this one only ever fails on a loaded runner — where a re-run to look
+        // closer costs the whole suite. The tree and the session already hold the answer.
+        throw AssertionError("\"$name\" never became enabled. ${diagnose(name, shell)}", timeout)
+    }
+    onNode(button).performClick()
+}
+
+/** What the button and the session behind it looked like when the wait above ran out. */
+@OptIn(ExperimentalTestApi::class)
+private fun ComposeUiTest.diagnose(name: String, shell: DesktopShell?): String {
+    val nodes = onAllNodes(hasContentDescription(name) and !isSelectable()).fetchSemanticsNodes()
+    val drawn = nodes.joinToString(" | ") { node ->
+        "bounds=${node.boundsInRoot} disabled=${node.config.contains(SemanticsProperties.Disabled)}"
+    }
+    val pane = shell?.sessions?.active?.focusedPane
+    val session = pane?.let { "pane=${it.id} state=${it.controller.uiState::class.simpleName}" } ?: "no active pane"
+    val runner = shell?.runner?.let { "runnerActive=${it.active} pending=${it.pending != null} phase=${it.phase}" } ?: ""
+    // Whether one more settled frame flips it: a button still disabled after the tree goes idle is
+    // a predicate that says no, not a frame the wait above failed to pump.
+    waitForIdle()
+    val afterIdle = onAllNodes(hasContentDescription(name) and isEnabled() and !isSelectable())
+        .fetchSemanticsNodes().size
+    return "${nodes.size} node(s) carry that name: $drawn. $session $runner enabledAfterIdle=$afterIdle"
+}
 
 /**
  * Every string the tree draws, in order. Unmerged: a text node absorbed into a clickable ancestor's

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSheetOutlivesSessionTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/mobile/MobileSheetOutlivesSessionTest.kt
@@ -1,0 +1,62 @@
+package app.skerry.ui.mobile
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.ui.app.MobileRoute
+import app.skerry.ui.connection.ConnectionUiState
+import app.skerry.ui.connection.toTarget
+import app.skerry.ui.desktop.runMobileShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.lib_snippets_screen_title
+import app.skerry.ui.generated.resources.term_header_menu
+import app.skerry.ui.generated.resources.lib_snippets_run_title
+import kotlin.test.Test
+
+/**
+ * The phone's half of what the desktop toolbar fixed: a sheet raised over a session must not come
+ * back by itself when that session reconnects.
+ *
+ * The pane id survives a drop — the controller reconnects in place — so the flag behind the sheet
+ * is not reset by anything, and its render guard only hides it while the terminal is gone. Auto
+ * reconnect then brings the sheet up over the shell the user just got their caret back in.
+ */
+@OptIn(ExperimentalTestApi::class)
+class MobileSheetOutlivesSessionTest {
+
+    @Test
+    fun `a sheet open when the session dropped does not come back with it`() = runMobileShell(withSessions = true) { shell ->
+        val sessions = requireNotNull(shell.sessions)
+        shell.state.push(MobileRoute.Terminal)
+        waitForIdle()
+
+        onNodeWithContentDescription(string(Res.string.term_header_menu)).performClick()
+        waitForIdle()
+        onNodeWithText(string(Res.string.lib_snippets_screen_title)).performClick()
+        val placeholder = string(Res.string.lib_snippets_run_title)
+        waitUntil("the snippet sheet to open", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val controller = sessions.active!!.focusedPane.controller
+        controller.disconnect()
+        waitUntil("the sheet to go with the session", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isEmpty()
+        }
+
+        val host = shell.hosts.hosts.first()
+        controller.connect(host.toTarget(), SshAuth.Password(""))
+        waitUntil("the session to come back", timeoutMillis = 10_000) {
+            controller.uiState is ConnectionUiState.Connected
+        }
+        waitForIdle()
+        onNodeWithText(placeholder).assertDoesNotExist()
+        // The screen itself is still there — this is about the sheet, not the terminal.
+        onNodeWithContentDescription(string(Res.string.term_header_menu)).assertIsDisplayed()
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookEditorFormTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/runbook/RunbookEditorFormTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.performTextInput
 import app.skerry.shared.runbook.RunbookStep
 import app.skerry.ui.app.DesktopView
 import app.skerry.ui.app.UiTags
+import app.skerry.ui.desktop.clickIconWhenEnabled
 import app.skerry.ui.desktop.onField
 import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.desktop.string
@@ -88,7 +89,7 @@ class RunbookEditorFormTest {
         shell.runbooks.save(RunbookDraft(label = "Runnable", steps = listOf(RunbookStep.Command(id = "s1", command = "uptime"))))
         shell.runbooks.save(RunbookDraft(label = "Synced empty procedure"))
 
-        onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).performClick()
+        clickIconWhenEnabled(string(Res.string.runbook_toolbar_tip), shell)
         // The palette fills from the library on the shell's own scope, which waitForIdle does not
         // wait for: asserting on the frame after the click reads an empty palette on a loaded
         // runner and a full one on an idle machine (issue #330).
@@ -105,7 +106,7 @@ class RunbookEditorFormTest {
     fun `the palette says why it offers nothing`() = runDesktopShell(withSessions = true) { shell ->
         shell.runbooks.save(RunbookDraft(label = "Synced empty procedure"))
 
-        onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).performClick()
+        clickIconWhenEnabled(string(Res.string.runbook_toolbar_tip), shell)
         waitUntil("the palette to say why it offers nothing", timeoutMillis = 10_000) {
             onAllNodesWithText(string(Res.string.runbook_none_runnable)).fetchSemanticsNodes().isNotEmpty()
         }

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/session/SessionTabsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/session/SessionTabsTest.kt
@@ -2,10 +2,12 @@ package app.skerry.ui.session
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
 import app.skerry.ui.desktop.DesktopShell
 import app.skerry.ui.desktop.onTab
+import app.skerry.ui.desktop.clickIconWhenEnabled
 import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
@@ -77,7 +79,7 @@ class SessionTabsTest {
         // With one pane there is nothing to synchronize, so the toggle is not drawn yet.
         onNodeWithContentDescription(string(Res.string.shell_tip_sync_panes)).assertDoesNotExist()
 
-        onNodeWithContentDescription(string(Res.string.shell_tip_add_pane)).performClick()
+        clickIconWhenEnabled(string(Res.string.shell_tip_add_pane), shell)
         waitForIdle()
         assertTrue(requireNotNull(sessions.activeTerminal).isSplit, "adding a pane splits the tab")
 
@@ -90,14 +92,15 @@ class SessionTabsTest {
     }
 
     /**
-     * A tab's grid is bounded ([MAX_PANES]). The button stays on screen but stops acting — pressing
-     * it again must not quietly drop the pane it cannot place.
+     * A tab's grid is bounded ([MAX_PANES]). The button goes disabled at the limit rather than
+     * staying lit over a refusal, so the presses past it land on nothing at all.
      */
     @Test
     fun `a full grid refuses another pane`() = runDesktopShell { shell ->
         val sessions = requireNotNull(shell.sessions)
         repeat(MAX_PANES + 1) {
-            onNodeWithContentDescription(string(Res.string.shell_tip_add_pane)).performClick()
+            val button = onNodeWithContentDescription(string(Res.string.shell_tip_add_pane))
+            if (it < MAX_PANES - 1) button.performClick() else button.assertIsNotEnabled()
             waitForIdle()
         }
         assertEquals(

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetOneTapRunTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/SnippetOneTapRunTest.kt
@@ -2,10 +2,9 @@ package app.skerry.ui.snippet
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasContentDescription
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import app.skerry.ui.desktop.clickIconWhenEnabled
 import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
@@ -35,12 +34,7 @@ class SnippetOneTapRunTest {
         shell.snippets.save(SnippetDraft(label = "Rollout", command = "echo " + "x".repeat(300)))
         waitForIdle()
 
-        // The nav rail's Snippets destination carries the same name — the one wanted here is the
-        // toolbar button over the terminal, which has no rail tag.
-        onNode(
-            hasContentDescription(string(Res.string.shell_tip_snippets)) and
-                !hasTestTag("nav.rail.view.Snippets"),
-        ).performClick()
+        clickIconWhenEnabled(string(Res.string.shell_tip_snippets), shell)
         waitForIdle()
         onNodeWithText("Rollout").performClick()
         waitForIdle()

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/snippet/UntrustedSnippetTextTest.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import app.skerry.ui.generated.resources.lib_snippets_field_notes
 import app.skerry.ui.generated.resources.lib_snippets_run_title
 import app.skerry.ui.app.DesktopView
+import app.skerry.ui.desktop.clickIconWhenEnabled
 import app.skerry.ui.desktop.runDesktopShell
 import app.skerry.ui.runbook.RunbookDraft
 import app.skerry.ui.generated.resources.runbook_toolbar_tip
@@ -339,7 +340,7 @@ class UntrustedSnippetTextTest {
 
             shell.state.showView(DesktopView.Terminal)
             waitForIdle()
-            onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).performClick()
+            clickIconWhenEnabled(string(Res.string.runbook_toolbar_tip), shell)
             waitForIdle()
             assertNothingReordered()
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalTypingTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/TerminalTypingTest.kt
@@ -29,7 +29,11 @@ class TerminalTypingTest {
     fun `a typed character reaches the session`() = runDesktopShell {
         FakeShellInput.clear()
         onRoot().performKeyInput { pressKey(Key.L) }
-        waitUntil { FakeShellInput.all().contains("l") }
+        // The write leaves on the session's own scope (Dispatchers.Default), which the test clock
+        // does not drive: the default one-second budget is the loaded runner's, not the code's.
+        waitUntil("the typed character to reach the channel", timeoutMillis = 10_000) {
+            FakeShellInput.all().contains("l")
+        }
     }
 
     /** Ctrl+C is not a character: it goes down the wire as the interrupt byte. */
@@ -37,7 +41,9 @@ class TerminalTypingTest {
     fun `ctrl-C sends the interrupt byte`() = runDesktopShell {
         FakeShellInput.clear()
         onRoot().performKeyInput { withKeyDown(Key.CtrlLeft) { pressKey(Key.C) } }
-        waitUntil { FakeShellInput.all().contains(INTERRUPT) }
+        waitUntil("the interrupt byte to reach the channel", timeoutMillis = 10_000) {
+            FakeShellInput.all().contains(INTERRUPT)
+        }
     }
 }
 

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/ToolbarDisabledActionsTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/terminal/ToolbarDisabledActionsTest.kt
@@ -1,0 +1,179 @@
+package app.skerry.ui.terminal
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isSelectable
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performMouseInput
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
+import app.skerry.shared.ssh.SshAuth
+import app.skerry.ui.app.UiTags
+import app.skerry.ui.connection.toTarget
+import app.skerry.ui.desktop.clickIconWhenEnabled
+import app.skerry.ui.desktop.runDesktopShell
+import app.skerry.ui.desktop.string
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.runbook_palette_placeholder
+import app.skerry.ui.generated.resources.runbook_toolbar_tip
+import app.skerry.ui.generated.resources.share_session
+import app.skerry.ui.generated.resources.shell_tip_add_pane
+import app.skerry.ui.generated.resources.shell_tip_record
+import app.skerry.ui.generated.resources.shell_tip_play
+import app.skerry.ui.generated.resources.shell_tip_snippets
+import app.skerry.ui.generated.resources.term_run_snippet_placeholder
+import app.skerry.ui.session.MAX_PANES
+import kotlin.test.Test
+
+/**
+ * A toolbar action with nothing to act on has to be a disabled button, not a lit one that drops the
+ * press.
+ *
+ * The palettes and the add-pane button drew themselves faint and kept their click action, guarding
+ * inside the handler instead: the press landed, took focus, and nothing happened — no palette, no
+ * reason, and a screen reader still announcing a button. It is the same gap the palette tests kept
+ * tripping over, since a click sent one frame before the toolbar caught up with the connection is
+ * swallowed in exactly this way.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ToolbarDisabledActionsTest {
+
+    @Test
+    fun `the palettes are disabled with no session to run into`() = runDesktopShell(withSessions = false) {
+        onNodeWithContentDescription(string(Res.string.runbook_toolbar_tip)).assertIsNotEnabled()
+        toolbarButton(string(Res.string.shell_tip_snippets)).assertIsNotEnabled()
+        toolbarButton(string(Res.string.shell_tip_record)).assertIsNotEnabled()
+    }
+
+    /**
+     * The other half of the contract, and the one that keeps the fix honest: disabling the button
+     * for good would satisfy the test above on its own. Waited for rather than asserted on the spot
+     * — the seeded session connects on a background scope, and the toolbar learns about it a frame
+     * later.
+     */
+    @Test
+    fun `the palettes become buttons once a session is connected`() = runDesktopShell {
+        waitUntil("the palettes to become clickable", timeoutMillis = 10_000) {
+            onAllNodes(isEnabled() and hasContentDescription(string(Res.string.runbook_toolbar_tip)))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        toolbarButton(string(Res.string.shell_tip_snippets)).assertIsEnabled()
+        toolbarButton(string(Res.string.shell_tip_record)).assertIsEnabled()
+    }
+
+    /**
+     * An open palette that outlives its session is worse than a stale panel: the popup is hidden
+     * while the pane is down, but the flag behind it stays set, so an auto-reconnect brings the
+     * palette back unasked — and it is focusable, so it takes the caret out of the shell the user
+     * just got back. Driven on the pane's own controller, the way a reconnect goes: replacing the
+     * pane would re-key the button's state and hide a missing reset instead of proving it.
+     */
+    @Test
+    fun `a palette open when the session dropped does not come back with it`() = runDesktopShell { shell ->
+        val sessions = requireNotNull(shell.sessions)
+        val placeholder = string(Res.string.term_run_snippet_placeholder)
+        val snippets = string(Res.string.shell_tip_snippets)
+        clickIconWhenEnabled(snippets, shell)
+        waitUntil("the snippet palette to open", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val controller = sessions.active!!.focusedPane.controller
+        controller.disconnect()
+        waitUntil("the palette to go with the session", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isEmpty()
+        }
+
+        val host = shell.hosts.hosts.first()
+        controller.connect(host.toTarget(), SshAuth.Password(""))
+        waitUntil("the pane to come back", timeoutMillis = 10_000) {
+            onAllNodes(isEnabled() and hasContentDescription(snippets) and !isSelectable())
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText(placeholder).assertDoesNotExist()
+    }
+
+    /**
+     * The same contract for the runbook palette, which has one more moving part than the snippet
+     * one: its button doubles as the way back to a run in progress, so the reset has to sit ahead
+     * of that branch rather than inside the palette half of it.
+     */
+    @Test
+    fun `the runbook palette does not come back with the session either`() = runDesktopShell { shell ->
+        val sessions = requireNotNull(shell.sessions)
+        val placeholder = string(Res.string.runbook_palette_placeholder)
+        val runbooks = string(Res.string.runbook_toolbar_tip)
+        clickIconWhenEnabled(runbooks, shell)
+        waitUntil("the runbook palette to open", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        val controller = sessions.active!!.focusedPane.controller
+        controller.disconnect()
+        waitUntil("the palette to go with the session", timeoutMillis = 10_000) {
+            onAllNodesWithText(placeholder).fetchSemanticsNodes().isEmpty()
+        }
+
+        val host = shell.hosts.hosts.first()
+        controller.connect(host.toTarget(), SshAuth.Password(""))
+        waitUntil("the pane to come back", timeoutMillis = 10_000) {
+            onAllNodes(isEnabled() and hasContentDescription(runbooks) and !isSelectable())
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText(placeholder).assertDoesNotExist()
+    }
+
+    @Test
+    fun `add pane is disabled once the tab is full`() = runDesktopShell { shell ->
+        val sessions = requireNotNull(shell.sessions)
+        repeat(MAX_PANES - 1) { sessions.addPane() }
+        waitForIdle()
+        onNodeWithContentDescription(string(Res.string.shell_tip_add_pane)).assertIsNotEnabled()
+    }
+
+    /**
+     * The tooltip is the only name an icon button has, and `clickable` stops emitting hover the
+     * moment it is disabled — so disabling the button is exactly where its name is easiest to lose.
+     */
+    @Test
+    fun `a disabled action still names itself under the pointer`() = runDesktopShell(withSessions = false) {
+        val name = string(Res.string.runbook_toolbar_tip)
+        onNodeWithContentDescription(name).assertIsNotEnabled().performMouseInput { moveTo(center) }
+        waitUntil("the tooltip of the disabled button", timeoutMillis = 10_000) {
+            onAllNodesWithText(name).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /**
+     * The row and the overflow menu are two renderings of one action set, and the menu is the one a
+     * narrow window leaves the user: a row that fires a request nothing acts on costs the press and
+     * the menu both.
+     */
+    @Test
+    fun `the overflow menu refuses what the row would refuse`() = runDesktopShell(withSessions = false, windowWidth = 560) {
+        onNodeWithTag(UiTags.TOOLBAR_OVERFLOW).performClick()
+        waitUntil("the overflow menu to open", timeoutMillis = 10_000) {
+            onAllNodesWithText(string(Res.string.shell_tip_snippets)).fetchSemanticsNodes().isNotEmpty()
+        }
+        onNodeWithText(string(Res.string.shell_tip_snippets)).assertIsNotEnabled()
+        onNodeWithText(string(Res.string.runbook_toolbar_tip)).assertIsNotEnabled()
+        // Share is gated on the session too, and by a rule of its own: a running stream keeps the
+        // control that stops it, so the row cannot simply read `terminal != null`.
+        onNodeWithText(string(Res.string.share_session)).assertIsNotEnabled()
+        // Not everything in the menu is session-scoped: the recording player opens from a file.
+        onNodeWithText(string(Res.string.shell_tip_play)).assertIsEnabled()
+    }
+
+    /**
+     * The nav rail's Snippets entry carries the same name as the toolbar's button, and only the rail
+     * one is a selectable navigation target.
+     */
+    private fun ComposeUiTest.toolbarButton(name: String) =
+        onNode(hasContentDescription(name) and !isSelectable())
+}


### PR DESCRIPTION
A toolbar action with nothing to act on is now a disabled button, not a lit one that drops the press.

The session palettes and the add-pane button drew themselves faint but kept their click action and guarded inside the handler. The press landed, took the focus, and nothing happened — no palette, no reason given, and a screen reader still announcing an ordinary button. The same gap made the shell tests race the connection: a click sent one frame before the toolbar caught up was swallowed in exactly this way.

## What changed

**One rule, one place.** `toolbarActionEnabled` is a plain function over three booleans — a live terminal, an idle runbook runner, a running share — with a `@Composable` wrapper that reads them from the composition. The toolbar row, the overflow menu and each button now ask the same function, so a row in the menu can no longer be lit where the button is disabled. Share is the case that needed it: a running stream keeps the control that stops it, so the rule is not `terminal != null`.

**A palette does not outlive its session.** `CloseWhenUnavailable` closes a panel when what it acts on goes away. The popup was already hidden while the pane was down, but the flag behind it stayed set — an auto-reconnect brought the palette back unasked, and it is focusable, so it took the caret out of the shell the user had just got back. Applied to the snippet palette, the runbook palette, the share panel, and the phone's three session sheets.

**Chords are consumed where they would land somewhere worse.** Ctrl+Shift+D over a full tab used to fall through to the shell as EOT and end the session. The snippet, recording, find and command-palette chords used to be typed into a VNC/RDP guest that holds the keyboard. All of them are now consumed — and consumed is all they do there: a panel that can reach no terminal is a worse answer than a key that does nothing, so the chord acts only where there is a connected pane.

**A disabled button keeps its name.** `clickable` stops emitting hover once disabled, and the tooltip is the only accessible name an icon button has, so `IconBtn` tracks hover on a source of its own. Overflow rows dim their icon and label together.

The recording player's button is disabled while its file picker is up rather than merely dimmed, and the VNC test fakes moved into `ConnectionTestFixtures.kt`.

`SessionsController` gained `acceptsPane` — a full grid, a remote desktop and a recording player each have nowhere to put another pane — and `addPane` enforces it.

## Tests

- `ToolbarDisabledActionsTest` (new, desktop) — the palettes are disabled with no session, become buttons once connected, do not come back with a reconnect (snippets and runbooks both), name themselves under the pointer while disabled, and the overflow menu refuses what the row refuses.
- `ToolbarActionEnabledTest` (new, common) — every arm of the rule, including a share that outlived its pane.
- `MobileSheetOutlivesSessionTest` (new, desktop) — the phone sheet does not return with the reconnect.
- `DesktopShortcutsTest` — add-pane is consumed once the tab is full; the session chords fall through with nothing connected, and over a remote desktop or in the preview shell they are consumed while asking for nothing (both request flows are collected and asserted empty).
- `SessionsControllerTest` — `acceptsPane` names every tab with nowhere to put one.

## Verifying by hand

Open the app with no session: the snippet, runbook and record icons are grey and refuse the click, and hovering one still shows its name. Narrow the window until the toolbar collapses into "⋯" — the same entries are dimmed there. Connect a host, open the snippet palette, kill the connection on the server side and let it reconnect: the palette stays closed. Split the tab to the last pane and press Ctrl+Shift+D: nothing happens, and nothing is typed into the shell.
