### PR TITLE
Treat a remote listing as the server's answer, not a fact (#309, #306)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
@@ -28,6 +28,9 @@
     <string name="ftail_err_open_target">Не удалось открыть файл для записи</string>
     <string name="ftail_err_session_closed">Сессия закрыта до начала передачи</string>
     <string name="ftail_err_too_large">Файл слишком большой, чтобы открыть его</string>
+    <string name="ftail_err_tree_too_large">Дерево каталогов слишком глубокое или слишком большое для передачи</string>
+    <string name="ftail_err_tree_too_deep">Дерево каталогов слишком глубокое для обхода</string>
+    <string name="ftail_err_unexpected">Непредвиденная ошибка</string>
 
     <!-- Ошибки просмотрщика/редактора (F3/F4) -->
     <string name="ftail_edit_err_read">Не удалось прочитать файл</string>

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
@@ -28,6 +28,9 @@
     <string name="ftail_err_open_target">无法打开保存目标</string>
     <string name="ftail_err_session_closed">会话在传输开始前已关闭</string>
     <string name="ftail_err_too_large">文件太大，无法打开</string>
+    <string name="ftail_err_tree_too_large">目录树太深或太大，无法传输</string>
+    <string name="ftail_err_tree_too_deep">目录树太深，无法遍历</string>
+    <string name="ftail_err_unexpected">意外错误</string>
 
     <!-- 查看器/编辑器（F3/F4）失败原因 -->
     <string name="ftail_edit_err_read">读取文件失败</string>

--- a/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
@@ -28,6 +28,9 @@
     <string name="ftail_err_open_target">Failed to open the save target</string>
     <string name="ftail_err_session_closed">Session closed before it started</string>
     <string name="ftail_err_too_large">File is too large to open</string>
+    <string name="ftail_err_tree_too_large">Folder tree is too deep or too large to transfer</string>
+    <string name="ftail_err_tree_too_deep">Folder tree is too deep to walk</string>
+    <string name="ftail_err_unexpected">Unexpected error</string>
 
     <!-- Viewer/editor (F3/F4) failures -->
     <string name="ftail_edit_err_read">Failed to read the file</string>

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileEditController.kt
@@ -156,9 +156,10 @@ class FileEditController(
                 state = FileEditState.Failed(
                     if (e.failure == FileBrowserFailure.TooLarge) FileEditFailure.TooLarge else FileEditFailure.Read,
                 )
-            } catch (_: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") _: Throwable) {
                 // Anything the source didn't wrap still has to land somewhere: an unhandled type
-                // would otherwise leave the editor spinning on Loading with no explanation.
+                // would otherwise leave the editor spinning on Loading with no explanation, and an
+                // Error would take the session's shared scope down on its way out.
                 state = FileEditState.Failed(FileEditFailure.Read)
             } finally {
                 busy = false
@@ -250,7 +251,9 @@ class FileEditController(
             onSaved()
         } catch (e: CancellationException) {
             throw e
-        } catch (_: FileBrowserException) {
+        } catch (@Suppress("TooGenericExceptionCaught") _: Throwable) {
+            // Same rule as the read above: a save that ends on something the source never wraps is
+            // still a save the user asked for, and still theirs to be told about.
             saveFailure = FileEditFailure.Write
         } finally {
             saving = false

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
@@ -15,6 +15,9 @@ import app.skerry.ui.generated.resources.ftail_err_open_target
 import app.skerry.ui.generated.resources.ftail_err_session_closed
 import app.skerry.ui.generated.resources.ftail_err_sftp
 import app.skerry.ui.generated.resources.ftail_err_too_large
+import app.skerry.ui.generated.resources.ftail_err_tree_too_deep
+import app.skerry.ui.generated.resources.ftail_err_tree_too_large
+import app.skerry.ui.generated.resources.ftail_err_unexpected
 import app.skerry.ui.generated.resources.ftail_transfer_error
 import org.jetbrains.compose.resources.stringResource
 
@@ -28,6 +31,11 @@ fun fileBrowserFailureText(failure: FileBrowserFailure): String = stringResource
         FileBrowserFailure.OpenSource -> Res.string.ftail_err_open_source
         FileBrowserFailure.OpenTarget -> Res.string.ftail_err_open_target
         FileBrowserFailure.TooLarge -> Res.string.ftail_err_too_large
+        // The pane's own walk is the recursive delete, which is bounded by depth and never by size,
+        // so the reason it stops is never "too large" — and the transfer wording would name a verb
+        // this operation has nothing to do with.
+        FileBrowserFailure.TreeTooLarge -> Res.string.ftail_err_tree_too_deep
+        FileBrowserFailure.Unexpected -> Res.string.ftail_err_unexpected
     },
 )
 
@@ -52,5 +60,6 @@ fun transferFailureText(failure: FileTransferFailure): String = stringResource(
         FileTransferFailure.OpenSource -> Res.string.ftail_err_open_source
         FileTransferFailure.OpenTarget -> Res.string.ftail_err_open_target
         FileTransferFailure.SessionClosed -> Res.string.ftail_err_session_closed
+        FileTransferFailure.TreeTooLarge -> Res.string.ftail_err_tree_too_large
     },
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FilePaneController.kt
@@ -634,14 +634,23 @@ class FilePaneController(
         scope.launch { gate.withLock { runOp(block) } }.invokeOnCompletion { pending-- }
     }
 
