### PR TITLE
Bound an SFTP listing, and three protocol fixes (#340, #315, #307, #304)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings_ftail.xml
@@ -29,7 +29,7 @@
     <string name="ftail_err_session_closed">Сессия закрыта до начала передачи</string>
     <string name="ftail_err_too_large">Файл слишком большой, чтобы открыть его</string>
     <string name="ftail_err_tree_too_large">Дерево каталогов слишком глубокое или слишком большое для передачи</string>
-    <string name="ftail_err_tree_too_deep">Дерево каталогов слишком глубокое для обхода</string>
+    <string name="ftail_err_dir_too_large">Дерево каталогов слишком глубокое или в каталоге слишком много объектов</string>
     <string name="ftail_err_unexpected">Непредвиденная ошибка</string>
 
     <!-- Ошибки просмотрщика/редактора (F3/F4) -->

--- a/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values-zh/strings_ftail.xml
@@ -29,7 +29,7 @@
     <string name="ftail_err_session_closed">会话在传输开始前已关闭</string>
     <string name="ftail_err_too_large">文件太大，无法打开</string>
     <string name="ftail_err_tree_too_large">目录树太深或太大，无法传输</string>
-    <string name="ftail_err_tree_too_deep">目录树太深，无法遍历</string>
+    <string name="ftail_err_dir_too_large">目录树太深，或目录中条目过多</string>
     <string name="ftail_err_unexpected">意外错误</string>
 
     <!-- 查看器/编辑器（F3/F4）失败原因 -->

--- a/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings_ftail.xml
@@ -29,7 +29,7 @@
     <string name="ftail_err_session_closed">Session closed before it started</string>
     <string name="ftail_err_too_large">File is too large to open</string>
     <string name="ftail_err_tree_too_large">Folder tree is too deep or too large to transfer</string>
-    <string name="ftail_err_tree_too_deep">Folder tree is too deep to walk</string>
+    <string name="ftail_err_dir_too_large">Folder tree is too deep, or the folder has too many entries</string>
     <string name="ftail_err_unexpected">Unexpected error</string>
 
     <!-- Viewer/editor (F3/F4) failures -->

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/FileFailureText.kt
@@ -15,7 +15,7 @@ import app.skerry.ui.generated.resources.ftail_err_open_target
 import app.skerry.ui.generated.resources.ftail_err_session_closed
 import app.skerry.ui.generated.resources.ftail_err_sftp
 import app.skerry.ui.generated.resources.ftail_err_too_large
-import app.skerry.ui.generated.resources.ftail_err_tree_too_deep
+import app.skerry.ui.generated.resources.ftail_err_dir_too_large
 import app.skerry.ui.generated.resources.ftail_err_tree_too_large
 import app.skerry.ui.generated.resources.ftail_err_unexpected
 import app.skerry.ui.generated.resources.ftail_transfer_error
@@ -31,10 +31,10 @@ fun fileBrowserFailureText(failure: FileBrowserFailure): String = stringResource
         FileBrowserFailure.OpenSource -> Res.string.ftail_err_open_source
         FileBrowserFailure.OpenTarget -> Res.string.ftail_err_open_target
         FileBrowserFailure.TooLarge -> Res.string.ftail_err_too_large
-        // The pane's own walk is the recursive delete, which is bounded by depth and never by size,
-        // so the reason it stops is never "too large" — and the transfer wording would name a verb
-        // this operation has nothing to do with.
-        FileBrowserFailure.TreeTooLarge -> Res.string.ftail_err_tree_too_deep
+        // Two shapes reach the pane under one value: a tree with no bottom (the recursive delete's
+        // depth bound) and a single directory the client cannot hold. The wording names both, and
+        // neither names the verb the transfer wording does — nothing is being transferred here.
+        FileBrowserFailure.TreeTooLarge -> Res.string.ftail_err_dir_too_large
         FileBrowserFailure.Unexpected -> Res.string.ftail_err_unexpected
     },
 )

--- a/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
+++ b/composeApp/src/commonMain/kotlin/app/skerry/ui/files/TransferPlan.kt
@@ -3,9 +3,12 @@ package app.skerry.ui.files
 import app.skerry.shared.files.FileBrowser
 import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
+import app.skerry.shared.files.MAX_LISTING_ENTRIES
 import app.skerry.shared.files.TreeWalkLimit
+import app.skerry.shared.files.refuseOversizedListing
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntryType
 
@@ -45,7 +48,12 @@ internal suspend fun buildDownloadPlan(
     remoteDir: String,
 ): TransferPlan<DownloadTask> {
     val walk = DownloadWalk(sftp)
-    items.forEach { walk.walk(WalkEntry(it.name, it.type, it.size), childPath(remoteDir, it.name), localDir, depth = 0) }
+    items.forEach {
+        val entry = WalkEntry(it.name, it.type, it.size)
+        // Each selected item is walked in turn, so each one starts with the whole listing budget:
+        // what the one before it held is gone by the time this call runs.
+        walk.walk(entry, childPath(remoteDir, it.name), localDir, depth = 0, hold = MAX_LISTING_ENTRIES)
+    }
     return walk.plan
 }
 