-    /** Body shared by [op]/[queuedOp]: runs the operation, mapping a failure into [FilePaneState.Error]. */
+    /**
+     * Body shared by [op]/[queuedOp]: runs the operation, mapping a failure into
+     * [FilePaneState.Error].
+     *
+     * Throwable, not [FileBrowserException]: this runs on the scope the whole composition shares,
+     * and that scope carries a plain Job. Anything the source throws without wrapping — a walk over
+     * a server's listing that overflows the stack, a bug — used to leave the launch uncaught, which
+     * cancels every other session's coroutines and, on Android, kills the process. The pane showed
+     * nothing at all for an action the user had confirmed.
+     */
     private suspend fun runOp(block: suspend () -> Unit) {
         try {
             block()
         } catch (e: CancellationException) {
             throw e
-        } catch (e: FileBrowserException) {
-            state = FilePaneState.Error(e.failure)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+            state = FilePaneState.Error((e as? FileBrowserException)?.failure ?: FileBrowserFailure.Unexpected)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
@@ -5,6 +5,7 @@ import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.shared.files.TreeWalkLimit
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntryType
 
@@ -17,6 +18,13 @@ internal class TransferPlan<T> {
     val dirs = mutableListOf<String>()
     val files = mutableListOf<T>()
 }
+
+/**
+ * What a walk knows about one entry before it plans it: the listing's [name], [type] and [size], and
+ * nothing else. Deliberately not a [FileItem] — that carries a path, and on the remote side the path
+ * in a listing is the server's to choose; every path a walk uses is rebuilt from a validated name.
+ */
+private class WalkEntry(val name: String, val type: FileItemType, val size: Long)
 
 /** One download task: [name] for the progress bar, remote [remotePath] to local [localPath]. */
 internal data class DownloadTask(val name: String, val remotePath: String, val localPath: String, val size: Long)
@@ -37,13 +45,14 @@ internal suspend fun buildDownloadPlan(
     remoteDir: String,
 ): TransferPlan<DownloadTask> {
     val walk = DownloadWalk(sftp)
-    items.forEach { walk.walk(it.name, childPath(remoteDir, it.name), it.type, it.size, localDir) }
+    items.forEach { walk.walk(WalkEntry(it.name, it.type, it.size), childPath(remoteDir, it.name), localDir, depth = 0) }
     return walk.plan
 }
 
 /**
  * Walks a remote tree entry, filling the plan it carries. A file becomes a download task; a directory adds a
- * local subdirectory and recurses; symlinks/other are skipped.
+ * local subdirectory and recurses; symlinks/other are skipped. [depth] is how far below the selected
+ * item this entry sits, checked against [TreeWalkLimit] before descending.
  *
  * Path-traversal guard against an untrusted server: [name] must be a plain name (no `/`/`\`
  * separators, not `.`/`..`, not empty). Child remote paths are rebuilt from the parent + a
@@ -52,22 +61,29 @@ internal suspend fun buildDownloadPlan(
  */
 private class DownloadWalk(private val sftp: SftpClient) {
     val plan = TransferPlan<DownloadTask>()
+    private val limit = TreeWalkLimit()
 
-    suspend fun walk(name: String, remotePath: String, type: FileItemType, size: Long, localDir: String) {
-        if (isUnsafeListingName(name)) {
-            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+    suspend fun walk(entry: WalkEntry, remotePath: String, localDir: String, depth: Int) {
+        if (isUnsafeListingName(entry.name)) {
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = entry.name)
         }
-        val localPath = childPath(localDir, name)
-        when (type) {
-            FileItemType.File -> plan.files += DownloadTask(name, remotePath, localPath, size)
+        val localPath = childPath(localDir, entry.name)
+        when (entry.type) {
+            FileItemType.File -> {
+                limit.count()
+                plan.files += DownloadTask(entry.name, remotePath, localPath, entry.size)
+            }
             FileItemType.Directory -> {
+                limit.count()
+                limit.descend(depth + 1)
                 plan.dirs += localPath
                 // De-duplicated by name, not by path: the walk reads the SFTP client directly rather
                 // than the browser that de-duplicates for the panel, and every local path it writes
                 // is built from the name. A repeat would plan two tasks onto one local file, and the
                 // second would overwrite the first while the progress bar counted two.
                 sftp.list(remotePath).distinctBy { it.name }.forEach { child ->
-                    walk(child.name, childPath(remotePath, child.name), child.type.toItemType(), child.size, localPath)
+                    val next = WalkEntry(child.name, child.type.toItemType(), child.size)
+                    walk(next, childPath(remotePath, child.name), localPath, depth + 1)
                 }
             }
             FileItemType.Symlink, FileItemType.Other -> Unit
@@ -82,30 +98,37 @@ internal suspend fun buildUploadPlan(
     remoteDir: String,
 ): TransferPlan<UploadTask> {
     val walk = UploadWalk(localBrowser)
-    items.forEach { walk.walk(it.name, it.path, it.type, it.size, remoteDir) }
+    items.forEach { walk.walk(WalkEntry(it.name, it.type, it.size), it.path, remoteDir, depth = 0) }
     return walk.plan
 }
 
 /**
  * Walks a local tree entry, filling the plan it carries (mirrors [DownloadWalk]). A file becomes an upload task;
  * a directory adds a remote subdirectory and recurses ([localBrowser] lists the local FS);
- * symlinks/other are skipped. Remote paths are rebuilt from [remoteDir] + a validated name; local
- * paths come from the trusted local listing.
+ * symlinks/other are skipped. [depth] is bounded by the same [TreeWalkLimit]: a local loop is a bind
+ * mount away, and the plan is built before a byte moves either way. Remote paths are rebuilt from
+ * [remoteDir] + a validated name; local paths come from the trusted local listing.
  */
 private class UploadWalk(private val localBrowser: FileBrowser) {
     val plan = TransferPlan<UploadTask>()
+    private val limit = TreeWalkLimit()
 
-    suspend fun walk(name: String, localPath: String, type: FileItemType, size: Long, remoteDir: String) {
-        if (isUnsafeListingName(name)) {
-            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = name)
+    suspend fun walk(entry: WalkEntry, localPath: String, remoteDir: String, depth: Int) {
+        if (isUnsafeListingName(entry.name)) {
+            throw FileBrowserException(FileBrowserFailure.IllegalName, detail = entry.name)
         }
-        val remotePath = childPath(remoteDir, name)
-        when (type) {
-            FileItemType.File -> plan.files += UploadTask(name, localPath, remotePath, size)
+        val remotePath = childPath(remoteDir, entry.name)
+        when (entry.type) {
+            FileItemType.File -> {
+                limit.count()
+                plan.files += UploadTask(entry.name, localPath, remotePath, entry.size)
+            }
             FileItemType.Directory -> {
+                limit.count()
+                limit.descend(depth + 1)
                 plan.dirs += remotePath
                 localBrowser.list(localPath).forEach { child ->
-                    walk(child.name, child.path, child.type, child.size, remotePath)
+                    walk(WalkEntry(child.name, child.type, child.size), child.path, remotePath, depth + 1)
                 }
             }
             FileItemType.Symlink, FileItemType.Other -> Unit

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
@@ -62,7 +62,11 @@ private class DownloadWalk(private val sftp: SftpClient) {
             FileItemType.File -> plan.files += DownloadTask(name, remotePath, localPath, size)
             FileItemType.Directory -> {
                 plan.dirs += localPath
-                sftp.list(remotePath).forEach { child ->
+                // De-duplicated by name, not by path: the walk reads the SFTP client directly rather
+                // than the browser that de-duplicates for the panel, and every local path it writes
+                // is built from the name. A repeat would plan two tasks onto one local file, and the
+                // second would overwrite the first while the progress bar counted two.
+                sftp.list(remotePath).distinctBy { it.name }.forEach { child ->
                     walk(child.name, childPath(remotePath, child.name), child.type.toItemType(), child.size, localPath)
                 }
             }

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferRunner.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferRunner.kt
@@ -86,10 +86,11 @@ internal class TransferRunner(private val scope: CoroutineScope, private val que
     }
 
     /**
-     * Starts the next operation, or goes idle when there is none. Any error closes its entry as
-     * [TransferStatus.Failed] (named after the step it stopped on); [CancellationException]
-     * propagates. A scope that has already died runs nothing: what is left is released instead, or
-     * the handles would sit in a queue that never advances again.
+     * Starts the next operation, or goes idle when there is none. Anything thrown closes its entry
+     * as [TransferStatus.Failed] (named after the step it stopped on) — an `Error` included, since
+     * an entry nobody closes is one the queue keeps forever; [CancellationException] propagates. A
+     * scope that has already died runs nothing: what is left is released instead, or the handles
+     * would sit in a queue that never advances again.
      *
      * [CoroutineStart.ATOMIC] closes the gap between that check and the dispatch: a scope cancelled
      * in between would otherwise skip the body altogether, and with it the `finally` that releases
@@ -120,7 +121,14 @@ internal class TransferRunner(private val scope: CoroutineScope, private val que
                 // progress bar that never moves again.
                 queue.end(TransferStatus.Failed(FileTransferFailure.Transfer))
                 throw e
-            } catch (e: Exception) {
+            } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+                // Throwable, not Exception: a tree walk deep enough to overflow the stack arrives as
+                // an Error, and an Exception-shaped handler lets it past — leaving the entry Active
+                // for good, with a progress bar that never moves again and an idle auto-lock that
+                // keeps deferring on it. The entry is closed and the error is not rethrown: the
+                // stack has already unwound by the time this runs, and taking the window down is not
+                // a better answer than a failed row. This closes the row, nothing more — it is not a
+                // claim that the process is healthy after every Error.
                 val failure = (e as? FileBrowserException)?.failure?.toTransferFailure() ?: FileTransferFailure.Transfer
                 queue.end(TransferStatus.Failed(failure))
             } finally {

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferState.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferState.kt
@@ -27,6 +27,9 @@ enum class FileTransferFailure {
 
     /** The session closed while the operation was still waiting its turn on the channel. */
     SessionClosed,
+
+    /** The tree to transfer is deeper or bigger than a plan may hold — a loop, or simply too much. */
+    TreeTooLarge,
 }
 
 /** Maps a browser failure onto the transfer bar's reason; I/O-level causes collapse to [FileTransferFailure.Transfer]. */
@@ -34,7 +37,8 @@ internal fun FileBrowserFailure.toTransferFailure(): FileTransferFailure = when 
     FileBrowserFailure.IllegalName -> FileTransferFailure.IllegalName
     FileBrowserFailure.OpenSource -> FileTransferFailure.OpenSource
     FileBrowserFailure.OpenTarget -> FileTransferFailure.OpenTarget
-    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp, FileBrowserFailure.TooLarge ->
+    FileBrowserFailure.TreeTooLarge -> FileTransferFailure.TreeTooLarge
+    FileBrowserFailure.LocalIo, FileBrowserFailure.Sftp, FileBrowserFailure.TooLarge, FileBrowserFailure.Unexpected ->
         FileTransferFailure.Transfer
 }
 

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/mobile/MobileFilesPane.kt
@@ -136,6 +136,11 @@ internal fun MobileLivePane(
     val scroll = rememberScrollState()
     LaunchedEffect(pane.path) { scroll.scrollTo(0) }
 
+    // The listing and the failure notice are two branches of the same `when`, so the switch
+    // between them is an insertion, not a change a screen reader is told about (WCAG 4.1.3).
+    // The announcer sits above it, outlives the switch and carries the reason itself; every
+    // other state says nothing, so navigation churn stays silent.
+    StatusAnnouncer((pane.state as? FilePaneState.Error)?.let { fileBrowserFailureText(it.failure) } ?: "")
     Box(modifier.fillMaxWidth()) {
         when (val st = pane.state) {
             FilePaneState.Loading -> MobileFilesNoticeBox("sync", stringResource(Res.string.sftp_loading), null, Skerry.colors.faint)

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/sftp/SftpPane.kt
@@ -62,6 +62,7 @@ import org.jetbrains.compose.resources.stringResource
 import androidx.compose.runtime.DisposableEffect
 import app.skerry.ui.design.HLine
 import app.skerry.ui.design.IconBtn
+import app.skerry.ui.design.StatusAnnouncer
 import app.skerry.ui.design.Sym
 import app.skerry.ui.design.Txt
 import app.skerry.ui.design.fieldFocus
@@ -178,6 +179,11 @@ internal fun LivePane(
             )
             HLine()
         }
+        // The listing and the failure notice are two branches of the same `when`, so the switch
+        // between them is an insertion, not a change a screen reader is told about (WCAG 4.1.3).
+        // The announcer sits above it, outlives the switch and carries the reason itself; every
+        // other state says nothing, so navigation churn stays silent.
+        StatusAnnouncer((pane.state as? FilePaneState.Error)?.let { fileBrowserFailureText(it.failure) } ?: "")
         Box(Modifier.weight(1f).fillMaxWidth()) {
             when (val st = pane.state) {
                 FilePaneState.Loading -> PaneNotice("sync", stringResource(Res.string.sftp_loading), null, Skerry.colors.faint)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FileEditControllerTest.kt
@@ -295,6 +295,28 @@ class FileEditControllerTest {
         assertTrue(c.conflict)
         assertEquals("one\n", browser.contents.getValue(PATH).decodeToString())
     }
+
+    @Test
+    fun `a read that dies on something the source never wraps stops spinning`() = runTest {
+        // The editor runs on the session's scope, which the whole composition shares: an unwrapped
+        // throw used to leave it Loading for good and take that scope with it.
+        browser.unwrapped = true
+        val c = opened()
+
+        assertEquals(FileEditState.Failed(FileEditFailure.Read), c.state)
+    }
+
+    @Test
+    fun `a save that dies the same way is still reported`() = runTest {
+        val c = opened()
+        c.edit("server {\n  listen 80;\n}\n")
+        browser.unwrapped = true
+
+        c.save(); advanceUntilIdle()
+
+        assertEquals(FileEditFailure.Write, c.saveFailure)
+        assertFalse(c.saving)
+    }
 }
 
 /** In-memory [FileContentBrowser]; navigation isn't exercised by the editor. */
@@ -310,6 +332,9 @@ private class FakeContentBrowser : FileContentBrowser, FileBrowser {
     /** When set, [stat] fails — the editor must not lose its conflict baseline over it. */
     var statFails = false
 
+    /** When set, read/write die on something the source is not supposed to throw at all. */
+    var unwrapped = false
+
     override suspend fun realpath(path: String) = path
     override suspend fun list(path: String): List<FileItem> = emptyList()
     override suspend fun mkdir(path: String) = Unit
@@ -322,11 +347,13 @@ private class FakeContentBrowser : FileContentBrowser, FileBrowser {
     }
 
     override suspend fun readFile(path: String, maxBytes: Long): ByteArray {
+        if (unwrapped) throw StackOverflowError()
         failure?.let { throw FileBrowserException(it) }
         return contents[path] ?: throw FileBrowserException(FileBrowserFailure.Sftp)
     }
 
     override suspend fun writeFile(path: String, data: ByteArray) {
+        if (unwrapped) throw StackOverflowError()
         failure?.let { throw FileBrowserException(it) }
         writes++
         contents[path] = data

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
@@ -10,6 +10,7 @@ import app.skerry.ui.sftp.FakeSftpClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -91,6 +92,33 @@ class FilePaneControllerTest {
 
         assertEquals("$HOME/alpha", c.path)
         assertEquals(listOf("inside.txt"), c.loaded().entries.map { it.name })
+    }
+
+    @Test
+    fun `an operation that dies on something the source never wraps still lands on the pane`() = runTest {
+        // The pane runs on the composition-wide scope every session shares. Anything the source
+        // throws that is not a FileBrowserException used to leave that launch uncaught: the scope
+        // is a plain Job, so it takes every other session's coroutines down with it — and on
+        // Android the process — while the pane shows no error at all for an action the user
+        // confirmed.
+        val base = seededBrowser()
+        val brittle = object : FileBrowser {
+            override val label: String get() = base.label
+            override suspend fun realpath(path: String): String = base.realpath(path)
+            override suspend fun list(path: String): List<FileItem> = base.list(path)
+            override suspend fun mkdir(path: String) = base.mkdir(path)
+            override suspend fun delete(item: FileItem): Unit = throw StackOverflowError()
+            override suspend fun rename(from: String, to: String) = base.rename(from, to)
+        }
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+        val c = FilePaneController(brittle, scope)
+        c.start(); advanceUntilIdle()
+
+        c.delete(c.entry("readme.txt"))
+        advanceUntilIdle()
+
+        assertEquals(FilePaneState.Error(FileBrowserFailure.Unexpected), c.state)
+        assertTrue(scope.isActive, "the shared scope died with the operation")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -3,6 +3,8 @@ package app.skerry.ui.files
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.shared.sftp.SftpEntry
+import app.skerry.shared.sftp.SftpEntryType
 import app.skerry.ui.sftp.FakeSftpClient
 import app.skerry.ui.sftp.TransferDirection
 import kotlinx.coroutines.CompletableDeferred
@@ -382,6 +384,63 @@ class TransferCoordinatorTest {
         // The library text ("disk full") never reaches the bar — only the typed reason does.
         val failed = assertIs<TransferState.Failed>(r.coordinator.transfer)
         assertEquals(FileTransferFailure.Transfer, failed.failure)
+    }
+
+    @Test
+    fun `a tree with no bottom ends as a queue row that says why`() = runTest {
+        // The typed reason has to survive the whole way out — walk, coordinator, runner, queue — or
+        // the refusal reads as an ordinary transfer error and the string added for it is dead.
+        val remote = remoteFake().apply {
+            seedDir("$RHOME/loop")
+            listAnswer = { path ->
+                if (path.endsWith("/loop")) {
+                    listOf(SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0b111_101_101))
+                } else {
+                    null
+                }
+            }
+        }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+        r.remote.toggle(r.remote.entry("loop"))
+
+        r.coordinator.downloadSelection()
+        advanceUntilIdle()
+
+        assertEquals(
+            TransferStatus.Failed(FileTransferFailure.TreeTooLarge),
+            r.coordinator.queue.single().status,
+        )
+    }
+
+    @Test
+    fun `a move over a tree with no bottom keeps its sources`() = runTest {
+        // A move deletes the sources once the transfer is through. The refusal happens while the
+        // plan is being built, so nothing has moved and nothing may be deleted — the one outcome
+        // that would turn a refused transfer into lost data.
+        val remote = remoteFake().apply {
+            seedDir("$RHOME/loop")
+            listAnswer = { path ->
+                if (path.endsWith("/loop")) {
+                    listOf(SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0b111_101_101))
+                } else {
+                    null
+                }
+            }
+        }
+        val r = rig(remote = remote)
+        r.remote.refresh(); advanceUntilIdle()
+        r.remote.toggle(r.remote.entry("loop"))
+
+        r.coordinator.moveSelection(fromLocal = false)
+        advanceUntilIdle()
+
+        assertEquals(
+            TransferStatus.Failed(FileTransferFailure.TreeTooLarge),
+            r.coordinator.queue.single().status,
+        )
+        r.remote.refresh(); advanceUntilIdle()
+        assertTrue("loop" in (r.remote.state as FilePaneState.Loaded).entries.map { it.name }, "it deleted the source")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
@@ -4,6 +4,8 @@ import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.shared.files.MAX_TREE_DEPTH
+import app.skerry.shared.files.MAX_TREE_ENTRIES
 import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.shared.sftp.SftpEntry
 import app.skerry.shared.sftp.SftpEntryType
@@ -82,6 +84,145 @@ class TransferPlanTest {
         }
 
         assertEquals(FileBrowserFailure.IllegalName, failure.failure)
+    }
+
+    @Test
+    fun `a nested listing that repeats a name is planned once`() = runTest {
+        // The walk reads the SFTP client directly, not the de-duplicated browser, and it builds every
+        // local path from the entry's name — so a repeat inside a directory being downloaded plans two
+        // tasks writing the same local file, and the second silently overwrites the first while the
+        // progress bar counts two.
+        val entry = SftpEntry("dup.txt", "$REMOTE/proj/dup.txt", SftpEntryType.File, 5, 0, 0b110_100_100)
+        val remote = remote().apply {
+            listAnswer = { path -> if (path == "$REMOTE/proj") listOf(entry, entry) else null }
+        }
+
+        val plan = buildDownloadPlan(
+            remote,
+            listOf(item("proj", FileItemType.Directory, "$REMOTE/proj")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertEquals(listOf("$LOCAL/proj/dup.txt"), plan.files.map { it.localPath })
+    }
+
+    @Test
+    fun `a directory that lists itself as its own child stops the walk`() = runTest {
+        // A bind mount that contains itself, a FUSE mount, or a server that simply says so: the tree
+        // has no bottom, and the walk runs until the stack or the heap gives out — before a byte has
+        // moved, and outside the transfer's own error handling (#306).
+        val remote = remote().apply {
+            seedDir("$REMOTE/loop")
+            listAnswer = { path ->
+                if (path.endsWith("/loop")) {
+                    listOf(SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0b111_101_101))
+                } else {
+                    null
+                }
+            }
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildDownloadPlan(
+                remote,
+                listOf(item("loop", FileItemType.Directory, "$REMOTE/loop")),
+                localDir = LOCAL,
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+    }
+
+    @Test
+    fun `an upload walk over a local loop stops the same way`() = runTest {
+        // The upload walk carries its own copy of the guard, like the name check above.
+        val local = FakeSftpClient(startDir = LOCAL).apply {
+            seedDir("$LOCAL/loop")
+            listAnswer = { path ->
+                if (path.endsWith("/loop")) {
+                    listOf(SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0b111_101_101))
+                } else {
+                    null
+                }
+            }
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildUploadPlan(
+                SftpFileBrowser(local, "This Mac"),
+                listOf(item("loop", FileItemType.Directory, "$LOCAL/loop")),
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+    }
+
+    @Test
+    fun `a plan bigger than the cap stops before it is built`() = runTest {
+        // Depth is not the only way out of a bounded plan: one directory whose listing never ends
+        // is flat and still unbounded. The depth cap says nothing about it.
+        val remote = remote().apply {
+            seedDir("$REMOTE/wide")
+            val wide = (0..MAX_TREE_ENTRIES).map {
+                SftpEntry("f$it", "$REMOTE/wide/f$it", SftpEntryType.File, 1, 0, 0b110_100_100)
+            }
+            listAnswer = { path -> if (path == "$REMOTE/wide") wide else null }
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildDownloadPlan(
+                remote,
+                listOf(item("wide", FileItemType.Directory, "$REMOTE/wide")),
+                localDir = LOCAL,
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+    }
+
+    @Test
+    fun `a tree exactly as wide as the cap allows is still planned whole`() = runTest {
+        // The other half of the same boundary: the directory itself is one of the entries the walk
+        // takes on, so the last file the cap allows is the one that makes the count exact.
+        val remote = remote().apply {
+            seedDir("$REMOTE/wide")
+            val wide = (1 until MAX_TREE_ENTRIES).map {
+                SftpEntry("f$it", "$REMOTE/wide/f$it", SftpEntryType.File, 1, 0, 0b110_100_100)
+            }
+            listAnswer = { path -> if (path == "$REMOTE/wide") wide else null }
+        }
+
+        val plan = buildDownloadPlan(
+            remote,
+            listOf(item("wide", FileItemType.Directory, "$REMOTE/wide")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertEquals(MAX_TREE_ENTRIES - 1, plan.files.size)
+    }
+
+    @Test
+    fun `a tree exactly as deep as the cap allows is still planned whole`() = runTest {
+        // The caps bound a tree that has no bottom, not a tree anyone keeps: the last level the cap
+        // allows has to go through, or the bound is one level tighter than it says it is.
+        val remote = remote()
+        val deepest = (1..MAX_TREE_DEPTH).fold(REMOTE) { dir, level -> "$dir/d$level".also { remote.seedDir(it) } }
+        remote.seedFile("$deepest/leaf.txt", size = 1)
+
+        val plan = buildDownloadPlan(
+            remote,
+            listOf(item("d1", FileItemType.Directory, "$REMOTE/d1")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertEquals(MAX_TREE_DEPTH, plan.dirs.size)
+        assertEquals(1, plan.files.size)
     }
 
     @Test
@@ -169,26 +310,5 @@ class TransferPlanTest {
         assertEquals("$REMOTE/a.txt", safeRemoteChild("a.txt", REMOTE))
         assertFailsWith<FileBrowserException> { safeRemoteChild("../a.txt", REMOTE) }
         assertFailsWith<FileBrowserException> { safeRemoteChild("..", REMOTE) }
-    }
-
-    @Test
-    fun `a nested listing that repeats a name is planned once`() = runTest {
-        // The walk reads the SFTP client directly, not the de-duplicated browser, and it builds every
-        // local path from the entry's name — so a repeat inside a directory being downloaded plans two
-        // tasks writing the same local file, and the second silently overwrites the first while the
-        // progress bar counts two.
-        val entry = SftpEntry("dup.txt", "$REMOTE/proj/dup.txt", SftpEntryType.File, 5, 0, 0b110_100_100)
-        val remote = remote().apply {
-            listAnswer = { path -> if (path == "$REMOTE/proj") listOf(entry, entry) else null }
-        }
-
-        val plan = buildDownloadPlan(
-            remote,
-            listOf(item("proj", FileItemType.Directory, "$REMOTE/proj")),
-            localDir = LOCAL,
-            remoteDir = REMOTE,
-        )
-
-        assertEquals(listOf("$LOCAL/proj/dup.txt"), plan.files.map { it.localPath })
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
@@ -5,6 +5,8 @@ import app.skerry.shared.files.FileBrowserFailure
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.shared.sftp.SftpEntry
+import app.skerry.shared.sftp.SftpEntryType
 import app.skerry.ui.sftp.FakeSftpClient
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -167,5 +169,26 @@ class TransferPlanTest {
         assertEquals("$REMOTE/a.txt", safeRemoteChild("a.txt", REMOTE))
         assertFailsWith<FileBrowserException> { safeRemoteChild("../a.txt", REMOTE) }
         assertFailsWith<FileBrowserException> { safeRemoteChild("..", REMOTE) }
+    }
+
+    @Test
+    fun `a nested listing that repeats a name is planned once`() = runTest {
+        // The walk reads the SFTP client directly, not the de-duplicated browser, and it builds every
+        // local path from the entry's name — so a repeat inside a directory being downloaded plans two
+        // tasks writing the same local file, and the second silently overwrites the first while the
+        // progress bar counts two.
+        val entry = SftpEntry("dup.txt", "$REMOTE/proj/dup.txt", SftpEntryType.File, 5, 0, 0b110_100_100)
+        val remote = remote().apply {
+            listAnswer = { path -> if (path == "$REMOTE/proj") listOf(entry, entry) else null }
+        }
+
+        val plan = buildDownloadPlan(
+            remote,
+            listOf(item("proj", FileItemType.Directory, "$REMOTE/proj")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        assertEquals(listOf("$LOCAL/proj/dup.txt"), plan.files.map { it.localPath })
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRunnerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferRunnerTest.kt
@@ -1,0 +1,52 @@
+package app.skerry.ui.files
+
+import app.skerry.ui.sftp.TransferDirection
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * How an operation's queue entry is closed, whatever the operation died of.
+ *
+ * The queue is the only place a user can see that something they asked for is over. An entry left
+ * Active is worse than a failed one: the strip shows a progress bar that will never move again, the
+ * vault's idle auto-lock keeps deferring on it ([TransferCoordinator.writeInFlight]), and nothing
+ * ever comes back to close it. A tree walk deep enough to overflow the stack throws
+ * `StackOverflowError`, which is an `Error` and not an `Exception`, so an `Exception`-shaped
+ * handler lets it past (#306). Closing the row is all this claims: the stack has unwound by the
+ * time the handler runs, so the row is honest, but nothing here says the JVM is well after an
+ * `Error` of any kind.
+ */
+class TransferRunnerTest {
+
+    @Test
+    fun `an operation that dies on an Error still closes its entry`() = runTest {
+        val queue = TransferQueue { 0L }
+        val runner = TransferRunner(scope(), queue)
+
+        runner.submit(TransferDirection.Download, "tree") { throw StackOverflowError() }
+        advanceUntilIdle()
+
+        assertEquals(TransferStatus.Failed(FileTransferFailure.Transfer), queue.list.single().status)
+        assertFalse(queue.hasWork, "the queue still owes work it will never do")
+    }
+
+    @Test
+    fun `the operation behind it still gets its turn`() = runTest {
+        // The failing entry is closed by the same `finally` that starts the next one; a handler that
+        // lets the Error past leaves the entry open, and the queue believes one is still running.
+        val queue = TransferQueue { 0L }
+        val runner = TransferRunner(scope(), queue)
+
+        runner.submit(TransferDirection.Download, "tree") { throw StackOverflowError() }
+        runner.submit(TransferDirection.Upload, "after") { }
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(TransferStatus.Failed(FileTransferFailure.Transfer), TransferStatus.Done),
+            queue.list.map { it.status },
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -44,7 +44,20 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
     /** When set, [list] blocks until it completes — lets a test hold a pane's load in flight. */
     var listGate: CompletableDeferred<Unit>? = null
 
+    /**
+     * Listings a tree cannot hold, answered in place of a directory's own children: two entries
+     * under one name, or a directory that lists itself as its own child. Called with the normalized
+     * path [list] was asked for; returning `null` falls back to the tree. A real server is under no
+     * obligation to send a listing that a tree could hold, which is exactly what the callers of
+     * [list] have to survive.
+     */
+    var listAnswer: ((String) -> List<SftpEntry>?)? = null
+
     override suspend fun list(path: String): List<SftpEntry> {
+        listAnswer?.invoke(realpathSync(path))?.let { answer ->
+            listGate?.await()
+            return answer
+        }
         val dir = children[realpathSync(path)] ?: throw SftpException("No directory $path")
         // Answered from the tree as it was when the request arrived, like a real round trip: a
         // listing held in flight must be able to land stale.

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/PaneErrorAnnouncementTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/PaneErrorAnnouncementTest.kt
@@ -1,0 +1,100 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileItem
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.desktop.string
+import app.skerry.ui.files.FilePaneController
+import app.skerry.ui.generated.resources.Res
+import app.skerry.ui.generated.resources.ftail_err_unexpected
+import app.skerry.ui.mobile.MobileLivePane
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlin.test.Test
+
+/**
+ * What a screen reader is told when a pane operation the user asked for ends in a failure.
+ *
+ * The pane replaces its listing with a notice, and a sighted user sees it. A branch of a `when` is
+ * an insertion, not a change to a node that was already there, so nothing is announced and nothing
+ * takes focus: a user who confirms a delete and loses it hears silence (WCAG 4.1.3). The announcer
+ * has to sit above the `when` and carry the reason itself — the same shape [StatusAnnouncer]'s own
+ * doc prescribes and the transfer queue already uses.
+ */
+@OptIn(ExperimentalTestApi::class)
+class PaneErrorAnnouncementTest {
+
+    private val polite = SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, LiveRegionMode.Polite)
+
+    @Test
+    fun `a failed pane operation is announced on the desktop panel`() = failedPane { pane ->
+        LivePane(
+            pane = pane,
+            icon = "dns",
+            iconColor = Color.White,
+            badge = "remote",
+            badgeAccent = true,
+            mono = FontFamily.Monospace,
+            listState = rememberLazyListState(),
+            active = true,
+            onActivate = {},
+            onEditingPath = {},
+            onEditingFilter = {},
+            filterTick = 0,
+            onFilterClose = {},
+            restoreFocus = {},
+            modifier = Modifier,
+        )
+    }
+
+    @Test
+    fun `and on the phone, where the same operation is one tap away`() = failedPane { pane ->
+        MobileLivePane(
+            pane = pane,
+            mono = FontFamily.Monospace,
+            onTransfer = {},
+            onDownloadHere = null,
+            onOpenEditor = { _, _ -> },
+            modifier = Modifier,
+        )
+    }
+
+    /** Renders [content] over a pane whose listing failed on something the source never wraps. */
+    private fun failedPane(content: @Composable (FilePaneController) -> Unit) {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val pane = FilePaneController(UnwrappedBrowser, scope)
+        pane.start()
+        try {
+            runForm({ content(pane) }, body())
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private fun body(): ComposeUiTest.() -> Unit = {
+        onNode(polite).assertContentDescriptionEquals(string(Res.string.ftail_err_unexpected))
+    }
+}
+
+/** A source that fails the way [FileBrowserFailure.Unexpected] exists for: without wrapping. */
+private object UnwrappedBrowser : FileBrowser {
+    override val label: String = "prod-web-01"
+    override suspend fun realpath(path: String): String = "/"
+    override suspend fun list(path: String): List<FileItem> = throw StackOverflowError()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/PaneListHarness.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/PaneListHarness.kt
@@ -1,0 +1,49 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.text.font.FontFamily
+import app.skerry.shared.files.FileBrowser
+import app.skerry.shared.files.FileItem
+import app.skerry.ui.desktop.runForm
+import app.skerry.ui.files.FilePaneController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+
+/**
+ * Draws [entries] with the live listing the session panel uses, and runs [body] over the result.
+ *
+ * The pane controller is real but never lists anything: what these tests are about is what
+ * [LivePaneList] does with entries it is given, so the entries are handed in directly and the
+ * browser behind the pane only exists because the controller needs one.
+ */
+@OptIn(ExperimentalTestApi::class)
+internal fun renderPaneList(entries: List<FileItem>, body: ComposeUiTest.() -> Unit) {
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    val pane = FilePaneController(EmptyBrowser, scope)
+    try {
+        runForm({
+            LivePaneList(
+                pane = pane,
+                entries = entries,
+                mono = FontFamily.Monospace,
+                listState = rememberLazyListState(),
+                active = true,
+                onActivate = {},
+            )
+        }, body)
+    } finally {
+        scope.cancel()
+    }
+}
+
+private object EmptyBrowser : FileBrowser {
+    override val label: String = "stub"
+    override suspend fun realpath(path: String): String = "/"
+    override suspend fun list(path: String): List<FileItem> = emptyList()
+    override suspend fun mkdir(path: String) = Unit
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingKeyTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingKeyTest.kt
@@ -1,0 +1,60 @@
+package app.skerry.ui.sftp
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import app.skerry.shared.files.FileItem
+import app.skerry.shared.files.SftpFileBrowser
+import app.skerry.shared.sftp.SftpEntry
+import app.skerry.shared.sftp.SftpEntryType
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+private const val DIR = "/var/www"
+
+/**
+ * What the remote listing does with a directory that names one entry twice.
+ *
+ * `LazyColumn` keys every row through `SaveableStateHolder`, which refuses a duplicate key with an
+ * `IllegalArgumentException` — thrown during composition, so it takes the window (desktop) or the
+ * activity (Android) with it. The rows are keyed by the path the server reported, and a repeated
+ * name in one directory is one packet away: an overlay filesystem, a buggy server, or one that
+ * simply says so.
+ *
+ * The test goes through [SftpFileBrowser] rather than handing [LivePaneList] its entries, because
+ * the join is the thing under test: what the browser hands out has to be usable as a row key.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SftpListingKeyTest {
+
+    @Test
+    fun `a listing that names one entry twice draws one row instead of taking the panel down`() {
+        val entries = listing(
+            SftpEntry("dup.txt", "$DIR/dup.txt", SftpEntryType.File, 42, 0, 0b110_100_100),
+            SftpEntry("dup.txt", "$DIR/dup.txt", SftpEntryType.File, 42, 0, 0b110_100_100),
+        )
+
+        renderPaneList(entries) { onAllNodesWithText("dup.txt").assertCountEquals(1) }
+    }
+
+    @Test
+    fun `entries the user can tell apart are all drawn`() {
+        val entries = listing(
+            SftpEntry("one.txt", "$DIR/one.txt", SftpEntryType.File, 1, 0, 0b110_100_100),
+            SftpEntry("two.txt", "$DIR/two.txt", SftpEntryType.File, 2, 0, 0b110_100_100),
+        )
+
+        renderPaneList(entries) {
+            onAllNodesWithText("one.txt").assertCountEquals(1)
+            onAllNodesWithText("two.txt").assertCountEquals(1)
+        }
+    }
+
+    /** The listing [DIR] answers with, as the panel would receive it — through the SFTP browser. */
+    private fun listing(vararg answer: SftpEntry): List<FileItem> {
+        val client = FakeSftpClient(startDir = DIR).apply {
+            listAnswer = { path -> if (path == DIR) answer.toList() else null }
+        }
+        return runBlocking { SftpFileBrowser(client, "prod-web-01").list(DIR) }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingNameTest.kt
+++ b/composeApp/src/desktopTest/kotlin/app/skerry/ui/sftp/SftpListingNameTest.kt
@@ -1,22 +1,14 @@
 package app.skerry.ui.sftp
 
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.text.font.FontFamily
-import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
-import app.skerry.ui.desktop.runForm
 import app.skerry.ui.desktop.string
 import app.skerry.ui.generated.resources.Res
 import app.skerry.ui.generated.resources.sftp_unprintable_name
-import app.skerry.ui.files.FilePaneController
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlin.test.Test
 
 /**
@@ -64,37 +56,12 @@ class SftpListingNameTest {
     }
 
     /** One remote entry on screen, drawn by the live listing the session panel uses. */
-    private fun listing(name: String, body: ComposeUiTest.() -> Unit) {
-        val scope = CoroutineScope(Dispatchers.Unconfined)
-        val pane = FilePaneController(StubBrowser, scope)
-        val entries = listOf(
+    private fun listing(name: String, body: ComposeUiTest.() -> Unit) = renderPaneList(
+        listOf(
             FileItem(name = name, path = "/var/www/$name", type = FileItemType.File, size = 12, modifiedEpochSeconds = 0),
-        )
-        try {
-            runForm({
-                LivePaneList(
-                    pane = pane,
-                    entries = entries,
-                    mono = FontFamily.Monospace,
-                    listState = rememberLazyListState(),
-                    active = true,
-                    onActivate = {},
-                )
-            }, body)
-        } finally {
-            scope.cancel()
-        }
-    }
-}
-
-/** The listing under test is handed its entries directly; the browser is only what the pane holds. */
-private object StubBrowser : FileBrowser {
-    override val label: String = "stub"
-    override suspend fun realpath(path: String): String = "/"
-    override suspend fun list(path: String): List<FileItem> = emptyList()
-    override suspend fun mkdir(path: String) = Unit
-    override suspend fun delete(item: FileItem) = Unit
-    override suspend fun rename(from: String, to: String) = Unit
+        ),
+        body,
+    )
 }
 
 /** U+202E before the tail: the row draws as `invoiceexe.png`, the file it opens is `invoicegnp.exe`. */

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
@@ -42,9 +42,8 @@ interface FileBrowser {
 
     /**
      * Contents of directory [path], excluding `.` and `..`; order is not guaranteed (the panel sorts).
-     * Paths and names are both distinct — the panel keys its rows by [FileItem.path] and every
-     * operation on a row resolves its name, so a repeat of either is a crash or a wrong file, and a
-     * source that cannot promise it de-duplicates before answering.
+     * Paths are distinct — the panel keys its rows by [FileItem.path], and a repeat there is a
+     * crash, so a source that cannot promise it de-duplicates before answering.
      * @throws FileBrowserException if the path doesn't exist, isn't a directory, or access is denied
      */
     suspend fun list(path: String): List<FileItem>
@@ -122,6 +121,16 @@ enum class FileBrowserFailure {
 
     /** The file is larger than the caller's cap (whole-file read for the viewer/editor). */
     TooLarge,
+
+    /** The directory tree to transfer is deeper or bigger than a transfer plan may hold. */
+    TreeTooLarge,
+
+    /**
+     * Nothing else fits: an operation ended on something the source was not supposed to throw. The
+     * row exists so the failure is still the user's to see — an operation that ends in silence, or
+     * takes the session's scope down with it, is the outcome this value replaces.
+     */
+    Unexpected,
 }
 
 /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
@@ -42,6 +42,9 @@ interface FileBrowser {
 
     /**
      * Contents of directory [path], excluding `.` and `..`; order is not guaranteed (the panel sorts).
+     * Paths and names are both distinct — the panel keys its rows by [FileItem.path] and every
+     * operation on a row resolves its name, so a repeat of either is a crash or a wrong file, and a
+     * source that cannot promise it de-duplicates before answering.
      * @throws FileBrowserException if the path doesn't exist, isn't a directory, or access is denied
      */
     suspend fun list(path: String): List<FileItem>

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
@@ -19,8 +19,22 @@ class SftpFileBrowser(
 
     override suspend fun realpath(path: String): String = guard { sftp.realpath(path) }
 
+    /**
+     * A listing is entirely the other side's text, and nothing in SFTP promises the entries in one
+     * are distinct — an overlay/merged filesystem repeats a name by construction, a hostile server
+     * by choice. Both halves of an entry have to be unique, for two different reasons:
+     *
+     * - the panel keys its rows by [FileItem.path], and Compose refuses a duplicate key
+     *   mid-composition, which takes the window (desktop) or the activity (Android) with it;
+     * - a row draws the name and never the path, and every operation on a row resolves that name
+     *   against the directory it was listed in, so two rows under one name are two rows the user
+     *   cannot tell apart that act on one file.
+     *
+     * The first entry of each wins: which of them the server meant is unknowable, and keeping the
+     * later one would make the listing depend on packet order.
+     */
     override suspend fun list(path: String): List<FileItem> =
-        guard { sftp.list(path).map { it.toFileItem() } }
+        guard { sftp.list(path).map { it.toFileItem() }.distinctBy { it.path }.distinctBy { it.name } }
 
     override suspend fun mkdir(path: String): Unit = guard { sftp.mkdir(path) }
 

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
@@ -42,11 +42,11 @@ class SftpFileBrowser(
      * Recursive delete: a directory is emptied first (contents removed by the same [deleteTree]),
      * then removed with `rmdir`; a file/symlink/other uses `remove` (`SSH_FXP_REMOVE` removes the
      * link itself, not its target — a symlink's target directory is not entered). SFTP has no
-     * protocol-level recursive delete, so the traversal is client-side. Tree depth is unbounded:
-     * pathologically deep trees could in theory overflow the stack.
+     * protocol-level recursive delete, so the traversal is client-side, over listings the server
+     * writes — so it is bounded by [refuseTooDeep], and by nothing else: see [deleteTree].
      */
     override suspend fun delete(item: FileItem): Unit = guard {
-        deleteTree(item.path, item.type == FileItemType.Directory)
+        deleteTree(item.path, item.type == FileItemType.Directory, depth = 0)
     }
 
     /**
@@ -54,19 +54,33 @@ class SftpFileBrowser(
      * calls here throw [SftpException], caught by the outer [guard] (the whole recursion runs inside
      * its single try). Before descending into a child, verifies its path is actually nested under
      * [path] — otherwise a server returning a listing entry outside the directory (by bug or by
-     * intent) could cause deletion of something the user didn't select.
+     * intent) could cause deletion of something the user didn't select. That check passes at every
+     * level of a directory listed as its own child, because the path only grows: [refuseTooDeep] is
+     * what ends such a walk, and [FileBrowserFailure.TreeTooLarge] then passes through [guard]
+     * untouched. It ends the recursion; it does not promise the tree is untouched. Files beside the
+     * loop at each level are removed on the way down, and SFTP has no recursive delete to make that
+     * atomic — a mid-tree refusal here has the same shape a permission denied always had.
+     *
+     * Depth is the only bound. This walk deletes as it goes rather than deciding first, so a cap on
+     * how many entries it may take on would stop it with most of the tree already gone, on a verb
+     * where "refused" and "half done" are not the same answer at all. Width is bounded through
+     * depth: it holds no plan, only one listing per active level.
+     *
+     * The listing is not de-duplicated here, unlike [list]: an entry dropped from it is an entry
+     * never removed, and `rmdir` would then fail on a directory that is not empty.
      */
-    private suspend fun deleteTree(path: String, isDirectory: Boolean) {
+    private suspend fun deleteTree(path: String, isDirectory: Boolean, depth: Int) {
         if (!isDirectory) {
             sftp.remove(path)
             return
         }
+        refuseTooDeep(depth + 1)
         val prefix = if (path.endsWith("/")) path else "$path/"
         sftp.list(path).forEach { child ->
             if (!child.path.startsWith(prefix)) {
                 throw SftpException("Listing $path returned a path outside the directory: ${child.path}")
             }
-            deleteTree(child.path, child.type == SftpEntryType.Directory)
+            deleteTree(child.path, child.type == SftpEntryType.Directory, depth + 1)
         }
         sftp.rmdir(path)
     }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/TreeWalkLimit.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/TreeWalkLimit.kt
@@ -1,0 +1,61 @@
+package app.skerry.shared.files
+
+/**
+ * How deep a client-side walk over a remote tree descends before it refuses to go further.
+ *
+ * A remote tree is the server's answer, not a fact. A bind mount that contains itself, a FUSE mount,
+ * or a server that simply lists a directory as its own child gives a tree with no bottom, and a
+ * recursion over it runs until the stack or the heap gives out. 64 levels is far below any tree a
+ * person keeps and far above any tree they walk by hand.
+ */
+const val MAX_TREE_DEPTH = 64
+
+/**
+ * How many entries one walk that builds a plan may take on.
+ *
+ * Depth alone does not bound a walk: a directory that lists a thousand directories, each listing a
+ * thousand more, is three levels deep and a billion entries wide. The number is what a plan held
+ * whole in memory costs before a byte moves — around 350 bytes an entry, so 100 000 is tens of
+ * megabytes, which an Android heap can hold and ten times that cannot. It is deliberately a bound on
+ * the client's own memory, not an opinion about how much a person may transfer: a tree bigger than
+ * this is refused with a reason on the queue rather than taken on and dropped halfway.
+ */
+const val MAX_TREE_ENTRIES = 100_000
+
+/**
+ * Refuses a descent past [MAX_TREE_DEPTH]: below that a tree is a loop, not a tree.
+ *
+ * Every client-side recursion over a server's listing calls this, because a listing that has no
+ * bottom is what they all have in common. It refuses before the level it is asked about is entered,
+ * so a walk that has done nothing yet has still done nothing.
+ */
+fun refuseTooDeep(depth: Int) {
+    if (depth > MAX_TREE_DEPTH) {
+        throw FileBrowserException(FileBrowserFailure.TreeTooLarge, detail = "deeper than $MAX_TREE_DEPTH levels")
+    }
+}
+
+/**
+ * The budget one walk that *builds a plan* runs under: [count] once per entry it takes on, [descend]
+ * before it enters a directory. One instance per walk, shared across every top-level item of it, so
+ * a server that fans out cannot buy itself a fresh budget per selection.
+ *
+ * The entry half belongs to the transfer walks alone. They decide the whole plan before a byte
+ * moves, so refusing at entry 100 001 costs nothing but the walk. A recursion that mutates as it
+ * goes — the recursive delete — must not carry it: it would stop with most of the tree already
+ * removed and report the tree as refused. Those recursions call [refuseTooDeep] and nothing else.
+ */
+class TreeWalkLimit {
+    private var entries = 0
+
+    /** Counts an entry the walk is about to take on, and refuses the one past [MAX_TREE_ENTRIES]. */
+    fun count() {
+        entries++
+        if (entries > MAX_TREE_ENTRIES) {
+            throw FileBrowserException(FileBrowserFailure.TreeTooLarge, detail = "more than $MAX_TREE_ENTRIES entries")
+        }
+    }
+
+    /** @see refuseTooDeep */
+    fun descend(depth: Int) = refuseTooDeep(depth)
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
@@ -103,6 +103,65 @@ class SftpFileBrowserTest {
     }
 
     @Test
+    fun `a delete over a directory that lists itself stops instead of recursing forever`() = runTest {
+        // This fixture's loop holds nothing but itself, which is why nothing is removed before the
+        // refusal — see the test below for what a loop with a file beside it costs.
+        // The recursive delete walks the same untrusted listing the transfer walk does, on the more
+        // destructive verb: a directory listed as its own child has no bottom, the containment check
+        // passes at every level because the path only grows, and the recursion ends as an Error that
+        // no handler on the pane's path catches.
+        client.listAnswer = { path ->
+            if (path.endsWith("/loop")) listOf(SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0)) else null
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            browser().delete(FileItem("loop", "/d/loop", FileItemType.Directory, 0, 0))
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+        assertTrue(client.calls.none { it.startsWith("remove:") || it.startsWith("rmdir:") }, "it removed something")
+    }
+
+    @Test
+    fun `a loop with files beside it loses them before the refusal`() = runTest {
+        // The bound ends the recursion, and that is all it ends: SFTP has no recursive delete, so a
+        // walk that stops in the middle stops with what it has already removed gone. Recorded here
+        // rather than left to be discovered — the refusal the user is shown is not "nothing
+        // happened", and no wording can make it one.
+        client.listAnswer = { path ->
+            if (path.endsWith("/loop")) {
+                listOf(
+                    SftpEntry("keep.txt", "$path/keep.txt", SftpEntryType.File, 1, 0, 0b110_100_100),
+                    SftpEntry("loop", "$path/loop", SftpEntryType.Directory, 0, 0, 0),
+                )
+            } else {
+                null
+            }
+        }
+
+        assertFailsWith<FileBrowserException> {
+            browser().delete(FileItem("loop", "/d/loop", FileItemType.Directory, 0, 0))
+        }
+
+        assertEquals(MAX_TREE_DEPTH, client.calls.count { it.startsWith("remove:") })
+    }
+
+    @Test
+    fun `a directory wider than a transfer plan may hold is still deleted whole`() = runTest {
+        // The entry cap is what a plan held whole in memory costs. This walk holds no plan and
+        // deletes as it goes, so the same cap would stop it with most of the tree already gone —
+        // and report the tree as refused, on an operation that destroyed two thirds of it. A tree
+        // with no bottom is bounded by depth, which refuses before anything is removed.
+        val wide = List(MAX_TREE_ENTRIES + 1) { SftpEntry("f$it", "/d/big/f$it", SftpEntryType.File, 0, 0, 0b110_100_100) }
+        client.listAnswer = { path -> if (path == "/d/big") wide else null }
+
+        browser().delete(FileItem("big", "/d/big", FileItemType.Directory, 0, 0))
+
+        assertEquals(MAX_TREE_ENTRIES + 1, client.calls.count { it.startsWith("remove:") })
+        assertTrue("rmdir:/d/big" in client.calls)
+    }
+
+    @Test
     fun `mkdir and rename are delegated`() = runTest {
         browser().mkdir("/d/new")
         browser().rename("/d/a", "/d/b")
@@ -242,11 +301,14 @@ private class RecordingSftp : SftpClient {
     var failList = false
     var cancelList = false
 
+    /** Listings a map cannot hold — a directory that lists itself as its own child. */
+    var listAnswer: ((String) -> List<SftpEntry>?)? = null
+
     override suspend fun list(path: String): List<SftpEntry> {
         if (cancelList) throw CancellationException("cancelled")
         if (failList) throw SftpException("boom")
         calls += "list:$path"
-        return listings[path] ?: listResult
+        return listAnswer?.invoke(path) ?: listings[path] ?: listResult
     }
 
     override suspend fun stat(path: String): SftpEntry? {

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
@@ -56,6 +56,53 @@ class SftpFileBrowserTest {
     }
 
     @Test
+    fun `two entries under one path collapse into the first`() = runTest {
+        // Nothing in SFTP promises the names in a listing are distinct: a merged/overlay filesystem,
+        // a buggy server or a hostile one can all repeat one. The panel keys its rows by path, and a
+        // repeat there takes the window down mid-composition (#309), so the repeat stops here.
+        client.listResult = listOf(
+            SftpEntry("dup", "/d/dup", SftpEntryType.File, 42, 100, 0b110_100_100),
+            // A different name, so this row is collapsed by the path filter and by nothing else.
+            SftpEntry("other", "/d/dup", SftpEntryType.Directory, 0, 200, 0b111_101_101),
+        )
+
+        val items = browser().list("/d")
+
+        // The first one wins: which of the two the server meant is unknowable, and picking the later
+        // one would make the listing depend on the order the packets happened to arrive in.
+        assertEquals(1, items.size)
+        assertEquals(FileItemType.File, items.single().type)
+        assertEquals(42, items.single().size)
+    }
+
+    @Test
+    fun `two entries under one name collapse too, whatever paths they claim`() = runTest {
+        // A row draws the name and never the path, and every operation on a row resolves that name
+        // against the directory it was listed in (#313). So a listing that repeats a name under two
+        // paths draws two rows the user cannot tell apart, and deleting the second one deletes the
+        // file behind the first: the duplicate-key crash one layer up, with the panel still standing.
+        client.listResult = listOf(
+            SftpEntry("dup", "/d/dup", SftpEntryType.File, 1, 100, 0b110_100_100),
+            SftpEntry("dup", "/d/sub/dup", SftpEntryType.File, 2, 200, 0b110_100_100),
+        )
+
+        val items = browser().list("/d")
+
+        assertEquals(1, items.size)
+        assertEquals("/d/dup", items.single().path)
+    }
+
+    @Test
+    fun `entries the user can act on separately all survive`() = runTest {
+        client.listResult = listOf(
+            SftpEntry("one", "/d/one", SftpEntryType.File, 1, 100, 0b110_100_100),
+            SftpEntry("two", "/d/two", SftpEntryType.File, 2, 200, 0b110_100_100),
+        )
+
+        assertEquals(2, browser().list("/d").size)
+    }
+
+    @Test
     fun `mkdir and rename are delegated`() = runTest {
         browser().mkdir("/d/new")
         browser().rename("/d/a", "/d/b")


### PR DESCRIPTION
Two issues about the same thing: a directory listing is the server's answer, not a fact, and the file
panel treated it as one. Two commits, one per issue — **merge without squashing**.

## `SftpFileBrowser.list` de-duplicates a listing (#309)

Nothing in SFTP promises the entries in one listing are distinct. An overlay/merged filesystem
repeats a name by construction; a buggy or hostile server does it by choice. Both halves of an entry
have to be unique, for two different reasons:

- the panel keys its rows by the reported path, and compose-runtime-saveable refuses a duplicate key
  with an `IllegalArgumentException` thrown *during composition* — it takes the window down on
  desktop and the activity on Android, and re-opening the directory hits it again;
- a row draws the name and never the path, while every operation on a row resolves that name against
  the directory it was listed in, so two rows under one name are two rows the user cannot tell apart
  that act on one file — deleting the second deletes what the first one showed.

The first entry of each path and of each name wins: which the server meant is unknowable, and
keeping the later one would make the listing depend on packet order. `FileBrowser.list` states
distinctness as part of the contract. The download walk plans from the SFTP client rather than from
that browser, so it de-duplicates its own child listing by name.

## The tree walks are bounded, and a dead operation closes its row (#306)

`DownloadWalk`/`UploadWalk` recursed once per directory level with no cap on depth and none on the
size of the plan. A tree that loops — a bind mount that contains itself, a FUSE mount, or a server
that lists a directory as its own child — never terminates: the walk blows the stack before a byte
has moved. Symlinks were never the vector; directory-typed loops are.

- Both walks run under a `TreeWalkLimit` (64 levels, 100 000 entries) and refuse what exceeds it
  with a typed `FileBrowserFailure.TreeTooLarge`, so the queue row says why.
- The recursive SFTP delete walks the same untrusted listing on the more destructive verb and takes
  the **depth** half of that bound only. It deletes as it goes rather than deciding first, so an
  entry cap would stop it with most of the tree already gone — on a verb where "refused" and "half
  done" are not the same answer.
- `StackOverflowError` is an `Error`, so `TransferRunner`'s `catch (e: Exception)` never matched it
  and the queue entry stayed Active for good: a progress bar that never moves again, and an idle
  auto-lock that keeps deferring on it. It catches `Throwable` now and closes the entry as Failed.
  `FilePaneController` and the viewer/editor do the same on their own paths — both run on the scope
  the whole composition shares, where an uncaught throw cancels every other session's work and, on
  Android, kills the process.
- A pane operation that ends in a failure is now announced. The listing and the failure notice are
  two branches of one `when`, so the switch between them is an insertion rather than a change a
  screen reader is told about; a user who confirmed a delete and lost it heard nothing.

## Behaviour change worth naming

A transfer of a tree with more than 100 000 entries is now **refused** rather than attempted. The
plan is held whole in memory before the first byte moves, so the cap is what the client can hold —
not an opinion about how much a person may transfer. The recursive delete is not capped this way and
still deletes trees of any width.

## Verification

`checks · tests · build (lint) · detekt · :androidApp:compileDebugKotlin` all green, and the first
commit compiles and passes its own tests in isolation, so bisecting through the pair works.

By hand, on Linux desktop: open a directory whose listing repeats an entry — before, the window
went; now one row is drawn. Start a download of a directory that lists itself — before, the app
died on a stack overflow; now the queue row reads "Folder tree is too deep or too large to
transfer" and the next transfer gets its turn.

**Not verified:** Android, a live server, TalkBack/Orca/NVDA, Windows and macOS.

## Known, deliberately out of scope

A single directory listing is still unbounded at `SshjSftpClient.list` (`sftp.ls`), so the entry cap
and the de-duplication both sit above the allocation they bound. A hostile server can still drive
the heap during an ordinary directory open — now recovered as a failed pane rather than a dead
process. The fix is a sshj `RemoteResourceSelector` returning `BREAK` past a limit; it belongs to
its own issue, not to either of these.

Closes #309
Closes #306