@@ -63,7 +71,21 @@ private class DownloadWalk(private val sftp: SftpClient) {
     val plan = TransferPlan<DownloadTask>()
     private val limit = TreeWalkLimit()
 
-    suspend fun walk(entry: WalkEntry, remotePath: String, localDir: String, depth: Int) {
+    /**
+     * [hold] is what is left of [MAX_LISTING_ENTRIES] for the levels this call is inside, the same
+     * budget [app.skerry.shared.files.SftpFileBrowser] runs its delete under. The plan's own count
+     * cannot stand in for it: that counts entries the walk has *taken on*, and a descent into the
+     * first child of a level counts one entry while the whole listing of every level above stays
+     * alive in its frame. Sixty-four of those is a plan that never gets built because the heap went
+     * first, and an `OutOfMemoryError` is not a refusal anyone can read.
+     */
+    suspend fun walk(
+        entry: WalkEntry,
+        remotePath: String,
+        localDir: String,
+        depth: Int,
+        hold: Int,
+    ) {
         if (isUnsafeListingName(entry.name)) {
             throw FileBrowserException(FileBrowserFailure.IllegalName, detail = entry.name)
         }
@@ -81,9 +103,15 @@ private class DownloadWalk(private val sftp: SftpClient) {
                 // than the browser that de-duplicates for the panel, and every local path it writes
                 // is built from the name. A repeat would plan two tasks onto one local file, and the
                 // second would overwrite the first while the progress bar counted two.
-                sftp.list(remotePath).distinctBy { it.name }.forEach { child ->
+                // The listing is bounded as it is read, not after: the plan's own entry cap is
+                // checked per entry taken on, which is too late to stop a server answering one
+                // directory with more names than the client can hold.
+                val children = sftp.list(remotePath, hold)
+                refuseOversizedListing(remotePath, children.size, hold)
+                val childHold = hold - children.size
+                children.distinctBy { it.name }.forEach { child ->
                     val next = WalkEntry(child.name, child.type.toItemType(), child.size)
-                    walk(next, childPath(remotePath, child.name), localPath, depth + 1)
+                    walk(next, childPath(remotePath, child.name), localPath, depth + 1, childHold)
                 }
             }
             FileItemType.Symlink, FileItemType.Other -> Unit
@@ -138,18 +166,36 @@ private class UploadWalk(private val localBrowser: FileBrowser) {
 
 /**
  * Creates directory [path] in [browser] (local or remote) if missing. `mkdir` without `-p` throws
- * on an already-existing directory, which is normal on a repeat transfer: a listing check confirms
- * the directory exists before the error is ignored; otherwise (no permission / it's a file) the
- * original mkdir error is rethrown.
+ * on an already-existing directory, which is normal on a repeat transfer: a [FileContentBrowser.stat]
+ * confirms a directory is what is already there before the error is ignored; otherwise (no
+ * permission, or it is a file) the original mkdir error is rethrown.
+ *
+ * `stat` rather than a listing: the question is whether one path exists, and listing it to find out
+ * would pull a whole directory over the wire — as many entries as the server cares to answer with —
+ * once per directory in the plan.
+ *
+ * A symlink is the one case that still costs a listing. `stat` reports the link, not what it points
+ * at (SFTP's is `SSH_FXP_LSTAT`, the local one is a no-follow metadata read), and a symlinked
+ * destination directory is ordinary — so the walk that a plain `stat` cannot answer for is finished
+ * by opening it, which follows the link on both sources. A link to a file fails there, as it should.
  */
-internal suspend fun ensureDir(browser: FileBrowser, path: String) {
+internal suspend fun ensureDir(browser: FileContentBrowser, path: String) {
     try {
         browser.mkdir(path)
     } catch (e: FileBrowserException) {
-        try {
-            browser.list(path)
+        val existing = try {
+            browser.stat(path)
         } catch (_: FileBrowserException) {
-            throw e
+            null
+        }
+        when (existing?.type) {
+            FileItemType.Directory -> Unit
+            FileItemType.Symlink -> try {
+                browser.list(path)
+            } catch (_: FileBrowserException) {
+                throw e
+            }
+            else -> throw e
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/connection/ConnectionControllerTest.kt
@@ -570,7 +570,7 @@ private class RecordingSftpClient : SftpClient {
     var closed = false
         private set
 
-    override suspend fun list(path: String): List<SftpEntry> = emptyList()
+    override suspend fun list(path: String, limit: Int): List<SftpEntry> = emptyList()
     override suspend fun stat(path: String): SftpEntry? = null
     override suspend fun realpath(path: String): String = "/"
     override suspend fun read(path: String, maxBytes: Long): ByteArray = ByteArray(0)

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/FilePaneControllerTest.kt
@@ -538,9 +538,9 @@ class FilePaneControllerTest {
         assertEquals("$HOME/alpha", c.path, "the navigation still lands")
         assertEquals(
             listOf("alpha", "build.log", "manual.txt", "zeta"),
-            fake.list(HOME).map { it.name }.sorted(),
+            fake.listAll(HOME).map { it.name }.sorted(),
         )
-        assertEquals(emptyList(), fake.list("$HOME/alpha").map { it.name })
+        assertEquals(emptyList(), fake.listAll("$HOME/alpha").map { it.name })
     }
 
     /** The pane says when it is working, so a screen can show it instead of looking stuck. */

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferCoordinatorTest.kt
@@ -55,9 +55,9 @@ class TransferCoordinatorTest {
         advanceUntilIdle()
 
         // Remote directory is recreated along with the nested file.
-        val remoteTop = r.remoteFake.list(RHOME).map { it.name }
+        val remoteTop = r.remoteFake.listAll(RHOME).map { it.name }
         assertTrue("sub" in remoteTop, "expected remote directory sub, have: $remoteTop")
-        val remoteSub = r.remoteFake.list("$RHOME/sub").map { it.name }
+        val remoteSub = r.remoteFake.listAll("$RHOME/sub").map { it.name }
         assertTrue("inner.txt" in remoteSub, "expected remote sub/inner.txt, have: $remoteSub")
         assertEquals("$LHOME/sub/inner.txt" to "$RHOME/sub/inner.txt", r.remoteFake.lastUpload)
         assertTrue(r.local.selection.isEmpty())
@@ -91,9 +91,9 @@ class TransferCoordinatorTest {
         advanceUntilIdle()
 
         // Local subdirectories are recreated.
-        val localTop = r.localFake.list(LHOME).map { it.name }
+        val localTop = r.localFake.listAll(LHOME).map { it.name }
         assertTrue("proj" in localTop, "expected local directory proj, have: $localTop")
-        val localNested = r.localFake.list("$LHOME/proj").map { it.name }
+        val localNested = r.localFake.listAll("$LHOME/proj").map { it.name }
         assertTrue("nested" in localNested, "expected local directory proj/nested, have: $localNested")
 
         // Both files in the tree are downloaded to their local paths.
@@ -113,7 +113,7 @@ class TransferCoordinatorTest {
         r.coordinator.downloadSelection()
         advanceUntilIdle()
 
-        assertTrue("empty" in r.localFake.list(LHOME).map { it.name })
+        assertTrue("empty" in r.localFake.listAll(LHOME).map { it.name })
         assertTrue(r.remoteFake.downloads.isEmpty())
         assertEquals(TransferState.Idle, r.coordinator.transfer)
     }
@@ -274,8 +274,8 @@ class TransferCoordinatorTest {
         r.coordinator.moveSelection(fromLocal = true)
         advanceUntilIdle()
 
-        assertTrue("sub" in r.remoteFake.list(RHOME).map { it.name })
-        assertTrue("inner.txt" in r.remoteFake.list("$RHOME/sub").map { it.name })
+        assertTrue("sub" in r.remoteFake.listAll(RHOME).map { it.name })
+        assertTrue("inner.txt" in r.remoteFake.listAll("$RHOME/sub").map { it.name })
         assertTrue("sub" !in (r.local.state as FilePaneState.Loaded).entries.map { it.name })
         assertEquals(TransferState.Idle, r.coordinator.transfer)
     }
@@ -307,7 +307,7 @@ class TransferCoordinatorTest {
         r.coordinator.moveSelection(fromLocal = false)
         advanceUntilIdle()
 
-        assertTrue("proj" in r.localFake.list(LHOME).map { it.name })
+        assertTrue("proj" in r.localFake.listAll(LHOME).map { it.name })
         assertTrue("proj" !in (r.remote.state as FilePaneState.Loaded).entries.map { it.name })
         assertEquals(TransferState.Idle, r.coordinator.transfer)
     }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/files/TransferPlanTest.kt
@@ -2,9 +2,11 @@ package app.skerry.ui.files
 
 import app.skerry.shared.files.FileBrowserException
 import app.skerry.shared.files.FileBrowserFailure
+import app.skerry.shared.files.FileContentBrowser
 import app.skerry.shared.files.FileItem
 import app.skerry.shared.files.FileItemType
 import app.skerry.shared.files.MAX_TREE_DEPTH
+import app.skerry.shared.files.MAX_LISTING_ENTRIES
 import app.skerry.shared.files.MAX_TREE_ENTRIES
 import app.skerry.shared.files.SftpFileBrowser
 import app.skerry.shared.sftp.SftpEntry
@@ -162,14 +164,17 @@ class TransferPlanTest {
 
     @Test
     fun `a plan bigger than the cap stops before it is built`() = runTest {
-        // Depth is not the only way out of a bounded plan: one directory whose listing never ends
-        // is flat and still unbounded. The depth cap says nothing about it.
+        // Depth is not the only way out of a bounded plan: a shallow tree of directories none of
+        // which is too wide to list is flat and still unbounded. The depth cap says nothing about
+        // it, and neither does the per-listing one — three legal listings are over the plan's cap.
+        val perDir = 40_000
         val remote = remote().apply {
-            seedDir("$REMOTE/wide")
-            val wide = (0..MAX_TREE_ENTRIES).map {
-                SftpEntry("f$it", "$REMOTE/wide/f$it", SftpEntryType.File, 1, 0, 0b110_100_100)
+            listAnswer = { path ->
+                when (path) {
+                    "$REMOTE/wide" -> (0..2).map { dirEntry("$REMOTE/wide/s$it") }
+                    else -> CountingListing(path, perDir)
+                }
             }
-            listAnswer = { path -> if (path == "$REMOTE/wide") wide else null }
         }
 
         val failure = assertFailsWith<FileBrowserException> {
@@ -185,15 +190,96 @@ class TransferPlanTest {
     }
 
     @Test
-    fun `a tree exactly as wide as the cap allows is still planned whole`() = runTest {
-        // The other half of the same boundary: the directory itself is one of the entries the walk
-        // takes on, so the last file the cap allows is the one that makes the count exact.
+    fun `a listing too wide to hold is refused before the plan counts it`() = runTest {
+        // The plan's entry cap counts entries the walk takes on, which is after the listing that
+        // holds them exists. One directory answered with more names than the client can hold has to
+        // be refused as it is read, or the heap is gone before the cap is ever consulted.
+        val wide = CountingListing("$REMOTE/wide", MAX_LISTING_ENTRIES + 1)
         val remote = remote().apply {
             seedDir("$REMOTE/wide")
-            val wide = (1 until MAX_TREE_ENTRIES).map {
-                SftpEntry("f$it", "$REMOTE/wide/f$it", SftpEntryType.File, 1, 0, 0b110_100_100)
-            }
             listAnswer = { path -> if (path == "$REMOTE/wide") wide else null }
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildDownloadPlan(
+                remote,
+                listOf(item("wide", FileItemType.Directory, "$REMOTE/wide")),
+                localDir = LOCAL,
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+        // Without the guard the plan's own cap would refuse this too, one entry at a time, having
+        // walked the listing first. What is under test is that nothing read it at all.
+        assertEquals(0, wide.reads, "the listing was walked before it was refused")
+    }
+
+    @Test
+    fun `listings held on the way down share one budget, not one each`() = runTest {
+        // The plan's own count cannot stand in for this. It counts entries the walk has taken on,
+        // and a descent into the first child of a level counts exactly one while the whole listing
+        // of every level above stays alive in its frame — sixty-four of those is the heap, and an
+        // OutOfMemoryError is not a refusal anyone can read.
+        val wide = 30_000 // under the cap alone, over it once two levels hold one each
+        val remote = remote().apply {
+            listAnswer = { path ->
+                when (path) {
+                    "$REMOTE/a", "$REMOTE/a/f0" -> CountingListing(path, wide, firstIsDirectory = true)
+                    else -> emptyList()
+                }
+            }
+        }
+
+        val failure = assertFailsWith<FileBrowserException> {
+            buildDownloadPlan(
+                remote,
+                listOf(item("a", FileItemType.Directory, "$REMOTE/a")),
+                localDir = LOCAL,
+                remoteDir = REMOTE,
+            )
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, failure.failure)
+        // The plan bounds the first listing, what the first listing holds bounds the second.
+        assertEquals(listOf(MAX_LISTING_ENTRIES, MAX_LISTING_ENTRIES - wide), remote.listLimits)
+    }
+
+    @Test
+    fun `each level asks a listing for what the level above it left`() = runTest {
+        // The budget is spent as it is walked, not reset per call: a level asks for what the levels
+        // above it did not already take, so the ordinary case shows the subtraction too.
+        val remote = remote().apply {
+            seedDir("$REMOTE/a")
+            seedFile("$REMOTE/a/f1")
+            seedFile("$REMOTE/a/f2")
+            seedDir("$REMOTE/a/sub")
+        }
+
+        buildDownloadPlan(
+            remote,
+            listOf(item("a", FileItemType.Directory, "$REMOTE/a")),
+            localDir = LOCAL,
+            remoteDir = REMOTE,
+        )
+
+        // `a` gets the whole budget; its three children come out of it before `sub` is listed.
+        assertEquals(listOf(MAX_LISTING_ENTRIES, MAX_LISTING_ENTRIES - 3), remote.listLimits)
+    }
+
+    @Test
+    fun `a tree exactly as wide as the cap allows is still planned whole`() = runTest {
+        // The other half of the same boundary: the directories themselves are entries the walk takes
+        // on too, so the last file the cap allows is the one that makes the count exact.
+        val perDir = (MAX_TREE_ENTRIES - 4) / 3
+        assertEquals(MAX_TREE_ENTRIES, 4 + perDir * 3, "the tree below has to land on the cap exactly")
+        val remote = remote().apply {
+            listAnswer = { path ->
+                when (path) {
+                    "$REMOTE/wide" -> (0..2).map { dirEntry("$REMOTE/wide/s$it") }
+                    else -> CountingListing(path, perDir)
+                }
+            }
         }
 
         val plan = buildDownloadPlan(
@@ -203,7 +289,7 @@ class TransferPlanTest {
             remoteDir = REMOTE,
         )
 
-        assertEquals(MAX_TREE_ENTRIES - 1, plan.files.size)
+        assertEquals(perDir * 3, plan.files.size)
     }
 
     @Test
@@ -286,17 +372,21 @@ class TransferPlanTest {
 
         ensureDir(SftpFileBrowser(remote, "prod"), "$REMOTE/proj")
 
-        // Creating first and excusing the failure afterwards, not probing first: a listing that
-        // says nothing is there is stale the moment it returns, and the ordering decides which of
-        // the two errors the user is told about.
+        // Creating first and excusing the failure afterwards, not probing first: a probe that says
+        // nothing is there is stale the moment it returns, and the ordering decides which of the
+        // two errors the user is told about.
         assertEquals(1, remote.mkdirCalls)
+        // And the probe is a stat, not a listing: whether one path exists is a yes/no question, and
+        // answering it by listing the directory pulls as many entries as the server cares to send,
+        // once per directory in the plan.
+        assertEquals(emptyList(), remote.listLimits)
     }
 
     @Test
-    fun `a directory that cannot be created reports the mkdir failure, not the listing one`() = runTest {
-        // The path is taken by a *file*: mkdir fails, the listing that would have excused it fails
-        // too, and what the user hears has to be why the directory could not be made — the "no
-        // directory" from the probe explains nothing.
+    fun `a directory that cannot be created reports the mkdir failure, not the probe`() = runTest {
+        // The path is taken by a *file*: mkdir fails, the probe that would have excused it answers
+        // "file", and what the user hears has to be why the directory could not be made — what the
+        // probe found explains nothing.
         val browser = SftpFileBrowser(remote(), "prod")
 
         val failure = assertFailsWith<FileBrowserException> { ensureDir(browser, "$REMOTE/loose.txt") }
@@ -306,9 +396,88 @@ class TransferPlanTest {
     }
 
     @Test
+    fun `a destination that is a symlink to a directory is not an error`() = runTest {
+        // `stat` answers about the link, not about what it points at — both browsers read it without
+        // following (SSH_FXP_LSTAT, okio's NOFOLLOW metadata). A symlinked destination directory is
+        // ordinary, so the probe that cannot decide it has to be finished by opening the path.
+        val browser = SymlinkedDest(linkedToDirectory = true)
+
+        ensureDir(browser, "$REMOTE/proj")
+
+        assertEquals(1, browser.listed, "the symlink was decided without opening it")
+    }
+
+    @Test
+    fun `a destination that is a symlink to a file still reports the mkdir failure`() = runTest {
+        // The other side of the same probe: opening it fails, and what the user hears is why the
+        // directory could not be made, not what the probe ran into.
+        val browser = SymlinkedDest(linkedToDirectory = false)
+
+        val failure = assertFailsWith<FileBrowserException> { ensureDir(browser, "$REMOTE/proj") }
+
+        assertTrue(failure.detail.orEmpty().startsWith("Path taken"), "got: ${failure.detail}")
+    }
+
+    @Test
     fun `a delete path is rebuilt from the pane's directory, never from the listing`() {
         assertEquals("$REMOTE/a.txt", safeRemoteChild("a.txt", REMOTE))
         assertFailsWith<FileBrowserException> { safeRemoteChild("../a.txt", REMOTE) }
         assertFailsWith<FileBrowserException> { safeRemoteChild("..", REMOTE) }
+    }
+}
+
+/**
+ * A destination path that is already taken by a symlink: `mkdir` fails, `stat` reports the link
+ * itself, and opening the path succeeds only when it points at a directory.
+ */
+private class SymlinkedDest(private val linkedToDirectory: Boolean) : FileContentBrowser {
+    /** How many times the path was opened — the fallback probe, which costs a round trip. */
+    var listed = 0
+        private set
+
+    override val label = "prod"
+
+    override suspend fun list(path: String): List<FileItem> {
+        listed++
+        if (!linkedToDirectory) {
+            throw FileBrowserException(FileBrowserFailure.Sftp, detail = "Not a directory: $path")
+        }
+        return emptyList()
+    }
+
+    override suspend fun mkdir(path: String): Unit =
+        throw FileBrowserException(FileBrowserFailure.Sftp, detail = "Path taken: $path")
+
+    override suspend fun stat(path: String) =
+        FileItem(path.substringAfterLast('/'), path, FileItemType.Symlink, 0, 0)
+
+    override suspend fun realpath(path: String) = path
+    override suspend fun delete(item: FileItem) = Unit
+    override suspend fun rename(from: String, to: String) = Unit
+    override suspend fun readFile(path: String, maxBytes: Long) = ByteArray(0)
+    override suspend fun writeFile(path: String, data: ByteArray) = Unit
+}
+
+/** One directory row in a listing a test answers with, named after the last segment of [path]. */
+private fun dirEntry(path: String) =
+    SftpEntry(path.substringAfterLast('/'), path, SftpEntryType.Directory, 0, 0, 0b111_101_101)
+
+/**
+ * A listing too big to hold in a test, generated on demand: the walk must decide on its size before
+ * it reads it, so nothing here is ever materialised.
+ */
+private class CountingListing(
+    private val path: String,
+    override val size: Int,
+    private val firstIsDirectory: Boolean = false,
+) : AbstractList<SftpEntry>() {
+    /** How many entries a caller actually took — a listing refused for its width is never read. */
+    var reads = 0
+        private set
+
+    override fun get(index: Int): SftpEntry {
+        reads++
+        val type = if (index == 0 && firstIsDirectory) SftpEntryType.Directory else SftpEntryType.File
+        return SftpEntry("f$index", "$path/f$index", type, 1, 0, 0b110_100_100)
     }
 }

--- a/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
+++ b/composeApp/src/commonTest/kotlin/app/skerry/ui/sftp/FakeSftpClient.kt
@@ -1,5 +1,6 @@
 package app.skerry.ui.sftp
 
+import app.skerry.shared.files.MAX_LISTING_ENTRIES
 import app.skerry.shared.sftp.SftpClient
 import app.skerry.shared.sftp.SftpEntry
 import app.skerry.shared.sftp.SftpEntryType
@@ -53,18 +54,32 @@ class FakeSftpClient(val startDir: String = "/home/skerry") : SftpClient {
      */
     var listAnswer: ((String) -> List<SftpEntry>?)? = null
 
-    override suspend fun list(path: String): List<SftpEntry> {
+    override suspend fun list(path: String, limit: Int): List<SftpEntry> {
+        listLimits += limit
         listAnswer?.invoke(realpathSync(path))?.let { answer ->
             listGate?.await()
-            return answer
+            return answer.bounded(limit)
         }
         val dir = children[realpathSync(path)] ?: throw SftpException("No directory $path")
         // Answered from the tree as it was when the request arrived, like a real round trip: a
         // listing held in flight must be able to land stale.
         val answer = dir.values.toList()
         listGate?.await()
-        return answer
+        return answer.bounded(limit)
     }
+
+    /** The whole listing, for assertions that have no ceiling of their own to name. */
+    suspend fun listAll(path: String): List<SftpEntry> = list(path, MAX_LISTING_ENTRIES)
+
+    /** Limits [list] was asked for, in call order — a walk must ask for no more than it can hold. */
+    val listLimits = mutableListOf<Int>()
+
+    /**
+     * The contract a real client honours: stop one entry past the limit, so the caller can tell a
+     * full listing from a truncated one. Long, so a limit of `Int.MAX_VALUE` needs no special case.
+     */
+    private fun List<SftpEntry>.bounded(limit: Int): List<SftpEntry> =
+        if (size.toLong() > limit.toLong() + 1) subList(0, limit + 1) else this
 
     override suspend fun stat(path: String): SftpEntry? {
         val norm = realpathSync(path)

--- a/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotFakes.kt
+++ b/composeApp/src/desktopMain/kotlin/app/skerry/ui/desktop/ScreenshotFakes.kt
@@ -171,7 +171,9 @@ internal class FakeSftpClient : SftpClient {
         SftpEntry("deploy.sh", "/var/www/deploy.sh", SftpEntryType.File, 1843, 0, 0b111_101_101),
     )
 
-    override suspend fun list(path: String): List<SftpEntry> = listing
+    // No truncation: the fixture is five rows, so the limit can never bind. A fake that grows past
+    // it has to honour the contract like every other implementation does.
+    override suspend fun list(path: String, limit: Int): List<SftpEntry> = listing
     override suspend fun stat(path: String): SftpEntry? = null
     override suspend fun realpath(path: String): String = "/var/www"
     override suspend fun read(path: String, maxBytes: Long): ByteArray = ByteArray(0)

--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -57,6 +57,7 @@ mandatory. Tests included (see `RoutesTestSupport` on the server).
 | Mosh session key, framing, timing, wire messages | `mosh/MoshKey`, `MoshFragment`, `MoshTiming`, `MoshSync`, `MoshWire` (codec in jvmShared) |
 | Host tag normalisation and prod-first ordering | `tag/Tags`: `normalizeTag`, `orderTagsProdFirst` |
 | Risk scoring of a production command | `guard/ProductionGuard` + `ProductionGuardPolicy` |
+| Bounding a client-side walk over a server's listing (depth, whole plan, one listing) | `files/TreeWalkLimit`: `refuseTooDeep`, `TreeWalkLimit`, `refuseOversizedListing` |
 | App version compare, release lookup, update settings | `update/UpdateVersion`, `ReleaseInfo`, `UpdateChecker`, `UpdateSettings` |
 | Server: admin-token guard | route-scoped plugin (one, in Routes) — don't inline the check per route |
 | Server: rate limit, path id, parameter limits | helpers `requiredPathId` / `limitParam` / the rate-limit helper |

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/FileBrowser.kt
@@ -122,7 +122,11 @@ enum class FileBrowserFailure {
     /** The file is larger than the caller's cap (whole-file read for the viewer/editor). */
     TooLarge,
 
-    /** The directory tree to transfer is deeper or bigger than a transfer plan may hold. */
+    /**
+     * A walk over a remote tree was refused for its size. Three shapes reach this one value: a tree
+     * with no bottom (past the depth bound), a transfer plan wider than the client can hold, and a
+     * single directory answered with more entries than there is room for.
+     */
     TreeTooLarge,
 
     /**

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/SftpFileBrowser.kt
@@ -32,9 +32,18 @@ class SftpFileBrowser(
      *
      * The first entry of each wins: which of them the server meant is unknowable, and keeping the
      * later one would make the listing depend on packet order.
+     *
+     * How long the listing is is decided before it is mapped: both de-duplication passes build a
+     * `HashSet` over whatever came back, so a listing too big to hold has to be refused before it is
+     * copied, not after. [SftpClient.list] stops one entry past the cap, so an answer longer than it
+     * is a listing the server cut short — [refuseOversizedListing] turns that into a failed pane
+     * rather than a directory drawn short without saying so.
      */
-    override suspend fun list(path: String): List<FileItem> =
-        guard { sftp.list(path).map { it.toFileItem() }.distinctBy { it.path }.distinctBy { it.name } }
+    override suspend fun list(path: String): List<FileItem> = guard {
+        val entries = sftp.list(path, MAX_LISTING_ENTRIES)
+        refuseOversizedListing(path, entries.size)
+        entries.map { it.toFileItem() }.distinctBy { it.path }.distinctBy { it.name }
+    }
 
     override suspend fun mkdir(path: String): Unit = guard { sftp.mkdir(path) }
 
@@ -46,7 +55,7 @@ class SftpFileBrowser(
      * writes — so it is bounded by [refuseTooDeep], and by nothing else: see [deleteTree].
      */
     override suspend fun delete(item: FileItem): Unit = guard {
-        deleteTree(item.path, item.type == FileItemType.Directory, depth = 0)
+        deleteTree(item.path, item.type == FileItemType.Directory, depth = 0, hold = MAX_LISTING_ENTRIES)
     }
 
     /**
@@ -61,26 +70,39 @@ class SftpFileBrowser(
      * loop at each level are removed on the way down, and SFTP has no recursive delete to make that
      * atomic — a mid-tree refusal here has the same shape a permission denied always had.
      *
-     * Depth is the only bound. This walk deletes as it goes rather than deciding first, so a cap on
-     * how many entries it may take on would stop it with most of the tree already gone, on a verb
-     * where "refused" and "half done" are not the same answer at all. Width is bounded through
-     * depth: it holds no plan, only one listing per active level.
+     * Depth is the only bound on the walk. This walk deletes as it goes rather than deciding first,
+     * so a cap on how many entries it may take on would stop it with most of the tree already gone,
+     * on a verb where "refused" and "half done" are not the same answer at all — the plan cap
+     * ([MAX_TREE_ENTRIES]) is deliberately not applied here.
+     *
+     * One listing is bounded, though, and for a different reason: it is held in memory whole, and a
+     * directory too wide to hold cannot be deleted either. [refuseOversizedListing] runs before any
+     * child of that directory is removed, so what it refuses it also leaves intact.
+     *
+     * [hold] is what is left of that bound, not a fresh copy of it. The walk keeps every listing on
+     * the way down alive while it works on the level below, so sixty-four levels each allowed a full
+     * [MAX_LISTING_ENTRIES] would hold sixty-four times the memory the cap names. Each level hands
+     * its children what remains after its own listing; siblings are walked in turn and each one's
+     * listings are released before the next starts, so a wide tree is not refused for its breadth.
      *
      * The listing is not de-duplicated here, unlike [list]: an entry dropped from it is an entry
      * never removed, and `rmdir` would then fail on a directory that is not empty.
      */
-    private suspend fun deleteTree(path: String, isDirectory: Boolean, depth: Int) {
+    private suspend fun deleteTree(path: String, isDirectory: Boolean, depth: Int, hold: Int) {
         if (!isDirectory) {
             sftp.remove(path)
             return
         }
         refuseTooDeep(depth + 1)
         val prefix = if (path.endsWith("/")) path else "$path/"
-        sftp.list(path).forEach { child ->
+        val children = sftp.list(path, hold)
+        refuseOversizedListing(path, children.size, hold)
+        val childHold = hold - children.size
+        children.forEach { child ->
             if (!child.path.startsWith(prefix)) {
                 throw SftpException("Listing $path returned a path outside the directory: ${child.path}")
             }
-            deleteTree(child.path, child.type == SftpEntryType.Directory, depth + 1)
+            deleteTree(child.path, child.type == SftpEntryType.Directory, depth + 1, childHold)
         }
         sftp.rmdir(path)
     }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/files/TreeWalkLimit.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/files/TreeWalkLimit.kt
@@ -59,3 +59,58 @@ class TreeWalkLimit {
     /** @see refuseTooDeep */
     fun descend(depth: Int) = refuseTooDeep(depth)
 }
+
+/**
+ * How many entries one directory listing may hold.
+ *
+ * [MAX_TREE_ENTRIES] bounds a walk once its listings exist; this bounds a single one of them as it
+ * is read. Nothing else does: a listing is the server's answer, so how much is allocated to hold it
+ * is the server's decision, and one `SSH_FXP_READDIR` loop is enough to exhaust the heap during an
+ * ordinary browse — before any guard above it runs.
+ *
+ * The number is the peak, not the row. One entry costs several times the
+ * [app.skerry.shared.sftp.SftpEntry] it ends up as: sshj holds a list node, a `RemoteResourceInfo`,
+ * a `PathComponents` and a `FileAttributes` (with a map of its own) for the whole listing before it
+ * returns any of it, the browser then builds a `FileItem` beside every entry and de-duplicates
+ * twice, and the pane keeps a sorted copy alongside the filtered one. Around 600 bytes an entry
+ * alive at once, so this is ~30 MB in flight and ~8 MB per pane afterwards.
+ *
+ * The floor it is weighed against is Android's, not the desktop's: the app asks for no large heap,
+ * so what it gets is `dalvik.vm.heapgrowthlimit` — 128 MB on a mid-range device, less on an old one.
+ * Desktop therefore pays a lower ceiling than it needs, which is the cheaper mistake: a refusal is a
+ * line of text, and the alternative is an `OutOfMemoryError`, which is not a failure anyone can read
+ * or retry. A directory of 50 000 rows is already past what a pane can usefully draw; past that the
+ * user is told, not crashed.
+ *
+ * It bounds a walk as well as a browse, so it is also what a directory download may take on in one
+ * directory — deliberately, for the same reason.
+ *
+ * It is the budget for a whole root-to-leaf path, not for one call. A recursive walk holds one
+ * listing per level it is currently inside, so each level passes what is left of it down as
+ * [refuseOversizedListing]'s `cap`; sixty-four levels each holding a full one is not a bound
+ * at all. Breadth does not consume it: siblings are walked one after another and a sibling's
+ * listings are gone before the next one starts.
+ *
+ * A local listing has no cap of its own. okio's `FileSystem.list` has no streaming form, so the
+ * whole directory is materialised by the call itself and a limit applied to what it returns would
+ * refuse after the allocation it was meant to prevent. What bounds it there is the local filesystem.
+ */
+const val MAX_LISTING_ENTRIES = 50_000
+
+/**
+ * Refuses a directory listing longer than [cap] — [MAX_LISTING_ENTRIES] for a walk that is not
+ * holding anything else, less for one already holding the listings of the levels above it.
+ *
+ * Called with the size the source answered with, before that answer is mapped or de-duplicated, so
+ * the refusal costs one comparison rather than a second copy of the listing. It refuses rather than
+ * truncates on purpose: a listing drawn short without saying so is a directory the user believes
+ * they have seen.
+ */
+fun refuseOversizedListing(path: String, entries: Int, cap: Int = MAX_LISTING_ENTRIES) {
+    if (entries > cap) {
+        throw FileBrowserException(
+            FileBrowserFailure.TreeTooLarge,
+            detail = "listing of $path is longer than the $cap entries there is room for",
+        )
+    }
+}

--- a/shared/src/commonMain/kotlin/app/skerry/shared/sftp/SftpClient.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/sftp/SftpClient.kt
@@ -17,9 +17,21 @@ interface SftpClient {
 
     /**
      * Contents of directory [path], excluding `.` and `..`. Order is server-supplied (not sorted).
-     * @throws SftpException path doesn't exist, isn't a directory, or lacks permission
+     *
+     * At most `limit + 1` entries are read: how many a listing holds is the server's decision, and
+     * the whole answer is built in memory before the caller sees any of it. Stopping one entry past
+     * [limit] bounds that allocation while still telling a full directory apart from a truncated
+     * one — a caller that gets `limit + 1` back knows the listing was cut short, and decides what to
+     * do about it (`app.skerry.shared.files.refuseOversizedListing`). There is no default: what the
+     * client can hold is the caller's number, not this interface's.
+     *
+     * The count is not the whole size: an implementation may also refuse a listing holding an entry
+     * no filesystem could name, since a bounded number of 32 KB names is not a bounded listing.
+     *
+     * @throws SftpException path doesn't exist, isn't a directory, lacks permission, or answered
+     * with an entry whose name no filesystem could hold
      */
-    suspend fun list(path: String): List<SftpEntry>
+    suspend fun list(path: String, limit: Int): List<SftpEntry>
 
     /** Metadata for one object, or `null` if [path] doesn't exist. */
     suspend fun stat(path: String): SftpEntry?

--- a/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/ssh/SshConfigParser.kt
@@ -82,7 +82,12 @@ object SshConfigParser {
         val blocks = mutableListOf<Block>()
         val warnings = LinkedHashSet<String>()
         var current: Block? = null
-        var ignoringMatch = false
+        // Set by a block whose options cannot be honoured: a `Match` (no host context to evaluate
+        // it against) or a `Host` line that produced no usable pattern. Both leave `current` null,
+        // which on its own is indistinguishable from "before the first Host" — and that is where
+        // the parser synthesises a global `*` block, so without this flag a malformed entry handed
+        // its User/IdentityFile to every alias in the file.
+        var skippingOptions = false
         var totalPatterns = 0
 
         for (rawLine in text.lineSequence()) {
@@ -95,29 +100,32 @@ object SshConfigParser {
             val (keyword, args) = splitKeyword(trimmed) ?: continue
             when (keyword.lowercase()) {
                 "host" -> {
-                    ignoringMatch = false
                     val tokens = tokenize(args)
                     val patterns = tokens.filter { it.length <= MAX_PATTERN_LEN }
                     if (patterns.size < tokens.size) warnings.add("Some host patterns were too long and skipped")
                     val capped = patterns.take(MAX_PATTERNS - totalPatterns)
                     if (capped.size < patterns.size) warnings.add("Too many entries — not all lines were parsed")
+                    skippingOptions = capped.isEmpty()
                     if (capped.isEmpty()) {
                         current = null
+                        warnings.add("A Host line had no usable pattern — its options were skipped")
                     } else {
                         totalPatterns += capped.size
                         current = Block(capped).also { blocks.add(it) }
                     }
                 }
                 "match" -> {
-                    ignoringMatch = true
+                    skippingOptions = true
                     current = null
                     warnings.add("Match blocks are ignored")
                 }
                 "include" -> warnings.add("Include is not supported")
                 else -> {
-                    if (ignoringMatch) continue
+                    if (skippingOptions) continue
                     val value = tokenize(args).firstOrNull() ?: continue
                     // Options before the first Host apply globally (OpenSSH) — model as a `*` block.
+                    // Only reachable before the first Host: any block that failed to parse sets
+                    // [skippingOptions] and returned above.
                     val block = current ?: Block(listOf("*")).also { blocks.add(it); current = it; totalPatterns++ }
                     block.options.putIfAbsent(keyword.lowercase(), value)
                 }

--- a/shared/src/commonMain/kotlin/app/skerry/shared/telnet/TelnetCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/telnet/TelnetCodec.kt
@@ -103,15 +103,27 @@ class TelnetCodec(
 
                 Phase.SUBNEG ->
                     when {
-                        b == IAC -> phase = Phase.SUBNEG_IAC
                         // The SB body must not grow unbounded (the server may never send SE) —
-                        // past the threshold, stop buffering and scan for the closing IAC SE.
-                        subneg.size >= MAX_SUBNEG_BYTES -> { subneg.clear(); phase = Phase.SUBNEG_DROP }
+                        // past the threshold, stop buffering and scan for the closing IAC SE. The
+                        // cap is checked before the IAC branch, not after it: an escaped 0xFF is a
+                        // body byte like any other, and letting it jump the check meant a body of
+                        // `IAC IAC` pairs grew the buffer forever without the cap ever being read.
+                        subneg.size >= MAX_SUBNEG_BYTES -> {
+                            subneg.clear()
+                            // The byte that trips the cap is consumed here, so an IAC has to carry
+                            // its meaning into the drop scanner — otherwise the closing IAC SE that
+                            // arrives exactly at the boundary is swallowed and the SB never ends.
+                            phase = if (b == IAC) Phase.SUBNEG_DROP_IAC else Phase.SUBNEG_DROP
+                        }
+                        b == IAC -> phase = Phase.SUBNEG_IAC
                         else -> subneg.add(b)
                     }
 
                 Phase.SUBNEG_IAC -> when (b) {
-                    IAC -> { subneg.add(IAC); phase = Phase.SUBNEG } // escaped 0xFF in the SB body
+                    // Escaped 0xFF in the SB body. No cap of its own: this phase is only reachable
+                    // from a SUBNEG byte that passed the check above, so the buffer is under the cap
+                    // when this appends and at most at it afterwards.
+                    IAC -> { subneg.add(IAC); phase = Phase.SUBNEG }
                     SE -> { if (reply.size < MAX_REPLY_BYTES) handleSubnegotiation(subneg, reply); phase = Phase.DATA }
                     else -> phase = Phase.DATA // malformed sequence — reset
                 }
@@ -201,7 +213,9 @@ class TelnetCodec(
         add(IAC.toByte()); add(cmd.toByte()); add(option.toByte())
     }
 
-    private companion object {
+    // Internal, not private: the cap is a number the tests have to name, and a copy of it in a
+    // test file is a copy that can drift away from the parser it claims to describe.
+    internal companion object {
         const val IAC = 255
         const val SE = 240
         const val SB = 250

--- a/shared/src/commonMain/kotlin/app/skerry/shared/vnc/RfbCodec.kt
+++ b/shared/src/commonMain/kotlin/app/skerry/shared/vnc/RfbCodec.kt
@@ -506,8 +506,19 @@ class RfbCodec(
         sink.write(msg)
     }
 
+    /**
+     * ClientCutText (6). RFB (RFC 6143 7.5.6) defines the text as ISO 8859-1 — the same encoding
+     * [readBoundedLatin1] decodes the other direction with, byte 1:1 to code point. Encoding UTF-8
+     * here made the two directions disagree, so every non-ASCII paste reached the server as
+     * mojibake. A code point Latin-1 cannot carry becomes `?` (what TigerVNC substitutes); a
+     * surrogate pair is two of them. Dropping such characters instead would leave the user with a
+     * paste that is quietly short rather than visibly incomplete.
+     */
     suspend fun writeClientCutText(text: String) {
-        val body = text.encodeToByteArray()
+        val body = ByteArray(text.length) { i ->
+            val code = text[i].code
+            if (code <= 0xFF) code.toByte() else LATIN1_SUBSTITUTE
+        }
         val msg = ByteArray(8 + body.size)
         msg[0] = 6 // ClientCutText
         putU32(msg, 4, body.size.toLong())
@@ -601,6 +612,9 @@ class RfbCodec(
         const val MAX_NAME_LEN = 64 * 1024
         const val MAX_REASON_LEN = 64 * 1024
         const val MAX_CLIPBOARD_LEN = 4 * 1024 * 1024
+
+        /** What a code point outside Latin-1 becomes in an outgoing ClientCutText: `?`. */
+        const val LATIN1_SUBSTITUTE: Byte = 0x3F
 
         /** Cursor sprites are ~32-96px in practice; 1024 leaves room for hi-dpi and still caps pixels+mask at ~4.3 MB. */
         const val MAX_CURSOR_DIMENSION = 1024

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/SftpFileBrowserTest.kt
@@ -147,18 +147,93 @@ class SftpFileBrowserTest {
     }
 
     @Test
-    fun `a directory wider than a transfer plan may hold is still deleted whole`() = runTest {
-        // The entry cap is what a plan held whole in memory costs. This walk holds no plan and
-        // deletes as it goes, so the same cap would stop it with most of the tree already gone —
-        // and report the tree as refused, on an operation that destroyed two thirds of it. A tree
-        // with no bottom is bounded by depth, which refuses before anything is removed.
-        val wide = List(MAX_TREE_ENTRIES + 1) { SftpEntry("f$it", "/d/big/f$it", SftpEntryType.File, 0, 0, 0b110_100_100) }
-        client.listAnswer = { path -> if (path == "/d/big") wide else null }
+    fun `a tree wider than a transfer plan may hold is still deleted whole`() = runTest {
+        // Two things at once. The entry cap is what a plan held whole in memory costs; this walk
+        // holds no plan and deletes as it goes, so the same cap would stop it with most of the tree
+        // already gone and report the tree as refused, on an operation that destroyed two thirds of
+        // it. And breadth must not consume the budget either: siblings are walked one after another,
+        // so each one gets the same room as the last — a budget decremented per listing instead of
+        // per level would delete the first two directories and refuse the third.
+        val perDirectory = 34_000
+        val subdirs = List(3) { SftpEntry("s$it", "/d/big/s$it", SftpEntryType.Directory, 0, 0, 0b111_101_101) }
+        client.listAnswer = { path ->
+            when {
+                path == "/d/big" -> subdirs
+                path.startsWith("/d/big/s") -> List(perDirectory) {
+                    SftpEntry("f$it", "$path/f$it", SftpEntryType.File, 0, 0, 0b110_100_100)
+                }
+                else -> null
+            }
+        }
 
         browser().delete(FileItem("big", "/d/big", FileItemType.Directory, 0, 0))
 
-        assertEquals(MAX_TREE_ENTRIES + 1, client.calls.count { it.startsWith("remove:") })
+        assertEquals(3 * perDirectory, client.calls.count { it.startsWith("remove:") })
+        assertTrue(subdirs.all { "rmdir:${it.path}" in client.calls })
         assertTrue("rmdir:/d/big" in client.calls)
+        // Every sibling asked for the same room: what the level above holds, and nothing more.
+        assertEquals(
+            listOf(MAX_LISTING_ENTRIES) + List(3) { MAX_LISTING_ENTRIES - subdirs.size },
+            client.listLimits,
+        )
+    }
+
+    @Test
+    fun `a listing bigger than the client can hold is refused, not drawn short`() = runTest {
+        // The listing is the server's answer, and nothing above this call bounds it: the transfer
+        // plan's cap is checked after the listing exists, and the de-duplication passes run over it.
+        // A listing cut short without saying so is a directory the user believes they have seen.
+        client.listAnswer = { path -> if (path == "/d/huge") oversizedListing(path, MAX_LISTING_ENTRIES + 1) else null }
+
+        val e = assertFailsWith<FileBrowserException> { browser().list("/d/huge") }
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+    }
+
+    @Test
+    fun `the browser asks the client for one entry past the cap`() = runTest {
+        // How the truncation is detected at all: the client stops one over, so "full" and "cut
+        // short" are distinguishable without holding the server's whole answer.
+        browser().list("/d")
+
+        assertEquals(listOf(MAX_LISTING_ENTRIES), client.listLimits)
+    }
+
+    @Test
+    fun `a directory too wide to list is refused before its contents are removed`() = runTest {
+        // Same shape as the depth refusal: the walk ends without promising the tree is untouched,
+        // but nothing inside the directory it refused was deleted.
+        client.listAnswer = { path -> if (path == "/d/huge") oversizedListing(path, MAX_LISTING_ENTRIES + 1) else null }
+
+        val e = assertFailsWith<FileBrowserException> {
+            browser().delete(FileItem("huge", "/d/huge", FileItemType.Directory, 0, 0))
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+        assertTrue(client.calls.none { it.startsWith("remove:") || it.startsWith("rmdir:") })
+    }
+
+    @Test
+    fun `listings held on the way down share one budget, not one each`() = runTest {
+        // The walk keeps every listing above it alive while it works on the level below, so a level
+        // allowed a full cap of its own would hold as many caps as the tree is deep. The first child
+        // is the directory, so the refusal lands before anything beside it is removed.
+        val held = 30_000
+        client.listAnswer = { path ->
+            when (path) {
+                "/d/deep" -> oversizedListing(path, held, firstIsDirectory = true)
+                "/d/deep/f0" -> oversizedListing(path, MAX_LISTING_ENTRIES)
+                else -> null
+            }
+        }
+
+        val e = assertFailsWith<FileBrowserException> {
+            browser().delete(FileItem("deep", "/d/deep", FileItemType.Directory, 0, 0))
+        }
+
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+        // The cap minus what the level above is holding: the nested listing is asked for the rest.
+        assertEquals(listOf(MAX_LISTING_ENTRIES, MAX_LISTING_ENTRIES - held), client.listLimits)
+        assertTrue(client.calls.none { it.startsWith("remove:") || it.startsWith("rmdir:") })
     }
 
     @Test
@@ -304,11 +379,18 @@ private class RecordingSftp : SftpClient {
     /** Listings a map cannot hold — a directory that lists itself as its own child. */
     var listAnswer: ((String) -> List<SftpEntry>?)? = null
 
-    override suspend fun list(path: String): List<SftpEntry> {
+    /** Limits the browser asked for, in call order — the contract is "at most limit + 1 entries". */
+    val listLimits = mutableListOf<Int>()
+
+    override suspend fun list(path: String, limit: Int): List<SftpEntry> {
         if (cancelList) throw CancellationException("cancelled")
         if (failList) throw SftpException("boom")
         calls += "list:$path"
-        return listAnswer?.invoke(path) ?: listings[path] ?: listResult
+        listLimits += limit
+        val all = listAnswer?.invoke(path) ?: listings[path] ?: listResult
+        // Long: the contract is "one past the limit", and a limit of Int.MAX_VALUE must not wrap
+        // into a negative ceiling here any more than it does in the real client.
+        return if (all.size.toLong() > limit.toLong() + 1) all.subList(0, limit + 1) else all
     }
 
     override suspend fun stat(path: String): SftpEntry? {
@@ -338,3 +420,20 @@ private class RecordingSftp : SftpClient {
     override suspend fun rename(from: String, to: String) { calls += "rename:$from->$to" }
     override suspend fun close() {}
 }
+
+/**
+ * A listing too big to hold in a test, generated on demand: the browser must decide on its size
+ * before it maps it, so nothing here is ever materialised.
+ */
+private fun oversizedListing(path: String, count: Int, firstIsDirectory: Boolean = false): List<SftpEntry> =
+    object : AbstractList<SftpEntry>() {
+        override val size = count
+        override fun get(index: Int) = SftpEntry(
+            "f$index",
+            "$path/f$index",
+            if (index == 0 && firstIsDirectory) SftpEntryType.Directory else SftpEntryType.File,
+            0,
+            0,
+            0b110_100_100,
+        )
+    }

--- a/shared/src/commonTest/kotlin/app/skerry/shared/files/TreeWalkLimitTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/files/TreeWalkLimitTest.kt
@@ -1,0 +1,35 @@
+package app.skerry.shared.files
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** The bounds every client-side walk over a server's listing shares. */
+class TreeWalkLimitTest {
+
+    @Test
+    fun `a listing at the cap is allowed and the entry past it is refused`() {
+        refuseOversizedListing("/d", MAX_LISTING_ENTRIES)
+
+        val e = assertFailsWith<FileBrowserException> { refuseOversizedListing("/d", MAX_LISTING_ENTRIES + 1) }
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+    }
+
+    @Test
+    fun `a listing is measured against the room left, not against the whole cap`() {
+        // A walk already holding the listings of the levels above it passes down what is left of the
+        // bound, so the same directory is fine at the top of a walk and too wide halfway into one.
+        refuseOversizedListing("/d", entries = 10, cap = 10)
+
+        val e = assertFailsWith<FileBrowserException> { refuseOversizedListing("/d", entries = 10, cap = 9) }
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+    }
+
+    @Test
+    fun `a descent at the depth limit is allowed and the level past it is refused`() {
+        refuseTooDeep(MAX_TREE_DEPTH)
+
+        val e = assertFailsWith<FileBrowserException> { refuseTooDeep(MAX_TREE_DEPTH + 1) }
+        assertEquals(FileBrowserFailure.TreeTooLarge, e.failure)
+    }
+}

--- a/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/ssh/SshConfigParserTest.kt
@@ -2,6 +2,7 @@ package app.skerry.shared.ssh
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class SshConfigParserTest {
@@ -262,6 +263,63 @@ class SshConfigParserTest {
         val alias = "b".repeat(120)
         val result = parse("Host $stars\n    User u\n\nHost $alias\n    HostName 10.0.0.1")
         assertEquals("10.0.0.1", result.hosts.single { it.alias == alias }.hostName)
+    }
+
+    @Test
+    fun `options under an argument-less Host line do not become global defaults`() {
+        // "no current block" is also how the parser models options that appear before the first
+        // Host, so a Host line that produced no pattern used to hand its options to every alias.
+        val result = parse(
+            """
+            Host
+                User root
+                IdentityFile ~/.ssh/id_root
+
+            Host web
+                HostName 10.0.0.1
+            """.trimIndent()
+        )
+
+        val web = result.hosts.single { it.alias == "web" }
+        assertNull(web.user, "a malformed Host block leaked its User to every alias")
+        assertNull(web.identityFile, "a malformed Host block leaked its IdentityFile to every alias")
+        assertEquals("10.0.0.1", web.hostName)
+        assertTrue(result.warnings.any { it.contains("host", ignoreCase = true) }, "the malformed line was not reported")
+    }
+
+    @Test
+    fun `options under a Host line whose every pattern was too long are dropped`() {
+        // The other way a Host line ends up with no usable pattern: every token over the length cap.
+        val huge = "a".repeat(5_000)
+        val result = parse(
+            """
+            Host $huge
+                User root
+
+            Host web
+                HostName 10.0.0.1
+            """.trimIndent()
+        )
+
+        assertNull(result.hosts.single { it.alias == "web" }.user)
+    }
+
+    @Test
+    fun `options before the first Host still apply globally`() {
+        // The regression guard for the fix above: a real global block must survive it.
+        val result = parse(
+            """
+            User global
+            Port 2200
+
+            Host web
+                HostName 10.0.0.1
+            """.trimIndent()
+        )
+
+        val web = result.hosts.single { it.alias == "web" }
+        assertEquals("global", web.user)
+        assertEquals(2200, web.port)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/telnet/TelnetCodecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/telnet/TelnetCodecTest.kt
@@ -5,17 +5,20 @@ import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-private const val IAC = 255
-private const val SE = 240
-private const val SB = 250
-private const val WILL = 251
-private const val WONT = 252
-private const val DO = 253
-private const val DONT = 254
-private const val ECHO = 1
-private const val SGA = 3
-private const val TERMINAL_TYPE = 24
-private const val NAWS = 31
+// Aliases, not copies: a second spelling of 255 in a test file is a number that can drift away from
+// the parser it claims to describe.
+private const val IAC = TelnetCodec.IAC
+private const val SE = TelnetCodec.SE
+private const val SB = TelnetCodec.SB
+private const val WILL = TelnetCodec.WILL
+private const val WONT = TelnetCodec.WONT
+private const val DO = TelnetCodec.DO
+private const val DONT = TelnetCodec.DONT
+private const val ECHO = TelnetCodec.ECHO
+private const val SGA = TelnetCodec.SGA
+private const val TERMINAL_TYPE = TelnetCodec.TERMINAL_TYPE
+private const val NAWS = TelnetCodec.NAWS
+private const val TT_SEND = TelnetCodec.TT_SEND
 
 private fun bytes(vararg v: Int) = ByteArray(v.size) { v[it].toByte() }
 
@@ -142,6 +145,41 @@ class TelnetCodecTest {
         assertEquals("", d.data.decodeToString(), "subnegotiation body reached the terminal as data")
         // The real end of the subnegotiation still works, and data after it is passed through.
         assertEquals("ok", codec.consume(bytes(IAC, SE) + "ok".encodeToByteArray()).data.decodeToString())
+    }
+
+    @Test
+    fun `a body of escaped IACs trips the cap instead of buffering without bound`() {
+        val codec = TelnetCodec()
+        // TERMINAL-TYPE SEND: a body the codec acts on, so "was it buffered?" is observable.
+        codec.consume(bytes(IAC, SB, TERMINAL_TYPE, TT_SEND))
+        // A body made only of escaped 0xFF. Each pair is one byte of body, and the escape path is
+        // the one that used to append without ever consulting the cap.
+        val d = codec.consume(ByteArray(4 * TelnetCodec.MAX_SUBNEG_BYTES) { IAC.toByte() })
+        assertTrue(d.reply.isEmpty(), "an oversized body must not be answered mid-flood")
+
+        // The body is past the cap, so the closing IAC SE must find nothing left to act on.
+        val closed = codec.consume(bytes(IAC, SE))
+        assertTrue(closed.reply.isEmpty(), "an oversized subnegotiation was buffered and answered")
+        assertEquals("", closed.data.decodeToString())
+
+        // The stream recovers: the next subnegotiation is parsed normally.
+        val next = codec.consume(bytes(IAC, SB, TERMINAL_TYPE, TT_SEND, IAC, SE))
+        assertTrue(next.reply.isNotEmpty(), "parser did not recover after the dropped body")
+    }
+
+    @Test
+    fun `an escaped IAC straddling the cap does not swallow the closing IAC SE`() {
+        val codec = TelnetCodec()
+        // TERMINAL-TYPE SEND again, so a body that was buffered would be answered and a body that
+        // was dropped would not — otherwise the two orderings of the cap check look identical here.
+        codec.consume(bytes(IAC, SB, TERMINAL_TYPE, TT_SEND))
+        // Fill the buffer to exactly the cap, so the very next byte trips it.
+        codec.consume(ByteArray(TelnetCodec.MAX_SUBNEG_BYTES - 2) { 0x20 })
+        // That next byte is the IAC of the closing sequence: the cap must not eat the marker.
+        val d = codec.consume(bytes(IAC, SE) + "after".encodeToByteArray())
+
+        assertTrue(d.reply.isEmpty(), "a body past the cap was buffered and answered")
+        assertEquals("after", d.data.decodeToString(), "the closing IAC SE was swallowed by the cap")
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/app/skerry/shared/vnc/RfbCodecTest.kt
+++ b/shared/src/commonTest/kotlin/app/skerry/shared/vnc/RfbCodecTest.kt
@@ -722,6 +722,59 @@ class RfbCodecTest {
             codec(FixtureSource(stream), CapturingSink(), RemoteFramebuffer(1, 1)).readMessage()
         }
     }
+
+    @Test
+    fun client_cut_text_is_encoded_as_latin1() = runTest {
+        // RFC 6143 7.5.6 defines ClientCutText as ISO 8859-1, and readServerCutText already decodes
+        // it that way. UTF-8 here made every non-ASCII paste arrive as mojibake on the server.
+        val sink = CapturingSink()
+        codec(FixtureSource(ByteArray(0)), sink, RemoteFramebuffer(1, 1)).writeClientCutText("café")
+
+        val msg = sink.messages.single()
+        assertEquals(6, msg[0].toInt())
+        assertEquals(4, s32At(msg, 4))
+        assertContentEquals(byteArrayOf(0x63, 0x61, 0x66, 0xE9.toByte()), msg.copyOfRange(8, msg.size))
+    }
+
+    @Test
+    fun client_cut_text_substitutes_code_points_latin1_cannot_carry() = runTest {
+        // Latin-1 has no Cyrillic and no em dash. A visible placeholder is what TigerVNC sends;
+        // dropping the characters silently would leave the user with a paste that is quietly wrong.
+        val sink = CapturingSink()
+        codec(FixtureSource(ByteArray(0)), sink, RemoteFramebuffer(1, 1)).writeClientCutText("a—привет")
+
+        val msg = sink.messages.single()
+        assertEquals(8, s32At(msg, 4))
+        assertEquals("a???????", msg.copyOfRange(8, msg.size).map { (it.toInt() and 0xFF).toChar() }.joinToString(""))
+    }
+
+    @Test
+    fun client_cut_text_sends_two_placeholders_for_one_astral_character() = runTest {
+        // An emoji is one code point and two UTF-16 chars. The body is built per char, so it costs
+        // two placeholders — the length field must agree with that, or every byte after it in the
+        // stream is read at the wrong offset.
+        val sink = CapturingSink()
+        codec(FixtureSource(ByteArray(0)), sink, RemoteFramebuffer(1, 1)).writeClientCutText("a\uD83D\uDE00b")
+
+        val msg = sink.messages.single()
+        assertEquals(4, s32At(msg, 4))
+        assertContentEquals(byteArrayOf(0x61, 0x3F, 0x3F, 0x62), msg.copyOfRange(8, msg.size))
+    }
+
+    @Test
+    fun client_cut_text_round_trips_what_server_cut_text_decodes() = runTest {
+        // The two directions must agree: whatever the read path turns bytes into, the write path
+        // must turn back into the same bytes.
+        val body = byteArrayOf(0x41, 0xE9.toByte(), 0xFF.toByte(), 0x20)
+        val stream = Wire().u8(RfbCodec.MSG_SERVER_CUT_TEXT).u8(0).u8(0).u8(0).s32(body.size).bytes(body).build()
+        val sink = CapturingSink()
+        val c = codec(FixtureSource(stream), sink, RemoteFramebuffer(1, 1))
+
+        val text = (c.readMessage().single() as VncUpdate.ClipboardText).text
+        c.writeClientCutText(text)
+
+        assertContentEquals(body, sink.messages.single().copyOfRange(8, 8 + body.size))
+    }
 }
 
 /** FramebufferUpdate with one ExtendedDesktopSize rect: header x/y carry [reason]/[status]. */

--- a/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
+++ b/shared/src/desktopTest/kotlin/app/skerry/shared/sftp/SshjSftpClientTest.kt
@@ -1,12 +1,17 @@
 package app.skerry.shared.sftp
 
+import app.skerry.shared.files.MAX_LISTING_ENTRIES
 import app.skerry.shared.ssh.HostKeyVerifier
 import app.skerry.shared.ssh.SshAuth
 import app.skerry.shared.ssh.SshConnection
 import app.skerry.shared.ssh.SshTarget
 import app.skerry.shared.ssh.SshjTransport
 import kotlinx.coroutines.test.runTest
+import com.hierynomus.sshj.sftp.RemoteResourceSelector
 import net.schmizz.sshj.SSHClient
+import net.schmizz.sshj.sftp.FileAttributes
+import net.schmizz.sshj.sftp.PathComponents
+import net.schmizz.sshj.sftp.RemoteResourceInfo
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory
 import org.apache.sshd.server.SshServer
@@ -90,7 +95,7 @@ class SshjSftpClientTest {
     @Test
     fun `list returns directory entries without dot and dotdot`() = runTest {
         withSftp { sftp ->
-            val names = sftp.list("/").map { it.name }
+            val names = sftp.list("/", MAX_LISTING_ENTRIES).map { it.name }
             assertTrue("readme.txt" in names, "expected readme.txt, got $names")
             assertTrue("sub" in names, "expected directory sub, got $names")
             assertTrue("." !in names && ".." !in names, "listing should not contain . or .., got $names")
@@ -98,9 +103,48 @@ class SshjSftpClientTest {
     }
 
     @Test
+    fun `the listing selector takes one entry past the limit and then breaks`() {
+        // The selector is the object `list` installs, so testing it is testing the wiring: the count
+        // and the name check both have to live on the instance `sftp.ls` is handed.
+        val selector = listingSelector("/d", limit = 2)
+
+        repeat(3) { assertEquals(RemoteResourceSelector.Result.ACCEPT, selector.select(entry("/d", "f$it"))) }
+        assertEquals(RemoteResourceSelector.Result.BREAK, selector.select(entry("/d", "f3")))
+    }
+
+    @Test
+    fun `the listing selector refuses an entry no filesystem could name`() {
+        // A cap on how many entries a listing holds is not a cap on what it weighs: an SSH string
+        // may be 32 KB. The limits are POSIX's own, so this cannot be provoked through a real server
+        // — the filesystem behind it refuses the name first — and no real server ever trips them.
+        val selector = listingSelector("/d", limit = 2)
+        selector.select(entry(parent = "/d", name = "file.txt"))
+
+        assertFailsWith<SftpException> { selector.select(entry("/d", "x".repeat(256))) }
+        assertFailsWith<SftpException> { selector.select(entry("/" + "d".repeat(4096), "f")) }
+    }
+
+    private fun entry(parent: String, name: String) =
+        RemoteResourceInfo(PathComponents(parent, name, "/"), FileAttributes.EMPTY)
+
+    @Test
+    fun `list stops one entry past the limit it was given`() = runTest {
+        // The allocation the limit exists for happens inside sshj's READDIR loop, so the stop has
+        // to be proven against a real server rather than a fake: what comes back must be limit + 1,
+        // no matter how many names the directory actually holds.
+        val wide = root.resolve("wide").createDirectory()
+        repeat(40) { wide.resolve("f$it").writeText("x") }
+
+        withSftp { sftp ->
+            assertEquals(11, sftp.list("/wide", limit = 10).size)
+            assertEquals(40, sftp.list("/wide", limit = 100).size)
+        }
+    }
+
+    @Test
     fun `list distinguishes files from directories`() = runTest {
         withSftp { sftp ->
-            val byName = sftp.list("/").associateBy { it.name }
+            val byName = sftp.list("/", MAX_LISTING_ENTRIES).associateBy { it.name }
             assertEquals(SftpEntryType.File, byName.getValue("readme.txt").type)
             assertEquals(SftpEntryType.Directory, byName.getValue("sub").type)
             assertEquals(README_BODY.length.toLong(), byName.getValue("readme.txt").size)
@@ -269,7 +313,7 @@ class SshjSftpClientTest {
     @Test
     fun `list on a missing path throws SftpException`() = runTest {
         withSftp { sftp ->
-            assertFailsWith<SftpException> { sftp.list("/does-not-exist") }
+            assertFailsWith<SftpException> { sftp.list("/does-not-exist", MAX_LISTING_ENTRIES) }
         }
     }
 
@@ -292,7 +336,7 @@ class SshjSftpClientTest {
         withSftp { sftp ->
             // stat uses lstat — the link isn't followed, type is Symlink, not the target's Directory.
             assertEquals(SftpEntryType.Symlink, sftp.stat("/sub-link")?.type)
-            val fromList = sftp.list("/").first { it.name == "sub-link" }
+            val fromList = sftp.list("/", MAX_LISTING_ENTRIES).first { it.name == "sub-link" }
             assertEquals(SftpEntryType.Symlink, fromList.type)
         }
     }
@@ -315,7 +359,7 @@ class SshjSftpClientTest {
         try {
             val sftp = connection.openSftp()
             sftp.close()
-            assertFailsWith<SftpException> { sftp.list("/") }
+            assertFailsWith<SftpException> { sftp.list("/", MAX_LISTING_ENTRIES) }
             assertFailsWith<SftpException> { sftp.stat("/readme.txt") }
         } finally {
             connection.disconnect()

--- a/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sftp/SshjSftpClient.kt
+++ b/shared/src/jvmSharedMain/kotlin/app/skerry/shared/sftp/SshjSftpClient.kt
@@ -1,5 +1,6 @@
 package app.skerry.shared.sftp
 
+import com.hierynomus.sshj.sftp.RemoteResourceSelector
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
@@ -35,9 +36,21 @@ internal class SshjSftpClient(
 
     private val closed = AtomicBoolean(false)
 
-    override suspend fun list(path: String): List<SftpEntry> = io("Failed to read directory $path") {
+    /**
+     * `sftp.ls` accumulates `SSH_FXP_NAME` responses until the server says there are no more, so
+     * without a selector how long that list grows is the server's decision: one `ls` answered with
+     * tens of millions of names exhausts the heap during an ordinary browse, before any guard above
+     * this call gets to run. [listingSelector] bounds the accumulated list — one entry past [limit],
+     * enough for the caller to see the listing was cut short, and no more than that held.
+     *
+     * The list, not the packet. sshj reads a whole SFTP reply into its own buffer before a single
+     * entry is parsed, and that buffer is capped by sshj at 1 GiB and then kept for the life of the
+     * channel; nothing on this side of the API can bound it. What is bounded here is everything
+     * built from those packets, which is what grows without limit as the server keeps answering.
+     */
+    override suspend fun list(path: String, limit: Int): List<SftpEntry> = io("Failed to read directory $path") {
         // sshj filters . and .. out of the listing itself.
-        sftp.ls(path).map { it.toEntry() }
+        sftp.ls(path, listingSelector(path, limit)).map { it.toEntry() }
     }
 
     override suspend fun stat(path: String): SftpEntry? = withContext(Dispatchers.IO) {
@@ -171,6 +184,38 @@ internal class SshjSftpClient(
     private companion object {
         /** Default channel-level read cap for [read]; the shared contract's [SFTP_MAX_READ_BYTES]. */
         const val DEFAULT_MAX_READ_BYTES = SFTP_MAX_READ_BYTES
+    }
+}
+
+/** Longest single path component any of the filesystems behind an SFTP server can name. */
+private const val NAME_MAX = 255
+
+/** Longest whole path those same filesystems can name. */
+private const val PATH_MAX = 4096
+
+/**
+ * The selector every entry of a listing of [path] goes through: at most `limit + 1` entries taken,
+ * and an entry no filesystem could have produced refused outright.
+ *
+ * How many entries is only half of a bound. One SSH string may be 32 KB, so a hundred thousand of
+ * them is three orders of magnitude more memory than the count suggests. [NAME_MAX] and [PATH_MAX]
+ * are POSIX's own limits, so no real server trips them; one that does is describing itself, not a
+ * file the user might want, and the listing is refused rather than drawn short. What is left is the
+ * honest residual: `limit` times a name a filesystem can hold, which is the number the caller's cap
+ * was chosen against.
+ *
+ * One selector per listing — it counts.
+ */
+internal fun listingSelector(path: String, limit: Int): RemoteResourceSelector {
+    // Long, so a caller asking for Int.MAX_VALUE needs no special case: the ceiling is one past the
+    // limit whatever the limit is, and a special case is a branch nothing exercises.
+    var taken = 0L
+    val ceiling = limit.toLong() + 1
+    return RemoteResourceSelector { info ->
+        if (info.name.length > NAME_MAX || info.path.length > PATH_MAX) {
+            throw SftpException("Listing $path returned an entry no filesystem can name")
+        }
+        if (taken++ < ceiling) RemoteResourceSelector.Result.ACCEPT else RemoteResourceSelector.Result.BREAK
     }
 }
 


### PR DESCRIPTION
Four protocol-level fixes, one commit each.

### A single SFTP directory listing is unbounded (#340)

The tree walks were bounded by depth and by how many entries a plan may hold, but one listing was
not bounded at all: it is the server's answer, so how much memory went into holding it was the
server's decision, and one `SSH_FXP_READDIR` loop was enough to exhaust the heap during an ordinary
browse — before any guard above it ran.

`SftpClient.list` now takes the number of entries the caller can hold and stops one past it, so a
full listing and a truncated one stay distinguishable. The sshj implementation applies the limit
through a resource selector, as the listing is read, and refuses an entry no filesystem could name
(`NAME_MAX` / `PATH_MAX`). The browser refuses a listing that came back over the cap instead of
drawing it short — a listing cut short without saying so is a directory the user believes they have
seen.

The cap is a budget for a whole root-to-leaf path, not for one call: a recursive walk holds one
listing per level it is inside, so each level passes down what is left of it. Breadth does not
consume it, so a wide tree is still deleted whole and still planned whole.

### Telnet: an escaped IAC inside a subnegotiation bypassed the body cap (#315)

The subnegotiation buffer was capped, but the check ran after the branch that decodes `IAC IAC`, so
a peer sending nothing but escaped `0xFF` bytes grew it without limit. The cap now runs first, and
the boundary IAC is carried into the dropping state so the option's terminator is still recognised.

### ssh_config: options under a malformed Host line became global defaults (#307)

A `Host` line whose patterns could not be parsed left the parser in the global section, so every
option below it — `IdentityFile`, `User`, `ProxyJump` included — applied to every host in the file.
Options are now skipped until the next block keyword, so a malformed `Host` applies to nothing.

### VNC: ClientCutText was sent as UTF-8 (#304)

RFC 6143 §7.5.6 defines the cut-text encoding as ISO 8859-1. Anything outside ASCII arrived at the
server as mojibake, and the length field disagreed with the character count. Characters with no
Latin-1 representation are sent as `?`.

## Verifying by hand

- **#340** — open an SFTP pane on a directory with tens of thousands of entries: it either draws or
  reports "directory is too large", never a short listing presented as complete. Downloading and
  deleting that directory behave the same way.
- **#315** — connect to a telnet host that negotiates terminal type; the session comes up as before.
- **#307** — put a broken `Host` line (`Host "unclosed`) above `User root` in `~/.ssh/config`: the
  option no longer leaks into every host in the picker.
- **#304** — copy `привет` in a VNC session and paste it on the server side.

## Not verified

Android, a live SFTP/VNC/telnet server, TalkBack, Windows and macOS. Desktop tests and the full
build gate are green on Linux.
